### PR TITLE
use gcc assembly for arm 6

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -74,13 +74,13 @@ static void delay_loop(uint32_t count)
     : "cc"
   );
 }
-#else // GCC
+#elif  defined ( __GNUC__ ) ||  (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
 MBED_NOINLINE
 static void delay_loop(uint32_t count)
 {
   __asm__ volatile (
     "%=:\n\t"
-#if defined(__thumb__) && !defined(__thumb2__) && !defined(TOOLCHAIN_ARMC6)
+#if defined(__thumb__) && !defined(__thumb2__) && !defined(__ARMCC_VERSION)
     "SUB  %0, #1\n\t"
 #else
     "SUBS %0, %0, #1\n\t"

--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -80,7 +80,7 @@ static void delay_loop(uint32_t count)
 {
   __asm__ volatile (
     "%=:\n\t"
-#if defined(__thumb__) && !defined(__thumb2__)
+#if defined(__thumb__) && !defined(__thumb2__) && !defined(TOOLCHAIN_ARMC6)
     "SUB  %0, #1\n\t"
 #else
     "SUBS %0, %0, #1\n\t"


### PR DESCRIPTION
## Description

fix the armc6 compile error,  ARM 6 is compatible with GCC  so unify GCC and ARM 6 code 

```
00:00:44.012         [DEBUG] Output: ./TESTS/mbed_hal/flash/functional_tests/main.cpp:82:11: error: no flag-preserving variant of this instruction available
00:00:44.012         [DEBUG] Output:     "%=:\n\t"
00:00:44.013         [DEBUG] Output:           ^
00:00:44.013         [DEBUG] Output: <inline asm>:2:2: note: instantiated into assembly here
00:00:44.013         [DEBUG] Output:         SUB  r0, #1
```

__asm behavior between arm 5 and arm 6

### arm compiler  6.8 :

1. For embedded assembly, you **cannot** use the __asm keyword on the **function declaration**.
2. The __asm keyword can incorporate inline GCC syntax assembly code into a function
[reference 6.8](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.100067_0608_00_en/chr1383658400125.html)

### arm compiler  5.06:
The __asm keyword can declare or define an **embedded assembly function** [reference 5.06 ](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0491c/CHDFIJAE.html)
## Related PRs
https://github.com/ARMmbed/mbed-os/pull/4949

