### PR TITLE
doxygen: Change FileSystemHandle group to platform

### DIFF
--- a/platform/FileSystemHandle.h
+++ b/platform/FileSystemHandle.h
@@ -24,7 +24,7 @@
 #include "platform/NonCopyable.h"
 
 namespace mbed {
-/** \addtogroup drivers */
+/** \addtogroup platform */
 /** @{*/
 
 


### PR DESCRIPTION
Was drivers, should be platform, wasn't updated during move

cc @sg-, @theotherjimmy 