### PR TITLE
Modify description of set_time() function.

### DIFF
--- a/platform/mbed_rtc_time.h
+++ b/platform/mbed_rtc_time.h
@@ -63,6 +63,10 @@ extern "C" {
  *
  * @note Synchronization level: Thread safe
  *
+ * @note On some platforms time can not be set to 0 since it is invalid value.
+ *       In such case when 0 value is passed to this function, then RTC time
+ *       value is set to 1.
+ *
  * Example:
  * @code
  * #include "mbed.h"


### PR DESCRIPTION
## Description
Add note about setting RTC time value to 0. 

This PR is a result of discussion from [PR#5087](https://github.com/ARMmbed/mbed-os/pull/5087):

> >  set_time() function on some platforms does not set RTC time to 0. In such case specific driver function - rtc_write() sets time to 1 instead of 0. This is caused because on some platforms 0 is an invalid time. Unfortunately there is no information about this behaviour. Maybe a warning should be added to the set_time() function description?

> Just a note in the doxygen should be enough.


## Status
READY


## Migrations
NO
