### PR TITLE
STM32: Lock / Unlock flash for each operation

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
@@ -26,17 +26,33 @@
 
 int32_t flash_init(flash_t *obj)
 {
-    /* Unlock the Flash to enable the flash control register access *************/
-    HAL_FLASH_Unlock();
     return 0;
 }
 
 int32_t flash_free(flash_t *obj)
 {
-    /* Lock the Flash to disable the flash control register access (recommended
-     * to protect the FLASH memory against possible unwanted operation) *********/
-    HAL_FLASH_Lock();
     return 0;
+}
+
+static int32_t flash_unlock(void)
+{
+    /* Allow Access to Flash control registers and user Falsh */
+    if (HAL_FLASH_Unlock()) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+static int32_t flash_lock(void)
+{
+    /* Disable the Flash option control register access (recommended to protect
+    the option Bytes against possible unwanted operations) */
+    if (HAL_FLASH_Lock()) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 int32_t flash_erase_sector(flash_t *obj, uint32_t address)
@@ -44,9 +60,14 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
     uint32_t FirstPage = 0;
     uint32_t PAGEError = 0;
     FLASH_EraseInitTypeDef EraseInitStruct;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
 
+        return -1;
+    }
+
+    if (flash_unlock() != HAL_OK) {
         return -1;
     }
 
@@ -65,16 +86,20 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
      DCRST and ICRST bits in the FLASH_CR register. */
 
     if (HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError) != HAL_OK) {
-        return -1;
-    } else {
-        return 0;
+        status = -1;
     }
+
+    flash_lock();
+
+    return status;
+
 }
 
 int32_t flash_program_page(flash_t *obj, uint32_t address,
         const uint8_t *data, uint32_t size)
 {
     uint32_t StartAddress = 0;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return -1;
@@ -85,6 +110,10 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
         return -1;
     }
 
+    if (flash_unlock() != HAL_OK) {
+        return -1;
+    }
+
     /* Program the user Flash area word by word */
     StartAddress = address;
 
@@ -92,7 +121,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
      *  parameters doesn't ensure  */
     if ((uint32_t) data % 4 != 0) {
         volatile uint32_t data32;
-        while (address < (StartAddress + size)) {
+        while ((address < (StartAddress + size)) && (status == 0)) {
             for (uint8_t i =0; i < 4; i++) {
                 *(((uint8_t *) &data32) + i) = *(data + i);
             }
@@ -101,21 +130,23 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
                 address = address + 4;
                 data = data + 4;
             } else {
-                return -1;
+                status = -1;
             }
         }
     } else { /*  case where data is aligned, so let's avoid any copy */
-        while (address < (StartAddress + size)) {
+        while ((address < (StartAddress + size)) && (status == 0)) {
             if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, *((uint32_t*) data)) == HAL_OK) {
                 address = address + 4;
                 data = data + 4;
             } else {
-                return -1;
+                status = -1;
             }
         }
     }
 
-    return 0;
+    flash_lock();
+
+    return status;
 }
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address) {

--- a/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
@@ -26,17 +26,33 @@
 
 int32_t flash_init(flash_t *obj)
 {
-    /* Unlock the Flash to enable the flash control register access *************/
-    HAL_FLASH_Unlock();
     return 0;
 }
 
 int32_t flash_free(flash_t *obj)
 {
-    /* Lock the Flash to disable the flash control register access (recommended
-     * to protect the FLASH memory against possible unwanted operation) *********/
-    HAL_FLASH_Lock();
     return 0;
+}
+
+static int32_t flash_unlock(void)
+{
+    /* Allow Access to Flash control registers and user Falsh */
+    if (HAL_FLASH_Unlock()) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+static int32_t flash_lock(void)
+{
+    /* Disable the Flash option control register access (recommended to protect
+    the option Bytes against possible unwanted operations) */
+    if (HAL_FLASH_Lock()) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 int32_t flash_erase_sector(flash_t *obj, uint32_t address)
@@ -44,9 +60,14 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
     uint32_t FirstPage = 0;
     uint32_t PAGEError = 0;
     FLASH_EraseInitTypeDef EraseInitStruct;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
 
+        return -1;
+    }
+
+    if (flash_unlock() != HAL_OK) {
         return -1;
     }
 
@@ -63,16 +84,20 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
      DCRST and ICRST bits in the FLASH_CR register. */
 
     if (HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError) != HAL_OK) {
-        return -1;
-    } else {
-        return 0;
+        status = -1;
     }
+
+    flash_lock();
+
+    return status;
+
 }
 
 int32_t flash_program_page(flash_t *obj, uint32_t address,
         const uint8_t *data, uint32_t size)
 {
     uint32_t StartAddress = 0;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return -1;
@@ -83,6 +108,10 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
         return -1;
     }
 
+    if (flash_unlock() != HAL_OK) {
+        return -1;
+    }
+
     /* Program the user Flash area word by word */
     StartAddress = address;
 
