### PR TITLE
STM32: Remove compilation warnings

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
@@ -95,9 +95,6 @@ void ETH_IRQHandler(void)
  */
 static void _eth_arch_low_level_init(struct netif *netif)
 {
-    uint32_t regvalue = 0;
-    HAL_StatusTypeDef hal_eth_init_status;
-
     /* Init ETH */
     uint8_t MACAddr[6];
     EthHandle.Instance = ETH;
@@ -119,7 +116,7 @@ static void _eth_arch_low_level_init(struct netif *netif)
     EthHandle.Init.RxMode = ETH_RXINTERRUPT_MODE;
     EthHandle.Init.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE;
     EthHandle.Init.MediaInterface = ETH_MEDIA_INTERFACE_RMII;
-    hal_eth_init_status = HAL_ETH_Init(&EthHandle);
+    HAL_ETH_Init(&EthHandle);
 
     /* Initialize Tx Descriptors list: Chain Mode */
     HAL_ETH_DMATxDescListInit(&EthHandle, DMATxDscrTab, &Tx_Buff[0][0], ETH_TXBUFNB);

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -478,9 +478,7 @@ void serial_clear(serial_t *obj)
 void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-
-    //HAL_LIN_SendBreak(huart);
+    UART_HandleTypeDef *huart __attribute__((unused)) = &uart_handlers[obj_s->index];
 }
 
 #if DEVICE_SERIAL_ASYNCH
@@ -798,9 +796,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -874,8 +872,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
-    UNUSED(tmpval);
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear RXNE flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -172,7 +172,7 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
             }
         }
     }
@@ -542,13 +542,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear PE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear FE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear NE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
     }
 }
 
@@ -599,9 +599,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -675,7 +675,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear errors flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -259,7 +259,7 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
             }
         }
     }
@@ -720,13 +720,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear PE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear FE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear NE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
     }
 }
 
@@ -777,9 +777,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -853,7 +853,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear error flags
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear error flags
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -697,9 +697,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -773,8 +773,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
-    UNUSED(tmpval);
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear RXNE flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -286,7 +286,7 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
             }
         }
     }
@@ -782,13 +782,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear PE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear FE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear NE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
     }
 }
 
@@ -839,9 +839,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -915,7 +915,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear errors flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -763,9 +763,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -838,7 +838,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     __HAL_UART_DISABLE_IT(huart, UART_IT_ERR);
     
     // clear flags
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear RXNE
     __HAL_UART_CLEAR_IT(huart, UART_CLEAR_PEF);
     __HAL_UART_CLEAR_IT(huart, UART_CLEAR_FEF);
     __HAL_UART_CLEAR_IT(huart, UART_CLEAR_NEF);

--- a/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
@@ -57,7 +57,6 @@ static int32_t flash_lock(void)
 
 int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 {
-    uint32_t FirstPage = 0;
     uint32_t PAGEError = 0;
     FLASH_EraseInitTypeDef EraseInitStruct;
     int32_t status = 0;

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -673,9 +673,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -749,7 +749,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_PEF | UART_CLEAR_FEF | UART_CLEAR_OREF);
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear RXNE flag
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear RXNE flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
@@ -57,7 +57,6 @@ static int32_t flash_lock(void)
 
 int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 {
-    uint32_t FirstPage = 0;
     uint32_t PAGEError = 0;
     FLASH_EraseInitTypeDef EraseInitStruct;
     int32_t status = 0;

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -203,7 +203,7 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
             }
         }
     }
@@ -607,13 +607,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear PE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear PE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear FE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear FE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear NE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear NE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->DR; // Clear ORE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
     }
 }
 
@@ -664,9 +664,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -740,7 +740,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->DR; // Clear errors flag
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear errors flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -230,7 +230,7 @@ static void uart_irq(int id)
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
-                volatile uint32_t tmpval = huart->Instance->RDR; // Clear ORE flag
+                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear ORE flag
             }
         }
     }
