### PR TITLE
Enable uvision+armc6 exporter

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -36,8 +36,10 @@ from tools.export import qtcreator
 from tools.targets import TARGET_NAMES
 
 EXPORTERS = {
-    'uvision5': uvision.Uvision,
-    'uvision': uvision.Uvision,
+    'uvision5-armc6': uvision.UvisionArmc6,
+    'uvision5-armc5': uvision.UvisionArmc5,
+    'uvision5': uvision.UvisionArmc5,
+    'uvision': uvision.UvisionArmc5,
     'lpcxpresso': lpcxpresso.LPCXpresso,
     'gcc_arm': makefile.GccArm,
     'make_gcc_arm': makefile.GccArm,

--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -97,6 +97,7 @@ class DeviceCMSIS():
         cpu = cpu.replace("Cortex-","ARMC")
         cpu = cpu.replace("+","P")
         cpu = cpu.replace("F","_FP")
+        cpu = cpu.replace("-NS", "")
         return cpu
 
 

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -163,18 +163,19 @@ class Uvision(Exporter):
             ",".join(filter(lambda f: f.startswith("-D"), flags['asm_flags'])))
         flags['asm_flags'] = asm_flag_string
 
+        config_option = self.toolchain.get_config_option(
+            self.toolchain.get_config_header())
         c_flags = set(flags['c_flags'] + flags['cxx_flags'] +flags['common_flags'])
         in_template = set(["--no_vla", "--cpp", "--c99", "-std=gnu99",
-                           "-std=g++98"] + self.toolchain.get_config_option(
-                               self.toolchain.get_config_header()))
+                           "-std=g++98"] + config_option)
 
-        valid_flag = lambda x: x not in in_template or not x.startswith("-O")
+        invalid_flag = lambda x: x in in_template or x.startswith("-O")
         is_define = lambda s: s.startswith("-D")
 
         flags['c_flags'] = " ".join(f.replace('"','\\"') for f in c_flags
-                                    if (valid_flag(f) and not is_define(f)))
-        flags['c_flags'] += " ".join(self.toolchain.get_config_option(
-            self.toolchain.get_config_header()))
+                                    if (not invalid_flag(f) and not is_define(f)))
+        flags['c_flags'] += " "
+        flags['c_flags'] += " ".join(config_option)
         flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))
         flags['ld_flags'] = " ".join(set(flags['ld_flags']))
         return flags

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -168,7 +168,7 @@ class Uvision(Exporter):
                                 self.resources.file_basepath[config_header])
         config_option = self.toolchain.get_config_option(config_header)
         c_flags = set(flags['c_flags'] + flags['cxx_flags'] +flags['common_flags'])
-        in_template = set(["--no_vla", "--cpp", "--c99"] + config_option)
+        in_template = set(["--no_vla", "--cpp", "--c99", "-MMD"] + config_option)
 
         invalid_flag = lambda x: (x in in_template or
                                   x.startswith("-O") or
@@ -181,7 +181,6 @@ class Uvision(Exporter):
         flags['c_flags'] += " ".join(config_option)
         flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))
         flags['ld_flags'] = " ".join(set(flags['ld_flags']))
-        print(flags['c_flags'])
         return flags
 
     def format_src(self, srcs):

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -37,6 +37,7 @@ class DeviceUvision(DeviceCMSIS):
         cpu = self.core.replace("Cortex-", "C")
         cpu = cpu.replace("+", "")
         cpu = cpu.replace("F", "")
+        cpu = cpu.replace("-NS", "")
         cpu_flag = "p"+cpu
 
         # Locations found in Keil_v5/TOOLS.INI
@@ -222,15 +223,14 @@ class Uvision(Exporter):
             'device': DeviceUvision(self.target),
         }
         self.generated_files.append(ctx['linker_script'])
-        core = ctx['device'].core
-        ctx['cputype'] = core.rstrip("FD")
-        if core.endswith("FD"):
+        ctx['cputype'] = ctx['device'].core.rstrip("FD").replace("-NS", "")
+        if ctx['device'].core.endswith("FD"):
             ctx['fpu_setting'] = 3
-        elif core.endswith("F"):
+        elif ctx['device'].core.endswith("F"):
             ctx['fpu_setting'] = 2
         else:
             ctx['fpu_setting'] = 1
