### PR TITLE
CMSE Secure library creation

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -352,7 +352,9 @@ extern "C" void PREFIX(_exit)(int return_code) {
 }
 
 extern "C" void _ttywrch(int ch) {
+#if DEVICE_SERIAL
     serial_putc(&stdio_uart, ch);
+#endif
 }
 #endif
 
@@ -734,6 +736,7 @@ extern "C" int errno;
 
 // Dynamic memory allocation related syscall.
 #if defined(TARGET_NUVOTON)
+
 // Overwrite _sbrk() to support two region model (heap and stack are two distinct regions).
 // __wrap__sbrk() is implemented in:
 // TARGET_NUMAKER_PFM_NUC472    targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/TOOLCHAIN_GCC_ARM/nuc472_retarget.c

--- a/platform/mbed_tz_context.c
+++ b/platform/mbed_tz_context.c
@@ -1,0 +1,200 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+
+#include "cmsis.h"
+#include "mbed_rtx.h"
+#include "tz_context.h"
+
+
+/// Number of process slots (threads may call secure library code)
+#ifndef TZ_PROCESS_STACK_SLOTS
+#define TZ_PROCESS_STACK_SLOTS     8U
+#endif
+
+/// Stack size of the secure library code
+#ifndef TZ_PROCESS_STACK_SIZE
+#define TZ_PROCESS_STACK_SIZE      512U
+#endif
+
+typedef struct {
+    uint32_t sp_top;              // stack space top
+    uint32_t sp_limit;            // stack space limit
+    uint32_t sp;                  // current stack pointer
+} stack_info_t;
+
+static stack_info_t ProcessStackInfo  [TZ_PROCESS_STACK_SLOTS];
+static uint64_t     ProcessStackMemory[TZ_PROCESS_STACK_SLOTS][TZ_PROCESS_STACK_SIZE/8U];
+static uint32_t     ProcessStackFreeSlot = 0xFFFFFFFFU;
+
+
+/// Initialize secure context memory system
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_InitContextSystem_S (void)
+{
+    uint32_t n;
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    for (n = 0U; n < TZ_PROCESS_STACK_SLOTS; n++) {
+        ProcessStackInfo[n].sp = 0U;
+        ProcessStackInfo[n].sp_limit = (uint32_t)&ProcessStackMemory[n];
+        ProcessStackInfo[n].sp_top     = (uint32_t)&ProcessStackMemory[n] + TZ_PROCESS_STACK_SIZE;
+        *((uint32_t *)ProcessStackMemory[n]) = n + 1U;
+    }
+    *((uint32_t *)ProcessStackMemory[--n]) = 0xFFFFFFFFU;
+
+    ProcessStackFreeSlot = 0U;
+
+    // Default process stack pointer and stack limit
+    __set_PSPLIM ((uint32_t)ProcessStackMemory);
+    __set_PSP ((uint32_t)ProcessStackMemory);
+
+    // Privileged Thread Mode using PSP
+    __set_CONTROL(0x02U);
+
+    return 1U;        // Success
+}
+
+
+/// Allocate context memory for calling secure software modules in TrustZone
+/// \param[in]  module   identifies software modules called from non-secure mode
+/// \return value != 0 id TrustZone memory slot identifier
+/// \return value 0    no memory available or internal error
+__attribute__((cmse_nonsecure_entry))
+TZ_MemoryId_t TZ_AllocModuleContext_S (TZ_ModuleId_t module)
+{
+    uint32_t slot;
+
+    (void)module;   // Ignore (fixed Stack size)
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    if (ProcessStackFreeSlot == 0xFFFFFFFFU) {
+        return 0U;    // No slot available
+    }
+
+    slot = ProcessStackFreeSlot;
+    ProcessStackFreeSlot = *((uint32_t *)ProcessStackMemory[slot]);
+
+    ProcessStackInfo[slot].sp = ProcessStackInfo[slot].sp_top;
+
+    return (slot + 1U);
+}
+
+/// Free context memory that was previously allocated with \ref TZ_AllocModuleContext_S
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_FreeModuleContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+    ProcessStackInfo[slot].sp = 0U;
+
+    *((uint32_t *)ProcessStackMemory[slot]) = ProcessStackFreeSlot;
+    ProcessStackFreeSlot = slot;
+
+    return 1U;        // Success
+}
+
+
+/// Load secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_LoadContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+
+    if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+        return 0U;    // Thread Mode or using Main Stack for threads
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+
+    // Setup process stack pointer and stack limit
+    __set_PSPLIM(ProcessStackInfo[slot].sp_limit);
+    __set_PSP     (ProcessStackInfo[slot].sp);
+
+    return 1U;        // Success
+}
+
+
+/// Store secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_StoreContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+    uint32_t sp;
+
+    if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+        return 0U;    // Thread Mode or using Main Stack for threads
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+
+    sp = __get_PSP();
+    if ((sp < ProcessStackInfo[slot].sp_limit) ||
+            (sp > ProcessStackInfo[slot].sp_top)) {
+        return 0U;    // SP out of range
+    }
+    ProcessStackInfo[slot].sp = sp;
+
+    // Default process stack pointer and stack limit
+    __set_PSPLIM((uint32_t)ProcessStackMemory);
+    __set_PSP     ((uint32_t)ProcessStackMemory);
+
+    return 1U;        // Success
+}
+#endif

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -320,6 +320,12 @@ void mbed_start_main(void)
     _main_thread_attr.cb_mem = &_main_obj;
     _main_thread_attr.priority = osPriorityNormal;
     _main_thread_attr.name = "main_thread";