@@ -659,13 +659,13 @@ void HAL_UART_TxCpltCallback(UART_HandleTypeDef *huart) {
 
 void HAL_UART_ErrorCallback(UART_HandleTypeDef *huart) {
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_PE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->RDR; // Clear PE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear PE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->RDR; // Clear FE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear FE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_NE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->RDR; // Clear NE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear NE flag
     } else if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-        volatile uint32_t tmpval = huart->Instance->RDR; // Clear ORE flag
+        volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear ORE flag
     }
 }
 
@@ -716,9 +716,9 @@ int serial_irq_handler_asynch(serial_t *obj)
     HAL_UART_IRQHandler(huart);
     
     // Abort if an error occurs
-    if (return_event & SERIAL_EVENT_RX_PARITY_ERROR ||
-            return_event & SERIAL_EVENT_RX_FRAMING_ERROR ||
-            return_event & SERIAL_EVENT_RX_OVERRUN_ERROR) {
+    if ((return_event & SERIAL_EVENT_RX_PARITY_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_FRAMING_ERROR) ||
+        (return_event & SERIAL_EVENT_RX_OVERRUN_ERROR)) {
         return return_event;
     }
     
@@ -792,7 +792,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_RXNE);
-    volatile uint32_t tmpval = huart->Instance->RDR; // Clear errors flag
+    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear errors flag
     
     // reset states
     huart->RxXferCount = 0;

--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -725,8 +725,10 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
     int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
 
-    if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
-        (obj_s->XferOperation == I2C_LAST_FRAME)) {
+    // Trick to remove compiler warning "left and right operands are identical" in some cases
+    uint32_t op1 = I2C_FIRST_AND_LAST_FRAME;
+    uint32_t op2 = I2C_LAST_FRAME;
+    if ((obj_s->XferOperation == op1) || (obj_s->XferOperation == op2)) {
         if (stop)
             obj_s->XferOperation = I2C_FIRST_AND_LAST_FRAME;
         else
@@ -777,8 +779,10 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
     int count = I2C_ERROR_BUS_BUSY, ret = 0;
     uint32_t timeout = 0;
 
-    if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
-        (obj_s->XferOperation == I2C_LAST_FRAME)) {
+    // Trick to remove compiler warning "left and right operands are identical" in some cases
+    uint32_t op1 = I2C_FIRST_AND_LAST_FRAME;
+    uint32_t op2 = I2C_LAST_FRAME;
+    if ((obj_s->XferOperation == op1) || (obj_s->XferOperation == op2)) {
         if (stop)
             obj_s->XferOperation = I2C_FIRST_AND_LAST_FRAME;
         else
@@ -1065,8 +1069,10 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
 
     /* Set operation step depending if stop sending required or not */
     if ((tx_length && !rx_length) || (!tx_length && rx_length)) {
-        if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
-            (obj_s->XferOperation == I2C_LAST_FRAME)) {
+        // Trick to remove compiler warning "left and right operands are identical" in some cases
+        uint32_t op1 = I2C_FIRST_AND_LAST_FRAME;
+        uint32_t op2 = I2C_LAST_FRAME;
+        if ((obj_s->XferOperation == op1) || (obj_s->XferOperation == op2)) {
             if (stop)
                 obj_s->XferOperation = I2C_FIRST_AND_LAST_FRAME;
             else
@@ -1088,8 +1094,10 @@ void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length, void *rx,
     }
     else if (tx_length && rx_length) {
         /* Two steps operation, don't modify XferOperation, keep it for next step */
-        if ((obj_s->XferOperation == I2C_FIRST_AND_LAST_FRAME) ||
-            (obj_s->XferOperation == I2C_LAST_FRAME)) {
+        // Trick to remove compiler warning "left and right operands are identical" in some cases
+        uint32_t op1 = I2C_FIRST_AND_LAST_FRAME;
+        uint32_t op2 = I2C_LAST_FRAME;
+        if ((obj_s->XferOperation == op1) || (obj_s->XferOperation == op2)) {
                 HAL_I2C_Master_Sequential_Transmit_IT(handle, address, (uint8_t*)tx, tx_length, I2C_FIRST_FRAME);
         } else if ((obj_s->XferOperation == I2C_FIRST_FRAME) ||
             (obj_s->XferOperation == I2C_NEXT_FRAME)) {


### PR DESCRIPTION
## Description
Remove compilation warnings due to unused variables, missing parenthesis and identical left/right operands.

## Status
**READY**

## Migrations
NO
