### PR TITLE
Add doxygen group for HAL specification

### DIFF
--- a/hal/test-headers/hal_specification.h
+++ b/hal/test-headers/hal_specification.h
@@ -1,0 +1,39 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * \defgroup hal_specification HAL specification
+ * Technical specification of the HAL consisting of defined behavior, tests which verify this behavior and behaior not defined by this specification.
+ * @{
+ */
+
+
+#ifndef HAL_SPECIFICATION_H
+#define HAL_SPECIFICATION_H
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/**@}*/
+


### PR DESCRIPTION
Add the doxygen group hal_specification as a container group for all the HAL API specifications.
