### PR TITLE
Add profile argument to mbed-os example build tools

### DIFF
--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -55,7 +55,7 @@ def main():
                                     official_target_names, "MCU")),
                             default=official_target_names)
 
-    compile_cmd.add_argument("-p", "--profile",
+    compile_cmd.add_argument("--profile",
                              help=("build profile file"),
                              metavar="profile")
 

--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -54,6 +54,11 @@ def main():
                                 argparse_force_uppercase_type(
                                     official_target_names, "MCU")),
                             default=official_target_names)
+
+    compile_cmd.add_argument("-p", "--profile",
+                             help=("build profile file"),
+                             metavar="profile")
+
     export_cmd = subparsers.add_parser("export")
     export_cmd.set_defaults(fn=do_export),
     export_cmd.add_argument(
@@ -111,7 +116,7 @@ def do_deploy(_, config, examples):
 def do_compile(args, config, examples):
     """Do the compile step"""
     results = {}
-    results = lib.compile_repos(config, args.toolchains, args.mcu, examples)
+    results = lib.compile_repos(config, args.toolchains, args.mcu, args.profile, examples)
     
     lib.print_summary(results)
     failures = lib.get_num_failures(results)

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -311,7 +311,7 @@ def export_repos(config, ides, targets, examples):
     return results
 
 
-def compile_repos(config, toolchains, targets, examples):
+def compile_repos(config, toolchains, targets, profile, examples):
     """Compiles combinations of example programs, targets and compile chains.
 
        The results are returned in a [key: value] dictionary format:
@@ -355,8 +355,14 @@ def compile_repos(config, toolchains, targets, examples):
                                                                 valid_choices(example['toolchains'], toolchains),
                                                                 example['features']):
                     print("Compiling %s for %s, %s" % (name, target, toolchain))
-                    proc = subprocess.Popen(["mbed-cli", "compile", "-t", toolchain,
-                                             "-m", target, "-v"])
+                    build_command = ["mbed-cli", "compile", "-t", toolchain, "-m", target, "-v"]
+
+                    if profile:
+                        build_command.append("--profile")
+                        build_command.append(profile)
+
+                    proc = subprocess.Popen(build_command)
+
                     proc.wait()
                     example_summary = "{} {} {}".format(name, target, toolchain)
                     if proc.returncode:


### PR DESCRIPTION
Allows custom build profiles to be passed to the example build script. 