+
+    /* Allow main thread to call secure functions */
+#if (__DOMAIN_NS == 1U)
+    _main_thread_attr.tz_module = 1U;
+#endif
+
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
         error("Pre main thread not created");

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -60,6 +60,8 @@
 # define OS_PRIVILEGE_MODE           0
 #endif
 
+#define OS_SECURE_CALLABLE_THREAD    1
+
 #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
 
 /* Number of process slots (threads may call secure library code) */

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -60,4 +60,20 @@
 # define OS_PRIVILEGE_MODE           0
 #endif
 
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+
+/* Number of process slots (threads may call secure library code) */
+#ifndef MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS
+#define MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS     8U
+#endif
+
+/* Stack size of the secure library code */
+#ifndef MBED_CONF_APP_TZ_PROCESS_STACK_SIZE
+#define MBED_CONF_APP_TZ_PROCESS_STACK_SIZE      512U
+#endif
+
+#define TZ_PROCESS_STACK_SLOTS      MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS
+#define TZ_PROCESS_STACK_SIZE       MBED_CONF_APP_TZ_PROCESS_STACK_SIZE
+#endif
+
 #endif /* MBED_RTX_CONF_H */

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_ARM/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_ARM/irq_armv8mbl.S
@@ -220,8 +220,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if not secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_ARM/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_ARM/irq_armv8mbl.S
@@ -23,6 +23,11 @@
 ; * -----------------------------------------------------------------------------
 ; */
 
+
+#ifndef __DOMAIN_NS
+__DOMAIN_NS     EQU      0
+#endif
+
 I_T_RUN_OFS     EQU      28                     ; osInfo.thread.run offset
 TCB_SM_OFS      EQU      48                     ; TCB.stack_mem offset
 TCB_SP_OFS      EQU      56                     ; TCB.SP offset
