### PR TITLE
Fix non-portable defines

### DIFF
--- a/platform/mbed_application.h
+++ b/platform/mbed_application.h
@@ -21,7 +21,12 @@
 
 #include<stdint.h>
 
-#define MBED_APPLICATION_SUPPORT defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7)
+#if defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7)
+#define MBED_APPLICATION_SUPPORT 1
+#else
+#define MBED_APPLICATION_SUPPORT 0
+#endif
+
 #if MBED_APPLICATION_SUPPORT
 #ifdef __cplusplus
 extern "C" {

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -23,7 +23,11 @@
 #include "platform/mbed_assert.h"
 #include "platform/mbed_toolchain.h"
 
-#define EXCLUSIVE_ACCESS (!defined (__CORTEX_M0) && !defined (__CORTEX_M0PLUS))
+#if !defined (__CORTEX_M0) && !defined (__CORTEX_M0PLUS)
+#define EXCLUSIVE_ACCESS 1
+#else
+#define EXCLUSIVE_ACCESS 0
+#endif
 
 static volatile uint32_t interrupt_enable_counter = 0;
 static volatile bool critical_interrupts_disabled = false;


### PR DESCRIPTION
A define which expands to more defines is not portable across all compilers and GCC warns about this. Restructure this so the behavior is defined. This fixes the GCC warning:
"this use of "defined" may not be portable"