### PR TITLE
Fix us_ticker collision and race for RTL8195AM

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/us_ticker.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/us_ticker.c
@@ -21,7 +21,7 @@
 
 #define TICK_READ_FROM_CPU  0   // 1: read tick from CPU, 0: read tick from G-Timer
 #define SYS_TIM_ID          1   // the G-Timer ID for System
-#define APP_TIM_ID          6   // the G-Timer ID for Application
+#define APP_TIM_ID          2   // the G-Timer ID for Application
 
 /*
  * For RTL8195AM, clock source is 32k


### PR DESCRIPTION
Switch to timer 2 for us_ticker for timer 6 might be used
for power saving.

Signed-off-by: Tony Wu <tonywu@realtek.com>