### PR TITLE
Change ARM compiler options to use -O2 instead of -O3

### DIFF
--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -27,7 +27,7 @@
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O3"],
+                   "--multibyte_chars", "-O2"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -36,7 +36,7 @@
     "uARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O3", "-D__MICROLIB",
+                   "--multibyte_chars", "-O2", "-D__MICROLIB",
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -27,7 +27,7 @@
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O3", "-DNDEBUG"],
+                   "--multibyte_chars", "-O2", "-DNDEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         "cxx": ["--cpp", "--no_rtti", "--no_vla"],
@@ -36,7 +36,7 @@
     "uARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
-                   "--multibyte_chars", "-O3", "-D__MICROLIB",
+                   "--multibyte_chars", "-O2", "-D__MICROLIB",
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD", "-DNDEBUG"],
         "asm": [],
         "c": ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],


### PR DESCRIPTION
## Description

Decrease optimisation level from 3 to 2. Reason being that we are
seeing multiple compiler issues with level 3 and this is the workaround
to get around those. We assume the impact on any performance/size will
be non-visible to anyone.

This is a workaround for IOTCLT-2038 / SingletonPtr corrupts.

## Status
**READY**


## Migrations
If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO


## Related PRs

IOTCLT-2038
