### PR TITLE
LPC1768: Fix ETHMEM_SECTION placement for ARM

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_NXP/lpc17_emac.c
@@ -153,7 +153,7 @@ struct lpc_enetdata {
 #     define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
 #  endif
 #elif defined(TARGET_LPC17XX)
-#  if defined(TOOLCHAIN_GCC_ARM)
+#  if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_ARM)
 #     define ETHMEM_SECTION __attribute__((section("AHBSRAM1"),aligned))
 #  endif
 #endif


### PR DESCRIPTION

## Description
Ethernet on LPC1768 is broken in 5.6 as per #5298
This corrects the placement of Ethernet memory with the ARM compiler.

## Status
**READY**


## Migrations
NO


## Related PRs

branch | PR
------ | ------

## Todos

## Deploy notes


## Steps to test or reproduce
Build the TCPSocket_Example with 5.5.7 and it will work, any 5.6\master will fail to get an IP, using static IP will still fail to work properly.

Fixes #5298 