### PR TITLE
Lpc1768 bootloader support

### DIFF
--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -92,6 +92,26 @@
 #endif
 #endif
 
+/** MBED_USED
+ *  Inform the compiler that a static variable is to be retained in the object file, even if it is unreferenced.
+ *
+ *  @code
+ *  #include "mbed_toolchain.h"
+ *
+ *  MBED_USED int foo;
+ *
+ *  @endcode
+ */
+#ifndef MBED_USED
+#if defined(__GNUC__) || defined(__clang__) || defined(__CC_ARM)
+#define MBED_USED __attribute__((used))
+#elif defined(__ICCARM__)
+#define MBED_USED __root
+#else
+#define MBED_USED
+#endif
+#endif
+
 /** MBED_WEAK
  *  Mark a function as being weak.
  *

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
@@ -1,0 +1,18 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	 http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !defined(MBED_APP_START) // do not include CRP if there is a bootloader.
+    long CRP_Key __attribute__((section(".ARM.__at_0x000002FC "))) = 0xFFFFFFFF;
+#endif

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
@@ -51,10 +51,4 @@ performed on the device.
 #define CRP CRP_NONE
 #endif
 
-#if defined (__ICCARM__)
-    __root const long CRP_Key@APPLICATION_ADDR + 0x000002FC = CRP;
-#elif defined (__ARMCC_VERSION)
-    const long CRP_Key __attribute__((used)) __attribute__((at(APPLICATION_ADDR+0x000002FC))) = CRP;
-#elif defined (__GNUC__)
-    const long CRP_Key __attribute__((used)) __attribute__((section(".CRPSection"))) = CRP;
-#endif
+MBED_SECTION(".CRPSection") MBED_USED const long CRP_Key = CRP;

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/CRP.c
@@ -13,6 +13,48 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if !defined(MBED_APP_START) // do not include CRP if there is a bootloader.
-    long CRP_Key __attribute__((section(".ARM.__at_0x000002FC "))) = 0xFFFFFFFF;
+ 
+ #include "mbed_toolchain.h"
+
+ /* Code Read Protection
+
+NONE	0xFFFFFFFF - No code protection.
+
+CRP1    0x12345678 - Write to RAM command can not access RAM below 0x10000200.
+                   - Read Memory command: disabled.
+                   - Copy RAM to Flash command: cannot write to Sector 0.
+                   - "Go" command: disabled.
+                   - Erase sector(s) command: can erase any individual sector except 
+                   	 sector 0 only, or can erase all sectors at once.
+                   - Compare command: disabled
+
+CRP2    0x87654321 - Write to RAM command: disabled.
+                   - Copy RAM to Flash: disabled.
+                   - Erase command: only allows erase of all sectors.
+
+CRP3    0x43218765 - Access to chip via the SWD pins is disabled. ISP entry
+                     by pulling PIO0_1 LOW is disabled if a valid user code is
+                     present in flash sector 0.
+Caution: If CRP3 is selected, no future factory testing can be
+performed on the device.
+*/
+#if !defined(APPLICATION_ADDR) // Relocate CRP if there is a bootloader.
+    #define APPLICATION_ADDR 0
+#endif
+
+#define CRP_NONE	0xFFFFFFFF
+#define CRP_1		0x12345678 
+#define CRP_2		0x87654321
+#define CRP_3		0x43218765
+
+#ifndef CRP
+#define CRP CRP_NONE
+#endif
+
+#if defined (__ICCARM__)
+    __root const long CRP_Key@APPLICATION_ADDR + 0x000002FC = CRP;
+#elif defined (__ARMCC_VERSION)
+    const long CRP_Key __attribute__((used)) __attribute__((at(APPLICATION_ADDR+0x000002FC))) = CRP;
+#elif defined (__GNUC__)
+    const long CRP_Key __attribute__((used)) __attribute__((section(".CRPSection"))) = CRP;
 #endif

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/LPC1768.sct
@@ -9,10 +9,16 @@
 #endif
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
-   *.o (RESET, +First)
-   *(InRoot$$Sections)
-   .ANY (+RO)
+  ER_IROM0 MBED_APP_START 0x2FC  {  ; load address = execution address
+    *.o (RESET, +First)
+    .ANY (+RO)
+  }
+  ER_CRP (MBED_APP_START + 0x2FC) FIXED 4  {
+    *.o (.CRPSection)
+  }
+  ER_IROM1 (MBED_APP_START + (0x2FC + 4)) FIXED (MBED_APP_SIZE - (0x2FC + 4))  {
+    *(InRoot$$Sections)
+    .ANY (+RO)
   }
   ; 8_byte_aligned(49 vect * 4 bytes) =  8_byte_aligned(0xC4) = 0xC8
   ; 32KB (RAM size) - 0xC8 (NIVT) - 32 (topmost 32 bytes used by IAP functions) = 0x7F18

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/LPC1768.sct
@@ -1,6 +1,15 @@
+#! armcc -E
 
