### PR TITLE
UBLOX_EVK_ODIN_W2- add BUTTON1/2 definitions

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
@@ -95,7 +95,7 @@ typedef enum {
     P_A17   = PD_12,  // GPIO-3
     P_A18   = PA_3,   // UART-DSR
     // B
-	  // C
+    // C
     P_C5    = PG_4,   // SPI-IRQ
     P_C6    = PE_13,  // SPI-MISO
     P_C8    = PE_12,  // Res
@@ -153,9 +153,14 @@ typedef enum {
     LED1    = PE_0,   // Red / Mode
     LED2    = PB_6,   // Green / Switch-1
     LED3    = PB_8,   // Blue
-	LED4    = D10,
+    LED4    = D10,
     SW0     = PF_2,   // Switch-0
     SW1     = PB_6,   // Green / Switch-1
+
+    // Standardized button names
+    BUTTON1 = SW0,
+    BUTTON2 = SW1,
+
     // ST-Link
     USBRX   = PA_10,
     USBTX   = PA_9,


### PR DESCRIPTION
UBLOX_ODIN_EVK_W2 is missing the abstract button definitions originally
introduced with PR https://github.com/ARMmbed/mbed-os/pull/4249.

Fix two tab to spaces issues on the go as well.

## Description

Fix abstract buttons for UBLOX_EVK_ODIN_W2.

## Status
**READY**

## Migrations
NO

## Related PRs


# Todos
- [ ] Tests
- [ ] Documentation

Mbed OS generic documentation for board porting would have to list the abstract button definition as a requirement.

## Deploy notes
N/A

## Steps to test or reproduce

Compile a test app which used BUTTON1 or BUTTON2.

