### PR TITLE
Add simple change impact detection script for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,4 @@ install:
   - pip install mock
   - pip install coverage
   - pip install coveralls
+  - pip install jsonschema

--- a/tools/file_impact.py
+++ b/tools/file_impact.py
@@ -1,0 +1,48 @@
+from __future__ import print_function
+import sys
+import argparse
+import json
+from os.path import abspath, join, dirname
+
+# Be sure that the tools directory is in the search path
+ROOT = abspath(join(dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from tools.build_api import prepare_toolchain, scan_resources
+from tools.toolchains import mbedToolchain, TOOLCHAIN_CLASSES, TOOLCHAIN_PATHS
+from tools.targets import TARGET_MAP
+from tools.config import ConfigException
+from tools.arm_pack_manager import do_queue, Reader
+
+def should_be_built(target_name, toolchain_name, to_find):
+    if toolchain_name not in TARGET_MAP[target_name].supported_toolchains:
+        return False
+    k = prepare_toolchain(ROOT, "BUILD", target_name, toolchain_name,
+                            notify=lambda _, __: True)
+    try:
+        r = scan_resources([ROOT], k)
+        combo_files = set(
+            r.headers + r.c_sources + r.cpp_sources + r.s_sources +
+            r.objects + r.libraries + r.hex_files + r.bin_files +
+            r.json_files)
+        if combo_files.intersection(to_find):
+            return True
+    except ConfigException:
+        pass
+    return False
+
+def main():
+    to_build = {}
+    to_find = set([abspath(f.strip()) for f in sys.stdin.readlines()])
+    for target_name in TARGET_MAP:
+        for toolchain_name in TOOLCHAIN_CLASSES:
+            if should_be_built(target_name, toolchain_name, to_find):
+                to_build.setdefault(target_name, [])
+                to_build[target_name].append(toolchain_name)
+    if not to_build:
+        to_build = {t_name: TOOLCHAIN_CLASSES.keys() for t_name in TARGET_MAP}
+    json.dump(to_build, sys.stdout, indent=True)
+    print()
+
+if __name__ == "__main__":
+    main()

--- a/tools/test/file_impact/output-schema.json
+++ b/tools/test/file_impact/output-schema.json
@@ -1,0 +1,10 @@
+{
+    "type": "object",
+    "additionalProperties": {
+        "type": "array",
+        "uniqueItems": true,
+        "items": {
+            "enum": ["GCC_ARM", "ARM", "uARM", "ARMC6", "IAR"]
+        }
+    }
+}

--- a/tools/test/file_impact/test_file_impact.py
+++ b/tools/test/file_impact/test_file_impact.py
@@ -1,0 +1,79 @@
+from __future__ import print_function
+
+import pytest
+import json
+
+from os.path import join, dirname
+from StringIO import StringIO
+from mock import patch
+from jsonschema import validate
+
+import tools.file_impact
+from tools.config import ConfigException
+from tools.toolchains import Resources
+from tools.targets import TARGET_MAP
+from tools.toolchains import TOOLCHAIN_CLASSES
+
+def test_false_should_be_built():
+    with patch('tools.file_impact.prepare_toolchain') as pt,\
+         patch('tools.file_impact.scan_resources') as sr:
+        sr.return_value = Resources()
+        assert not tools.file_impact.should_be_built("K64F", "GCC_ARM", "not/present")
+
+def test_true_should_be_built():
+    with patch('tools.file_impact.prepare_toolchain') as pt,\
+         patch('tools.file_impact.scan_resources') as sr:
+        sr.return_value = Resources()
+        sr.return_value.c_sources.append("present.c")
+        assert tools.file_impact.should_be_built("K64F", "GCC_ARM", ["present.c"])
+
+def test_ignore_config_error():
+    with patch('tools.file_impact.prepare_toolchain') as pt,\
+         patch('tools.file_impact.scan_resources') as sr:
+        sr.side_effect = ConfigException("Config failed")
+        assert not tools.file_impact.should_be_built("K64F", "GCC_ARM", ["present.c"])
+
+def test_pass_other_errors():
+    with patch('tools.file_impact.prepare_toolchain') as pt,\
+         patch('tools.file_impact.scan_resources') as sr:
+        sr.side_effect = Exception("No config failure")
+        with pytest.raises(Exception):
+            tools.file_impact.should_be_built("K64F", "GCC_ARM", ["present.c"])
+
+schema = json.load(open(join(dirname(__file__), "output-schema.json")))
+
+@pytest.mark.parametrize("file_present", [False, True])
+def test_main_schema(file_present):
+    with patch('tools.file_impact.should_be_built') as sbb, \
+         patch('sys.stdout', new_callable=StringIO) as out, \
+         patch('sys.stdin', new_callable=StringIO) as input:
+        sbb.return_value = file_present
+        tools.file_impact.main()
+        dumped = json.loads(out.getvalue())
+        assert validate(dumped, schema) is None
+        assert all(t in dumped for t in TARGET_MAP)
+        for value in dumped.values():
+            assert all(tc in value for tc in TOOLCHAIN_CLASSES)
+
+@pytest.mark.parametrize("target", ["K64F", "LPC1768"])
+def test_main_contains_required_targets(target):
+    def mocked_sbb(in_target, _, __):
+        return in_target == target
+    with patch('tools.file_impact.should_be_built') as sbb, \
+         patch('sys.stdout', new_callable=StringIO) as out, \
+         patch('sys.stdin', new_callable=StringIO) as input:
+        sbb.side_effect = mocked_sbb
+        tools.file_impact.main()
+        assert target in json.loads(out.getvalue())
+
+@pytest.mark.parametrize("toolchain", ["IAR", "GCC_ARM", "ARM", "ARMC6"])
+def test_main_contains_required_toolcahin(toolchain):
+    def mocked_sbb(_, in_toolchain, __):
+        return in_toolchain == toolchain
+    with patch('tools.file_impact.should_be_built') as sbb, \
+         patch('sys.stdout', new_callable=StringIO) as out, \
+         patch('sys.stdin', new_callable=StringIO) as input:
+        sbb.side_effect = mocked_sbb
+        tools.file_impact.main()
+        assert all(toolchain in tcs for tcs in json.loads(out.getvalue()).values())
+


### PR DESCRIPTION
This script must be invoked as follows:
```bash
git diff master --name-only | python2 tools/file_impact.py
```

The script accepts file names on stdin and dump json to stdout. This
json blob is of the following structure:
```json
{
  "TARGET_NAME": [
    "TOOLCHAIN_NAME",
    "ANOTHER_TOOLCHAIN_NAME",
    ...
  ],
  ...
}
```

-------------
Testing this will be done in two parts: unit tests and an integration
test on a staging environment.
 - [x] Unit tests
 - [ ] Staging environment test

The unit tests (subsequent commits) will test that, in isolation, the
script dumps json that conforms to the aforementioned structure and that
it is always conservative. Conservative in this context means that the
script always reports at least the targets required for a test of a
changeset.

In the staging environment we will setup a pipeline that acts as if this
PR has already made it to master and verify that it correctly triggers
the subset of tests we expect on a PR that only impacts a single target
or a subset of all targets.