### PR TITLE
Add quotes to preprocessor path on export

### DIFF
--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -244,7 +244,7 @@ class GNUARMEclipse(Exporter):
             opts['ld']['system_libraries'] = self.system_libraries
             opts['ld']['script'] = join(id.capitalize(),
                                         "linker-script-%s.ld" % id)
-            opts['cpp_cmd'] = "".join('"{}"'.format(toolchain.preproc[0])) + " " + " ".join(toolchain.preproc[1:])
+            opts['cpp_cmd'] = '"{}"'.format(toolchain.preproc[0]) + " " + " ".join(toolchain.preproc[1:])
 
             # Unique IDs used in multiple places.
             # Those used only once are implemented with {{u.id}}.

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -244,7 +244,7 @@ class GNUARMEclipse(Exporter):
             opts['ld']['system_libraries'] = self.system_libraries
             opts['ld']['script'] = join(id.capitalize(),
                                         "linker-script-%s.ld" % id)
-            opts['cpp_cmd'] = " ".join(toolchain.preproc)
+            opts['cpp_cmd'] = "".join('"{}"'.format(toolchain.preproc[0])) + " " + " ".join(toolchain.preproc[1:])
 
             # Unique IDs used in multiple places.
             # Those used only once are implemented with {{u.id}}.


### PR DESCRIPTION
# Metadata
Type: Bugfix
Resolves: #5186 
**Ready**

# Description
Hi, 

So this is a fix for #5186 tested on windows only. So can someone test this on the other systems mbed and the exporter is running.

cheers 
mathias
