### PR TITLE
fs: Fix fstat retarget for regular files

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -446,6 +446,7 @@ int _lseek(FILEHANDLE fh, int offset, int whence)
 #if defined(__ARMCC_VERSION)
     int whence = SEEK_SET;
 #endif
+
     if (fh < 3) {
         errno = ESPIPE;
         return -1;
@@ -536,13 +537,21 @@ extern "C" __value_in_regs struct __initial_stackheap __user_setup_stackheap(uin
 
 
 #if !defined(__ARMCC_VERSION) && !defined(__ICCARM__)
-extern "C" int _fstat(int fd, struct stat *st) {
-    if (fd < 3) {
+extern "C" int _fstat(int fh, struct stat *st) {
+    if (fh < 3) {
         st->st_mode = S_IFCHR;
         return  0;
     }
-    errno = EBADF;
-    return -1;
+
+    FileHandle* fhc = filehandles[fh-3];
+    if (fhc == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+
+    st->st_mode = fhc->isatty() ? S_IFCHR : S_IFREG;
+    st->st_size = fhc->size();
+    return 0;
 }
 #endif
 


### PR DESCRIPTION
GCC's newlib library depends on fstat to get in-flight information about a file's type an size. A working fstat for regular files is needed for seek and related functions to work correctly.

Side note about testing this and https://github.com/ARMmbed/mbed-os/pull/5183, I have tests inbound, which is what's finding these bugs. They're currently targeting littlefs [here](https://github.com/ARMmbed/mbed-littlefs/tree/littlefs-test-conversion), but I will also bring them over the FAT filesystem once they're up and running.