### PR TITLE
STM32: add ADC calibration for L4, F1, F3 devices

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/analogin_api.c
@@ -33,6 +33,7 @@
 #include "mbed_wait_api.h"
 #include "cmsis.h"
 #include "pinmap.h"
+#include "mbed_error.h"
 #include "PeripheralPins.h"
 
 int adc_inited = 0;
@@ -93,7 +94,13 @@ void analogin_init(analogin_t *obj, PinName pin)
         obj->handle.Init.DiscontinuousConvMode = DISABLE;
         obj->handle.Init.NbrOfDiscConversion   = 0;
         obj->handle.Init.ExternalTrigConv      = ADC_SOFTWARE_START;
-        HAL_ADC_Init(&obj->handle);
+
+        if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
+            error("Cannot initialize ADC\n");
+        }
+
+        // Calibrate ADC
+        HAL_ADCEx_Calibration_Start(&obj->handle);
     }
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_api.c
@@ -130,6 +130,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
         error("Cannot initialize ADC");
     }
+
+    // Calibrate ADC
+    HAL_ADCEx_Calibration_Start(&obj->handle, ADC_SINGLE_ENDED);
 }
 
 static inline uint16_t adc_read(analogin_t *obj)

--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_api.c
@@ -96,6 +96,9 @@ void analogin_init(analogin_t *obj, PinName pin)
         if (HAL_ADC_Init(&obj->handle) != HAL_OK) {
             error("Cannot initialize ADC\n");
         }
+
+        // Calibrate ADC
+        HAL_ADCEx_Calibration_Start(&obj->handle, ADC_SINGLE_ENDED);
     }
 }
 


### PR DESCRIPTION
## Description
Add ADC calibration in the initialization phase.

Tested with a basic analogin read example. Without the calibration the read value is not precise enough.

## Status
**READY**

## Migrations
NO
