### PR TITLE
Remove excessive use of printf/scanf in mbed_fdopen/_open

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -828,7 +828,7 @@ std::FILE *mbed_fdopen(FileHandle *fh, const char *mode)
 {
     // This is to avoid scanf(buf, ":%.4s", fh) and the bloat it brings.
     char buf[2 + sizeof(fh) + 1]; /* :(pointer) + null byte */
-    static_assert(sizeof(buf) == 7, "Pointers should be 4 bytes.");
+    MBED_STATIC_ASSERT(sizeof(buf) == 7, "Pointers should be 4 bytes.");
     buf[0] = ':';
     memcpy(buf + 1, &fh, sizeof(fh));
     buf[1 + sizeof(fh)] = '\0';

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -827,11 +827,10 @@ void mbed_set_unbuffered_stream(std::FILE *_file) {
 std::FILE *mbed_fdopen(FileHandle *fh, const char *mode)
 {
     // This is to avoid scanf(buf, ":%.4s", fh) and the bloat it brings.
-    char buf[2 + sizeof(fh) + 1]; /* :(pointer) + null byte */
-    MBED_STATIC_ASSERT(sizeof(buf) == 7, "Pointers should be 4 bytes.");
+    char buf[1 + sizeof(fh)]; /* :(pointer) */
+    MBED_STATIC_ASSERT(sizeof(buf) == 5, "Pointers should be 4 bytes.");
     buf[0] = ':';
     memcpy(buf + 1, &fh, sizeof(fh));
-    buf[1 + sizeof(fh)] = '\0';
 
     std::FILE *stream = std::fopen(buf, mode);
     /* newlib-nano doesn't appear to ever call _isatty itself, so

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -228,7 +228,7 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
 
     FileHandle *res = NULL;
 
-    /* FILENAME: ":0x12345678" describes a FileHandle* */
+    /* FILENAME: ":(pointer)" describes a FileHandle* */
     if (name[0] == ':') {
         void *p;
         memcpy(&p, name + 1, sizeof(p));
@@ -826,6 +826,7 @@ void mbed_set_unbuffered_stream(std::FILE *_file) {
  */
 std::FILE *mbed_fdopen(FileHandle *fh, const char *mode)
 {
+    // This is to avoid scanf(buf, ":%.4s", fh) and the bloat it brings.
     char buf[2 + sizeof(fh) + 1]; /* :(pointer) + null byte */
     static_assert(sizeof(buf) == 7, "Pointers should be 4 bytes.");
     buf[0] = ':';


### PR DESCRIPTION
## Description
From #4830, implementing Option A. This saves ~3.3kB in firmware that's not using scanf otherwise. It also likely saves a few bytes of stack since buf is 5 bytes smaller.


## Status
READY


## Migrations
NO

