### PR TITLE
Add missing device_name for targets with bootloader

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2763,6 +2763,7 @@
         "macros": ["EFM32PG12B500F1024GL125", "TRANSACTION_QUEUE_SIZE_SPI=4"],
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM", "IAR"],
         "release_versions": ["2", "5"],
+        "device_name": "EFM32PG12B500F1024GL125",
         "public": false,
         "bootloader_supported": true
     },
@@ -2815,6 +2816,7 @@
         "macros": ["EFR32MG12P332F1024GL125", "TRANSACTION_QUEUE_SIZE_SPI=4"],
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM", "IAR"],
         "release_versions": ["2", "5"],
+        "device_name": "EFR32MG12P332F1024GL125",
         "public": false,
         "bootloader_supported": true
     },


### PR DESCRIPTION
Some EFM32 targets with bootloader support are missing the required `device_name`. This PR fixes it using an analogy to other targets.

Notes:
* I have accepted the [contributor agreement](https://os.mbed.com/contributor_agreement/).

## Status
**READY**

## Migrations
NO