### PR TITLE
mbedtls: STM32F439xI: Don't enable AES acceleration by default

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
@@ -20,7 +20,9 @@
 #ifndef MBEDTLS_DEVICE_H
 #define MBEDTLS_DEVICE_H
 
-#define MBEDTLS_AES_ALT
+/* FIXME: Don't enable AES hardware acceleration until issue #4928 is fixed.
+ * (https://github.com/ARMmbed/mbed-os/issues/4928) */
+/* #define MBEDTLS_AES_ALT */
 
 #define MBEDTLS_SHA256_ALT
 


### PR DESCRIPTION
# Critical workaround to issue #4928. This issue blocks releases until either the issue is fixed or this workaround is merged.

STM32F439xI-family AES hardware acceleration occasionally produces
incorrect output (https://github.com/ARMmbed/mbed-os/issues/4928).

Don't enable AES HW acceleration on STM32F439xI-family targets by
default until issue #4928 is fixed.

## Status
**READY for REVIEW as WORKAROUND**
- @adustm to perform initial investigation of #4928 
- If a fix to #4928 is ready before the next patch release, this workaround PR will be discarded.


This is a workaround for issue #4928