-        ctx['fputype'] = self.format_fpu(core)
+        ctx['fputype'] = self.format_fpu(ctx['device'].core)
         ctx['armc6'] = int(self.TOOLCHAIN is 'ARMC6')
         ctx['toolchain_name'] = self.TOOLCHAIN_NAME
         ctx.update(self.format_flags())

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -117,8 +117,6 @@ class Uvision(Exporter):
     project file (.uvprojx).
     The needed information can be viewed in uvision.tmpl
     """
-    NAME = 'uvision5'
-    TOOLCHAIN = 'ARM'
 
     POST_BINARY_WHITELIST = set([
         "MCU_NRF51Code.binary_hook",
@@ -130,12 +128,6 @@ class Uvision(Exporter):
         "NCS36510TargetCode.ncs36510_addfib"
     ])
 
-    @classmethod
-    def is_target_supported(cls, target_name):
-        target = TARGET_MAP[target_name]
-        return apply_supported_whitelist(
-            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target) and\
-            DeviceCMSIS.check_supported(target_name)
 
     #File associations within .uvprojx file
     file_types = {'.cpp': 8, '.c': 1, '.s': 2,
@@ -166,22 +158,25 @@ class Uvision(Exporter):
     def format_flags(self):
         """Format toolchain flags for Uvision"""
         flags = copy.deepcopy(self.flags)
-        # to be preprocessed with armcc
         asm_flag_string = (
             '--cpreproc --cpreproc_opts=-D__ASSERT_MSG,' +
             ",".join(filter(lambda f: f.startswith("-D"), flags['asm_flags'])))
         flags['asm_flags'] = asm_flag_string
-        # All non-asm flags are in one template field
-        c_flags = list(set(flags['c_flags'] + flags['cxx_flags'] +flags['common_flags']))
-        ld_flags = list(set(flags['ld_flags'] ))
-        # These flags are in template to be set by user i n IDE
-        template = ["--no_vla", "--cpp", "--c99"]
-        # Flag is invalid if set in template
-        # Optimizations are also set in the template
-        invalid_flag = lambda x: x in template or re.match("-O(\d|time)", x) 
-        flags['c_flags'] = [flag.replace('"','\\"') for flag in c_flags if not invalid_flag(flag)]
-        flags['c_flags'] = " ".join(flags['c_flags'])
-        flags['ld_flags'] = " ".join(flags['ld_flags'])
+
+        c_flags = set(flags['c_flags'] + flags['cxx_flags'] +flags['common_flags'])
+        in_template = set(["--no_vla", "--cpp", "--c99", "-std=gnu99",
+                           "-std=g++98"] + self.toolchain.get_config_option(
+                               self.toolchain.get_config_header()))
+
+        valid_flag = lambda x: x not in in_template or not x.startswith("-O")
+        is_define = lambda s: s.startswith("-D")
+
+        flags['c_flags'] = " ".join(f.replace('"','\\"') for f in c_flags
+                                    if (valid_flag(f) and not is_define(f)))
+        flags['c_flags'] += " ".join(self.toolchain.get_config_option(
+            self.toolchain.get_config_header()))
+        flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))
+        flags['ld_flags'] = " ".join(set(flags['ld_flags']))
         return flags
 
     def format_src(self, srcs):
@@ -232,6 +227,8 @@ class Uvision(Exporter):
         else:
             ctx['fpu_setting'] = 1
         ctx['fputype'] = self.format_fpu(core)
+        ctx['armc6'] = int(self.TOOLCHAIN is 'ARMC6')
+        ctx['toolchain_name'] = self.TOOLCHAIN_NAME
         ctx.update(self.format_flags())
         self.gen_file('uvision/uvision.tmpl', ctx, self.project_name+".uvprojx")
         self.gen_file('uvision/uvision_debug.tmpl', ctx, self.project_name + ".uvoptx")
@@ -269,3 +266,29 @@ class Uvision(Exporter):
             return -1
         else:
             return 0
+
+class UvisionArmc5(Uvision):
+    NAME = 'uvision5-armc5'
+    TOOLCHAIN = 'ARM'
+    TOOLCHAIN_NAME = ''
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return apply_supported_whitelist(
+            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target) and\
+            DeviceCMSIS.check_supported(target_name)
+
+class UvisionArmc6(Uvision):
+    NAME = 'uvision5-armc6'
+    TOOLCHAIN = 'ARMC6'
+    TOOLCHAIN_NAME = '6070000::V6.7::.\ARMCLANG'
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        return (apply_supported_whitelist(
+            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target) or
+                apply_supported_whitelist(
+            'ARM', Uvision.POST_BINARY_WHITELIST, target)) and\
+            DeviceCMSIS.check_supported(target_name)

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -10,6 +10,10 @@
       <TargetName>{{name}}</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
+      {% if toolchain_name %}
+      <pCCUsed>{{toolchain_name}}</pCCUsed>
+      {% endif %}
+      <uAC6>{{armc6}}</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>{{device.dname}}</Device>
@@ -354,7 +358,7 @@
             <Optim>1</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
-            <OneElfS>0</OneElfS>
+            <OneElfS>1</OneElfS>
             <Strict>0</Strict>
             <EnumInt>0</EnumInt>
             <PlainCh>0</PlainCh>
@@ -365,8 +369,8 @@
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <useXO>0</useXO>
-            <v6Lang>1</v6Lang>
-            <v6LangP>1</v6LangP>
+            <v6Lang>4</v6Lang>
+            <v6LangP>2</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
             <v6Lto>0</v6Lto>
@@ -374,7 +378,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>{{c_flags}}</MiscControls>
-              <Define></Define>
+              <Define>{{c_defines}}</Define>
               <Undefine></Undefine>
               <IncludePath>{{include_paths}}</IncludePath>
             </VariousControls>
@@ -434,5 +438,4 @@
       </Groups>
     </Target>
   </Targets>
-
 </Project>

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -217,7 +217,7 @@
             <AdsLsxf>1</AdsLsxf>
             <RvctClst>0</RvctClst>
             <GenPPlst>0</GenPPlst>
-            <AdsCpuType>"{{device.core.replace("D","").replace("F","")}}"</AdsCpuType>
+            <AdsCpuType>"{{cputype}}"</AdsCpuType>
             <RvctDeviceName></RvctDeviceName>
             <mOS>0</mOS>
             <uocRom>0</uocRom>


### PR DESCRIPTION
This pull request generalizes the Keil exporter to handle both arm
compiler 5 and 6. Further, I moved the C/C++ defines so that they show
up in the GUI as preprocessor defines instead of miscellaneous options.

cc @deepikabhavnani