### PR TITLE
Enable access to kernel tick information in ISR

### DIFF
--- a/rtos/TARGET_CORTEX/rtx5/rtx_kernel.c
+++ b/rtos/TARGET_CORTEX/rtx5/rtx_kernel.c
@@ -607,8 +607,7 @@ void osKernelResume (uint32_t sleep_ticks) {
 /// Get the RTOS kernel tick count.
 uint64_t osKernelGetTickCount (void) {
   if (IS_IRQ_MODE() || IS_IRQ_MASKED()) {
-    EvrRtxKernelGetTickCount(0U);
-    return  0U;
+    return svcRtxKernelGetTickCount();
   } else {
     return  __svcKernelGetTickCount();
   }
@@ -617,8 +616,7 @@ uint64_t osKernelGetTickCount (void) {
 /// Get the RTOS kernel tick frequency.
 uint32_t osKernelGetTickFreq (void) {
   if (IS_IRQ_MODE() || IS_IRQ_MASKED()) {
-    EvrRtxKernelGetTickFreq(0U);
-    return  0U;
+    return svcRtxKernelGetTickFreq();
   } else {
     return  __svcKernelGetTickFreq();
   }


### PR DESCRIPTION
## Description
The osKernelGetTickCount() is the only function to get kernel tick information, however it's not allowed to access in ISR.
The implementation is already enabled in API v2.1.1.
https://github.com/ARM-software/CMSIS_5/commit/f32dc4c2c51a68d614a92d59dd634d8edecb4e69
