### PR TITLE
Bluepill: hse config fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/system_clock.c
@@ -45,7 +45,7 @@
 
 
 /* Select the clock sources (other than HSI) to start with (0=OFF, 1=ON) */
-#define USE_PLL_HSE_EXTC (1) /* Use external clock */
+#define USE_PLL_HSE_EXTC (0) /* Use external clock */
 #define USE_PLL_HSE_XTAL (1) /* Use external xtal */
 
 


### PR DESCRIPTION
Notes:
## Description
fixed the BLUEPILL (and likely other F1XX devices) oscillator setup
Problem described in issue #4753 


## Status
READY


## Migrations
NO



## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
as said, it may impact other F1xx branches, but the HSI (fallback of the startup procedure) was doing 64Mhz), so systems may do faster than expected

## Steps to test or reproduce
I started the mbed build app in a remote target with GDB, and printed SystemCoreClock
