### PR TITLE
Remove direct use of us and lp ticker from tests

### DIFF
--- a/TESTS/mbed_drivers/lp_timeout/main.cpp
+++ b/TESTS/mbed_drivers/lp_timeout/main.cpp
@@ -23,7 +23,6 @@
 #include "greentea-client/test_env.h"
 
 #include "mbed.h"
-#include "us_ticker_api.h"
 
 using namespace utest::v1;
 
@@ -42,6 +41,7 @@ void cb_done() {
 void lp_timeout_1s_deepsleep(void)
 {
     complete = false;
+    LowPowerTimer timer;
 
     /*
      * Since deepsleep() may shut down the UART peripheral, we wait for 10ms
@@ -54,33 +54,32 @@ void lp_timeout_1s_deepsleep(void)
     wait_ms(10);
 
     /*
-     * We use here lp_ticker_read() instead of us_ticker_read() for start and
+     * We use here the low power timer instead of microsecond timer for start and
      * end because the microseconds timer might be disable during deepsleep.
      */
-    timestamp_t start = lp_ticker_read();
+    timer.start();
     lpt.attach(&cb_done, 1);
     deepsleep();
     while (!complete);
-    timestamp_t end = lp_ticker_read();
 
     /* It takes longer to wake up from deep sleep */
-    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
+    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, timer.read_us());
     TEST_ASSERT_TRUE(complete);
 }
 
 void lp_timeout_1s_sleep(void)
 {
     complete = false;
+    Timer timer;
+    timer.start();
 
     sleep_manager_lock_deep_sleep();
-    timestamp_t start = us_ticker_read();
     lpt.attach(&cb_done, 1);
     sleep();
     while (!complete);
-    timestamp_t end = us_ticker_read();
     sleep_manager_unlock_deep_sleep();
 
-    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
+    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, timer.read_us());
     TEST_ASSERT_TRUE(complete);
 }
 #endif /* DEVICE_SLEEP */
@@ -88,14 +87,14 @@ void lp_timeout_1s_sleep(void)
 void lp_timeout_us(uint32_t delay_us, uint32_t tolerance)
 {
     complete = false;
+    Timer timer;
+    timer.start();
 
-    timestamp_t start = us_ticker_read();
     lpt.attach_us(&cb_done, delay_us);
     while (!complete);
-    timestamp_t end = us_ticker_read();
 
     /* Using RTC which is less accurate */
-    TEST_ASSERT_UINT32_WITHIN(tolerance, delay_us, end - start);
+    TEST_ASSERT_UINT32_WITHIN(tolerance, delay_us, timer.read_us());
     TEST_ASSERT_TRUE(complete);
 }
 

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -23,17 +23,16 @@
 #include "greentea-client/test_env.h"
 
 #include "mbed.h"
-#include "us_ticker_api.h"
 #include "lp_ticker_api.h"
-#include "TimerEvent.h"
 
 using namespace utest::v1;
 
 static volatile bool complete;
-static volatile timestamp_t complete_timestamp;
+static volatile timestamp_t complete_time;
 static ticker_event_t delay_event;
 static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
-
+static Timer timer;
+static LowPowerTimer lp_timer;
 
 /* Timeouts are quite arbitrary due to large number of boards with varying level of accuracy */
 #define LONG_TIMEOUT (100000)
