### PR TITLE
Ensure us_ticker is initialized before it is used

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -263,6 +263,7 @@ timestamp_t ticker_read(const ticker_data_t *const ticker)
 
 us_timestamp_t ticker_read_us(const ticker_data_t *const ticker)
 {
+    initialize(ticker);
     update_present_time(ticker);
     return ticker->queue->present_time;
 }

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1049,9 +1049,8 @@ void operator delete[](void *ptr)
 extern "C" clock_t clock()
 {
     _mutex->lock();
-    clock_t t = us_ticker_read();
+    clock_t t = ticker_read(get_us_ticker_data());
     t /= 1000000 / CLOCKS_PER_SEC; // convert to processor time
     _mutex->unlock();
     return t;
 }
-

--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -30,8 +30,9 @@ void wait_ms(int ms) {
 }
 
 void wait_us(int us) {
-    uint32_t start = us_ticker_read();
-    while ((us_ticker_read() - start) < (uint32_t)us);
+    const ticker_data_t *const ticker = get_us_ticker_data();
+    uint32_t start = ticker_read(ticker);
+    while ((ticker_read(ticker) - start) < (uint32_t)us);
 }
 
 #endif // #ifndef MBED_CONF_RTOS_PRESENT

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -22,6 +22,7 @@
 #include "hal/us_ticker_api.h"
 #include "rtos/rtos.h"
 #include "platform/mbed_critical.h"
+#include "platform/mbed_sleep.h"
 
 void wait(float s) {
     wait_us(s * 1000000.0f);
@@ -32,15 +33,19 @@ void wait_ms(int ms) {
 }
 
 void wait_us(int us) {
-    uint32_t start = us_ticker_read();
+    const ticker_data_t *const ticker = get_us_ticker_data();
+
+    uint32_t start = ticker_read(ticker);
     // Use the RTOS to wait for millisecond delays if possible
     int ms = us / 1000;
     if ((ms > 0) && core_util_are_interrupts_enabled()) {
+        sleep_manager_lock_deep_sleep();
         Thread::wait((uint32_t)ms);
+        sleep_manager_unlock_deep_sleep();
     }
     // Use busy waiting for sub-millisecond delays, or for the whole
     // interval if interrupts are not enabled
-    while ((us_ticker_read() - start) < (uint32_t)us);
+    while ((ticker_read(ticker) - start) < (uint32_t)us);
 }
 
 #endif // #if MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
Update platform code to use the ticker common layer rather than using HAL us ticker directly. This both ensures that the underlying ticker is properly initialized and that the value read is in microseconds with full 32-bit range.