### PR TITLE
Add LED color remapping definitions to Odin target

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
@@ -157,6 +157,10 @@ typedef enum {
     SW0     = PF_2,   // Switch-0
     SW1     = PB_6,   // Green / Switch-1
 
+    LED_RED   = LED1,
+    LED_GREEN = LED2,
+    LED_BLUE  = LED3,
+
     // Standardized button names
     BUTTON1 = SW0,
     BUTTON2 = SW1,


### PR DESCRIPTION
Odin target was missing LED_RED/GREEN/BLUE definitions that other client targets used. Adding these definitions removes the need to #ifdef around Odin targets in client source when referencing LEDs.

Majority of whitespace changes were to line up the assignments. Lines 157-159 are the import changes with the addition of:

```c++
LED_RED     = LED1,
LED_GREEN   = LED2,
LED_BLUE    = LED3,
```

CC @mray19027 