### PR TITLE
cb: Fix uninitialized memory used for equality check

### DIFF
--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -77,7 +77,7 @@ public:
      */
     Callback(R (*func)() = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -590,6 +590,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }
@@ -651,7 +652,7 @@ public:
      */
     Callback(R (*func)(A0) = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -1165,6 +1166,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }
@@ -1226,7 +1228,7 @@ public:
      */
     Callback(R (*func)(A0, A1) = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -1741,6 +1743,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }
@@ -1802,7 +1805,7 @@ public:
      */
     Callback(R (*func)(A0, A1, A2) = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -2318,6 +2321,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }
@@ -2379,7 +2383,7 @@ public:
      */
     Callback(R (*func)(A0, A1, A2, A3) = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -2896,6 +2900,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }
@@ -2957,7 +2962,7 @@ public:
      */
     Callback(R (*func)(A0, A1, A2, A3, A4) = 0) {
         if (!func) {
-            _ops = 0;
+            memset(this, 0, sizeof(Callback));
         } else {
             generate(func);
         }
@@ -3475,6 +3480,7 @@ private:
 
         MBED_STATIC_ASSERT(sizeof(Callback) - sizeof(_ops) >= sizeof(F),
                 "Type F must not exceed the size of the Callback class");
+        memset(this, 0, sizeof(Callback));
         new (this) F(f);
         _ops = &ops;
     }


### PR DESCRIPTION
Fixed by zeroing the uninitialized memory. A more "correct" approach may be to add an additional op for equality, and use the "==" operator on the F type in the generate function. But this adds the requirement that F supports equality.

cc @0xc0170, @pan- 
fixes #5017