### PR TITLE
EFM32: fix fire interrupt (set flags)

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/us_ticker.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/us_ticker.c
@@ -213,6 +213,8 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 
 void us_ticker_fire_interrupt(void)
 {
+    ticker_int_cnt = 0;
+    TIMER_IntSet(US_TICKER_TIMER, TIMER_IF_CC0);
     NVIC_SetPendingIRQ(US_TICKER_TIMER_IRQ);
 }
 


### PR DESCRIPTION
There's overflow counter that needs to be 0, and
CC0 flag set.

Fixes #5051

Tested with example in the issue, the callback is fired as it should. I've been testing it with leopard gecko (any efm32 should do the trick).

cc @fkjagodzinski 