### PR TITLE
Allow user to set default transfer byte for block read

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -32,7 +32,8 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
 #endif
         _bits(8),
         _mode(0),
-        _hz(1000000) {
+        _hz(1000000),
+        _dummy(0x00) {
     // No lock needed in the constructor
 
     spi_init(&_spi, mosi, miso, sclk, ssel);
@@ -102,7 +103,7 @@ int SPI::write(int value) {
 int SPI::write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
     lock();
     _acquire();
-    int ret = spi_master_block_write(&_spi, tx_buffer, tx_length, rx_buffer, rx_length);
+    int ret = spi_master_block_write(&_spi, tx_buffer, tx_length, rx_buffer, rx_length, _dummy);
     unlock();
     return ret;
 }
@@ -113,6 +114,12 @@ void SPI::lock() {
 
 void SPI::unlock() {
     _mutex->unlock();
+}
+
+void SPI::dummy(char data) {
+    lock();
+    _dummy = data;
+    unlock();
 }
 
 #if DEVICE_SPI_ASYNCH

--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -33,7 +33,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
         _bits(8),
         _mode(0),
         _hz(1000000),
-        _dummy(0x00) {
+        _write_fill(SPI_FILL_CHAR) {
     // No lock needed in the constructor
 
     spi_init(&_spi, mosi, miso, sclk, ssel);
@@ -103,7 +103,7 @@ int SPI::write(int value) {
 int SPI::write(const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
     lock();
     _acquire();
-    int ret = spi_master_block_write(&_spi, tx_buffer, tx_length, rx_buffer, rx_length, _dummy);
+    int ret = spi_master_block_write(&_spi, tx_buffer, tx_length, rx_buffer, rx_length, _write_fill);
     unlock();
     return ret;
 }
@@ -116,9 +116,9 @@ void SPI::unlock() {
     _mutex->unlock();
 }
 
-void SPI::dummy(char data) {
+void SPI::set_default_write_value(char data) {
     lock();
-    _dummy = data;
+    _write_fill = data;
     unlock();
 }
 

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -143,13 +143,14 @@ public:
      */
     virtual void unlock(void);
 
-    /** SPI block read dummy data
-      * SPI requires master to send dummy data, in order to perform read operation.
-      * Dummy bytes can be different for devices. Example SD Card require 0xFF.
+    /** Set default write data
+      * SPI requires the master to send some data during a read operation.
+      * Different devices may require different default byte values.
+      * For example: A SD Card requires default bytes to be 0xFF.
       *
-      * @param dummy    Dummy character to be transmitted while read operation
+      * @param data    Default character to be transmitted while read operation
       */
-    void dummy(char data);
+    void set_default_write_value(char data);
 
 #if DEVICE_SPI_ASYNCH
 
@@ -279,7 +280,7 @@ protected:
     int _bits;
     int _mode;
     int _hz;
-    char _dummy;
+    char _write_fill;
 
 private:
     /* Private acquire function without locking/unlocking

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -143,6 +143,14 @@ public:
      */
     virtual void unlock(void);
 
+    /** SPI block read dummy data
+      * SPI requires master to send dummy data, in order to perform read operation.
+      * Dummy bytes can be different for devices. Example SD Card require 0xFF.
+      *
+      * @param dummy    Dummy character to be transmitted while read operation
+      */
+    void dummy(char data);
+
 #if DEVICE_SPI_ASYNCH
 
     /** Start non-blocking SPI transfer using 8bit buffers.
@@ -271,6 +279,7 @@ protected:
     int _bits;
     int _mode;
     int _hz;
+    char _dummy;
 
 private:
     /* Private acquire function without locking/unlocking

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -127,11 +127,12 @@ int  spi_master_write(spi_t *obj, int value);
  * @param[in] tx_length Number of bytes to write, may be zero
  * @param[in] rx_buffer Pointer to the byte-array of data to read from the device
  * @param[in] rx_length Number of bytes to read, may be zero
+ * @param[in] dummy     Dummy data transmitted while performing read
  * @returns
  *      The number of bytes written and read from the device. This is
  *      maximum of tx_length and rx_length.
  */
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length);
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char dummy);
 
 /** Check if a value is available to read
  *

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -33,6 +33,7 @@
 #define SPI_EVENT_INTERNAL_TRANSFER_COMPLETE (1 << 30) // Internal flag to report that an event occurred
 
 #define SPI_FILL_WORD         (0xFFFF)
+#define SPI_FILL_CHAR         (0xFF)
 
 #if DEVICE_SPI_ASYNCH
 /** Asynch SPI HAL structure
@@ -122,17 +123,17 @@ int  spi_master_write(spi_t *obj, int value);
  *  tx_length and rx_length. The bytes written will be padded with the
  *  value 0xff.
  *
- * @param[in] obj       The SPI peripheral to use for sending
- * @param[in] tx_buffer Pointer to the byte-array of data to write to the device
- * @param[in] tx_length Number of bytes to write, may be zero
- * @param[in] rx_buffer Pointer to the byte-array of data to read from the device
- * @param[in] rx_length Number of bytes to read, may be zero
- * @param[in] dummy     Dummy data transmitted while performing read
+ * @param[in] obj        The SPI peripheral to use for sending
+ * @param[in] tx_buffer  Pointer to the byte-array of data to write to the device
+ * @param[in] tx_length  Number of bytes to write, may be zero
+ * @param[in] rx_buffer  Pointer to the byte-array of data to read from the device
+ * @param[in] rx_length  Number of bytes to read, may be zero
+ * @param[in] write_fill Default data transmitted while performing a read
  * @returns
  *      The number of bytes written and read from the device. This is
  *      maximum of tx_length and rx_length.
  */
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char dummy);
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill);
 
 /** Check if a value is available to read
  *

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/spi_api.c
@@ -262,11 +262,12 @@ int spi_master_write(spi_t *obj, int value) {
     return data;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
@@ -256,13 +256,13 @@ int spi_master_write(spi_t *obj, int value)
 }
 
 int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length)
+                           char *rx_buffer, int rx_length, char write_fill)
 {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
     char out, in;
 
     for (int i = 0; i < total; i++) {
-        out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        out = (i < tx_length) ? tx_buffer[i] : write_fill;
         in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
@@ -268,11 +268,12 @@ int spi_master_write(spi_t *obj, int value) {
     return (ssp_read(obj));
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
@@ -268,11 +268,12 @@ int spi_master_write(spi_t *obj, int value) {
     return (ssp_read(obj));
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/spi_api.c
@@ -555,11 +555,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/spi_api.c
@@ -296,11 +296,12 @@ int  spi_master_write(spi_t *obj, int value)
     return 0;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char _write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : _write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/spi_api.c
@@ -140,11 +140,12 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->POPR;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
@@ -141,11 +141,12 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->D & 0xff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
@@ -120,11 +120,12 @@ int spi_master_write(spi_t *obj, int value) {
     return obj->spi->D & 0xff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
@@ -199,11 +199,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ret;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
@@ -199,11 +199,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ret;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/spi_api.c
@@ -118,11 +118,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/spi_api.c
@@ -118,11 +118,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/spi_api.c
@@ -115,11 +115,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/spi_api.c
@@ -115,11 +115,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/spi_api.c
@@ -117,11 +117,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/spi_api.c
@@ -117,11 +117,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/spi_api.c
@@ -117,11 +117,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/spi_api.c
@@ -117,11 +117,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/spi_api.c
@@ -127,11 +127,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
@@ -576,13 +576,13 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
-status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer, char dummy)
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
 {
     assert(transfer);
 
     uint16_t wordToSend = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = dummy;
+    uint8_t dummyData = DSPI_DUMMY_DATA;
     uint8_t bitsPerFrame;
 
     uint32_t command;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.c
@@ -576,13 +576,13 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
     handle->userData = userData;
 }
 
-status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer)
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer, char dummy)
 {
     assert(transfer);
 
     uint16_t wordToSend = 0;
     uint16_t wordReceived = 0;
-    uint8_t dummyData = DSPI_DUMMY_DATA;
+    uint8_t dummyData = dummy;
     uint8_t bitsPerFrame;
 
     uint32_t command;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
@@ -1058,7 +1058,7 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
  * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
-status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer, char dummy);
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
 
 /*!
  * @brief DSPI master transfer data using interrupts.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/drivers/fsl_dspi.h
@@ -1058,7 +1058,7 @@ void DSPI_MasterTransferCreateHandle(SPI_Type *base,
  * @param transfer Pointer to the dspi_transfer_t structure.
  * @return status of status_t.
  */
-status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer);
+status_t DSPI_MasterTransferBlocking(SPI_Type *base, dspi_transfer_t *transfer, char dummy);
 
 /*!
  * @brief DSPI master transfer data using interrupts.

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -127,7 +127,7 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char dummy) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t){
@@ -135,7 +135,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
         .rxData = (uint8_t *)rx_buffer,
         .dataSize = total,
         .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
-    });
+    }, dummy);
 
     DSPI_ClearStatusFlags(spi_address[obj->spi.instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -127,17 +127,17 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char dummy) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t){
-        .txData = (uint8_t *)tx_buffer,
-        .rxData = (uint8_t *)rx_buffer,
-        .dataSize = total,
-        .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
-    }, dummy);
-
-    DSPI_ClearStatusFlags(spi_address[obj->spi.instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
+    for (int i = 0; i < total; i++) {
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
+        char in = spi_master_write(obj, out);
+        if (i < rx_length) {
+            rx_buffer[i] = in;
+        }
+    }
 
     return total;
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/spi_api.c
@@ -179,11 +179,12 @@ int spi_master_write(spi_t *obj, int value)
     return result;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/spi_api.c
@@ -179,11 +179,12 @@ int spi_master_write(spi_t *obj, int value)
     return result;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/spi_api.c
@@ -231,11 +231,12 @@ int spi_master_write(spi_t *obj, int value)
     return spi_master_transaction(obj, value, MXC_S_SPI_FIFO_DIR_BOTH);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
@@ -167,11 +167,12 @@ int spi_master_write(spi_t *obj, int value)
     return *req.rx_data;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/spi_api.c
@@ -167,11 +167,12 @@ int spi_master_write(spi_t *obj, int value)
     return *req.rx_data;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/spi_api.c
@@ -263,11 +263,12 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/spi_api.c
@@ -487,11 +487,12 @@ int spi_master_write(spi_t *obj, int value)
     return p_spi_info->rx_buf;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/spi_api.c
@@ -241,11 +241,12 @@ int spi_master_write(spi_t *obj, int value)
     return value2;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/spi_api.c
@@ -244,11 +244,12 @@ int spi_master_write(spi_t *obj, int value)
     return value2;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -190,11 +190,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -156,11 +156,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -192,11 +192,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -184,11 +184,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -248,11 +248,12 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer,
+                           int tx_length, char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -190,11 +190,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -197,11 +197,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -177,11 +177,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -196,11 +196,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -178,11 +178,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -174,11 +174,12 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/spi_api.c
@@ -83,11 +83,12 @@ int  spi_master_write(spi_t *obj, int value)
     return(fSpiWriteB(obj, value));
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
@@ -260,11 +260,12 @@ int spi_master_write(spi_t *obj, int value) {
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/spi_api.c
@@ -311,11 +311,12 @@ int spi_master_write(spi_t *obj, int value) {
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Realtek/TARGET_AMEBA/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/spi_api.c
@@ -241,12 +241,13 @@ int spi_master_write (spi_t *obj, int value)
     return ssi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length)
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill)
 {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -387,12 +387,13 @@ int spi_master_write(spi_t *obj, int value)
     }
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length)
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill)
 {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -391,11 +391,12 @@ int spi_master_write(spi_t *obj, int value)
     return spi_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;

--- a/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
@@ -183,11 +183,12 @@ int spi_master_write(spi_t *obj, int value) {
     return ssp_read(obj);
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;


### PR DESCRIPTION
## Description
Default 0x00 byte was transmitted for SPI read operations. SD card require default data to be 0xFF.
Added API for user to set the required default data byte for SPI read. 

## Status
**Ready**

## Migrations
Default data was 0x00 for few targets, and default behavior has changed with this code change. Default now is 0xFF and user can set required value with API '_spi.set_default_write_value(data);'

## Issue #4743 