### PR TITLE
PWMOut: lock deesleep addition

### DIFF
--- a/drivers/PwmOut.h
+++ b/drivers/PwmOut.h
@@ -21,6 +21,7 @@
 #if defined (DEVICE_PWMOUT) || defined(DOXYGEN_ONLY)
 #include "hal/pwmout_api.h"
 #include "platform/mbed_critical.h"
+#include "platform/mbed_sleep.h"
 
 namespace mbed {
 /** \addtogroup drivers */
@@ -56,9 +57,15 @@ public:
      *
      *  @param pin PwmOut pin to connect to
      */
-    PwmOut(PinName pin) {
+    PwmOut(PinName pin) : _deep_sleep_locked(false) {
         core_util_critical_section_enter();
         pwmout_init(&_pwm, pin);
+        core_util_critical_section_exit();
+    }
+
+    ~PwmOut() {
+        core_util_critical_section_enter();
+        unlock_deep_sleep();
         core_util_critical_section_exit();
     }
 
@@ -71,6 +78,7 @@ public:
      */
     void write(float value) {
         core_util_critical_section_enter();
+        lock_deep_sleep();
         pwmout_write(&_pwm, value);
         core_util_critical_section_exit();
     }
@@ -177,7 +185,24 @@ public:
     }
 
 protected:
+    /** Lock deep sleep only if it is not yet locked */
+    void lock_deep_sleep() {
+        if (_deep_sleep_locked == false) {
+            sleep_manager_lock_deep_sleep();
+            _deep_sleep_locked = true;
+        }
+    }
+
+    /** Unlock deep sleep in case it is locked */
+    void unlock_deep_sleep() {
+        if (_deep_sleep_locked == true) {
+            sleep_manager_unlock_deep_sleep();
+            _deep_sleep_locked = false;
+        }
+    }
+
     pwmout_t _pwm;
+    bool _deep_sleep_locked;
 };
 
 } // namespace mbed


### PR DESCRIPTION
As discussed here https://github.com/ARMmbed/mbed-os/pull/5157, PWMOut should lock deepsleep while active.

As PWMOut in most cases depend on high speed freq clock, it should lock deepsleep while active.

cc @c1728p9 @ccli8 