### PR TITLE
GCC_ARM: newlib thread safety

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -898,31 +898,6 @@ extern "C" WEAK void __iar_file_Mtxunlock(__iar_Rmtx *mutex) {}
 #elif defined(__CC_ARM)
 // Do nothing
 #elif defined (__GNUC__)
-// Stub out locks when an rtos is not present
-extern "C" WEAK void __rtos_malloc_lock( struct _reent *_r ) {}
-extern "C" WEAK void __rtos_malloc_unlock( struct _reent *_r ) {}
-extern "C" WEAK void __rtos_env_lock( struct _reent *_r ) {}
-extern "C" WEAK void __rtos_env_unlock( struct _reent *_r ) {}
-
-extern "C" void __malloc_lock( struct _reent *_r )
-{
-    __rtos_malloc_lock(_r);
-}
-
-extern "C" void __malloc_unlock( struct _reent *_r )
-{
-    __rtos_malloc_unlock(_r);
-}
-
-extern "C" void __env_lock( struct _reent *_r )
-{
-    __rtos_env_lock(_r);
-}
-
-extern "C" void __env_unlock( struct _reent *_r )
-{
-    __rtos_env_unlock(_r);
-}
 
 #define CXA_GUARD_INIT_DONE             (1 << 0)
 #define CXA_GUARD_INIT_IN_PROGRESS      (1 << 1)

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -528,6 +528,9 @@ void __retarget_lock_init(struct __lock** lock)
     if (*lock) {
         init_lock(*lock, "newlib_dynamic_mutex");
     }
+    else {
+        error("newlib mutex init is out of memory\r\n");
+    }
 }
 
 void __retarget_lock_init_recursive(struct __lock **lock)
@@ -535,6 +538,9 @@ void __retarget_lock_init_recursive(struct __lock **lock)
     *lock = (struct __lock*)malloc(sizeof(**lock));
     if (*lock) {
         init_recursive_lock(*lock, "newlib_dynamic_recursive_mutex");
+    }
+    else {
+        error("newlib mutex init is out of memory\r\n");
     }
 }
 

