### PR TITLE
Force preprocessing of asm for make_armc5

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -97,20 +97,26 @@ all: $(PROJECT).bin $(PROJECT)-combined.hex size
 all: $(PROJECT).bin $(PROJECT).hex size
 {% endif %}
 
-.asm.o:
-	+@$(call MAKEDIR,$(dir $@))
-	+@echo "Assemble: $(notdir $<)"
-	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -o $@ $<
-
 .s.o:
 	+@$(call MAKEDIR,$(dir $@))
 	+@echo "Assemble: $(notdir $<)"
+  {% if needs_asm_preproc %}
+	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -E -o $(@:.o=.E.s) $<
+	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -o $@ $(@:.o=.E.s)
+  {% else %}
 	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -o $@ $<
+  {% endif %}
+
 
 .S.o:
 	+@$(call MAKEDIR,$(dir $@))
 	+@echo "Assemble: $(notdir $<)"
+  {% if needs_asm_preproc %}
+	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -E -o $(@:.o=.E.s) $<
+	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -o $@ $(@:.o=.E.s)
+  {% else %}
 	@$(AS) -c $(ASM_FLAGS) $(INCLUDE_PATHS) -o $@ $<
+  {% endif %}
 
 .c.o:
 	+@$(call MAKEDIR,$(dir $@))

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -35,6 +35,8 @@ class Makefile(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
+    PREPROCESS_ASM = False
+
     POST_BINARY_WHITELIST = set([
         "MCU_NRF51Code.binary_hook",
         "TEENSY3_1Code.binary_hook",
@@ -96,6 +98,7 @@ class Makefile(Exporter):
             'link_script_ext': self.toolchain.LINKER_EXT,
             'link_script_option': self.LINK_SCRIPT_OPTION,
             'user_library_flag': self.USER_LIBRARY_FLAG,
+            'needs_asm_preproc': self.PREPROCESS_ASM,
         }
 
         if hasattr(self.toolchain, "preproc"):
@@ -236,6 +239,7 @@ class Armc5(Arm):
     """ARM Compiler 5 (armcc) specific makefile target"""
     NAME = 'Make-ARMc5'
     TOOLCHAIN = "ARM"
+    PREPROCESS_ASM = True
 
 class Armc6(Arm):
     """ARM Compiler 6 (armclang) specific generic makefile target"""


### PR DESCRIPTION
`armasm` seem to preprocess asm with the `.S` extension on linux, but the
windows build of Arm Compiler 5 seems to omit the preprocessing step
unless you have a `.sx` extension. Odd.

Resolves #5145