### PR TITLE
Release deep sleep lock in destructor of Timer class

### DIFF
--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -28,6 +28,15 @@ Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker
     reset();
 }
 
+Timer::~Timer() {
+    core_util_critical_section_enter();
+    if (_running) {
+        sleep_manager_unlock_deep_sleep();
+    }
+    _running = 0;
+    core_util_critical_section_exit();
+}
+
 void Timer::start() {
     core_util_critical_section_enter();
     if (!_running) {

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -53,6 +53,7 @@ class Timer : private NonCopyable<Timer> {
 public:
     Timer();
     Timer(const ticker_data_t *data);
+    ~Timer();
 
     /** Start the timer
      */


### PR DESCRIPTION
Release the deep sleep lock when running instances of the Timer class are deleted. This ensures that deep sleep locks are properly released by the Timer class.