### PR TITLE
Remove unused header files includes for REALTEK_RTL8195AM

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a.h
@@ -28,13 +28,10 @@
 #include "hal_diag.h"
 #include "hal_spi_flash.h"
 #include "rtl8195a_spi_flash.h"
-//#include "hal_timer.h"
 #include "hal_util.h"
 #include "hal_efuse.h"
 #include "hal_soc_ps_monitor.h"
 #include "diag.h"
-//#include "hal_common.h"
-//#include "hal_soc_ps_monitor.h"
 
 
 // from RDC team
@@ -153,7 +150,6 @@ __##name##_Disable(void)                                         \
 #include "rtl8195a_clk.h"
 #include "rtl8195a_misc.h"
 #include "rtl8195a_sdio.h"
-//#include "rtl8195a_luart.h"
 
 #endif
 
@@ -203,10 +199,6 @@ __##name##_Disable(void)                                         \
 #include "rtl8195a_i2c.h"
 #endif
 
-//#ifdef CONFIG_PCM_EN
-//#include "hal_pcm.h"
-//#include "rtl8195a_pcm.h"
-//#endif
 
 #ifdef CONFIG_PWM_EN
 #include "hal_pwm.h"


### PR DESCRIPTION
By removing these headfile includes shall it prevent confusion