### PR TITLE
Add tickless idle loop

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/idle_loop/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/idle_loop/main.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "rtos.h"
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
+
+#if !DEVICE_LOWPOWERTIMER
+    #error [NOT_SUPPORTED] Low power timer not supported for this target
+#endif
+
+using namespace utest::v1;
+
+void idle_loop_test_sleep_ms_callback(timestamp_t *time_ms)
+{
+    LowPowerTimer timer;
+    timer.start();
+    Thread::wait(*time_ms);
+    const timestamp_t end = timer.read_ms();
+
+    // this does not test accurancy for waking up
+    // just that we are with some margin awake (10ms)
+    // sleep/low power ticker will test this
+    // Note: if this does not work, we wake up with
+    // default freq - 1ms
+    TEST_ASSERT_UINT32_WITHIN(3, *time_ms, end);
+}
+
+template<timestamp_t time_ms>
+void idle_loop_test_sleep_ms()
+{
+    Thread t;
+    timestamp_t delay = time_ms;
+    t.start(callback(idle_loop_test_sleep_ms_callback, &delay));
+
+    Thread::yield();
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) 
+{
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+Case cases[] = {
+    Case("Idle loop - sleep for 10 ms", idle_loop_test_sleep_ms<10>, greentea_failure_handler),
+    Case("Idle loop - sleep for 100 ms", idle_loop_test_sleep_ms<100>, greentea_failure_handler),
+    Case("Idle loop - sleep for 500 ms", idle_loop_test_sleep_ms<500>, greentea_failure_handler),
+    Case("Idle loop - sleep for 1 s", idle_loop_test_sleep_ms<1000>, greentea_failure_handler),
+    Case("Idle loop - sleep for 5 s", idle_loop_test_sleep_ms<5000>, greentea_failure_handler),
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) 
+{
+    GREENTEA_SETUP(25, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() 
+{
+    Harness::run(specification);
+}
+

--- a/TESTS/mbedmicro-rtos-mbed/idle_loop/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/idle_loop/main.cpp
@@ -31,8 +31,10 @@ void idle_loop_test_sleep_ms_callback(timestamp_t *time_ms)
 {
     LowPowerTimer timer;
     timer.start();
+    const uint64_t kernel_tick_start = osKernelGetTickCount();
     Thread::wait(*time_ms);
     const timestamp_t end = timer.read_ms();
+    const uint64_t kernel_tick_end = osKernelGetTickCount();
 
     // this does not test accurancy for waking up
     // just that we are with some margin awake (10ms)
@@ -40,6 +42,8 @@ void idle_loop_test_sleep_ms_callback(timestamp_t *time_ms)
     // Note: if this does not work, we wake up with
     // default freq - 1ms
     TEST_ASSERT_UINT32_WITHIN(3, *time_ms, end);
+    uint64_t kernel_ticks_expected = (uint64_t)*time_ms * osKernelGetTickFreq() * 1000UL;
+    TEST_ASSERT_UINT32_WITHIN(3, kernel_ticks_expected, kernel_tick_end - kernel_tick_start);
 }
 
 template<timestamp_t time_ms>

--- a/rtos/rtos_idle.c
+++ b/rtos/rtos_idle.c
@@ -22,14 +22,50 @@
 
 #include "rtos/rtos_idle.h"
 #include "platform/mbed_sleep.h"
+#include "mbed_critical.h"
+#include "hal/ticker_api.h"
+#include "hal/lp_ticker_api.h"
+#include "cmsis_os2.h"
+#include <limits.h>
+
+static ticker_event_t idle_loop_event;
+
+void idle_loop_handler(uint32_t id)
+{
+    (void)id;
+}
 
 static void default_idle_hook(void)
 {
-    /* Sleep: ideally, we should put the chip to sleep.
-       Unfortunately, this usually requires disconnecting the interface chip (debugger).
-       This can be done, but it would break the local file system.
-    */
+#if DEVICE_LOWPOWERTIMER
+    uint32_t tick_freq = osKernelGetTickFreq();
+    timestamp_t time_in_sleep = 0UL;
+
+    uint32_t ticks_to_sleep = osKernelSuspend();
+    if (ticks_to_sleep) {
+        core_util_critical_section_enter();
+        uint64_t us_to_sleep = ticks_to_sleep * tick_freq; 
+        // Calculate the maximum period we can sleep and stay within
+        uint64_t max_us_sleep = (UINT_MAX / tick_freq) * tick_freq; 
+        if (us_to_sleep > max_us_sleep) {
+            us_to_sleep = max_us_sleep;
+        }
+
+        const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
+        ticker_remove_event(lp_ticker_data, &idle_loop_event);
+        ticker_set_handler(lp_ticker_data, &idle_loop_handler);
+        timestamp_t start_time = lp_ticker_read();
+        ticker_insert_event_us(lp_ticker_data, &idle_loop_event, us_to_sleep, (uint32_t)&idle_loop_event);
+
+        sleep();
+        core_util_critical_section_exit();
+        // calculate how long we slept
+        time_in_sleep = lp_ticker_read() - start_time;
+    }
+    osKernelResume(time_in_sleep / tick_freq);
+#else
     sleep();
+#endif
 }
 static void (*idle_hook_fptr)(void) = &default_idle_hook;
 


### PR DESCRIPTION
Use low power ticker if it is available to suspend kernel and keep ticks. 
I added simple test that just waits and make sure we wake up.

cc @c1728p9 @pan- @bulislaw 