### PR TITLE
Add heap stats for IAR

### DIFF
--- a/TESTS/mbed_drivers/stats/main.cpp
+++ b/TESTS/mbed_drivers/stats/main.cpp
@@ -22,7 +22,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-#if !defined(MBED_HEAP_STATS_ENABLED) || !MBED_HEAP_STATS_ENABLED || defined(__ICCARM__)
+#if !defined(MBED_HEAP_STATS_ENABLED)
   #error [NOT_SUPPORTED] test not supported
 #endif
 


### PR DESCRIPTION
Heap stats were not calculated for IAR, since we didn't have mechanism to hook IAR functions.

IAR has internal heap statistic data, which can be enabled and used. Below is the reference link
https://www.iar.com/support/tech-notes/general/iar-dlib-library-heap-usage-statistics/

Only current heap size (with 8 bytes of overhead per malloc) and max heap size is reported. 
Below is the output for simple malloc program allocating and freeing 1000 bytes of memory
  
```
Allocating 1000 bytes
Current heap: 1008
Total heap size: 65536
Freeing 1000 bytes
Current heap after: 0
Total heap size: 65536

```