### PR TITLE
Add flush to the BLE UART Service

### DIFF
--- a/features/FEATURE_BLE/ble/services/UARTService.h
+++ b/features/FEATURE_BLE/ble/services/UARTService.h
@@ -141,6 +141,19 @@ public:
     }
 
     /**
+     * Flush sendBuffer, i.e., forcefully write its contents to the UART RX
+     * characteristic even if the buffer is not full.
+     */
+    void flush() {
+        if (ble.getGapState().connected) {
+            if (sendBufferIndex != 0) {
+                ble.gattServer().write(getRXCharacteristicHandle(), static_cast<const uint8_t *>(sendBuffer), sendBufferIndex);
+                sendBufferIndex = 0;
+            }
+        }
+    }
+
+    /**
      * Override for Stream::_putc().
      * @param  c
      *         This function writes the character c, cast to an unsigned char, to stream.


### PR DESCRIPTION
If only buffer-full events and LF characters trigger the flush of
the send buffer then only line-based communication can be
implemented over the BLE UART Service. This patch extends the
service API by adding an explicit `flush` method to force sending
the buffer contents, thus enabling protocols with short (e.g.,
single character) messages.

## Status
**READY**

## Migrations
NO
