### PR TITLE
Sleep API update (branch feature-hal-spec-sleep)

### DIFF
--- a/hal/sleep_api.h
+++ b/hal/sleep_api.h
@@ -29,32 +29,27 @@ extern "C" {
 
 /** Send the microcontroller to sleep
  *
- * The processor is setup ready for sleep, and sent to sleep using __WFI(). In this mode, the
+ * The processor is setup ready for sleep, and sent to sleep. In this mode, the
  * system clock to the core is stopped until a reset or an interrupt occurs. This eliminates
  * dynamic power used by the processor, memory systems and buses. The processor, peripheral and
  * memory state are maintained, and the peripherals continue to work and can generate interrupts.
  *
  * The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 us.
+ * 
  */
 void hal_sleep(void);
 
 /** Send the microcontroller to deep sleep
  *
  * This processor is setup ready for deep sleep, and sent to sleep using __WFI(). This mode
- * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
- * is still maintained.
+ * has the same sleep features as sleep plus it powers down peripherals and high frequency clocks.
+ * All state is still maintained.
  *
- * The processor can only be woken up by an external interrupt on a pin or a watchdog timer.
+ * The processor can only be woken up by low power ticker, RTC, an external interrupt on a pin or a watchdog timer.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 ms.
  */
 void hal_deepsleep(void);
 

--- a/platform/mbed_sleep.h
+++ b/platform/mbed_sleep.h
@@ -38,10 +38,7 @@ extern "C" {
  *
  * The processor can be woken up by any internal peripheral interrupt or external pin interrupt.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 us.
  */
 __INLINE static void sleep(void)
 {
@@ -64,12 +61,9 @@ __INLINE static void sleep(void)
  * has the same sleep features as sleep plus it powers down peripherals and clocks. All state
  * is still maintained.
  *
- * The processor can only be woken up by an external interrupt on a pin or a watchdog timer.
+ * The processor can only be woken up by low power ticker, RTC, an external interrupt on a pin or a watchdog timer.
  *
- * @note
- *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
- * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
- * able to access the LocalFileSystem
+ * The wake-up time shall be less than 10 ms.
  */
 __INLINE static void deepsleep(void)
 {

--- a/targets/TARGET_NXP/TARGET_LPC176X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/sleep.c
@@ -17,6 +17,13 @@
 #include "cmsis.h"
 #include "mbed_interface.h"
 
+/*
+ * @note
+ *  The mbed interface semihosting is disconnected as part of going to sleep, and can not be restored.
+ * Flash re-programming and the USB serial port will remain active, but the mbed program will no longer be
+ * able to access the LocalFileSystem
+ */
+
 void hal_sleep(void) {
 
 #if (DEVICE_SEMIHOST == 1)


### PR DESCRIPTION
This goes to feature-hal-spec branch, update to sleep API. This was previously part of sleep manager, but should come as separate patch that will require testing and further target updates.

Sleep - within 10us
Deepsleep - within 10ms

Note about mbed boards with interface, moved to lpc176x, as they are target related,
should be documented in the target documentation.

The tests will come as separate PR, to conform to this updates to sleep API.

cc @bulislaw @c1728p9 