### PR TITLE
Allow using of malloc() for reserving the Nanostack's heap.

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/README.md
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/README.md
@@ -34,6 +34,7 @@ An example of the configuration file:
 | Parameter name  | Value         | Description |
 | --------------- | ------------- | ----------- |
 | heap-size       | number [0-0xfffe] | Nanostack's internal heap size |
+| use-malloc-for-heap | `false` or `true` | Use `malloc()` for reserving the internal heap. Default: `false` |
 
 ### Thread related configuration parameters
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed_lib.json
@@ -2,6 +2,7 @@
     "name": "mbed-mesh-api",
     "config": {
         "heap-size": 32500,
+        "use-malloc-for-heap": false,
         "6lowpan-nd-channel-mask": "(1<<12)",
         "6lowpan-nd-channel-page": 0,
         "6lowpan-nd-channel": 12,

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/mesh_system.c
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/mesh_system.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include <stdlib.h>
 #include "eventOS_scheduler.h"
 #include "eventOS_event.h"
 #include "net_interface.h"
@@ -22,13 +23,18 @@
 #include "platform/arm_hal_timer.h"
 #include "ns_hal_init.h"
 #include "include/mesh_system.h"
+#include "mbed_assert.h"
 // For tracing we need to define flag, have include and define group
 #define HAVE_DEBUG 1
 #include "ns_trace.h"
 #define TRACE_GROUP  "m6-mesh-system"
 
 /* Heap for NanoStack */
+#if !MBED_CONF_MBED_MESH_API_USE_MALLOC_FOR_HEAP
 static uint8_t app_stack_heap[MBED_CONF_MBED_MESH_API_HEAP_SIZE + 1];
+#else
+static uint8_t *app_stack_heap;
+#endif
 static bool mesh_initialized = false;
 
 /*
@@ -55,6 +61,10 @@ static void mesh_system_heap_error_handler(heap_fail_t event)
 void mesh_system_init(void)
 {
     if (mesh_initialized == false) {
+#if MBED_CONF_MBED_MESH_API_USE_MALLOC_FOR_HEAP
+        app_stack_heap = malloc(MBED_CONF_MBED_MESH_API_HEAP_SIZE+1);
+        MBED_ASSERT(app_stack_heap);
+#endif
         ns_hal_init(app_stack_heap, MBED_CONF_MBED_MESH_API_HEAP_SIZE,
                     mesh_system_heap_error_handler, NULL);
         eventOS_scheduler_mutex_wait();


### PR DESCRIPTION
## Description
Some devices have RAM memory split into two sections.
This becames a problem for GCC based toolchains as they don't
support splitting .bss or .data sections into two memory parts.
When we run out of memory from .bss sections, allocating the stack
by malloc() allows it to be moved to .data section which might already
be in the second memory section. For example KW24D platform.

## Status
**In Review**

## Migrations
For devices that run out of memory with mesh applications, add following line to `mbed_app.json`
```
"mbed-mesh-api.use-malloc-for-heap": true
```