### PR TITLE
Stm32 spi 3 wires mode support

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_spi.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_spi.c
@@ -655,6 +655,10 @@ HAL_StatusTypeDef HAL_SPI_Transmit(SPI_HandleTypeDef *hspi, uint8_t *pData, uint
     hspi->ErrorCode = HAL_SPI_ERROR_FLAG;
   }
 
+  if (hspi->Init.Direction == SPI_DIRECTION_1LINE) {
+      __HAL_SPI_DISABLE(hspi);
+  }
+
   /* Clear overrun flag in 2 Lines communication mode because received is not read */
   if (hspi->Init.Direction == SPI_DIRECTION_2LINES)
   {

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -75,7 +75,14 @@ void init_spi(spi_t *obj)
         error("Cannot initialize SPI");
     }
 
-    __HAL_SPI_ENABLE(handle);
+    /* In case of standard 4 wires SPI,PI can be kept enabled all time
+     * and SCK will only be generated during the write operations. But in case
+     * of 3 wires, it should be only enabled during rd/wr unitary operations,
+     * which is handled inside STM32 HAL layer.
+     */
+    if (handle->Init.Direction  == SPI_DIRECTION_2LINES) {
+        __HAL_SPI_ENABLE(handle);
+    }
 }
 
 void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -63,6 +63,9 @@
 #   define DEBUG_PRINTF(...) {}
 #endif
 
+/* Consider 10ms as the default timeout for sending/receving 1 byte */
+#define TIMEOUT_1_BYTE 10
+
 void init_spi(spi_t *obj)
 {
     struct spi_s *spiobj = SPI_S(obj);
@@ -367,7 +370,7 @@ int spi_master_write(spi_t *obj, int value)
     SPI_HandleTypeDef *handle = &(spiobj->handle);
 
     if (handle->Init.Direction == SPI_DIRECTION_1LINE) {
-        return HAL_SPI_Transmit(handle, (uint8_t*)&value, 1, 10);
+        return HAL_SPI_Transmit(handle, (uint8_t*)&value, 1, TIMEOUT_1_BYTE);
     }
 
 #if defined(LL_SPI_RX_FIFO_TH_HALF)
@@ -422,13 +425,13 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
     } else {
         /* In case of 1 WIRE only, first handle TX, then Rx */
         if (tx_length != 0) {
-            if (HAL_OK != HAL_SPI_Transmit(handle, (uint8_t*)tx_buffer, tx_length, tx_length*10)) {
+            if (HAL_OK != HAL_SPI_Transmit(handle, (uint8_t*)tx_buffer, tx_length, tx_length*TIMEOUT_1_BYTE)) {
                 /*  report an error */
                 total = 0;
             }
         }
         if (rx_length != 0) {
-            if (HAL_OK != HAL_SPI_Receive(handle, (uint8_t*)rx_buffer, rx_length, rx_length*10)) {
+            if (HAL_OK != HAL_SPI_Receive(handle, (uint8_t*)rx_buffer, rx_length, rx_length*TIMEOUT_1_BYTE)) {
                 /*  report an error */
                 total = 0;
             }

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -445,17 +445,13 @@ int spi_slave_receive(spi_t *obj)
 
 int spi_slave_read(spi_t *obj)
 {
-    SPI_TypeDef *spi = SPI_INST(obj);
     struct spi_s *spiobj = SPI_S(obj);
     SPI_HandleTypeDef *handle = &(spiobj->handle);
     while (!ssp_readable(obj));
-    if (handle->Init.DataSize == SPI_DATASIZE_8BIT) {
-        // Force 8-bit access to the data register
-        uint8_t *p_spi_dr = 0;
-        p_spi_dr = (uint8_t *) & (spi->DR);
-        return (int)(*p_spi_dr);
+    if (handle->Init.DataSize == SPI_DATASIZE_16BIT) {
+        return LL_SPI_ReceiveData16(SPI_INST(obj));
     } else {
-        return (int)spi->DR;
+        return LL_SPI_ReceiveData8(SPI_INST(obj));
     }
 }
 


### PR DESCRIPTION
## Description
This PR contains the required changes for supporting SPI 3-wires mode communication.
This allows to save 1 pin in constrained PCB designs. 

## Status
**READY**

## Tests
This mode has been validated by using a ST Sensor by @mapellil @nikapov-ST 
The SPI standard mode has been tested with tests-api-spi of ci-test-shield suite and has not shown any regression on any of all STM32 target families. 