### PR TITLE
equeue: add config option to use different timer classes

### DIFF
--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -24,35 +24,35 @@
 #include "mbed.h"
 
 #if MBED_CONF_EVENTS_USE_LOWPOWER_TIMER_TICKER
-    #define AliasTimer      LowPowerTimer
-    #define AliasTicker     LowPowerTicker
-    #define AliasTimeout    LowPowerTimeout
+#define ALIAS_TIMER      LowPowerTimer
+#define ALIAS_TICKER     LowPowerTicker
+#define ALIAS_TIMEOUT    LowPowerTimeout
 #else
-    #define AliasTimer      Timer
-    #define AliasTicker     Ticker
-    #define AliasTimeout    Timeout
+#define ALIAS_TIMER      Timer
+#define ALIAS_TICKER     Ticker
+#define ALIAS_TIMEOUT    Timeout
 #endif
 
 // Ticker operations
 static bool equeue_tick_inited = false;
 static volatile unsigned equeue_minutes = 0;
 static unsigned equeue_timer[
-        (sizeof(AliasTimer)+sizeof(unsigned)-1)/sizeof(unsigned)];
+        (sizeof(ALIAS_TIMER)+sizeof(unsigned)-1)/sizeof(unsigned)];
 static unsigned equeue_ticker[
-        (sizeof(AliasTicker)+sizeof(unsigned)-1)/sizeof(unsigned)];
+        (sizeof(ALIAS_TICKER)+sizeof(unsigned)-1)/sizeof(unsigned)];
 
 static void equeue_tick_update() {
-    equeue_minutes += reinterpret_cast<AliasTimer*>(equeue_timer)->read_ms();
-    reinterpret_cast<AliasTimer*>(equeue_timer)->reset();
+    equeue_minutes += reinterpret_cast<ALIAS_TIMER*>(equeue_timer)->read_ms();
+    reinterpret_cast<ALIAS_TIMER*>(equeue_timer)->reset();
 }
 
 static void equeue_tick_init() {
-    MBED_STATIC_ASSERT(sizeof(equeue_timer) >= sizeof(AliasTimer),
+    MBED_STATIC_ASSERT(sizeof(equeue_timer) >= sizeof(ALIAS_TIMER),
             "The equeue_timer buffer must fit the class Timer");
-    MBED_STATIC_ASSERT(sizeof(equeue_ticker) >= sizeof(AliasTicker),
+    MBED_STATIC_ASSERT(sizeof(equeue_ticker) >= sizeof(ALIAS_TICKER),
             "The equeue_ticker buffer must fit the class Ticker");
-    AliasTimer *timer = new (equeue_timer) AliasTimer;
-    AliasTicker *ticker = new (equeue_ticker) AliasTicker;
+    ALIAS_TIMER *timer = new (equeue_timer) ALIAS_TIMER;
+    ALIAS_TICKER *ticker = new (equeue_ticker) ALIAS_TICKER;
 
     equeue_minutes = 0;
     timer->start();
@@ -71,7 +71,7 @@ unsigned equeue_tick() {
 
     do {
         minutes = equeue_minutes;
-        ms = reinterpret_cast<AliasTimer*>(equeue_timer)->read_ms();
+        ms = reinterpret_cast<ALIAS_TIMER*>(equeue_timer)->read_ms();
     } while (minutes != equeue_minutes);
 
     return minutes + ms;
@@ -141,7 +141,7 @@ static void equeue_sema_timeout(equeue_sema_t *s) {
 
 bool equeue_sema_wait(equeue_sema_t *s, int ms) {
     int signal = 0;
-    AliasTimeout timeout;
+    ALIAS_TIMEOUT timeout;
     if (ms == 0) {
         return false;
     } else if (ms > 0) {

--- a/events/mbed_lib.json
+++ b/events/mbed_lib.json
@@ -21,6 +21,7 @@
         "shared-highprio-eventsize": {
             "help": "Event buffer size (bytes) for shared high-priority event queue",
             "value": 256
-        }
+        },
+        "use-lowpower-timer-ticker": 0
     }
 }

--- a/events/mbed_lib.json
+++ b/events/mbed_lib.json
@@ -22,6 +22,9 @@
             "help": "Event buffer size (bytes) for shared high-priority event queue",
             "value": 256
         },
-        "use-lowpower-timer-ticker": 0
+        "use-lowpower-timer-ticker": {
+            "help": "Enable use of low power timer and ticker classes. May reduce the accuracy of the event queue.",
+            "value": 0
+        }
     }
 }


### PR DESCRIPTION
…use LowPowerTimer, LowPowerTimeout and LowPowerTicker instead of Timer/Timeout/Ticker.

This way, on SiLabs boards the low power sleep states will be used when using event queue.
