### PR TITLE
Add implementation for running mbed-client-pal over STM32L4xx platforms

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.c
@@ -404,6 +404,18 @@ uint32_t HAL_GetDEVID(void)
 }
 
 /**
+  * @brief Return the unique device identifier (UID based on 96 bits)
+  * @param UID: pointer to 3 words array.
+  * @retval Device identifier
+  */
+void HAL_GetUID_12Byte(uint32_t *UID)
+{
+    UID[0] = (uint32_t)(READ_REG(*((uint32_t *)UID_BASE)));
+    UID[1] = (uint32_t)(READ_REG(*((uint32_t *)(UID_BASE + 4U))));
+    UID[2] = (uint32_t)(READ_REG(*((uint32_t *)(UID_BASE + 8U))));
+}
+
+/**
   * @brief  Return the first word of the unique device identifier (UID based on 96 bits)
   * @retval Device identifier
   */

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal.h
@@ -582,6 +582,7 @@ void HAL_ResumeTick(void);
 uint32_t HAL_GetHalVersion(void);
 uint32_t HAL_GetREVID(void);
 uint32_t HAL_GetDEVID(void);
+void HAL_GetUID_12Byte(uint32_t *UID);
 uint32_t HAL_GetUIDw0(void);
 uint32_t HAL_GetUIDw1(void);
 uint32_t HAL_GetUIDw2(void);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1349,7 +1349,7 @@
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L476xG", "STM32L476VG"],
         "detect_code": ["0820"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "PAL_USE_HW_ROT=1"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476VG"


### PR DESCRIPTION
@MarceloSalazar 

Add a function reading RoT (a 12byte device unique ID) from the device.

It enables pal to call HAL_GetUID_12Byte(uint32_t *UID).
Reading hardware RoT feature is required and tested using ARMmbed/mbed-cloud-client-example-sources-internal over DISCO_L476VG with esp8266.
