### PR TITLE
mbedtls: Disable MD5, SHA1, SHA256 HW ACC for STM32F439xI

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
@@ -24,10 +24,12 @@
  * (https://github.com/ARMmbed/mbed-os/issues/4928) */
 /* #define MBEDTLS_AES_ALT */
 
-#define MBEDTLS_SHA256_ALT
+/* FIXME: Don't enable SHA1, SHA256 and MD5 hardware acceleration until issue
+ * #5079 is fixed. (https://github.com/ARMmbed/mbed-os/issues/5079) */
+/* #define MBEDTLS_SHA256_ALT */
 
-#define MBEDTLS_SHA1_ALT
+/* #define MBEDTLS_SHA1_ALT */
 
-#define MBEDTLS_MD5_ALT
+/* #define MBEDTLS_MD5_ALT */
 
 #endif /* MBEDTLS_DEVICE_H */


### PR DESCRIPTION
# **Critical workaround to issue #5079.**

STM32F439xI-family MD5, SHA1 and SHA256 hardware acceleration
occasionally produces incorrect output (#5079).

Don't enable MD5, SHA1 and SHA256 HW acceleration on STM32F439xI-family
targets by default until issue #5079 is fixed.

## Status

READY for REVIEW as WORKAROUND