### PR TITLE
Fix ISR powerdown in mbed_application.c

### DIFF
--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -44,12 +44,12 @@ void mbed_start_application(uintptr_t address)
 
 static void powerdown_nvic()
 {
-    int isr_count;
+    int isr_groups_32;
     int i;
     int j;
 
-    isr_count = (SCnSCB->ICTR & SCnSCB_ICTR_INTLINESNUM_Msk) >> SCnSCB_ICTR_INTLINESNUM_Pos;
-    for (i = 0; i < isr_count; i++) {
+    isr_groups_32 = ((SCnSCB->ICTR & SCnSCB_ICTR_INTLINESNUM_Msk) >> SCnSCB_ICTR_INTLINESNUM_Pos) + 1;
+    for (i = 0; i < isr_groups_32; i++) {
         NVIC->ICER[i] = 0xFFFFFFFF;
         NVIC->ICPR[i] = 0xFFFFFFFF;
         for (j = 0; j < 8; j++) {


### PR DESCRIPTION
Fix a calculation error in in powerdown_nvic preventing the last
group of 32 interrupts from getting powered down. The ARMv7m reference
manual states ""the total number of interrupt lines is up
to (32*(INTLINESNUM+1)).".

Also rename isr_count to isr_groups_32 for clarity, since this is
actually the number of 32 interrupt groups.