### PR TITLE
STM32: Fix analogout structure/variable wrong initialization

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/analogout_device.c
@@ -36,7 +36,7 @@
 #include "PeripheralPins.h"
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -71,6 +71,8 @@ void analogout_init(dac_t *obj, PinName pin) {
 
     // Configure DAC
     obj->handle.Instance = (DAC_TypeDef *)(obj->dac);
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32F3/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogout_device.c
@@ -40,7 +40,7 @@ static int pa4_used = 0;
 static int pa5_used = 0;
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -83,6 +83,8 @@ void analogout_init(dac_t *obj, PinName pin) {
 
     // Configure DAC
     obj->handle.Instance = (DAC_TypeDef *)(obj->dac);
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32F4/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/analogout_device.c
@@ -36,7 +36,7 @@
 #include "PeripheralPins.h"
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name (DAC_1, ...) from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -71,6 +71,8 @@ void analogout_init(dac_t *obj, PinName pin) {
     __HAL_RCC_DAC_CLK_ENABLE();
 
     obj->handle.Instance = DAC;
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32F7/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/analogout_device.c
@@ -36,7 +36,7 @@
 #include "PeripheralPins.h"
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name (DAC_1, ...) from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -71,6 +71,8 @@ void analogout_init(dac_t *obj, PinName pin) {
     __DAC_CLK_ENABLE();
 
     obj->handle.Instance = DAC;
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32L0/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/analogout_device.c
@@ -40,7 +40,7 @@ static int channel1_used = 0;
 static int channel2_used = 0;
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -74,6 +74,8 @@ void analogout_init(dac_t *obj, PinName pin) {
 
     // Configure DAC
     obj->handle.Instance = DAC;
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32L1/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogout_device.c
@@ -40,7 +40,7 @@ static int pa4_used = 0;
 static int pa5_used = 0;
 
 void analogout_init(dac_t *obj, PinName pin) {
-    DAC_ChannelConfTypeDef sConfig;
+    DAC_ChannelConfTypeDef sConfig = {0};
 
     // Get the peripheral name (DAC_1, ...) from the pin and assign it to the object
     obj->dac = (DACName)pinmap_peripheral(pin, PinMap_DAC);
@@ -68,6 +68,8 @@ void analogout_init(dac_t *obj, PinName pin) {
     obj->pin = pin;
 
     obj->handle.Instance = DAC;
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }

--- a/targets/TARGET_STM/TARGET_STM32L4/analogout_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogout_device.c
@@ -75,6 +75,8 @@ void analogout_init(dac_t *obj, PinName pin) {
 
     // Configure DAC
     obj->handle.Instance = DAC;
+    obj->handle.State = HAL_DAC_STATE_RESET;
+
     if (HAL_DAC_Init(&obj->handle) != HAL_OK ) {
         error("HAL_DAC_Init failed");
     }


### PR DESCRIPTION
## Description
This is an extension of PR #5188 to all other STM32 platforms:
- initializes the sConfig structure to zero
- initializes the object handle State variable to its Reset value

Prevent a potential issue with tests-api-analogout with GCC_ARM 

## Status
**READY**

## Migrations
NO

## Related PRs
#5188
