### PR TITLE
target BLUEPILL_F103C8 compile fix

### DIFF
--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -37,6 +37,7 @@
 #define INITIAL_SP              (0x20004000UL)
 
 #elif (defined(TARGET_STM32F103RB) ||\
+       defined(TARGET_STM32F103C8) ||\
        defined(TARGET_STM32L072CZ) ||\
        defined(TARGET_STM32L073RZ))
 #define INITIAL_SP              (0x20005000UL)


### PR DESCRIPTION
INITIAL_SP missing when compile, here is a quick fix
