### PR TITLE
fs: Add FileSystem::reformat

### DIFF
--- a/features/filesystem/FileSystem.cpp
+++ b/features/filesystem/FileSystem.cpp
@@ -24,6 +24,11 @@ FileSystem::FileSystem(const char *name)
 {
 }
 
+int FileSystem::reformat(BlockDevice *bd)
+{
+    return -ENOSYS;
+}
+
 int FileSystem::remove(const char *path)
 {
     return -ENOSYS;

--- a/features/filesystem/FileSystem.h
+++ b/features/filesystem/FileSystem.h
@@ -68,6 +68,16 @@ public:
      */
     virtual int unmount() = 0;
 
+    /** Reformats a filesystem, results in an empty and mounted filesystem
+     *
+     *  @param bd       BlockDevice to reformat and mount. If NULL, the mounted
+     *                  block device will be used.
+     *                  Note: if mount fails, bd must be provided.
+     *                  Default: NULL
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int reformat(BlockDevice *bd = NULL);
+
     /** Remove a file from the filesystem.
      *
      *  @param path     The name of the file to remove.

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -318,6 +318,36 @@ int FATFileSystem::format(BlockDevice *bd, int allocation_unit) {
     return 0;
 }
 
+int FATFileSystem::reformat(BlockDevice *bd, int allocation_unit) {
+    lock();
+    if (_id != -1) {
+        if (!bd) {
+            bd = _ffs[_id];
+        }
+
+        int err = unmount();
+        if (err) {
+            unlock();
+            return err;
+        }
+    }
+
+    if (!bd) {
+        unlock();
+        return -ENODEV;
+    }
+
+    int err = FATFileSystem::format(bd, allocation_unit);
+    if (err) {
+        unlock();
+        return err;
+    }
+
+    err = mount(bd);
+    unlock();
+    return err;
+}
+
 int FATFileSystem::remove(const char *path) {
     Deferred<const char*> fpath = fat_path_prefix(_id, path);
 

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -75,6 +75,39 @@ public:
      */
     virtual int unmount();
 
+    /** Reformats a filesystem, results in an empty and mounted filesystem
+     *
+     *  @param bd
+     *      BlockDevice to reformat and mount. If NULL, the mounted
+     *      block device will be used.
+     *      Note: if mount fails, bd must be provided.
+     *      Default: NULL
+     *
+     *  @param allocation_unit
+     *      This is the number of bytes per cluster size. The valid value is N
+     *      times the sector size. N is a power of 2 from 1 to 128 for FAT
+     *      volume and upto 16MiB for exFAT volume. If zero is given,
+     *      the default allocation unit size is selected by the underlying
+     *      filesystem, which depends on the volume size.
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int reformat(BlockDevice *bd, int allocation_unit);
+
+    /** Reformats a filesystem, results in an empty and mounted filesystem
+     *
+     *  @param bd       BlockDevice to reformat and mount. If NULL, the mounted
+     *                  block device will be used.
+     *                  Note: if mount fails, bd must be provided.
+     *                  Default: NULL
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int reformat(BlockDevice *bd = NULL)
+    {
+        // required for virtual inheritance shenanigans
+        return reformat(bd, 0);
+    }
+
     /** Remove a file from the filesystem.
      *
      *  @param path     The name of the file to remove.

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -120,6 +120,9 @@ extern "C" {
 #undef EXDEV
 #define EXDEV       18      /* Cross-device link */
 
+#undef ENODEV
+#define ENODEV      19
+
 #undef EINVAL
 #define EINVAL      22      /* Invalid argument */
 


### PR DESCRIPTION
This function provides a shortcut to reformatting a mounted filesystem.

Usage without mounted filesystem:
``` cpp
BlockDevice *bd = user_provided;
int err = fs.mount(bd);
if (err) {
    fs.reformat(bd);
}
// fs is now mounted
```

Usage with mounted filesystem:
``` cpp
fs.reformat();
// fs is now mounted
```

Formatting without mounting
``` cpp
BlockDevice *bd = user_provided;
FATFileSystem::format(bd);
// fs is not mounted
```

Also, since this function is a virtual member of the FileSystem class, the user does not need to know the underlying filesystem to reformat the underlying storage.

can replace https://github.com/ARMmbed/mbed-os/pull/4886
resolves #4903
related https://github.com/ARMmbed/mbed-os/issues/4407
cc @netanelgonen, @sg-, @pan-, @theotherjimmy 


