### PR TITLE
ARMCC - FromELF multiple regions

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -238,7 +238,7 @@ class ARM(mbedToolchain):
     @hook_tool
     def binary(self, resources, elf, bin):
         _, fmt = splitext(bin)
-        bin_arg = {".bin": "--bin", ".hex": "--i32"}[fmt]
+        bin_arg = {".bin": "--bincombined", ".hex": "--i32"}[fmt]
         cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
         cmd = self.hook.get_cmdline_binary(cmd)
         self.cc_verbose("FromELF: %s" % ' '.join(cmd))


### PR DESCRIPTION
## Description
ELF files containing multiple regions were being converted to a folder with each region as a separate file, this caused the build scripts to fail since the .bin was not created.

This was noticed when building LPC1768 with a bootloader as the CRP word is set as a seperate region.
https://github.com/ARMmbed/mbed-os/blob/5bddd881e98101f5c491cccf3367894ecb4e89dd/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/startup_LPC17xx.S#L86

## Status
**READY**


## Migrations

NO


## Related PRs


## Todos

## Deploy notes

## Steps to test or reproduce
Enable bootloader support for LPC1768 and try and build
```
Link: mbed-os-example-bootloader-blinky_application
[DEBUG] Link: C:/Keil_v5/ARM/ARMCC\bin\armlink --via .\BUILD\lpc1768\arm\.link_files.txt
[DEBUG] Return: 0
Elf2Bin: mbed-os-example-bootloader-blinky_application
[DEBUG] FromELF: C:/Keil_v5/ARM/ARMCC\bin\fromelf --bin -o .\BUILD\lpc1768\arm\mbed-os-example-bootloader-blinky_application.bin .\BUILD\lpc1768\arm\mbed-os-example-bootloader-blinky_application.elf
[DEBUG] Return: 1
[DEBUG] Errors: Error: Q0147E: Failed to create Directory .\BUILD\lpc1768\arm\mbed-os-example-bootloader-blinky_application.bin\ER$$.ARM.__at_0x02FC: File exists
[DEBUG] Errors: Finished: 0 information, 0 warning and 1 error messages.
Traceback (most recent call last):
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\make.py", line 296, in <module>
    stats_depth=options.stats_depth)
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\build_api.py", line 544, in build_project
    res, _ = toolchain.link_program(resources, build_path, name + "_application")
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\toolchains\__init__.py", line 1128, in link_program
    self.binary(r, elf, bin)
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\hooks.py", line 51, in wrapper
    res = function(t_self, *args, **kwargs)
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\toolchains\arm.py", line 229, in binary
    self.default_cmd(cmd)
  File "c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\toolchains\__init__.py", line 1152, in default_cmd
    raise ToolException(_stderr)
ToolException: Error: Q0147E: Failed to create Directory .\BUILD\lpc1768\arm\mbed-os-example-bootloader-blinky_application.bin\ER$$.ARM.__at_0x02FC: File exists
Finished: 0 information, 0 warning and 1 error messages.

[mbed] ERROR: "c:\python27\python.exe" returned error code 1.
[mbed] ERROR: Command "c:\python27\python.exe -u c:\Code\Chris\mbed-os-example-bootloader-blinky\mbed-os\tools\make.py -t arm -m lpc1768 --source . --build .\BUILD\lpc1768\arm -v" in "c:\Code\Chris\mbed-os-example-bootloader-blinky"
---
```
![image](https://user-images.githubusercontent.com/3310276/30062135-00c5b6d4-9242-11e7-90d8-aa4c0ac1bdc5.png)

![image](https://user-images.githubusercontent.com/3310276/30062166-16929554-9242-11e7-9c00-79a1d90b1089.png)

