### PR TITLE
Added interface version information to mbed detect command.

### DIFF
--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -102,7 +102,8 @@ def main():
         
 def get_interface_version(mount_point):
     """ Function returns interface version from the target mounted on the specified mount point
-            mount_point = mut['port']
+            Example of mount_point:
+                mount_point = mut['disk']
         @param mount_point Name of disk where platform is connected to host machine.
     """
     if get_module_avail('mbed_lstools'):

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -31,6 +31,7 @@ check_required_modules(['prettytable'])
 # Imports related to mbed build api
 from tools.build_api import mcu_toolchain_matrix
 from tools.test_api import get_autodetected_MUTS_list
+from tools.test_api import get_mounted_details_txt
 from argparse import ArgumentParser
 
 
@@ -75,9 +76,11 @@ def main():
         count = 0
         for mut in muts.values():
             if re.match(mcu_filter, mut['mcu']):
+                # Grab additional target details about the mut
+                details_txt = get_mounted_details_txt(mut['disk'])
                 print ""
-                print "[mbed] Detected %s, port %s, mounted %s" % \
-                    (mut['mcu'], mut['port'], mut['disk'])
+                print "[mbed] Detected %s, port %s, mounted %s, DAPLink version %s" % \
+                    (mut['mcu'], mut['port'], mut['disk'], details_txt['Interface Version'])
                 print "[mbed] Supported toolchains for %s" % mut['mcu']
                 print mcu_toolchain_matrix(platform_filter=mut['mcu'])
                 count += 1

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -103,16 +103,20 @@ def main():
 def get_interface_version(mount_point):
     """ Function returns interface version from the target mounted on the specified mount point
     
-            mount_point can be acquired via the following:
-                muts = get_autodetected_MUTS_list()
-                for mut in muts.values():
-                    mount_point = mut['disk']
+        mount_point can be acquired via the following:
+            muts = get_autodetected_MUTS_list()
+            for mut in muts.values():
+                mount_point = mut['disk']
                     
         @param mount_point Name of disk where platform is connected to host machine.
     """
     if get_module_avail('mbed_lstools'):
         mbeds = mbed_lstools.create()
         details_txt = mbeds.get_details_txt(mount_point)
+        
+        if (details_txt is None):
+            details_txt = {}
+            
         
         if 'Interface Version' in details_txt:
             return details_txt['Interface Version']

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -102,8 +102,12 @@ def main():
         
 def get_interface_version(mount_point):
     """ Function returns interface version from the target mounted on the specified mount point
-            Example of mount_point:
-                mount_point = mut['disk']
+    
+            mount_point can be acquired via the following:
+                muts = get_autodetected_MUTS_list()
+                for mut in muts.values():
+                    mount_point = mut['disk']
+                    
         @param mount_point Name of disk where platform is connected to host machine.
     """
     if get_module_avail('mbed_lstools'):

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -79,7 +79,7 @@ def main():
                 # Grab additional target details about the mut
                 details_txt = get_mounted_details_txt(mut['disk'])
                 print ""
-                print "[mbed] Detected %s, port %s, mounted %s, DAPLink version %s" % \
+                print "[mbed] Detected %s, port %s, mounted %s, interface version %s" % \
                     (mut['mcu'], mut['port'], mut['disk'], details_txt['Interface Version'])
                 print "[mbed] Supported toolchains for %s" % mut['mcu']
                 print mcu_toolchain_matrix(platform_filter=mut['mcu'])

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -113,7 +113,7 @@ def get_interface_version(mount_point):
     if get_module_avail('mbed_lstools'):
         try :
             mbeds = mbed_lstools.create()
