### PR TITLE
add ARMC6 in supported compiler

### DIFF
--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -19,7 +19,7 @@ from tools.build_api import get_mbed_official_release
 from tools.targets import TARGET_MAP
 from tools.export import EXPORTERS
 
-SUPPORTED_TOOLCHAINS = ["ARM", "IAR", "GCC_ARM"]
+SUPPORTED_TOOLCHAINS = ["ARM", "IAR", "GCC_ARM", "ARMC6"]
 SUPPORTED_IDES = [exp for exp in EXPORTERS.keys() if exp != "cmsis" and exp != "zip"]
 
 


### PR DESCRIPTION
Add ARMC6 in supported list of compiler

```
00:00:00.031  ARMC6 --mcu ARCH_PRO
00:00:00.290 usage: examples.py compile [-h] [-m MCU] [toolchains [toolchains ...]]
00:00:00.290 examples.py compile: error: argument toolchains: ARMC6 is not a supported toolchain. Supported toolchains are:
00:00:00.290 ARM,     IAR,     GCC_ARM  
00:00:00.307 + echo 2
```