### PR TITLE
Use DSPI SDK driver API's in SPI HAL driver

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -131,13 +131,17 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
                            char *rx_buffer, int rx_length, char write_fill) {
     int total = (tx_length > rx_length) ? tx_length : rx_length;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
+    // Default write is done in each and every call, in future can create HAL API instead
+    DSPI_SetDummyData(spi_address[obj->spi.instance], write_fill);
+
+    DSPI_MasterTransferBlocking(spi_address[obj->spi.instance], &(dspi_transfer_t){
+          .txData = (uint8_t *)tx_buffer,
+          .rxData = (uint8_t *)rx_buffer,
+          .dataSize = total,
+          .configFlags = kDSPI_MasterCtar0 | kDSPI_MasterPcs0 | kDSPI_MasterPcsContinuous,
+    });
+
+    DSPI_ClearStatusFlags(spi_address[obj->spi.instance], kDSPI_RxFifoDrainRequestFlag | kDSPI_EndOfQueueFlag);
 
     return total;
 }


### PR DESCRIPTION
DSPI driver is update to support write_fill for default TX data. Dependent on PR #4805 

## Status
**READY**
