### PR TITLE
  lwIP: Add memory configs to JSON

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -137,9 +137,24 @@
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
 // Number of pool pbufs.
-// Each requires 684 bytes of RAM.
+// Each requires 684 bytes of RAM (if MSS=536 and PBUF_POOL_BUFSIZE defaulting to be based on MSS)
+#ifdef MBED_CONF_LWIP_PBUF_POOL_SIZE
+#undef PBUF_POOL_SIZE
+#define PBUF_POOL_SIZE              MBED_CONF_LWIP_PBUF_POOL_SIZE
+#else
 #ifndef PBUF_POOL_SIZE
 #define PBUF_POOL_SIZE              5
+#endif
+#endif
+
+#ifdef MBED_CONF_LWIP_PBUF_POOL_BUFSIZE
+#undef PBUF_POOL_BUFSIZE
+#define PBUF_POOL_BUFSIZE           MBED_CONF_LWIP_PBUF_POOL_BUFSIZE
+#endif
+
+#ifdef MBED_CONF_LWIP_MEM_SIZE
+#undef MEM_SIZE
+#define MEM_SIZE                    MBED_CONF_LWIP_MEM_SIZE
 #endif
 
 // One tcp_pcb_listen is needed for each TCPServer.

--- a/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
+++ b/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
@@ -72,6 +72,18 @@
             "help": "Maximum number of open UDPSocket instances allowed, including one used internally for DNS.  Each requires 84 bytes of pre-allocated RAM",
             "value": 4
         },
+        "pbuf-pool-size": {
+            "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
+        "pbuf-pool-bufsize": {
+            "help": "Size of pbufs in pool. If set to null, lwIP will base the size on the TCP MSS, which is 536 unless overridden by the target",
+            "value": null
+        },
+        "mem-size": {
+            "help": "Size of heap (bytes) - used for outgoing packets, and also used by some drivers for reception. Current default (used if null here) is set to 1600 in opt.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
         "tcpip-thread-stacksize": {
             "help": "Stack size for lwip TCPIP thread",
             "value": 1200


### PR DESCRIPTION
We currently set the lwIP pbuf pool size small - to 5 x 576-byte
buffers.

This is insufficient to hold a single DTLS handshake flight, so can
cause cloud client connections to fail. STM-based platforms are failing
handshake because of this. (K64F works because it doesn't use the pbuf
pool for reception, but lwIP does recommend drivers use the pbuf pool).

Not changing the default memory sizes here, as intended for a patch
release, but adding mbed configuration options to allow the numbers to
be adjusted for memory tuning in an application.

In a future minor revision, I would recommend increasing the default
PBUF_POOL_SIZE - we are well below lwIP's out-of-the-box default - and
offsetting by a reduction in MEM_SIZE for the drivers that don't use
PBUF_RAM.