### PR TITLE
fix unresolved linker msg: __wrap_

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -200,7 +200,9 @@ class GccArm(Makefile):
 
     @staticmethod
     def prepare_lib(libname):
-        return "-l" + libname[3:-2]
+        if "lib" == libname[:3]:
+            libname = libname[3:-2]
+        return "-l" + libname
 
     @staticmethod
     def prepare_sys_lib(libname):

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -200,7 +200,7 @@ class GccArm(Makefile):
 
     @staticmethod
     def prepare_lib(libname):
-        return "-l:" + libname
+        return "-l" + libname[3:-2]
 
     @staticmethod
     def prepare_sys_lib(libname):

--- a/tools/export/makefile/make-gcc-arm.tmpl
+++ b/tools/export/makefile/make-gcc-arm.tmpl
@@ -1,6 +1,6 @@
 {% extends "makefile/Makefile.tmpl" %}
 
-{%- block sys_libs -%} -Wl,--start-group {{ld_sys_libs|join(" ")}} -Wl,--end-group {%- endblock -%}
+{%- block sys_libs -%} -Wl,--start-group {{ld_sys_libs|join(" ")}} {{libraries|join(" ")}} -Wl,--end-group {%- endblock -%}
 
 {% block elf2bin %}
 	$(ELF2BIN) -O binary $< $@


### PR DESCRIPTION
## Description
Issue #3673
The make_gcc_arm exporter for mbed os 2 fails with linker errors for wrapper functions. These can be fixed by adding the libraries to the linker group


## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Todos
- [ ] Tests


## Steps to test or reproduce
import mbed classic program
mbed export -i make_gcc_arm
make

will fail with messages like:
```
undefined` reference to `__wrap__free_r'
```