### PR TITLE
Implement functional Wifi tests

### DIFF
--- a/TESTS/network/wifi/get_interface.cpp
+++ b/TESTS/network/wifi/get_interface.cpp
@@ -1,5 +1,12 @@
 #include "mbed.h"
+
+#if TARGET_UBLOX_EVK_ODIN_W2
+#include "OdinWiFiInterface.h"
+#elif TARGET_REALTEK_RTL8195AM
+#include "RTWInterface.h"
+#else
 #include "ESP8266Interface.h"
+#endif
 
 WiFiInterface *get_interface()
 {
@@ -9,10 +16,8 @@ WiFiInterface *get_interface()
         delete interface;
 
 #if TARGET_UBLOX_EVK_ODIN_W2
-#include "OdinWiFiInterface.h"
     interface = new OdinWiFiInterface();
 #elif TARGET_REALTEK_RTL8195AM
-#include "RTWInterface.h"
     interface = new RTWInterface();
 #else
     interface = new ESP8266Interface(D1, D0);

--- a/TESTS/network/wifi/get_interface.cpp
+++ b/TESTS/network/wifi/get_interface.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 
 // Pick the correct driver based on mbed_app.json

--- a/TESTS/network/wifi/get_interface.cpp
+++ b/TESTS/network/wifi/get_interface.cpp
@@ -1,0 +1,21 @@
+#include "mbed.h"
+#include "ESP8266Interface.h"
+
+WiFiInterface *get_interface()
+{
+    static WiFiInterface *interface = NULL;
+
+    if (interface)
+        delete interface;
+
+#if TARGET_UBLOX_EVK_ODIN_W2
+#include "OdinWiFiInterface.h"
+    interface = new OdinWiFiInterface();
+#elif TARGET_REALTEK_RTL8195AM
+#include "RTWInterface.h"
+    interface = new RTWInterface();
+#else
+    interface = new ESP8266Interface(D1, D0);
+#endif
+    return interface;
+}

--- a/TESTS/network/wifi/get_interface.cpp
+++ b/TESTS/network/wifi/get_interface.cpp
@@ -1,11 +1,32 @@
 #include "mbed.h"
 
+// Pick the correct driver based on mbed_app.json
+#define INTERNAL            1
+#define WIFI_ESP8266        2
+#define X_NUCLEO_IDW01M1    3
+
+#if MBED_CONF_APP_WIFI_DRIVER == INTERNAL
+
 #if TARGET_UBLOX_EVK_ODIN_W2
 #include "OdinWiFiInterface.h"
+#define DRIVER OdinWiFiInterface
+
 #elif TARGET_REALTEK_RTL8195AM
 #include "RTWInterface.h"
+#define DRIVER RTWInterface
 #else
+#error [NOT_SUPPORTED] Unsupported Wifi driver
+#endif
+
+#elif MBED_CONF_APP_WIFI_DRIVER == WIFI_ESP8266
 #include "ESP8266Interface.h"
+#define DRIVER ESP8266Interface
+
+#elif MBED_CONF_APP_WIFI_DRIVER == X_NUCLEO_IDW01M1
+#include "SpwfSAInterface.h"
+#define DRIVER SpwfSAInterface
+#else
+#error [NOT_SUPPORTED] Unsupported Wifi driver
 #endif
 
 WiFiInterface *get_interface()
@@ -15,12 +36,10 @@ WiFiInterface *get_interface()
     if (interface)
         delete interface;
 
-#if TARGET_UBLOX_EVK_ODIN_W2
-    interface = new OdinWiFiInterface();
-#elif TARGET_REALTEK_RTL8195AM
-    interface = new RTWInterface();
+#if MBED_CONF_APP_WIFI_DRIVER == INTERNAL
+    interface = new DRIVER();
 #else
-    interface = new ESP8266Interface(D1, D0);
+    interface = new DRIVER(MBED_CONF_APP_WIFI_TX, MBED_CONF_APP_WIFI_RX);
 #endif
     return interface;
 }

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -4,6 +4,21 @@
 #include "utest.h"
 #include "wifi_tests.h"
 
