### PR TITLE
Sleep: add sleep manager API (feature-hal-spec branch)

### DIFF
--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -78,4 +78,25 @@ void sleep_manager_sleep_auto(void)
     core_util_critical_section_exit();
 }
 
+#else
+
+// locking is valid only if DEVICE_SLEEP is defined
+// we provide empty implementation
+
+void sleep_manager_lock_deep_sleep(void)
+{
+
+}
+
+void sleep_manager_unlock_deep_sleep(void)
+{
+
+}
+
+bool sleep_manager_can_deep_sleep(void)
+{
+    // no sleep implemented
+    return false;
+}
+
 #endif

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -1,0 +1,81 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed_sleep.h"
+#include "mbed_critical.h"
+#include "mbed_error.h"
+#include "sleep_api.h"
+#include <limits.h>
+
+#if DEVICE_SLEEP
+
+// deep sleep locking counter. A target is allowed to deep sleep if counter == 0
+static uint16_t deep_sleep_lock = 0U;
+
+void sleep_manager_lock_deep_sleep(void)
+{
+    core_util_critical_section_enter();
+    if (deep_sleep_lock == USHRT_MAX) {
+        core_util_critical_section_exit();
+        error("Deep sleep lock would overflow (> USHRT_MAX)");
+    }
+    core_util_atomic_incr_u16(&deep_sleep_lock, 1);
+    core_util_critical_section_exit();
+}
+
+void sleep_manager_unlock_deep_sleep(void)
+{
+    core_util_critical_section_enter();
+    if (deep_sleep_lock == 0) {
+        core_util_critical_section_exit();
+        error("Deep sleep lock would underflow (< 0)");
+    }
+    core_util_atomic_decr_u16(&deep_sleep_lock, 1);
+    core_util_critical_section_exit();
+}
+
+bool sleep_manager_can_deep_sleep(void)
+{
+    core_util_critical_section_enter();
+
+    bool can_deep_sleep;
+    if (deep_sleep_lock == 0) {
+        can_deep_sleep = true;
+    } else {
+        can_deep_sleep = false;
+    }
+
+    core_util_critical_section_exit();
+    return can_deep_sleep;
+}
+
+void sleep_manager_sleep_auto(void)
+{
+    core_util_critical_section_enter();
+// debug profile should keep debuggers attached, no deep sleep allowed
+#ifdef MBED_DEBUG
+    hal_sleep();
+#else
+    if (sleep_manager_can_deep_sleep()) {
+        hal_deepsleep();
+    } else {
+        hal_sleep();
+    }
+#endif
+    core_util_critical_section_exit();
+}
+
+#endif

