### PR TITLE
Tools: Check for toolchain and core support for Arm Compilers

### DIFF
--- a/tools/test/toolchains/arm_support_test.py
+++ b/tools/test/toolchains/arm_support_test.py
@@ -1,0 +1,65 @@
+"""Tests for the arm toolchain supported checks"""
+import sys
+import os
+from string import printable
+from copy import deepcopy
+from mock import MagicMock, patch
+from hypothesis import given, settings
+from hypothesis.strategies import text, lists, sampled_from
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..",
+                                    ".."))
+sys.path.insert(0, ROOT)
+
+from tools.toolchains.arm import ARM_STD, ARM_MICRO, ARMC6
+from tools.utils import NotSupportedException
+
+ARMC5_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
+               "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD"]
+ARMC6_CORES = ARMC5_CORES + ["Cortex-M23", "Cortex-M23-NS",
+                             "Cortex-M33", "CortexM33-NS"]
+
+CORE_SUF_ALPHA = ["MDFNS02347-+"]
+
+@given(lists(sampled_from(["ARM", "uARM", "GCC_ARM", "ARMC6", "IAR", "GARBAGE"])),
+       text(alphabet=CORE_SUF_ALPHA))
+def test_arm_std(supported_toolchains, core):
+    mock_target = MagicMock()
+    mock_target.core = "Cortex-" + core
+    mock_target.supported_toolchains = supported_toolchains
+    try:
+        ARM_STD(mock_target)
+        assert "ARM" in supported_toolchains
+        assert mock_target.core in ARMC5_CORES
+    except NotSupportedException:
+        assert "ARM" not in supported_toolchains or mock_target.core not in ARMC5_CORES
+
+
+@given(lists(sampled_from(["ARM", "uARM", "GCC_ARM", "ARMC6", "IAR", "GARBAGE"])),
+       text(alphabet=CORE_SUF_ALPHA))
+def test_arm_micro(supported_toolchains, core):
+    mock_target = MagicMock()
+    mock_target.core = "Cortex-" + core
+    mock_target.supported_toolchains = supported_toolchains
+    try:
+        ARM_MICRO(mock_target)
+        assert "ARM" in supported_toolchains or "uARM" in supported_toolchains
+        assert mock_target.core in ARMC5_CORES
+    except NotSupportedException:
+        assert ("ARM" not in supported_toolchains and "uARM" not in supported_toolchains)\
+            or mock_target.core not in ARMC5_CORES
+
+
+@given(lists(sampled_from(["ARM", "uARM", "GCC_ARM", "ARMC6", "IAR", "GARBAGE"])),
+       text(alphabet=CORE_SUF_ALPHA))
+def test_armc6(supported_toolchains, core):
+    mock_target = MagicMock()
+    mock_target.core = "Cortex-" + core
+    mock_target.supported_toolchains = supported_toolchains
+    try:
+        ARMC6(mock_target)
+        assert "ARM" in supported_toolchains or "ARMC6" in supported_toolchains
+        assert mock_target.core in ARMC6_CORES
+    except NotSupportedException:
+        assert ("ARM" not in supported_toolchains and "ARMC6" not in supported_toolchains)\
+            or mock_target.core not in ARMC6_CORES

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -49,9 +49,6 @@ class ARM(mbedToolchain):
                                extra_verbose=extra_verbose,
                                build_profile=build_profile)
 
-        if "ARM" not in target.supported_toolchains:
-            raise NotSupportedException("ARM compiler support is required for ARM build")
-
         if target.core == "Cortex-M0+":
             cpu = "Cortex-M0"
         elif target.core == "Cortex-M4F":
@@ -265,10 +262,26 @@ class ARM(mbedToolchain):
 
 
 class ARM_STD(ARM):
-    pass
+    def __init__(self, target, notify=None, macros=None,
+                 silent=False, extra_verbose=False, build_profile=None,
+                 build_dir=None):
+        ARM.__init__(self, target, notify, macros, silent,
+                     build_dir=build_dir, extra_verbose=extra_verbose,
+                     build_profile=build_profile)
+        if "ARM" not in target.supported_toolchains:
+            raise NotSupportedException("ARM compiler support is required for ARM build")
+
 
 class ARM_MICRO(ARM):
     PATCHED_LIBRARY = False
+    def __init__(self, target, notify=None, macros=None,
+                 silent=False, extra_verbose=False, build_profile=None,
+                 build_dir=None):
+        ARM.__init__(self, target, notify, macros, silent,
+                     build_dir=build_dir, extra_verbose=extra_verbose,
+                     build_profile=build_profile)
+        if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):
+            raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
 
 class ARMC6(ARM_STD):
     SHEBANG = "#! armclang -E --target=arm-arm-none-eabi -x c"

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -33,6 +33,8 @@ class ARM(mbedToolchain):
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
     DEP_PATTERN = re.compile('\S+:\s(?P<file>.+)\n')
     SHEBANG = "#! armcc -E"
+    SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
+                       "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD"]
 
     @staticmethod
     def check_executable():
@@ -48,6 +50,9 @@ class ARM(mbedToolchain):
                                build_dir=build_dir,
                                extra_verbose=extra_verbose,
                                build_profile=build_profile)
+        if target.core not in self.SUPPORTED_CORES:
+            raise NotSupportedException(
+                "this compiler does not support the core %s" % target.core)
 
         if target.core == "Cortex-M0+":
             cpu = "Cortex-M0"
@@ -285,12 +290,19 @@ class ARM_MICRO(ARM):
 
 class ARMC6(ARM_STD):
     SHEBANG = "#! armclang -E --target=arm-arm-none-eabi -x c"
+    SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
+                       "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD",
+                       "Cortex-M23", "Cortex-M23-NS", "Cortex-M33",
+                       "CortexM33-NS"]
     @staticmethod
     def check_executable():
         return mbedToolchain.generic_check_executable("ARMC6", "armclang", 1)
 
     def __init__(self, target, *args, **kwargs):
         mbedToolchain.__init__(self, target, *args, **kwargs)
+        if target.core not in self.SUPPORTED_CORES:
+            raise NotSupportedException(
+                "this compiler does not support the core %s" % target.core)
 
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")


### PR DESCRIPTION
Fixes #5266 when deployed to the online compiler
Fixes #5345

Also corrects offline compiling of uARM for every target that supports uARM but
not ARM.

TODO:
 - [ ] A test so that I can't break this again