+// Test for parameters
+#if !defined(MBED_CONF_APP_AP_MAC_SECURE)      || \
+    !defined(MBED_CONF_APP_AP_MAC_UNSECURE)    || \
+    !defined(MBED_CONF_APP_MAX_SCAN_SIZE)      || \
+    !defined(MBED_CONF_APP_WIFI_CH_SECURE)     || \
+    !defined(MBED_CONF_APP_WIFI_CH_UNSECURE)   || \
+    !defined(MBED_CONF_APP_WIFI_DRIVER)        || \
+    !defined(MBED_CONF_APP_WIFI_PASSWORD)      || \
+    !defined(MBED_CONF_APP_WIFI_RX)            || \
+    !defined(MBED_CONF_APP_WIFI_SECURE_SSID)   || \
+    !defined(MBED_CONF_APP_WIFI_TX)            || \
+    !defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
+#error [NOT_SUPPORTED] Requires parameters from mbed_app.json
+#endif
+
 using namespace utest::v1;
 
 utest::v1::status_t test_setup(const size_t number_of_cases) {

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -7,7 +7,7 @@
 using namespace utest::v1;
 
 utest::v1::status_t test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(120, "default_auto");
+    GREENTEA_SETUP(240, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -1,196 +1,39 @@
-/* mbed Microcontroller Library
- * Copyright (c) 2016 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-#include "utest/utest.h"
-#include "unity/unity.h"
-#include "greentea-client/test_env.h"
-
 #include "mbed.h"
-
-#if TARGET_UBLOX_EVK_ODIN_W2
-#include "OdinWiFiInterface.h"
-#else
-#error [NOT_SUPPORTED] Only built in WiFi modules are supported at this time.
-#endif
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
 
 using namespace utest::v1;
 
-/**
- * WiFi tests require following macros to be defined:
- * - MBED_CONF_APP_WIFI_SSID - SSID of a network the test will try connecting to
- * - MBED_CONF_APP_WIFI_PASSWORD - Passphrase that will be used to connecting to the network
- * - WIFI_TEST_NETWORKS - List of network that presence will be asserted e.g. "net1", "net2", "net3"
- */
-#if !defined(MBED_CONF_APP_WIFI_SSID) || !defined(MBED_CONF_APP_WIFI_PASSWORD) || !defined(MBED_CONF_APP_WIFI_NETWORKS)
-#error [NOT_SUPPORTED] MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD and MBED_CONF_APP_WIFI_NETWORKS have to be defined for this test.
-#endif
-
-const char *networks[] = {MBED_CONF_APP_WIFI_NETWORKS, NULL};
-
-WiFiInterface *wifi;
-
-/* In normal circumstances the WiFi object could be global, but the delay introduced by WiFi initialization is an issue
-   for the tests. It causes Greentea to timeout on syncing with the board. To solve it we defer the actual object
-   creation till we actually need it.
- */
-WiFiInterface *get_wifi()
-{
-    if (wifi == NULL) {
-        /* We don't really care about freeing this, as its lifetime is through the full test suit run. */
-#if TARGET_UBLOX_EVK_ODIN_W2
-        wifi = new OdinWiFiInterface;
-#endif
-    }
-
-    return wifi;
+utest::v1::status_t test_setup(const size_t number_of_cases) {
+    GREENTEA_SETUP(120, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
 }
 
-void check_wifi(const char *ssid, bool *net_stat)
-{
-    int i = 0;
-    while(networks[i]) {
-        if (strcmp(networks[i], ssid) == 0) {
-            net_stat[i] = true;
-            break;
-        }
-        i++;
-    }
-}
-
-void wifi_scan()
-{
-    int count;
-    WiFiAccessPoint *aps;
-    const int net_len = sizeof(networks)/sizeof(networks[0]);
-    bool net_stat[net_len - 1];
-
-    memset(net_stat, 0, sizeof(net_stat));
-
-    count = get_wifi()->scan(NULL, 0);
-    TEST_ASSERT_MESSAGE(count >= 0, "WiFi interface returned error");
-    TEST_ASSERT_MESSAGE(count > 0, "Scan result empty");
-
-    aps = new WiFiAccessPoint[count];
-    count = get_wifi()->scan(aps, count);
-    for(int i = 0; i < count; i++) {
-        check_wifi(aps[i].get_ssid(), net_stat);
-    }
-
-    delete[] aps;
-
-    for (unsigned i = 0; i < sizeof(net_stat); i++) {
-        TEST_ASSERT_MESSAGE(net_stat[i] == true, "Not all required WiFi network detected");
-    }
-}
-
-void wifi_connect()
-{
-    int ret;
-
-    ret = get_wifi()->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT_MESSAGE(ret == 0, "Connect failed");
-
-    ret = get_wifi()->disconnect();
-    TEST_ASSERT_MESSAGE(ret == 0, "Disconnect failed");
-}
-
-void wifi_connect_scan()
-{
-    int ret;
-    int count;
-    WiFiAccessPoint *aps;
-    const int net_len = sizeof(networks)/sizeof(networks[0]);
-    bool net_stat[net_len - 1];
-
-    memset(net_stat, 0, sizeof(net_stat));
-
-    ret = get_wifi()->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT_MESSAGE(ret == 0, "Connect failed");
-
-    count = get_wifi()->scan(NULL, 0);
-    TEST_ASSERT_MESSAGE(count >= 0, "WiFi interface returned error");
-    TEST_ASSERT_MESSAGE(count > 0, "Scan result empty");
-
-    aps = new WiFiAccessPoint[count];
-    count = get_wifi()->scan(aps, count);
-    for(int i = 0; i < count; i++) {
-        check_wifi(aps[i].get_ssid(), net_stat);
-    }
-
-    delete[] aps;
-
-    ret = get_wifi()->disconnect();
-    TEST_ASSERT_MESSAGE(ret == 0, "Disconnect failed");
-
-    for (unsigned i = 0; i < sizeof(net_stat); i++) {
-        TEST_ASSERT_MESSAGE(net_stat[i] == true, "Not all required WiFi network detected");
-    }
-}
-
-void wifi_http()
-{
-    TCPSocket socket;
-    int ret;
-
-    ret = get_wifi()->connect(MBED_CONF_APP_WIFI_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2);
-    TEST_ASSERT_MESSAGE(ret == 0, "Connect failed");
-
-    // Open a socket on the network interface, and create a TCP connection to www.arm.com
-    ret = socket.open(get_wifi());
-    TEST_ASSERT_MESSAGE(ret == 0, "Socket open failed");
-    ret = socket.connect("www.arm.com", 80);
-    TEST_ASSERT_MESSAGE(ret == 0, "Socket connect failed");
-
-    // Send a simple http request
-    char sbuffer[] = "GET / HTTP/1.1\r\nHost: www.arm.com\r\n\r\n";
-    int scount = socket.send(sbuffer, sizeof sbuffer);
-    TEST_ASSERT_MESSAGE(scount >= 0, "Socket send failed");
-
-    // Recieve a simple http response and check if it's not empty
-    char rbuffer[64];
-    int rcount = socket.recv(rbuffer, sizeof rbuffer);
-    TEST_ASSERT_MESSAGE(rcount >= 0, "Socket recv error");
-    TEST_ASSERT_MESSAGE(rcount > 0, "No data received");
-
-    ret = socket.close();
-    TEST_ASSERT_MESSAGE(ret == 0, "Socket close failed");
-
-    ret = get_wifi()->disconnect();
-    TEST_ASSERT_MESSAGE(ret == 0, "Disconnect failed");
-}
-
-status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
-    greentea_case_failure_abort_handler(source, reason);
-    return STATUS_CONTINUE;
-}
-
+// Test cases
 Case cases[] = {
-    Case("Scan test", wifi_scan, greentea_failure_handler),
-    Case("Connect test", wifi_connect, greentea_failure_handler),
-    Case("Scan while connected test", wifi_connect_scan, greentea_failure_handler),
-    Case("HTTP test", wifi_http, greentea_failure_handler),
+    Case("WIFI-CONSTRUCTOR", wifi_constructor),
+    Case("WIFI-SET-CREDENTIAL", wifi_set_credential),
+    Case("WIFI-SET-CHANNEL", wifi_set_channel),
+    Case("WIFI-GET-RSSI", wifi_get_rssi),
+    Case("WIFI-CONNECT-PARAMS-NULL", wifi_connect_params_null),
+    Case("WIFI-CONNECT-PARAMS-VALID-UNSECURE", wifi_connect_params_valid_unsecure),
+    Case("WIFI-CONNECT-PARAMS-VALID-SECURE", wifi_connect_params_valid_secure),
+    Case("WIFI-CONNECT-PARAMS-CHANNEL", wifi_connect_params_channel),
+    Case("WIFI-CONNECT-PARAMS-CHANNEL-FAIL", wifi_connect_params_channel_fail),
+    Case("WIFI-CONNECT-NOCREDENTIALS", wifi_connect_nocredentials),
+    Case("WIFI-CONNECT", wifi_connect),
+    Case("WIFI-CONNECT-SECURE", wifi_connect_secure),
+    Case("WIFI-CONNECT-SECURE-FAIL", wifi_connect_secure_fail),
+    Case("WIFI-CONNECT-DISCONNECT-REPEAT", wifi_connect_disconnect_repeat),
+    Case("WIFI-SCAN-NULL", wifi_scan_null),
+    Case("WIFI-SCAN", wifi_scan),
 };
 
-status_t greentea_test_setup(const size_t number_of_cases) {
-    GREENTEA_SETUP(90, "default_auto");
-    return greentea_test_setup_handler(number_of_cases);
-}
+Specification specification(test_setup, cases);
 
-
+// Entry point into the tests
 int main() {
-    Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
-    Harness::run(specification);
+    return !Harness::run(specification);
 }

--- a/TESTS/network/wifi/template_mbed_app.txt
+++ b/TESTS/network/wifi/template_mbed_app.txt
@@ -1,21 +1,36 @@
 {
     "config": {
-        "wifi-ssid": {
+        "wifi-secure-ssid": {
             "help": "WiFi SSID",
-            "value": "\"SSID\""
+            "value": "\"SSID-SECURE\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID",
+            "value": "\"SSID-UNSECURE\""
         },
         "wifi-password": {
             "help": "WiFi Password",
-            "value": "\"PASS\""
+            "value": "\"PASSWORD\""
         },
-        "wifi-networks": {
-            "help": "WiFi SSIDs which presence will be asserted in the test",
-            "value": "\"SSID1\",\"SSID2\",\"SSID3\""
-        }
-    },
-    "target_overrides": {
-        "UBLOX_EVK_ODIN_W2": {
-            "target.device_has": ["EMAC"]
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": 1
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": 2
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
         }
     }
 }

--- a/TESTS/network/wifi/template_mbed_app.txt
+++ b/TESTS/network/wifi/template_mbed_app.txt
@@ -1,11 +1,11 @@
 {
     "config": {
         "wifi-secure-ssid": {
-            "help": "WiFi SSID",
+            "help": "WiFi SSID for WPA2 secured network",
             "value": "\"SSID-SECURE\""
         },
         "wifi-unsecure-ssid": {
-            "help": "WiFi SSID",
+            "help": "WiFi SSID for unsecure netwrok",
             "value": "\"SSID-UNSECURE\""
         },
         "wifi-password": {

--- a/TESTS/network/wifi/template_mbed_app.txt
+++ b/TESTS/network/wifi/template_mbed_app.txt
@@ -20,6 +20,18 @@
             "help": "Channel number of unsecure SSID",
             "value": 2
         },
+        "wifi-driver": {
+            "help": "Wifi driver to use, valid values are INTERNAL, WIFI_ESP8266 and X_NUCLEO_IDW01M1",
+            "value": "INTERNAL"
+        },
+        "wifi-tx": {
+            "help": "TX pin for serial connection to external device",
+            "value": "D1"
+        },
+        "wifi-rx": {
+            "help": "RX pin for serial connection to external device",
+            "value": "D0"
+        },
         "ap-mac-secure": {
             "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
             "value": "\"AA:AA:AA:AA:AA:AA\""

--- a/TESTS/network/wifi/wifi-constructor.cpp
+++ b/TESTS/network/wifi/wifi-constructor.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi-constructor.cpp
+++ b/TESTS/network/wifi/wifi-constructor.cpp
@@ -1,0 +1,12 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_constructor() {
+    WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi);
+}

--- a/TESTS/network/wifi/wifi_connect.cpp
+++ b/TESTS/network/wifi/wifi_connect.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect.cpp
+++ b/TESTS/network/wifi/wifi_connect.cpp
@@ -1,0 +1,16 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL));
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+}

--- a/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -1,0 +1,23 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_disconnect_repeat(void)
+{
+    WiFiInterface *wifi = get_interface();
+    nsapi_error_t error;
+
+    error = wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    for(int i=0; i<10; i++) {
+        error = wifi->connect();
+        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        error = wifi->disconnect();
+        TEST_ASSERT(error == NSAPI_ERROR_OK);
+    }
+}

--- a/TESTS/network/wifi/wifi_connect_nocredentials.cpp
+++ b/TESTS/network/wifi/wifi_connect_nocredentials.cpp
@@ -1,0 +1,16 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_nocredentials(void)
+{
+    WiFiInterface *wifi = get_interface();
+    nsapi_error_t error;
+    error = wifi->connect();
+    wifi->disconnect();
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+}

--- a/TESTS/network/wifi/wifi_connect_nocredentials.cpp
+++ b/TESTS/network/wifi/wifi_connect_nocredentials.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_channel.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_channel.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel.cpp
@@ -1,0 +1,21 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_params_channel(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("set_channel() not supported");
+        return;
+    }
+
+    nsapi_error_t error = wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2, MBED_CONF_APP_WIFI_CH_SECURE);
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
+}
+

--- a/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
@@ -1,0 +1,21 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_params_channel_fail(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("set_channel() not supported");
+        return;
+    }
+
+    nsapi_error_t error = wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2, MBED_CONF_APP_WIFI_CH_UNSECURE);
+    TEST_ASSERT(error==NSAPI_ERROR_CONNECTION_TIMEOUT || error==NSAPI_ERROR_NO_CONNECTION);
+}
+

