### PR TITLE
Add support for IAR version 8.x

### DIFF
--- a/TESTS/mbed_drivers/stl_features/main.cpp
+++ b/TESTS/mbed_drivers/stl_features/main.cpp
@@ -26,6 +26,7 @@
 #include <queue>
 #include <map>
 #include <math.h>
+#include <functional>
 
 using namespace utest::v1;
 

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -110,7 +110,7 @@ static bool set_CNMI(ATCmdParser *at)
     // New SMS indication configuration
     // set AT+CMTI=[mode, index] , 0 PDU mode, 1 text mode
     // Multiple URCs for SMS, i.e., CMT, CMTI, UCMT, CBMI, CDSI as DTE could be following any of these SMS formats
-    bool success = at->send("AT+CNMI=2,"CTX) && at->recv("OK");
+    bool success = at->send("AT+CNMI=2,""1") && at->recv("OK");
     return success;
 }
 
@@ -141,7 +141,7 @@ static void CMT_URC(ATCmdParser *at)
 
 static bool set_atd(ATCmdParser *at)
 {
-    bool success = at->send("ATD*99***"CTX"#") && at->recv("CONNECT");
+    bool success = at->send("ATD*99***""1""#") && at->recv("CONNECT");
 
     return success;
 }
@@ -469,7 +469,7 @@ retry_without_dual_stack:
 #endif
     success = _at->send("AT"
                           "+FCLASS=0;" // set to connection (ATD) to data mode
-                          "+CGDCONT="CTX",\"%s\",\"%s%s\"",
+                          "+CGDCONT=""1"",\"%s\",\"%s%s\"",
                           pdp_type, auth, _apn
                          )
                    && _at->recv("OK");

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -110,7 +110,7 @@ static bool set_CNMI(ATCmdParser *at)
     // New SMS indication configuration
     // set AT+CMTI=[mode, index] , 0 PDU mode, 1 text mode
     // Multiple URCs for SMS, i.e., CMT, CMTI, UCMT, CBMI, CDSI as DTE could be following any of these SMS formats
-    bool success = at->send("AT+CNMI=2,""1") && at->recv("OK");
+    bool success = at->send("AT+CNMI=2," CTX) && at->recv("OK");
     return success;
 }
 
@@ -141,7 +141,7 @@ static void CMT_URC(ATCmdParser *at)
 
 static bool set_atd(ATCmdParser *at)
 {
-    bool success = at->send("ATD*99***""1""#") && at->recv("CONNECT");
+    bool success = at->send("ATD*99***" CTX"#") && at->recv("CONNECT");
 
     return success;
 }
@@ -469,7 +469,7 @@ retry_without_dual_stack:
 #endif
     success = _at->send("AT"
                           "+FCLASS=0;" // set to connection (ATD) to data mode
-                          "+CGDCONT=""1"",\"%s\",\"%s%s\"",
+                          "+CGDCONT=" CTX",\"%s\",\"%s%s\"",
                           pdp_type, auth, _apn
                          )
                    && _at->recv("OK");

--- a/features/storage/FEATURE_STORAGE/cfstore/configuration-store/configuration_store.h
+++ b/features/storage/FEATURE_STORAGE/cfstore/configuration-store/configuration_store.h
@@ -189,7 +189,7 @@ typedef struct _ARM_CFSTORE_STATUS {
     }while(0)
 #endif
 
-#if defined __MBED__ && defined TOOLCHAIN_IAR
+#if defined __MBED__ && defined __ICCARM__
 /** @brief  Helper macro to swap 2 handles, which is useful for the Find() idiom. */
 /* note, memory barriers may be required in the following implementation */
 #define CFSTORE_HANDLE_SWAP(__a_HaNdLe, __b_HaNdLe)         \

--- a/features/storage/FEATURE_STORAGE/storage-volume-manager/storage-volume-manager/storage_volume_manager.h
+++ b/features/storage/FEATURE_STORAGE/storage-volume-manager/storage-volume-manager/storage_volume_manager.h
@@ -35,7 +35,7 @@
  * FlashJournal_t. The caller will only allocate a FlashJournal_t and expect the
  * Sequential Strategy to reuse that space for a SequentialFlashJournal_t.
  */
