### PR TITLE
tools/toolhains - Test for flag passing in constructor

### DIFF
--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -84,7 +84,7 @@ class IAR(mbedToolchain):
         self.cc += self.flags["common"] + c_flags_cmd + self.flags["c"]
         self.cppc += self.flags["common"] + c_flags_cmd + cxx_flags_cmd + self.flags["cxx"]
         
-        self.ld   = [join(IAR_BIN, "ilinkarm")]
+        self.ld   = [join(IAR_BIN, "ilinkarm")] + self.flags['ld']
         self.ar = join(IAR_BIN, "iarchive")
         self.elf2bin = join(IAR_BIN, "ielftool")
 
@@ -186,7 +186,7 @@ class IAR(mbedToolchain):
     def link(self, output, objects, libraries, lib_dirs, mem_map):
         # Build linker command
         map_file = splitext(output)[0] + ".map"
-        cmd = self.ld + [ "-o", output, "--map=%s" % map_file] + objects + libraries + self.flags['ld']
+        cmd = self.ld + [ "-o", output, "--map=%s" % map_file] + objects + libraries
 
         if mem_map:
             cmd.extend(["--config", mem_map])


### PR DESCRIPTION
# Metadata

Fixes #5181

# Descirption

This PR moves the passing of ld flags when compiling with `IAR` to the
constructor.

This PR also adds tests that certify that all toolchains pass all
arguments from their build profiles both:
 - In the constructor
 - On the command line invocation

This is stronger than the prior guarantee, which was: The compilers (C,
C++, Assembler) all pass their build profile arguments to the command
line invocation.

# Testing
 - [x] Manual verification that the test fail when the aforementioned conditions are not met. You can verify for yourself by checking out just the first commit in this PR.
 - [x] Travis CI passing (This is where these tests run)