--- a/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -1,0 +1,13 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_params_null(void)
+{
+    WiFiInterface *wifi = get_interface();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_PARAMETER, wifi->connect(NULL, NULL));
+}

--- a/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -1,0 +1,13 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_params_valid_secure(void)
+{
+    WiFiInterface *wifi = get_interface();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2));
+}

--- a/TESTS/network/wifi/wifi_connect_params_valid_unsecure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_unsecure.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_params_valid_unsecure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_unsecure.cpp
@@ -1,0 +1,14 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_params_valid_unsecure(void)
+{
+    WiFiInterface *wifi = get_interface();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL));
+}
+

--- a/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -1,0 +1,17 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_secure(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2));
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+}
+

--- a/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -1,0 +1,17 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_connect_secure_fail(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, "aaaaaaaa", NSAPI_SECURITY_WPA2));
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_AUTH_FAILURE, wifi->connect());
+}
+

--- a/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -1,0 +1,21 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_get_rssi(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL));
+
+    TEST_ASSERT_EQUAL_INT8(0, wifi->get_rssi());
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+
+    TEST_ASSERT_INT8_WITHIN(-35, -65, wifi->get_rssi()); // -30 ... -100
+}
+

--- a/TESTS/network/wifi/wifi_scan.cpp
+++ b/TESTS/network/wifi/wifi_scan.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_scan.cpp
+++ b/TESTS/network/wifi/wifi_scan.cpp
@@ -1,0 +1,50 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+#include <stdbool.h>
+
+using namespace utest::v1;
+
+void wifi_scan(void)
+{
+    WiFiInterface *wifi = get_interface();
+
+    WiFiAccessPoint ap[MBED_CONF_APP_MAX_SCAN_SIZE];
+
+    int size = wifi->scan(ap, MBED_CONF_APP_MAX_SCAN_SIZE);
+    TEST_ASSERT(size >= 2);
+
+    bool secure_found = false;
+    bool unsecure_found = false;
+
+    char secure_bssid[6];
+    char unsecure_bssid[6];
+    const char *coversion_string = "%hhx:%hhx:%hhx:%hhx:%hhx:%hhx";
+    TEST_ASSERT_EQUAL_INT_MESSAGE(6, sscanf(MBED_CONF_APP_AP_MAC_SECURE, coversion_string, &secure_bssid[0], &secure_bssid[1], &secure_bssid[2], &secure_bssid[3], &secure_bssid[4], &secure_bssid[5]), "Failed to convert ap-mac-secure from mbed_app.json");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(6, sscanf(MBED_CONF_APP_AP_MAC_UNSECURE, coversion_string, &unsecure_bssid[0], &unsecure_bssid[1], &unsecure_bssid[2], &unsecure_bssid[3], &unsecure_bssid[4], &unsecure_bssid[5]), "Failed to convert ap-mac-unsecure from mbed_app.json");
+
+    for (int i=0; i<size; i++) {
+        const char *ssid = ap[i].get_ssid();
+        const uint8_t *bssid = ap[i].get_bssid();
+        nsapi_security_t security = ap[i].get_security();
+        int8_t rssi = ap[i].get_rssi();
+        uint8_t ch = ap[i].get_channel();
+        TEST_ASSERT_NOT_EQUAL(0, strlen(ssid));
+        TEST_ASSERT_INT8_WITHIN(-35, -65, rssi);
+        if (strcmp(MBED_CONF_APP_WIFI_SECURE_SSID, ssid) == 0) {
+            secure_found = true;
+            TEST_ASSERT_EQUAL_INT(NSAPI_SECURITY_WPA2, security);
+            TEST_ASSERT_EQUAL_INT(MBED_CONF_APP_WIFI_CH_SECURE, ch);
+        }
+        if (strcmp(MBED_CONF_APP_WIFI_UNSECURE_SSID, ssid) == 0) {
+            unsecure_found = true;
+            TEST_ASSERT_EQUAL_INT(NSAPI_SECURITY_NONE, security);
+            TEST_ASSERT_EQUAL_INT(MBED_CONF_APP_WIFI_CH_UNSECURE, ch);
+        }
+    }
+    TEST_ASSERT_TRUE(secure_found);
+    TEST_ASSERT_TRUE(unsecure_found);
+}
+

