### PR TITLE
Refactor memap for speed

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -166,7 +166,7 @@ class MemapParser(object):
                 return '[lib]/' + object_name
 
             else:
-                print "Malformed input found when parsing GCC map: %s" % line
+                print "Unknown object name found in GCC map file: %s" % line
                 return '[misc]'
 
     def parse_section_gcc(self, line, prefixes):
@@ -188,9 +188,10 @@ class MemapParser(object):
 
         is_section = re.match(RE_STD_SECTION_GCC, line)
         if is_section:
-            o_name = self.parse_object_name_gcc(is_section.group(3), prefixes)
             o_size = int(is_section.group(2), 16)
-            return [o_name, o_size]
+            if o_size:
+                o_name = self.parse_object_name_gcc(is_section.group(3), prefixes)
+                return [o_name, o_size]
 
         return ["", 0]
 

--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -34,7 +34,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -31,7 +31,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -31,7 +31,7 @@
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
-        "ld": []
+        "ld": ["--show_full_path"]
     },
     "uARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",

--- a/tools/test/memap/arm.map
+++ b/tools/test/memap/arm.map
@@ -1,0 +1,47 @@
+Component: ARM Compiler 5.06 update 5 (build 528) Tool: armlink [4d35e2]
+
+==============================================================================
+
+Memory Map of the image
+
+  Image Entry point : 0x0001b0c1
+
+  Load Region LR_IROM1 (Base: 0x0001b000, Size: 0x0000ed04, Max: 0x00025000, ABSOLUTE, COMPRESSED[0x0000e23c])
+
+    Execution Region ER_IROM1 (Base: 0x0001b000, Size: 0x0000e1c4, Max: 0x00025000, ABSOLUTE)
+
+    Base Addr    Size         Type   Attr      Idx    E Section Name        Object
+
+    0x0001b000   0x000000c0   Data   RO         7002    RESET               /common/path/startup/startup.o
+    0x0001b0c0   0x00000008   Code   RO         8820  * !!!main             /installed/libs/../lib/armlib/c_p.l(__main.o)
+    0x0001b26c   0x00000098   Code   RO         6076    .text               /common/path/irqs/irqs.o
+    0x000206a0   0x00000036   Code   RO           27    i._Z9time_funcPN4mbed5TimerEi  /common/path/main.o
+    0x200039b4   0x00000018   Data   RW         8092    .data               /common/path/data/data.o
+    0x20003af8   0x00000198   Zero   RW           57    .bss                /common/path/data/data.o
+
+==============================================================================
+
+Image component sizes
+
+
+      Code (inc. data)   RO Data    RW Data    ZI Data      Debug   
+
+       344        368          0         24        408      36188   Object Totals
+         8          0          0          0          0       7596   Library Totals
+
+==============================================================================
+
+
+      Code (inc. data)   RO Data    RW Data    ZI Data      Debug   
+
+       352        376          0         24        408      17208   Grand Totals
+       352        376          0         24        408      17208   ELF Image Totals (compressed)
+       352        376          0         24          0          0   ROM Totals
+
+==============================================================================
+
+    Total RO  Size (Code + RO Data)                  352 (   0.35kB)
+    Total RW  Size (RW Data + ZI Data)               432 (   0.43kB)
+    Total ROM Size (Code + RO Data + RW Data)        376 (   0.37kB)
+
+==============================================================================

