### PR TITLE
Add sleep manager API

### DIFF
--- a/TESTS/mbed_hal/sleep_manager/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager/main.cpp
@@ -1,0 +1,60 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#if !DEVICE_SLEEP
+#error [NOT_SUPPORTED] test not supported
+#endif
+
+using namespace utest::v1;
+
+void sleep_manager_deepsleep_counter_test()
+{
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE(deep_sleep_allowed);
+    
+    sleep_manager_lock_deep_sleep();
+    deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_FALSE(deep_sleep_allowed);
+
+    sleep_manager_unlock_deep_sleep();
+    deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE(deep_sleep_allowed);
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) 
+{
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) 
+{
+    GREENTEA_SETUP(20, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("sleep manager -  deep sleep counter", sleep_manager_deepsleep_counter_test, greentea_failure_handler),
+};
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() {
+    Harness::run(specification);
+}

--- a/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -1,0 +1,99 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#if !DEVICE_SLEEP
+#error [NOT_SUPPORTED] test not supported
+#endif
+
+using namespace utest::v1;
+
+void sleep_manager_locking_thread_test()
+{
+    for (uint32_t i = 0; i < 100; i++) {
+        sleep_manager_lock_deep_sleep();
+        Thread::wait(25);
+        sleep_manager_unlock_deep_sleep();
+    }
+}
+
+void sleep_manager_multithread_test()
+{
+    {
+        Callback<void()> cb(sleep_manager_locking_thread_test);
+        Thread t1;
+        Thread t2;
+
+        t1.start(callback(cb));
+        Thread::wait(25);
+        t2.start(callback(cb));
+
+        // Wait for the threads to finish
+        t1.join();
+        t2.join();
+    }
+
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
+}
+
+void sleep_manager_locking_irq_test()
+{
+    sleep_manager_lock_deep_sleep();
+    sleep_manager_unlock_deep_sleep();
+}
+
+void sleep_manager_irq_test()
+{
+    {
+        Ticker ticker1;
+        Timer timer;
+
+        ticker1.attach_us(&sleep_manager_locking_irq_test, 500);
+
+        // run this for 5 seconds
+        timer.start();
+        int start = timer.read();
+        int end = start + 5;
+        while (timer.read() < end) {
+            sleep_manager_locking_irq_test();
+        }
+        timer.stop();
+    }
+
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
+}
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) 
+{
+    GREENTEA_SETUP(30, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("sleep manager HAL - locking multithreaded", sleep_manager_multithread_test),
+    Case("sleep manager HAL - locking IRQ", sleep_manager_irq_test),
+};
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() {
+    Harness::run(specification);
+}

--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -116,7 +116,10 @@ int CAN::filter(unsigned int id, unsigned int mask, CANFormat format, int handle
 void CAN::attach(Callback<void()> func, IrqType type) {
     lock();
     if (func) {
-        sleep_manager_lock_deep_sleep();
+        // lock deep sleep only the first time
+        if (_irq[(CanIrqType)type] == callback(donothing)) {
+            sleep_manager_lock_deep_sleep();
+        }
         _irq[(CanIrqType)type] = func;
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {

--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -22,13 +22,11 @@
 
 namespace mbed {
 
-static void donothing() {}
-
 CAN::CAN(PinName rd, PinName td) : _can(), _irq() {
     // No lock needed in constructor
 
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
-        _irq[i] = callback(donothing);
+        _irq[i] = NULL;
     }
 
     can_init(&_can, rd, td);
@@ -39,7 +37,7 @@ CAN::CAN(PinName rd, PinName td, int hz) : _can(), _irq() {
     // No lock needed in constructor
 
     for (size_t i = 0; i < sizeof _irq / sizeof _irq[0]; i++) {
-        _irq[i] = callback(donothing);
+        _irq[i] = NULL;
     }
 
     can_init_freq(&_can, rd, td, hz);
@@ -117,17 +115,17 @@ void CAN::attach(Callback<void()> func, IrqType type) {
     lock();
     if (func) {
         // lock deep sleep only the first time
-        if (_irq[(CanIrqType)type] == callback(donothing)) {
+        if (!_irq[(CanIrqType)type]) {
             sleep_manager_lock_deep_sleep();
         }
         _irq[(CanIrqType)type] = func;
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {
         // unlock deep sleep only the first time
-        if (_irq[(CanIrqType)type] != callback(donothing)) {
+        if (_irq[(CanIrqType)type]) {
             sleep_manager_unlock_deep_sleep();
         }
-        _irq[(CanIrqType)type] = callback(donothing);
+        _irq[(CanIrqType)type] = NULL;
         can_irq_set(&_can, (CanIrqType)type, 0);
     }
     unlock();
@@ -135,7 +133,9 @@ void CAN::attach(Callback<void()> func, IrqType type) {
 
 void CAN::_irq_handler(uint32_t id, CanIrqType type) {
     CAN *handler = (CAN*)id;
-    handler->_irq[type].call();
+    if (handler->_irq[type]) {
+        handler->_irq[type].call();
+    }
 }
 
 void CAN::lock() {

--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -18,6 +18,7 @@
 #if DEVICE_CAN
 
 #include "cmsis.h"
+#include "platform/mbed_sleep.h"
 
 namespace mbed {
 
@@ -115,9 +116,11 @@ int CAN::filter(unsigned int id, unsigned int mask, CANFormat format, int handle
 void CAN::attach(Callback<void()> func, IrqType type) {
     lock();
     if (func) {
+        sleep_manager_lock_deep_sleep();
         _irq[(CanIrqType)type] = func;
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {
+        sleep_manager_unlock_deep_sleep();
         _irq[(CanIrqType)type] = callback(donothing);
         can_irq_set(&_can, (CanIrqType)type, 0);
     }

--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -123,7 +123,10 @@ void CAN::attach(Callback<void()> func, IrqType type) {
         _irq[(CanIrqType)type] = func;
         can_irq_set(&_can, (CanIrqType)type, 1);
     } else {
-        sleep_manager_unlock_deep_sleep();
+        // unlock deep sleep only the first time
+        if (_irq[(CanIrqType)type] != callback(donothing)) {
+            sleep_manager_unlock_deep_sleep();
+        }
         _irq[(CanIrqType)type] = callback(donothing);
         can_irq_set(&_can, (CanIrqType)type, 0);
     }

--- a/drivers/CAN.h
+++ b/drivers/CAN.h
@@ -235,7 +235,9 @@ public:
 
     /** Attach a function to call whenever a CAN frame received interrupt is
      *  generated.
-     *
+     *  
+     *  This function locks the deep sleep while a callback is attached
+     *  
      *  @param func A pointer to a void function, or 0 to set as none
      *  @param type Which CAN interrupt to attach the member function to (CAN::RxIrq for message received, CAN::TxIrq for transmitted or aborted, CAN::EwIrq for error warning, CAN::DoIrq for data overrun, CAN::WuIrq for wake-up, CAN::EpIrq for error passive, CAN::AlIrq for arbitration lost, CAN::BeIrq for bus error)
      */

--- a/drivers/I2C.cpp
+++ b/drivers/I2C.cpp
@@ -129,11 +129,11 @@ void I2C::unlock() {
 int I2C::transfer(int address, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, const event_callback_t& callback, int event, bool repeated)
 {
     lock();
-    sleep_manager_lock_deep_sleep();
     if (i2c_active(&_i2c)) {
         unlock();
         return -1; // transaction ongoing
     }
+    sleep_manager_lock_deep_sleep();
     aquire();
 
     _callback = callback;

--- a/drivers/I2C.cpp
+++ b/drivers/I2C.cpp
@@ -17,6 +17,10 @@
 
 #if DEVICE_I2C
 
+#if DEVICE_I2C_ASYNCH
+#include "platform/mbed_sleep.h"
+#endif
+
 namespace mbed {
 
 I2C *I2C::_owner = NULL;
@@ -125,6 +129,7 @@ void I2C::unlock() {
 int I2C::transfer(int address, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, const event_callback_t& callback, int event, bool repeated)
 {
     lock();
+    sleep_manager_lock_deep_sleep();
     if (i2c_active(&_i2c)) {
         unlock();
         return -1; // transaction ongoing
@@ -143,6 +148,7 @@ void I2C::abort_transfer(void)
 {
     lock();
     i2c_abort_asynch(&_i2c);
+    sleep_manager_unlock_deep_sleep();
     unlock();
 }
 
@@ -151,6 +157,9 @@ void I2C::irq_handler_asynch(void)
     int event = i2c_irq_handler_asynch(&_i2c);
     if (_callback && event) {
         _callback.call(event);
+    }
+    if (event) {
+        sleep_manager_unlock_deep_sleep();
     }
 
 }

--- a/drivers/I2C.h
+++ b/drivers/I2C.h
@@ -159,6 +159,8 @@ public:
 
     /** Start non-blocking I2C transfer.
      *
+     * This function locks the deep sleep until any event has occured
+     * 
      * @param address   8/10 bit I2c slave address
      * @param tx_buffer The TX buffer with data to be transfered
      * @param tx_length The length of TX buffer in bytes

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -156,6 +156,8 @@ public:
 
     /** Start non-blocking SPI transfer using 8bit buffers.
      *
+     * This function locks the deep sleep until any event has occured
+     * 
      * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
      *                  the default SPI value is sent
      * @param tx_length The length of TX buffer in bytes

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -84,7 +84,10 @@ void SerialBase::attach(Callback<void()> func, IrqType type) {
         _irq[type] = func;
         serial_irq_set(&_serial, (SerialIrq)type, 1);
     } else {
-        sleep_manager_unlock_deep_sleep();
+        // unlock deep sleep only the first time
+        if (_irq[type] != donothing) {
+            sleep_manager_unlock_deep_sleep();
+        } 
         _irq[type] = donothing;
         serial_irq_set(&_serial, (SerialIrq)type, 0);
     }
@@ -248,6 +251,7 @@ void SerialBase::start_read(void *buffer, int buffer_size, char buffer_width, co
 {
     _rx_callback = callback;
     _thunk_irq.callback(&SerialBase::interrupt_handler_asynch);
+    sleep_manager_lock_deep_sleep();
     serial_rx_asynch(&_serial, buffer, buffer_size, buffer_width, _thunk_irq.entry(), event, char_match, _rx_usage);
 }
 

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -16,17 +16,21 @@
 #include "drivers/SerialBase.h"
 #include "platform/mbed_wait_api.h"
 #include "platform/mbed_critical.h"
+#include "platform/mbed_sleep.h"
 
 #if DEVICE_SERIAL
 
 namespace mbed {
 
 static void donothing() {};
+static void donothing2(int arg) {};
+
 
 SerialBase::SerialBase(PinName tx, PinName rx, int baud) :
 #if DEVICE_SERIAL_ASYNCH
                                                  _thunk_irq(this), _tx_usage(DMA_USAGE_NEVER),
-                                                 _rx_usage(DMA_USAGE_NEVER),
+                                                 _rx_usage(DMA_USAGE_NEVER), _tx_callback(donothing2),
+                                                 _rx_callback(donothing2),
 #endif
                                                 _serial(), _baud(baud) {
     // No lock needed in the constructor
@@ -73,9 +77,11 @@ void SerialBase::attach(Callback<void()> func, IrqType type) {
     // Disable interrupts when attaching interrupt handler
     core_util_critical_section_enter();
     if (func) {
+        sleep_manager_lock_deep_sleep();
         _irq[type] = func;
         serial_irq_set(&_serial, (SerialIrq)type, 1);
     } else {
+        sleep_manager_unlock_deep_sleep();
         _irq[type] = donothing;
         serial_irq_set(&_serial, (SerialIrq)type, 0);
     }
@@ -173,16 +179,27 @@ void SerialBase::start_write(const void *buffer, int buffer_size, char buffer_wi
     _tx_callback = callback;
 
     _thunk_irq.callback(&SerialBase::interrupt_handler_asynch);
+    sleep_manager_lock_deep_sleep();
     serial_tx_asynch(&_serial, buffer, buffer_size, buffer_width, _thunk_irq.entry(), event, _tx_usage);
 }
 
 void SerialBase::abort_write(void)
 {
+    // rx might still be active
+    if (_rx_callback == &donothing2) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    _tx_callback = donothing2;
     serial_tx_abort_asynch(&_serial);
 }
 
 void SerialBase::abort_read(void)
 {
+    // tx might still be active
+    if (_tx_callback == &donothing2) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    _rx_callback = donothing2;
     serial_rx_abort_asynch(&_serial);
 }
 
@@ -235,13 +252,21 @@ void SerialBase::interrupt_handler_asynch(void)
 {
     int event = serial_irq_handler_asynch(&_serial);
     int rx_event = event & SERIAL_EVENT_RX_MASK;
+    bool unlock_deepsleep = false;
+
     if (_rx_callback && rx_event) {
+        unlock_deepsleep = true;
         _rx_callback.call(rx_event);
     }
 
     int tx_event = event & SERIAL_EVENT_TX_MASK;
     if (_tx_callback && tx_event) {
+        unlock_deepsleep = true;
         _tx_callback.call(tx_event);
+    }
+    // unlock if tx or rx events are generated
+    if (unlock_deepsleep) {
+        sleep_manager_unlock_deep_sleep();
     }
 }
 

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -77,7 +77,10 @@ void SerialBase::attach(Callback<void()> func, IrqType type) {
     // Disable interrupts when attaching interrupt handler
     core_util_critical_section_enter();
     if (func) {
-        sleep_manager_lock_deep_sleep();
+        // lock deep sleep only the first time
+        if (_irq[type] == donothing) {
+            sleep_manager_lock_deep_sleep();
+        } 
         _irq[type] = func;
         serial_irq_set(&_serial, (SerialIrq)type, 1);
     } else {

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -167,6 +167,8 @@ public:
 
     /** Begin asynchronous write using 8bit buffer. The completition invokes registered TX event callback
      *
+     *  This function locks the deep sleep until any event has occured
+     * 
      *  @param buffer   The buffer where received data will be stored
      *  @param length   The buffer length in bytes
      *  @param callback The event callback function
@@ -176,6 +178,8 @@ public:
 
     /** Begin asynchronous write using 16bit buffer. The completition invokes registered TX event callback
      *
+     *  This function locks the deep sleep until any event has occured
+     * 
      *  @param buffer   The buffer where received data will be stored
      *  @param length   The buffer length in bytes
      *  @param callback The event callback function
@@ -189,6 +193,8 @@ public:
 
     /** Begin asynchronous reading using 8bit buffer. The completition invokes registred RX event callback.
      *
+     *  This function locks the deep sleep until any event has occured
+     * 
      *  @param buffer     The buffer where received data will be stored
      *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
@@ -199,6 +205,8 @@ public:
 
     /** Begin asynchronous reading using 16bit buffer. The completition invokes registred RX event callback.
      *
+     *  This function locks the deep sleep until any event has occured
+     * 
      *  @param buffer     The buffer where received data will be stored
      *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
@@ -241,10 +249,10 @@ protected:
 
 #if DEVICE_SERIAL_ASYNCH
     CThunk<SerialBase> _thunk_irq;
-    event_callback_t _tx_callback;
-    event_callback_t _rx_callback;
     DMAUsage _tx_usage;
     DMAUsage _rx_usage;
+    event_callback_t _tx_callback;
+    event_callback_t _rx_callback;
 #endif
 
     serial_t         _serial;

--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -26,6 +26,7 @@ void Ticker::detach() {
     core_util_critical_section_enter();
     remove();
     _function = 0;
+    sleep_manager_unlock_deep_sleep();
     core_util_critical_section_exit();
 }
 

--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -25,8 +25,11 @@ namespace mbed {
 void Ticker::detach() {
     core_util_critical_section_enter();
     remove();
+    // unlocked only if we were attached (we locked it)
+    if (_function) {
+        sleep_manager_unlock_deep_sleep();
+    }
     _function = 0;
-    sleep_manager_unlock_deep_sleep();
     core_util_critical_section_exit();
 }
 

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -20,6 +20,7 @@
 #include "platform/Callback.h"
 #include "platform/mbed_toolchain.h"
 #include "platform/NonCopyable.h"
+#include "platform/mbed_sleep.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -103,6 +104,7 @@ public:
      */
     void attach_us(Callback<void()> func, us_timestamp_t t) {
         _function = func;
+        sleep_manager_lock_deep_sleep();
         setup(t);
     }
 

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -64,10 +64,10 @@ namespace mbed {
 class Ticker : public TimerEvent, private NonCopyable<Ticker> {
 
 public:
-    Ticker() : TimerEvent() {
+    Ticker() : TimerEvent(), _function(0) {
     }
 
-    Ticker(const ticker_data_t *data) : TimerEvent(data) {
+    Ticker(const ticker_data_t *data) : TimerEvent(data), _function(0) {
         data->interface->init();
     }
 
@@ -103,8 +103,11 @@ public:
      *  @param t the time between calls in micro-seconds
      */
     void attach_us(Callback<void()> func, us_timestamp_t t) {
+        // lock only for the initial callback setup
+        if (!_function) {
+            sleep_manager_lock_deep_sleep();
+        }
         _function = func;
-        sleep_manager_lock_deep_sleep();
         setup(t);
     }
 

--- a/drivers/Timeout.h
+++ b/drivers/Timeout.h
@@ -18,6 +18,7 @@
 
 #include "drivers/Ticker.h"
 #include "platform/NonCopyable.h"
+#include "platform/mbed_sleep.h"
 
 namespace mbed {
 /** \addtogroup drivers */

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -31,6 +31,7 @@ Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker
 void Timer::start() {
     core_util_critical_section_enter();
     if (!_running) {
+        sleep_manager_lock_deep_sleep();
         _start = ticker_read_us(_ticker_data);
         _running = 1;
     }
@@ -41,6 +42,7 @@ void Timer::stop() {
     core_util_critical_section_enter();
     _time += slicetime();
     _running = 0;
+    sleep_manager_unlock_deep_sleep();
     core_util_critical_section_exit();
 }
 

--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -41,8 +41,10 @@ void Timer::start() {
 void Timer::stop() {
     core_util_critical_section_enter();
     _time += slicetime();
+    if (_running) {
+        sleep_manager_unlock_deep_sleep();
+    }
     _running = 0;
-    sleep_manager_unlock_deep_sleep();
     core_util_critical_section_exit();
 }
 

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -19,6 +19,7 @@
 #include "platform/platform.h"
 #include "hal/ticker_api.h"
 #include "platform/NonCopyable.h"
+#include "platform/mbed_sleep.h"
 
 namespace mbed {
 /** \addtogroup drivers */

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -68,4 +68,25 @@ void sleep_manager_sleep_auto(void)
     core_util_critical_section_exit();
 }
 
+#else
+
+// locking is valid only if DEVICE_SLEEP is defined
+// we provide empty implementation
+
+void sleep_manager_lock_deep_sleep(void)
+{
+
+}
+
+void sleep_manager_unlock_deep_sleep(void)
+{
+
+}
+
+bool sleep_manager_can_deep_sleep(void)
+{
+    // no sleep implemented
+    return false;
+}
+
 #endif

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -1,0 +1,71 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed_sleep.h"
+#include "mbed_critical.h"
+#include "sleep_api.h"
+#include "mbed_error.h"
+#include <limits.h>
+
+#if DEVICE_SLEEP
+
+// deep sleep locking counter. A target is allowed to deep sleep if counter == 0
+static uint16_t deep_sleep_lock = 0U;
+
+void sleep_manager_lock_deep_sleep(void)
+{
+    core_util_critical_section_enter();
+    if (deep_sleep_lock == USHRT_MAX) {
+        core_util_critical_section_exit();
+        error("Deep sleep lock would overflow (> USHRT_MAX)");
+    }
+    core_util_atomic_incr_u16(&deep_sleep_lock, 1);
+    core_util_critical_section_exit();
+}
+
+void sleep_manager_unlock_deep_sleep(void)
+{
+    core_util_critical_section_enter();
+    if (deep_sleep_lock == 0) {
+        core_util_critical_section_exit();
+        error("Deep sleep lock would underflow (< 0)");
+    }
+    core_util_atomic_decr_u16(&deep_sleep_lock, 1);
+    core_util_critical_section_exit();
+}
+
+bool sleep_manager_can_deep_sleep(void)
+{
+    return deep_sleep_lock == 0 ? true : false;
+}
+
+void sleep_manager_sleep_auto(void)
+{
+    core_util_critical_section_enter();
+// debug profile should keep debuggers attached, no deep sleep allowed
+#ifdef MBED_DEBUG
+    hal_sleep();
+#else
+    if (sleep_manager_can_deep_sleep()) {
+        hal_deepsleep();
+    } else {
+        hal_sleep();
+    }
+#endif
+    core_util_critical_section_exit();
+}
+
+#endif

--- a/mbed.h
+++ b/mbed.h
@@ -90,6 +90,7 @@
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
 #include "platform/CriticalSectionLock.h"
+#include "platform/DeepSleepLock.h"
 
 // mbed Non-hardware components
 #include "platform/Callback.h"

--- a/platform/DeepSleepLock.h
+++ b/platform/DeepSleepLock.h
@@ -1,0 +1,67 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEEPSLEEPLOCK_H
+#define MBED_DEEPSLEEPLOCK_H
+
+#include "platform/mbed_sleep.h"
+
+namespace mbed {
+
+
+/** RAII object for disabling, then restoring the deep sleep mode
+  * Usage:
+  * @code
+  *
+  * void f() {
+  *     // some code here
+  *     {
+  *         DeepSleepLock lock;
+  *         // Code in this block will run with the deep sleep mode locked
+  *     }
+  *     // deep sleep mode will be restored to their previous state
+  * }
+  * @endcode
+  */
+class DeepSleepLock {
+public:
+    DeepSleepLock()
+    {
+        sleep_manager_lock_deep_sleep();
+    }
+
+    ~DeepSleepLock()
+    {
+        sleep_manager_unlock_deep_sleep();
+    }
+
+    /** Mark the start of a locked deep sleep section
+     */
+    void lock()
+    {
+        sleep_manager_lock_deep_sleep();
+    }
+
+    /** Mark the end of a locked deep sleep section
+     */
+    void unlock()
+    {
+        sleep_manager_unlock_deep_sleep();
+    }
+};
+
+}
+
+#endif

--- a/platform/mbed_sleep.h
+++ b/platform/mbed_sleep.h
@@ -20,10 +20,86 @@
 #define MBED_SLEEP_H
 
 #include "sleep_api.h"
+#include "mbed_toolchain.h"
+#include <stdbool.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/** Sleep manager API
+ * The sleep manager provides API to automatically select sleep mode.
+ *
+ * There are two sleep modes:
+ * - sleep
+ * - deepsleep
+ *
+ * Use locking/unlocking deepsleep for drivers that depend on features that
+ * are not allowed (=disabled) during the deepsleep. For instance, high frequency
+ * clocks.
+ *
+ * Example:
+ * @code
+ *
+ * void driver::handler()
+ * {
+ *     if (_sensor.get_event()) {
+ *         // any event - we are finished, unlock the deepsleep
+ *         sleep_manager_unlock_deep_sleep();
+ *         _callback();
+ *     }
+ * }
+ *
+ * int driver::measure(event_t event, callback_t& callback)
+ * {
+ *      _callback = callback;
+ *      sleep_manager_lock_deep_sleep();
+ *      // start async transaction, we are waiting for an event
+ *      return _sensor.start(event, callback);
+ * }
+ * @endcode
+ */
+
+/** Lock the deep sleep mode
+ *
+ * This locks the automatic deep mode selection. 
+ * sleep_manager_sleep_auto() will ignore deepsleep mode if
+ * this function is invoked at least once (the internal counter is non-zero)
+ *
+ * Use this locking mechanism for interrupt driven API that are
+ * running in the background and deepsleep could affect their functionality
+ * 
+ * The lock is a counter, can be locked up to USHRT_MAX
+ * This function is IRQ and thread safe
+ */
+void sleep_manager_lock_deep_sleep(void);
+
+/** Unlock the deep sleep mode
+ *
+ * Use unlocking in pair with sleep_manager_lock_deep_sleep(). 
+ * 
+ * The lock is a counter, should be equally unlocked as locked
+ * This function is IRQ and thread safe
+ */
+void sleep_manager_unlock_deep_sleep(void);
+
+/** Get the status of deep sleep allowance for a target
+ *
+ * @return true if a target can go to deepsleep, false otherwise
+ */
+bool sleep_manager_can_deep_sleep(void);
+
+/** Enter auto selected sleep mode. It chooses the sleep or deeepsleep modes based
+ *  on the deepsleep locking counter
+ *
+ * This function is IRQ and thread safe
+ *
+ * @note
+ * If MBED_DEBUG is defined, only hal_sleep is allowed. This ensures the debugger
+ * to be active for debug modes.
+ * 
+ */
+void sleep_manager_sleep_auto(void);
 
 /** Send the microcontroller to sleep
  *
@@ -46,11 +122,9 @@ extern "C" {
 __INLINE static void sleep(void)
 {
 #if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
-#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
-    hal_sleep();
+    sleep_manager_sleep_auto();
 #endif /* DEVICE_SLEEP */
-#endif /* MBED_DEBUG */
 #endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 
@@ -60,7 +134,7 @@ __INLINE static void sleep(void)
  * @note This function will be a noop in debug mode (debug build profile when MBED_DEBUG is defined)
  * @note This function will be a noop while uVisor is in use.
  *
- * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
+ * This processor is setup ready for deep sleep, and sent to sleep. This mode
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
  * is still maintained.
  *
@@ -71,14 +145,14 @@ __INLINE static void sleep(void)
  * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
  * able to access the LocalFileSystem
  */
+
+MBED_DEPRECATED_SINCE("mbed-os-5.6", "One entry point for an application, use sleep()")
 __INLINE static void deepsleep(void)
 {
 #if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
-#ifndef MBED_DEBUG
 #if DEVICE_SLEEP
-    hal_deepsleep();
+    sleep_manager_sleep_auto();
 #endif /* DEVICE_SLEEP */
-#endif /* MBED_DEBUG */
 #endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 }
 

--- a/rtos/rtos_idle.c
+++ b/rtos/rtos_idle.c
@@ -22,14 +22,16 @@
 
 #include "rtos/rtos_idle.h"
 #include "platform/mbed_sleep.h"
+#include "mbed_critical.h"
 
 static void default_idle_hook(void)
 {
-    /* Sleep: ideally, we should put the chip to sleep.
-       Unfortunately, this usually requires disconnecting the interface chip (debugger).
-       This can be done, but it would break the local file system.
-    */
+    // critical section to complete sleep with locked deepsleep
+    core_util_critical_section_enter();
+    sleep_manager_lock_deep_sleep();
     sleep();
+    sleep_manager_unlock_deep_sleep();
+    core_util_critical_section_exit();
 }
 static void (*idle_hook_fptr)(void) = &default_idle_hook;
 


### PR DESCRIPTION
This goes to feature-hal-spec, based on the sleep manager work that is here #4882 . Review only the last commit (at the moment SHA 34f9f43). This goes to `feature-hal-spec` branch = work in progress

To move further with sleep, I am sending this early to get feedback.

The goal is to have deepsleep locks for those drivers that depend on high speed clocks (it can be that some drivers for a target might support deep sleep but this is not usual, plus speed is limited often).

@bulislaw @c1728p9 @pan- 

