### PR TITLE
Make HAL & US tickers IRQ and idle safe

### DIFF
--- a/targets/TARGET_STM/hal_tick_16b.c
+++ b/targets/TARGET_STM/hal_tick_16b.c
@@ -161,15 +161,15 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
     return HAL_OK;
 }
 
+/* NOTE: must be called with interrupts disabled! */
 void HAL_SuspendTick(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
+/* NOTE: must be called with interrupts disabled! */
 void HAL_ResumeTick(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 

--- a/targets/TARGET_STM/hal_tick_32b.c
+++ b/targets/TARGET_STM/hal_tick_32b.c
@@ -131,15 +131,15 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
     return HAL_OK;
 }
 
+/* NOTE: must be called with interrupts disabled! */
 void HAL_SuspendTick(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 
+/* NOTE: must be called with interrupts disabled! */
 void HAL_ResumeTick(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
 }
 

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -40,17 +40,25 @@ extern void HAL_ResumeTick(void);
 
 void hal_sleep(void)
 {
+    // Disable IRQs
+    core_util_critical_section_enter();
+
     // Stop HAL tick to avoid to exit sleep in 1ms
     HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
     // Restart HAL tick
     HAL_ResumeTick();
+
+    // Enable IRQs
+    core_util_critical_section_exit();
 }
 
 void hal_deepsleep(void)
 {
+    // Disable IRQs
+    core_util_critical_section_enter();
+
     // Stop HAL tick
     HAL_SuspendTick();
     uint32_t EnterTimeUS = us_ticker_read();
@@ -81,6 +89,9 @@ void hal_deepsleep(void)
 
     // Restart HAL tick
     HAL_ResumeTick();
+
+    // Enable IRQs
+    core_util_critical_section_exit();
 
     // After wake-up from STOP reconfigure the PLL
     SetSysClock();

--- a/targets/TARGET_STM/us_ticker_16b.c
+++ b/targets/TARGET_STM/us_ticker_16b.c
@@ -26,22 +26,13 @@ TIM_HandleTypeDef TimMasterHandle;
 volatile uint32_t SlaveCounter = 0;
 volatile uint32_t oc_int_part = 0;
 
-static int us_ticker_inited = 0;
-
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) return;
-    us_ticker_inited = 1;
-
-    TimMasterHandle.Instance = TIM_MST;
-
-    HAL_InitTick(0); // The passed value is not used
+    /* NOTE: assuming that HAL tick has already been initialized! */
 }
 
 uint32_t us_ticker_read()
 {
-    if (!us_ticker_inited) us_ticker_init();
-
     uint16_t cntH_old, cntH, cntL;
     do {
         cntH_old = SlaveCounter;
@@ -73,7 +64,7 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     // NOTE: This function must be called with interrupts disabled to keep our
     //       timer interrupt setup atomic
-    TimMasterHandle.Instance = TIM_MST;
+
     // Set new output compare value
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, timestamp & 0xFFFF);
     // Ensure the compare event starts clear
@@ -178,20 +169,21 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 
 void us_ticker_fire_interrupt(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
     HAL_TIM_GenerateEvent(&TimMasterHandle, TIM_EVENTSOURCE_CC1);
 }
 
 void us_ticker_disable_interrupt(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
+    core_util_critical_section_enter();
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+    core_util_critical_section_exit();
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
-    __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
+    core_util_critical_section_enter();
+    __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+    core_util_critical_section_exit();
 }
 
 #endif // TIM_MST_16BIT

--- a/targets/TARGET_STM/us_ticker_32b.c
+++ b/targets/TARGET_STM/us_ticker_32b.c
@@ -35,8 +35,8 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    /* Disable global IRQs */
-    core_util_critical_section_enter();
+    // NOTE: This function must be called with interrupts disabled to keep our
+    //       timer interrupt setup atomic
 
     // disable IT while we are handling the correct timestamp
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
@@ -44,9 +44,6 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, (uint32_t)timestamp);
     // Enable IT
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
-
-    /* Enable global IRQs */
-    core_util_critical_section_exit();
 }
 
 void us_ticker_fire_interrupt(void)

--- a/targets/TARGET_STM/us_ticker_32b.c
+++ b/targets/TARGET_STM/us_ticker_32b.c
@@ -23,33 +23,30 @@
 
 TIM_HandleTypeDef TimMasterHandle;
 
-static int us_ticker_inited = 0;
-
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) return;
-    us_ticker_inited = 1;
-
-    TimMasterHandle.Instance = TIM_MST;
-
-    HAL_InitTick(0); // The passed value is not used
+    /* NOTE: assuming that HAL tick has already been initialized! */
 }
 
 uint32_t us_ticker_read()
 {
-    if (!us_ticker_inited) us_ticker_init();
     return TIM_MST->CNT;
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TimMasterHandle.Instance = TIM_MST;
+    /* Disable global IRQs */
+    core_util_critical_section_enter();
+
     // disable IT while we are handling the correct timestamp
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
     // Set new output compare value
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, (uint32_t)timestamp);
     // Enable IT
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+
+    /* Enable global IRQs */
+    core_util_critical_section_exit();
 }
 
 void us_ticker_fire_interrupt(void)
@@ -59,14 +56,16 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_disable_interrupt(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
+    core_util_critical_section_enter();
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+    core_util_critical_section_exit();
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TimMasterHandle.Instance = TIM_MST;
+    core_util_critical_section_enter();
     __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+    core_util_critical_section_exit();
 }
 
 #endif // !TIM_MST_16BIT


### PR DESCRIPTION
## Description
The new RTX5 seems to call `hal_sleep()` with interrupts enabled, therefore we need to protect this function against interrupt to guarantee that a thread reschedule does **not** leave the system with HAL ticks suspended.

## Status
**READY**

## Migrations
 NO

## People
@bcostm @adustm @LMESTM 