### PR TITLE
Avoid wait_ms() spin

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -19,7 +19,12 @@
 #include <errno.h>
 #include "UARTSerial.h"
 #include "platform/mbed_poll.h"
+
+#if MBED_CONF_RTOS_PRESENT
+#include "rtos/Thread.h"
+#else
 #include "platform/mbed_wait_api.h"
+#endif
 
 namespace mbed {
 
@@ -277,6 +282,17 @@ void UARTSerial::tx_irq(void)
     }
 }
 
+void UARTSerial::wait_ms(uint32_t millisec)
+{
+    /* wait_ms implementation for RTOS spins until exact microseconds - we
+     * want to just sleep until next tick.
+     */
+#if MBED_CONF_RTOS_PRESENT
+    rtos::Thread::wait(millisec);
+#else
+    ::wait_ms(millisec);
+#endif
+}
 } //namespace mbed
 
 #endif //(DEVICE_SERIAL && DEVICE_INTERRUPTIN)

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -160,6 +160,8 @@ public:
 
 private:
 
+    void wait_ms(uint32_t millisec);
+
     /** SerialBase lock override */
     virtual void lock(void);
 

--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -66,7 +66,7 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout)
 #ifdef MBED_CONF_RTOS_PRESENT
         // TODO - proper blocking
         // wait for condition variable, wait queue whatever here
-        rtos::Thread::yield();
+        rtos::Thread::wait(1);
 #endif
     }
     return count;


### PR DESCRIPTION
System's wait_ms() spins to achieve a precise delay - we don't want this.
Call Thread::wait directly.

This PR is partly for testing, and to initiate discussion. I would personally like to see wait_ms() changed, or an alternative call in mbed_wait_api() brought in to avoid the unwanted CPU-sapping spin.
