### PR TITLE
disable -f option for assembly files for IAR

### DIFF
--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -145,15 +145,16 @@ class IAR(mbedToolchain):
 
     def get_compile_options(self, defines, includes, for_asm=False):
         opts = ['-D%s' % d for d in defines]
+        if for_asm :
+            return opts
         if self.RESPONSE_FILES:
             opts += ['-f', self.get_inc_file(includes)]
         else:
             opts += ["-I%s" % i for i in includes]
 
-        if not for_asm:
-            config_header = self.get_config_header()
-            if config_header is not None:
-                opts = opts + self.get_config_option(config_header)
+        config_header = self.get_config_header()
+        if config_header is not None:
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool


### PR DESCRIPTION
This fixes IAR build failure https://github.com/ARMmbed/mbed-os/issues/4879 .
 
