### PR TITLE
Remove time() mutex

### DIFF
--- a/platform/mbed_rtc_time.cpp
+++ b/platform/mbed_rtc_time.cpp
@@ -44,7 +44,6 @@ time_t time(time_t *timer)
 #endif
 
 {
-    _mutex->lock();
     if (_rtc_isenabled != NULL) {
         if (!(_rtc_isenabled())) {
             set_time(0);
@@ -59,7 +58,6 @@ time_t time(time_t *timer)
     if (timer != NULL) {
         *timer = t;
     }
-    _mutex->unlock();
     return t;
 }
 


### PR DESCRIPTION
## Description
calling time() inside an interrupt casues
```
Mutex 0x2000157c error -6: Not allowed in ISR context
```
I cant think why it would need a mutex?

there are perhaps other unnecessary mutexes in here too.

## Status
**READY**


## Migrations
NO


## Related PRs

branch | PR


## Todos

## Deploy notes

## Steps to test or reproduce
Call time() within an ISR.

Fixes #4904 