--- a/rtos/mbed_boot.c
+++ b/rtos/mbed_boot.c
@@ -415,20 +415,28 @@ void __rt_entry (void) {
 
 #endif /* ARMC */
 #elif defined (__GNUC__) /******************** GCC ********************/
+#include <stdlib.h>
 
 extern int main(int argc, char* argv[]);
 extern void __libc_init_array (void);
 extern int __real_main(void);
 
-osMutexId_t               malloc_mutex_id;
-mbed_rtos_storage_mutex_t malloc_mutex_obj;
-osMutexAttr_t             malloc_mutex_attr;
 
-osMutexId_t               env_mutex_id;
-mbed_rtos_storage_mutex_t env_mutex_obj;
-osMutexAttr_t             env_mutex_attr;
+struct __lock {
+    osMutexId_t               id;
+    mbed_rtos_storage_mutex_t obj;
+    osMutexAttr_t             attr;
+};
 
-static int                main_running;
+struct __lock   __lock___sinit_recursive_mutex;
+struct __lock   __lock___sfp_recursive_mutex;
+struct __lock   __lock___at_quick_exit_mutex;
+struct __lock   __lock___malloc_recursive_mutex;
+struct __lock   __lock___env_recursive_mutex;
+struct __lock   __lock___tz_mutex;
+struct __lock   __lock___arc4random_mutex;
+
+static int      main_running;
 
 /* newlib reentrancy data. */
 static struct _reent      os_libspace[OS_THREAD_LIBSPACE_NUM] \
@@ -441,6 +449,10 @@ __attribute__((section(".bss.os")));
 #include "uvisor-lib/uvisor-lib.h"
 #endif/* FEATURE_UVISOR */
 
+static void init_lock(struct __lock* pLock, const char* pName);
+static void init_recursive_lock(struct __lock* pLock, const char* pName);
+
+
 int __wrap_main(void) {
     mbed_main();
     return __real_main();
@@ -449,24 +461,20 @@ int __wrap_main(void) {
 void pre_main(void)
 {
     main_running = 1;
-    
+
     singleton_mutex_attr.name = "singleton_mutex";
     singleton_mutex_attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
     singleton_mutex_attr.cb_size = sizeof(singleton_mutex_obj);
     singleton_mutex_attr.cb_mem = &singleton_mutex_obj;
     singleton_mutex_id = osMutexNew(&singleton_mutex_attr);
 
-    malloc_mutex_attr.name = "malloc_mutex";
-    malloc_mutex_attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
-    malloc_mutex_attr.cb_size = sizeof(malloc_mutex_obj);
-    malloc_mutex_attr.cb_mem = &malloc_mutex_obj;
-    malloc_mutex_id = osMutexNew(&malloc_mutex_attr);
-
-    env_mutex_attr.name = "env_mutex";
-    env_mutex_attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
-    env_mutex_attr.cb_size = sizeof(env_mutex_obj);
-    env_mutex_attr.cb_mem = &env_mutex_obj;
-    env_mutex_id = osMutexNew(&env_mutex_attr);
+    init_recursive_lock(&__lock___sinit_recursive_mutex, "sinit_mutex");
+    init_recursive_lock(&__lock___sfp_recursive_mutex, "sfp_mutex");
+    init_recursive_lock(&__lock___malloc_recursive_mutex, "malloc_mutex");
+    init_recursive_lock(&__lock___env_recursive_mutex, "env_mutex");
+    init_lock(&__lock___at_quick_exit_mutex, "at_quick_exit_mutex");
+    init_lock(&__lock___tz_mutex, "tz_mutex");
+    init_lock(&__lock___arc4random_mutex, "arc4random_mutex");
 
     __libc_init_array();
 
@@ -495,24 +503,85 @@ void software_init_hook(void)
     mbed_start_main();
 }
 
-void __rtos_malloc_lock( struct _reent *_r )
+static void init_lock_common(struct __lock* pLock, const char* pName, uint32_t attributeBits)
 {
-    osMutexAcquire(malloc_mutex_id, osWaitForever);
+    pLock->attr.name = pName;
+    pLock->attr.attr_bits = attributeBits;
+    pLock->attr.cb_size = sizeof(pLock->obj);
+    pLock->attr.cb_mem = &pLock->obj;
+    pLock->id = osMutexNew(&pLock->attr);
 }
 
-void __rtos_malloc_unlock( struct _reent *_r )
+static void init_lock(struct __lock* pLock, const char* pName)
 {
-    osMutexRelease(malloc_mutex_id);
+    init_lock_common(pLock, pName, osMutexPrioInherit | osMutexRobust);
 }
 
-void __rtos_env_lock( struct _reent *_r )
+static void init_recursive_lock(struct __lock* pLock, const char* pName)
 {
-    osMutexAcquire(env_mutex_id, osWaitForever);
+    init_lock_common(pLock, pName, osMutexRecursive | osMutexPrioInherit | osMutexRobust);
 }
 
-void __rtos_env_unlock( struct _reent *_r )
+void __retarget_lock_init(struct __lock** lock)
 {
-    osMutexRelease(env_mutex_id);
+    *lock = (struct __lock*)malloc(sizeof(**lock));
+    if (*lock) {
+        init_lock(*lock, "newlib_dynamic_mutex");
+    }
+}
+
+void __retarget_lock_init_recursive(struct __lock **lock)
+{
+    *lock = (struct __lock*)malloc(sizeof(**lock));
+    if (*lock) {
+        init_recursive_lock(*lock, "newlib_dynamic_recursive_mutex");
+    }
+}
+
+void __retarget_lock_close(struct __lock* lock)
+{
+    if (lock) {
+        osMutexDelete(lock->id);
+        free(lock);
+    }
+}
+
+void __retarget_lock_close_recursive(struct __lock* lock)
+{
+    if (lock) {
+        osMutexDelete(lock->id);
+        free(lock);
+    }
+}
+
+void __retarget_lock_acquire(struct __lock* lock)
+{
+    osMutexAcquire(lock->id, osWaitForever);
+}
+
+void __retarget_lock_acquire_recursive(struct __lock* lock)
+{
+    osMutexAcquire(lock->id, osWaitForever);
+}
+
+int __retarget_lock_try_acquire(struct __lock* lock)
+{
+    return osMutexAcquire(lock->id, 0);
+}
+
+int __retarget_lock_try_acquire_recursive(struct __lock* lock)
+{
+    return osMutexAcquire(lock->id, 0);
+}
+
+void __retarget_lock_release(struct __lock* lock)
+{
+    osMutexRelease(lock->id);
+}
+
+void __retarget_lock_release_recursive(struct __lock* lock)
+{
+    osMutexRelease(lock->id);
 }
 
 

--- a/rtos/rtx5/TARGET_CORTEX_M/RTX_Config.h
+++ b/rtos/rtx5/TARGET_CORTEX_M/RTX_Config.h
@@ -373,7 +373,7 @@
 // Number of Threads which use standard C/C++ library libspace
 // (when thread specific memory allocation is not used).
 #if (OS_THREAD_OBJ_MEM == 0)
-#define OS_THREAD_LIBSPACE_NUM      4
+#define OS_THREAD_LIBSPACE_NUM      5
 #else
 #define OS_THREAD_LIBSPACE_NUM      OS_THREAD_NUM
 #endif

--- a/rtos/rtx5/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_GCC/irq_cm0.S
+++ b/rtos/rtx5/TARGET_CORTEX_M/TARGET_M0/TOOLCHAIN_GCC/irq_cm0.S
@@ -98,6 +98,12 @@ SVC_ContextRestore:
         SUBS     R0,R0,#32              // Adjust address
         LDMIA    R0!,{R4-R7}            // Restore R4..R7
 
+SVC_ContextForNewlib:
+        MOV      R0,R2                  // Pass in current thread id
+        BL       __user_perthread_libspace // Fetch _reent structure for this thread
+        LDR      R1,=_impure_ptr        // Place it in _impure_ptr for newlib
+        STR      R0,[R1]
+
         MOVS     R0,#~0xFFFFFFFD
         MVNS     R0,R0                  // Set EXC_RETURN value
         BX       R0                     // Exit from handler

--- a/rtos/rtx5/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_GCC/irq_cm0.S
+++ b/rtos/rtx5/TARGET_CORTEX_M/TARGET_M0P/TOOLCHAIN_GCC/irq_cm0.S
@@ -98,6 +98,12 @@ SVC_ContextRestore:
         SUBS     R0,R0,#32              // Adjust address
         LDMIA    R0!,{R4-R7}            // Restore R4..R7
 
+SVC_ContextForNewlib:
+        MOV      R0,R2                  // Pass in current thread id
+        BL       __user_perthread_libspace // Fetch _reent structure for this thread
+        LDR      R1,=_impure_ptr        // Place it in _impure_ptr for newlib
+        STR      R0,[R1]
+
         MOVS     R0,#~0xFFFFFFFD
         MVNS     R0,R0                  // Set EXC_RETURN value
         BX       R0                     // Exit from handler

--- a/rtos/rtx5/TARGET_CORTEX_M/TARGET_M3/TOOLCHAIN_GCC/irq_cm3.S
+++ b/rtos/rtx5/TARGET_CORTEX_M/TARGET_M3/TOOLCHAIN_GCC/irq_cm3.S
@@ -94,9 +94,15 @@ SVC_ContextRestore:
 #ifdef FEATURE_UVISOR
         CPSIE I                         // The PSP has been set. Re-enable interrupts.
 #endif
-        MVN      LR,#~0xFFFFFFFD        // Set EXC_RETURN value
+
+SVC_ContextForNewlib:
+        MOV      R0,R2                  // Pass in current thread id
+        BL       __user_perthread_libspace // Fetch _reent structure for this thread
+        LDR      R1,=_impure_ptr        // Place it in _impure_ptr for newlib
+        STR      R0,[R1]
 
 SVC_Exit:
+        MVN      LR,#~0xFFFFFFFD        // Set EXC_RETURN value
         BX       LR                     // Exit from handler
 
 SVC_User:

--- a/rtos/rtx5/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_GCC/irq_cm4f.S
+++ b/rtos/rtx5/TARGET_CORTEX_M/TARGET_RTOS_M4_M7/TOOLCHAIN_GCC/irq_cm4f.S
@@ -121,8 +121,15 @@ SVC_ContextRestore:
         CPSIE I                         // The PSP has been set. Re-enable interrupts.
 #endif
 
+SVC_ContextForNewlib:
+        PUSH     {R12,LR}               // Save EXC_RETURN before next BL
+        MOV      R0,R2                  // Pass in current thread id
+        BL       __user_perthread_libspace // Fetch _reent structure for this thread
+        LDR      R1,=_impure_ptr        // Place it in _impure_ptr for newlib
+        STR      R0,[R1]
+
 SVC_Exit:
-        BX       LR                     // Exit from handler
+        POP      {R12,PC}               // Exit from handler
 
 SVC_User:
         PUSH     {R4,LR}                // Save registers

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/m451_retarget.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_GCC_ARM/m451_retarget.c
@@ -19,18 +19,18 @@ extern uint32_t __mbed_krbs_start;
 #define NU_HEAP_ALIGN       32
 
 /**
- * The default implementation of _sbrk() (in common/retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
- * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk() to
- * override the default _sbrk(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+ * The default implementation of _sbrk_r() (in platform/mbed_retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
+ * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk_r() to
+ * override the default _sbrk_r(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk_r') or in _sbrk_r().
  */
-void *__wrap__sbrk(int incr)
+void *__wrap__sbrk_r(struct _reent *preent, int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
     uint32_t heap_ind_old = NU_ALIGN_UP(heap_ind, NU_HEAP_ALIGN);
     uint32_t heap_ind_new = NU_ALIGN_UP(heap_ind_old + incr, NU_HEAP_ALIGN);
     
-    if (heap_ind_new > &__mbed_krbs_start) {
-        errno = ENOMEM;
+    if (heap_ind_new > (uint32_t)&__mbed_krbs_start) {
+        preent->_errno = ENOMEM;
         return (void *) -1;
     } 
     

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/nuc472_retarget.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_GCC_ARM/nuc472_retarget.c
@@ -19,18 +19,18 @@ extern uint32_t __mbed_krbs_start;
 #define NU_HEAP_ALIGN       32
 
 /**
- * The default implementation of _sbrk() (in common/retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
- * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk() to
- * override the default _sbrk(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+ * The default implementation of _sbrk_r() (in platform/mbed_retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
+ * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk_r() to
+ * override the default _sbrk_r(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk_r') or in _sbrk_r().
  */
-void *__wrap__sbrk(int incr)
+void *__wrap__sbrk_r(struct _reent *preent, int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
     uint32_t heap_ind_old = NU_ALIGN_UP(heap_ind, NU_HEAP_ALIGN);
     uint32_t heap_ind_new = NU_ALIGN_UP(heap_ind_old + incr, NU_HEAP_ALIGN);
     
-    if (heap_ind_new > &__mbed_krbs_start) {
-        errno = ENOMEM;
+    if (heap_ind_new > (uint32_t)&__mbed_krbs_start) {
+        preent->_errno = ENOMEM;
         return (void *) -1;
     } 
     

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -19,6 +19,11 @@
 
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #if defined(TARGET_NUMAKER_PFM_NUC472)
 
 #if defined(__CC_ARM)
@@ -71,6 +76,10 @@
     #error "no toolchain defined"
 #endif
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif  // MBED_MBED_RTX_H


### PR DESCRIPTION
Make the **newlib** Standard C Library shipped in the **GNU ARM Embedded *6* Toolchain** thread safe when used with **mbed-os**.

There are four major components of this PR:
* Switch the syscall functions in **platform/mbed_retarget.cpp** to be *reentrant*. This adds a **\_r** extension to the syscall function name and an additional **struct \_reent** parameter. This \_reent structure contains per thread copies of important C Library state such as **errno**.
* Modify RTX to update **\_impure_ptr** on each thread context switch. \_impure_ptr is switched to point to the \_reent structure for the currently running thread.
* Implement **\_\_retarget\_lock** newlib interface in mbed-os. The full version of newlib shipped with the latest GNU ARM Embedded Toolchain calls this generic locking interface when it needs exclusive access to C Library globals such as the heap (ie. malloc()/free()).
* Even though newlib-nano was built single threaded, there are still many areas of the code which call locking routines that can be provided to synchronize key areas. I have added implementations of these locking routines to mbed-os when linking with newlib-nano. I have also used GNU linker wraps for some newlib functions which are missing the required lock calls in newlib-nano.

## Important Things To Document
* The libspace pool only has room for **OS_THREAD_LIBSPACE_NUM** reentrancy structures, similar to the existing ARM implementation. For the ARM Standard C Library, a reentrancy structure is only required for threads that actually use the Standard C Library and end up calling **\_\_user_perthread\_libspace()**. For the newlib Standard C Library, a structure is required for every thread that executes, even if they never use the Standard C Library. This means that the original default of OS_THREAD_LIBSPACE_NUM=4 is too small on GCC_ARM. I increased this number to 5 so that a simple TCP/IP server application could still run after these changes. It might make sense to increase this number even more for GCC_ARM. For newlib-nano, each additional thread added increases the RAM usage by 100 bytes but for the full version of newlib it increases it by more than 1000 bytes. It should be documented that the user will need to increase this setting in **rtos/rtx5/TARGET_CORTEX_M/RTX_Config.h** if they hit a **"CMSIS-RTOS error: STD C/C++ library libspace not available..."** stop message. It needs to match the number of additional worker threads created in their application (explicitly created by the developer and implicitly by libraries such as the networking stack). The count doesn't need to include the main thread itself as a \_reent structure is always reserved for it separately.
* The per **FILE\*** locks are the only area that can't be made thread safe with **newlib-nano** after applying this PR. It will need to be documented that multiple threads sharing the same FILE\* object need to manually synchronize their usage when using newlib-nano. The full version of newlib does contain the required synchronization for these locks.
* These newlib Standard C Library thread safety changes only apply when you are using recent releases of the GCC_ARM tools, **GNU ARM Embedded 6** or newer.

## Other Important Notes/Questions
* This PR doesn't include the necessary changes to the mbed build system to add the wraps which are required when linking with **newlib-nano**. It should be noted that no additional wraps are required when linking with the full version of newlib. I conducted my testing with custom makefiles that included these wraps. The additional wraps required for the mbed build tools when linking with newlib-nano are:
  * ```--wrap=arc4random,```
  * ```--wrap=arc4random_buf,```
  * ```--wrap=__sfp,```
  * ```--wrap=__sinit,```
  * ```--wrap=at_quick_exit```
* I tested these changes with the GNU ARM Embedded 6 Toolchain on macOS using custom makefiles against the following 3 target devices:
  * KL25Z (Cortex-M0+)
  * LPC1768 (Cortex-M3)
  * K64F (Cortex-M4F)
* I also uploaded this change to the online compiler and tested there as well using my LPC1768 board to find and correct any build breaks that I introduced for the ARM compiler.

Please refer to individual commit messages in this PR for more detailed information about each change.