-#ifndef TOOLCHAIN_IAR
+#ifndef __ICCARM__
 typedef char AssertStorageVolumeManagerMaxVolumesIsSane[(((MAX_VOLUMES) > 0) && ((MAX_VOLUMES) <= 8)) ? 0:-1];
 #endif
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -884,6 +884,9 @@ extern "C" WEAK void __iar_file_Mtxinit(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxdst(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxlock(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxunlock(__iar_Rmtx *mutex) {}
+#if (__IAR_SYSTEMS_ICC__ >= 8)
+extern "C" WEAK void *__aeabi_read_tp (void) {}
+#endif
 #elif defined(__CC_ARM)
 // Do nothing
 #elif defined (__GNUC__)

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -843,7 +843,7 @@ std::FILE *mbed_fdopen(FileHandle *fh, const char *mode)
 }
 
 int mbed_getc(std::FILE *_file){
-#if defined (__ICCARM__)
+#if (defined (__ICCARM__) && (__IAR_SYSTEMS_ICC__ < 8) )
     /*This is only valid for unbuffered streams*/
     int res = std::fgetc(_file);
     if (res>=0){
@@ -858,7 +858,7 @@ int mbed_getc(std::FILE *_file){
 }
 
 char* mbed_gets(char*s, int size, std::FILE *_file){
-#if defined (__ICCARM__)
+#if (defined (__ICCARM__) && (__IAR_SYSTEMS_ICC__ < 8))
     /*This is only valid for unbuffered streams*/
     char *str = fgets(s,size,_file);
     if (str!=NULL){

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -843,7 +843,7 @@ std::FILE *mbed_fdopen(FileHandle *fh, const char *mode)
 }
 
 int mbed_getc(std::FILE *_file){
-#if (defined (__ICCARM__) && (__IAR_SYSTEMS_ICC__ < 8) )
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
     /*This is only valid for unbuffered streams*/
     int res = std::fgetc(_file);
     if (res>=0){
@@ -858,7 +858,7 @@ int mbed_getc(std::FILE *_file){
 }
 
 char* mbed_gets(char*s, int size, std::FILE *_file){
-#if (defined (__ICCARM__) && (__IAR_SYSTEMS_ICC__ < 8))
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
     /*This is only valid for unbuffered streams*/
     char *str = fgets(s,size,_file);
     if (str!=NULL){
@@ -884,8 +884,8 @@ extern "C" WEAK void __iar_file_Mtxinit(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxdst(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxlock(__iar_Rmtx *mutex) {}
 extern "C" WEAK void __iar_file_Mtxunlock(__iar_Rmtx *mutex) {}
-#if (__IAR_SYSTEMS_ICC__ >= 8)
-extern "C" WEAK void *__aeabi_read_tp (void) {}
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ >= 8000000)
+extern "C" WEAK void *__aeabi_read_tp (void) { return NULL ;}
 #endif
 #elif defined(__CC_ARM)
 // Do nothing

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -168,7 +168,7 @@
 #include "cmsis_os2.h"
 #include "mbed_toolchain.h"
 #include "mbed_error.h"
-#if (defined(__ICCARM__) && (__IAR_SYSTEMS_ICC__ >= 8) )
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ >= 8000000)
 #include <DLib_Threads.h>
 #endif
 /* Heap limits - only used if set */
@@ -576,7 +576,7 @@ void pre_main(void)
     singleton_mutex_attr.cb_mem = &singleton_mutex_obj;
     singleton_mutex_id = osMutexNew(&singleton_mutex_attr);
 
-#if (__IAR_SYSTEMS_ICC__ >= 8)
+#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ >= 8000000)
     __iar_Initlocks();
 #endif
 

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -168,7 +168,9 @@
 #include "cmsis_os2.h"
 #include "mbed_toolchain.h"
 #include "mbed_error.h"
-
+#if (defined(__ICCARM__) && (__IAR_SYSTEMS_ICC__ >= 8) )
+#include <DLib_Threads.h>
+#endif
 /* Heap limits - only used if set */
 extern unsigned char *mbed_heap_start;
 extern uint32_t mbed_heap_size;

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -554,7 +554,7 @@ void __rtos_env_unlock( struct _reent *_r )
 
 #endif
 
-#if defined(TOOLCHAIN_IAR) /******************** IAR ********************/
+#if defined(__ICCARM__) /******************** IAR ********************/
 
 extern void* __vector_table;
 extern int  __low_level_init(void);

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -576,9 +576,14 @@ void pre_main(void)
     singleton_mutex_attr.cb_mem = &singleton_mutex_obj;
     singleton_mutex_id = osMutexNew(&singleton_mutex_attr);
 
+#if (__IAR_SYSTEMS_ICC__ >= 8)
+    __iar_Initlocks();
+#endif
+
     if (low_level_init_needed) {
         __iar_dynamic_initialization();
     }
+
     mbed_main();
     main();
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.cpp
@@ -217,7 +217,7 @@ emac_interface_t *wlan_emac_init_interface()
 {
 
     if (_emac == NULL) {
-        _emac = new emac_interface_t();
+        _emac = (emac_interface_t*) malloc(sizeof(emac_interface_t));
     	if (_emac == NULL) {//new emac_interface_t fail
         	printf("emac initialization failed\r\n");
 		return NULL;


### PR DESCRIPTION
Added support to IAR 8.x, with the reference of [release document](http://netstorage.iar.com/SuppDB/Public/UPDINFO/012120/arm/doc/infocenter/iccarm.ENU.html)

__aeabi_read_tp - Weak empty function is added to support the build. It should be implemented with TLS support in IAR Dlib.
