### PR TITLE
RTL8195AM - Handle MSP properly and enlarge lwip TCP thread stacksize

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
+++ b/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
@@ -84,5 +84,10 @@
             "help": "Thread stack size for PPP",
             "value": 768
         }
+    },
+    "target_overrides": {
+        "REALTEK_RTL8195AM": {
+            "tcpip-thread-stacksize": 1600
+        }
     }
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a_startup.S
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a_startup.S
@@ -1,0 +1,31 @@
+;
+; Copyright (c) 2017 Realtek Semiconductor Corp.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+            PRESERVE8
+            THUMB
+
+            AREA    |i.PLAT_Start|, CODE, READONLY
+
+PLAT_Start  PROC
+
+            EXPORT  PLAT_Start
+    IMPORT  |Image$$ARM_LIB_STACK$$ZI$$Limit|
+    IMPORT  PLAT_Init
+            LDR     SP, =|Image$$ARM_LIB_STACK$$ZI$$Limit|
+            LDR     R0, =PLAT_Init
+            BX      R0
+            ENDP
+            ALIGN
+            END

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a_startup.S
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a_startup.S
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2017 Realtek Semiconductor Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+    .syntax unified
+    .thumb
+
+    .global  __StackTop
+    .global  PLAT_Init
+
+    /* entry point of application image */
+    .section  .text.PLAT_Start
+    .weak  PLAT_Start
+    .type  PLAT_Start, %function
+PLAT_Start:
+    ldr   sp, =__StackTop
+    ldr   r0, =PLAT_Init
+    bx    r0
+    .size  PLAT_Start, .-PLAT_Start
+    .end

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a_startup.S
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a_startup.S
@@ -1,0 +1,31 @@
+;
+; Copyright (c) 2017 Realtek Semiconductor Corp.
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+
+    MODULE  ?cstartup
+
+    SECTION .text:CODE:NOROOT:REORDER(2)
+    EXTERN  CSTACK$$Limit
+    EXTERN  PLAT_Init
+
+    ; Default image 2 entry
+    THUMB
+    PUBWEAK PLAT_Start
+
+PLAT_Start
+    LDR     SP, =CSTACK$$Limit
+    LDR     R0, =PLAT_Init
+    BX      R0
+
+    END

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
@@ -40,13 +40,11 @@ extern uint8_t Image$$RW_DRAM2$$ZI$$Limit[];
 #define __bss_dtcm_end__   Image$$TCM_OVERLAY$$ZI$$Limit
 #define __bss_dram_start__ Image$$RW_DRAM2$$ZI$$Base
 #define __bss_dram_end__   Image$$RW_DRAM2$$ZI$$Limit
-#define __stackp           Image$$ARM_LIB_STACK$$ZI$$Limit
 
 #elif defined (__ICCARM__)
 
 #pragma section=".ram.bss"
 
-extern uint32_t CSTACK$$Limit;
 uint8_t *__bss_start__;
 uint8_t *__bss_end__;
 
@@ -55,12 +53,9 @@ void __iar_data_init_app(void)
     __bss_start__ = (uint8_t *)__section_begin(".ram.bss");
     __bss_end__   = (uint8_t *)__section_end(".ram.bss");
 }
-#define __stackp           CSTACK$$Limit
 
 #else
 
-extern uint32_t __StackTop;
-extern uint32_t __StackLimit;
 extern uint8_t __bss_sram_start__[];
 extern uint8_t __bss_sram_end__[];
 extern uint8_t __bss_dtcm_start__[];
@@ -68,7 +63,6 @@ extern uint8_t __bss_dtcm_end__[];
 extern uint8_t __bss_dram_start__[];
 extern uint8_t __bss_dram_end__[];
 
-#define __stackp           __StackTop
 #endif
 
 extern VECTOR_Func NewVectorTable[];
@@ -173,29 +167,24 @@ void TRAP_HardFaultHandler_Patch(void)
 
 extern _LONG_CALL_ void * __rtl_memset_v1_00(void * m , int c , size_t n);
 // Image2 Entry Function
-void PLAT_Start(void)
+void PLAT_Init(void)
 {
     uint32_t val;
 
-#if defined (__ICCARM__)
-    __iar_data_init_app();
+    // Overwrite vector table
+    NewVectorTable[2] = (VECTOR_Func) TRAP_NMIHandler;
+#if defined ( __ICCARM__ )
+    NewVectorTable[3] = (VECTOR_Func) TRAP_HardFaultHandler_Patch;
 #endif
 
     // Clear RAM BSS
 #if defined (__ICCARM__)
+    __iar_data_init_app();
     __rtl_memset_v1_00((void *)__bss_start__, 0, __bss_end__ - __bss_start__);
 #else
     __rtl_memset_v1_00((void *)__bss_sram_start__, 0, __bss_sram_end__ - __bss_sram_start__);
     __rtl_memset_v1_00((void *)__bss_dtcm_start__, 0, __bss_dtcm_end__ - __bss_dtcm_start__);
     __rtl_memset_v1_00((void *)__bss_dram_start__, 0, __bss_dram_end__ - __bss_dram_start__);
-#endif
-
-    // Set MSP
-    __set_MSP((uint32_t)&__stackp - 0x100);
-    // Overwrite vector table
-    NewVectorTable[2] = (VECTOR_Func) TRAP_NMIHandler;
-#if defined ( __ICCARM__ )
-    NewVectorTable[3] = (VECTOR_Func) TRAP_HardFaultHandler_Patch;
 #endif
 
     extern HAL_TIMER_OP_EXT HalTimerOpExt;


### PR DESCRIPTION
Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Description
Handle MSP properly and enlarge lwip tcp thread stacksize. 

Set MSP in assembly block before jumping to the real platform startup code to avoid
redundant SP push/pop in prologue and epilogue. GCC does that when sibling code optimization is turned off which unfortunately happens under debug profile.

Also enlarge lwip tcp thread stacksize to reserve extra head room for GCC debug profile. 

## Status
READY

## Migrations
NO

## Related PRs
#4665 

## Todos
NONE

## Deploy notes
NONE

## Steps to test or reproduce
NONE