### PR TITLE
Add API to set ticker IRQ handler.

### DIFF
--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -34,6 +34,19 @@ extern "C" {
  * @{
  */
 
+typedef void (*ticker_irq_handler_type)(const ticker_data_t *const);
+
+/** Set low power ticker IRQ handler
+ *
+ * @param ticker_irq_handler IRQ handler to be connected
+ *
+ * @return previous ticker IRQ handler
+ *
+ * @note by default IRQ handler is set to ticker_irq_handler()
+ *
+ */
+ticker_irq_handler_type set_lp_ticker_irq_handler(ticker_irq_handler_type ticker_irq_handler);
+
 /** Get low power ticker's data
  *
  * @return The low power ticker data

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -19,6 +19,8 @@
 
 static ticker_event_queue_t events = { 0 };
 
+static ticker_irq_handler_type irq_handler = ticker_irq_handler;
+
 static const ticker_interface_t lp_interface = {
     .init = lp_ticker_init,
     .read = lp_ticker_read,
@@ -38,9 +40,20 @@ const ticker_data_t* get_lp_ticker_data(void)
     return &lp_data;
 }
 
+ticker_irq_handler_type set_lp_ticker_irq_handler(ticker_irq_handler_type ticker_irq_handler)
+{
+    ticker_irq_handler_type prev_irq_handler = irq_handler;
+
+    irq_handler = ticker_irq_handler;
+
+    return prev_irq_handler;
+}
+
 void lp_ticker_irq_handler(void)
 {
-    ticker_irq_handler(&lp_data);
+    if (irq_handler) {
+        irq_handler(&lp_data);
+    }
 }
 
 #endif

--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -17,6 +17,8 @@
 
 static ticker_event_queue_t events = { 0 };
 
+static ticker_irq_handler_type irq_handler = ticker_irq_handler;
+
 static const ticker_interface_t us_interface = {
     .init = us_ticker_init,
     .read = us_ticker_read,
@@ -36,7 +38,18 @@ const ticker_data_t* get_us_ticker_data(void)
     return &us_data;
 }
 
+ticker_irq_handler_type set_us_ticker_irq_handler(ticker_irq_handler_type ticker_irq_handler)
+{
+    ticker_irq_handler_type prev_irq_handler = irq_handler;
+
+    irq_handler = ticker_irq_handler;
+
+    return prev_irq_handler;
+}
+
 void us_ticker_irq_handler(void)
 {
-    ticker_irq_handler(&us_data);
+    if (irq_handler) {
+        irq_handler(&us_data);
+    }
 }

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -31,6 +31,19 @@ extern "C" {
  * @{
  */
 
+typedef void (*ticker_irq_handler_type)(const ticker_data_t *const);
+
+/** Set ticker IRQ handler
+ *
+ * @param ticker_irq_handler IRQ handler to be connected
+ *
+ * @return previous ticker IRQ handler
+ *
+ * @note by default IRQ handler is set to ticker_irq_handler()
+ *
+ */
+ticker_irq_handler_type set_us_ticker_irq_handler(ticker_irq_handler_type ticker_irq_handler);
+
 /** Get ticker's data
  *
  * @return The low power ticker data


### PR DESCRIPTION
## Description
Add API to set IRQ handler for high frequency ticker and low power ticker.
This is done to be able to test HAL ticker API without using mbed upper layers to connect IRQ handler.

## Status
READY


## Migrations
YES
Add API to set IRQ handler for high frequency ticker and low power ticker.
Original IRQ handler is set as default ticker IRQ handler.

## Related PRs
------ | ------
ARMmbed:feature-hal-spec-ticker | https://github.com/ARMmbed/mbed-os/pull/5233
