### PR TITLE
RTL8195AM - Fix us_ticker porting

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -19,18 +19,9 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
 
   ER_IRAM +0 FIXED {
     *rtl8195a_crypto.o (+RO)
-    * (i.mbedtls*)
+    *(i.mbedtls*)
     *libc.a (+RO)
-    
-	*rtx_*.o (+RO)
-    *Ticker.o (+RO)
-    *Timeout.o (+RO)
-	*rtx_timer.o (+RO)
-    *TimerEvent.o (+RO)
-    *mbed_ticker_api.o (+RO)
-    *mbed_critical.o (+RO)
-    *us_ticker.o (+RO)
-    
+    *rtx_*.o (+RO)
     *lib_peripheral_mbed_arm.ar (+RO)
   }
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
@@ -70,15 +70,7 @@ SECTIONS
         *rtl8195a_crypto.o (.text* .rodata*)
         *mbedtls*.o (.text* .rodata*)
         *libc.a: (.text* .rodata*)
-        *Ticker.o (.text*)
-        *Timeout.o (.text*)
-        *TimerEvent.o (.text*)
-        *mbed_ticker_api.o (.text*)
-        *mbed_critical.o (.text*)
-        *us_ticker.o (.text*)
-        
         *lib_peripheral_mbed_gcc.a: (.text*)
-        
     } > SRAM1
 
     .text.sram2 :

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a.icf
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_IAR/rtl8195a.icf
@@ -213,13 +213,6 @@ define block MBEDTLS_TEXT with alignment = 8, fixed order{
 
 define block .sram1.text with fixed order   {  
                                                 block MBEDTLS_TEXT,
-                                                section .text* object Ticker.o,
-                                                section .text* object Timeout.o,
-                                                section .text* object TimerEvent.o,
-                                                section .text* object mbed_ticker_api.o,
-                                                section .text* object mbed_critical.o,
-                                                section .text* object us_ticker.o,
-                                                
                                                 section .text* object lib_peripheral_mbed_iar.a,
                                             };
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/us_ticker.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/us_ticker.c
@@ -20,10 +20,22 @@
 #include "PeripheralNames.h"
 
 #define TICK_READ_FROM_CPU  0   // 1: read tick from CPU, 0: read tick from G-Timer
-#define SYS_TIM_ID      1   // the G-Timer ID for System
-#define APP_TIM_ID      6   // the G-Timer ID for Application
+#define SYS_TIM_ID          1   // the G-Timer ID for System
+#define APP_TIM_ID          6   // the G-Timer ID for Application
 
-#define TICK_TO_US(x)     (uint64_t)(((x)/2) * 61 + ((x)%2) * TIMER_TICK_US)
+/*
+ * For RTL8195AM, clock source is 32k
+ *
+ *   us per tick: 30.5
+ *   tick per ms: 32.7
+ *   tick per us: 0.032
+ *   tick per sec: 32768
+ *
+ * Define the following macros to convert between TICK and US.
+ */
+#define MS_TO_TICK(x)       (uint64_t)(((x)*327) / 10)
+#define US_TO_TICK(x)       (uint64_t)(((x)*32) / 1000)
+#define TICK_TO_US(x)       (uint64_t)(((x)/2) * 61 + ((x)%2) * TIMER_TICK_US)
 
 static int us_ticker_inited = 0;
 static TIMER_ADAPTER TimerAdapter;
@@ -34,23 +46,22 @@ extern HAL_TIMER_OP_EXT HalTimerOpExt;
 VOID _us_ticker_irq_handler(void *Data)
 {
     us_ticker_irq_handler();
-    HalTimerOp.HalTimerDis((u32)TimerAdapter.TimerId);
 }
 
-void us_ticker_init(void) 
+void us_ticker_init(void)
 {
-    
-    if (us_ticker_inited){
+    if (us_ticker_inited) {
         return;
     }
-    
+
     us_ticker_inited = 1;
-    
+
+    // Reload and restart sys-timer
     HalTimerOp.HalTimerDis(SYS_TIM_ID);
     HalTimerOpExt.HalTimerReLoad(SYS_TIM_ID, 0xFFFFFFFFUL);
     HalTimerOp.HalTimerEn(SYS_TIM_ID);
-    
-    // Initial a G-Timer
+
+    // Initial a app-timer
     TimerAdapter.IrqDis = 0;    // Enable Irq @ initial
     TimerAdapter.IrqHandle.IrqFun = (IRQ_FUN) _us_ticker_irq_handler;
     TimerAdapter.IrqHandle.IrqNum = TIMER2_7_IRQ;
@@ -66,22 +77,22 @@ void us_ticker_init(void)
     DBG_TIMER_INFO("%s: Timer_Id=%d\n", __FUNCTION__, APP_TIM_ID);
 }
 
-uint32_t us_ticker_read(void) 
+uint32_t us_ticker_read(void)
 {
     uint32_t tick_cnt;
     uint64_t tick_us;
-    
+
     if (!us_ticker_inited) {
         us_ticker_init();
     }
-    
+
     tick_cnt = HalTimerOp.HalTimerReadCount(SYS_TIM_ID);
     tick_us = TICK_TO_US(0xFFFFFFFFUL - tick_cnt);
 
     return ((uint32_t)tick_us);  //return ticker value in micro-seconds (us)
 }
 
-void us_ticker_set_interrupt(timestamp_t timestamp) 
+void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     uint32_t time_cur;
     uint32_t time_cnt;
@@ -95,9 +106,9 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
         HalTimerOp.HalTimerEn((u32)TimerAdapter.TimerId);
         us_ticker_fire_interrupt();
         return;
-    }    
+    }
 
