### PR TITLE
STM32: Initialize RTC structures at init phase.

### DIFF
--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -57,8 +57,8 @@ static void RTC_IRQHandler(void);
 
 void rtc_init(void)
 {
-    RCC_OscInitTypeDef RCC_OscInitStruct;
-    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct;
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+    RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
     // Enable access to Backup domain
     HAL_PWR_EnableBkUpAccess();
@@ -162,7 +162,7 @@ void rtc_free(void)
 #endif
 
     // Disable LSI and LSE clocks
-    RCC_OscInitTypeDef RCC_OscInitStruct;
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
     RCC_OscInitStruct.LSIState       = RCC_LSI_OFF;
@@ -217,8 +217,8 @@ It is then not a problem to not use shifts.
 
 time_t rtc_read(void)
 {
-    RTC_DateTypeDef dateStruct;
-    RTC_TimeTypeDef timeStruct;
+    RTC_DateTypeDef dateStruct = {0};
+    RTC_TimeTypeDef timeStruct = {0};
     struct tm timeinfo;
 
     RtcHandle.Instance = RTC;
@@ -247,8 +247,8 @@ time_t rtc_read(void)
 
 void rtc_write(time_t t)
 {
-    RTC_DateTypeDef dateStruct;
-    RTC_TimeTypeDef timeStruct;
+    RTC_DateTypeDef dateStruct = {0};
+    RTC_TimeTypeDef timeStruct = {0};
 
     RtcHandle.Instance = RTC;
 

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -64,6 +64,7 @@ void rtc_init(void)
     HAL_PWR_EnableBkUpAccess();
 
     RtcHandle.Instance = RTC;
+    RtcHandle.State = HAL_RTC_STATE_RESET;
 
 #if !RTC_LSI
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;


### PR DESCRIPTION
## Description
- Initialize the structures at init phase to zero.
- Initialize the handle State variable to RESET state.

Solve ST internal RTC test on NUCLEO_F030R8 with GCC_ARM.

## Status
**READY**

## Migrations
NO

## Related PRs
Structures initialization also done in PR #5188 and #5263

ST_INTERNAL_REF 36019
