### PR TITLE
Add dynamic heap support to IAR

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/device/TOOLCHAIN_IAR/BEETLE.icf
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/device/TOOLCHAIN_IAR/BEETLE.icf
@@ -42,7 +42,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_IAR/MPS2.icf
@@ -48,7 +48,7 @@ initialize by copy { readwrite };
 do not initialize  { section .noinit };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 place in ROM_region   { readonly };

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/device/TOOLCHAIN_IAR/MK20D5.icf
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/device/TOOLCHAIN_IAR/MK20D5.icf
@@ -34,7 +34,7 @@ define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_r
 define region FlexRAM_region = mem:[from __region_FlexRAM_start__ to __region_FlexRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
 

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/device/TOOLCHAIN_IAR/MKL05Z4.icf
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/device/TOOLCHAIN_IAR/MKL05Z4.icf
@@ -27,7 +27,7 @@ define region ROM_region = mem:[from __ICFEDIT_region_ROM_start__ to (__FlashCon
 define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_region_RAM_end__] | mem:[from __region_RAM2_start__ to __region_RAM2_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
 

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/device/TOOLCHAIN_IAR/MKL25Z4.icf
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/device/TOOLCHAIN_IAR/MKL25Z4.icf
@@ -27,7 +27,7 @@ define region ROM_region = mem:[from __ICFEDIT_region_ROM_start__ to (__FlashCon
 define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_region_RAM_end__] | mem:[from __region_RAM2_start__ to __region_RAM2_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
 

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/device/TOOLCHAIN_IAR/MKL26Z4.icf
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/device/TOOLCHAIN_IAR/MKL26Z4.icf
@@ -27,7 +27,7 @@ define region ROM_region = mem:[from __ICFEDIT_region_ROM_start__ to (__FlashCon
 define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_region_RAM_end__] | mem:[from __region_RAM2_start__ to __region_RAM2_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
 

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/device/TOOLCHAIN_IAR/MKL46Z4.icf
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/device/TOOLCHAIN_IAR/MKL46Z4.icf
@@ -27,8 +27,7 @@ define region ROM_region = mem:[from __ICFEDIT_region_ROM_start__ to (__FlashCon
 define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_region_RAM_end__] | mem:[from __region_RAM2_start__ to __region_RAM2_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
-
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
 
 initialize by copy { readwrite };

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
@@ -97,7 +97,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_IAR/MK82FN256xxx15.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_IAR/MK82FN256xxx15.icf
@@ -105,7 +105,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_IAR/MKL27Z64xxx4.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_IAR/MKL27Z64xxx4.icf
@@ -97,7 +97,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_IAR/MKL43Z256xxx4.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_IAR/MKL43Z256xxx4.icf
@@ -94,7 +94,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_IAR/MKL82Z128xxx7.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_IAR/MKL82Z128xxx7.icf
@@ -108,7 +108,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_IAR/MKW24D512xxx5.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_IAR/MKW24D512xxx5.icf
@@ -104,7 +104,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_IAR/MKW41Z512xxx4.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_IAR/MKW41Z512xxx4.icf
@@ -92,7 +92,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_IAR/MK22F51212.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_IAR/MK22F51212.icf
@@ -101,7 +101,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_IAR/MK24FN1M0xxx12.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_IAR/MK24FN1M0xxx12.icf
@@ -100,7 +100,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
@@ -109,7 +109,7 @@ define region CSTACK_region = mem:[from m_data_2_end-__size_cstack__+1 to m_data
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8 { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_Maxim/TARGET_MAX32600/device/TOOLCHAIN_IAR/MAX32600.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/device/TOOLCHAIN_IAR/MAX32600.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x0800;
 define symbol __size_heap__   = 0x3000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32610/device/TOOLCHAIN_IAR/MAX32610.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/device/TOOLCHAIN_IAR/MAX32610.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x0800;
 define symbol __size_heap__   = 0x3000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32620/device/TOOLCHAIN_IAR/MAX32620.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/device/TOOLCHAIN_IAR/MAX32620.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x1000;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625MBED/MAX32625.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625MBED/MAX32625.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x5000;
 define symbol __size_heap__   = 0xA000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625NEXPAQ/MAX32625.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/device/TOOLCHAIN_IAR/TARGET_MAX32625NEXPAQ/MAX32625.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x5000;
 define symbol __size_heap__   = 0xA000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Maxim/TARGET_MAX32630/device/TOOLCHAIN_IAR/MAX3263x.icf
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/device/TOOLCHAIN_IAR/MAX3263x.icf
@@ -18,7 +18,7 @@ define region RAM_region      = mem:[from __region_RAM_start__   to __region_RAM
 define symbol __size_cstack__ = 0x5000;
 define symbol __size_heap__   = 0xA000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8    { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
@@ -20,8 +20,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
-
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8    { };
 initialize by copy { readwrite };
 do not initialize  { section .noinit };
 

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
@@ -22,7 +22,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
@@ -23,7 +23,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -23,7 +23,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -23,7 +23,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_IAR/M453.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 64)          { };
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_IAR/M487.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 96)          { };
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 
 initialize by copy { readwrite };

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_SUPPORTED/NUC472_442.icf
@@ -24,7 +24,7 @@ define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFED
 define region XRAM_region  = mem:[from __ICFEDIT_region_XRAM_start__  to __ICFEDIT_region_XRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 142)         { };
 /* Move non-critical libraries to external SRAM while internal SRAM is insufficient. */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_IAR/TARGET_NU_XRAM_UNSUPPORTED/NUC472_442.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region IRAM_region  = mem:[from __ICFEDIT_region_IRAM_start__  to __ICFEDIT_region_IRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 /* NOTE: Vector table base requires to be aligned to the power of vector table size. Give a safe value here. */
 define block IRAMVEC   with alignment = 1024, size = 4 * (16 + 142)         { };
 

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/device/TOOLCHAIN_IAR/TARGET_LPC11U68/LPC11U68.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/device/TOOLCHAIN_IAR/TARGET_LPC11U68/LPC11U68.icf
@@ -33,7 +33,7 @@ define region RAM_USB_region 	= mem:[from __RAM_USB_start__  to __RAM_USB_end__]
 define region CRP_region   		= mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK	with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP   with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP   with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U24_301/LPC11U24.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U24_301/LPC11U24.icf
@@ -28,7 +28,7 @@ define region URAM_region  = mem:[from __URAM_start__  to __URAM_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U24_401/LPC11U24.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U24_401/LPC11U24.icf
@@ -28,7 +28,7 @@ define region URAM_region  = mem:[from __URAM_start__  to __URAM_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U35_401/LPC11U35.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U35_401/LPC11U35.icf
@@ -28,7 +28,7 @@ define region URAM_region  = mem:[from __URAM_start__  to __URAM_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U35_501/LPC11U35.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U35_501/LPC11U35.icf
@@ -32,7 +32,7 @@ define region SRAM1_region = mem:[from __SRAM1_start__ to __SRAM1_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U37_501/LPC11U37.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_LPC11U37_501/LPC11U37.icf
@@ -32,7 +32,7 @@ define region SRAM1_region = mem:[from __SRAM1_start__ to __SRAM1_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_OC_MBUINO/LPC11U24.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/device/TOOLCHAIN_IAR/TARGET_OC_MBUINO/LPC11U24.icf
@@ -28,7 +28,7 @@ define region URAM_region  = mem:[from __URAM_start__  to __URAM_end__];
 define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/device/TOOLCHAIN_IAR/TARGET_LPC11CXX/LPC11C24.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/device/TOOLCHAIN_IAR/TARGET_LPC11CXX/LPC11C24.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/device/TOOLCHAIN_IAR/TARGET_LPC11XX/LPC1114.icf
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/device/TOOLCHAIN_IAR/TARGET_LPC11XX/LPC1114.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC13XX/device/TOOLCHAIN_IAR/LPC1347.icf
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/device/TOOLCHAIN_IAR/LPC1347.icf
@@ -32,7 +32,7 @@ define region USB_PKG_RAM_region = mem:[from __region_USB_PKG_RAM_start__ to __r
 define region RAM1_region  = mem:[from __RAM1_start__ to __RAM1_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_IAR/LPC15xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/device/TOOLCHAIN_IAR/LPC15xx.icf
@@ -25,7 +25,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -32,7 +32,7 @@ define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 define region RAM1_region  = mem:[from __RAM1_start__ to __RAM1_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 
 initialize by copy { readwrite };

--- a/targets/TARGET_NXP/TARGET_LPC408X/device/TOOLCHAIN_IAR/LPC4088.icf
+++ b/targets/TARGET_NXP/TARGET_LPC408X/device/TOOLCHAIN_IAR/LPC4088.icf
@@ -29,7 +29,7 @@ define region CRP_region   = mem:[from __CRP_start__ to __CRP_end__];
 define region RAM1_region  = mem:[from __RAM1_start__ to __RAM1_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC43XX/device/TOOLCHAIN_IAR/LPC43xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/device/TOOLCHAIN_IAR/LPC43xx.icf
@@ -24,7 +24,7 @@ define region AHB_RAM_region = mem:[from _AHB_RAM_start__ to _AHB_RAM_end__];
 define symbol __size_cstack__   = 0x4000;
 define symbol __size_heap__     = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_NXP/TARGET_LPC81X/TARGET_ELEKTOR_COCORICO/device/TOOLCHAIN_IAR/LPC812.icf
+++ b/targets/TARGET_NXP/TARGET_LPC81X/TARGET_ELEKTOR_COCORICO/device/TOOLCHAIN_IAR/LPC812.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/device/TOOLCHAIN_IAR/LPC810.icf
+++ b/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/device/TOOLCHAIN_IAR/LPC810.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/device/TOOLCHAIN_IAR/LPC812.icf
+++ b/targets/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/device/TOOLCHAIN_IAR/LPC812.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/device/TOOLCHAIN_IAR/LPC824.icf
+++ b/targets/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/device/TOOLCHAIN_IAR/LPC824.icf
@@ -24,7 +24,7 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define region CRP_region   = mem:[from  __CRP_start__ to __CRP_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/TOOLCHAIN_IAR/LPC54114J256_cm4.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/TOOLCHAIN_IAR/LPC54114J256_cm4.icf
@@ -110,7 +110,7 @@ define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_in
 define region rpmsg_sh_mem_region     = mem:[from rpmsg_sh_mem_start to rpmsg_sh_mem_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/device/TOOLCHAIN_IAR/LPC54618J512.icf
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/device/TOOLCHAIN_IAR/LPC54618J512.icf
@@ -93,7 +93,7 @@ define region CSTACK_region = mem:[from m_data_end-__size_cstack__+1 to m_data_e
 define region m_interrupts_ram_region = mem:[from m_interrupts_ram_start to m_interrupts_ram_end];
 
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block RW        { readwrite };
 define block ZI        { zi };
 

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/device/TOOLCHAIN_IAR/NCS36510.icf
@@ -53,7 +53,7 @@ define overlay MIBOVERLAY { section MIBSTARTSECTION };
 define overlay MIBOVERLAY { section MIBSECTION };
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 define block RAM_VECTORS  with alignment = 8, size = 0x90     { };
 
 initialize by copy { readwrite };

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/TOOLCHAIN_IAR/MBRZA1H.icf
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/TOOLCHAIN_IAR/MBRZA1H.icf
@@ -45,7 +45,7 @@ define block IRQ_STACK with alignment = 8, size = __ICFEDIT_size_irqstack__ { };
 define block FIQ_STACK with alignment = 8, size = __ICFEDIT_size_fiqstack__ { };
 define block UND_STACK with alignment = 8, size = __ICFEDIT_size_undstack__ { };
 define block ABT_STACK with alignment = 8, size = __ICFEDIT_size_abtstack__ { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/device/TOOLCHAIN_IAR/VKRZA1H.icf
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/device/TOOLCHAIN_IAR/VKRZA1H.icf
@@ -47,7 +47,7 @@ define block IRQ_STACK with alignment = 8, size = __ICFEDIT_size_irqstack__ { };
 define block FIQ_STACK with alignment = 8, size = __ICFEDIT_size_fiqstack__ { };
 define block UND_STACK with alignment = 8, size = __ICFEDIT_size_undstack__ { };
 define block ABT_STACK with alignment = 8, size = __ICFEDIT_size_abtstack__ { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a.icf
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a.icf
@@ -39,7 +39,7 @@ define region BD_RAM_region           = mem:[from __ICFEDIT_region_BD_RAM_start_
 define region SDRAM_RAM_region       = mem:[from __ICFEDIT_region_SDRAM_RAM_start__       to __ICFEDIT_region_SDRAM_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 //initialize by copy { readwrite };
 //initialize by copy with packing = none { section __DLIB_PERTHREAD }; // Required in a multi-threaded application

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_IAR/stm32f030x8.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_IAR/stm32f030x8.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_IAR/stm32f031x6.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_IAR/stm32f031x6.icf
@@ -18,7 +18,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_IAR/stm32f042x6.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_IAR/stm32f042x6.icf
@@ -18,7 +18,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
@@ -18,7 +18,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
@@ -18,7 +18,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_IAR/stm32f091xc.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_IAR/stm32f091xc.icf
@@ -18,7 +18,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_IAR/stm32f103xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_IAR/stm32f103xb.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/TOOLCHAIN_IAR/stm32f302x8.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/TOOLCHAIN_IAR/stm32f302x8.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x800;
 define symbol __size_heap__   = 0x1000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_IAR/stm32f303x8.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_IAR/stm32f303x8.icf
@@ -23,7 +23,7 @@ define region CCMRAM_region = mem:[from __region_CCMRAM_start__ to __region_CCMR
 define symbol __size_cstack__ = 0x600;
 define symbol __size_heap__   = 0xC00;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_IAR/stm32f303xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_IAR/stm32f303xe.icf
@@ -23,7 +23,7 @@ define region CCMRAM_region = mem:[from __region_CCMRAM_start__ to __region_CCMR
 define symbol __size_cstack__ = 0x2000;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/TOOLCHAIN_IAR/stm32f334x8.icf
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/TOOLCHAIN_IAR/stm32f334x8.icf
@@ -22,7 +22,7 @@ define region CCMRAM_region = mem:[from __region_CCMRAM_start__ to __region_CCMR
 define symbol __size_cstack__ = 0x600;
 define symbol __size_heap__   = 0xC00;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/TOOLCHAIN_IAR/stm32f411xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/TOOLCHAIN_IAR/stm32f411xe.icf
@@ -20,7 +20,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0xe68;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/TOOLCHAIN_IAR/stm32f405xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/TOOLCHAIN_IAR/stm32f405xx.icf
@@ -26,7 +26,7 @@ define region RAM_region      = mem:[from __ICFEDIT_region_RAM_start__   to __IC
 define region CCMRAM_region   = mem:[from __ICFEDIT_region_CCMRAM_start__   to __ICFEDIT_region_CCMRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_IAR/stm32f411xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_IAR/stm32f411xe.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_IAR/stm32f401xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_IAR/stm32f401xe.icf
@@ -21,7 +21,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_IAR/stm32f410xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_IAR/stm32f410xx.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x1000;
 define symbol __size_heap__   = 0x2000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_IAR/stm32f411xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_IAR/stm32f411xe.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
@@ -21,7 +21,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_IAR/stm32f429xx_flash.icf
@@ -27,7 +27,7 @@ define region RAM_region      = mem:[from __ICFEDIT_region_RAM_start__   to __IC
 define region CCMRAM_region   = mem:[from __ICFEDIT_region_CCMRAM_start__   to __ICFEDIT_region_CCMRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_IAR/stm32f437xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_IAR/stm32f437xx.icf
@@ -30,7 +30,7 @@ define region CCMRAM_region   = mem:[from __ICFEDIT_region_CCMRAM_start__ to __I
 define region BKPSRAM_region  = mem:[from __ICFEDIT_region_BKPSRAM_start__ to __ICFEDIT_region_BKPSRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
@@ -27,7 +27,7 @@ define region RAM_region      = mem:[from __ICFEDIT_region_RAM_start__   to __IC
 define region CCMRAM_region   = mem:[from __ICFEDIT_region_CCMRAM_start__   to __ICFEDIT_region_CCMRAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_IAR/stm32f446xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_IAR/stm32f446xx.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x8000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
@@ -23,7 +23,7 @@ define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_IT
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x13000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_IAR/stm32f756xg.icf
@@ -22,7 +22,7 @@ define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_IT
 define symbol __size_cstack__ = 0x4000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
@@ -22,7 +22,7 @@ define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_IT
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_IAR/stm32f769xi.icf
@@ -22,7 +22,7 @@ define region ITCMRAM_region = mem:[from __region_ITCMRAM_start__ to __region_IT
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_IAR/stm32l072xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_IAR/stm32l072xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x500;
 define symbol __size_heap__   = 0x1000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_IAR/stm32l031xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_IAR/stm32l031xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x400;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_IAR/stm32l073xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_IAR/stm32l073xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x500;
 define symbol __size_heap__   = 0x1000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/device/TOOLCHAIN_IAR/stm32l053xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/device/TOOLCHAIN_IAR/stm32l053xx.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x400;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/stm32l152xc.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/stm32l152xc.icf
@@ -18,7 +18,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x800;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/stm32l152xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/stm32l152xe.icf
@@ -19,7 +19,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x2800;
 define symbol __size_heap__   = 0x5000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/stm32l152xc.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/stm32l152xc.icf
@@ -20,7 +20,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 define symbol __size_cstack__ = 0x800;
 define symbol __size_heap__   = 0x800;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
@@ -18,7 +18,7 @@ define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_
 define symbol __size_cstack__ = 0x2000;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -25,7 +25,7 @@ define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0xa000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -25,7 +25,7 @@ define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0xa000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
@@ -22,7 +22,7 @@ define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_
 define symbol __size_cstack__ = 0x8000;
 define symbol __size_heap__   = 0xa000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
-define block HEAP      with alignment = 8, size = __size_heap__     { };
+define block HEAP      with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/device/TARGET_1024K/TOOLCHAIN_IAR/efm32gg990f1024.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/device/TARGET_1024K/TOOLCHAIN_IAR/efm32gg990f1024.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/device/TARGET_64K/TOOLCHAIN_IAR/efm32hg322f64.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/device/TARGET_64K/TOOLCHAIN_IAR/efm32hg322f64.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/device/TARGET_256K/TOOLCHAIN_IAR/efm32lg990f256.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/device/TARGET_256K/TOOLCHAIN_IAR/efm32lg990f256.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/device/TARGET_256K/TOOLCHAIN_IAR/efm32pg1b200f256.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/device/TARGET_256K/TOOLCHAIN_IAR/efm32pg1b200f256.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_IAR/EFM32PG12B500F1024GL125.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_IAR/EFM32PG12B500F1024GL125.icf
@@ -30,7 +30,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/device/TARGET_256K/TOOLCHAIN_IAR/efm32wg990f256.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/device/TARGET_256K/TOOLCHAIN_IAR/efm32wg990f256.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/device/TARGET_32K/TOOLCHAIN_IAR/efm32zg222f32.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/device/TARGET_32K/TOOLCHAIN_IAR/efm32zg222f32.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_IAR/efr32mg1p232f256mg48.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_IAR/efr32mg1p232f256mg48.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_IAR/efr32mg12p332f1024gl125.icf
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_IAR/efr32mg12p332f1024gl125.icf
@@ -25,7 +25,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_IAR/tmpm066fwug.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_IAR/tmpm066fwug.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500ECO/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500ECO/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500P/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500P/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -19,7 +19,7 @@ define region ROM_region   = mem:[from __ICFEDIT_region_ROM_start__   to __ICFED
 define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFEDIT_region_RAM_end__];
 
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
-define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+define block HEAP      with expanding size, minimum size = __ICFEDIT_size_heap__, alignment = 8     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };

--- a/targets/TARGET_ublox/TARGET_HI2110/device/TOOLCHAIN_IAR/hi2110.icf
+++ b/targets/TARGET_ublox/TARGET_HI2110/device/TOOLCHAIN_IAR/hi2110.icf
@@ -41,7 +41,7 @@ define region CSTACK_region  = mem:[from __region_CSTACK_start__ to __region_CST
 define region IPC_region     = mem:[from __region_IPC_start__ to __region_IPC_end__];
 
 define block CSTACK     with alignment = 8, size = __size_cstack__     { };
-define block HEAP       with alignment = 8, size = __size_heap__       { };
+define block HEAP       with expanding size, minimum size = __size_heap__, alignment = 8     { };
 define block RW         { readwrite };
 define block ZI         { zi };
 


### PR DESCRIPTION
Two new block properties available in linker configuration files:
"expanding size" and "minimum size" for IAR 8.11.2 and above

Sample:
define block HEAP with expanding size, minimum size = 16K, alignment = 8 {};

This block will expand to consume all remaining available space in
the range where it is placed. If several such blocks end up in the same
range, they will share the remaining space.
Cannot place a block with expanding size inside another block with
expanding size, inside a block with maximum size, or inside an overlay.

Dependency: IAR 8.11.2