--- a/TESTS/network/wifi/wifi_scan_null.cpp
+++ b/TESTS/network/wifi/wifi_scan_null.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_scan_null.cpp
+++ b/TESTS/network/wifi/wifi_scan_null.cpp
@@ -1,0 +1,14 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_scan_null(void)
+{
+    WiFiInterface *wifi = get_interface();
+    TEST_ASSERT(wifi->scan(NULL, 0) >= 2);
+}
+

--- a/TESTS/network/wifi/wifi_set_channel.cpp
+++ b/TESTS/network/wifi/wifi_set_channel.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_set_channel.cpp
+++ b/TESTS/network/wifi/wifi_set_channel.cpp
@@ -1,0 +1,56 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+#include <stdbool.h>
+
+using namespace utest::v1;
+
+void wifi_set_channel(void)
+{
+    bool is_2Ghz = false;
+    bool is_5Ghz = false;
+
+    WiFiInterface *wifi = get_interface();
+
+    if (wifi->set_channel(1) == NSAPI_ERROR_UNSUPPORTED && wifi->set_channel(36) == NSAPI_ERROR_UNSUPPORTED) {
+        TEST_IGNORE_MESSAGE("set_channel() not supported");
+        return;
+    }
+
+    nsapi_error_t error;
+    error = wifi->set_channel(1);
+    if (error == NSAPI_ERROR_OK) {
+        is_2Ghz = true;
+    }
+
+    error = wifi->set_channel(30);
+    if (error == NSAPI_ERROR_OK) {
+        is_5Ghz = true;
+    }
+
+    TEST_ASSERT(is_2Ghz || is_5Ghz);
+
+    if (is_2Ghz) {
+        error = wifi->set_channel(0);
+        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+        error = wifi->set_channel(1);
+        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        error = wifi->set_channel(13);
+        TEST_ASSERT(error == NSAPI_ERROR_OK || error == NSAPI_ERROR_PARAMETER);
+        error = wifi->set_channel(15);
+        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    }
+
+    if (is_5Ghz) {
+        error = wifi->set_channel(30);
+        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+        error = wifi->set_channel(36);
+        TEST_ASSERT(error == NSAPI_ERROR_OK);
+        error = wifi->set_channel(169);
+        TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    }
+
+}
+