--- a/hal/sleep_api.h
+++ b/hal/sleep_api.h
@@ -29,32 +29,26 @@ extern "C" {
 
 /** Send the microcontroller to sleep
  *
- * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
+ * The processor is setup ready for sleep, and sent to sleep. In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
  * dynamic power used by the processor, memory systems and buses. The processor, peripheral and
  * memory state are maintained, and the peripherals continue to work and can generate interrupts.
  *
  * The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 us.
  */
 void hal_sleep(void);
 
 /** Send the microcontroller to deep sleep
  *
- * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
- * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
- * is still maintained.
+ * This processor is setup ready for deep sleep, and sent to sleep. This mode
+ * has the same sleep features as sleep plus it powers down peripherals and high speed clocks.
+ * All state is still maintained.
  *
- * The processor can only be woken up by an external interrupt on a pin or a watchdog timer.
+ * The processor can only be woken up by lp ticker, RTC, an external interrupt on a pin or a watchdog timer.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 ms.
  */
 void hal_deepsleep(void);
 

--- a/platform/mbed_sleep.h
+++ b/platform/mbed_sleep.h
@@ -20,10 +20,88 @@
 #define MBED_SLEEP_H
 
 #include "sleep_api.h"
+#include "mbed_toolchain.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Sleep manager API
+ * The sleep manager provides API to automatically select sleep mode.
+ *
+ * There are two sleep modes:
+ * - sleep
+ * - deepsleep
+ *
+ * Use locking/unlocking deepsleep for drivers that depend on features that
+ * are not allowed (=disabled) during the deepsleep. For instance, high frequency
+ * clocks.
+ *
+ * Example:
+ * @code
+ *
+ * void driver::handler()
+ * {
+ *     if (_sensor.get_event()) {
+ *         // any event - we are finished, unlock the deepsleep
+ *         sleep_manager_unlock_deep_sleep();
+ *         _callback();
+ *     }
+ * }
+ *
+ * int driver::measure(event_t event, callback_t& callback)
+ * {
+ *      _callback = callback;
+ *      sleep_manager_lock_deep_sleep();
+ *      // start async transaction, we are waiting for an event
+ *      return _sensor.start(event, callback);
+ * }
+ * @endcode
+ */
+
+/** Lock the deep sleep mode
+ *
+ * This locks the automatic deep mode selection. 
+ * sleep_manager_sleep_auto() will ignore deepsleep mode if
+ * this function is invoked at least once (the internal counter is non-zero)
+ *
+ * Use this locking mechanism for interrupt driven API that are
+ * running in the background and deepsleep could affect their functionality
+ * 
+ * The lock is a counter, can be locked up to USHRT_MAX
+ * This function is IRQ and thread safe
+ */
+void sleep_manager_lock_deep_sleep(void);
+
+/** Unlock the deep sleep mode
+ *
+ * Use unlocking in pair with sleep_manager_lock_deep_sleep(). 
+ * 
+ * The lock is a counter, should be equally unlocked as locked
+ * This function is IRQ and thread safe
+ */
+void sleep_manager_unlock_deep_sleep(void);
+
+/** Get the status of deep sleep allowance for a target
+ *
+ * This function is IRQ and thread safe
+ *
+ * @return true if a target can go to deepsleep, false otherwise
+ */
+bool sleep_manager_can_deep_sleep(void);
+
+/** Enter auto selected sleep mode. It chooses the sleep or deeepsleep modes based
+ *  on the deepsleep locking counter
+ *
+ * This function is IRQ and thread safe
+ *
+ * @note
+ * If MBED_DEBUG is defined, only hal_sleep is allowed. This ensures the debugger
+ * to be active for debug modes.
+ * 
+ */
+void sleep_manager_sleep_auto(void);
 
 /** Send the microcontroller to sleep
  *
@@ -31,26 +109,21 @@ extern "C" {
  * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined).
  * @note This function will be a noop while uVisor is in use.
  *
- * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
+ * The processor is setup ready for sleep, and sent to sleep. In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
  * dynamic power used by the processor, memory systems and buses. The processor, peripheral and
  * memory state are maintained, and the peripherals continue to work and can generate interrupts.
  *
  * The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 us.
  */
 __INLINE static void sleep(void)
 {
 #if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
-#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
-    hal_sleep();
+    sleep_manager_sleep_auto();
 #endif /* DEVICE_SLEEP */
-#endif /* MBED_DEBUG */
 #endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 
@@ -60,25 +133,22 @@ __INLINE static void sleep(void)
  * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
  * @note This function will be a noop while uVisor is in use.
  *
- * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
+ * This processor is setup ready for deep sleep, and sent to sleep. This mode
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
  * is still maintained.
  *
- * The processor can only be woken up by an external interrupt on a pin or a watchdog timer.
+ * The processor can only be woken up by RTC, an external interrupt on a pin or a watchdog timer.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ *  The wake-up time shall be less than 10 ms.
  */
+
+MBED_DEPRECATED_SINCE("mbed-os-5.6", "One entry point for an application, use sleep()")
 __INLINE static void deepsleep(void)
 {
 #if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
-#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
-    hal_deepsleep();
+    sleep_manager_sleep_auto();
 #endif /* DEVICE_SLEEP */
-#endif /* MBED_DEBUG */
 #endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 


### PR DESCRIPTION
*Note*: this goes to the feature branch `feature-hal-spec` (shall go to the next minor release at minimum). I rebased it on top of the latest master. We can then use this for the other work, and build on top of it or update it according to feedback.

Sleep manager provides API to lock/unlock deepsleep. This API allows a user to
control deep sleep.

This API should be done via atomic operations (to be IRQ/thread safe).

Add wake-up times for sleep and deep sleep. Sleep should wake up within 10 us,
deep sleep within 5 milliseconds (sufficient time to restore clock if required).

Deprecates deepsleep that is being replaced by auto function from sleep manager.

There are tests to test this changeset, currently private, will be shared later.

cc @c1728p9 @geky @pan- @bulislaw