### PR TITLE
Optimize memory usage of wifi scan for REALTEK_RTW8195AM

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -73,7 +73,7 @@ static rtw_result_t scan_result_handler( rtw_scan_handler_result_t* malloced_sca
             }
             ap.rssi = record->signal_strength;
             ap.channel = record->channel;
-            new (&scan_handler->ap_details[scan_handler->ap_num]) WiFiAccessPoint(ap);
+            scan_handler->ap_details[scan_handler->ap_num] = WiFiAccessPoint(ap);
         }
         scan_handler->ap_num++;
     } else{

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -73,9 +73,7 @@ static rtw_result_t scan_result_handler( rtw_scan_handler_result_t* malloced_sca
             }
             ap.rssi = record->signal_strength;
             ap.channel = record->channel;
-            WiFiAccessPoint *accesspoint = new WiFiAccessPoint(ap);
-            memcpy(&scan_handler->ap_details[scan_handler->ap_num], accesspoint, sizeof(WiFiAccessPoint));
-            delete[] accesspoint;
+            new (&scan_handler->ap_details[scan_handler->ap_num]) WiFiAccessPoint(ap);
         }
         scan_handler->ap_num++;
     } else{


### PR DESCRIPTION
To prevent new and delete frequently, use placement new to create instance at local array. 