### PR TITLE
Interface for alternative stdio retargeting

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -32,6 +32,9 @@
 #endif
 #include <errno.h>
 #include "platform/mbed_retarget.h"
+#if MBED_CONF_RETARGET_STDIO_ALT
+#include "platform/mbed_retarget_alt.h"
+#endif
 
 #if defined(__ARMCC_VERSION)
 #   include <rt_sys.h>
@@ -96,6 +99,7 @@ void remove_filehandle(FileHandle *file) {
 }
 }
 
+#if !MBED_CONF_RETARGET_STDIO_ALT
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
@@ -114,6 +118,7 @@ static void init_serial() {
 #endif
 #endif
 }
+#endif
 
 /**
  * Sets errno when file opening fails.
@@ -199,13 +204,25 @@ extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {
     /* Use the posix convention that stdin,out,err are filehandles 0,1,2.
      */
     if (std::strcmp(name, __stdin_name) == 0) {
+#if !MBED_CONF_RETARGET_STDIO_ALT
         init_serial();
+#else
+        retarget_stdio_init_alt(0);
+#endif
         return 0;
     } else if (std::strcmp(name, __stdout_name) == 0) {
+#if !MBED_CONF_RETARGET_STDIO_ALT
         init_serial();
+#else
+        retarget_stdio_init_alt(1);
+#endif
         return 1;
     } else if (std::strcmp(name, __stderr_name) == 0) {
+#if !MBED_CONF_RETARGET_STDIO_ALT
         init_serial();
+#else
+        retarget_stdio_init_alt(2);
+#endif
         return 2;
     }
     #endif
@@ -298,6 +315,7 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 #endif
 
     if (fh < 3) {
+#if !MBED_CONF_RETARGET_STDIO_ALT
 #if DEVICE_SERIAL
         if (!stdio_uart_inited) init_serial();
 #if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
@@ -315,6 +333,14 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 #endif
 #endif
         n = length;
+#else
+        // use alternative/custom stdio write function
+        n = retarget_stdio_write_alt(fh, buffer, length);
+        if (n < 0) {
+            errno = n;
+            return -1;
+        }
+#endif
     } else {
         FileHandle* fhc = filehandles[fh-3];
         if (fhc == NULL) {
@@ -349,6 +375,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 
     if (fh < 3) {
         // only read a character at a time from stdin
+#if !MBED_CONF_RETARGET_STDIO_ALT
 #if DEVICE_SERIAL
         if (!stdio_uart_inited) init_serial();
 #if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
@@ -375,6 +402,14 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 #endif
 #endif
         n = 1;
+#else
+        // use alternative/custom stdio read function
+        n = retarget_stdio_read_alt(fh, buffer, length);
+        if (n < 0) {
+            errno = n;
+            return -1;
+        }
+#endif
     } else {
         FileHandle* fhc = filehandles[fh-3];
         if (fhc == NULL) {

--- a/platform/mbed_retarget_alt.h
+++ b/platform/mbed_retarget_alt.h
@@ -26,14 +26,14 @@ extern "C" {
 #endif
     /** Alternative stdio initialization interface function
      *
-     * @pararm fh   The file handle of the stdio operation
+     * @param fh    The file handle of the stdio operation
      *              (0 = stdin, 1 = stdout, 2 = stderr)
      */
     void retarget_stdio_init_alt(unsigned int fh);
     
     /** Alternative stdio write interface function
      *
-     * @pararm fh      The file handle of the stdio operation
+     * @param fh       The file handle of the stdio operation
      * @param buffer   The buffer containing the data to write
      * @param length   The length of the valid data in the buffer
      *
@@ -47,7 +47,7 @@ extern "C" {
      *  This shall be a blocking function not returning before at least one
      *  character has been read.
      *
-     * @pararm fh      The file handle of the stdio operation
+     * @param fh       The file handle of the stdio operation
      * @param buffer   The buffer for the read data
      * @param length   The size of the buffer
      *

--- a/platform/mbed_retarget_alt.h
+++ b/platform/mbed_retarget_alt.h
@@ -1,0 +1,62 @@
+/*
+ * mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Alternative (custom) stdio retarget interface declaration
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#ifndef RETARGET_ALT_H
+#define RETARGET_ALT_H
+
+#if __cplusplus
+extern "C" {
+#endif
+    /** Alternative stdio initialization interface function
+     *
+     * @pararm fh   The file handle of the stdio operation
+     *              (0 = stdin, 1 = stdout, 2 = stderr)
+     */
+    void retarget_stdio_init_alt(unsigned int fh);
+    
+    /** Alternative stdio write interface function
+     *
+     * @pararm fh      The file handle of the stdio operation
+     * @param buffer   The buffer containing the data to write
+     * @param length   The length of the valid data in the buffer
+     *
+     * @return the number of bytes written or negative errno on failure
+     *         (e.g. -EIO from errno.h)
+     */
+    int retarget_stdio_write_alt(unsigned int fh, const unsigned char *buffer, unsigned int length);
+    
+    /** Alternative stdio read interface function
+     *
+     *  This shall be a blocking function not returning before at least one
+     *  character has been read.
+     *
+     * @pararm fh      The file handle of the stdio operation
+     * @param buffer   The buffer for the read data
+     * @param length   The size of the buffer
+     *
+     * @return the number of bytes read or negative errno on failure
+     *         (e.g. -EIO from errno.h)
+     */
+    int retarget_stdio_read_alt(unsigned int fh, unsigned char *buffer, unsigned int length);
+#if __cplusplus
+}
+#endif
+
+#endif /* RETARGET_ALT_H */


### PR DESCRIPTION
## Description
This changes implement the `mbed_retarget_alt.h` interface that allows using an alternative/custom stdin/stdout/stderr interface other than the default serial port.
By setting `MBED_CONF_RETARGET_STDIO_ALT = 1` the custom interface will be enabled.
An example implementation can be found in the [0x6d61726b/mbed-os-retarget-segger-rtt](https://github.com/0x6d61726b/mbed-os-retarget-segger-rtt) repository.


## Todos
- [?] Documentation
- what else?


## Deploy notes
?




## Steps to test or reproduce
The following test program can be used for testing general functionality:

```
#include <stdio.h>
int main() {
    printf("-------------------------------------------------------------------------------\n");
    printf("Segger Real-Time Terminal ECHO program (type '.' to exit)\n");
    char c;
    while ((c = getchar()) != '.') {
        putchar(c);
    }
    
    printf("\n\nExit!\n");
    while (true);
}
```

Result (when typing `Hello World!.`):

![demo](https://user-images.githubusercontent.com/25281946/31844602-fdd77e7c-b5f9-11e7-9ae7-0be45cad5486.png)
