### PR TITLE
Fix use of AES_ALT on STM32F439 for example-tls-client 

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
@@ -20,9 +20,7 @@
 #ifndef MBEDTLS_DEVICE_H
 #define MBEDTLS_DEVICE_H
 
-/* FIXME: Don't enable AES hardware acceleration until issue #4928 is fixed.
- * (https://github.com/ARMmbed/mbed-os/issues/4928) */
-/* #define MBEDTLS_AES_ALT */
+#define MBEDTLS_AES_ALT
 
 #define MBEDTLS_SHA256_ALT
 

--- a/features/mbedtls/targets/TARGET_STM/aes_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/aes_alt.h
@@ -1,7 +1,7 @@
 /*
  *  aes_alt.h AES block cipher
  *******************************************************************************
- * Copyright (c) 2016, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  *  SPDX-License-Identifier: Apache-2.0
  *
  *  Licensed under the Apache License, Version 2.0 (the "License"); you may
@@ -239,10 +239,12 @@ int mbedtls_aes_crypt_ctr( mbedtls_aes_context *ctx,
  * \param ctx       AES context
  * \param input     Plaintext block
  * \param output    Output (ciphertext) block
+ *
+ * \return          0 if successful
  */
-void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
-                          const unsigned char input[16],
-                          unsigned char output[16] );
+int mbedtls_internal_aes_encrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] );
 
 /**
  * \brief           Internal AES block decryption function
@@ -252,10 +254,49 @@ void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
  * \param ctx       AES context
  * \param input     Ciphertext block
  * \param output    Output (plaintext) block
+ *
+ * \return          0 if successful
  */
-void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
-                          const unsigned char input[16],
-                          unsigned char output[16] );
+int mbedtls_internal_aes_decrypt( mbedtls_aes_context *ctx,
+                                  const unsigned char input[16],
+                                  unsigned char output[16] );
+
+#if !defined(MBEDTLS_DEPRECATED_REMOVED)
+#if defined(MBEDTLS_DEPRECATED_WARNING)
+#define MBEDTLS_DEPRECATED      __attribute__((deprecated))
+#else
+#define MBEDTLS_DEPRECATED
+#endif
+/**
+ * \brief           Deprecated internal AES block encryption function
+ *                  without return value.
+ *
+ * \deprecated      Superseded by mbedtls_aes_encrypt_ext() in 2.5.0
+ *
+ * \param ctx       AES context
+ * \param input     Plaintext block
+ * \param output    Output (ciphertext) block
+ */
+MBEDTLS_DEPRECATED void mbedtls_aes_encrypt( mbedtls_aes_context *ctx,
+                                             const unsigned char input[16],
+                                             unsigned char output[16] );
+
+/**
+ * \brief           Deprecated internal AES block decryption function
+ *                  without return value.
+ *
+ * \deprecated      Superseded by mbedtls_aes_decrypt_ext() in 2.5.0
+ *
+ * \param ctx       AES context
+ * \param input     Ciphertext block
+ * \param output    Output (plaintext) block
+ */
+MBEDTLS_DEPRECATED void mbedtls_aes_decrypt( mbedtls_aes_context *ctx,
+                                             const unsigned char input[16],
+                                             unsigned char output[16] );
+
+#undef MBEDTLS_DEPRECATED
+#endif /* !MBEDTLS_DEPRECATED_REMOVED */
 
 #ifdef __cplusplus
 }

--- a/features/mbedtls/targets/TARGET_STM/aes_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/aes_alt.h
@@ -31,7 +31,8 @@
 extern "C" {
 #endif
 
-#define ST_AES_TIMEOUT    ((uint32_t) 3)
+#define ST_AES_TIMEOUT    ((uint32_t) 0xFF) /* 255 ms timeout for the crypto processor */
+#define ST_ERR_AES_BUSY   (-0x0023)      /* Crypto processor is busy, timeout occured */
 /**
  * \brief          AES context structure
  *
@@ -45,7 +46,6 @@ typedef struct
     unsigned char      aes_key[32]; /* Decryption key */
     CRYP_HandleTypeDef hcryp_aes;
     uint32_t           ctx_save_cr; /* save context for multi-instance */
-    uint32_t           save_iv[4];  /* save context for multi-instance */
 }
 mbedtls_aes_context;
 

--- a/features/mbedtls/targets/TARGET_STM/aes_alt.h
+++ b/features/mbedtls/targets/TARGET_STM/aes_alt.h
@@ -30,6 +30,8 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define ST_AES_TIMEOUT    ((uint32_t) 3)
 /**
  * \brief          AES context structure
  *
@@ -43,6 +45,7 @@ typedef struct
     unsigned char      aes_key[32]; /* Decryption key */
     CRYP_HandleTypeDef hcryp_aes;
     uint32_t           ctx_save_cr; /* save context for multi-instance */
+    uint32_t           save_iv[4];  /* save context for multi-instance */
 }
 mbedtls_aes_context;
 


### PR DESCRIPTION
## Description
tls-client example is calling aes_encrypt with 4 separated instances (ctx), in ECB mode.
There is a moment where we have : 
```
call aes_set_key(ctx3)   <-- here the key of ctx3 is copied in ctx3->key
call aes_encrypt(ctx3)   <-- here ctx3->key is copied in the hardware registers
call aes_set_key(ctx4)   <-- here the key of ctx4 is copied in ctx4->key
call aes_encrypt(ctx4)   <-- here ctx4->key is copied in the hardware registers
call aes_encrypt(ctx3)   <-- PROBLEM: hardware registers still contain the key of ctx4
call aes_encrypt(ctx3)...

```
I have added 
    ctx->hcryp_aes.Phase = HAL_CRYP_PHASE_READY;
in aesecb_encrypt function so that the firmware manages all the time the copy of ctx->key in hardware registers

I have removed the workaround implemented by @patater in #4934 

## Status
**READY**
Resolves #4928 

## Steps to test or reproduce
```
mbed import http://mbed.org/teams/mbed-os-examples/code/mbed-os-example-tls-tls-client
cd mbed-os-example-tls-tls-client
mbed compile -c -m NUCLEO_F439ZI -t GCC_ARM

```Connect the NUCLEO_F439ZI to the computer and plug ethernet wire to a network
Open an hyperterminal
copy ./BUILD/NUCLEO_F439ZI/GCC_ARM/mbed-os-example-tls-tls-client.bin on the platform
```
Without the fix, you will have : 
```
ssl_tls.c:3961: |2| got an alert message, type: [2:20]
ssl_tls.c:3969: |1| is a fatal alert message (msg 20)
ssl_tls.c:3744: |1| mbedtls_ssl_handle_message_type() returned -30592 (-0x7780)
ssl_cli.c:3184: |1| mbedtls_ssl_read_record() returned -30592 (-0x7780)
ssl_tls.c:6354: |2| <= handshake
mbedtls_ssl_handshake() failed: -0x7780 (-30592): SSL - A fatal alert message was received from our peer
```
with the fix you will have : 
```
Starting the TLS handshake...
TLS connection to developer.mbed.org established
... 
Hello world!

```

cc @andresag01 @RonEld @Patater @JanneKiiskila @sg- @RobMeades 