### PR TITLE
Fix for configurable network driver tests

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2003,7 +2003,7 @@ def get_test_config(config_name, target_name):
     """Finds the path to a test configuration file
     config_name: path to a custom configuration file OR mbed OS interface "ethernet, wifi_odin, etc"
     target_name: name of target to determing if mbed OS interface given is valid
-    returns path to config, boolean of whether it is a module or mbed OS interface
+    returns path to config, will return None if no valid config is found
     """
     # If they passed in a full path
     if exists(config_name):

--- a/tools/test_configs/__init__.py
+++ b/tools/test_configs/__init__.py
@@ -10,11 +10,10 @@ TARGET_CONFIGS = json_file_to_dict(join(CONFIG_DIR, "target_configs.json"))
 def get_valid_configs(target_name):
     if target_name in TARGET_CONFIGS:
         target_config = TARGET_CONFIGS[target_name]
+    elif (target_name in TARGET_MAP and 'LWIP' in TARGET_MAP[target_name].features):
+        target_config = { "default_test_configuration": "ETHERNET", "test_configurations": ["ETHERNET"] }
     else:
-        if 'LWIP' in TARGET_MAP[target_name].features:
-            target_config = { "default_test_configuration": "ETHERNET", "test_configurations": ["ETHERNET"] }
-        else:
-            return {}
+        return {}
 
     config_dict = {}
     for attr in CONFIG_MAP:
@@ -35,11 +34,7 @@ def get_default_config(target_name):
         if config_name == "NONE":
             return None
         return join(CONFIG_DIR, CONFIG_MAP[config_name])
-    elif target_name in TARGET_MAP:
-        if 'LWIP' in TARGET_MAP[target_name].features:
-            config_name = "ETHERNET"
-            return join(CONFIG_DIR, CONFIG_MAP[config_name])
-        else:
-            return None
+    elif (target_name in TARGET_MAP and 'LWIP' in TARGET_MAP[target_name].features):
+        return join(CONFIG_DIR, CONFIG_MAP["ETHERNET"])
     else:
         return None

--- a/tools/test_configs/__init__.py
+++ b/tools/test_configs/__init__.py
@@ -1,6 +1,7 @@
 from os.path import dirname, abspath, join
 
 from tools.utils import json_file_to_dict
+from tools.targets import TARGET_MAP
 
 CONFIG_DIR = dirname(abspath(__file__))
 CONFIG_MAP = json_file_to_dict(join(CONFIG_DIR, "config_paths.json"))
@@ -10,7 +11,10 @@ def get_valid_configs(target_name):
     if target_name in TARGET_CONFIGS:
         target_config = TARGET_CONFIGS[target_name]
     else:
-        return {}
+        if 'LWIP' in TARGET_MAP[target_name].features:
+            target_config = { "default_test_configuration": "ETHERNET", "test_configurations": ["ETHERNET"] }
+        else:
+            return {}
 
     config_dict = {}
     for attr in CONFIG_MAP:
@@ -31,5 +35,11 @@ def get_default_config(target_name):
         if config_name == "NONE":
             return None
         return join(CONFIG_DIR, CONFIG_MAP[config_name])
+    elif target_name in TARGET_MAP:
+        if 'LWIP' in TARGET_MAP[target_name].features:
+            config_name = "ETHERNET"
+            return join(CONFIG_DIR, CONFIG_MAP[config_name])
+        else:
+            return None
     else:
         return None

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -3,10 +3,6 @@
         "default_test_configuration": "NONE",
         "test_configurations": ["ODIN_WIFI", "ODIN_ETHERNET"]
     },
-    "K64F": {
-        "default_test_configuration": "ETHERNET",
-        "test_configurations": ["ETHERNET"]
-    },
     "REALTEK_RTL8195AM": {
         "default_test_configuration": "NONE",
         "test_configurations": ["REALTEK_WIFI"]


### PR DESCRIPTION
## Description
This change fixes a bug with @sarahmarshy's configurable network driver tests. These tests can be invoked with an existing interface inside mbed OS or a new NSAPI implementation via:

`mbed test -m [MCU] -t gcc_arm -n mbed-os-tests-netsocket* --test-config ethernet`
or
`mbed test -m [MCU] -t gcc_arm -n mbed-os-tests-netsocket* --test-config path\to\config\file`

Bug fixed allows for any board with LWIP (not just K64F or Odin) to run mbed OS network tests. Also fixed a comment that describes what the `get_test_config` function returns.

Edit:
Also, `mbed test -m [MCU] -t gcc_arm -n mbed-os-tests-netsocket*` will by default choose the Ethernet interface for any target with LWIP.

## Related PRs

branch | PR
------ | ------
mbed-os/master | [Add configurable network driver tests #4795](https://github.com/ARMmbed/mbed-os/pull/4795)

@sarahmarshy @theotherjimmy 