--- a/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/TESTS/network/wifi/wifi_set_credential.cpp
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2017, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "unity.h"

--- a/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/TESTS/network/wifi/wifi_set_credential.cpp
@@ -1,0 +1,37 @@
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+#include "wifi_tests.h"
+
+using namespace utest::v1;
+
+void wifi_set_credential(void)
+{
+    WiFiInterface *iface = get_interface();
+    nsapi_error_t error;
+
+    error = iface->set_credentials(NULL, NULL, NSAPI_SECURITY_NONE);
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+
+    error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_NONE);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WEP);
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+
+    error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WPA_WPA2);
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA2);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA_WPA2);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni82", NSAPI_SECURITY_WPA2);
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+}

--- a/TESTS/network/wifi/wifi_tests.h
+++ b/TESTS/network/wifi/wifi_tests.h
@@ -1,0 +1,26 @@
+#ifndef WIFI_TESTS_H
+#define WIFI_TESTS_H
+
+#include "WiFiInterface.h"
+
+WiFiInterface *get_interface(void);
+
+/* Test cases */
+void wifi_constructor(void);
+void wifi_set_credential(void);
+void wifi_set_channel(void);
+void wifi_get_rssi(void);
+void wifi_connect_params_null(void);
+void wifi_connect_params_valid_unsecure(void);
+void wifi_connect_params_valid_secure(void);
+void wifi_connect_params_channel(void);
+void wifi_connect_params_channel_fail(void);
+void wifi_connect(void);
+void wifi_connect_nocredentials(void);
+void wifi_connect_secure(void);
+void wifi_connect_secure_fail(void);
+void wifi_connect_disconnect_repeat(void);
+void wifi_scan_null(void);
+void wifi_scan(void);
+
+#endif //WIFI_TESTS_H

