### PR TITLE
Emit dependency information with ARMC6

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -19,7 +19,7 @@
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O0",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
-                   "-fno-exceptions"],
+                   "-fno-exceptions", "-MMD"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -18,7 +18,7 @@
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
-                   "-fno-exceptions"],
+                   "-fno-exceptions", "-MMD"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -18,7 +18,7 @@
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
-                   "-fno-exceptions"],
+                   "-fno-exceptions", "-MMD"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],


### PR DESCRIPTION
Which allows it to be parsed, and dependency information is restored!

Resolves #5110