### PR TITLE
mbed_rtx_idle: uVisor: Don't attempt to sleep

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -195,6 +195,14 @@ static void default_idle_hook(void)
     core_util_critical_section_exit();
 }
 
+#elif defined(FEATURE_UVISOR)
+
+static void default_idle_hook(void)
+{
+    /* uVisor can't sleep. See <https://github.com/ARMmbed/uvisor/issues/420>
+     * for details. */
+}
+
 #else
 
 static void default_idle_hook(void)


### PR DESCRIPTION
## Description
mbed_rtx_idle: uVisor: Don't attempt to sleep

When uVisor is enabled, don't attempt to sleep. Attempting to sleep will fail, as per <https://github.com/ARMmbed/uvisor/issues/420>.

Fixes OOB issue https://github.com/ARMmbed/mbed-os-example-uvisor/issues/55

## Status
**READY**