### PR TITLE
Fixing lp ticker and sleep manager tests

### DIFF
--- a/TESTS/mbed_drivers/lp_timeout/main.cpp
+++ b/TESTS/mbed_drivers/lp_timeout/main.cpp
@@ -72,11 +72,13 @@ void lp_timeout_1s_sleep(void)
 {
     complete = false;
 
+    sleep_manager_lock_deep_sleep();
     timestamp_t start = us_ticker_read();
     lpt.attach(&cb_done, 1);
     sleep();
     while (!complete);
     timestamp_t end = us_ticker_read();
+    sleep_manager_unlock_deep_sleep();
 
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
     TEST_ASSERT_TRUE(complete);

--- a/TESTS/mbed_drivers/timeout/main.cpp
+++ b/TESTS/mbed_drivers/timeout/main.cpp
@@ -36,7 +36,7 @@
 
 using namespace utest::v1;
 
-#define ONE_MILLI_SEC 1000
+#define PERIOD_US   10000
 
 volatile int ticker_count = 0;
 volatile uint32_t callback_trigger_count = 0;
@@ -44,7 +44,7 @@ static const int test_timeout = 240;
 Timeout timeout;
 
 void set_incremeant_count() {
-    timeout.attach_us(set_incremeant_count, ONE_MILLI_SEC);
+    timeout.attach_us(set_incremeant_count, PERIOD_US);
     ++callback_trigger_count;
 }
 
@@ -56,7 +56,7 @@ void test_case_timeout() {
     uint8_t results_size = 0;
 
     greentea_send_kv("timing_drift_check_start", 0);
-    timeout.attach_us(set_incremeant_count, ONE_MILLI_SEC);
+    timeout.attach_us(set_incremeant_count, PERIOD_US);
 
     // wait for 1st signal from host
     do {
@@ -64,11 +64,11 @@ void test_case_timeout() {
         expected_key = strcmp(_key, "base_time");
     } while (expected_key);
 
-    greentea_send_kv(_key, callback_trigger_count * ONE_MILLI_SEC);
+    greentea_send_kv(_key, callback_trigger_count * PERIOD_US);
 
     // wait for 2nd signal from host
     greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
-    greentea_send_kv(_key, callback_trigger_count * ONE_MILLI_SEC);
+    greentea_send_kv(_key, callback_trigger_count * PERIOD_US);
 
     //get the results from host
     greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -25,6 +25,7 @@
 #include "mbed.h"
 #include "us_ticker_api.h"
 #include "lp_ticker_api.h"
+#include "TimerEvent.h"
 
 using namespace utest::v1;
 
@@ -39,13 +40,23 @@ static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 #define SHORT_TIMEOUT (600)
 
 void cb_done(uint32_t id) {
-    complete_timestamp = us_ticker_read();
-    complete = true;
+    if ((uint32_t)&delay_event == id) {
+        complete_timestamp = us_ticker_read();
+        complete = true;
+    } else {
+        // Normal ticker handling
+        TimerEvent::irq(id);
+    }
 }
 
 void cb_done_deepsleep(uint32_t id) {
-    complete_timestamp = lp_ticker_read();
-    complete = true;
+    if ((uint32_t)&delay_event == id) {
+        complete_timestamp = lp_ticker_read();
+        complete = true;
+    } else {
+        // Normal ticker handling
+        TimerEvent::irq(id);
+    }
 }
 
 void lp_ticker_delay_us(uint32_t delay_us, uint32_t tolerance)

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -109,11 +109,13 @@ void lp_ticker_1s_sleep()
     ticker_remove_event(lp_ticker_data, &delay_event);
     delay_ts = lp_ticker_read() + 1000000;
 
+    sleep_manager_lock_deep_sleep();
     timestamp_t start = us_ticker_read();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     sleep();
     while (!complete);
     timestamp_t end = complete_timestamp;
+    sleep_manager_unlock_deep_sleep();
 
     TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
     TEST_ASSERT_TRUE(complete);

--- a/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -24,6 +24,8 @@
 
 using namespace utest::v1;
 
+#define TEST_STACK_SIZE 256
+
 void sleep_manager_locking_thread_test()
 {
     for (uint32_t i = 0; i < 100; i++) {
@@ -37,8 +39,8 @@ void sleep_manager_multithread_test()
 {
     {
         Callback<void()> cb(sleep_manager_locking_thread_test);
-        Thread t1;
-        Thread t2;
+        Thread t1(osPriorityNormal, TEST_STACK_SIZE);
+        Thread t2(osPriorityNormal, TEST_STACK_SIZE);
 
         t1.start(callback(cb));
         Thread::wait(25);

--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -43,7 +43,9 @@ void Ticker::setup(us_timestamp_t t) {
 
 void Ticker::handler() {
     insert_absolute(event.timestamp + _delay);
-    _function();
+    if (_function) {
+        _function();
+    }
 }
 
 } // namespace mbed

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/sleep.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/sleep.c
@@ -64,6 +64,8 @@ void fncs36510_deepsleep(void)
     /** Enter into deep sleep mode */
     __ISB();
     __WFI();
+    __NOP();
+    __NOP();
 
     /** Wait for the external 32MHz to be power-ed up & running
      * Re-power down the 32MHz internal osc

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3195,7 +3195,7 @@
         },
         "OUTPUT_EXT": "hex",
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
-        "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000", "MBED_TICKLESS"],
+        "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
         "release_versions": ["2", "5"]


### PR DESCRIPTION
Couple of fixes here:

- lp ticker - use Timer to wait (this will however need more investigation with wait_ms as it should work, I'll create a tracking issue for this, this should be the functionally same affect for this test)
- sleep manager - decrease the stack for Threads as the default one is too big for the test purposes (out of memory for small targets)

See failures: https://github.com/ARMmbed/mbed-os/pull/4987#issuecomment-328255913

Whats left to do - nrf52 critical section - seems like the critical section does not work, look at sleep manager  race condition. It fails. This is interesting as we have some race conditions tests, for instance also for threads. I'll review the test again, are we using it correctly, and the bug is in nordic implementation of critical section, as the rest of platforms are fine (using default implementation of critical section)
cc @nvlsianpu @anangl @pan-  Any suggestions, fixes welcome !

This will require nightly as its fixing some tests.

@c1728p9 @bulislaw @sg-