### PR TITLE
Develop.json - optimize on size rather than performance

### DIFF
--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -25,7 +25,7 @@
         "ld": ["--legacyalign", "--no_strict_wchar_size", "--no_strict_enum_size"]
     },
     "ARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O3"],
         "asm": [],
@@ -34,7 +34,7 @@
         "ld": ["--show_full_path"]
     },
     "uARM": {
-        "common": ["-c", "--gnu", "-Otime", "--split_sections",
+        "common": ["-c", "--gnu", "-Ospace", "--split_sections",
                    "--apcs=interwork", "--brief_diagnostics", "--restrict",
                    "--multibyte_chars", "-O3", "-D__MICROLIB",
                    "--library_type=microlib", "-DMBED_RTOS_SINGLE_THREAD"],
@@ -46,7 +46,7 @@
     "IAR": {
         "common": [
             "--no_wrap_diagnostics", "-e",
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Oh"],
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz"],
         "asm": [],
         "c": ["--vla"],
         "cxx": ["--guard_calls", "--no_static_destruction"],


### PR DESCRIPTION
## Description

The profiles must now have different optimization targets,
if customer assumes the tests done with develop are the same
as with release profile (sans the debugs) - they would be assuming
wrongly. The code can behave unfortunately very differently if one
is optimizing for size and one for performance.

If customer wants to optimize for performance, they should change
it to both profiles so that any tests done with develop and release
match as closely as possible.

This change impacts both IAR and ARM CC.
- ARM and uARM were optimizing on time in release profile.
- IAR was optimizing on "High, balaned" in develop profile.

GCC is defined to behave logically between these profiles (-Os).

## Status
**READY**


## Migrations
NO

