### PR TITLE
STM32: RTC: Call irq_handler whenever interrupt fires

### DIFF
--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -295,13 +295,10 @@ int rtc_isenabled(void)
 
 static void RTC_IRQHandler(void)
 {
+    /*  Update HAL state */
     HAL_RTCEx_WakeUpTimerIRQHandler(&RtcHandle);
-}
-
-void HAL_RTCEx_WakeUpTimerEventCallback(RTC_HandleTypeDef *hrtc)
-{
+    /* In case of registered handler, call it. */
     if (irq_handler) {
-        // Fire the user callback
         irq_handler();
     }
 }


### PR DESCRIPTION
# Description 

This is a FIX for #5159.

lp_ticker driver is the known registered user of RTC handler API.

In case, a lp_ticker is set in the past, the lp_ticker_fire_interrupt
will be called which itself sets the RTC interrupt as pending by calling
NVIC_SetPendingIRQ(RTC_WKUP_IRQn). This all happens without actual
programing of the RTC wake-up.

As a result the RTC HW and corresponding HAL layer doesn't expect an
interrupt to happen and will not call HAL_RTCEx_WakeUpTimerEventCallback.

To sove this situation, we will not use HAL_RTCEx_WakeUpTimerEventCallback
weak definition but rather call handler whenever an RTC interrupt fires.

Notes:
* Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
* This is just a template, so feel free to use/remove the unnecessary things

## Status
**READY**

## Todos
- [x] Tests
```
+-------------------+---------------+-------------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                    | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+-------------------------------+--------+--------------------+-------------+
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_drivers-lp_timeout | OK     | 212.08             | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_drivers-rtc        | OK     | 212.85             | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-lp_ticker      | OK     | 211.02             | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-lp_us_tickers  | OK     | 204.27             | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-rtc_time       | OK     | 260.86             | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_drivers-rtc        | OK     | 212.89             | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_hal-lp_us_tickers  | OK     | 202.3              | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_hal-rtc_time       | OK     | 228.74             | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_drivers-rtc        | OK     | 211.66             | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_hal-lp_us_tickers  | OK     | 202.11             | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_hal-rtc_time       | OK     | 211.99             | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-lp_timeout | OK     | 211.46             | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-rtc        | OK     | 212.13             | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_ticker      | OK     | 211.54             | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-lp_us_tickers  | OK     | 204.95             | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-rtc_time       | OK     | 225.78             | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_drivers-lp_timeout | OK     | 211.41             | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_drivers-rtc        | OK     | 213.11             | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-lp_ticker      | OK     | 208.04             | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-lp_us_tickers  | OK     | 203.07             | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-rtc_time       | OK     | 210.38             | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_drivers-lp_timeout | OK     | 207.25             | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_drivers-rtc        | OK     | 210.96             | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_ticker      | OK     | 209.13             | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-lp_us_tickers  | OK     | 202.78             | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-rtc_time       | OK     | 206.58             | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_drivers-lp_timeout | OK     | 216.19             | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_drivers-rtc        | OK     | 213.53             | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-lp_ticker      | OK     | 211.46             | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-lp_us_tickers  | OK     | 206.86             | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-rtc_time       | OK     | 285.56             | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_drivers-lp_timeout | OK     | 211.89             | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_drivers-rtc        | OK     | 212.44             | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-lp_ticker      | OK     | 212.19             | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-lp_us_tickers  | OK     | 204.22             | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-rtc_time       | OK     | 246.03             | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_drivers-lp_timeout | OK     | 211.57             | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_drivers-rtc        | OK     | 212.22             | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-lp_ticker      | OK     | 213.02             | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-lp_us_tickers  | OK     | 208.26             | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-rtc_time       | OK     | 240.66             | default     |
+-------------------+---------------+-------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 41 OK
```