### PR TITLE
LPC MCUXpresso: fix write_fill argument for block write function

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/api/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/api/spi_api.c
@@ -154,11 +154,12 @@ int spi_master_write(spi_t *obj, int value)
     return rx_data & 0xffff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length) {
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, 
+                           char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
     for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : 0xff;
+        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
         char in = spi_master_write(obj, out);
         if (i < rx_length) {
             rx_buffer[i] = in;


### PR DESCRIPTION
The latest HAL extension was not applied to the LPC MCUXpresso targets.

Tested build for both broken targets (same HAL implementation used).