### PR TITLE
STM32: fix F410RB vectors size

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_ARM_MICRO/stm32f410xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_ARM_MICRO/stm32f410xb.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 112 vectors = 448 bytes (0x1C0) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C0) (0x8000-0x1C0)  {  ; RW data
+  ; Total: 114 vectors = 456 bytes (0x1C8) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x8000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_ARM_STD/stm32f410xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_ARM_STD/stm32f410xb.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 112 vectors = 448 bytes (0x1C0) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C0) (0x8000-0x1C0)  {  ; RW data
+  ; Total: 114 vectors = 456 bytes (0x1C8) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x8000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 


### PR DESCRIPTION
On F410RB, the size reserved to vectors with ARM toolchain was not properly
defined,which was not the case for other toolchains.

This would cause few tests to fail like EXAMPLE_1 with below error:

HOST: Unknown property: mbed assertation failed: _ptr == (T *)&_data, file: C:/github/mbed/BUILD/mbed/platform/SingletonPtr.h, line 91

## Steps to test or reproduce
EXAMPLE_1 was failed before and is now passed:
```
+--------+---------------------+-----------+-----------+------------------+--------------------+---------------+-------+
| Result | Target              | Toolchain | Test ID   | Test Description | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------------+-----------+-----------+------------------+--------------------+---------------+-------+
| OK     | NUCLEO_F410RB[F61A] | ARM       | EXAMPLE_1 | /dev/null        |        3.39        |       20      |  1/1  |
+--------+---------------------+-----------+-----------+------------------+--------------------+---------------+-------+
```