### PR TITLE
SAM_CortexM0P uses uninitialized memory in i2c and uses out of bounds array in pwmout

### DIFF
--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/i2c_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/i2c_api.c
@@ -173,7 +173,7 @@ void i2c_frequency(i2c_t *obj, int hz)
     int32_t baud_rate;
     int32_t tmp_baud;
     int32_t tmp_baud_hs;
-    enum status_code tmp_status_code;
+    enum status_code tmp_status_code = STATUS_OK;
 
     /* Sanity check arguments */
     MBED_ASSERT(obj);

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/pwmout_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/pwmout_api.c
@@ -60,7 +60,7 @@ static void pwmout_set_period(pwmout_t* obj, int period_us)
 
     freq_hz = system_gclk_gen_get_hz(obj->clock_source);
 
-    for (i=0; i<sizeof(tcc_prescaler); i++) {
+    for (i=0; i<sizeof(tcc_prescaler) / sizeof(tcc_prescaler[0]); i++) {
         div_freq = freq_hz >> tcc_prescaler[i];
         if (!div_freq) break;
         us_per_cycle = 1000000.00 / div_freq;


### PR DESCRIPTION
I know these are mbed 2 targets, but I still think we should fix these bugs.

Found them using cppcheck.