### PR TITLE
Enable crypto HW acceleration for STM32F437xG platforms

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/mbedtls_device.h
@@ -1,0 +1,31 @@
+/*
+ *  mbedtls_device.h
+ *******************************************************************************
+ * Copyright (c) 2017, STMicroelectronics
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+#ifndef MBEDTLS_DEVICE_H
+#define MBEDTLS_DEVICE_H
+
+#define MBEDTLS_AES_ALT
+
+#define MBEDTLS_SHA256_ALT
+
+#define MBEDTLS_SHA1_ALT
+
+#define MBEDTLS_MD5_ALT
+
+#endif /* MBEDTLS_DEVICE_H */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1707,7 +1707,7 @@
                 "macro_name": "MODEM_ON_BOARD_UART"
             }
         },
-        "macros_add": ["RTC_LSI=1", "HSE_VALUE=12000000", "GNSSBAUD=9600"],
+        "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "RTC_LSI=1", "HSE_VALUE=12000000", "GNSSBAUD=9600"],
         "device_has_add": ["ANALOGOUT", "SERIAL_FC", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "public": false,


### PR DESCRIPTION
Enable crypto HW acceleration for STM43F437xG platforms, i.e. ublox C030 family boards.

`mbed-os-example-tls/benchmark/` before:

```
  SHA-256                  :       2936 KB/s
  SHA-512                  :        886 KB/s
  AES-CBC-128              :       2315 KB/s
  AES-CBC-192              :       2031 KB/s
  AES-CBC-256              :       1810 KB/s
  AES-GCM-128              :        708 KB/s
  AES-GCM-192              :        679 KB/s
  AES-GCM-256              :        652 KB/s
  AES-CCM-128              :        957 KB/s
  AES-CCM-192              :        857 KB/s
  AES-CCM-256              :        776 KB/s
  CTR_DRBG (NOPR)          :       1922 KB/s
  CTR_DRBG (PR)            :       1361 KB/s
  HMAC_DRBG SHA-256 (NOPR) :        337 KB/s
  HMAC_DRBG SHA-256 (PR)   :        296 KB/s
  RSA-2048                 :      20 ms/ public
  RSA-2048                 :     782 ms/private
  RSA-4096                 :      68 ms/ public
  RSA-4096                 :    4160 ms/private
  ECDHE-secp384r1          :     696 ms/handshake
  ECDHE-secp256r1          :     461 ms/handshake
  ECDHE-Curve25519         :     386 ms/handshake
  ECDH-secp384r1           :     343 ms/handshake
  ECDH-secp256r1           :     232 ms/handshake
  ECDH-Curve25519          :     192 ms/handshake
```
....and after:

```
  SHA-256                  :      15081 KB/s
  SHA-512                  :        886 KB/s
  AES-CBC-128              :      31542 KB/s
  AES-CBC-192              :      31542 KB/s
  AES-CBC-256              :      31542 KB/s
  AES-GCM-128              :        913 KB/s
  AES-GCM-192              :        913 KB/s
  AES-GCM-256              :        903 KB/s
  AES-CCM-128              :       2172 KB/s
  AES-CCM-192              :       2172 KB/s
  AES-CCM-256              :       2170 KB/s
  CTR_DRBG (NOPR)          :       8512 KB/s
  CTR_DRBG (PR)            :       5244 KB/s
  HMAC_DRBG SHA-256 (NOPR) :        470 KB/s
  HMAC_DRBG SHA-256 (PR)   :        411 KB/s
  RSA-2048                 :      20 ms/ public
  RSA-2048                 :     781 ms/private
  RSA-4096                 :      68 ms/ public
  RSA-4096                 :    4054 ms/private
  ECDHE-secp384r1          :     692 ms/handshake
  ECDHE-secp256r1          :     461 ms/handshake
  ECDHE-Curve25519         :     385 ms/handshake
  ECDH-secp384r1           :     339 ms/handshake
  ECDH-secp256r1           :     232 ms/handshake
  ECDH-Curve25519          :     199 ms/handshake
```

Test results for `mbed-os-tests-mbedtls-selftest`:

```
+-------------------------+-----------------+--------------------------------+---------------------------+--------+--------+--------+--------------------+
| target                  | platform_name   | test suite                     | test case                 | passed | failed | result | elapsed_time (sec) |
+-------------------------+-----------------+--------------------------------+---------------------------+--------+--------+--------+--------------------+
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | mbed-os-tests-mbedtls-selftest | mbedtls_entropy_self_test | 1      | 0      | OK     | 0.06               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | mbed-os-tests-mbedtls-selftest | mbedtls_sha256_self_test  | 1      | 0      | OK     | 0.11               |
| UBLOX_C030_U201-GCC_ARM | UBLOX_C030_U201 | mbed-os-tests-mbedtls-selftest | mbedtls_sha512_self_test  | 1      | 0      | OK     | 1.98               |
+-------------------------+-----------------+--------------------------------+---------------------------+--------+--------+--------+--------------------+
```
NOTE: this should only be merged once PR #5018 (which fixes an AES HW crypto driver issue) has been merged.