-            details_txt = mbeds.get_details_txt(mount_point)    
+            details_txt = mbeds.get_details_txt(mount_point)
             
             if 'Interface Version' in details_txt:
                 return details_txt['Interface Version']

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -111,18 +111,18 @@ def get_interface_version(mount_point):
         @param mount_point Name of disk where platform is connected to host machine.
     """
     if get_module_avail('mbed_lstools'):
-        mbeds = mbed_lstools.create()
-        details_txt = mbeds.get_details_txt(mount_point)
-        
-        if (details_txt is None):
-            details_txt = {}
+        try :
+            mbeds = mbed_lstools.create()
+            details_txt = mbeds.get_details_txt(mount_point)    
             
-        
-        if 'Interface Version' in details_txt:
-            return details_txt['Interface Version']
-        
-        elif 'Version' in details_txt:
-            return details_txt['Version']
+            if 'Interface Version' in details_txt:
+                return details_txt['Interface Version']
+            
+            elif 'Version' in details_txt:
+                return details_txt['Version']
+            
+        except :
+            return 'unknown'
         
     return 'unknown'
 

--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -31,9 +31,13 @@ check_required_modules(['prettytable'])
 # Imports related to mbed build api
 from tools.build_api import mcu_toolchain_matrix
 from tools.test_api import get_autodetected_MUTS_list
-from tools.test_api import get_mounted_details_txt
+from tools.test_api import get_module_avail
 from argparse import ArgumentParser
 
+try:
+    import mbed_lstools
+except:
+    pass
 
 def main():
     """Entry Point"""
@@ -76,17 +80,17 @@ def main():
         count = 0
         for mut in muts.values():
             if re.match(mcu_filter, mut['mcu']):
-                # Grab additional target details about the mut
-                details_txt = get_mounted_details_txt(mut['disk'])
+                interface_version = get_interface_version(mut['disk'])
                 print ""
-                print "[mbed] Detected %s, port %s, mounted %s, interface version %s" % \
-                    (mut['mcu'], mut['port'], mut['disk'], details_txt['Interface Version'])
+                print "[mbed] Detected %s, port %s, mounted %s, interface version %s:" % \
+                        (mut['mcu'], mut['port'], mut['disk'], interface_version)
+                                    
                 print "[mbed] Supported toolchains for %s" % mut['mcu']
                 print mcu_toolchain_matrix(platform_filter=mut['mcu'])
                 count += 1
 
         if count == 0:
-            print "[mbed] No mbed targets where detected on your system."
+            print "[mbed] No mbed targets were detected on your system."
 
     except KeyboardInterrupt:
         print "\n[CTRL+c] exit"
@@ -95,6 +99,23 @@ def main():
         traceback.print_exc(file=sys.stdout)
         print "[ERROR] %s" % str(exc)
         sys.exit(1)
+        
+def get_interface_version(mount_point):
+    """ Function returns interface version from the target mounted on the specified mount point
+            mount_point = mut['port']
+        @param mount_point Name of disk where platform is connected to host machine.
+    """
+    if get_module_avail('mbed_lstools'):
+        mbeds = mbed_lstools.create()
+        details_txt = mbeds.get_details_txt(mount_point)
+        
+        if 'Interface Version' in details_txt:
+            return details_txt['Interface Version']
+        
+        elif 'Version' in details_txt:
+            return details_txt['Version']
+        
+    return 'unknown'
 
 if __name__ == '__main__':
     main()

--- a/tools/test/detect_targets_test.py
+++ b/tools/test/detect_targets_test.py
@@ -1,6 +1,6 @@
 """
 mbed SDK
-Copyright (c) 2016 ARM Limited
+Copyright (c) 2017 ARM Limited
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,8 +16,6 @@ limitations under the License.
 """
 
 import unittest
-from collections import namedtuple
-from mock import patch, MagicMock
 from tools.detect_targets import get_interface_version
 from tools.test_api import get_autodetected_MUTS_list
 

--- a/tools/test/detect_targets_test.py
+++ b/tools/test/detect_targets_test.py
@@ -1,0 +1,85 @@
+"""
+mbed SDK
+Copyright (c) 2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import unittest
+from collections import namedtuple
+from mock import patch, MagicMock
+from tools.detect_targets import get_interface_version
+from tools.test_api import get_autodetected_MUTS_list
+
+"""
+Tests for detect_targets.py
+"""
+
+class DetectTargetsTests(unittest.TestCase):
+    """
+    Test cases for Detect Target functionality
+    """
+
+    def setUp(self):
+        """
+        Called before each test case
+
+        :return:
+        """
+        # Gather a valid mount point from the host machine
+        muts = get_autodetected_MUTS_list()
+        
+        count = 0
+        
+        for mut in muts.values():
+            
+            count += 1
+            self.valid_mount_point = mut['disk']
+            break
+        
+        # If no targets are found, there is no way to determine Host OS mount point.
+        # Function should handle failure gracefully regardless of a mount point being present.
+        # Therefore it is safe to assume a valid mount point.
+        if count is 0:
+            self.valid_mount_point = "D:"        
+        
+        self.invalid_mount_point = "23z/e\n"
+        self.missing_mount_point = None
+
+    def tearDown(self):
+        """
+        Nothing to tear down.
+        Called after each test case
+
+        :return:
+        """
+        pass
+
+    def test_interface_version_valid_mount_point(self):
+        
+        interface_version = get_interface_version(self.valid_mount_point)
+        assert len(interface_version) > 0
+
+    def test_interface_version_invalid_mount_point(self):
+        
+        interface_version = get_interface_version(self.invalid_mount_point)
+        assert interface_version == 'unknown'
+        
+    def test_interface_version_missing_mount_point(self):
+        
+        interface_version = get_interface_version(self.missing_mount_point)
+        assert interface_version == 'unknown'
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test/detect_targets_test.py
+++ b/tools/test/detect_targets_test.py
@@ -21,6 +21,9 @@ from tools.detect_targets import get_interface_version
 
 
 class MbedLsToolsMock():
