### PR TITLE
Fix documentation of BLE GattCharacteristic

### DIFF
--- a/features/FEATURE_BLE/ble/GattService.h
+++ b/features/FEATURE_BLE/ble/GattService.h
@@ -46,8 +46,7 @@ public:
 
 public:
     /**
-     *  @brief  Creates a new GattService using the specified 16-bit
-     *          UUID, value length, and properties.
+     *  @brief  Creates a new GattService using the specified UUID and characteristics.
      *
      *  @note   The UUID value must be unique and is normally >1.
      *


### PR DESCRIPTION
The constructor doc incorrectly suggested that only short (16-bit)
UUIDs were accepted. The same doc also referred to properties
instead of characteristics. (And to "value length", which seemed to
be completely out of place in the context of the current code.)

## Status
**READY**

## Migrations
NO
