### PR TITLE
Fix SmartCard HAL on STM32 BluePill board.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/stm32f103xb.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/stm32f103xb.h
@@ -10630,6 +10630,24 @@ typedef struct
   * @}
   */
 
+#define SC_USART                           USART3
+#define SC_USART_CLK_ENABLE()              __HAL_RCC_USART3_CLK_ENABLE()
+#define SC_USART_CLK_DISABLE();            __HAL_RCC_USART3_CLK_DISABLE()
+#define SC_USART_FORCE_RESET()             __HAL_RCC_USART3_FORCE_RESET()
+#define SC_USART_RELEASE_RESET()           __HAL_RCC_USART3_RELEASE_RESET()
+#define SC_USART_IRQn                      USART3_IRQn
+#define SC_USART_IRQHandler                USART3_IRQHandler
+
+#define SC_USART_TX_PIN                    GPIO_PIN_10                
+#define SC_USART_TX_GPIO_PORT              GPIOB                       
+#define SC_USART_TX_CLK_ENABLE()           __HAL_RCC_GPIOB_CLK_ENABLE()
+
+#define SC_USART_CK_PIN                    GPIO_PIN_12                
+#define SC_USART_CK_GPIO_PORT              GPIOB
+#define SC_USART_CK_CLK_ENABLE()           __HAL_RCC_GPIOB_CLK_ENABLE()
+
+#define SC_RECEIVE_TIMEOUT  400  /* Direction to reader */
+#define SC_TRANSMIT_TIMEOUT 200  /* Direction to transmit */
 
 #ifdef __cplusplus
   }

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/stm32f1xx_hal_msp.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/stm32f1xx_hal_msp.c
@@ -1,0 +1,127 @@
+/**
+  ******************************************************************************
+  * @file    SMARTCARD_T0/Src/stm32f1xx_hal_msp.c
+  * @author  MCD Application Team
+  * @version V1.3.0
+  * @date    18-December-2015
+  * @brief   HAL MSP module.
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2015 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/* Includes ------------------------------------------------------------------*/
+#include "stm32f1xx.h"
+
+/** @addtogroup STM32F1xx_HAL_Examples
+  * @{
+  */
+
+/** @addtogroup SMARTCARD_T0
+  * @{
+  */
+
+/* Private typedef -----------------------------------------------------------*/
+/* Private define ------------------------------------------------------------*/
+/* Private macro -------------------------------------------------------------*/
+/* Private variables ---------------------------------------------------------*/
+/* Private function prototypes -----------------------------------------------*/
+/* Private functions ---------------------------------------------------------*/
+
+/** @defgroup HAL_MSP_Private_Functions
+  * @{
+  */
+
+/**
+  * @brief SMARTCARD MSP Initialization 
+  *        This function configures the hardware resources used in this example: 
+  *           - Peripheral's clock enable
+  *           - Peripheral's GPIO Configuration  
+  *           - NVIC configuration
+  * @param hsmartcard: SmartCard handle pointer
+  * @retval None
+  */
+void HAL_SMARTCARD_MspInit(SMARTCARD_HandleTypeDef *hsc)
+{
+  GPIO_InitTypeDef  GPIO_InitStruct;
+  
+  /* Enable Smartcard GPIO clocks */
+  SC_USART_TX_CLK_ENABLE();
+  SC_USART_CK_CLK_ENABLE();
+                         
+  /* Enable SmartCard clock */
+  SC_USART_CLK_ENABLE();
+
+  /* Configure USART Clock pin as alternate function push-pull */
+  GPIO_InitStruct.Pin = SC_USART_CK_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_HIGH;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  HAL_GPIO_Init(SC_USART_CK_GPIO_PORT, &GPIO_InitStruct);
+  
+  /* Configure USART Tx pin as alternate function open-drain */
+  GPIO_InitStruct.Pin = SC_USART_TX_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_AF_OD;
+  HAL_GPIO_Init(SC_USART_TX_GPIO_PORT, &GPIO_InitStruct);
+
+  /* Enable SC_USART IRQ */
+  HAL_NVIC_SetPriority(SC_USART_IRQn, 0, 0);
+  HAL_NVIC_EnableIRQ(SC_USART_IRQn);
+}
+
+/**
+  * @brief SMARTCARD MSP De-Initialization 
+  *        This function frees the hardware resources used in this example:
+  *          - Disable the Peripheral's clock
+  *          - Revert GPIO, DMA and NVIC configuration to their default state
+  * @param huart: UART handle pointer
+  * @retval None
+  */
+void HAL_SMARTCARD_MspDeInit(SMARTCARD_HandleTypeDef *hsmartcard)
+{
+  /*##-1- Reset peripherals ##################################################*/
+  SC_USART_FORCE_RESET(); 
+  SC_USART_RELEASE_RESET();
+
+  /* Disable SmartCard clock */
+  SC_USART_CLK_DISABLE();
+}
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_smartcard.c
@@ -500,7 +500,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *
   */
 HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint16_t* tmp;
   uint32_t tickstart = 0U;
   
   if(hsc->RxState == HAL_SMARTCARD_STATE_READY)
@@ -530,8 +529,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *p
       {
         return HAL_TIMEOUT;
       }
-      tmp = (uint16_t*) pData;
-      *tmp = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
+      *pData = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
       pData +=1U;
     }
 


### PR DESCRIPTION
## Description
The current HAL_SMARTCARD_Receive function corrupts the memory. Changes pData[Size] to 0. That's outside of the pData. Also the MSP is missing and that's needed for smartcard hal to work.

## Status
**READY**
