### PR TITLE
Fix STM32 CAN reset to not lose context

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -128,6 +128,13 @@ struct dac_s {
 };
 #endif
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -130,7 +130,7 @@ struct dac_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -132,6 +132,7 @@ struct dac_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -116,6 +116,13 @@ struct analogin_s {
     uint8_t channel;
 };
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -118,7 +118,7 @@ struct analogin_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -120,6 +120,7 @@ struct analogin_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -139,6 +139,7 @@ struct pwmout_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 
 #define GPIO_IP_WITHOUT_BRR

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -136,11 +136,13 @@ struct pwmout_s {
     uint8_t inverted;
 };
 
+#ifdef DEVICE_CAN
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
     int hz;
 };
+#endif
 
 #define GPIO_IP_WITHOUT_BRR
 #include "gpio_object.h"

--- a/targets/TARGET_STM/TARGET_STM32F2/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/objects.h
@@ -137,7 +137,7 @@ struct pwmout_s {
 };
 
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/objects.h
@@ -54,13 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-#if defined (DEVICE_CAN)
-struct can_s {
-    CANName can;
-    int index;
-};
-#endif
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -128,6 +128,7 @@ struct analogin_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -124,6 +124,13 @@ struct analogin_s {
     uint8_t channel;
 };
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -126,7 +126,7 @@ struct analogin_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/objects.h
@@ -40,11 +40,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/objects.h
@@ -40,11 +40,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/objects.h
@@ -59,11 +59,6 @@ struct trng_s {
 };
 
 #include "common_objects.h"
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -133,6 +133,13 @@ struct dac_s {
 };
 #endif
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -137,6 +137,7 @@ struct dac_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/common_objects.h
@@ -135,7 +135,7 @@ struct dac_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -132,6 +132,13 @@ struct flash_s {
     uint32_t dummy;
 };
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -134,7 +134,7 @@ struct flash_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/common_objects.h
@@ -136,6 +136,7 @@ struct flash_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/objects.h
@@ -54,11 +54,6 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
-struct can_s {
-    CANName can;
-    int index;
-};
-
 struct trng_s {
     RNG_HandleTypeDef handle;
 };

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -135,6 +135,13 @@ struct dac_s {
 }
 #endif
 
+#if DEVICE_CAN
+struct can_s {
+    CANName can;
+    int index;
+};
+#endif
+
 /* STM32L4 HAL doesn't provide this API called in rtc_api.c */
 #define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__)
 

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -139,6 +139,7 @@ struct dac_s {
 struct can_s {
     CAN_HandleTypeDef CanHandle;
     int index;
+    int hz;
 };
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -137,7 +137,7 @@ struct dac_s {
 
 #if DEVICE_CAN
 struct can_s {
-    CANName can;
+    CAN_HandleTypeDef CanHandle;
     int index;
 };
 #endif

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -211,7 +211,11 @@ int can_frequency(can_t *obj, int f)
             }
         }
         if (status != 0) {
-            can->BTR = btr;
+            /*  Do not erase all BTR registers (e.g. silent mode), only the
+             *  ones calculated in can_speed */
+            can->BTR &= ~(CAN_BTR_TS2 | CAN_BTR_TS1 | CAN_BTR_SJW | CAN_BTR_BRP);
+            can->BTR |= btr;
+
             can->MCR &= ~(uint32_t)CAN_MCR_INRQ;
             /* Get tick */
             tickstart = HAL_GetTick();


### PR DESCRIPTION
## Description
This pull request is a FIX to #4396 
Resolves #4396 
Up to now, can_reset for STM32 was not restoring the registers state as they were before reset,
which seems to be expected from application side. 

## Status
**READY**

## Tests
Tessted by adding a call to can_reset() in the for loop of MBED_A28 CAN loopback test


Test ID | Test Description | Target | Toolchain | Result
-- | -- | -- | -- | --
MBED_A28 | CAN loopback test | NUCLEO_F446RE | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_F103RB | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_F091RC | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_F207ZG | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_L476RG | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_F303ZE | ARM | OK
MBED_A28 | CAN loopback test | NUCLEO_F767ZI | ARM | OK

