### PR TITLE
Revert "Adjusting Stack size Allocation (IAR, LPC176x)"

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -12,10 +12,9 @@ define symbol __ICFEDIT_region_RAM_start__   = 0x100000C8;
 define symbol __ICFEDIT_region_RAM_end__     = 0x10007FDF;
 
 /*-Sizes-*/
-/* Heap 7K, Vector table stack about 4K (this is actual stack size in mbed-os 2) */
+/*Heap 1/4 of ram and stack 1/8*/
 define symbol __ICFEDIT_size_cstack__   = 0x1000;
-define symbol __ICFEDIT_size_heap__     = 0x1C00;
-
+define symbol __ICFEDIT_size_heap__     = 0x2000;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __CRP_start__   = 0x000002FC;


### PR DESCRIPTION
This reverts commit fce2ca212263c58089c7bd54e48dfba00316ad3f. With the current heap for IAR (no dynamic yet), 2 tcp/udp tests fail with not enough heap memory.

@hasnainvirk @kjbracey-arm @geky 

parallel tests fail, they allocate on heap Echo class

```
    // Startup echo threads in parallel
    for (unsigned int i = 0; i < MBED_CFG_UDP_CLIENT_ECHO_THREADS; i++) {
        echoers[i] = new Echo;
        echoers[i]->start(i, uuid);
    }
```

Should Arch PRO decrease any config there in those tests ,as not having enough heap ? With previous heap, there was not enough memory left for cellullar application, with the current our 2 tests fail due to not enough heap. I do not see the requirements for parallel testing - how much heap these test require. I can spot there 2x buffers 64bytes plus other objects, multiplied by 3, makes t he test to require lets assume something below 1k of heap... the target has at the moment 7k.