### PR TITLE
Omit libraries and tests from tools coverage numbers

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+     */usr/local/lib*
+     */tools/test/*
+
+[report]
+omit =
+     */usr/local/lib*
+     */tools/test/*


### PR DESCRIPTION
I noticed recently, that our coverage numbers changed when we updated a
package we depend on. This is nonsense. Our coverage numbers should
reflect only our code.