### PR TITLE
Update devices to have minimum 2K RAM and heap, also added test

### DIFF
--- a/TESTS/mbed_hal/minimum_requirements/main.cpp
+++ b/TESTS/mbed_hal/minimum_requirements/main.cpp
@@ -1,0 +1,71 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+
+#include "mbed.h"
+
+using namespace utest::v1;
+
+/**
+ * This test is intended to gate devices that do not have enough RAM to run
+ * Mbed os. Devices passing this test should have enough RAM to run all
+ * other Mbed OS tests.
+ *
+ * If your device does not pass this test, then you should determine the
+ * cause of high memory usage and fix it. If you cannot free enough memory,
+ * then you should turn off Mbed OS support for this device.
+ */
+
+#define MIN_HEAP_SIZE   2048
+#define MIN_DATA_SIZE   2048
+
+volatile uint8_t test_buffer[MIN_DATA_SIZE];
+
+static void minimum_heap_test()
+{
+    void *mem = malloc(MIN_HEAP_SIZE);
+    TEST_ASSERT_NOT_EQUAL(NULL, mem);
+    free(mem);
+}
+
+static void minimum_data_test()
+{
+    // Use test buffer so it is not optimized away
+    for (int i = 0; i < MIN_DATA_SIZE; i++) {
+        test_buffer[i] = i & 0xFF;
+    }
+}
+
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases) 
+{
+    GREENTEA_SETUP(30, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Minimum heap test", minimum_heap_test),
+    Case("Minimum data test", minimum_data_test),
+};
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main() {
+    Harness::run(specification);
+}

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/device/TOOLCHAIN_IAR/MKL25Z4.icf
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/device/TOOLCHAIN_IAR/MKL25Z4.icf
@@ -11,9 +11,8 @@ define symbol __ICFEDIT_region_NVIC_end__   = 0x1ffff0bf;
 define symbol __ICFEDIT_region_RAM_start__ = 0x1ffff0c0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x1fffffff;
 /*-Sizes-*/
-/*Heap 1/4 of ram and stack 1/8*/
-define symbol __ICFEDIT_size_cstack__ = 0x800;
-define symbol __ICFEDIT_size_heap__   = 0x1000;
+define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_heap__   = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __region_RAM2_start__ 		= 0x20000000;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -9,8 +9,8 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x00020000 - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x600;
-define symbol __ICFEDIT_size_heap__   = 0xE00;
+define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_heap__   = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -45,6 +45,13 @@
     #error "no toolchain defined"
 #endif
 
+#if defined(TARGET_NANO100)
+#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#endif
+#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
+#endif
+
 #endif  // TARGET_NUVOTON
 
 #endif  // MBED_MBED_RTX_H

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F070XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F070XB.ld
@@ -1,4 +1,5 @@
 /* Linker script to configure memory regions. */
+StackSize = 0x400;
 MEMORY
 { 
   FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 128k
@@ -113,6 +114,20 @@ SECTIONS
 
     } > RAM
 
+    /* .stack section doesn't contains any symbols. It is only
+     * used for linker to reserve space for the main stack section
+     */
+    .stack (NOLOAD):
+    {
+        __StackLimit = .;
+        *(.stack*);
+        . += StackSize - (. - __StackLimit);
+    } > RAM
+    __StackTop = ADDR(.stack) + SIZEOF(.stack);
+    _estack = __StackTop;
+    __StackLimit = ADDR(.stack);
+    PROVIDE(__stack = __StackTop);
+
     .bss :
     {
         . = ALIGN(4);
@@ -129,25 +144,13 @@ SECTIONS
     {
         __end__ = .;
         end = __end__;
-        *(.heap*)
+        *(.heap*);
+        . += (ORIGIN(RAM) + LENGTH(RAM) - .);
         __HeapLimit = .;
     } > RAM
 
-    /* .stack_dummy section doesn't contains any symbols. It is only
-     * used for linker to calculate size of stack sections, and assign
-     * values to stack symbols later */
-    .stack_dummy (COPY):
-    {
-        *(.stack*)
-    } > RAM
+    PROVIDE(__heap_size = SIZEOF(.heap));
+    PROVIDE(__mbed_sbrk_start = ADDR(.heap));
+    PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
 
-    /* Set stack top to end of RAM, and stack limit move down by
-     * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
-    _estack = __StackTop;
-    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
-    PROVIDE(__stack = __StackTop);
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F0xxx_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F0xxx_retarget.c
@@ -1,0 +1,54 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <errno.h>
+#include "stm32f0xx.h"
+extern uint32_t __mbed_sbrk_start;
+extern uint32_t __mbed_krbs_start;
+
+/* Support heap with two-region model
+ *
+ * The default implementation of _sbrk() (in mbed_retarget.cpp) for GCC_ARM requires one-region
+ * model (heap and stack share one region), which doesn't fit two-region model (heap and stack
+ * are two distinct regions)
+ * Hence, override _sbrk() here to support heap with two-region model.
+ */
+void *_sbrk(int incr)
+{
+    static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
+    uint32_t heap_ind_old = heap_ind;
+    uint32_t heap_ind_new = heap_ind_old + incr;
+
+    if (heap_ind_new > (uint32_t) &__mbed_krbs_start) {
+        errno = ENOMEM;
+        return (void *) -1;
+    }
+
+    heap_ind = heap_ind_new;
+
+    return (void *) heap_ind_old;
+}

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_IAR/stm32f070xb.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x200000C0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x400;
-define symbol __ICFEDIT_size_heap__   = 0x1000;
+define symbol __ICFEDIT_size_heap__   = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 define memory mem with size = 4G;

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F072XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F072XB.ld
@@ -1,4 +1,5 @@
 /* Linker script to configure memory regions. */
+StackSize = 0x400;
 MEMORY
 { 
   FLASH (rx)      : ORIGIN = 0x08000000, LENGTH = 128k
@@ -113,6 +114,20 @@ SECTIONS
 
     } > RAM
 
+    /* .stack section doesn't contains any symbols. It is only
+     * used for linker to reserve space for the main stack section
+     */
+    .stack (NOLOAD):
+    {
+        __StackLimit = .;
+        *(.stack*);
+        . += StackSize - (. - __StackLimit);
+    } > RAM
+    __StackTop = ADDR(.stack) + SIZEOF(.stack);
+    _estack = __StackTop;
+    __StackLimit = ADDR(.stack);
+    PROVIDE(__stack = __StackTop);
+
     .bss :
     {
         . = ALIGN(4);
@@ -129,25 +144,13 @@ SECTIONS
     {
         __end__ = .;
         end = __end__;
-        *(.heap*)
+        *(.heap*);
+        . += (ORIGIN(RAM) + LENGTH(RAM) - .);
         __HeapLimit = .;
     } > RAM
 
-    /* .stack_dummy section doesn't contains any symbols. It is only
-     * used for linker to calculate size of stack sections, and assign
-     * values to stack symbols later */
-    .stack_dummy (COPY):
-    {
-        *(.stack*)
-    } > RAM
+    PROVIDE(__heap_size = SIZEOF(.heap));
+    PROVIDE(__mbed_sbrk_start = ADDR(.heap));
+    PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
 
-    /* Set stack top to end of RAM, and stack limit move down by
-     * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
-    _estack = __StackTop;
-    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
-    PROVIDE(__stack = __StackTop);
-
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F0xxx_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F0xxx_retarget.c
@@ -1,0 +1,54 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <errno.h>
+#include "stm32f0xx.h"
+extern uint32_t __mbed_sbrk_start;
+extern uint32_t __mbed_krbs_start;
+
+/* Support heap with two-region model
+ *
+ * The default implementation of _sbrk() (in mbed_retarget.cpp) for GCC_ARM requires one-region
+ * model (heap and stack share one region), which doesn't fit two-region model (heap and stack
+ * are two distinct regions)
+ * Hence, override _sbrk() here to support heap with two-region model.
+ */
+void *_sbrk(int incr)
+{
+    static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
+    uint32_t heap_ind_old = heap_ind;
+    uint32_t heap_ind_new = heap_ind_old + incr;
+
+    if (heap_ind_new > (uint32_t) &__mbed_krbs_start) {
+        errno = ENOMEM;
+        return (void *) -1;
+    }
+
+    heap_ind = heap_ind_new;
+
+    return (void *) heap_ind_old;
+}

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_IAR/stm32f072xb.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x200000C0;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x400;
-define symbol __ICFEDIT_size_heap__   = 0x1000;
+define symbol __ICFEDIT_size_heap__   = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 define memory mem with size = 4G;

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -136,4 +136,11 @@ extern uint32_t               __HeapLimit[];
 #define ISR_STACK_SIZE        ((uint32_t)((uint32_t)__StackTop - (uint32_t)__StackLimit))
 #endif
 
+#if (defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB))
+#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#endif
+#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
+#endif
+
 #endif  // MBED_MBED_RTX_H

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -137,10 +137,22 @@ extern uint32_t               __HeapLimit[];
 #endif
 
 #if (defined(TARGET_STM32F070RB) || defined(TARGET_STM32F072RB))
+#if (defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION))
+extern uint32_t               __StackLimit;
+extern uint32_t               __StackTop;
+extern uint32_t               __end__;
+extern uint32_t               __HeapLimit;
+#define HEAP_START            ((unsigned char*) &__end__)
+#define HEAP_SIZE             ((uint32_t)((uint32_t) &__HeapLimit - (uint32_t) HEAP_START))
+#define ISR_STACK_START       ((unsigned char*) &__StackLimit)
+#define ISR_STACK_SIZE        ((uint32_t)((uint32_t) &__StackTop - (uint32_t) &__StackLimit))
+#endif
+
 #ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
 #undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
 #endif
 #define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
+
 #endif
 
 #endif  // MBED_MBED_RTX_H

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_IAR/tmpm066fwug.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/device/TOOLCHAIN_IAR/tmpm066fwug.icf
@@ -9,8 +9,8 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x0001FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ 	= 0x200;
-define symbol __ICFEDIT_size_heap__   	= 0x1400;
+define symbol __ICFEDIT_size_cstack__   = 0x400;
+define symbol __ICFEDIT_size_heap__     = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/device/TOOLCHAIN_IAR/tmpm3h6fwfg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/device/TOOLCHAIN_IAR/tmpm3h6fwfg.icf
@@ -8,9 +8,9 @@ define symbol __ICFEDIT_region_ROM_start__ = 0x00000000;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0001FFFF;
 define symbol __ICFEDIT_region_RAM_start__ = 0x20000218;     /* 8_byte_aligned(117 + 16 vect * 4 bytes) */
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
-/* Heap 1/4 of ram and stack 1/8 */
-define symbol __ICFEDIT_size_cstack__   = 0x400;
-define symbol __ICFEDIT_size_heap__     = 0x1200;
+/*-Sizes-*/
+define symbol __ICFEDIT_size_cstack__      = 0x400;
+define symbol __ICFEDIT_size_heap__        = 0xC00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_TOSHIBA/mbed_rtx.h
+++ b/targets/TARGET_TOSHIBA/mbed_rtx.h
@@ -22,6 +22,10 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP                        (0x20004000UL)
 #endif
+#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#endif
+#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
 
 #endif
 
@@ -30,6 +34,10 @@
 #ifndef INITIAL_SP
 #define INITIAL_SP                        (0x20080000UL)
 #endif
+#ifdef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#undef MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
+#endif
+#define MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE 3072
 
 #endif
 

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20004000;
 /*-Heap 1/4 of ram and stack 1/8-*/
 define symbol __ICFEDIT_size_cstack__ = 0x00000400;
-define symbol __ICFEDIT_size_heap__   = 0x00001000;
+define symbol __ICFEDIT_size_heap__   = 0x00000C00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500ECO/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500ECO/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20004000;
 /*-Heap 1/4 of ram and stack 1/8-*/
 define symbol __ICFEDIT_size_cstack__ = 0x00000400;
-define symbol __ICFEDIT_size_heap__   = 0x00001000;
+define symbol __ICFEDIT_size_heap__   = 0x00000C00;
 /**** End of ICF editor section. ###ICF###*/
 
 

--- a/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500P/device/TOOLCHAIN_IAR/W7500_Flash.icf
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/TARGET_WIZwiki_W7500P/device/TOOLCHAIN_IAR/W7500_Flash.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_RAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20004000;
 /*-Heap 1/4 of ram and stack 1/8-*/
 define symbol __ICFEDIT_size_cstack__ = 0x00000400;
-define symbol __ICFEDIT_size_heap__   = 0x00001000;
+define symbol __ICFEDIT_size_heap__   = 0x00000C00;
 /**** End of ICF editor section. ###ICF###*/
 
 


### PR DESCRIPTION
Update the linker scripts (memory map) of targets to have atleast  2K free ram and 2K free heap. 
Add a test to ensure the same, this test should be the first test that fails due to running out of ram or heap.
