### PR TITLE
Dual Flash and Hex file support on NCS36510

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
@@ -1,49 +1,82 @@
+/*###ICF### Section handled by ICF editor, don't touch! ****/
+/*-Editor annotation file-*/
+/* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_1.xml" */
+/*-Specials-*/
+define symbol __ICFEDIT_intvec_start__ = 0x00003000;
+/*-Memory Regions-*/
+define symbol __ICFEDIT_region_IROM1_start__ = 0x00003000;     /* FLASHA program start*/
+define symbol __ICFEDIT_region_IROM1_end__   = 0x00051FFF;     /* 316K = 320K - 4K(FIB table), FLASHA end */
+define symbol __ICFEDIT_region_IROM2_start__ = 0x00102000;
+define symbol __ICFEDIT_region_IROM2_end__   = 0x00151FFF;     /* 320K */
+define symbol __ICFEDIT_region_EROM1_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM1_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM2_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM2_end__   = 0x0;
+define symbol __ICFEDIT_region_EROM3_start__ = 0x0;
+define symbol __ICFEDIT_region_EROM3_end__   = 0x0;
 
-/* The memory space denoting the maximum possible amount of addressable memory */
-define memory Mem with size = 4G;
+define symbol __ICFEDIT_region_IRAM1_start__ = 0x3FFFC000;       /* RAMA start                  */
+define symbol __ICFEDIT_region_IRAM1_end__   = 0x3FFFFFFF;       /* RAMA end                    */
+define symbol __ICFEDIT_region_IRAM2_start__ = 0x3FFF8000;       /* RAMB start                  */
+define symbol __ICFEDIT_region_IRAM2_end__   = 0x3FFFBFFF;       /* RAMB end                    */
+define symbol __ICFEDIT_region_IRAM3_start__ = 0x3FFF4000;       /* RAMC start                  */
+define symbol __ICFEDIT_region_IRAM3_end__   = 0x3FFF7FFF;       /* RAMC end                    */
+define symbol __ICFEDIT_region_ERAM1_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM1_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM2_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM2_end__   = 0x0;
+define symbol __ICFEDIT_region_ERAM3_start__ = 0x0;
+define symbol __ICFEDIT_region_ERAM3_end__   = 0x0;
 
-/* Memory regions in an address space */
-define region FLASHA = Mem:[from 0x00003000 size 0x4D000]; /* 308K = 320K - 4K(FIB table) - 8K(Persistent) */
-define region FLASHB = Mem:[from 0x00100000 size 0x50000];
-define region RAMA = Mem:[from 0x3FFFC000 size 0x4000];
-define region RAMB = Mem:[from 0x3FFF8000 size 0x4000];
-/* G2H ZPRO requires RAMC to be enabled */
-define region RAMC = Mem:[from 0x3FFF4000 + 0x90 size 0x4000 - 0x90]; /* 8_byte_aligned(35 vectors * 4 bytes each) = 0x90 */
-define region RAM_ALL = Mem:[from 0x3FFF4000 + 0x90 size 0xC000 - 0x90]; /* 8_byte_aligned(35 vectors * 4 bytes each) = 0x90 */
+/*-Sizes-*/
+define symbol __ICFEDIT_size_cstack__ = 0x200;
+define symbol __ICFEDIT_size_heap__   = 0x4000;
+/**** End of ICF editor section. ###ICF###*/
 
-/* Create a stack */
-define block CSTACK with size = 0x200, alignment = 8 { };
 
-/* No Heap is created for C library, all memory management should be handled by the application */
- define block HEAP with alignment = 8, size = 0x3000    { }; 
+define memory mem with size = 4G;
+define region FLASH_region   =   mem:[from __ICFEDIT_region_IROM1_start__ to __ICFEDIT_region_IROM1_end__]
+                              |  mem:[from __ICFEDIT_region_IROM2_start__ to __ICFEDIT_region_IROM2_end__];
 
-/* Handle initialization */
-do not initialize { section .noinit };
+define region RAM_VECTOR_region   =   mem:[from __ICFEDIT_region_IRAM3_start__  to __ICFEDIT_region_IRAM3_start__ + 0x90 - 1];
 
