### PR TITLE
HAL LPCs SPI: Fix mask bits for SPI clock rate

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -110,7 +110,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -146,7 +146,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -76,7 +76,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -112,7 +112,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -112,7 +112,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -148,7 +148,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -104,7 +104,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -140,7 +140,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -98,7 +98,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -146,7 +146,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -118,7 +118,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -153,7 +153,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -98,7 +98,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
 
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -133,7 +133,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
 
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -117,7 +117,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
     
     int FRF = 0;                   // FRF (frame format) = SPI
     uint32_t tmp = obj->spi->CR0;
-    tmp &= ~(0xFFFF);
+    tmp &= ~(0x00FF);              // Clear DSS, FRF, CPOL and CPHA [7:0]
     tmp |= DSS << 0
         | FRF << 4
         | SPO << 6
@@ -152,7 +152,7 @@ void spi_frequency(spi_t *obj, int hz) {
             obj->spi->CPSR = prescaler;
             
             // divider
-            obj->spi->CR0 &= ~(0xFFFF << 8);
+            obj->spi->CR0 &= ~(0xFF00);  // Clear SCR: Serial clock rate [15:8]
             obj->spi->CR0 |= (divider - 1) << 8;
             ssp_enable(obj);
             return;


### PR DESCRIPTION
## Description
This PR fix mask bits for SPI clock rate issue.  See https://github.com/ARMmbed/mbed-os/issues/4847 more detail information.

## Status
**READY**

## Tested with following platforms
*  LPC176x - LPC1768
* LPC11Uxx - LPC11U24
* LPC11U6x - LPCXpresso11U68
* LPC4337 - LPCXpresso4337
* LPC11xx_11Cxx - LPC1114
* LPC4088/DM - LPC4088 QuickStart board

LPC13xx has not been tested as we have no official target hardware.
