### PR TITLE
ds5 & e2studio export fix

### DIFF
--- a/tools/export/ds5_5/__init__.py
+++ b/tools/export/ds5_5/__init__.py
@@ -29,6 +29,7 @@ class DS5_5(Exporter):
         'UBLOX_C027',
         'ARCH_PRO',
         'RZ_A1H',
+        'VK_RZ_A1H',
     ]
 
     USING_MICROLIB = [

--- a/tools/export/e2studio/__init__.py
+++ b/tools/export/e2studio/__init__.py
@@ -25,6 +25,7 @@ class E2Studio(Exporter):
 
     TARGETS = [
         'RZ_A1H',
+        'VK_RZ_A1H',
     ]
 
     def generate(self):


### PR DESCRIPTION
Notes:
* This is the PR supposed to fix the ds5 & e2studio exporters. but I very much doubt it will fix the online exporter issue.

## Description
* Online Project exporter persistently refuses to work. The details can be found in issue #3768, which obviously continues to be an issue.
* No information for used RAM and ROM in the online compiler, when compiling projects for VK_RZ_A1H platform.

## Steps to test or reproduce
Try to export standard mbed_blinky project for platform VK_RZ_A1H with the online compiler (export option) for toolchains IAR or ds5 or e2studio.
