### PR TITLE
fs: Add FileSystem::get_block_device

### DIFF
--- a/features/filesystem/FileSystem.cpp
+++ b/features/filesystem/FileSystem.cpp
@@ -44,6 +44,11 @@ int FileSystem::mkdir(const char *path, mode_t mode)
     return -ENOSYS;
 }
 
+BlockDevice *FileSystem::get_block_device() const
+{
+    return NULL;
+}
+
 int FileSystem::file_sync(fs_file_t file)
 {
     return 0;

--- a/features/filesystem/FileSystem.h
+++ b/features/filesystem/FileSystem.h
@@ -99,6 +99,13 @@ public:
      */
     virtual int mkdir(const char *path, mode_t mode);
 
+    /** Get the underlying block device
+     *
+     *  @return         The underlying block device, or NULL if no block
+     *                  device has been mounted
+     */
+    virtual BlockDevice *get_block_device() const;
+
 protected:
     friend class File;
     friend class Dir;

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -293,6 +293,15 @@ int FATFileSystem::unmount()
     return fat_error_remap(res);
 }
 
+BlockDevice *FATFileSystem::get_block_device() const
+{
+    if (_id != -1) {
+        return _ffs[_id];
+    } else {
+        return NULL;
+    }
+}
+
 /* See http://elm-chan.org/fsw/ff/en/mkfs.html for details of f_mkfs() and
  * associated arguments. */
 int FATFileSystem::format(BlockDevice *bd, int allocation_unit) {

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -106,6 +106,13 @@ public:
      */
     virtual int mkdir(const char *path, mode_t mode);
 
+    /** Get the underlying block device
+     *
+     *  @return         The underlying block device, or NULL if no block
+     *                  device has been mounted
+     */
+    virtual BlockDevice *get_block_device() const;
+
 protected:
     /** Open a file on the filesystem
      *


### PR DESCRIPTION
Required for accessing the underlying block device. This can be used to modify the state of the block device outside of the filesystem.

The best example is if you are reformatting a filesystem:
``` cpp
BlockDevice *bd = fs.get_block_device();
fs.unmount();
FATFileSystem::format(bd);
fs.mount(bd);
```

This is required as part of https://github.com/ARMmbed/mbed-os/issues/4737
alternative: https://github.com/ARMmbed/mbed-os/pull/4908
cc @sg-, @netanelgonen, let me know if this API doesn't work for you