### PR TITLE
UARTSerial: Avoid readable() ambiguity

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -56,6 +56,12 @@ public:
      */
     virtual short poll(short events) const;
 
+    /* Resolve ambiguities versus our private SerialBase
+     * (for writable, spelling differs, but just in case)
+     */
+    using FileHandle::readable;
+    using FileHandle::writable;
+
     /** Write the contents of a buffer to a file
      *
      *  @param buffer   The buffer to write from


### PR DESCRIPTION
`UARTSerial` inherits both `FileHandle::readable()` [public] and
`SerialBase::readable()` [private], so calling `readable()` on a UARTSerial
object produces an ambiguous member error.

Add `using` declarations to direct towards the `FileHandle` versions of
`readable` and `writable`.

There's currently no ambiguity for `writable`, as `SerialBase` uses the
spelling `writeable`, but add a `using` directive for that anyway, in case
`SerialBase` gains `writable` later.

Resolves issue #5035 