### PR TITLE
LPC54608: Swap LED pin connections to match naming on the board

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54608/TARGET_LPCXpresso/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54608/TARGET_LPCXpresso/PinNames.h
@@ -183,9 +183,9 @@ typedef enum {
     LED_RED   = P2_2,
 
     // mbed original LED naming
-    LED1 = LED_RED,
+    LED1 = P3_14,
     LED2 = P3_3,
-    LED3 = P3_14,
+    LED3 = LED_RED,
     LED4 = LED_RED,
 
     //Push buttons


### PR DESCRIPTION
## Status
**READY**

## Todos
- [x] Test with the mbed blinky application