-/* Initialize RW sections, exclude zero-initialized sections */
-initialize by copy with packing = none  { readwrite };
+define region RAM_region    =   mem:[from __ICFEDIT_region_IRAM3_start__ + 0x90 to __ICFEDIT_region_IRAM3_end__]
+                              | mem:[from __ICFEDIT_region_IRAM2_start__ to __ICFEDIT_region_IRAM2_end__]
+                              | mem:[from __ICFEDIT_region_IRAM1_start__ to __ICFEDIT_region_IRAM1_end__ - __ICFEDIT_size_cstack__ ];
+
+define region CSTACK_region =   mem:[from __ICFEDIT_region_IRAM1_end__ - __ICFEDIT_size_cstack__ + 1 to __ICFEDIT_region_IRAM1_end__];
+
+
+/* Define overlays for MIB's, ths allows view of one MIB from a application level while
+ * MAC and PHY only know about their own MIB */
+define overlay MIBOVERLAY { section MIBSTARTSECTION };
+define overlay MIBOVERLAY { section MIBSECTION };
+
+define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block RAM_VECTORS  with alignment = 8, size = 0x90     { };
+
+initialize by copy { readwrite };
+
+if (isdefinedsymbol(__USE_DLIB_PERTHREAD))
+{
+  // Required in a multi-threaded application
+  initialize by copy with packing = none { section __DLIB_PERTHREAD };
+}
 
 /* Initialize the code in RAM, copied over from FLASH */
 initialize by copy with packing = none { readonly code section EXECINRAM };
-/*keep { readonly code section .EXECINRAM* } except { readonly code section EXECINRAM };*/
 
-/* Place startup code at a fixed address */
-place at start of FLASHA { readonly section .intvec, readonly section SWVERSION,readonly section FIBTABLE,readonly section .cstartup };
-
-/* Place code and data */
-
-/* Place constants and initializers in FLASHA: .rodata and .data_init */
-place in FLASHA { readonly };
-
-/* Place .data, .bss, and .noinit */
-/* and STACK */
-/* The relocatable exception table needs to be aligned at 0x0 or multiple of 0x100,
- * hence, place it as first block in RAM.
- */
-place at start of RAM_ALL  { section RAM_VECTORS };
-place in RAM_ALL           { readonly code section EXECINRAM };
-place at end of RAM_ALL    { block CSTACK };
+/*initialize by copy { readwrite };*/
+do not initialize  { section .noinit };
 
 
-place in RAM_ALL           { readwrite };
-place in RAM_ALL           { block HEAP };
+place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec, readonly section SWVERSION, readonly section FIBTABLE };
+
+place in FLASH_region { readonly section .cstartup, readonly };
+
+place at start of RAM_VECTOR_region {block RAM_VECTORS};
+
+place in RAM_region { readwrite, block HEAP, section XHEAP, readonly code section EXECINRAM, overlay MIBOVERLAY, readwrite section MIBENDSECTION};
+
+place at end of CSTACK_region    { block CSTACK };

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3132,7 +3132,7 @@
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true
     },
