### PR TITLE
Move clock() function from mbed_rtc_time.cpp to mbed_retarget.cpp.

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <time.h>
 #include "platform/platform.h"
 #include "platform/FilePath.h"
 #include "hal/serial_api.h"
+#include "hal/us_ticker_api.h"
 #include "platform/mbed_toolchain.h"
 #include "platform/mbed_semihost_api.h"
 #include "platform/mbed_interface.h"
@@ -24,6 +26,7 @@
 #include "platform/mbed_error.h"
 #include "platform/mbed_stats.h"
 #include "platform/mbed_critical.h"
+#include "platform/PlatformMutex.h"
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
@@ -32,6 +35,8 @@
 #endif
 #include <errno.h>
 #include "platform/mbed_retarget.h"
+
+static SingletonPtr<PlatformMutex> _mutex;
 
 #if defined(__ARMCC_VERSION)
 #   include <rt_sys.h>
@@ -985,3 +990,23 @@ void operator delete[](void *ptr)
         free(ptr);
     }
 }
+
+/* @brief   standard c library clock() function.
+ *
+ * This function returns the number of clock ticks elapsed since the start of the program.
+ *
+ * @note Synchronization level: Thread safe
+ *
+ * @return
+ *  the number of clock ticks elapsed since the start of the program.
+ *
+ * */
+extern "C" clock_t clock()
+{
+    _mutex->lock();
+    clock_t t = us_ticker_read();
+    t /= 1000000 / CLOCKS_PER_SEC; // convert to processor time
+    _mutex->unlock();
+    return t;
+}
+

--- a/platform/mbed_rtc_time.cpp
+++ b/platform/mbed_rtc_time.cpp
@@ -15,10 +15,8 @@
  */
 #include "hal/rtc_api.h"
 
-#include <time.h>
 #include "platform/mbed_critical.h"
 #include "platform/mbed_rtc_time.h"
-#include "hal/us_ticker_api.h"
 #include "platform/SingletonPtr.h"
 #include "platform/PlatformMutex.h"
 
@@ -74,14 +72,6 @@ void set_time(time_t t) {
         _rtc_write(t);
     }
     _mutex->unlock();
-}
-
-clock_t clock() {
-    _mutex->lock();
-    clock_t t = us_ticker_read();
-    t /= 1000000 / CLOCKS_PER_SEC; // convert to processor time
-    _mutex->unlock();
-    return t;
 }
 
 void attach_rtc(time_t (*read_rtc)(void), void (*write_rtc)(time_t), void (*init_rtc)(void), int (*isenabled_rtc)(void)) {


### PR DESCRIPTION
## Description
Move clock() function from mbed_rtc_time.cpp to mbed_retarget.cpp as this is more suitable place for this function.
This PR is a result of discussion from [PR#5087:](https://github.com/ARMmbed/mbed-os/pull/5087)

> > There is no information in documentation neither header file about clock() function. Maybe this function should be removed? It is used nowhere and it looks like this is not API.

> I think it's a implementation of standard library function, maybe it's not the best place for it, you could try opening new PR and moving it to mbed_retarget.cpp.



## Status
READY


## Migrations
NO
