### PR TITLE
MTS targets: Don't use any printf() calls when NDEBUG is defined

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/system_clock.c
@@ -240,6 +240,8 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
+#if !defined(NDEBUG) || NDEBUG == 0
     printf("Hard Fault\n");
+#endif
     NVIC_SystemReset();
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/system_clock.c
@@ -243,6 +243,8 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
+#if !defined(NDEBUG) || NDEBUG == 0
     printf("Hard Fault\n");
+#endif
     NVIC_SystemReset();
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_clock.c
@@ -41,7 +41,7 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x0 /*!< Vector Table base offset field. 
+#define VECT_TAB_OFFSET  0x0 /*!< Vector Table base offset field.
                                   This value must be a multiple of 0x200. */
 
 /* Select the clock sources (other than HSI) to start with (0=OFF, 1=ON) */
@@ -253,7 +253,9 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
+#if !defined(NDEBUG) || NDEBUG == 0
     printf("Hard Fault\n");
+#endif
     NVIC_SystemReset();
 }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/xdot_low_power.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/xdot_low_power.c
@@ -31,6 +31,12 @@
 #include "xdot_low_power.h"
 #include "stdio.h"
 
+#if defined(NDEBUG) && NDEBUG == 1
+#define xdot_lp_debug(...) do {} while(0)
+#else
+#define xdot_lp_debug(...) printf(__VA_ARGS__)
+#endif
+
 static uint32_t portA[6];
 static uint32_t portB[6];
 static uint32_t portC[6];
@@ -230,7 +236,7 @@ void xdot_enter_stop_mode() {
     HSERCC_OscInitStruct.PLL.PLLMUL          = RCC_PLL_MUL4;
     HSERCC_OscInitStruct.PLL.PLLDIV          = RCC_PLL_DIV3;
     if (HAL_RCC_OscConfig(&HSERCC_OscInitStruct) != HAL_OK) {
-        printf("OSC initialization failed - initiating soft reset\r\n");
+        xdot_lp_debug("OSC initialization failed - initiating soft reset\r\n");
         NVIC_SystemReset();
     }
 
@@ -241,7 +247,7 @@ void xdot_enter_stop_mode() {
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
     if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
-        printf("PLL initialization failed - initiating soft reset\r\n");
+        xdot_lp_debug("PLL initialization failed - initiating soft reset\r\n");
         NVIC_SystemReset();
     }
 
@@ -254,7 +260,7 @@ void xdot_enter_stop_mode() {
         HSIRCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
         HAL_StatusTypeDef ret = HAL_RCC_OscConfig(&HSIRCC_OscInitStruct);
         if ( ret != HAL_OK ) {
-            printf("HSI initialization failed - ADC will not function properly\r\n");
+            xdot_lp_debug("HSI initialization failed - ADC will not function properly\r\n");
         }
     }
 


### PR DESCRIPTION
The current behavior prevents linking out `printf()` and friends in release builds. This patch makes blinky on xDot use 15K(!!!!) less flash when compiling release build with GCC_ARM.

/cc @chrissnow This pushes my bootloader for xDot to 22K on GCC, 21K on ARMCC.

@reissjason @sg- 