### PR TITLE
bd: Tweaked block device API to fit SD cards and FTLs better

### DIFF
--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -96,6 +96,22 @@ public:
         return 0;
     }
 
+    /** Mark blocks as no longer in use
+     *
+     *  This function provides a hint to the underlying block device that a region of blocks
+     *  is no longer in use and may be erased without side effects. Erase must still be called
+     *  before programming, but trimming allows flash-translation-layers to schedule erases when
+     *  the device is not busy.
+     *
+     *  @param addr     Address of block to mark as unused
+     *  @param size     Size to mark as unused in bytes, must be a multiple of erase block size
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int trim(bd_addr_t addr, bd_size_t size)
+    {
+        return 0;
+    }
+
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes

--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -91,7 +91,10 @@ public:
      *  @param size     Size to erase in bytes, must be a multiple of erase block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size) = 0;
+    virtual int erase(bd_addr_t addr, bd_size_t size)
+    {
+        return 0;
+    }
 
     /** Get the size of a readable block
      *
@@ -111,7 +114,10 @@ public:
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const = 0;
+    virtual bd_size_t get_erase_size() const
+    {
+        return get_program_size();
+    }
 
     /** Get the total size of the underlying device
      *

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -171,7 +171,7 @@
 /  disk_ioctl() function. */
 
 
-#define	_USE_TRIM	0
+#define	_USE_TRIM	1
 /* This option switches ATA-TRIM feature. (0:Disable or 1:Enable)
 /  To enable Trim feature, also CTRL_TRIM command should be implemented to the
 /  disk_ioctl() function. */

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -244,6 +244,15 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
         case GET_BLOCK_SIZE:
             *((DWORD*)buff) = 1; // default when not known
             return RES_OK;
+        case CTRL_TRIM:
+            if (_ffs[pdrv] == NULL) {
+                return RES_NOTRDY;
+            } else {
+                DWORD *sectors = (DWORD*)buff;
+                DWORD ssize = disk_get_sector_size(pdrv);
+                int err = _ffs[pdrv]->trim(sectors[0]*ssize, (sectors[1]-sectors[0]+1)*ssize);
+                return err ? RES_PARERR : RES_OK;
+            }
     }
 
     return RES_PARERR;


### PR DESCRIPTION
The block device API is currently tied very closely to flash devices. This is because flash devices are our primary targets, but it does make porting to other non-flash block devices a bit more confusing than is necessary (this includes SD cards, FTLs, and more ridiculous spinny disks).

These are a few tweaks from offline discussions with @deepikabhavnani that should improve things:
1. Provide default for erase function
   This means the function can simply be omitted from the SD card repo and the block device should behave as expected

2. Add trim function to provide hints for unused blocks
    See https://en.wikipedia.org/wiki/Trim_(computing) for prior art
    This allows a filesystem to hint when blocks are no longer in use, and can allow much better wear leveling performance when an FTL is present, such as in SD cards.

relevant range https://github.com/ARMmbed/mbed-os/compare/626256e...geky:bd-trim-erase
dependent on https://github.com/ARMmbed/mbed-os/pull/4843
related https://github.com/ARMmbed/sd-driver/pull/55
cc @deepikabhavnani, @sg- 