### PR TITLE
STM32F7 : RTC Wake Up Timer issue

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_rtc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_rtc_ex.c
@@ -1063,33 +1063,54 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
   
   /* Disable the write protection for RTC registers */
   __HAL_RTC_WRITEPROTECTION_DISABLE(hrtc);
-  
-  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
 
-  /* Get tick */
-  tickstart = HAL_GetTick();
-
-    /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
+  /*Check RTC WUTWF flag is reset only when wake up timer enabled*/
   if((hrtc->Instance->CR & RTC_CR_WUTE) != RESET)
   {
-    /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
-    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+    tickstart = HAL_GetTick();
+
+    /* Wait till RTC WUTWF flag is reset and if Time out is reached exit */
+    while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == SET)
     {
       if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
       {
         /* Enable the write protection for RTC registers */
         __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
        
-        hrtc->State = HAL_RTC_STATE_TIMEOUT; 
-      
-        /* Process Unlocked */ 
+        hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+        /* Process Unlocked */
         __HAL_UNLOCK(hrtc);
-      
+
         return HAL_TIMEOUT;
       }  
     }
   }
-  
+  /* Disable the Wake-Up timer */
+  __HAL_RTC_WAKEUPTIMER_DISABLE(hrtc);
+
+  /* Clear flag Wake-Up */
+  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
+
+  tickstart = HAL_GetTick();
+
+  /* Wait till RTC WUTWF flag is set and if Time out is reached exit */
+  while(__HAL_RTC_WAKEUPTIMER_GET_FLAG(hrtc, RTC_FLAG_WUTWF) == RESET)
+  {
+    if((HAL_GetTick() - tickstart ) > RTC_TIMEOUT_VALUE)
+    {
+      /* Enable the write protection for RTC registers */
+      __HAL_RTC_WRITEPROTECTION_ENABLE(hrtc);
+
+      hrtc->State = HAL_RTC_STATE_TIMEOUT;
+
+      /* Process Unlocked */
+      __HAL_UNLOCK(hrtc);
+
+      return HAL_TIMEOUT;
+    }
+  }
+
   /* Configure the Wakeup Timer counter */
   hrtc->Instance->WUTR = (uint32_t)WakeUpCounter;
 
@@ -1098,15 +1119,12 @@ HAL_StatusTypeDef HAL_RTCEx_SetWakeUpTimer_IT(RTC_HandleTypeDef *hrtc, uint32_t 
 
   /* Configure the clock source */
   hrtc->Instance->CR |= (uint32_t)WakeUpClock;
-  
+
   /* RTC WakeUpTimer Interrupt Configuration: EXTI configuration */
   __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_IT();
-  
-  EXTI->RTSR |= RTC_EXTI_LINE_WAKEUPTIMER_EVENT;
-  
-  /* Clear RTC Wake Up timer Flag */
-  __HAL_RTC_WAKEUPTIMER_CLEAR_FLAG(hrtc, RTC_FLAG_WUTF);
-  
+
+  __HAL_RTC_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
+
   /* Configure the Interrupt in the RTC_CR register */
   __HAL_RTC_WAKEUPTIMER_ENABLE_IT(hrtc,RTC_IT_WUT);
   


### PR DESCRIPTION
## Description
This corrects #5136 
Function from L4 family makes F7 works.

## Status
READY

## Tests results

| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.07               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.04               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.06               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.05               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-ARM      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.08               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.06               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-GCC_ARM  | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.07               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.09               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.07               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| DISCO_F746NG-IAR      | DISCO_F746NG  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.07               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.03               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.09               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.07               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| DISCO_F769NI-ARM      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.09               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.06               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.04               |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.04               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.06               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.07               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.04               |
| DISCO_F769NI-IAR      | DISCO_F769NI  | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| NUCLEO_F746ZG-ARM     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.07               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.08               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| NUCLEO_F746ZG-GCC_ARM | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.07               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.08               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.06               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.07               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.09               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.06               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| NUCLEO_F746ZG-IAR     | NUCLEO_F746ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.08               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| NUCLEO_F756ZG-ARM     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.06               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.07               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.11               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-GCC_ARM | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.1                |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.06               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.07               |
| NUCLEO_F756ZG-IAR     | NUCLEO_F756ZG | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.07               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.06               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.09               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.06               |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.04               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.1                |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1ms LowPowerTimeout                 | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout                | 1      | 0      | OK     | 1.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from deepsleep | 1      | 0      | OK     | 1.08               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 1sec LowPowerTimeout from sleep     | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 500us LowPowerTimeout               | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | 5sec LowPowerTimeout                | 1      | 0      | OK     | 5.05               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1ms lp_ticker                       | 1      | 0      | OK     | 0.03               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker                        | 1      | 0      | OK     | 1.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker deepsleep              | 1      | 0      | OK     | 1.06               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 1s lp_ticker sleep                  | 1      | 0      | OK     | 1.05               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 500us lp_ticker                     | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | 5s lp_ticker                        | 1      | 0      | OK     | 5.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Init                | 1      | 0      | OK     | 0.04               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read                | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | lp ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Init                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read                | 1      | 0      | OK     | 0.05               |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | us ticker HAL - Read in the loop    | 1      | 0      | OK     | 0.08               |


