### PR TITLE
Changed error print to assert

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/rtw_emac.cpp
@@ -218,10 +218,7 @@ emac_interface_t *wlan_emac_init_interface()
 
     if (_emac == NULL) {
         _emac = (emac_interface_t*) malloc(sizeof(emac_interface_t));
-    	if (_emac == NULL) {//new emac_interface_t fail
-        	printf("emac initialization failed\r\n");
-		return NULL;
-    	}
+        MBED_ASSERT(_emac);
         _emac->hw = NULL;
         memcpy((void*)&_emac->ops, &wlan_emac_interface, sizeof(wlan_emac_interface));
     }


### PR DESCRIPTION
Changed error print to assert function, since using malloc instead of new.

This PR is to close review comment related to emac_interface_t in PR #4938 

https://github.com/ARMmbed/mbed-os/pull/4938/files/6bd28ecb685542237808f9e009dbb9510372d14c#diff-5cc67fcf86ead5e18c66e794b692d326L220