### PR TITLE
Activate FLASH hal support on 2 STM32 boards

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1546,7 +1546,7 @@
             }
         },
         "detect_code": ["0833"],
-        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG"],
+        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L072CZ"
     },
@@ -1600,7 +1600,7 @@
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_FC", "TRNG"],
+        "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L475VG"
     },


### PR DESCRIPTION
## Description
The generic Flash support for L4 and L0 families is already there,
but was not activated by default on 2 recentely added boards:
DISCO_L475VG_IOT01A and DISCO_L072CZ_LRWAN1
This is done now.

## Status
**READY**

## Tests
```
+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
| target                  | platform_name       | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-flashiap | OK     | 19.08              | default     |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | OK     | 18.91              | default     |
+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 2 OK
mbedgt: test case report:
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite                  | test case                     | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-flashiap | FlashIAP - init               | 1      | 0      | OK     | 0.04               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-flashiap | FlashIAP - program            | 1      | 0      | OK     | 0.09               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-flashiap | FlashIAP - program errors     | 1      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - buffer alignment test | 1      | 0      | OK     | 0.09               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - clock and cache test  | 1      | 0      | OK     | 0.09               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - erase sector          | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - init                  | 1      | 0      | OK     | 0.08               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - mapping alignment     | 1      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-flash        | Flash - program page          | 1      | 0      | OK     | 0.09               |
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 9 OK
mbedgt: completed in 53.60 sec



+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
| target                  | platform_name       | test suite                  | result | elapsed_time (sec) | copy_method |
+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_drivers-flashiap | OK     | 24.31              | default     |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | OK     | 21.95              | default     |
+-------------------------+---------------------+-----------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 2 OK
mbedgt: test case report:
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite                  | test case                     | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_drivers-flashiap | FlashIAP - init               | 1      | 0      | OK     | 0.05               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_drivers-flashiap | FlashIAP - program            | 1      | 0      | OK     | 3.63               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_drivers-flashiap | FlashIAP - program errors     | 1      | 0      | OK     | 0.06               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - buffer alignment test | 1      | 0      | OK     | 0.18               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - clock and cache test  | 1      | 0      | OK     | 0.16               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - erase sector          | 1      | 0      | OK     | 0.16               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - init                  | 1      | 0      | OK     | 0.13               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - mapping alignment     | 1      | 0      | OK     | 0.05               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-flash        | Flash - program page          | 1      | 0      | OK     | 0.27               |
+-------------------------+---------------------+-----------------------------+-------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 9 OK
mbedgt: completed in 55.54 sec
```
