### PR TITLE
Update gcc-arm-embedded PPA in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - python tools/project.py -S
   - python tools/build_travis.py
 before_install:
-  - sudo add-apt-repository -y ppa:terry.guo/gcc-arm-embedded
+  - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
   - sudo add-apt-repository -y ppa:libreoffice/libreoffice-4-2
   - sudo apt-get update -qq
   - sudo apt-get install -qq gcc-arm-none-eabi doxygen --force-yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
   - sudo add-apt-repository -y ppa:libreoffice/libreoffice-4-2
   - sudo apt-get update -qq
-  - sudo apt-get install -qq gcc-arm-none-eabi doxygen --force-yes
+  - sudo apt-get install -qq gcc-arm-embedded doxygen --force-yes
   # Print versions we use
   - arm-none-eabi-gcc --version
   - python --version


### PR DESCRIPTION
## Description
`ppa:terry.guo/gcc-arm-embedded` has been [deprecated](https://launchpad.net/gcc-arm-embedded/+announcement/13824) in favor of `ppa:team-gcc-arm-embedded/ppa`

This also means switching from `4.9.3.2015q3` to `6-2017q2`


## Status
**READY**


## Migrations
NO