### PR TITLE
STM32: F1 GPIO: Enable AFIO clock

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/pin_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/pin_device.h
@@ -37,6 +37,9 @@ extern const uint32_t ll_pin_defines[16];
 
 static inline void stm_pin_DisconnectDebug(PinName pin)
 {
+    // Enable AFIO clock
+    __HAL_RCC_AFIO_CLK_ENABLE();
+
     // Disconnect JTAG-DP + SW-DP signals.
     // Warning: Need to reconnect under reset
     if ((pin == PA_13) || (pin == PA_14)) {


### PR DESCRIPTION
## Description

It is required to enable AFIO clock before using __HAL_AFIO_REMAP_xy
macros, which was missing here. Without clocks enable, the remap
actually doesn't occur. This would possibly cause some PIOs (part of
PB_3, PB_4, PA_13, PA_14, PA_15) to not behave as expected.

In most cases AFIO clock was enabled in stm_pin_SetAFPin function, so
that this bug was not visible. But there were few cases left were
stm_pin_DisconnectDebug would be called first. A typical case was
with GCC_ARM in case a DigitalInOut variable is declared as global.


## Status
**READY**


## Tests
Few MBED2 tests were failing on GCC_ARM/IAR before the fix.
Now: 

Test ID | Test Description | Target | Toolchain | Result
-- | -- | -- | -- | --
MBED_A5 | DigitalIn DigitalOut | NUCLEO_F103RB | ARM | OK
MBED_A5 | DigitalIn DigitalOut | NUCLEO_F103RB | GCC_ARM | OK
MBED_A5 | DigitalIn DigitalOut | NUCLEO_F103RB | IAR | OK
MBED_A5 | DigitalIn DigitalOut | NUCLEO_F103RB | uARM | OK
MBED_A6 | DigitalInOut | NUCLEO_F103RB | ARM | OK
MBED_A6 | DigitalInOut | NUCLEO_F103RB | GCC_ARM | OK
MBED_A6 | DigitalInOut | NUCLEO_F103RB | IAR | OK
MBED_A6 | DigitalInOut | NUCLEO_F103RB | uARM | OK
MBED_A7 | InterruptIn | NUCLEO_F103RB | ARM | OK
MBED_A7 | InterruptIn | NUCLEO_F103RB | GCC_ARM | OK
MBED_A7 | InterruptIn | NUCLEO_F103RB | IAR | OK
MBED_A7 | InterruptIn | NUCLEO_F103RB | uARM | OK



