### PR TITLE
Add bootloader support for NXP FRDM-KW24D

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
@@ -51,14 +51,22 @@
   #define __ram_vector_table_size__    0x00000000
 #endif
 
-#define m_interrupts_start             0x00000000
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
+#define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
-#define m_flash_config_start           0x00000400
+#define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
 
-#define m_text_start                   0x00000410
-#define m_text_size                    0x0007FBF0
+#define m_text_start                   MBED_APP_START + 0x410
+#define m_text_size                    MBED_APP_SIZE - 0x410
 
 #define m_interrupts_ram_start         0x1FFF8000
 #define m_interrupts_ram_size          __ram_vector_table_size__

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_GCC_ARM/MKW24D512xxx5.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_GCC_ARM/MKW24D512xxx5.ld
@@ -58,6 +58,14 @@ __stack_size__ = 0x400;
  * heap and the page heap in uVisor applications. */
 __heap_size__ = 0x4000;
 
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
 HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
@@ -65,9 +73,9 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
-  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
-  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x0007FBF0
+  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
+  m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
+  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
   m_data                (RW)  : ORIGIN = 0x1FFF8000, LENGTH = 0x00008000
   m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00008000
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_IAR/MKW24D512xxx5.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_IAR/MKW24D512xxx5.icf
@@ -48,17 +48,25 @@ define symbol __ram_vector_table__ = 1;
 define symbol __stack_size__=0x2000;
 define symbol __heap_size__=0x4000;
 
+if (!isdefinedsymbol(MBED_APP_START)) {
+    define symbol MBED_APP_START = 0;
+}
+
+if (!isdefinedsymbol(MBED_APP_SIZE)) {
+    define symbol MBED_APP_SIZE = 0x80000;
+}
+
 define symbol __ram_vector_table_size__ =  isdefinedsymbol(__ram_vector_table__) ? 0x00000400 : 0;
 define symbol __ram_vector_table_offset__ =  isdefinedsymbol(__ram_vector_table__) ? 0x000003FF : 0;
 
-define symbol m_interrupts_start       = 0x00000000;
-define symbol m_interrupts_end         = 0x000003FF;
+define symbol m_interrupts_start       = MBED_APP_START;
+define symbol m_interrupts_end         = MBED_APP_START + 0x3FF;
 
-define symbol m_flash_config_start     = 0x00000400;
-define symbol m_flash_config_end       = 0x0000040F;
+define symbol m_flash_config_start     = MBED_APP_START + 0x400;
+define symbol m_flash_config_end       = MBED_APP_START + 0x40F;
 
-define symbol m_text_start             = 0x00000410;
-define symbol m_text_end               = 0x0007FFFF;
+define symbol m_text_start             = MBED_APP_START + 0x410;
+define symbol m_text_end               = MBED_APP_START + MBED_APP_SIZE - 1;
 
 define symbol m_interrupts_ram_start   = 0x1FFF8000;
 define symbol m_interrupts_ram_end     = 0x1FFF8000 + __ram_vector_table_offset__;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -563,9 +563,10 @@
         "macros": ["CPU_MKW24D512VHA5", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0250"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
-        "device_name": "MKW24D512xxx5"
+        "device_name": "MKW24D512xxx5",
+        "bootloader_supported": true
     },
     "KW41Z": {
         "supported_form_factors": ["ARDUINO"],


### PR DESCRIPTION
## Description
Adds support for building the Mbed bootloader for the FRDM-KW24D platform.  The bootloader provides the mechanism to do firmware updates.

## Status
Review

## Related PRs
27 and 217

## Steps to test or reproduce
In bootloader project
mbed compile -m PLATFORM -t TOOLCHAIN
Copy compiled bootloader to FRDM-KW24D
Attach a ci-test-shield with a FAT32 formatted SD card inserted to the FRDM-KW24D
Connect the serial terminal, reset the board, and observer the bootloader initialization

