### PR TITLE
Adjust Stack size Allocation (IAR, LPC176x)

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -12,9 +12,10 @@ define symbol __ICFEDIT_region_RAM_start__   = 0x100000C8;
 define symbol __ICFEDIT_region_RAM_end__     = 0x10007FDF;
 
 /*-Sizes-*/
-/*Heap 1/4 of ram and stack 1/8*/
+/* Heap 7K, Vector table stack about 4K (this is actual stack size in mbed-os 2) */
 define symbol __ICFEDIT_size_cstack__   = 0x1000;
-define symbol __ICFEDIT_size_heap__     = 0x2000;
+define symbol __ICFEDIT_size_heap__     = 0x1C00;
+
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __CRP_start__   = 0x000002FC;


### PR DESCRIPTION
Since mbed-os 5.4.3, something increased foot print of mbed-os and the applications
that were barely fitting in started to spill.

IAR toolchain for LPC176x target family is set to use 2 RAM regions (32K each). RAM region
2 is being used for ETH/USB and 1 is being used for vector table, stack/heap/static data.

In this commit we have decreased heap size allocation from 8K to 7K so that the is more room for static data.