### PR TITLE
Travis: fix install phase - not use sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,8 +37,8 @@ before_install:
   - python --version
   - doxygen --version
 install:
-  - sudo pip install -r requirements.txt
-  - sudo pip install pytest
-  - sudo pip install pylint
-  - sudo pip install hypothesis
-  - sudo pip install mock
+  - pip install -r requirements.txt
+  - pip install pytest
+  - pip install pylint
+  - pip install hypothesis
+  - pip install mock


### PR DESCRIPTION
For testing purposes to find out why travis started failing suddenly

I checked travis-ci docs, they recommend using just pip install as they run in virtualenv. This however does not explain why it suddenly started failing.