### PR TITLE
Enable MPL by default for 6LoWPAN-ND.

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/nd_tasklet.c
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/nd_tasklet.c
@@ -23,6 +23,7 @@
 #include "include/nd_tasklet.h"
 #include "include/mesh_system.h"
 #include "ns_event_loop.h"
+#include "multicast_api.h"
 
 // For tracing we need to define flag, have include and define group
 #define HAVE_DEBUG 1
@@ -264,6 +265,13 @@ void nd_tasklet_configure_and_connect_to_network(void)
     arm_nwk_6lowpan_link_panid_filter_for_nwk_scan(
          tasklet_data_ptr->network_interface_id,
          MBED_CONF_MBED_MESH_API_6LOWPAN_ND_PANID_FILTER);
+
+    // Enable MPL by default
+    const uint8_t all_mpl_forwarders[16] = {0xff, 0x03, [15]=0xfc};
+    multicast_mpl_domain_subscribe(tasklet_data_ptr->network_interface_id,
+                                      all_mpl_forwarders,
+                                      MULTICAST_MPL_SEED_ID_DEFAULT,
+                                      NULL);
 
     status = arm_nwk_interface_up(tasklet_data_ptr->network_interface_id);
     if (status >= 0) {


### PR DESCRIPTION
In Thread network, MPL is already enabled so this causes
both to behave similarly.

This is part of fixes for https://github.com/ARMmbed/mbed-os-example-mesh-minimal/issues/130

## Status
**In test**

## Migrations

NO


## Related PRs
List related PRs against other branches:

https://github.com/ARMmbed/mbed-os-example-mesh-minimal/pull/137


## Todos
- [x] Tests

