### PR TITLE
InterruptIn: Use NULL callback by default

### DIFF
--- a/drivers/InterruptIn.cpp
+++ b/drivers/InterruptIn.cpp
@@ -19,16 +19,11 @@
 
 namespace mbed {
 
-static void donothing() {}
-
 InterruptIn::InterruptIn(PinName pin) : gpio(),
                                         gpio_irq(),
-                                        _rise(),
-                                        _fall() {
+                                        _rise(NULL),
+                                        _fall(NULL) {
     // No lock needed in the constructor
-
-    _rise = donothing;
-    _fall = donothing;
 
     gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
     gpio_init_in(&gpio, pin);
@@ -56,7 +51,7 @@ void InterruptIn::rise(Callback<void()> func) {
         _rise = func;
         gpio_irq_set(&gpio_irq, IRQ_RISE, 1);
     } else {
-        _rise = donothing;
+        _rise = NULL;
         gpio_irq_set(&gpio_irq, IRQ_RISE, 0);
     }
     core_util_critical_section_exit();
@@ -68,7 +63,7 @@ void InterruptIn::fall(Callback<void()> func) {
         _fall = func;
         gpio_irq_set(&gpio_irq, IRQ_FALL, 1);
     } else {
-        _fall = donothing;
+        _fall = NULL;
         gpio_irq_set(&gpio_irq, IRQ_FALL, 0);
     }
     core_util_critical_section_exit();
@@ -77,8 +72,16 @@ void InterruptIn::fall(Callback<void()> func) {
 void InterruptIn::_irq_handler(uint32_t id, gpio_irq_event event) {
     InterruptIn *handler = (InterruptIn*)id;
     switch (event) {
-        case IRQ_RISE: handler->_rise(); break;
-        case IRQ_FALL: handler->_fall(); break;
+        case IRQ_RISE: 
+            if (handler->_rise) {
+                handler->_rise();
+            }
+            break;
+        case IRQ_FALL: 
+            if (handler->_fall) {
+                handler->_fall(); 
+            }
+            break;
         case IRQ_NONE: break;
     }
 }


### PR DESCRIPTION
As we can check if callback was attached, we use NULL assignment.

Just a cosmetic change, that follows what we did for other attach() drivers.

@sg- @geky 