@@ -41,7 +40,7 @@ static const ticker_data_t *lp_ticker_data = get_lp_ticker_data();
 
 void cb_done(uint32_t id) {
     if ((uint32_t)&delay_event == id) {
-        complete_timestamp = us_ticker_read();
+        complete_time = timer.read_us();
         complete = true;
     } else {
         // Normal ticker handling
@@ -51,7 +50,7 @@ void cb_done(uint32_t id) {
 
 void cb_done_deepsleep(uint32_t id) {
     if ((uint32_t)&delay_event == id) {
-        complete_timestamp = lp_ticker_read();
+        complete_time = lp_timer.read_us();
         complete = true;
     } else {
         // Normal ticker handling
@@ -66,14 +65,15 @@ void lp_ticker_delay_us(uint32_t delay_us, uint32_t tolerance)
 
     ticker_set_handler(lp_ticker_data, cb_done);
     ticker_remove_event(lp_ticker_data, &delay_event);
-    delay_ts = lp_ticker_read() + delay_us;
+    delay_ts = ticker_read(lp_ticker_data) + delay_us;
 
-    timestamp_t start = us_ticker_read();
+    timer.reset();
+    timer.start();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     while (!complete);
-    timestamp_t end = complete_timestamp;
+    timer.stop();
 
-    TEST_ASSERT_UINT32_WITHIN(tolerance, delay_us, end - start);
+    TEST_ASSERT_UINT32_WITHIN(tolerance, delay_us, complete_time);
     TEST_ASSERT_TRUE(complete);
 }
 
@@ -95,19 +95,20 @@ void lp_ticker_1s_deepsleep()
 
     ticker_set_handler(lp_ticker_data, cb_done_deepsleep);
     ticker_remove_event(lp_ticker_data, &delay_event);
-    delay_ts = lp_ticker_read() + 1000000;
+    delay_ts = ticker_read(lp_ticker_data) + 1000000;
 
     /*
-     * We use here lp_ticker_read() instead of us_ticker_read() for start and
+     * We use here the low power timer instead of microsecond timer for start and
      * end because the microseconds timer might be disable during deepsleep.
      */
-    timestamp_t start = lp_ticker_read();
+    lp_timer.reset();
+    lp_timer.start();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     deepsleep();
     while (!complete);
-    timestamp_t end = complete_timestamp;
+    lp_timer.stop();
 
-    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
+    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, complete_time);
     TEST_ASSERT_TRUE(complete);
 }
 
@@ -118,17 +119,18 @@ void lp_ticker_1s_sleep()
 
     ticker_set_handler(lp_ticker_data, cb_done);
     ticker_remove_event(lp_ticker_data, &delay_event);
-    delay_ts = lp_ticker_read() + 1000000;
+    delay_ts = ticker_read(lp_ticker_data) + 1000000;
 
     sleep_manager_lock_deep_sleep();
-    timestamp_t start = us_ticker_read();
+    timer.reset();
+    timer.start();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     sleep();
     while (!complete);
-    timestamp_t end = complete_timestamp;
+    timer.stop();
     sleep_manager_unlock_deep_sleep();
 
-    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, end - start);
+    TEST_ASSERT_UINT32_WITHIN(LONG_TIMEOUT, 1000000, complete_time);
     TEST_ASSERT_TRUE(complete);
 }
 #endif /* DEVICE_SLEEP */

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -191,11 +191,12 @@ void test_dual_thread_lock_trylock_thread(Mutex *mutex)
 
 void test_dual_thread_lock_lock_thread(Mutex *mutex)
 {
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     osStatus stat = mutex->lock(TEST_DELAY);
     TEST_ASSERT_EQUAL(osErrorTimeout, stat);
-    TEST_ASSERT_UINT32_WITHIN(5000, TEST_DELAY*1000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(5000, TEST_DELAY*1000, timer.read_us());
 }
 
 /** Test dual thread lock

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -135,11 +135,12 @@ void test_get_empty_no_timeout()
 void test_get_empty_timeout()
 {
     Queue<uint32_t, 1> q;
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     osEvent evt = q.get(50);
     TEST_ASSERT_EQUAL(osEventTimeout, evt.status);
-    TEST_ASSERT_UINT32_WITHIN(5000, 50000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(5000, 50000, timer.read_us());
 }
 
 /** Test get empty wait forever
@@ -157,12 +158,13 @@ void test_get_empty_wait_forever()
 
     t.start(callback(thread_put_uint_msg<TEST_TIMEOUT>, &q));
 
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     osEvent evt = q.get();
     TEST_ASSERT_EQUAL(osEventMessage, evt.status);
     TEST_ASSERT_EQUAL(TEST_UINT_MSG, evt.value.v);
-    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, timer.read_us());
 }
 
 /** Test put full no timeout
@@ -195,11 +197,12 @@ void test_put_full_timeout()
     osStatus stat = q.put((uint32_t*) TEST_UINT_MSG, TEST_TIMEOUT);
     TEST_ASSERT_EQUAL(osOK, stat);
 
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     stat = q.put((uint32_t*) TEST_UINT_MSG, TEST_TIMEOUT);
     TEST_ASSERT_EQUAL(osErrorTimeout, stat);
-    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, timer.read_us());
 }
 
 /** Test put full wait forever
@@ -220,10 +223,11 @@ void test_put_full_waitforever()
     osStatus stat = q.put((uint32_t*) TEST_UINT_MSG);
     TEST_ASSERT_EQUAL(osOK, stat);
 
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
     stat = q.put((uint32_t*) TEST_UINT_MSG, osWaitForever);
     TEST_ASSERT_EQUAL(osOK, stat);
-    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(TEST_TIMEOUT * 100, TEST_TIMEOUT * 1000, timer.read_us());
 
     t.join();
 }

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -152,7 +152,8 @@ void test_timeout()
     Semaphore sem(0);
     osStatus res;
 
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
     res = t.start(callback(timeout_thread, &sem));
     TEST_ASSERT_EQUAL(osOK, res);
     Thread::wait(SHORT_WAIT);
@@ -160,7 +161,7 @@ void test_timeout()
     TEST_ASSERT_EQUAL(Thread::WaitingSemaphore, t.get_state());
 
     t.join();
-    TEST_ASSERT_UINT32_WITHIN(5000, 30000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(5000, 30000, timer.read_us());
 }
 
 /** Test no timeouts
@@ -180,12 +181,13 @@ void test_no_timeout()
 {
     Semaphore sem(T);
 
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     int32_t cnt = sem.wait(0);
     TEST_ASSERT_EQUAL(T, cnt);
 
-    TEST_ASSERT_UINT32_WITHIN(5000, 0, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(5000, 0, timer.read_us());
 }
 
 /** Test multiple tokens wait

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -377,11 +377,12 @@ void test_thread_stack_info() {
     then the thread sleeps for given amount of time
  */
 void test_thread_wait() {
-    uint32_t start = us_ticker_read();
+    Timer timer;
+    timer.start();
 
     Thread::wait(150);
 
-    TEST_ASSERT_UINT32_WITHIN(50000, 150000, us_ticker_read() - start);
+    TEST_ASSERT_UINT32_WITHIN(50000, 150000, timer.read_us());
 }
 
 /** Testing thread name


### PR DESCRIPTION
Remove the direct use of the microsecond and low power ticker from the tests. This enforces that sleep mode is properly locked when using timers. Furthermore, this prepares the codebase for new ticker changes which allow differing clock frequencies and timer bit widths.