### PR TITLE
add flash iap and bootloader support to K66F

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -52,14 +52,22 @@
   #define __ram_vector_table_size__    0x00000000
 #endif
 
-#define m_interrupts_start             0x00000000
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x200000
+#endif
+
+#define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
-#define m_flash_config_start           0x00000400
+#define m_flash_config_start           MBED_APP_START + 0x400
 #define m_flash_config_size            0x00000010
 
-#define m_text_start                   0x00000410
-#define m_text_size                    0x001FFBF0
+#define m_text_start                   MBED_APP_START + 0x410
+#define m_text_size                    MBED_APP_SIZE - 0x410
 
 #define m_interrupts_ram_start         0x1FFF0000
 #define m_interrupts_ram_size          __ram_vector_table_size__

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_GCC_ARM/MK66FN2M0xxx18.ld
@@ -59,6 +59,14 @@ __stack_size__ = 0x400;
  * heap and the page heap in uVisor applications. */
 __heap_size__ = 0x6000;
 
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x200000
+#endif
+
 HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
@@ -66,9 +74,9 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
-  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
-  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x001FFBF0
+  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
+  m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
+  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
   m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
   m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
@@ -54,7 +54,7 @@ if (!isdefinedsymbol(MBED_APP_START)) {
 }
 
 if (!isdefinedsymbol(MBED_APP_SIZE)) {
-    define symbol MBED_APP_SIZE = 0x100000;
+    define symbol MBED_APP_SIZE = 0x200000;
 }
 
 define symbol __ram_vector_table_size__ =  isdefinedsymbol(__ram_vector_table__) ? 0x00000400 : 0;
@@ -120,4 +120,3 @@ place in DATA_region                        { block ZI };
 place in DATA_region                        { last block HEAP };
 place in CSTACK_region                      { block CSTACK };
 place in m_interrupts_ram_region            { section m_interrupts_ram };
-

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_IAR/MK66FN2M0xxx18.icf
@@ -49,17 +49,25 @@ define symbol __ram_vector_table__ = 1;
 define symbol __stack_size__=0x8000;
 define symbol __heap_size__=0x10000;
 
+if (!isdefinedsymbol(MBED_APP_START)) {
+    define symbol MBED_APP_START = 0;
+}
+
+if (!isdefinedsymbol(MBED_APP_SIZE)) {
+    define symbol MBED_APP_SIZE = 0x100000;
+}
+
 define symbol __ram_vector_table_size__ =  isdefinedsymbol(__ram_vector_table__) ? 0x00000400 : 0;
 define symbol __ram_vector_table_offset__ =  isdefinedsymbol(__ram_vector_table__) ? 0x000003FF : 0;
 
-define symbol m_interrupts_start       = 0x00000000;
-define symbol m_interrupts_end         = 0x000003FF;
+define symbol m_interrupts_start       = MBED_APP_START;
+define symbol m_interrupts_end         = MBED_APP_START + 0x3FF;
 
-define symbol m_flash_config_start     = 0x00000400;
-define symbol m_flash_config_end       = 0x0000040F;
+define symbol m_flash_config_start     = MBED_APP_START + 0x400;
+define symbol m_flash_config_end       = MBED_APP_START + 0x40F;
 
-define symbol m_text_start             = 0x00000410;
-define symbol m_text_end               = 0x001FFFFF;
+define symbol m_text_start             = MBED_APP_START + 0x410;
+define symbol m_text_end               = MBED_APP_START + MBED_APP_SIZE - 1;
 
 define symbol m_interrupts_ram_start   = 0x1FFF0000;
 define symbol m_interrupts_ram_end     = 0x1FFF0000 + __ram_vector_table_offset__;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -649,7 +649,7 @@
         "macros": ["CPU_MK66FN2M0VMD18", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0311"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "MK66FN2M0xxx18"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -652,7 +652,8 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "MK66FN2M0xxx18"
+        "device_name": "MK66FN2M0xxx18",
+        "bootloader_supported": true
     },
     "K82F": {
         "supported_form_factors": ["ARDUINO"],


### PR DESCRIPTION
## Description
Updates the linker files and configuration to enable flash in-application-programming and bootloader support on K66F.  This requires updates to the flash drivers for K66F, which are in a separate PR.  

## Status
Hold until https://github.com/ARMmbed/mbed-os/pull/4982 is merged.   


## Migrations
 NO


## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4982


## Todos
N/A

## Deploy notes
N/A

## Steps to test or reproduce
This was tested with https://github.com/ARMmbed/mbed-os-example-bootloader and was successful.  

cc @mmahadevan108 
