### PR TITLE
Allow exporters for NUCLEO_L486RG

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -23,6 +23,9 @@
     "STM32L476RG": {
         "OGChipSelectEditMenu": "STM32L476RG\tST STM32L476RG"
     },
+    "STM32L486RG": {
+        "OGChipSelectEditMenu": "STM32L486RG\tST STM32L486RG"
+    },
     "STM32L011K4": {
         "OGChipSelectEditMenu": "STM32L011x4\tST STM32L011x4"
     },

--- a/tools/export/sw4stm32/__init__.py
+++ b/tools/export/sw4stm32/__init__.py
@@ -249,6 +249,11 @@ class Sw4STM32(GNUARMEclipse):
             'name': 'NUCLEO-L476RG',
             'mcuId': 'STM32L476RGTx'
         },
+        'NUCLEO_L486RG':
+        {
+            'name': 'NUCLEO-L486RG',
+            'mcuId': 'STM32L486RGTx'
+        },
     }
 
     TARGETS = BOARDS.keys()


### PR DESCRIPTION
## Description
NUCLEO_L486RG is not handled by tool scripts for exporters.
With this PR we can export and debug this target.



## Status
READY
