### PR TITLE
Mapped lwip buffer error to nsapi no memory error

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -790,6 +790,7 @@ static nsapi_error_t mbed_lwip_err_remap(err_t err) {
         case ERR_CLSD:
             return 0;
         case ERR_MEM:
+        case ERR_BUF:
             return NSAPI_ERROR_NO_MEMORY;
         case ERR_CONN:
         case ERR_RST:


### PR DESCRIPTION
## Description
Mapped lwip internal ERR_BUF error value to NSAPI_ERROR_NO_MEMORY. 

This corrects issue: https://github.com/ARMmbed/mbed-os/issues/4981

## Status
READY


## Migrations
NO


## Related PRs
None


## Todos
- [ ] Tests
- [ ] Documentation


## Deploy notes
None


## Steps to test or reproduce
None
