### PR TITLE
Patch to fix compilation error in pwmout_api.c for target DISCO_F100RB

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/PeripheralNames.h
@@ -61,10 +61,13 @@ typedef enum {
 } I2CName;
 
 typedef enum {
-    PWM_1 = (int)TIM1_BASE,
-    PWM_2 = (int)TIM2_BASE,
-    PWM_3 = (int)TIM3_BASE,
-    PWM_4 = (int)TIM4_BASE
+    PWM_1  = (int)TIM1_BASE,
+    PWM_2  = (int)TIM2_BASE,
+    PWM_3  = (int)TIM3_BASE,
+    PWM_4  = (int)TIM4_BASE,
+    PWM_15 = (int)TIM15_BASE,
+    PWM_16 = (int)TIM16_BASE,
+    PWM_17 = (int)TIM17_BASE
 } PWMName;
 
 #ifdef __cplusplus


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
CLA accepted as of 20th july

## Description
Tittle says the most. pwmout_api.c won't compile for this target (DISCO_F100RB) because of missing declarations in PeriphealNames.h

The timers timer15, timer16 & timer17 are declared in stm32f100xb.h through TIM15_BASE etc. and hence referenced in pwmout_api.c. For this file to compile the corresponding members PWM_!%, PWM_16 & PWM_17 must be added to typedef PWMName in PeripheralNames.h


## Status
**READY**


## Migrations
NO
The above timers are not referenced anywhere else they are not used.
This is just to fix compilation errors.


## Related PRs
List related PRs against other branches:
None to my knowledge.


## Todos
None.

## Deploy notes
None

## Steps to test or reproduce
Try building a blinky