-    TimerAdapter.TimerLoadValueUs = time_cnt / TIMER_TICK_US;
+    TimerAdapter.TimerLoadValueUs = MAX(MS_TO_TICK(time_cnt/1000) + US_TO_TICK(time_cnt%1000), 1);
     HalTimerOpExt.HalTimerReLoad((u32)TimerAdapter.TimerId, TimerAdapter.TimerLoadValueUs);
     HalTimerOp.HalTimerEn((u32)TimerAdapter.TimerId);
 }
@@ -107,12 +118,12 @@ void us_ticker_fire_interrupt(void)
     NVIC_SetPendingIRQ(TIMER2_7_IRQ);
 }
 
-void us_ticker_disable_interrupt(void) 
+void us_ticker_disable_interrupt(void)
 {
     HalTimerOp.HalTimerDis((u32)TimerAdapter.TimerId);
 }
 
-void us_ticker_clear_interrupt(void) 
+void us_ticker_clear_interrupt(void)
 {
     HalTimerOp.HalTimerIrqClear((u32)TimerAdapter.TimerId);
 }


### PR DESCRIPTION
## Description

commit f7bc12626d06 (Re-work Rtl8195AM ticker) tried to address ticker drifting issue, but in
fact broke ticker functionality.This patch adjusts us_ticker porting to un-break it, and to fix the following tests:

    mbed-os-tests-mbed_drivers-ticker
    mbed-os-tests-mbed_drivers-timeout
    mbed-os-tests-mbedmicro-rtos-mbed-isr
    mbed-os-features-frameworks-utest-tests-unit_tests-minimal_async_scheduler
    mbed-os-features-frameworks-utest-tests-unit_tests-case_control_async
    mbed-os-features-frameworks-utest-tests-unit_tests-case_async_validate

Changes are:

1. Dont disable timer after every us_ticker interrupt. That basically
   breaks ticker functionality.

2. Fine-tune us to tick conversion macro. Previous conversion method
   yields 1 tick drift every 2 ms.

3. Remove special placement of ticker objects. No longer necessary.

## Status
READY

## Migrations
NO

## Related PRs
#5044 

## Todos
NONE

## Deploy notes
NONE

## Steps to test or reproduce
mbed greentea test 