### PR TITLE
Fix an incorrect comment in ticker API

### DIFF
--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -132,8 +132,9 @@ void ticker_insert_event(const ticker_data_t *const ticker, ticker_event_t *obj,
  *
  * The event will be executed in timestamp - ticker_read_us() us.
  *
- * @warning If an event is inserted with a timestamp less than the current
- * timestamp then the event will **not** be inserted.
+ * @note If an event is inserted with a timestamp less than the current
+ * timestamp then the event will be scheduled immediately resulting in
+ * an instant call to event handler.
  *
  * @param ticker    The ticker object.
  * @param obj       The event object to be inserted to the queue


### PR DESCRIPTION
## Description
Fix an incorrect warning on the use of `ticker_insert_event_us` with a `timestamp` from the past. For reference look at:
* [`/hal/mbed_ticker_api.c`](https://github.com/ARMmbed/mbed-os/blob/5bddd881e98101f5c491cccf3367894ecb4e89dd/hal/mbed_ticker_api.c#L120)
* [`/TESTS/mbed_hal/ticker/main.cpp`](https://github.com/ARMmbed/mbed-os/blob/5bddd881e98101f5c491cccf3367894ecb4e89dd/TESTS/mbed_hal/ticker/main.cpp#L941)


## Status
**READY**

@bulislaw @0xc0170 