### PR TITLE
Fix: DigitalIn of nRF5x was allocating GPIOTE channel

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
@@ -151,7 +151,7 @@ static void gpio_apply_config(uint8_t pin)
                         cfg.pull = NRF_GPIO_PIN_NOPULL;
                     break;
                 }
-                nrf_drv_gpiote_in_init(pin, &cfg, NULL);
+                nrf_gpio_cfg_input(pin,cfg.pull);
             }
         }
         else {


### PR DESCRIPTION
The allocation of GPIOTE channels for DigitalIn is unwanted behavior.
This caused early run-out of GPIOTE channels for InterruptPin.
This patch replacing input configuration that is using gpiote driver by configuration that is
using gpio hal.

Fix for InterruptPin part of ct-test-shield test issue https://github.com/ARMmbed/mbed-os/issues/5133