### PR TITLE
Remove build warnings in LWIP

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_tcp.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_tcp.c
@@ -358,7 +358,6 @@ tcp_close_shutdown_fin(struct tcp_pcb *pcb)
   default:
     /* Has already been closed, do nothing. */
     return ERR_OK;
-    break;
   }
 
   if (err == ERR_OK) {

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -293,7 +293,9 @@ static int get_ip_addr_type(const ip_addr_t *ip_addr)
         return IPADDR_TYPE_V4;
     }
 #endif
+#if LWIP_IPV6 && LWIP_IPV4
     return IPADDR_TYPE_ANY;
+#endif
 }
 
 void add_dns_addr(struct netif *lwip_netif)
@@ -658,7 +660,7 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
     if (!netif_is_link_up(&lwip_netif)) {
         if (sys_arch_sem_wait(&lwip_netif_linked, 15000) == SYS_ARCH_TIMEOUT) {
             if (ppp) {
-                ppp_lwip_disconnect();
+                (void) ppp_lwip_disconnect();
             }
             return NSAPI_ERROR_NO_CONNECTION;
         }
@@ -686,7 +688,7 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
     if (!mbed_lwip_get_ip_addr(true, &lwip_netif)) {
         if (sys_arch_sem_wait(&lwip_netif_has_any_addr, DHCP_TIMEOUT * 1000) == SYS_ARCH_TIMEOUT) {
             if (ppp) {
-                ppp_lwip_disconnect();
+                (void) ppp_lwip_disconnect();
             }
             return NSAPI_ERROR_DHCP_FAILURE;
         }


### PR DESCRIPTION
Addresses https://github.com/ARMmbed/mbed-os/issues/5318

Project built in exported projects (tested with make_armc5 in particular) or on the online compiler will generate a good amount of build warnings. These small fixes should resolve the LWIP warnings (and add error checking on ppp_lwip_disconnect calls).