### PR TITLE
Extend nRF51 AnalogIn voltage range to 3.6 V

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/analogin_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/analogin_api.c
@@ -67,7 +67,7 @@ uint16_t analogin_read_u16(analogin_t *obj)
     
     // initialization by assigment because IAR dosen't support variable initializer in declaration statement.
     adc_channel.config.config.resolution = NRF_ADC_CONFIG_RES_10BIT;
-    adc_channel.config.config.input      = NRF_ADC_CONFIG_SCALING_INPUT_FULL_SCALE;
+    adc_channel.config.config.input      = NRF_ADC_CONFIG_SCALING_INPUT_ONE_THIRD;
     adc_channel.config.config.reference  = NRF_ADC_CONFIG_REF_VBG;
     adc_channel.config.config.ain        = (obj->adc_pin);
     adc_channel.p_next = NULL;


### PR DESCRIPTION
Previous the voltage range was ste to 1.2 v from SoC internal reference source.
This caused problem with testing. It is unexpected that range is much
shorter than vdd as well.

Fix for analog part of ct-test-shield test issue https://github.com/ARMmbed/mbed-os/issues/5133