### PR TITLE
changed the stm32f1xx_hal_rcc.c to handle the HSE init properly 

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_rcc.c
@@ -285,6 +285,23 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     }
     else
     {
+      if((__HAL_RCC_GET_FLAG(RCC_CR_HSEBYP) != RESET) && (RCC_OscInitStruct->HSEState == RCC_HSE_ON)) 
+      {
+          /* if it's in bypass mode, and the new mode is HSE_ON, must disable the bypass first
+             which requires HSE off to be changed*/
+        CLEAR_BIT(RCC->CR, RCC_CR_HSEON);                   \
+        CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);                  \
+        tickstart = HAL_GetTick();
+
+        /* Wait till HSE is disabled        */
+        while(__HAL_RCC_GET_FLAG(RCC_FLAG_HSERDY) != RESET)
+        {
+          if((HAL_GetTick() - tickstart ) > HSE_TIMEOUT_VALUE)
+          {
+             return HAL_TIMEOUT;
+          }
+        } 
+      }
       /* Set the new HSE configuration ---------------------------------------*/
       __HAL_RCC_HSE_CONFIG(RCC_OscInitStruct->HSEState);
       


### PR DESCRIPTION
changed the stm32f1xx_hal_rcc.c to handle the HSE init properly when BYPASS is done before XTAL

## Description
after issue #4753  and first PR #4755 , this would be a proposed more general solution


## Status
READY


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs
#4755 


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
Haven'f fully tested (because my board is fixed with the define config!), but it's essentially the changes pulled out from #4755 done in a different way, to make it follow the issues flagged by the ST drivers team

## Steps to test or reproduce

