### PR TITLE
NUCLEO_F767ZI : boot issue with GCC

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/startup_stm32f767xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/startup_stm32f767xx.S
@@ -58,10 +58,6 @@ defined in linker script */
 .word  _sdata
 /* end address for the .data section. defined in linker script */
 .word  _edata
-/* start address for the .bss section. defined in linker script */
-.word  _sbss
-/* end address for the .bss section. defined in linker script */
-.word  _ebss
 /* stack used for SystemInit_ExtMemCtl; always internal RAM used */
 
 /**
@@ -95,24 +91,18 @@ LoopCopyDataInit:
   adds  r2, r0, r1
   cmp  r2, r3
   bcc  CopyDataInit
-  ldr  r2, =_sbss
-  b  LoopFillZerobss
-/* Zero fill the bss segment. */  
-FillZerobss:
-  movs  r3, #0
-  str  r3, [r2], #4
-    
-LoopFillZerobss:
-  ldr  r3, = _ebss
-  cmp  r2, r3
-  bcc  FillZerobss
 
 /* Call the clock system initialization function.*/
   bl  SystemInit   
 /* Call static constructors */
-    bl __libc_init_array
+  //bl __libc_init_array
 /* Call the application's entry point.*/
-  bl  main
+  //bl  main
+  // Calling the crt0 'cold-start' entry point. There __libc_init_array is called
+  // and when existing hardware_init_hook() and software_init_hook() before
+  // starting main(). software_init_hook() is available and has to be called due
+  // to initializsation when using rtos.
+  bl _start
   bx  lr    
 .size  Reset_Handler, .-Reset_Handler
 


### PR DESCRIPTION
## Description
Many tests are failed with NUCLEO_F767ZI and GCC_ARM since #4659 

## Status
READY


| OK     | NUCLEO_F767ZI | GCC_ARM   | DTCT_1      | Simple detect test                    |        0.51        |       10      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | EXAMPLE_1   | /dev/null                             |        3.45        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_10     | Hello World                           |        0.38        |       5       |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_12     | C++                                   |        1.35        |       10      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_16     | RTC                                   |        4.61        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_2      | stdio                                 |        0.73        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_23     | Ticker Int us                         |       11.37        |       15      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_24     | Timeout Int us                        |       11.41        |       15      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_25     | Time us                               |       11.37        |       15      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_26     | Integer constant division             |        1.39        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_34     | Ticker Two callbacks                  |       11.38        |       15      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_37     | Serial NC RX                          |        6.94        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_38     | Serial NC TX                          |        5.91        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_A1     | Basic                                 |        1.36        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_A21    | Call function before main (mbed_main) |        1.41        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_A28    | CAN loopback test                     |       10.38        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_A30    | CAN API                               |        1.39        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_A9     | Serial Echo at 115200                 |        1.27        |       20      |  1/1  |
| OK     | NUCLEO_F767ZI | GCC_ARM   | MBED_BUSOUT | BusOut                                |        2.27        |       30      |  1/1  |

