### PR TITLE
Fix analogin scaling for EFM32 target

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/analogin_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/analogin_api.c
@@ -99,8 +99,8 @@ uint16_t analogin_read_u16(analogin_t *obj)
 
 float analogin_read(analogin_t *obj)
 {
-    /* Convert from a uint16 to a float between 0 and 1 by division by 0xFFFF */
-    return analogin_read_u16(obj) / (float) 0xFFFF;
+    /* Convert from a uint16 to a float between 0 and 1 by division by 0xFFF0 */
+    return analogin_read_u16(obj) / (float) 0xFFF0;
 }
 
 #endif


### PR DESCRIPTION
Fixes #5115.

`analogin_read_u16` returns a value in the range `0x0000 - 0xFFF0`
since the resolution of the ADC is 12 bits. However, in
`analogin_read` this value gets divided by `0xFFFF` assuming the range
is `0x0000-0xFFFF`. This causes a small error in the value returned by
`AnalogIn::read` for the EFM32 target.