### PR TITLE
Add additional note on the HeapBlockDevice constructor block parameter

### DIFF
--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -56,7 +56,8 @@ public:
     /** Lifetime of the memory block device
      *
      * @param size      Size of the Block Device in bytes
-     * @param block     Block size in bytes
+     * @param block     Block size in bytes. Minimum read, program, and erase sizes are
+     *                  configured to this value
      */
     HeapBlockDevice(bd_size_t size, bd_size_t block=512);
     /** Lifetime of the memory block device


### PR DESCRIPTION
 https://github.com/ARMmbed/Handbook/pull/287#issuecomment-337388320 brought up some ambiguity in the difference between the constructors in HeapBlockDevice. Added a small blurb to avoid having to go to the source to see what the difference is.

Does this sound more in line with what you were thinking for the block parameter description @sg-?