+    """
+    Mock of mbedls tools
+    """
     
     def __init__(self, type):
         self.interface_test_type = type
@@ -144,11 +147,12 @@ class DetectTargetsTest(unittest.TestCase):
     @patch("mbed_lstools.create", return_value=MbedLsToolsMock('details_invalid_none'))
     def test_interface_version_missing_mount_point(self, mbed_lstools_mock):
         """
-        Test that checks function returns correctly when no moint point is supplied.
+        Test that checks function returns correctly when no mount point is supplied.
         
         :param mbed_lstools_mock: Mocks Mbed LS tools with MbedLsToolsMock
         :return 
         """
+        
         interface_version = get_interface_version(self.missing_mount_point)
         assert interface_version == 'unknown'
 

--- a/tools/test/detect_targets_test.py
+++ b/tools/test/detect_targets_test.py
@@ -25,8 +25,8 @@ class MbedLsToolsMock():
     Mock of mbedls tools
     """
     
-    def __init__(self, type):
-        self.interface_test_type = type
+    def __init__(self, test_type):
+        self.interface_test_type = test_type
     
     def get_details_txt(self, mount_point):
         return self.details_txt_types[self.interface_test_type];

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -1647,6 +1647,12 @@ def get_module_avail(module_name):
     """
     return module_name in sys.modules.keys()
 
+def get_mounted_details_txt(mount_point):
+    """ Function returns object containing details.txt information from the specified mount point
+        @param mount_point Name of disk where platform is connected to host machine.
+    """
+    mbeds = mbed_lstools.create()
+    return mbeds.get_details_txt(mount_point)
 
 def get_autodetected_MUTS_list(platform_name_filter=None):
     oldError = None

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -1643,16 +1643,9 @@ def detect_database_verbose(db_url):
 
 
 def get_module_avail(module_name):
-    """ This function returns True if module_name is already impored module
+    """ This function returns True if module_name is already imported module
     """
     return module_name in sys.modules.keys()
-
-def get_mounted_details_txt(mount_point):
-    """ Function returns object containing details.txt information from the specified mount point
-        @param mount_point Name of disk where platform is connected to host machine.
-    """
-    mbeds = mbed_lstools.create()
-    return mbeds.get_details_txt(mount_point)
 
 def get_autodetected_MUTS_list(platform_name_filter=None):
     oldError = None


### PR DESCRIPTION
## Description
This adds the additional information of the interface version (IE DAPlink, OpenSDA, etc) to the command `mbed detect`

This has proved useful when debugging applications, particularly when encountering interface issues. Not knowing about mbedls, I found it difficult to debug my application, where the USB driver and board was crashing when dragging the .bin to the disk for deployment in Windows 10. This information is a "nice to have" for a quick reference for mbed developers.

**Example output:**
```
...Desktop\mbed Workspace\mbed-os>mbed detect

[mbed] Detected K64F, port COM4, mounted D:, interface version 0243
[mbed] Supported toolchains for K64F
+--------+-----------+-----------+-----------+-----------+-----------+
| Target | mbed OS 2 | mbed OS 5 |    ARM    |  GCC_ARM  |    IAR    |
+--------+-----------+-----------+-----------+-----------+-----------+
| K64F   | Supported | Supported | Supported | Supported | Supported |
+--------+-----------+-----------+-----------+-----------+-----------+
Supported targets: 1
Supported toolchains: 3
```
## Status
Built on mbed OS 5.5, will be tested against mbed OS 5.6 when an rc is ready.

## Migrations
Added one method to test_api.py `def get_mounted_details_txt(mount_point)` to pull the details.txt for a specific target given it's mount point. This could prove useful later as additional information may want to be propagated to other tools using the test API.

## Related Issues
Submitted issue relating to this here:
https://github.com/ARMmbed/mbed-cli/issues/541

The approach was changed slightly from the original issue request. This was because the ``mut matrix PrettyTable`` for the command ``mbed detect`` displayed specifically MUT information. In order to not change the format of the MUT JSON, I decided to create the additional function ``def get_mounted_details_txt(mount_point)`` which created another mbed ls tools resource and display the information separately from the mut matrix.

## Steps to test or reproduce
Run the `mbed detect` command.

Expected output should be similar to:
```
[mbed] Detected K64F, port COM4, mounted D:, interface version 0243
[mbed] Supported toolchains for K64F
+--------+-----------+-----------+-----------+-----------+-----------+
| Target | mbed OS 2 | mbed OS 5 |    ARM    |  GCC_ARM  |    IAR    |
+--------+-----------+-----------+-----------+-----------+-----------+
| K64F   | Supported | Supported | Supported | Supported | Supported |
+--------+-----------+-----------+-----------+-----------+-----------+
Supported targets: 1
Supported toolchains: 3
```