--- a/TESTS/network/wifi/wifi_tests.h
+++ b/TESTS/network/wifi/wifi_tests.h
@@ -3,24 +3,61 @@
 
 #include "WiFiInterface.h"
 
+/** Get WiFiInterface based on provided
+ * app_json. */
 WiFiInterface *get_interface(void);
 
-/* Test cases */
+/*
+ * Test cases
+ */
+
+/** Test that constructor of the driver works. */
 void wifi_constructor(void);
+
+/** This test case is to test whether the driver accepts valid credentials and reject ones that are not valid. */
 void wifi_set_credential(void);
+
+/** Test validity of WiFiInterface::set_channel(). */
 void wifi_set_channel(void);
+
+/** Test WiFiInterface::get_rssi() API.
+ * When connected, it should return valid RSSI value. When unconnected it should return 0. */
 void wifi_get_rssi(void);
+
+/** Test WiFiInterface::connect(ssid, pass, security, channel) with NULL parameters */
 void wifi_connect_params_null(void);
+
+/** Test WiFiInterface::connect(ssid, pass, security) with valid parameters for unsecure network */
 void wifi_connect_params_valid_unsecure(void);
+
+/** Test WiFiInterface::connect(ssid, pass, security) with valid parameters for secure network */
 void wifi_connect_params_valid_secure(void);
