### PR TITLE
STM32 I2C : correct async issue

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_i2c.c
@@ -1462,7 +1462,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
         /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
       }
-      else
+      else if(Prev_State == I2C_STATE_MASTER_BUSY_RX) // MBED
       {
         /* Generate ReStart */
         hi2c->Instance->CR1 |= I2C_CR1_START;
@@ -1564,7 +1564,7 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
         /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
       }
-      else
+      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) // MBED
       {
         /* Enable Acknowledge */
         hi2c->Instance->CR1 |= I2C_CR1_ACK;
@@ -4008,7 +4008,7 @@ static HAL_StatusTypeDef I2C_MasterReceive_RXNE(I2C_HandleTypeDef *hi2c)
 
       /* Enable Pos */
       hi2c->Instance->CR1 |= I2C_CR1_POS;
-      
+
       /* Disable BUF interrupt */
       __HAL_I2C_DISABLE_IT(hi2c, I2C_IT_BUF);
     }
@@ -4078,6 +4078,12 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
+
+      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
+      {
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
     else
     {

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_i2c.c
@@ -1414,8 +1414,17 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Generate Start */    
     if((Prev_State == I2C_STATE_MASTER_BUSY_RX) || (Prev_State == I2C_STATE_NONE))
     {
-       /* Generate Start or ReStart */
+      /* Generate Start condition if first transfer */
+      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME))
+      {
+        /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
+      else if(Prev_State == I2C_STATE_MASTER_BUSY_RX) // MBED
+      {
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
 
     /* Process Unlocked */
@@ -1504,11 +1513,23 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     
     if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) || (hi2c->PreviousState == I2C_STATE_NONE))
     {
+      /* Generate Start condition if first transfer */
+      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME)  || (XferOptions == I2C_NO_OPTION_FRAME))
+      {
         /* Enable Acknowledge */
         hi2c->Instance->CR1 |= I2C_CR1_ACK;
-        
-        /* Generate Start or ReStart */
+
+        /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
+      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX)
+      {
+        /* Enable Acknowledge */
+        hi2c->Instance->CR1 |= I2C_CR1_ACK;
+
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
 
     /* Process Unlocked */
@@ -3996,6 +4017,12 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
+
+      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
+      {
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
     else
     {

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_i2c.c
@@ -1413,8 +1413,17 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Transmit_IT(I2C_HandleTypeDef *hi2c,
     /* Generate Start */    
     if((Prev_State == I2C_STATE_MASTER_BUSY_RX) || (Prev_State == I2C_STATE_NONE))
     {
-        /* Generate Start or ReStart */
+      /* Generate Start condition if first transfer */
+      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME))
+      {
+        /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
+      else if(Prev_State == I2C_STATE_MASTER_BUSY_RX) // MBED
+      {
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
 
     /* Process Unlocked */
@@ -1503,10 +1512,23 @@ HAL_StatusTypeDef HAL_I2C_Master_Sequential_Receive_IT(I2C_HandleTypeDef *hi2c, 
     
     if((hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX) || (hi2c->PreviousState == I2C_STATE_NONE))
     {
+      /* Generate Start condition if first transfer */
+      if((XferOptions == I2C_FIRST_AND_LAST_FRAME) || (XferOptions == I2C_FIRST_FRAME)  || (XferOptions == I2C_NO_OPTION_FRAME))
+      {
         /* Enable Acknowledge */
         hi2c->Instance->CR1 |= I2C_CR1_ACK;
-        /* Generate Start or ReStart */
+
+        /* Generate Start */
         hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
+      else if(hi2c->PreviousState == I2C_STATE_MASTER_BUSY_TX)
+      {
+        /* Enable Acknowledge */
+        hi2c->Instance->CR1 |= I2C_CR1_ACK;
+
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
 
     /* Process Unlocked */
@@ -3993,6 +4015,12 @@ static HAL_StatusTypeDef I2C_MasterReceive_BTF(I2C_HandleTypeDef *hi2c)
     {
       /* Disable Acknowledge */
       hi2c->Instance->CR1 &= ~I2C_CR1_ACK;
+
+      if((CurrentXferOptions == I2C_NEXT_FRAME) || (CurrentXferOptions == I2C_FIRST_FRAME))
+      {
+        /* Generate ReStart */
+        hi2c->Instance->CR1 |= I2C_CR1_START;
+      }
     }
     else
     {


### PR DESCRIPTION
## Description
MBED_A29 test was FAILED for F1/F2/F4/L1 since #4299 and even with #4365

| OK     | NUCLEO_F103RB | ARM       | MBED_A20    | I2C master/slave test   |        0.28        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | ARM       | MBED_A29    | i2c_master_slave_asynch |        0.47        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | uARM      | MBED_A20    | I2C master/slave test   |        0.28        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | uARM      | MBED_A29    | i2c_master_slave_asynch |        0.44        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | GCC_ARM   | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | GCC_ARM   | MBED_A29    | i2c_master_slave_asynch |        0.47        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | IAR       | MBED_A20    | I2C master/slave test   |        0.27        |       30      |  1/1  |
| OK     | NUCLEO_F103RB | IAR       | MBED_A29    | i2c_master_slave_asynch |        0.47        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | ARM       | MBED_A20    | I2C master/slave test   |        0.28        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | ARM       | MBED_A29    | i2c_master_slave_asynch |        0.45        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | uARM      | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | uARM      | MBED_A29    | i2c_master_slave_asynch |        0.48        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | GCC_ARM   | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | GCC_ARM   | MBED_A29    | i2c_master_slave_asynch |        0.48        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | IAR       | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F446RE | IAR       | MBED_A29    | i2c_master_slave_asynch |        0.45        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | ARM       | MBED_A20    | I2C master/slave test   |        0.28        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | ARM       | MBED_A29    | i2c_master_slave_asynch |        0.48        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | uARM      | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | uARM      | MBED_A29    | i2c_master_slave_asynch |        0.45        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | GCC_ARM   | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | GCC_ARM   | MBED_A29    | i2c_master_slave_asynch |        0.5         |       30      |  1/1  |
| OK     | NUCLEO_L152RE | IAR       | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_L152RE | IAR       | MBED_A29    | i2c_master_slave_asynch |        0.48        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | ARM       | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | ARM       | MBED_A29    | i2c_master_slave_asynch |        0.44        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | uARM      | MBED_A20    | I2C master/slave test   |        0.27        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | uARM      | MBED_A29    | i2c_master_slave_asynch |        0.45        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | GCC_ARM   | MBED_A20    | I2C master/slave test   |        0.27        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | GCC_ARM   | MBED_A29    | i2c_master_slave_asynch |        0.47        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | IAR       | MBED_A20    | I2C master/slave test   |        0.33        |       30      |  1/1  |
| OK     | NUCLEO_F207ZG | IAR       | MBED_A29    | i2c_master_slave_asynch |        0.48        |       30      |  1/1  |

CI shield test has also been tested:

| NUCLEO_F103RB-ARM     | NUCLEO_F103RB | tests-api-i2c         | OK     | 60.09              | shell       |
| NUCLEO_F103RB-ARM     | NUCLEO_F103RB | tests-assumptions-i2c | OK     | 57.08              | shell       |
| NUCLEO_F103RB-GCC_ARM | NUCLEO_F103RB | tests-api-i2c         | OK     | 60.89              | shell       |
| NUCLEO_F103RB-GCC_ARM | NUCLEO_F103RB | tests-assumptions-i2c | OK     | 57.85              | shell       |
| NUCLEO_F103RB-IAR     | NUCLEO_F103RB | tests-api-i2c         | OK     | 59.83              | shell       |
| NUCLEO_F103RB-IAR     | NUCLEO_F103RB | tests-assumptions-i2c | OK     | 56.82              | shell       |
| NUCLEO_F207ZG-ARM     | NUCLEO_F207ZG | tests-api-i2c         | OK     | 58.59              | shell       |
| NUCLEO_F207ZG-ARM     | NUCLEO_F207ZG | tests-assumptions-i2c | OK     | 54.12              | shell       |
| NUCLEO_F207ZG-GCC_ARM | NUCLEO_F207ZG | tests-api-i2c         | OK     | 58.52              | shell       |
| NUCLEO_F207ZG-GCC_ARM | NUCLEO_F207ZG | tests-assumptions-i2c | OK     | 56.0               | shell       |
| NUCLEO_F207ZG-IAR     | NUCLEO_F207ZG | tests-api-i2c         | OK     | 58.45              | shell       |
| NUCLEO_F207ZG-IAR     | NUCLEO_F207ZG | tests-assumptions-i2c | OK     | 55.71              | shell       |
| NUCLEO_F446RE-ARM     | NUCLEO_F446RE | tests-api-i2c         | OK     | 58.48              | shell       |
| NUCLEO_F446RE-ARM     | NUCLEO_F446RE | tests-assumptions-i2c | OK     | 55.64              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-api-i2c         | OK     | 58.69              | shell       |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-assumptions-i2c | OK     | 56.72              | shell       |
| NUCLEO_F446RE-IAR     | NUCLEO_F446RE | tests-api-i2c         | OK     | 58.73              | shell       |
| NUCLEO_F446RE-IAR     | NUCLEO_F446RE | tests-assumptions-i2c | OK     | 55.75              | shell       |
| NUCLEO_L152RE-ARM     | NUCLEO_L152RE | tests-api-i2c         | OK     | 59.37              | shell       |
| NUCLEO_L152RE-ARM     | NUCLEO_L152RE | tests-assumptions-i2c | OK     | 56.46              | shell       |
| NUCLEO_L152RE-GCC_ARM | NUCLEO_L152RE | tests-api-i2c         | OK     | 59.98              | shell       |
| NUCLEO_L152RE-GCC_ARM | NUCLEO_L152RE | tests-assumptions-i2c | OK     | 56.86              | shell       |
| NUCLEO_L152RE-IAR     | NUCLEO_L152RE | tests-api-i2c         | OK     | 58.38              | shell       |
| NUCLEO_L152RE-IAR     | NUCLEO_L152RE | tests-assumptions-i2c | OK     | 56.05              | shell       |



## Status
READY

