### PR TITLE
Integrate mbed OS RTC with mbed TLS

### DIFF
--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,6 +21,10 @@
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
+#if defined(DEVICE_RTC)
+#define MBEDTLS_HAVE_TIME_DATE
+#endif
+
 #if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif


### PR DESCRIPTION
## Description
This change integrates the mbed OS Real-Time Clock (RTC) into mbed TLS.

The integration is simply to define the macro `MBEDTLS_HAVE_TIME_DATE`
in the `features/mbedtls/platform/inc/platform_mbed.h`. The default
implementation of the `mbedtls_time()` function provided by mbed TLS is
sufficient to work with mbed OS because both use POSIX functions.

## Status
IN DEVELOPMENT

## Migrations
This patch modifies the behaviour of the X509 module in mbed TLS because now the certificate verification process will check that the certificates date/time validity is correct when it previously did not. For this to work correctly, the application needs to correctly set up the RTC with a call to [`set_time()`](https://github.com/ARMmbed/mbed-os/blob/4890261c9860dd3d8f5df14bb070c3cb8e538732/platform/mbed_rtc_time.h#L75). For example, this change causes the mbed TLS example application [tls-client](https://github.com/ARMmbed/mbed-os-example-tls/tree/master/tls-client) to fail.

YES 

## Todos
- [ ] Tests
- [ ] Documentation

## Steps to test or reproduce
Use mbed OS as normal. When verifying certificates, now the date/time validity checks will be exercised by the mbed TLS X509 module.
