### PR TITLE
platform: add CriticalSectionLock

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -89,6 +89,7 @@
 #include "platform/FileSystemHandle.h"
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
+#include "platform/CriticalSectionLock.h"
 
 // mbed Non-hardware components
 #include "platform/Callback.h"

--- a/platform/CriticalSectionLock.h
+++ b/platform/CriticalSectionLock.h
@@ -1,0 +1,71 @@
+/*
+ * PackageLicenseDeclared: Apache-2.0
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_CRITICALSECTIONLOCK_H
+#define MBED_CRITICALSECTIONLOCK_H
+
+#include "platform/mbed_critical.h"
+
+namespace mbed {
+
+/** RAII object for disabling, then restoring, interrupt state
+  * Usage:
+  * @code
+  *
+  * void f() {
+  *     // some code here
+  *     {
+  *         CriticalSectionLock lock;
+  *         // Code in this block will run with interrupts disabled
+  *     }
+  *     // interrupts will be restored to their previous state
+  * }
+  * @endcode
+  */
+class CriticalSectionLock {
+public:
+    CriticalSectionLock() 
+    {
+        core_util_critical_section_enter();
+    }
+
+    ~CriticalSectionLock() 
+    {
+        core_util_critical_section_exit();
+    }
+
+    /** Mark the start of a critical section
+     *     
+     */
+    void lock()
+    {
+        core_util_critical_section_enter();
+    }
+
+    /** Mark the end of a critical section
+     *     
+     */
+    void unlock()
+    {
+        core_util_critical_section_exit();
+    }
+};
+
+
+} // namespace mbed
+
+#endif


### PR DESCRIPTION
Critical section class RAII addition

I realized we dont have it here, and often used C API. This file is based on the class we used to have in core-util module (same thing, no changes, just different location).

cc @pan- @sg- @c1728p9 @bulislaw 
