### PR TITLE
missing includes for filesystem.cpp (build with VisualGDB fails)

### DIFF
--- a/features/filesystem/FileSystem.cpp
+++ b/features/filesystem/FileSystem.cpp
@@ -15,6 +15,8 @@
  */
 
 #include "mbed.h"
+#include "filesystem/Dir.h"
+#include "filesystem/File.h"
 #include "filesystem/FileSystem.h"
 #include <errno.h>
 


### PR DESCRIPTION
## Description
When building mbed-os with the third-party tool VisualGDB, it fails compiling after an exported project has been imported.

Building the filesystem driver failed because the Managed class was missing two includes (invalid use of incomplete type 'class mbed::Dir' / invalid use of incomplete type 'class mbed::File')

## Status
READY


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Steps to test or reproduce
Take exported package of Online Compiler, import it into VisualGDB and compile it.