### PR TITLE
CircularBuffer() extended to get the number of available transactions

### DIFF
--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -56,7 +56,7 @@ public:
 
     /** Pop the transaction from the buffer
      *
-     * @param data Data to be pushed to the buffer
+     * @param data Data to be popped from the buffer
      * @return True if the buffer is not empty and data contains a transaction, false otherwise
      */
     bool pop(T& data) {
@@ -104,6 +104,23 @@ public:
         _full = false;
         core_util_critical_section_exit();
     }
+    
+    /** Returns the available transactions the buffer can store */
+    CounterType available() {
+        core_util_critical_section_enter();
+        CounterType elements = 0;
+        if (!_full)
+        {
+            if (_head < _tail)
+                elements = BufferSize + _head - _tail;
+            else
+                elements = _head - _tail;
+            
+            elements /= sizeof(T);
+        }
+        core_util_critical_section_exit();
+        return elements;
+    }
 
 private:
     T _pool[BufferSize];
@@ -115,4 +132,3 @@ private:
 }
 
 #endif
-

--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -105,7 +105,7 @@ public:
         core_util_critical_section_exit();
     }
     
-    /** Returns the available transactions the buffer can store */
+    /** Returns the number of available transactions the buffer contains */
     CounterType available() {
         core_util_critical_section_enter();
         CounterType elements = 0;

--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -108,16 +108,16 @@ public:
     /** Returns the number of available transactions the buffer contains */
     CounterType available() {
         core_util_critical_section_enter();
-        CounterType elements = 0;
+        CounterType elements;
         if (!_full)
         {
             if (_head < _tail)
                 elements = BufferSize + _head - _tail;
             else
                 elements = _head - _tail;
-            
-            elements /= sizeof(T);
         }
+        else
+            elements = BufferSize;
         core_util_critical_section_exit();
         return elements;
     }


### PR DESCRIPTION
## Description
In some cases it is necessary (or efficient) to know how much transactions are stored in the buffer. Therefore, the class was extended with such a method.


## Status
**READY**


## Todos
- [ ? ] Documentation