### PR TITLE
Platform: Replace non throwing versions of new operator.

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1008,6 +1008,16 @@ void *operator new[](std::size_t count)
     return buffer;
 }
 
+void *operator new(std::size_t count, const std::nothrow_t& tag)
+{
+    return malloc(count);
+}
+
+void *operator new[](std::size_t count, const std::nothrow_t& tag)
+{
+    return malloc(count);
+}
+
 void operator delete(void *ptr)
 {
     if (ptr != NULL) {


### PR DESCRIPTION
## Description

This change prevents inclusion of non throwing versions of the new operator from
the compiler standard library. On GCC, the non throwing version bring with it
some portion of the exception support code.

Inclusion of exception support inflate the RAM required by the standard runtime.

## Status
**READY**


## Migrations
NO
