### PR TITLE
fatfs: Add lower bound to block sizes

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -167,12 +167,17 @@ static WORD disk_get_sector_size(BYTE pdrv)
         ssize = 512;
     }
 
+    MBED_ASSERT(ssize >= _MIN_SS && ssize <= _MAX_SS);
+    MBED_ASSERT(_ffs[pdrv]->get_read_size() <= _ffs[pdrv]->get_erase_size());
+    MBED_ASSERT(_ffs[pdrv]->get_program_size() <= _ffs[pdrv]->get_erase_size());
     return ssize;
 }
 
 static DWORD disk_get_sector_count(BYTE pdrv)
 {
-    return _ffs[pdrv]->size() / disk_get_sector_size(pdrv);
+    DWORD scount = _ffs[pdrv]->size() / disk_get_sector_size(pdrv);
+    MBED_ASSERT(scount >= 64);
+    return scount;
 }
 
 DSTATUS disk_status(BYTE pdrv)

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -308,7 +308,7 @@ int FATFileSystem::unmount()
 
 /* See http://elm-chan.org/fsw/ff/en/mkfs.html for details of f_mkfs() and
  * associated arguments. */
-int FATFileSystem::format(BlockDevice *bd, int allocation_unit) {
+int FATFileSystem::format(BlockDevice *bd, bd_size_t cluster_size) {
     FATFileSystem fs;
     int err = fs.mount(bd, false);
     if (err) {
@@ -317,7 +317,7 @@ int FATFileSystem::format(BlockDevice *bd, int allocation_unit) {
 
     // Logical drive number, Partitioning rule, Allocation unit size (bytes per cluster)
     fs.lock();
-    FRESULT res = f_mkfs(fs._fsid, 1, allocation_unit);
+    FRESULT res = f_mkfs(fs._fsid, 1, cluster_size);
     fs.unlock();
     if (res != FR_OK) {
         return fat_error_remap(res);

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -49,18 +49,18 @@ public:
      *  The block device to format should be mounted when this function is called.
      *
      *  @param bd
-     *    This is the block device that will be formated.
+     *    This is the block device that will be formatted.
      *
-     *  @param allocation_unit
-     *    This is the number of bytes per cluster size. The valid value is N
-     *    times the sector size. N is a power of 2 from 1 to 128 for FAT
-     *    volume and upto 16MiB for exFAT volume. If zero is given,
-     *    the default allocation unit size is selected by the underlying
-     *    filesystem, which depends on the volume size.
+     *  @param cluster_size
+     *    This is the number of bytes per cluster. A larger cluster size will decrease
+     *    the overhead of the FAT table, but also increase the minimum file size. The
+     *    cluster_size must be a multiple of the underlying device's allocation unit
+     *    and is currently limited to a max of 32,768 bytes. If zero, a cluster size
+     *    will be determined from the device's allocation unit. Defaults to zero.
      *   
      *  @return         0 on success, negative error code on failure
      */
-    static int format(BlockDevice *bd, int allocation_unit = 0);
+    static int format(BlockDevice *bd, bd_size_t cluster_size = 0);
 
     /** Mounts a filesystem to a block device
      *


### PR DESCRIPTION
Some block devices (for example I2C EEPROM) can be erased at the byte level. These aren't really block devices, but fall under the block device API. For these devices, the fat filesystem needs to use a lower bound on the block size. In this case we used 512 bytes is used since it is already a standard.