### PR TITLE
Correct long call macros for ARMC6

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_compiler.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_compiler.h
@@ -29,6 +29,12 @@
 #define __romcall
 #define __longcall
 
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+
+#ifndef __longcall
+#define __longcall
+#endif
+
 #elif defined(__CC_ARM)
 
 #ifndef __longcall

--- a/targets/TARGET_Realtek/TARGET_AMEBA/sdk/soc/realtek/common/bsp/basic_types.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/sdk/soc/realtek/common/bsp/basic_types.h
@@ -206,6 +206,23 @@ typedef	    __kernel_ssize_t	SSIZE_T;
 
 #define _LONG_CALL_ROM_     _LONG_CALL_
 
+#elif defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+#define SECTION(_name) __attribute__ ((__section__(_name)))
+#define ALIGNMTO(_bound) __attribute__ ((aligned (_bound)))
+#define _PACKED_       __attribute__ ((packed))
+#ifdef CONFIG_RELEASE_BUILD_LIBRARIES
+#define _LONG_CALL_
+#define _LONG_CALL_ROM_
+#ifdef E_CUT_ROM_DOMAIN
+#undef _LONG_CALL_ROM_
+#define _LONG_CALL_ROM_
+#endif
+#else
+#define _LONG_CALL_
+#define _LONG_CALL_ROM_     _LONG_CALL_
+#endif
+#define _WEAK           __attribute__ ((weak))
+
 #else
 #define SECTION(_name) __attribute__ ((__section__(_name)))
 #define ALIGNMTO(_bound) __attribute__ ((aligned (_bound)))


### PR DESCRIPTION
This should fix the extremely long compile times for the Realtek
RTL8195AM board. Could I get someone from Realtek to review?