### PR TITLE
Add RealTek WiFi test configuration

### DIFF
--- a/tools/test_configs/RealtekInterface.json
+++ b/tools/test_configs/RealtekInterface.json
@@ -1,0 +1,27 @@
+{
+    "config": {
+        "header-file": {
+            "help" : "String for including your driver header file",
+            "value" : "\"RTWInterface.h\""
+        },
+        "object-construction" : {
+            "value" : "new RTWInterface()"
+        },
+        "connect-statement" : {
+            "help" : "Must use 'net' variable name, replace WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY, WIFI_CHANNEL with your WiFi settings",
+            "value" : "((RTWInterface *)net)->connect(WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY, WIFI_CHANNEL)"
+        },
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"195.34.89.241\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        },
+        "tcp-echo-prefix" : {
+            "help" : "Some servers send a prefix before echoed message",
+            "value" : "\"Realtek Ameba TCP/UDP test service\\n\""
+        }
+    }
+}

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -1,5 +1,6 @@
 {
     "ETHERNET" : "EthernetInterface.json",
     "ODIN_WIFI" : "OdinInterface.json",
-    "ODIN_ETHERNET" : "Odin_EthernetInterface.json"
+    "ODIN_ETHERNET" : "Odin_EthernetInterface.json",
+    "REALTEK_WIFI" : "RealtekInterface.json"	
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -6,5 +6,9 @@
     "K64F": {
         "default_test_configuration": "ETHERNET",
         "test_configurations": ["ETHERNET"]
+    },
+    "REALTEK_RTL8195AM": {
+        "default_test_configuration": "REALTEK_WIFI",
+        "test_configurations": ["REALTEK_WIFI"]
     }
 }


### PR DESCRIPTION
This change adds necessary configuration files to configure Wifi tests for Realtek Ameba board.
