### PR TITLE
Kinetis RTC HAL: Allow writing 0 to the seconds register

### DIFF
--- a/targets/TARGET_Freescale/TARGET_K20XX/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/rtc_api.c
@@ -29,14 +29,14 @@ static void init(void) {
 
 void rtc_init(void) {
     init();
-    
+
     // Enable the oscillator
 #if defined (TARGET_K20D50M)
     RTC->CR |= RTC_CR_OSCE_MASK;
 #else
     // Teensy3.1 requires 20pF MCU loading capacitors for 32KHz RTC oscillator
     /* RTC->CR: SC2P=0,SC4P=1,SC8P=0,SC16P=1,CLKO=0,OSCE=1,UM=0,SUP=0,SPE=0,SWR=0 */
-    RTC->CR |= RTC_CR_OSCE_MASK |RTC_CR_SC16P_MASK | RTC_CR_SC4P_MASK; 
+    RTC->CR |= RTC_CR_OSCE_MASK |RTC_CR_SC16P_MASK | RTC_CR_SC4P_MASK;
 #endif
 
     //Configure the TSR. default value: 1
@@ -77,11 +77,6 @@ time_t rtc_read(void) {
 void rtc_write(time_t t) {
     // disable counter
     RTC->SR &= ~RTC_SR_TCE_MASK;
-
-    // we do not write 0 into TSR
-    // to avoid invalid time
-    if (t == 0)
-        t = 1;
 
     // write seconds
     RTC->TSR = t;

--- a/targets/TARGET_Freescale/TARGET_KLXX/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/rtc_api.c
@@ -26,7 +26,7 @@ static void init(void) {
 
     // select RTC clock source
     SIM->SOPT1 &= ~SIM_SOPT1_OSC32KSEL_MASK;
-    
+
     // Enable external crystal source if clock source is 32KHz
     if (extosc_frequency()==32768) {
         SIM->SOPT1 |= SIM_SOPT1_OSC32KSEL(OSC32KCLK);
@@ -103,11 +103,6 @@ time_t rtc_read(void) {
 void rtc_write(time_t t) {
     // disable counter
     RTC->SR &= ~RTC_SR_TCE_MASK;
-
-    // we do not write 0 into TSR
-    // to avoid invalid time
-    if (t == 0)
-        t = 1;
 
     // write seconds
     RTC->TSR = t;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
@@ -57,9 +57,6 @@ time_t rtc_read(void)
 
 void rtc_write(time_t t)
 {
-    if (t == 0) {
-        t = 1;
-    }
     RTC_StopTimer(RTC);
     RTC->TSR = t;
     RTC_StartTimer(RTC);

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/api/rtc_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/api/rtc_api.c
@@ -54,9 +54,6 @@ time_t rtc_read(void)
 
 void rtc_write(time_t t)
 {
-    if (t == 0) {
-        t = 1;
-    }
     RTC_StopTimer(RTC);
     RTC->COUNT = t;
     RTC_StartTimer(RTC);


### PR DESCRIPTION
There is no hardware limitation in writing a 0 value to the seconds register.