--- a/tools/test/memap/gcc.map
+++ b/tools/test/memap/gcc.map
@@ -1,0 +1,25 @@
+Archive member included to satisfy reference by file (symbol)
+
+Linker script and memory map
+.text           0x000000000001b000    0x11a30
+ .Vectors       0x000000000001b000       0x98 /common/path/irqs/irqs.o
+                0x000000000001b168       0x36 /common/path/main.o
+                0x000000000001b168                count5(unsigned int, unsigned int, unsigned int, unsigned int, unsigned int)
+                0x000000000001b200       0xc0 /common/path/startup/startup.o
+                0x000000000001b200                startup()
+                0x0000000000024020        0x8 /usr/lib/gcc/arm-none-eabi/7.1.0/../../../../arm-none-eabi/lib/armv6-m/libd16M_tlf.a(__main.o)
+
+.data           0x0000000020002ef8      0xac8 load address 0x000000000002ca38
+                0x0000000020002ef8                __data_start__ = .
+ *(vtable)
+ *(.data*)
+                0x0000000020002ef8       0x18 /common/path/data/data.o
+                0x0000000020002ef8                some_global_var
+
+.bss            0x0000000020003a80     0x2050 load address 0x000000000002d5c0
+                0x0000000020003a80                . = ALIGN (0x4)
+                0x0000000020003a80                __bss_start__ = .
+ *(.bss*)
+ .bss.completed.8574
+ .bss.counter   0x0000000020003c08      0x198 /common/path/data.o
+                0x0000000020003c08                some_zero_init_var

--- a/tools/test/memap/iar.map
+++ b/tools/test/memap/iar.map
@@ -1,0 +1,86 @@
+###############################################################################
+#
+# IAR ELF Linker V7.80.1.28/LNX for ARM                   18/Sep/2017  14:26:09
+# Copyright 2007-2016 IAR Systems AB.
+#
+#    Output file  =  
+#        /common/path/project.elf
+#    Map file     =  
+#        /common/path/project.map
+#    Command line =  
+#        -f
+#        /common/path/.link_files.txt
+#        (-o
+#        --map=/common/path/project.map
+#        /common/path/project.elf
+#        /common/path/main.o
+#        /common/path/startup/startup.o
+#        /common/path/irqs/irqs.o
+#        /common/path/data/data.o
+#
+###############################################################################
+
+*******************************************************************************
+*** RUNTIME MODEL ATTRIBUTES
+***
+
+CppFlavor                     = *
+__CPP_Exceptions              = Disabled
+__CPP_Language                = C++
+__Heap_Handler                = DLMalloc
+__SystemLibrary               = DLib
+__dlib_dynamic_initialization = postponed
+__dlib_has_iterator_debugging = 0
+__dlib_jmp_buf_num_elements   = 8
+
+
+*******************************************************************************
+*** PLACEMENT SUMMARY
+***
+
+"A0":  place at 0x0001b000 { ro section .intvec };
+"P1":  place in [from 0x0001b0c0 to 0x0003ffff] { ro };
+"P2":  place in [from 0x20002ef8 to 0x20007fff] { rw, block HEAP, block CSTACK };
+do not initialize { section .noinit };
+initialize by copy { rw };
+ { section .intvec };
+
+  Section               Kind        Address    Size  Object
+  -------               ----        -------    ----  ------
+"A0":                                          0xc0
+  .intvec               ro code  0x0001b000    0xc0  startup.o [4]
+                               - 0x0001b0c0    0xc0
+
+"P1":                                         0x
+  .text                 ro code  0x0001c753    0x36  main.o [3]
+  .text                 ro code  0x0001cfff    0x98  irqs.o [5]
+  .text                 ro code  0x0001c778     0x8  __main.o [67]
+
+"P2", part 1 of 2:                             0x18
+  P2-1                           0x20002ef8    0x18  <Init block>
+    .data               inited   0x20002fa8    0x18  data.o [6]
+
+"P2", part 2 of 2:                            0x198
+  P2-2                           0x20005388   0x198  <Init block>
+    .bss                  zero   0x20002fa8   0x198  data.o [6]
+
+*******************************************************************************
+*** INIT TABLE
+***
+
+*******************************************************************************
+*** MODULE SUMMARY
+***
+
+d16M_tlf.a: [67]
+    __main.o                          8
+    ------------------------------------------------
+    Total:                            8
+
+    Linker created                             
+---------------------------------------------------
+    Grand Total:                      
+
+*******************************************************************************
+*** ENTRY LIST
+***

