### PR TITLE
Add SPI spacing API

### DIFF
--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -110,6 +110,27 @@ public:
      */
     void frequency(int hz = 1000000);
 
+    /** Set spacing between bytes for multi-byte transfers
+     *
+     * Actual spacing may differ:
+     * - A target may be totally unable to space bytes during block transfers, in which
+     *   case this will return 0.
+     * - If the target does not have a DMA-based bulk write implementation, but
+     *   implements bulk transfers using byte-at-a-time PIO, then effectively the bytes
+     *   will always be widely-spaced due to the time taken to program the SPI peripheral
+     *   for each byte. In this case, this call should return an appropriately large
+     *   value to represent that, eg 1000 (= 1 microsecond).
+     * - Clock dividers may limit the available spacing granularity, in which case
+     *   the device should round up and return the actual spacing.
+     *
+     * Callers should check the return value, and if it is lower than required, take
+     * alternative action, such as lowering the clock frequency or using single-byte writes.
+     *
+     * @param ns  The desired extra inter-byte spacing in nanoseconds
+     * @return Actual inter-byte spacing
+     */
+    int write_spacing(int ns);
+
     /** Write to the SPI Slave and return the response
      *
      *  @param value Data to be sent to the SPI slave
@@ -282,6 +303,8 @@ protected:
     int _bits;
     int _mode;
     int _hz;
+    int _spacing_ns;
+    int _spacing_ns_actual;
     char _write_fill;
 
 private:

--- a/hal/spi_api.h
+++ b/hal/spi_api.h
@@ -103,6 +103,28 @@ void spi_format(spi_t *obj, int bits, int mode, int slave);
  */
 void spi_frequency(spi_t *obj, int hz);
 
+/** Set spacing between bytes for block transfers
+ *
+ * Actual spacing may differ:
+ * - A target may be totally unable to space bytes during block transfers, in which
+ *   case this will return 0.
+ * - If the target does not have a DMA-based block write implementation, but
+ *   implements block transfers using byte-at-a-time PIO, then effectively the bytes
+ *   will always be widely-spaced due to the time taken to program the SPI peripheral
+ *   for each byte. In this case, this call should return an appropriately large
+ *   value to represent that, eg 1000 (= 1 microsecond).
+ * - Clock dividers may limit the available spacing granularity, in which case
+ *   the device should round up and return the actual spacing.
+ *
+ * Callers should check the return value, and if it is lower than required, take
+ * alternative action, such as lowering the clock frequency or using non-block writes.
+ *
+ * @param[in,out] obj         The SPI object to configure
+ * @param[in]     spacing_ns  The desired extra inter-byte spacing in nanoseconds
+ * @return        Actual inter-byte spacing
+ */
+int spi_block_write_spacing(spi_t *obj, int spacing_ns);
+
 /**@}*/
 /**
  * \defgroup SynchSPI Synchronous SPI Hardware Abstraction Layer

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/spi_api.c
@@ -104,6 +104,11 @@ void spi_frequency(spi_t *obj, int hz)
     DSPI_MasterSetDelayTimes(spi_address[obj->spi.instance], kDSPI_Ctar0, kDSPI_LastSckToPcs, busClock, 500000000 / hz);
 }
 
+int spi_block_write_spacing(spi_t *obj, int spacing_ns) {
+    uint32_t busClock = CLOCK_GetFreq(spi_clocks[obj->spi.instance]);
+    return DSPI_MasterSetDelayTimes(spi_address[obj->spi.instance], kDSPI_Ctar0, kDSPI_PcsToSck, busClock, spacing_ns);
+}
+
 static inline int spi_readable(spi_t * obj)
 {
     return (DSPI_GetStatusFlags(spi_address[obj->spi.instance]) & kDSPI_RxFifoDrainRequestFlag);


### PR DESCRIPTION
Currently block SPI transfers have no spacing specified - a target may
achieve back-to-back continuous transfer, or might have very large
spacing between bytes due to PIO.

Some devices, such as the Atmel RF233 radio module, require some spacing
between bytes. Add an API to allow spacing to be requested.

Targets are not required to actually provide configurable spacing - they
may have fixed zero spacing, or fixed large spacing. Users of this API
will need to take this into consideration.

This first prototype commit implements the API on K64F only, pending
review comments.
