### PR TITLE
mts targets: fix debug() usage

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/system_clock.c
@@ -35,6 +35,7 @@
 **/
 
 #include "stm32f4xx.h"
+#include "mbed_debug.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -240,8 +241,6 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
-#if !defined(NDEBUG) || NDEBUG == 0
-    printf("Hard Fault\n");
-#endif
+    debug("Hard Fault\n");
     NVIC_SystemReset();
 }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/system_clock.c
@@ -35,7 +35,7 @@
 **/
 
 #include "stm32f4xx.h"
-
+#include "mbed_debug.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -243,8 +243,6 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
-#if !defined(NDEBUG) || NDEBUG == 0
-    printf("Hard Fault\n");
-#endif
+    debug("Hard Fault\n");
     NVIC_SystemReset();
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_clock.c
@@ -37,6 +37,7 @@
 
 #include "stm32l1xx.h"
 #include "stdio.h"
+#include "mbed_debug.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -253,9 +254,7 @@ uint8_t SetSysClock_PLL_HSI(void)
 /******************************************************************************/
 void HardFault_Handler(void)
 {
-#if !defined(NDEBUG) || NDEBUG == 0
-    printf("Hard Fault\n");
-#endif
+    debug("Hard Fault\n");
     NVIC_SystemReset();
 }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/xdot_low_power.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/xdot_low_power.c
@@ -30,12 +30,7 @@
 
 #include "xdot_low_power.h"
 #include "stdio.h"
-
-#if defined(NDEBUG) && NDEBUG == 1
-#define xdot_lp_debug(...) do {} while(0)
-#else
-#define xdot_lp_debug(...) printf(__VA_ARGS__)
-#endif
+#include "mbed_debug.h"
 
 static uint32_t portA[6];
 static uint32_t portB[6];
@@ -236,7 +231,7 @@ void xdot_enter_stop_mode() {
     HSERCC_OscInitStruct.PLL.PLLMUL          = RCC_PLL_MUL4;
     HSERCC_OscInitStruct.PLL.PLLDIV          = RCC_PLL_DIV3;
     if (HAL_RCC_OscConfig(&HSERCC_OscInitStruct) != HAL_OK) {
-        xdot_lp_debug("OSC initialization failed - initiating soft reset\r\n");
+        debug("OSC initialization failed - initiating soft reset\r\n");
         NVIC_SystemReset();
     }
 
@@ -247,7 +242,7 @@ void xdot_enter_stop_mode() {
     RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
     RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;           // 32 MHz
     if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_1) != HAL_OK) {
-        xdot_lp_debug("PLL initialization failed - initiating soft reset\r\n");
+        debug("PLL initialization failed - initiating soft reset\r\n");
         NVIC_SystemReset();
     }
 
@@ -260,7 +255,7 @@ void xdot_enter_stop_mode() {
         HSIRCC_OscInitStruct.PLL.PLLState = RCC_PLL_NONE;
         HAL_StatusTypeDef ret = HAL_RCC_OscConfig(&HSIRCC_OscInitStruct);
         if ( ret != HAL_OK ) {
-            xdot_lp_debug("HSI initialization failed - ADC will not function properly\r\n");
+            debug("HSI initialization failed - ADC will not function properly\r\n");
         }
     }
 


### PR DESCRIPTION
Instead of using #if NDEBUG, we can directly invoke debug() function. Fixes #5013

@janjongboom @sg- @mfiore02 