-    "36510": {
+    "NCS36510": {
         "inherits": ["Target"],
         "core": "Cortex-M3",
         "extra_labels": ["ONSEMI"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3132,7 +3132,7 @@
         "device_name": "NUC472HI8AE",
         "bootloader_supported": true
     },
-    "NCS36510": {
+    "36510": {
         "inherits": ["Target"],
         "core": "Cortex-M3",
         "extra_labels": ["ONSEMI"],
@@ -3162,6 +3162,7 @@
                 "value": "0xFFFFFFFF"
             }
         },
+        "OUTPUT_EXT": "hex",
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],

--- a/tools/targets/NCS.py
+++ b/tools/targets/NCS.py
@@ -18,9 +18,12 @@ import intelhex
 from tools.config import Config
 
 FIB_BASE = 0x2000
-FLASH_BASE = 0x3000
-FW_REV = 0x01000100
 TRIM_BASE = 0x2800
+FLASH_BASE = 0x3000
+FLASHA_SIZE = 0x52000
+FLASHB_BASE = 0x00102000
+FLASHB_SIZE = 0x52000
+FW_REV = 0x01000100
 
 def ranges(i):
     for _, b in itertools.groupby(enumerate(i), lambda x_y: x_y[1] - x_y[0]):
@@ -29,17 +32,17 @@ def ranges(i):
 
 
 def add_fib_at_start(arginput):
-    input_file = arginput + ".bin"
-    file_name_hex = arginput + "_fib.hex"
+    input_file = arginput + ".hex"
+    file_name_hex = arginput + ".hex"
     file_name_bin = arginput + ".bin"
 
     # Read in hex file
     input_hex_file = intelhex.IntelHex()
-    input_hex_file.padding = 0x00
-    input_hex_file.loadbin(input_file, offset=FLASH_BASE)
-
+    input_hex_file.loadhex(input_file)
+    #set padding value to be returned when reading from unspecified address
+    input_hex_file.padding = 0xFF
+    # Create new hex file
     output_hex_file = intelhex.IntelHex()
-    output_hex_file.padding = 0x00
 
     # Get the starting and ending address
     addresses = input_hex_file.addresses()
@@ -48,17 +51,41 @@ def add_fib_at_start(arginput):
     regions = len(start_end_pairs)
 
     if regions == 1:
+        #single range indicating fits within first flash block (<320K)
         start, end = start_end_pairs[0]
+        print("Memory start 0x%08X, end 0x%08X" % (start, end))
+        # Compute checksum over the range (don't include data at location of crc)
+        size = end - start + 1
+        data = input_hex_file.tobinarray(start=start, size=size)
+        crc32 = binascii.crc32(data) & 0xFFFFFFFF
     else:
-        start = min(min(start_end_pairs))
-        end = max(max(start_end_pairs))
+        #multiple ranges indicating requires both flash blocks (>320K)
+        start, end = start_end_pairs[0]
+        start2, end2 = start_end_pairs[1]
+        print("Region 1: memory start 0x%08X, end 0x%08X" % (start, end))
+        print("Region 2: memory start 0x%08X, end 0x%08X" % (start2, end2))
+        # Compute checksum over the range (don't include data at location of crc)
+        # replace end with end of flash block A
+        end = FLASHA_SIZE - 1
+        size = end - start + 1
+        data = input_hex_file.tobinarray(start=start, size=size)
+
+        # replace start2 with base of flash block B
+        start2 = FLASHB_BASE
+        size2 = end2 - start2 + 1
+        data2 = input_hex_file.tobinarray(start=start2, size=size2)
+
+        #concatenate data and data2 arrays together
+        data.extend(data2)
+        crc32 = binascii.crc32(data) & 0xFFFFFFFF
+
+        #replace size with sum of two memory region sizes
+        size = size + size2
 
     assert start >= FLASH_BASE, ("Error - start 0x%x less than begining of user\
     flash area" %start)
-    # Compute checksum over the range (don't include data at location of crc)
-    size = end - start + 1
-    data = input_hex_file.tobinarray(start=start, size=size)
-    crc32 = binascii.crc32(data) & 0xFFFFFFFF
+
+    assert regions <= 2, ("Error - more than 2 memory regions found")
 
     fw_rev = FW_REV
 
@@ -177,7 +204,7 @@ def add_fib_at_start(arginput):
     output_hex_file[trim_area_start + 1] = (mac_addr_low >> 8)  & 0xFF
     output_hex_file[trim_area_start + 2] = (mac_addr_low >> 16) & 0xFF
     output_hex_file[trim_area_start + 3] = (mac_addr_low >> 24) & 0xFF
-    
+
     output_hex_file[trim_area_start + 4] = mac_addr_high & 0xFF
     output_hex_file[trim_area_start + 5] = (mac_addr_high >> 8)  & 0xFF
     output_hex_file[trim_area_start + 6] = (mac_addr_high >> 16) & 0xFF
@@ -202,7 +229,7 @@ def add_fib_at_start(arginput):
     output_hex_file[trim_area_start + 21] = (txtune >> 8)  & 0xFF
     output_hex_file[trim_area_start + 22] = (txtune >> 16) & 0xFF
     output_hex_file[trim_area_start + 23] = (txtune >> 24) & 0xFF
-    
+
     # pad the rest of the area with 0xFF
     for i in range(trim_area_start + trim_size, user_code_start):
         output_hex_file[i] = 0xFF
@@ -212,4 +239,3 @@ def add_fib_at_start(arginput):
 
     # Write out file(s)
     output_hex_file.tofile(file_name_hex, 'hex')
-    output_hex_file.tofile(file_name_bin, 'bin')


### PR DESCRIPTION
## Description
Dual flash and Hex file support added.  This is a separate pull request to replace #4397.  The changes are the same as the latest revisions on the previous PR, including the changes requested by @maclobdell.


## Status
READY


## Related PRs
#4397 

## Deploy notes
Build output will be hex file. Post build script will insert FIB, User trim and trims gap.
Post script generates hex and binary file. Binary file required if user uses boot loader to download.


## Steps to test or reproduce

1. Clone latest branch of mbed-os, and modify NCS.py, ncs36510.icf, and targets.json
2. Clone mbed-os-example-blinky, and delete main.cpp
3. Update mbed-os.lib to point to local mbed-os library.  
4. mbed deploy ( or copy library into project) make sure changes are present in blinky project.  
5. mbed test -m NCS36510 -t IAR --compile  (Also tested with GCC and ARM)
6. mbed test -m NCS36510 -t IAR --run

All tests passed.  

Also tested 640k operation by restoring the top level main.cpp file with standard blinky example, and adding the line: 
const uint8_t array[12000] = {0};

This resulted in the compiled flash section being 327kB.  Hex file was loaded to the device and it runs properly.  

Also of note, the board is using the latest version of bootloader (V15) and the latest version of DAPLink (see links on original PR)