+
+/** Test WiFiInterface::connect(ssid, pass, security, channel) with valid parameters for secure network using channel specified. */
 void wifi_connect_params_channel(void);
+
+/** Test WiFiInterface::connect(ssid, pass, security, channel) with valid parameters for secure network using wrong channel number. */
 void wifi_connect_params_channel_fail(void);
+
+/** Test WiFiInterface::connect() without parameters. Use set_credentials() for setting parameters. */
 void wifi_connect(void);
+
+/** Test WiFiInterface::connect() without parameters. Don't set parameters with set_credentials() */
 void wifi_connect_nocredentials(void);
+
+/** Test WiFiInterface::connect() without parameters. Use secure settings for set_credentials. */
 void wifi_connect_secure(void);
+
+/** Test WiFiInterface::connect() failing with wrong password. */
 void wifi_connect_secure_fail(void);
+
+/** Test WiFiInterface::connect() - disconnect() repeatition works. */
 void wifi_connect_disconnect_repeat(void);
+
+/** Call WiFiInterface::scan() with null parameters to get number of networks available. */
 void wifi_scan_null(void);
+
+/** Call WiFiInterface::scan() with valid accesspoint list allocated */
 void wifi_scan(void);
 
 #endif //WIFI_TESTS_H


### PR DESCRIPTION
## Description
Implement 100% function coverage for WifiInterface as specified
in "Wifi test plan"

Idea is to have full coverage of `WiFiInterface` API callbacks. Does not test any of the socket functionality, those will be provided later, perhaps within https://github.com/ARMmbed/mbed-os/pull/4795

Uses idea of separating the code which detects the interface into one singe file `get_interface.c` and its callback `get_interface()` which always gives a new initialised interface and destroys the previous one. Assumption is that destructor should clean up the driver state and constructor should bring it in sane condition. That allows us to write all test cases separately, everyone within their own file for easy maintain.

## Status
**IN DEVELOPMENT**

Verified in ESP8266, does not pass without fixing the driver.

Missing the example `mbed_app.json` and some description about the test environment.
