### PR TITLE
Error if OS tickrate is changed

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -41,6 +41,10 @@
 
 #define OS_DYNAMIC_MEM_SIZE         0
 
+#if defined(OS_TICK_FREQ) && (OS_TICK_FREQ != 1000)
+#error "OS Tickrate must be 1000 for system timing"
+#endif
+
 #if defined (__CC_ARM) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
 /* ARM toolchain uses up to 8 static mutexes, any further mutexes will be allocated on the heap. */
 #define OS_MUTEX_OBJ_MEM            1


### PR DESCRIPTION
The current mbed-os drivers rely on a tickrate of 1ms for timing. This means that if OS_TICK_FREQ is set to any value other than 1000 then mbed-os driver will no longer delay for the correct amount of time. To prevent this from happening this patch triggers a compile time error if a tickrate other than 1m is used.
