### PR TITLE
STM32L432KC: increase RAM size from 48k to 64k

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l432xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l432xx.S
@@ -42,13 +42,13 @@
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __initial_sp
 
-__initial_sp    EQU     0x2000C000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
+__initial_sp    EQU     0x20010000 ; Top of RAM
 
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size       EQU     0x0BA00 ; 46KB (48KB, -2*1KB for main thread and scheduler)
+Heap_Size       EQU     0x0F800 ; 62KB (64KB, -2*1KB for main thread and scheduler)
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __heap_base

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_MICRO/stm32l432xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_MICRO/stm32l432xx.sct
@@ -36,12 +36,8 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  RW_IRAM1 0x20000000 0x0000C000  { ; RW data 48k L4-SRAM1
-   .ANY (+RW +ZI)
-  }
-
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM2 (0x10000000+0x188) (0x04000-0x188)  {  ; RW data 16k L4-ECC-SRAM2 retained in standby
+  RW_IRAM1 (0x20000000+0x188) (0x00010000-0x188)  {
   .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_STD/startup_stm32l432xx.S
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_STD/startup_stm32l432xx.S
@@ -39,7 +39,7 @@
 ;*
 ;*******************************************************************************
 
-__initial_sp    EQU     0x2000C000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
+__initial_sp    EQU     0x20010000 ; Top of RAM
 
                 PRESERVE8
                 THUMB

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_STD/stm32l432xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_ARM_STD/stm32l432xx.sct
@@ -36,13 +36,9 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  RW_IRAM1 0x20000000 0x0000C000  { ; RW data 48k L4-SRAM1
-  .ANY (+RW +ZI)
-  }
-
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM2 (0x10000000+0x188) (0x04000-0x188)  {  ; RW data 16k L4-ECC-SRAM2 retained in standby
-   .ANY (+RW +ZI)
+  RW_IRAM1 (0x20000000+0x188) (0x00010000-0x188)  {
+  .ANY (+RW +ZI)
   }
 
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_GCC_ARM/STM32L432XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_GCC_ARM/STM32L432XX.ld
@@ -2,8 +2,7 @@
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 256K
-  SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 16k - 0x188
-  SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 48k
+  SRAM1 (rwx)  : ORIGIN = 0x20000188, LENGTH = 64k - 0x188
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
@@ -5,20 +5,16 @@ define symbol __region_ROM_end__   = 0x0803FFFF;
 
 /* [RAM = 48kb + 16kb = 0xC000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
-define symbol __region_SRAM2_start__  = 0x10000188;
-define symbol __region_SRAM2_end__    = 0x10003FFF;
-define symbol __region_SRAM1_start__  = 0x20000000;
-define symbol __region_SRAM1_end__    = 0x2000BFFF;
+define symbol __NVIC_start__          = 0x20000000;
+define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __region_SRAM1_start__  = 0x20000188;
+define symbol __region_SRAM1_end__    = 0x2000FFFF;
 
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
 define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
-/* Stack 1/8 and Heap 1/4 of RAM */
 define symbol __size_cstack__ = 0x2000;
 define symbol __size_heap__   = 0x4000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
@@ -32,4 +28,3 @@ place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
 place in SRAM1_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/cmsis_nvic.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/cmsis_nvic.h
@@ -35,6 +35,6 @@
 // MCU Peripherals: 82 vectors = 328 bytes from 0x40 to 0x187
 // Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
 #define NVIC_NUM_VECTORS        98
-#define NVIC_RAM_VECTOR_ADDRESS 0x10000000    // Vectors positioned at start of SRAM2
+#define NVIC_RAM_VECTOR_ADDRESS SRAM1_BASE    // Vectors positioned at start of SRAM1
 
 #endif

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -53,7 +53,7 @@
 #define INITIAL_SP              (0x2000A000UL)
 
 #elif defined(TARGET_STM32L432KC)
-#define INITIAL_SP              (0x2000C000UL)
+#define INITIAL_SP              (0x20010000UL)
 
 #elif (defined(TARGET_STM32F303RE) ||\
        defined(TARGET_STM32F303ZE) ||\


### PR DESCRIPTION
## Description
RAM size is increased from 48k to 64k for STM32L432KC as proposed in #4823 

WARNING: you have to update ST-Link FW to V2J29M18
http://www.st.com/en/development-tools/stsw-link007.html


## Status
READY


## Tests
All OS2 and OS5 tests have been checked
