### PR TITLE
Remove use of internal RTX types

### DIFF
--- a/events/equeue/equeue_platform.h
+++ b/events/equeue/equeue_platform.h
@@ -51,7 +51,7 @@ extern "C" {
 #include <pthread.h>
 #elif defined(EQUEUE_PLATFORM_MBED)
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #endif
 
 
@@ -117,7 +117,7 @@ typedef struct equeue_sema {
 #elif defined(EQUEUE_PLATFORM_MBED) && defined(MBED_CONF_RTOS_PRESENT)
 typedef struct equeue_sema {
     osEventFlagsId_t id;
-    os_event_flags_t mem;
+    mbed_rtos_storage_event_flags_t mem;
 } equeue_sema_t;
 #elif defined(EQUEUE_PLATFORM_MBED)
 typedef volatile int equeue_sema_t;

--- a/rtos/Mail.h
+++ b/rtos/Mail.h
@@ -28,7 +28,7 @@
 #include "Queue.h"
 #include "MemoryPool.h"
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include "mbed_rtos1_types.h"
 
 #include "platform/NonCopyable.h"

--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include "cmsis_os2.h"
-#include "rtx_lib.h"
+#include "mbed_rtos_storage.h"
 #include "platform/Callback.h"
 #include "platform/NonCopyable.h"
 #include "platform/mbed_toolchain.h"
@@ -150,7 +150,7 @@ private:
 
     osTimerId_t _id;
     osTimerAttr_t _attr;
-    os_timer_t _obj_mem;
+    mbed_rtos_storage_timer_t _obj_mem;
     mbed::Callback<void()> _function;
 };
 

--- a/rtos/TARGET_CORTEX/mbed_rtos_storage.h
+++ b/rtos/TARGET_CORTEX/mbed_rtos_storage.h
@@ -41,6 +41,7 @@ extern "C" {
  */
 
 #include "rtx_lib.h"
+#include "mbed_rtx_conf.h"
 
 typedef os_mutex_t mbed_rtos_storage_mutex_t;
 typedef os_semaphore_t mbed_rtos_storage_semaphore_t;

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -24,6 +24,9 @@
 
 #include "mbed_rtx.h"
 
+/** Any access to RTX5 specific data structures used in common code should be wrapped in ifdef MBED_OS_BACKEND_RTX5 */
+#define MBED_OS_BACKEND_RTX5
+
 /** The thread's stack size can be configured by the application, if not explicitly specified it'll default to 4K */
 #ifndef MBED_CONF_APP_THREAD_STACK_SIZE
 #define MBED_CONF_APP_THREAD_STACK_SIZE 4096

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -26,7 +26,6 @@
 #include "cmsis_os2.h"
 #include "mbed_rtos1_types.h"
 #include "mbed_rtos_storage.h"
-#include "mbed_rtx_conf.h"
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
 #include "platform/NonCopyable.h"

--- a/rtos/rtos.h
+++ b/rtos/rtos.h
@@ -25,8 +25,6 @@
 #ifndef RTOS_H
 #define RTOS_H
 
-#include "mbed_rtx.h"
-#include "mbed_rtx_conf.h"
 #include "mbed_rtos_storage.h"
 #include "rtos/Thread.h"
 #include "rtos/Mutex.h"


### PR DESCRIPTION
Make calls to cmsis-os to get thread state, stack size, and max stack usage rather than accessing internal RTX data directly. Wrap the code which has no public RTX function in TARGET_CORTEX_M since this needs to be defined for RTX to be included.
