### PR TITLE
Ticker: add dtor implementation

### DIFF
--- a/drivers/Ticker.cpp
+++ b/drivers/Ticker.cpp
@@ -22,6 +22,10 @@
 
 namespace mbed {
 
+void Ticker::~Ticker() {
+    detach();
+}
+
 void Ticker::detach() {
     core_util_critical_section_enter();
     remove();

--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -76,6 +76,7 @@ public:
 #endif
     }
 
+    ~Ticker();
     /** Attach a function to be called by the Ticker, specifying the interval in seconds
      *
      *  @param func pointer to the function to be called


### PR DESCRIPTION
This depends on https://github.com/ARMmbed/mbed-os/pull/5148.
I'll rebase once that PR is integrated (CI now fails !), and will tag for review/tests

This addresses the issue reported here (https://github.com/ARMmbed/mbed-os/issues/5067). If Ticker locked deepsleep, it should unlock it (clean its resources in this case) in dtor.

Should it also invoke ``remove()`` in dtor?