### PR TITLE
STM32F4_HAL_MMC erase command check is wrong. == has higher precedence than &

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_mmc.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_mmc.c
@@ -1316,7 +1316,7 @@ HAL_StatusTypeDef HAL_MMC_Erase(MMC_HandleTypeDef *hmmc, uint32_t BlockStartAdd,
     hmmc->State = HAL_MMC_STATE_BUSY;
     
     /* Check if the card command class supports erase command */
-    if((hmmc->MmcCard.Class) & SDIO_CCCC_ERASE == 0U)
+    if(((hmmc->MmcCard.Class) & SDIO_CCCC_ERASE) == 0U)
     {
       /* Clear all the static flags */
       __HAL_MMC_CLEAR_FLAG(hmmc, SDIO_STATIC_FLAGS);


### PR DESCRIPTION
Maybe I'm wrong, but I think the check here is incorrect. This gets evaluated as:

```
if((hmmc->MmcCard.Class) & (SDIO_CCCC_ERASE == 0U))
```

Because `==` has higher precedence than `&`.