@@ -90,7 +119,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
      *  parameters doesn't ensure  */
     if ((uint32_t) data % 4 != 0) {
         volatile uint32_t data32;
-        while (address < (StartAddress + size)) {
+        while (address < (StartAddress + size) && (status == 0)) {
             for (uint8_t i =0; i < 4; i++) {
                 *(((uint8_t *) &data32) + i) = *(data + i);
             }
@@ -99,21 +128,23 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
                 address = address + 4;
                 data = data + 4;
             } else {
-                return -1;
+                status = -1;
             }
         }
     } else { /*  case where data is aligned, so let's avoid any copy */
-        while (address < (StartAddress + size)) {
+        while ((address < (StartAddress + size)) && (status == 0)) {
             if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_WORD, address, *((uint32_t*) data)) == HAL_OK) {
                 address = address + 4;
                 data = data + 4;
             } else {
-                return -1;
+                status = -1;
             }
         }
     }
 
-    return 0;
+    flash_lock();
+
+    return status;
 }
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address) 

--- a/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
@@ -80,8 +80,6 @@ static uint32_t GetBank(uint32_t Addr)
  */
 int32_t flash_init(flash_t *obj)
 {
-    /* Unlock the Flash to enable the flash control register access *************/
-    HAL_FLASH_Unlock();
     return 0;
 }
 
@@ -92,10 +90,28 @@ int32_t flash_init(flash_t *obj)
  */
 int32_t flash_free(flash_t *obj)
 {
-    /* Lock the Flash to disable the flash control register access (recommended
-     * to protect the FLASH memory against possible unwanted operation) *********/
-    HAL_FLASH_Lock();
     return 0;
+}
+
+static int32_t flash_unlock(void)
+{
+    /* Allow Access to Flash control registers and user Falsh */
+    if (HAL_FLASH_Unlock()) {
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
+static int32_t flash_lock(void)
+{
+    /* Disable the Flash option control register access (recommended to protect
+    the option Bytes against possible unwanted operations) */
+    if (HAL_FLASH_Lock()) {
+        return -1;
+    } else {
+        return 0;
+    }
 }
 
 /** Erase one sector starting at defined address
@@ -110,9 +126,14 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
     uint32_t FirstPage = 0, BankNumber = 0;
     uint32_t PAGEError = 0;
     FLASH_EraseInitTypeDef EraseInitStruct;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
 
+        return -1;
+    }
+
+    if (flash_unlock() != HAL_OK) {
         return -1;
     }
 
@@ -135,10 +156,12 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
      DCRST and ICRST bits in the FLASH_CR register. */
 
     if (HAL_FLASHEx_Erase(&EraseInitStruct, &PAGEError) != HAL_OK) {
-        return -1;
-    } else {
-        return 0;
+        status = -1;
     }
+
+    flash_lock();
+
+    return status;
 }
 
 /** Program one page starting at defined address
@@ -156,6 +179,7 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
         const uint8_t *data, uint32_t size)
 {
     uint32_t StartAddress = 0;
+    int32_t status = 0;
 
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return -1;
@@ -166,6 +190,10 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
         return -1;
     }
 
+    if (flash_unlock() != HAL_OK) {
+        return -1;
+    }
+
     /* Program the user Flash area word by word */
     StartAddress = address;
 
@@ -173,34 +201,39 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
      *  parameters doesn't ensure  */
     if ((uint32_t) data % 4 != 0) {
         volatile uint64_t data64;
-        while (address < (StartAddress + size)) {
+        while ((address < (StartAddress + size)) && (status == 0)) {
             for (uint8_t i =0; i < 8; i++) {
                 *(((uint8_t *) &data64) + i) = *(data + i);
             }
 
-            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data64) == HAL_OK) {
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, data64)
+                    == HAL_OK) {
                 address = address + 8;
                 data = data + 8;
             } else {
-                return -1;
+                status = -1;
             }
         }
     } else { /*  case where data is aligned, so let's avoid any copy */
-        while (address < (StartAddress + size)) {
-            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address, *((uint64_t*) data)) == HAL_OK) {
+        while ((address < (StartAddress + size)) && (status == 0)) {
+            if (HAL_FLASH_Program(FLASH_TYPEPROGRAM_DOUBLEWORD, address,
+                        *((uint64_t*) data))
+                    == HAL_OK) {
                 address = address + 8;
                 data = data + 8;
             } else {
-                return -1;
+                status = -1;
             }
         }
     }
 
