### PR TITLE
Separate string literal from macro

### DIFF
--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -141,7 +141,7 @@ static void CMT_URC(ATCmdParser *at)
 
 static bool set_atd(ATCmdParser *at)
 {
-    bool success = at->send("ATD*99***" CTX"#") && at->recv("CONNECT");
+    bool success = at->send("ATD*99***" CTX "#") && at->recv("CONNECT");
 
     return success;
 }
@@ -469,7 +469,7 @@ retry_without_dual_stack:
 #endif
     success = _at->send("AT"
                           "+FCLASS=0;" // set to connection (ATD) to data mode
-                          "+CGDCONT=" CTX",\"%s\",\"%s%s\"",
+                          "+CGDCONT=" CTX ",\"%s\",\"%s%s\"",
                           pdp_type, auth, _apn
                          )
                    && _at->recv("OK");


### PR DESCRIPTION
From C++11 and beyond string literals must be seperated by space
so that they are recongizable as seperate tokens.

Context macro in PPPCellularInterface (CTX) has been causing issues
as it was not augmented with a space from a nearby string literal.
