### PR TITLE
STM32F4: Increase ADC sample time for VREF

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -180,11 +180,12 @@ static inline uint16_t adc_read(analogin_t *obj)
             break;
         case 17:
             sConfig.Channel = ADC_CHANNEL_VREFINT;
+            /*  From experiment, measurement needs max sampling time to be valid */
+            sConfig.SamplingTime = ADC_SAMPLETIME_480CYCLES;
             break;
         case 18:
             sConfig.Channel = ADC_CHANNEL_VBAT;
-            /*  From experiment, VBAT measurement needs max
-             *  sampling time to be avlid */
+            /*  From experiment, measurement needs max sampling time to be valid */
             sConfig.SamplingTime = ADC_SAMPLETIME_480CYCLES;
             break;
         default:


### PR DESCRIPTION
## Description

To get a valid VREF measurement on STM32F4 targets, it is required to increase
the sampling time to its maximum value.

Issue reported here:
[https://developer.mbed.org/questions/78792/STM32_ADC_InternalChannels-program-does-/]()

## Status
**READY**

## Migrations
NO

## Related PRs
#4691 

ST_INTERNAL_REF 36013