--- a/tools/test/memap/parse_test.py
+++ b/tools/test/memap/parse_test.py
@@ -1,0 +1,36 @@
+import sys
+from io import open
+from os.path import isfile, join, dirname
+import json
+
+import pytest
+
+from tools.memap import MemapParser
+from copy import deepcopy
+
+
+PARSED_ARM_DATA = {
+    "startup/startup.o": {".text": 0xc0},
+    "[lib]/c_p.l/__main.o": {".text": 8},
+    "irqs/irqs.o": {".text": 0x98},
+    "data/data.o": {".data": 0x18, ".bss": 0x198},
+    "main.o": {".text": 0x36},
+}
+
+def test_parse_armcc():
+    memap = MemapParser()
+    memap.parse_map_file_armcc(open(join(dirname(__file__), "arm.map")))
+    assert memap.modules == PARSED_ARM_DATA
+
+PARSED_IAR_GCC_DATA = {
+    "startup/startup.o": {".text": 0xc0},
+    "[lib]/d16M_tlf.a/__main.o": {".text": 8},
+    "irqs/irqs.o": {".text": 0x98},
+    "data/data.o": {".data": 0x18, ".bss": 0x198},
+    "main.o": {".text": 0x36},
+}
+
+def test_parse_iar():
+    memap = MemapParser()
+    memap.parse_map_file_iar(open(join(dirname(__file__), "iar.map")))
+    assert memap.modules == PARSED_IAR_GCC_DATA

--- a/tools/test/memap/parse_test.py
+++ b/tools/test/memap/parse_test.py
@@ -39,3 +39,23 @@ def test_parse_gcc():
     memap = MemapParser()
     memap.parse_map_file_gcc(open(join(dirname(__file__), "gcc.map")))
     assert memap.modules == PARSED_IAR_GCC_DATA
+
+
+def test_add_empty_module():
+    memap = MemapParser()
+    old_modules = deepcopy(memap.modules)
+    memap.module_add("", 8, ".data")
+    assert(old_modules == memap.modules)
+    memap.module_add("main.o", 0, ".text")
+    assert(old_modules == memap.modules)
+    memap.module_add("main.o", 8, "")
+    assert(old_modules == memap.modules)
+
+def test_add_full_module():
+    memap = MemapParser()
+    old_modules = deepcopy(memap.modules)
+    memap.module_add("main.o", 8, ".data")
+    assert(old_modules != memap.modules)
+    assert("main.o" in memap.modules)
+    assert(".data" in memap.modules["main.o"])
+    assert(memap.modules["main.o"][".data"] == 8)

--- a/tools/test/memap/parse_test.py
+++ b/tools/test/memap/parse_test.py
@@ -34,3 +34,8 @@ def test_parse_iar():
     memap = MemapParser()
     memap.parse_map_file_iar(open(join(dirname(__file__), "iar.map")))
     assert memap.modules == PARSED_IAR_GCC_DATA
+
+def test_parse_gcc():
+    memap = MemapParser()
+    memap.parse_map_file_gcc(open(join(dirname(__file__), "gcc.map")))
+    assert memap.modules == PARSED_IAR_GCC_DATA

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -71,7 +71,7 @@ class ARM(mbedToolchain):
         self.cc = [main_cc] + self.flags['common'] + self.flags['c']
         self.cppc = [main_cc] + self.flags['common'] + self.flags['c'] + self.flags['cxx']
 
-        self.ld = [join(ARM_BIN, "armlink")]
+        self.ld = [join(ARM_BIN, "armlink")] + self.flags['ld']
 
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")


### PR DESCRIPTION
Improves performance by 10-15x on my machine. See below for individual compiler comparisons.

Resolves #4976
Resolves #5124
Resolves #5127 

Todo:
 - [x] Parsing tests (let's never let this non-performance bug in again)
 - [x] Resolve the `Malformed input...` output from GCC