### PR TITLE
Add list of defines to vscode exporter

### DIFF
--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -63,15 +63,18 @@ class VSCode(Makefile):
             "configurations": [
                 {
                     "name": "Windows",
-                    "includePath": [x.replace("/", "\\") for x in all_directories]
+                    "includePath": [x.replace("/", "\\") for x in all_directories],
+                    "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 },
                 {
                     "name": "Mac",
-                    "includePath": all_directories
+                    "includePath": all_directories,
+                    "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 },
                 {
                     "name": "Linux",
-                    "includePath": all_directories
+                    "includePath": all_directories,
+                    "defines": [symbol for symbol in self.toolchain.get_symbols()]
                 }
             ]
         }


### PR DESCRIPTION
The new Intellisense engine for Visual Studio Code requires a list of defines so it can properly index the code. Add the list of defines to the exporter.

In this PR I'm not switching to the new engine yet, because the new engine also needs the location of a bunch of v7m / cstdlib headers which come with the compiler, and I'm not sure how to automate this as their location depends on where your compiler was installed.