### PR TITLE
fs: Fix dir open during failure condition

### DIFF
--- a/features/filesystem/Dir.cpp
+++ b/features/filesystem/Dir.cpp
@@ -43,8 +43,12 @@ int Dir::open(FileSystem *fs, const char *path)
         return -EINVAL;
     }
 
-    _fs = fs;
-    return _fs->dir_open(&_dir, path);
+    int err = fs->dir_open(&_dir, path);
+    if (!err) {
+        _fs = fs;
+    }
+
+    return err;
 }
 
 int Dir::close()


### PR DESCRIPTION
Should leave the Dir in an openable state, currently does not since it thinks it's in use by the fs it failed to open on.