### PR TITLE
Enhancement - exporter/cdt

### DIFF
--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -1,6 +1,6 @@
 import re
 
-from os.path import join, exists, realpath, relpath, basename
+from os.path import join, exists
 from os import makedirs
 
 from tools.export.makefile import Makefile, GccArm, Armc5, IAR

--- a/tools/export/cdt/__init__.py
+++ b/tools/export/cdt/__init__.py
@@ -30,7 +30,9 @@ class Eclipse(Makefile):
 
 
         self.gen_file('cdt/pyocd_settings.tmpl', ctx,
-                      join('eclipse-extras',self.target+'_pyocd_settings.launch'))
+                      join('eclipse-extras',
+                           '{target}_pyocd_{project}_settings.launch'.format(target=self.target,
+                                                                             project=self.project_name)))
         self.gen_file('cdt/necessary_software.tmpl', ctx,
                       join('eclipse-extras','necessary_software.p2f'))
 

--- a/tools/export/cdt/pyocd_settings.tmpl
+++ b/tools/export/cdt/pyocd_settings.tmpl
@@ -49,7 +49,7 @@
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForImage" value="true"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useProjBinaryForSymbols" value="true"/>
 <booleanAttribute key="org.eclipse.cdt.debug.gdbjtag.core.useRemoteTarget" value="true"/>
-<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb.exe"/>
+<stringAttribute key="org.eclipse.cdt.dsf.gdb.DEBUG_NAME" value="arm-none-eabi-gdb"/>
 <booleanAttribute key="org.eclipse.cdt.dsf.gdb.UPDATE_THREADLIST_ON_SUSPEND" value="false"/>
 <intAttribute key="org.eclipse.cdt.launch.ATTR_BUILD_BEFORE_LAUNCH_ATTR" value="2"/>
 <stringAttribute key="org.eclipse.cdt.launch.COREFILE_PATH" value=""/>


### PR DESCRIPTION
## Description

1. Rename Eclipse `.launch` file according to project name:
    Since Eclipse supports working with multiple projects in the same workspace, .launch file name should include project name for creating unique per-project `.launch` file.
2. Fix CDT debugger settings on Linux - remove `.exe` suffix
    On Linux machines `arm-none-eabi-gdb` executable do not have `.exe` suffix.
    On Windows machines - it is possible to run an executable without explicit `.exe` suffix.
    This change fixes debugger settings for Linux hosts

## Status
READY

## Migrations
NO

## Related PRs
N/A

## Todos
N/A

## Deploy notes
N/A

## Steps to test or reproduce
On a Linux host execute following steps:
1. cd mbed-os-example-blinky
2. `mbed export -m K64F -i eclipse_gcc_arm`
3. Launch eclipse
4. Click `File->Import->General->Existing Projects into Workspace` 
5. Build
6. Launch the debugger
