### PR TITLE
Fix compiler warning for deprecated function call

### DIFF
--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -38,7 +38,7 @@ CAN::CAN(PinName rd, PinName td, int hz) : _can(), _irq() {
     // No lock needed in constructor
 
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
-        _irq[i].attach(donothing);
+        _irq[i] = callback(donothing);
     }
 
     can_init_freq(&_can, rd, td, hz);


### PR DESCRIPTION
Replaced the deprecated function call .attach() with an assignment.

Fixes #4821 Deprecated Callback function used
