### PR TITLE
STM32_us_ticker_16b: keep code to cope with past event

### DIFF
--- a/targets/TARGET_STM/us_ticker_16b.c
+++ b/targets/TARGET_STM/us_ticker_16b.c
@@ -152,6 +152,7 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
      */
     uint32_t current_time = us_ticker_read();
     uint32_t delta = timestamp - current_time;
+    /* Note: The case of delta <= 0 is handled in MBED upper layer */
     oc_int_part = (delta - 1) >> 16;
     if ( ((delta - 1) & 0xFFFF) >= 0x8000 &&
          __HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET ) {
@@ -169,6 +170,9 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 
 void us_ticker_fire_interrupt(void)
 {
+    /* When firing the event, the number of 16 bits counter wrap-ups (oc_int)
+     * must be re-initialized */
+    oc_int_part = 0;
     HAL_TIM_GenerateEvent(&TimMasterHandle, TIM_EVENTSOURCE_CC1);
 }
 


### PR DESCRIPTION
## Description

Fixes test suggested in #5004.

Fixing regression introduced in commit
"Ticker: add fire interrupt now function".

In above mentioned commit, the management of timestamp being in the past
has been moved to higher layer (hal/mbed_ticker_api.c), but the reset of
oc_int was missing when implementing the new us_ticker_fire_interrupt
function - which is fixed now.

## Status
**READY**

## Todos
- [x] Tests