### PR TITLE
Fix crashes on boot on some Kinetis devices

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/cmsis_nvic.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/cmsis_nvic.h
@@ -39,7 +39,7 @@ extern uint32_t __VECTOR_RAM[];
 #endif
 
 /* Symbols defined by the linker script */
-#define NVIC_NUM_VECTORS        (16 + 240)        // CORE + MCU Peripherals
+#define NVIC_NUM_VECTORS        (16 + 32)        // CORE + MCU Peripherals
 #define NVIC_RAM_VECTOR_ADDRESS (__VECTOR_RAM)    // Vectors positioned at start of RAM
 
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/cmsis_nvic.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/cmsis_nvic.h
@@ -39,7 +39,7 @@ extern uint32_t __VECTOR_RAM[];
 #endif
 
 /* Symbols defined by the linker script */
-#define NVIC_NUM_VECTORS        (16 + 240)        // CORE + MCU Peripherals
+#define NVIC_NUM_VECTORS        (16 + 32)        // CORE + MCU Peripherals
 #define NVIC_RAM_VECTOR_ADDRESS (__VECTOR_RAM)    // Vectors positioned at start of RAM
 
 #endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/cmsis_nvic.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/cmsis_nvic.h
@@ -39,7 +39,7 @@ extern uint32_t __VECTOR_RAM[];
 #endif
 
 /* Symbols defined by the linker script */
-#define NVIC_NUM_VECTORS        (16 + 240)        // CORE + MCU Peripherals
+#define NVIC_NUM_VECTORS        (16 + 32)        // CORE + MCU Peripherals
 #define NVIC_RAM_VECTOR_ADDRESS (__VECTOR_RAM)    // Vectors positioned at start of RAM
 
 #endif


### PR DESCRIPTION
Fix a crash on boot due to incorrectly size vector count. This patch also reduces the ram vector size for devices which reserved too much space.