@@ -46,10 +51,10 @@ SVC_Handler     PROC
                 EXPORT   SVC_Handler
                 IMPORT   osRtxUserSVC
                 IMPORT   osRtxInfo
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
-#endif
+                ENDIF
 
                 MRS      R0,PSP                 ; Get PSP
                 LDR      R1,[R0,#24]            ; Load saved PC from stack
@@ -74,7 +79,7 @@ SVC_Context
                 CBZ      R1,SVC_ContextSwitch   ; Branch if running thread is deleted
 
 SVC_ContextSave
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextSave1    ; Branch if there is no secure context
                 PUSH     {R1,R2,R3,R7}          ; Save registers
@@ -82,7 +87,7 @@ SVC_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-#endif
+                ENDIF
 
 SVC_ContextSave1
                 MRS      R0,PSP                 ; Get PSP
@@ -105,13 +110,13 @@ SVC_ContextSwitch
                 STR      R2,[R3]                ; osRtxInfo.thread.run: curr = next
 
 SVC_ContextRestore
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextRestore1 ; Branch if there is no secure context
                 PUSH     {R2,R3}                ; Save registers
                 BL       TZ_LoadContext_S       ; Load secure context
                 POP      {R2,R3}                ; Restore registers
-#endif
+                ENDIF
 
 SVC_ContextRestore1
                 MOV      R1,R2
@@ -122,16 +127,16 @@ SVC_ContextRestore1
                 ORRS     R0,R1
                 MOV      LR,R0                  ; Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LSLS     R0,R0,#25              ; Check domain of interrupted thread
                 BPL      SVC_ContextRestore2    ; Branch if non-secure
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 MSR      PSP,R0                 ; Set PSP
                 BX       LR                     ; Exit from handler
-#else
+                ELSE
                 LDR      R0,[R2,#TCB_SM_OFS]    ; Load stack memory base
                 MSR      PSPLIM,R0              ; Set PSPLIM
-#endif
+                ENDIF
 
 SVC_ContextRestore2
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
@@ -201,10 +206,10 @@ SysTick_Handler PROC
 Sys_Context     PROC
                 EXPORT   Sys_Context
                 IMPORT   osRtxInfo
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
-#endif
+                ENDIF
 
                 LDR      R3,=osRtxInfo+I_T_RUN_OFS; Load address of osRtxInfo.run
                 LDM      R3!,{R1,R2}            ; Load osRtxInfo.thread.run: curr & next
@@ -212,7 +217,7 @@ Sys_Context     PROC
                 BEQ      Sys_ContextExit        ; Branch when threads are the same
 
 Sys_ContextSave
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextSave1    ; Branch if there is no secure context
                 PUSH     {R1,R2,R3,R7}          ; Save registers
@@ -226,7 +231,7 @@ Sys_ContextSave
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2
-#endif
+                ENDIF
 
 Sys_ContextSave1
                 MRS      R0,PSP                 ; Get PSP
@@ -249,13 +254,13 @@ Sys_ContextSwitch
                 STR      R2,[R3]                ; osRtxInfo.run: curr = next
 
 Sys_ContextRestore
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextRestore1 ; Branch if there is no secure context
                 PUSH     {R2,R3}                ; Save registers
                 BL       TZ_LoadContext_S       ; Load secure context
                 POP      {R2,R3}                ; Restore registers
-#endif
+                ENDIF
 
 Sys_ContextRestore1
                 MOV      R1,R2
@@ -266,16 +271,16 @@ Sys_ContextRestore1
                 ORRS     R0,R1
                 MOV      LR,R0                  ; Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+                IF       __DOMAIN_NS = 1
                 LSLS     R0,R0,#25              ; Check domain of interrupted thread
                 BPL      Sys_ContextRestore2    ; Branch if non-secure
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
                 MSR      PSP,R0                 ; Set PSP
                 BX       LR                     ; Exit from handler
-#else
+                ELSE
                 LDR      R0,[R2,#TCB_SM_OFS]    ; Load stack memory base
                 MSR      PSPLIM,R0              ; Set PSPLIM
-#endif
+                ENDIF
 
 Sys_ContextRestore2
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_GCC/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_GCC/irq_armv8mbl.S
@@ -27,6 +27,10 @@
         .file    "irq_armv8mbl.S"
         .syntax  unified
 
+#ifndef __DOMAIN_NS
+        .equ     __DOMAIN_NS, 0
+#endif
+
         .equ     I_T_RUN_OFS, 28        // osRtxInfo.thread.run offset
         .equ     TCB_SM_OFS,  48        // TCB.stack_mem offset
         .equ     TCB_SP_OFS,  56        // TCB.SP offset
@@ -50,6 +54,7 @@ irqRtxLib:
         .fnstart
         .cantunwind
 SVC_Handler:
+
         MRS      R0,PSP                 // Get PSP
         LDR      R1,[R0,#24]            // Load saved PC from stack
         SUBS     R1,R1,#2               // Point to SVC instruction
@@ -73,7 +78,7 @@ SVC_Context:
         CBZ      R1,SVC_ContextSwitch   // Branch if running thread is deleted
 
 SVC_ContextSave:
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LDR      R0,[R1,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,SVC_ContextSave1    // Branch if there is no secure context
         PUSH     {R1,R2,R3,R7}          // Save registers
@@ -81,7 +86,7 @@ SVC_ContextSave:
         BL       TZ_StoreContext_S      // Store secure context
         MOV      LR,R7                  // Set EXC_RETURN
         POP      {R1,R2,R3,R7}          // Restore registers
-#endif
+        .endif
 
 SVC_ContextSave1:
         MRS      R0,PSP                 // Get PSP
@@ -104,13 +109,13 @@ SVC_ContextSwitch:
         STR      R2,[R3]                // osRtxInfo.thread.run: curr = next
 
 SVC_ContextRestore:
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LDR      R0,[R2,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,SVC_ContextRestore1 // Branch if there is no secure context
         PUSH     {R2,R3}                // Save registers
         BL       TZ_LoadContext_S       // Load secure context
         POP      {R2,R3}                // Restore registers
-#endif
+        .endif
 
 SVC_ContextRestore1:
         MOV      R1,R2
@@ -121,16 +126,16 @@ SVC_ContextRestore1:
         ORRS     R0,R1
         MOV      LR,R0                  // Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LSLS     R0,R0,#25              // Check domain of interrupted thread
         BPL      SVC_ContextRestore2    // Branch if non-secure
         LDR      R0,[R2,#TCB_SP_OFS]    // Load SP
         MSR      PSP,R0                 // Set PSP
         BX       LR                     // Exit from handler
-#else
+        .else
         LDR      R0,[R2,#TCB_SM_OFS]    // Load stack memory base
         MSR      PSPLIM,R0              // Set PSPLIM
-#endif
+        .endif
 
 SVC_ContextRestore2:
         LDR      R0,[R2,#TCB_SP_OFS]    // Load SP
@@ -216,7 +221,7 @@ Sys_Context:
         BEQ      Sys_ContextExit        // Branch when threads are the same
 
 Sys_ContextSave:
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LDR      R0,[R1,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,Sys_ContextSave1    // Branch if there is no secure context
         PUSH     {R1,R2,R3,R7}          // Save registers
@@ -226,11 +231,11 @@ Sys_ContextSave:
         POP      {R1,R2,R3,R7}          // Restore registers
         MOV      R0,LR                  // Get EXC_RETURN
         LSLS     R0,R0,#25              // Check domain of interrupted thread
-        BPL      Sys_ContextSave1       // Branch if not secure
+        BPL      Sys_ContextSave1       // Branch if non-secure
         MRS      R0,PSP                 // Get PSP
         STR      R0,[R1,#TCB_SP_OFS]    // Store SP
         B        Sys_ContextSave2
-#endif
+        .endif
 
 Sys_ContextSave1:
         MRS      R0,PSP                 // Get PSP
@@ -253,13 +258,13 @@ Sys_ContextSwitch:
         STR      R2,[R3]                // osRtxInfo.run: curr = next
 
 Sys_ContextRestore:
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LDR      R0,[R2,#TCB_TZM_OFS]   // Load TrustZone memory identifier
         CBZ      R0,Sys_ContextRestore1 // Branch if there is no secure context
         PUSH     {R2,R3}                // Save registers
         BL       TZ_LoadContext_S       // Load secure context
         POP      {R2,R3}                // Restore registers
-#endif
+        .endif
 
 Sys_ContextRestore1:
         MOV      R1,R2
@@ -270,16 +275,16 @@ Sys_ContextRestore1:
         ORRS     R0,R1
         MOV      LR,R0                  // Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+        .if      __DOMAIN_NS == 1
         LSLS     R0,R0,#25              // Check domain of interrupted thread
         BPL      Sys_ContextRestore2    // Branch if non-secure
         LDR      R0,[R2,#TCB_SP_OFS]    // Load SP
         MSR      PSP,R0                 // Set PSP
         BX       LR                     // Exit from handler
-#else
+        .else
         LDR      R0,[R2,#TCB_SM_OFS]    // Load stack memory base
         MSR      PSPLIM,R0              // Set PSPLIM
-#endif
+        .endif
 
 Sys_ContextRestore2:
         LDR      R0,[R2,#TCB_SP_OFS]    // Load SP

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_GCC/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_GCC/irq_armv8mbl.S
@@ -224,8 +224,9 @@ Sys_ContextSave:
         BL       TZ_StoreContext_S      // Store secure context
         MOV      LR,R7                  // Set EXC_RETURN
         POP      {R1,R2,R3,R7}          // Restore registers
-        LSLS     R7,R7,#25              // Check domain of interrupted thread
-        BMI      Sys_ContextSave1       // Branch if secure
+        MOV      R0,LR                  // Get EXC_RETURN
+        LSLS     R0,R0,#25              // Check domain of interrupted thread
+        BPL      Sys_ContextSave1       // Branch if not secure
         MRS      R0,PSP                 // Get PSP
         STR      R0,[R1,#TCB_SP_OFS]    // Store SP
         B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_IAR/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_IAR/irq_armv8mbl.S
@@ -214,8 +214,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if not secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_IAR/irq_armv8mbl_common.S
+++ b/rtos/TARGET_CORTEX/rtx5/TARGET_M23/TOOLCHAIN_IAR/irq_armv8mbl_common.S
@@ -24,7 +24,9 @@
 ; */
 
 
-                NAME    irq_armv8mbl.s
+#ifndef __DOMAIN_NS
+#define __DOMAIN_NS 0
+#endif
 
 I_T_RUN_OFS     EQU      28                     ; osRtxInfo.thread.run offset
 TCB_SM_OFS      EQU      48                     ; TCB.stack_mem offset
@@ -34,21 +36,23 @@ TCB_TZM_OFS     EQU      64                     ; TCB.tz_memory offset
 
 
                 PRESERVE8
-                SECTION .rodata:DATA:NOROOT(2)
 
 
+                SECTION  .rodata:DATA:NOROOT(2)
                 EXPORT   irqRtxLib
 irqRtxLib       DCB      0                      ; Non weak library reference
 
+
+                SECTION   .text:CODE:NOROOT(2)
+
                 THUMB
-                SECTION .text:CODE:NOROOT(2)
 
 
 SVC_Handler
                 EXPORT   SVC_Handler
                 IMPORT   osRtxUserSVC
                 IMPORT   osRtxInfo
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
 #endif
@@ -76,7 +80,7 @@ SVC_Context
                 CBZ      R1,SVC_ContextSwitch   ; Branch if running thread is deleted
 
 SVC_ContextSave
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextSave1    ; Branch if there is no secure context
                 PUSH     {R1,R2,R3,R7}          ; Save registers
@@ -107,7 +111,7 @@ SVC_ContextSwitch
                 STR      R2,[R3]                ; osRtxInfo.thread.run: curr = next
 
 SVC_ContextRestore
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,SVC_ContextRestore1 ; Branch if there is no secure context
                 PUSH     {R2,R3}                ; Save registers
@@ -124,7 +128,7 @@ SVC_ContextRestore1
                 ORRS     R0,R1
                 MOV      LR,R0                  ; Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LSLS     R0,R0,#25              ; Check domain of interrupted thread
                 BPL      SVC_ContextRestore2    ; Branch if non-secure
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
@@ -191,10 +195,11 @@ SysTick_Handler
                 B        Sys_Context
 
 
+
 Sys_Context
                 EXPORT   Sys_Context
                 IMPORT   osRtxInfo
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 IMPORT   TZ_LoadContext_S
                 IMPORT   TZ_StoreContext_S
 #endif
@@ -204,9 +209,8 @@ Sys_Context
                 CMP      R1,R2                  ; Check if thread switch is required
                 BEQ      Sys_ContextExit        ; Branch when threads are the same
 
-
 Sys_ContextSave
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LDR      R0,[R1,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextSave1    ; Branch if there is no secure context
                 PUSH     {R1,R2,R3,R7}          ; Save registers
@@ -214,9 +218,8 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                MOV      R0,LR                  ; Get EXC_RETURN
-                LSLS     R0,R0,#25              ; Check domain of interrupted thread
-                BPL      Sys_ContextSave1       ; Branch if not secure
+                LSLS     R7,R7,#25              ; Check domain of interrupted thread
+                BMI      Sys_ContextSave1       ; Branch if secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2
@@ -243,7 +246,7 @@ Sys_ContextSwitch
                 STR      R2,[R3]                ; osRtxInfo.run: curr = next
 
 Sys_ContextRestore
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LDR      R0,[R2,#TCB_TZM_OFS]   ; Load TrustZone memory identifier
                 CBZ      R0,Sys_ContextRestore1 ; Branch if there is no secure context
                 PUSH     {R2,R3}                ; Save registers
@@ -260,7 +263,7 @@ Sys_ContextRestore1
                 ORRS     R0,R1
                 MOV      LR,R0                  ; Set EXC_RETURN
 
-#ifdef __DOMAIN_NS
+#if (__DOMAIN_NS == 1)
                 LSLS     R0,R0,#25              ; Check domain of interrupted thread
                 BPL      Sys_ContextRestore2    ; Branch if non-secure
                 LDR      R0,[R2,#TCB_SP_OFS]    ; Load SP
@@ -285,5 +288,3 @@ Sys_ContextRestore2
 
 Sys_ContextExit
                 BX       LR                     ; Exit from handler
-
-                END

--- a/rtos/TARGET_CORTEX/rtx5/rtx_lib.c
+++ b/rtos/TARGET_CORTEX/rtx5/rtx_lib.c
@@ -128,7 +128,12 @@ static const osThreadAttr_t os_idle_thread_attr = {
   &os_idle_thread_stack,
   (uint32_t)sizeof(os_idle_thread_stack),
   osPriorityIdle,
-  0U, 0U
+#if (__DOMAIN_NS == 1U)
+  1U,
+#else
+  0U,
+#endif
+  0U
 };
 
 
@@ -176,7 +181,12 @@ static const osThreadAttr_t os_timer_thread_attr = {
   &os_timer_thread_stack,
   (uint32_t)sizeof(os_timer_thread_stack),
   (osPriority_t)OS_TIMER_THREAD_PRIO,
-  0U, 0U
+#if (__DOMAIN_NS == 1U)
+  1U,
+#else
+  0U,
+#endif
+  0U
 };
 
 // Timer Message Queue Control Block

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -35,7 +35,7 @@ extern "C" void thread_terminate_hook(osThreadId_t id)
 namespace rtos {
 
 void Thread::constructor(osPriority priority,
-        uint32_t stack_size, unsigned char *stack_mem, const char *name) {
+        uint32_t stack_size, unsigned char *stack_mem, const char *name, uint32_t tz_module) {
     _tid = 0;
     _dynamic_stack = (stack_mem == NULL);
     _finished = false;
@@ -45,11 +45,12 @@ void Thread::constructor(osPriority priority,
     _attr.stack_size = stack_size;
     _attr.name = name ? name : "application_unnamed_thread";
     _attr.stack_mem = (uint32_t*)stack_mem;
+    _attr.tz_module = tz_module;
 }
 
 void Thread::constructor(Callback<void()> task,
-        osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name) {
-    constructor(priority, stack_size, stack_mem, name);
+        osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name, uint32_t tz_module) {
+    constructor(priority, stack_size, stack_mem, name, tz_module);
 
     switch (start(task)) {
         case osErrorResource:

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -76,11 +76,12 @@ public:
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).
       @param   name           name to be used for this thread. It has to stay allocated for the lifetime of the thread (default: NULL)
+      @param   tz_module      trustzone thread identifier (default: 0)
     */
     Thread(osPriority priority=osPriorityNormal,
            uint32_t stack_size=OS_STACK_SIZE,
-           unsigned char *stack_mem=NULL, const char *name=NULL) {
-        constructor(priority, stack_size, stack_mem, name);
+           unsigned char *stack_mem=NULL, const char *name=NULL, uint32_t tz_module=0) {
+        constructor(priority, stack_size, stack_mem, name, tz_module);
     }
 
     /** Create a new thread, and start it executing the specified function.
@@ -353,12 +354,12 @@ private:
     void constructor(osPriority priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
                      unsigned char *stack_mem=NULL,
-                     const char *name=NULL);
+                     const char *name=NULL, uint32_t tz_module=0);
     void constructor(mbed::Callback<void()> task,
                      osPriority priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
                      unsigned char *stack_mem=NULL,
-                     const char *name=NULL);
+                     const char *name=NULL, uint32_t tz_module=0);
     static void _thunk(void * thread_ptr);
 
     mbed::Callback<void()>     _task;

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -274,9 +274,13 @@ class MemapParser(object):
                     section = '.data'
                 elif test_re_armcc.group(3) == 'Zero':
                     section = '.bss'
+                elif test_re_armcc.group(3) == 'Code':
+                    section = '.text'
                 else:
-                    print "Malformed input found when parsing armcc map: %s" %\
-                          line
+                    print "Malformed input found when parsing armcc map: %s, %r" %\
+                          (line, test_re_armcc.groups())
+
+                    return ["", 0, ""]
 
             # check name of object or library
             object_name = self.parse_object_name_armcc(\

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -278,6 +278,7 @@ class ARMC6(ARM_STD):
 
     def __init__(self, target, *args, **kwargs):
         mbedToolchain.__init__(self, target, *args, **kwargs)
+        build_dir = kwargs['build_dir']
 
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
@@ -311,6 +312,11 @@ class ARMC6(ARM_STD):
 
         if target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.flags['common'].append("-mcmse")
+
+        # Create Secure library
+        if target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = join(build_dir, "cmse_lib.o")
+            self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 
         asm_cpu = {
             "Cortex-M0+": "Cortex-M0",

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -93,6 +93,8 @@ class GCC(mbedToolchain):
 
         if target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.cpu.append("-mcmse")
+        elif target.core == "Cortex-M23-NS" or target.core == "Cortex-M33-NS":
+             self.flags["ld"].append("-D__DOMAIN_NS=1")
 
         self.flags["common"] += self.cpu
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -223,8 +223,7 @@ class GCC(mbedToolchain):
         cmd = self.ld + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
         # Create Secure library
         if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
-            secure_file = "cmse_lib.o"
-            secure_file = join(split(output)[0], secure_file)
+            secure_file = join(dirname(output), "cmse_lib.o")
             cmd.extend(["-Wl,--cmse-implib"])
             cmd.extend(["-Wl,--out-implib=%s" % secure_file])
 
@@ -248,7 +247,7 @@ class GCC(mbedToolchain):
         self.cc_verbose("Link: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
         if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
-            print "Secure File: %s" %secure_file
+            self.info("Secure Library Object %s" %secure_file)
 
     @hook_tool
     def archive(self, objects, lib_path):

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 import re
-from os.path import join, basename, splitext, dirname, exists
+from os.path import join, basename, splitext, dirname, exists, split
 from distutils.spawn import find_executable
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
@@ -219,6 +219,13 @@ class GCC(mbedToolchain):
         # Build linker command
         map_file = splitext(output)[0] + ".map"
         cmd = self.ld + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
+        # Create Secure library
+        if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = "cmse_lib.o"
+            secure_file = join(split(output)[0], secure_file)
+            cmd.extend(["-Wl,--cmse-implib"])
+            cmd.extend(["-Wl,--out-implib=%s" % secure_file])
+
         if mem_map:
             cmd.extend(['-T', mem_map])
 
@@ -238,6 +245,8 @@ class GCC(mbedToolchain):
         # Exec command
         self.cc_verbose("Link: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
+        if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            print "Secure File: %s" %secure_file
 
     @hook_tool
     def archive(self, objects, lib_path):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -16,7 +16,7 @@ limitations under the License.
 """
 import re
 from os import remove
-from os.path import join, splitext, exists
+from os.path import join, splitext, exists, dirname
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -66,6 +66,7 @@ class IAR(mbedToolchain):
         cxx_flags_cmd = [
             "--c++", "--no_rtti", "--no_exceptions"
         ]
+
         if target.core == "Cortex-M7FD":
             asm_flags_cmd += ["--fpu", "VFPv5"]
             c_flags_cmd.append("--fpu=VFPv5")
@@ -74,6 +75,12 @@ class IAR(mbedToolchain):
             c_flags_cmd.append("--fpu=VFPv5_sp")
         elif target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.flags["asm"] += ["--cmse"]
+            self.flags["common"] += ["--cmse"]
+
+        # Create Secure library
+        if target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = join(build_dir, "cmse_lib.o")
+            self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 
         IAR_BIN = join(TOOLCHAIN_PATHS['IAR'], "bin")
         main_cc = join(IAR_BIN, "iccarm")
@@ -187,6 +194,7 @@ class IAR(mbedToolchain):
         # Build linker command
         map_file = splitext(output)[0] + ".map"
         cmd = self.ld + [ "-o", output, "--map=%s" % map_file] + objects + libraries
+
 
         if mem_map:
             cmd.extend(["--config", mem_map])


### PR DESCRIPTION
Cortex v8 architecture based devices support secure/non-secure builds. Secure build should generate the object file/library from elf during link process which is used by non-secure binary during linking.
TZ_context functions are part of secure state binary and are used to handle secure stack for thread execution. 

NS flag in the core name in Target.json indicated Non Secure build for the core. It is supported for v8M devices only.
Secure library will be built as part of linking process for GCC compiler. Non-Secure project should add this secure object file as part of the linking process.

Secure library is named as cmse_lib.o.