-LR_IROM1 0x00000000 0x80000  {    ; load region size_region
-  ER_IROM1 0x00000000 0x80000  {  ; load address = execution address
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x00000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/startup_LPC17xx.S
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_MICRO/startup_LPC17xx.S
@@ -99,12 +99,6 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
                 DCD     PLL1_IRQHandler           ; 48: PLL1 Lock (USB PLL)
 
 
-                IF      :LNOT::DEF:NO_CRP
-                AREA    |.ARM.__at_0x02FC|, CODE, READONLY
-CRP_Key         DCD     0xFFFFFFFF
-                ENDIF
-
-
                 AREA    |.text|, CODE, READONLY
 
 

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
@@ -9,10 +9,16 @@
 #endif
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
-   *.o (RESET, +First)
-   *(InRoot$$Sections)
-   .ANY (+RO)
+  ER_IROM0 MBED_APP_START 0x2FC  {  ; load address = execution address
+    *.o (RESET, +First)
+    .ANY (+RO)
+  }
+  ER_CRP (MBED_APP_START + 0x2FC) FIXED 4  {
+    *.o (.CRPSection)
+  }
+  ER_IROM1 (MBED_APP_START + (0x2FC + 4)) FIXED (MBED_APP_SIZE - (0x2FC + 4))  {
+    *(InRoot$$Sections)
+    .ANY (+RO)
   }
   ; 8_byte_aligned(49 vect * 4 bytes) =  8_byte_aligned(0xC4) = 0xC8
   ; 32KB (RAM size) - 0xC8 (NIVT) - 32 (topmost 32 bytes used by IAP functions) = 0x7F18

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/LPC1768.sct
@@ -1,6 +1,15 @@
+#! armcc -E
 
-LR_IROM1 0x00000000 0x80000  {    ; load region size_region
-  ER_IROM1 0x00000000 0x80000  {  ; load address = execution address
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x00000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x80000
+#endif
+
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/startup_LPC17xx.S
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_ARM_STD/startup_LPC17xx.S
@@ -82,12 +82,6 @@ __Vectors       DCD     __initial_sp              ; Top of Stack
                 DCD     PLL1_IRQHandler           ; 48: PLL1 Lock (USB PLL)
 
 
-                IF      :LNOT::DEF:NO_CRP
-                AREA    |.ARM.__at_0x02FC|, CODE, READONLY
-CRP_Key         DCD     0xFFFFFFFF
-                ENDIF
-
-
                 AREA    |.text|, CODE, READONLY
 
 

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -1,9 +1,15 @@
 /* Linker script for mbed LPC1768 */
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x00000000
+#endif
 
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 512K
+#endif
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x00000000, LENGTH = 512K
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   RAM (rwx) : ORIGIN = 0x100000C8, LENGTH = (32K - 0xC8 - 32)  /* topmost 32 bytes used by IAP functions */
 
   USB_RAM(rwx) : ORIGIN = 0x2007C000, LENGTH = 16K

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_GCC_ARM/LPC1768.ld
@@ -49,6 +49,10 @@ SECTIONS
     .text :
     {
         KEEP(*(.isr_vector))
+        /* Code Read Protect data */
+        . = 0x000002FC ;
+        KEEP(*(.CRPSection))
+        /* End of Code Read Protect */
         *(.text*)
 
         KEEP(*(.init))
@@ -71,6 +75,8 @@ SECTIONS
         *(.rodata*)
 
         KEEP(*(.eh_frame*))
+		
+		
     } > FLASH
 
     .ARM.extab : 

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -19,8 +19,8 @@ define symbol __ICFEDIT_size_cstack__   = 0x1000;
 define symbol __ICFEDIT_size_heap__     = 0x2000;
 /**** End of ICF editor section. ###ICF###*/
 
-define symbol __CRP_start__   = 0x000002FC;
-define symbol __CRP_end__     = 0x000002FF;
+define symbol __CRP_start__   = MBED_APP_START + 0x000002FC;
+define symbol __CRP_end__     = MBED_APP_START + 0x000002FF;
 
 define symbol __RAM1_start__  = 0x2007C000;
 define symbol __RAM1_end__    = 0x20083FFF;
@@ -43,5 +43,5 @@ place in ROM_region   { readonly };
 place in RAM_region   { readwrite,
                         block HEAP, block CSTACK };
 
-place in CRP_region  	{ section .crp };
+place in CRP_region  	{ section .CRPSection };
 place in RAM1_region	{ section .ethusbram };

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -1,11 +1,13 @@
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x00000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x80000; }
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
 /*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = 0x00000000;
+define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 /*-Memory Regions-*/
-define symbol __ICFEDIT_region_ROM_start__   = 0x00000000;
-define symbol __ICFEDIT_region_ROM_end__     = 0x0007FFFF;
+define symbol __ICFEDIT_region_ROM_start__   = MBED_APP_START;
+define symbol __ICFEDIT_region_ROM_end__     = MBED_APP_START + MBED_APP_SIZE - 1;
 define symbol __ICFEDIT_region_NVIC_start__   = 0x10000000;
 define symbol __ICFEDIT_region_NVIC_end__   = 0x100000C7;
 define symbol __ICFEDIT_region_RAM_start__   = 0x100000C8;

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/startup_LPC17xx.S
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/startup_LPC17xx.S
@@ -350,26 +350,4 @@ USBActivity_IRQHandler
 CANActivity_IRQHandler
         B CANActivity_IRQHandler
 
-#ifndef SRAM
-        SECTION .crp:CODE:ROOT(2)
-        DATA
-/* Code Read Protection
-CRP1    0x12345678 - Write to RAM command can not access RAM below 0x10000200.
-                   - Read Memory command: disabled.
-                   - Copy RAM to Flash command: cannot write to Sector 0.
-                   - "Go" command: disabled.
-                   - Erase sector(s) command: can erase any individual sector except 
-                   	 sector 0 only, or can erase all sectors at once.
-                   - Compare command: disabled
-CRP2    0x87654321 - Write to RAM command: disabled.
-                   - Copy RAM to Flash: disabled.
-                   - Erase command: only allows erase of all sectors.
-CRP3    0x43218765 - Access to chip via the SWD pins is disabled. ISP entry
-                     by pulling PIO0_1 LOW is disabled if a valid user code is
-                     present in flash sector 0.
-Caution: If CRP3 is selected, no future factory testing can be
-performed on the device.
-*/
-	DCD	0xFFFFFFFF
-#endif
         END

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -241,7 +241,8 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
-        "device_name": "LPC1768"
+        "device_name": "LPC1768",
+        "bootloader_supported": true
     },
     "ARCH_PRO": {
         "supported_form_factors": ["ARDUINO"],
@@ -253,7 +254,8 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
-        "device_name": "LPC1768"
+        "device_name": "LPC1768",
+        "bootloader_supported": true
     },
     "UBLOX_C027": {
         "supported_form_factors": ["ARDUINO"],
@@ -277,7 +279,8 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
-        "device_name": "LPC1768"
+        "device_name": "LPC1768",
+        "bootloader_supported": true
     },
     "XBED_LPC1768": {
         "inherits": ["LPCTarget"],


### PR DESCRIPTION
## Description
Enable bootloaders for LPC1768 targets.

CRP word was being added to application builds which would overlap the bootloader and cause an sector erase inside the bootloader region.

Linker scripts have been updated.

## Status
**READY**


## Migrations
NO


## Related PRs

## Todos

## Deploy notes


## Steps to test or reproduce
