### PR TITLE
LPC1768: RAM end adjust fix

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/TOOLCHAIN_IAR/LPC17xx.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__     = 0x0007FFFF;
 define symbol __ICFEDIT_region_NVIC_start__   = 0x10000000;
 define symbol __ICFEDIT_region_NVIC_end__   = 0x100000C7;
 define symbol __ICFEDIT_region_RAM_start__   = 0x100000C8;
-define symbol __ICFEDIT_region_RAM_end__     = 0x10007FDF;
+define symbol __ICFEDIT_region_RAM_end__     = 0x10007FE0;
 
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/flash_api.c
@@ -108,10 +108,6 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 
 }
 
-/* IAP Call */
-typedef void (*IAP_Entry) (unsigned long *cmd, unsigned long *stat);
-#define IAP_Call ((IAP_Entry) 0x1FFF1FF1)
-
 int32_t flash_program_page(flash_t *obj, uint32_t address,
         const uint8_t *data, uint32_t size)
 {


### PR DESCRIPTION
The topmost 32 bytes used by IAP functions, this was not included in the RAM
end previously.

Running test multiple times to be certain this fixes it. The last 10 runs -- all OK

```
+-------------+---------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
| target      | platform_name | test suite                  | test case                 | passed | failed | result | elapsed_time (sec) |
+-------------+---------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
| LPC1768-IAR | LPC1768       | tests-mbed_drivers-flashiap | FlashIAP - init           | 1      | 0      | OK     | 0.05               |
| LPC1768-IAR | LPC1768       | tests-mbed_drivers-flashiap | FlashIAP - program        | 1      | 0      | OK     | 0.28               |
| LPC1768-IAR | LPC1768       | tests-mbed_drivers-flashiap | FlashIAP - program errors | 1      | 0      | OK     | 0.06               |
+-------------+---------------+-----------------------------+---------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 3 OK
mbedgt: completed in 17.66 sec
```

@chrissnow 