### PR TITLE
Test: deepsleep() API replacement

### DIFF
--- a/TESTS/mbed_drivers/lp_timeout/main.cpp
+++ b/TESTS/mbed_drivers/lp_timeout/main.cpp
@@ -59,7 +59,10 @@ void lp_timeout_1s_deepsleep(void)
      */
     timer.start();
     lpt.attach(&cb_done, 1);
-    deepsleep();
+    /* Make sure deepsleep is allowed, to go to deepsleep */
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
+    sleep();
     while (!complete);
 
     /* It takes longer to wake up from deep sleep */
@@ -75,6 +78,8 @@ void lp_timeout_1s_sleep(void)
 
     sleep_manager_lock_deep_sleep();
     lpt.attach(&cb_done, 1);
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_FALSE_MESSAGE(deep_sleep_allowed, "Deep sleep should be disallowed");
     sleep();
     while (!complete);
     sleep_manager_unlock_deep_sleep();

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -104,7 +104,10 @@ void lp_ticker_1s_deepsleep()
     lp_timer.reset();
     lp_timer.start();
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
-    deepsleep();
+    /* Make sure deepsleep is allowed, to go to deepsleep */
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
+    sleep();
     while (!complete);
     lp_timer.stop();
 
@@ -124,6 +127,8 @@ void lp_ticker_1s_sleep()
     sleep_manager_lock_deep_sleep();
     timer.reset();
     timer.start();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    TEST_ASSERT_FALSE_MESSAGE(deep_sleep_allowed, "Deep sleep should be disallowed");
     ticker_insert_event(lp_ticker_data, &delay_event, delay_ts, (uint32_t)&delay_event);
     sleep();
     while (!complete);


### PR DESCRIPTION
Use sleep() as entry function + check to be certain we
are entering deepsleep when required by test (should be allowed as we use LowPower object).

This has dependency on fixing this issue https://github.com/ARMmbed/mbed-os/issues/5076 (the test now fails, and will be fixed as today).

Tested using K64F and GCC ARM , these 2 tests affected, one failure at the moment

@jeromecoutant 