### PR TITLE
STM32: TRNG: remove call to deprecated HAL_RNG_GetRandomNumber

### DIFF
--- a/targets/TARGET_STM/trng_api.c
+++ b/targets/TARGET_STM/trng_api.c
@@ -24,18 +24,10 @@
 #include "cmsis.h"
 #include "trng_api.h"
 
-/** trng_get_byte
- *  @brief Get one byte of entropy from the RNG, assuming it is up and running.
- *  @param obj TRNG obj
- *  @param pointer to the hardware generated random byte.
- */
-static void trng_get_byte(trng_t *obj, unsigned char *byte )
-{
-    *byte = (unsigned char)HAL_RNG_GetRandomNumber(&obj->handle);
-}
 
 void trng_init(trng_t *obj)
 {
+    uint32_t dummy;
 #if defined(TARGET_STM32L4)
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
 
@@ -50,11 +42,13 @@ void trng_init(trng_t *obj)
 
     /* Initialize RNG instance */
     obj->handle.Instance = RNG;
+    obj->handle.State = HAL_RNG_STATE_RESET;
+    obj->handle.Lock = HAL_UNLOCKED;
+
     HAL_RNG_Init(&obj->handle);
 
     /* first random number generated after setting the RNGEN bit should not be used */
-    HAL_RNG_GetRandomNumber(&obj->handle);
-
+    HAL_RNG_GenerateRandomNumber(&obj->handle, &dummy);
 }
 
 void trng_free(trng_t *obj)
@@ -67,19 +61,26 @@ void trng_free(trng_t *obj)
 
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
-    int ret;
+    int ret = 0;
+    volatile uint8_t random[4];
+    *output_length = 0;
 
     /* Get Random byte */
-    for( uint32_t i = 0; i < length; i++ ){
-        trng_get_byte(obj, output + i );
+    while ((*output_length < length) && (ret ==0)) {
+        if ( HAL_RNG_GenerateRandomNumber(&obj->handle, (uint32_t *)random ) != HAL_OK) {
+                ret = -1;
+        } else {
+            for (uint8_t i =0; (i < 4) && (*output_length < length) ; i++) {
+                *output++ = random[i];
+                *output_length += 1;
+                random[i] = 0;
+            }
+        }
     }
 
-    *output_length = length;
     /* Just be extra sure that we didn't do it wrong */
     if( ( __HAL_RNG_GET_FLAG(&obj->handle, (RNG_FLAG_CECS | RNG_FLAG_SECS)) ) != 0 ) {
         ret = -1;
-    } else {
-        ret = 0;
     }
 
     return( ret );


### PR DESCRIPTION
## Description

HAL_RNG_GetRandomNumber is a deprecated API and replaced here with a call to HAL_RNG_GenerateRandomNumber. Doing so, we also rework the driver to use the 4 bytes returned by a call to HAL_RNG_GenerateRandomNumber instead of 1 byte out of 4.
HAL_RNG_GenerateRandomNumber was not returning any error code, so now we can also check the return code.

A second commit ensures that there is a single user at a time. 

## Status
**READY**


## Tests
```
+-----------------------+---------------+------------------------+--------+--------------------+-------------+
| target                | platform_name | test suite             | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+------------------------+--------+--------------------+-------------+
| NUCLEO_F091RC-ARM     | NUCLEO_F091RC | tests-mbedtls-selftest | OK     | 212.18             | default     |
| NUCLEO_F091RC-GCC_ARM | NUCLEO_F091RC | tests-mbedtls-selftest | OK     | 218.93             | default     |
| NUCLEO_F091RC-IAR     | NUCLEO_F091RC | tests-mbedtls-selftest | OK     | 257.7              | default     |
| NUCLEO_F103RB-ARM     | NUCLEO_F103RB | tests-mbedtls-selftest | OK     | 205.53             | default     |
| NUCLEO_F103RB-GCC_ARM | NUCLEO_F103RB | tests-mbedtls-selftest | OK     | 218.34             | default     |
| NUCLEO_F103RB-IAR     | NUCLEO_F103RB | tests-mbedtls-selftest | OK     | 209.21             | default     |
| NUCLEO_F207ZG-ARM     | NUCLEO_F207ZG | tests-mbedtls-selftest | OK     | 203.52             | default     |
| NUCLEO_F207ZG-GCC_ARM | NUCLEO_F207ZG | tests-mbedtls-selftest | OK     | 276.4              | default     |
| NUCLEO_F207ZG-IAR     | NUCLEO_F207ZG | tests-mbedtls-selftest | OK     | 200.14             | default     |
| NUCLEO_F303ZE-ARM     | NUCLEO_F303ZE | tests-mbedtls-selftest | OK     | 251.18             | default     |
| NUCLEO_F303ZE-GCC_ARM | NUCLEO_F303ZE | tests-mbedtls-selftest | OK     | 206.28             | default     |
| NUCLEO_F303ZE-IAR     | NUCLEO_F303ZE | tests-mbedtls-selftest | OK     | 202.71             | default     |
| NUCLEO_F446RE-ARM     | NUCLEO_F446RE | tests-mbedtls-selftest | OK     | 200.99             | default     |
| NUCLEO_F446RE-GCC_ARM | NUCLEO_F446RE | tests-mbedtls-selftest | OK     | 279.02             | default     |
| NUCLEO_F446RE-IAR     | NUCLEO_F446RE | tests-mbedtls-selftest | OK     | 197.36             | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbedtls-selftest | OK     | 197.78             | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbedtls-selftest | OK     | 198.37             | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbedtls-selftest | OK     | 201.52             | default     |
| NUCLEO_L073RZ-ARM     | NUCLEO_L073RZ | tests-mbedtls-selftest | OK     | 217.76             | default     |
| NUCLEO_L073RZ-GCC_ARM | NUCLEO_L073RZ | tests-mbedtls-selftest | OK     | 222.04             | default     |
| NUCLEO_L073RZ-IAR     | NUCLEO_L073RZ | tests-mbedtls-selftest | OK     | 253.9              | default     |
| NUCLEO_L152RE-ARM     | NUCLEO_L152RE | tests-mbedtls-selftest | OK     | 207.84             | default     |
| NUCLEO_L152RE-GCC_ARM | NUCLEO_L152RE | tests-mbedtls-selftest | OK     | 212.86             | default     |
| NUCLEO_L152RE-IAR     | NUCLEO_L152RE | tests-mbedtls-selftest | OK     | 210.24             | default     |
| NUCLEO_L476RG-ARM     | NUCLEO_L476RG | tests-mbedtls-selftest | OK     | 210.63             | default     |
| NUCLEO_L476RG-GCC_ARM | NUCLEO_L476RG | tests-mbedtls-selftest | OK     | 205.5              | default     |
| NUCLEO_L476RG-IAR     | NUCLEO_L476RG | tests-mbedtls-selftest | OK     | 203.64             | default     |
+-----------------------+---------------+------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 27 OK
```
+ All boards compiled OK, for which same tests is ongoing