### PR TITLE
tools: fix toolchain extend inc paths

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -863,7 +863,10 @@ class mbedToolchain:
 
         inc_paths = resources.inc_dirs
         if inc_dirs is not None:
-            inc_paths.extend(inc_dirs)
+            if isinstance(inc_dirs, list):
+                inc_paths.extend(inc_dirs)
+            else:
+                inc_paths.append(inc_dirs)
         # De-duplicate include paths
         inc_paths = set(inc_paths)
         # Sort include paths for consistency


### PR DESCRIPTION
inc paths might be a list or might not be (just single string). If they don't, we are ending up with non valid include paths (one letter include paths).
This as result would not compile. 

As inc_dirs might be just `D:/SomePath`, extend this would lead to producing [`D`, `:`, `S`..........] thus we were not able to compile with tools/build.py for instance. This is an example I was seeing
`[DEBUG] INC DIRS: ['C', ':', '\\', 'C', 'o', 'd', 'e', '\\', 'm', 'b', 'e', 'd', '-', 'o', 's', '\\', 'B', 'U', 'I', 'L', 'D', '\\', 'm', 'b', 'e', 'd', '\\', '.', 't', 'e', 'm', 'p', '\\', 'T', 'A', 'R', 'G', 'E', 'T', '_', 'N', 'U', 'C', 'L', 'E', 'O', '_', 'F', '4', '1', '1', 'R', 'E', '\\', 'T', 'O', 'O', 'L', 'C', 'H', 'A', 'I', 'N', '_', 'I', 'A', 'R']`

@jeromecoutant This should fix the issue you were seeing today with IAR

@theotherjimmy please review, we handle inc dirs in scan resources similarly, might be better to always consider this as a list, or hack like this. You can take this patch and just push to my branch.