### PR TITLE
Moved STDIO_UART defines for UBLOX_EVK_ODIN_W2

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PeripheralNames.h
@@ -57,9 +57,8 @@ typedef enum {
     UART_8 = (int)UART8_BASE
 } UARTName;
 
-#define STDIO_UART_TX  PA_9
-#define STDIO_UART_RX  PA_10
-#define STDIO_UART     UART_1
+#define STDIO_UART_TX  USBTX
+#define STDIO_UART_RX  USBRX
 
 typedef enum {
     SPI_1 = (int)SPI1_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
@@ -166,8 +166,8 @@ typedef enum {
     BUTTON2    = SW1,
 
     // ST-Link
-    USBRX      = PA_10,
-    USBTX      = PA_9,
+    USBRX      = MBED_CONF_TARGET_USB_RX,
+    USBTX      = MBED_CONF_TARGET_USB_TX,
     SWDIO      = PA_15,
     SWCLK      = PA_14,
     NTRST      = PB_4,

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1701,7 +1701,22 @@
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "STM32F439ZI",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "config": {
+            "usb_tx": {
+                "help": "Value: D8(default) or D1",
+                "value": "D8"
+            },
+            "usb_rx": {
+                "help": "Value: D2(default) or D0",
+                "value": "D2"
+            },
+            "stdio_uart": {
+                "help": "Value: UART_1(default) or UART_3",
+                "value": "UART_1",
+                "macro_name": "STDIO_UART"
+            }
+        }
     },
     "UBLOX_C030": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
## Description
Moved STDIO_UART defines to targets.json for UBLOX_EVK_ODIN_W2 instead of hardcoded.
The default UART(D2/D8) can be overriden in mbed_app.json like this to use UART_3 instead:

    "target_overrides": {
            "UBLOX_EVK_ODIN_W2": {
                "target.usb_tx": "D1",
                "target.usb_rx": "D0",
                "target.stdio_uart": "UART_3"
            }
    }

## Status
Should be reviewed and tested by @andrewc-arm to make sure it solves #5129

## Migrations
NO

## Related PRs
https://github.com/ARMmbed/mbed-os/issues/5129

## Todos
None

## Deploy notes
None

## Steps to test or reproduce
Have only run one test case to verify that it is still possible to run 'mbed test'.