-    return 0;
+    flash_lock();
+
+    return status;
 }
 
 /** Get sector size
- * 
+ *
  * @param obj The flash object
  * @param address The sector starting address
  * @return The size of a sector


### PR DESCRIPTION
## Description

Rather than Unlocking flash during flash object creation, and leaving
the flash possibly continuously unlocked a(s object might bever be freed),
we decide to Unlock then Lock again at each erase or program call.

This solves issue #4967 

## Status
**READY**

## TESTS

- [x] L0 
```
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_drivers-flashiap | OK     | 80.59              | shell       |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-flash        | OK     | 79.9               | shell       |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
```
- [x] L1 
```
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_drivers-flashiap | OK     | 59.48              | shell       |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-flash        | OK     | 56.14              | shell       |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
```
- [x] L4 
```
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| DISCO_L476VG-ARM  | DISCO_L476VG  | tests-mbed_drivers-flashiap | OK     | 88.25              | shell       |
| DISCO_L476VG-ARM  | DISCO_L476VG  | tests-mbed_hal-flash        | OK     | 89.7               | shell       |
| NUCLEO_L432KC-ARM | NUCLEO_L432KC | tests-mbed_drivers-flashiap | OK     | 88.64              | shell       |
| NUCLEO_L432KC-ARM | NUCLEO_L432KC | tests-mbed_hal-flash        | OK     | 89.81              | shell       |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_drivers-flashiap | OK     | 88.22              | shell       |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-flash        | OK     | 91.76              | shell       |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
```
- [x] F7 
```
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| DISCO_F746NG-ARM  | DISCO_F746NG  | tests-mbed_drivers-flashiap | OK     | 86.8               | shell       |
| DISCO_F746NG-ARM  | DISCO_F746NG  | tests-mbed_hal-flash        | OK     | 84.71              | shell       |
| DISCO_F769NI-ARM  | DISCO_F769NI  | tests-mbed_drivers-flashiap | OK     | 87.89              | shell       |
| DISCO_F769NI-ARM  | DISCO_F769NI  | tests-mbed_hal-flash        | OK     | 85.29              | shell       |
| NUCLEO_F746ZG-ARM | NUCLEO_F746ZG | tests-mbed_drivers-flashiap | OK     | 87.58              | shell       |
| NUCLEO_F746ZG-ARM | NUCLEO_F746ZG | tests-mbed_hal-flash        | OK     | 85.19              | shell       |
| NUCLEO_F756ZG-ARM | NUCLEO_F756ZG | tests-mbed_drivers-flashiap | OK     | 87.13              | shell       |
| NUCLEO_F756ZG-ARM | NUCLEO_F756ZG | tests-mbed_hal-flash        | OK     | 85.64              | shell       |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_drivers-flashiap | OK     | 86.89              | shell       |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-flash        | OK     | 84.49              | shell       |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
```
- [x] F4 
```
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
| DISCO_F413ZH-ARM  | DISCO_F413ZH  | tests-mbed_drivers-flashiap | OK     | 26.99              | shell       |
| DISCO_F413ZH-ARM  | DISCO_F413ZH  | tests-mbed_hal-flash        | OK     | 26.72              | shell       |
| DISCO_F429ZI-ARM  | DISCO_F429ZI  | tests-mbed_drivers-flashiap | OK     | 26.61              | shell       |
| DISCO_F429ZI-ARM  | DISCO_F429ZI  | tests-mbed_hal-flash        | OK     | 26.58              | shell       |
| DISCO_F469NI-ARM  | DISCO_F469NI  | tests-mbed_drivers-flashiap | OK     | 25.93              | shell       |
| DISCO_F469NI-ARM  | DISCO_F469NI  | tests-mbed_hal-flash        | OK     | 26.36              | shell       |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-mbed_drivers-flashiap | OK     | 27.19              | shell       |
| NUCLEO_F401RE-ARM | NUCLEO_F401RE | tests-mbed_hal-flash        | OK     | 26.13              | shell       |
| NUCLEO_F410RB-ARM | NUCLEO_F410RB | tests-mbed_drivers-flashiap | OK     | 24.56              | shell       |
| NUCLEO_F410RB-ARM | NUCLEO_F410RB | tests-mbed_hal-flash        | OK     | 24.79              | shell       |
| NUCLEO_F411RE-ARM | NUCLEO_F411RE | tests-mbed_drivers-flashiap | OK     | 26.43              | shell       |
| NUCLEO_F411RE-ARM | NUCLEO_F411RE | tests-mbed_hal-flash        | OK     | 26.24              | shell       |
| NUCLEO_F412ZG-ARM | NUCLEO_F412ZG | tests-mbed_drivers-flashiap | OK     | 27.16              | shell       |
| NUCLEO_F412ZG-ARM | NUCLEO_F412ZG | tests-mbed_hal-flash        | OK     | 26.68              | shell       |
| NUCLEO_F429ZI-ARM | NUCLEO_F429ZI | tests-mbed_drivers-flashiap | OK     | 26.49              | shell       |
| NUCLEO_F429ZI-ARM | NUCLEO_F429ZI | tests-mbed_hal-flash        | OK     | 26.85              | shell       |
| NUCLEO_F439ZI-ARM | NUCLEO_F439ZI | tests-mbed_drivers-flashiap | OK     | 26.47              | shell       |
| NUCLEO_F439ZI-ARM | NUCLEO_F439ZI | tests-mbed_hal-flash        | OK     | 26.63              | shell       |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-mbed_drivers-flashiap | OK     | 26.75              | shell       |
| NUCLEO_F446ZE-ARM | NUCLEO_F446ZE | tests-mbed_hal-flash        | OK     | 27.05              | shell       |
+-------------------+---------------+-----------------------------+--------+--------------------+-------------+
```