### PR TITLE
Add support and tests for extended RTC

### DIFF
--- a/TESTS/host_tests/rtc_calc_auto.py
+++ b/TESTS/host_tests/rtc_calc_auto.py
@@ -1,0 +1,138 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from mbed_host_tests import BaseHostTest
+import time
+import calendar
+import datetime
+
+class RTC_time_calc_test(BaseHostTest):
+    """
+    This is the host part of the test to verify if:
+    - _rtc_mktime function converts a calendar time into time since UNIX epoch as a time_t,
+    - _rtc_localtime function converts a given time in seconds since epoch into calendar time.
+    
+    The same algoritm to generate next calendar time to be tested is used by both parts of the test.
+    We will check if correct time since UNIX epoch is calculated for the first and the last day
+    of each month and across valid years.
+    
+    Mbed part of the test sends calculated time since UNIX epoch.
+    This part validates given value and responds to indicate pass or fail.
+    Additionally it sends also encoded day of week and day of year which
+    will be needed to verify _rtc_localtime.
+    
+    Support for both types of RTC devices is provided:
+    - RTCs which handles all leap years in the mentioned year range correctly. Leap year is determined by checking if
+      the year counter value is divisible by 400, 100, and 4. No problem here.
+    - RTCs which handles leap years correctly up to 2100. The RTC does a simple bit comparison to see if the two
+      lowest order bits of the year counter are zero. In this case 2100 year will be considered
+      incorrectly as a leap year, so the last valid point in time will be 28.02.2100 23:59:59 and next day will be
+      29.02.2100 (invalid). So after 28.02.2100 the day counter will be off by a day.
+      
+    """
+
+    edge_date = datetime.datetime(2100, 2, 28, 0, 0, 0)
+    
+    years = [1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
+             2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
+             2099, 2100, 2101, 2102, 2103, 2104, 2105, 2106]
+    year_id = 0
+             
+             
+
+    full_leap_year_support = False
+
+    RTC_FULL_LEAP_YEAR_SUPPORT = 0
+    RTC_PARTIAL_LEAP_YEAR_SUPPORT = 1
+
+    def _set_leap_year_support(self, key, value, timestamp):
+        if (int(value) == self.RTC_FULL_LEAP_YEAR_SUPPORT):
+            self.full_leap_year_support = True
+        else:
+            self.full_leap_year_support = False
+
+        self.first = True
+        self.date = datetime.datetime(1970, 1, 1, 23, 0, 0)
+        self.year_id = 0
+
+    def _verify_timestamp(self, key, value, timestamp):
+        # week day in python is counted from sunday(0) and on mbed side week day is counted from monday(0).
+        # year day in python is counted from 1 and on mbed side year day is counted from 0.
+        week_day = ((self.date.timetuple().tm_wday + 1) % 7)
+        year_day = self.date.timetuple().tm_yday - 1
+
+        # Fix for RTC which not have full leap year support.
+        if (not self.full_leap_year_support):
+            if self.date >= self.edge_date:
+                # After 28.02.2100 we should be one day off - add this day and store original
+                date_org = self.date
+                self.date += datetime.timedelta(days = 1)
+                
+                # Adjust week day.
+                week_day = ((self.date.timetuple().tm_wday + 1) % 7)
+
+                # Adjust year day.
+                if (self.date.year == 2100):
+                    year_day = self.date.timetuple().tm_yday - 1
+                else:
+                    year_day = date_org.timetuple().tm_yday - 1
+
+                # Last day in year
+                if (self.date.month == 1 and self.date.day == 1):
+                    if (self.date.year == 2101):
+                        # Exception for year 2100 - ivalid handled by RTC without full leap year support
+                        year_day = 365
+                    else:
+                        year_day = date_org.timetuple().tm_yday - 1
+
+        t = (self.date.year , self.date.month, self.date.day, self.date.hour, self.date.minute, self.date.second, 0, 0, 0)
+        
+        expected_timestamp = calendar.timegm(t)
+        actual_timestamp = int(value) & 0xffffffff # convert to unsigned int
+
+        # encode week day and year day in the response
+        response = (week_day << 16) | year_day
+        
+        if (actual_timestamp == expected_timestamp):
+            # response contains encoded week day and year day
+            self.send_kv("passed", str(response))
+        else:
+            self.send_kv("failed", 0)
+            print "expected = %d, result = %d" %  (expected_timestamp , actual_timestamp)
+
+        # calculate next date
+        if (self.first):
+            days_range = calendar.monthrange(self.date.year, self.date.month)
+            self.date = self.date.replace(day = days_range[1], minute = 59, second = 59)
+            self.first = not self.first
+        else:
+            self.date += datetime.timedelta(days = 1)
+            if (self.date.month == 1):
+                self.year_id += 1
+                self.date = self.date.replace(year = self.years[self.year_id])
+            self.date = self.date.replace(day = 1, minute = 0, second = 0)
+            self.first = not self.first
+
+    def setup(self):
+        self.register_callback('timestamp', self._verify_timestamp)
+        self.register_callback('leap_year_setup', self._set_leap_year_support)
+
+    def result(self):
+        return self.__result
+
+    def teardown(self):
+        pass

--- a/TESTS/mbed_hal/rtc_time_conv/main.cpp
+++ b/TESTS/mbed_hal/rtc_time_conv/main.cpp
@@ -1,0 +1,214 @@
+/*
+ * Copyright (c) 2013-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This is the mbed device part of the test to verify if:
+ * - _rtc_maketime() function converts a calendar time into time since UNIX epoch as a time_t,
+ * - _rtc_localtime() function converts a given time in seconds since epoch into calendar time.
+ */
+
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "mbed_mktime.h"
+
+#define LAST_VALID_YEAR 206
+
+using namespace utest::v1;
+
+static rtc_leap_year_support_t rtc_leap_year_support;
+
+/*
+ * regular is_leap_year, see platform/mbed_mktime.c for the optimised version
+ */
+bool is_leap_year(int year)
+{
+    year = 1900 + year;
+    if (year % 4) {
+        return false;
+    } else if (year % 100) {
+        return true;
+    } else if (year % 400) {
+        return false;
+    }
+    return true;
+}
+
+struct tm make_time_info(int year, int month, int day, int hours, int minutes, int seconds)
+{
+    struct tm timeinfo =
+    { seconds,    // tm_sec
+        minutes,    // tm_min
+        hours,      // tm_hour
+        day,        // tm_mday
+        month,      // tm_mon
+        year,       // tm_year
+        0,          // tm_wday
+        0,          // tm_yday
+        0,          // tm_isdst
+            };
+    return timeinfo;
+}
+
+/* Test _rtc_maketime() and _rtc_localtime() across wide range
+ *
+ * Note: This test functions handles both types of RTC devices:
+ * - devices which supports full leap years support in range 1970 - 2106.
+ * - devices which supports parial leap years support and incorrectly treats 2100 year as a leap year.
+ *
+ * Given is valid calendar time.
+ * When _rtc_maketime() is used to generate timestamp from calendar time and _rtc_localtime() is used to convert
+ * timestamp to calendar time.
+ * Then both operations gives valid results.
+ */
+void test_case_mktime_localtime()
+{
+    char _key[11] =
+    { };
+    char _value[128] =
+    { };
+
+    size_t years[] = {70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
+                      100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
+                      199, 200, 201, 202, 203, 204, 205};
+
+    /* Inform host part of the test about tested RTC type. */
+    greentea_send_kv("leap_year_setup",  rtc_leap_year_support);
+
+    /* Check the first and last last day of each month. */
+    for (size_t year_id = 0; year_id < (sizeof(years) /sizeof(size_t)) ; ++year_id) {
+        for (size_t month = 0; month < 12; ++month) {
+            for (size_t dayid = 0; dayid < 2; ++dayid) {
+
+                size_t year = years[year_id];
+
+                size_t day = 0;
+                /* Test the first and the last day of each month:
+                 * day 0 - first,
+                 * day 1 - last
+                 * */
+                switch (dayid)
+                {
+                    case 0:
+                        day = 1;
+                        break;
+
+                    case 1:
+                        day = 31;
+
+                        if (month == 3 || month == 5 || month == 8 || month == 10) {
+                            day = 30;
+                        }
+
+                        if (month == 1) {
+                            day = 28;
+                        }
+
+                        if (month == 1 && is_leap_year(year)) {
+                            day = 29;
+                        }
+
+                        /* Additional conditions for RTCs with partial leap year support. */
+                        if(month == 1 && year == 200 && rtc_leap_year_support == RTC_4_YEAR_LEAP_YEAR_SUPPORT) {
+                            day = 29;
+                        }
+
+                        break;
+
+                    default:
+                        break;
+                }
+
+                tm time_info = make_time_info(year, month, day, 23, dayid ? 59 : 0, dayid ? 59 : 0);
+
+                time_t actual_timestamp;
+
+                TEST_ASSERT_TRUE(_rtc_maketime(&time_info, &actual_timestamp, rtc_leap_year_support));
+
+                greentea_send_kv("timestamp", (int) actual_timestamp);
+
+                greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+
+                TEST_ASSERT_EQUAL_STRING("passed", _key);
+
+                /* Response which indicates success contains encoded week day
+                 * and year day needed to verify _rtc_localtime().
+                 * Use validated timestamp to generate and validate calendar time.
+                 */
+
+                unsigned int buf = (unsigned int) strtol(_value, NULL, 10);
+
+                time_info.tm_wday = ((buf >> 16) & 0x0000FFFF);
+                time_info.tm_yday = (buf & 0x0000FFFF);
+
+                tm actual_time_info;
+
+                bool result = _rtc_localtime((time_t) actual_timestamp, &actual_time_info, rtc_leap_year_support);
+
+                TEST_ASSERT_TRUE(result);
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_sec, actual_time_info.tm_sec, "invalid seconds");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_min, actual_time_info.tm_min, "invalid minutes");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_hour, actual_time_info.tm_hour, "invalid hours");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_mday, actual_time_info.tm_mday, "invalid day");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_mon, actual_time_info.tm_mon, "invalid month");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_year, actual_time_info.tm_year, "invalid year");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_wday, actual_time_info.tm_wday, "invalid weekday");
+                TEST_ASSERT_EQUAL_UINT32_MESSAGE(time_info.tm_yday, actual_time_info.tm_yday, "invalid year day");
+            }
+        }
+    }
+}
+
+utest::v1::status_t full_leap_year_case_setup_handler_t(const Case * const source, const size_t index_of_case)
+{
+    rtc_leap_year_support = RTC_FULL_LEAP_YEAR_SUPPORT;
+
+    return greentea_case_setup_handler(source, index_of_case);
+}
+
+utest::v1::status_t partial_leap_year_case_setup_handler_t(const Case * const source, const size_t index_of_case)
+{
+    rtc_leap_year_support = RTC_4_YEAR_LEAP_YEAR_SUPPORT;
+
+    return greentea_case_setup_handler(source, index_of_case);
+}
+
+utest::v1::status_t teardown_handler_t(const Case * const source, const size_t passed, const size_t failed,
+        const failure_t reason)
+{
+    return greentea_case_teardown_handler(source, passed, failed, reason);
+}
+
+// Test cases
+Case cases[] ={
+   Case("test make time and local time - RTC leap years full support", full_leap_year_case_setup_handler_t, test_case_mktime_localtime, teardown_handler_t),
+   Case("test make time and local time - RTC leap years partial support", partial_leap_year_case_setup_handler_t, test_case_mktime_localtime, teardown_handler_t),
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(300, "rtc_calc_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main()
+{
+    Harness::run(specification);
+}

--- a/platform/mbed_mktime.c
+++ b/platform/mbed_mktime.c
@@ -16,14 +16,17 @@
 
 #include "mbed_mktime.h"
 
-/*
- * time constants 
- */
+/* Time constants. */
 #define SECONDS_BY_MINUTES 60
 #define MINUTES_BY_HOUR 60
 #define SECONDS_BY_HOUR (SECONDS_BY_MINUTES * MINUTES_BY_HOUR)
 #define HOURS_BY_DAY 24 
 #define SECONDS_BY_DAY (SECONDS_BY_HOUR * HOURS_BY_DAY)
+#define LAST_VALID_YEAR 206
+
+/* Macros which will be used to determine if we are within valid range. */
+#define EDGE_TIMESTAMP_FULL_LEAP_YEAR_SUPPORT 3220095     // 7th of February 1970 at 06:28:15
+#define EDGE_TIMESTAMP_4_YEAR_LEAP_YEAR_SUPPORT 3133695  // 6th of February 1970 at 06:28:15
 
 /*
  * 2 dimensional array containing the number of seconds elapsed before a given 
@@ -63,10 +66,10 @@ static const uint32_t seconds_before_month[2][12] = {
     }
 };
 
-bool _rtc_is_leap_year(int year) {
+bool _rtc_is_leap_year(int year, rtc_leap_year_support_t leap_year_support) {
     /* 
      * since in practice, the value manipulated by this algorithm lie in the 
-     * range [70 : 138], the algorith can be reduced to: year % 4.
+     * range: [70 : 206] the algorithm can be reduced to: year % 4 with exception for 200 (year 2100 is not leap year).
      * The algorithm valid over the full range of value is: 
 
         year = 1900 + year;
@@ -80,86 +83,108 @@ bool _rtc_is_leap_year(int year) {
         return true;
 
      */ 
+    if (leap_year_support == RTC_FULL_LEAP_YEAR_SUPPORT && year == 200) {
+        return false; // 2100 is not a leap year
+    }
+
     return (year) % 4 ? false : true;
 }
 
-time_t _rtc_mktime(const struct tm* time) {
-    // partial check for the upper bound of the range
-    // normalization might happen at the end of the function 
-    // this solution is faster than checking if the input is after the 19th of 
-    // january 2038 at 03:14:07.  
-    if ((time->tm_year < 70) || (time->tm_year > 138)) { 
-        return ((time_t) -1);
+bool _rtc_maketime(const struct tm* time, time_t * seconds, rtc_leap_year_support_t leap_year_support) {
+    if (seconds == NULL || time == NULL) {
+        return false;
+    }
+
+    /* Partial check for the upper bound of the range - check years only. Full check will be performed after the
+     * elapsed time since the beginning of the year is calculated.
+     */
+    if ((time->tm_year < 70) || (time->tm_year > LAST_VALID_YEAR)) {
+        return false;
     }
 
     uint32_t result = time->tm_sec;
     result += time->tm_min * SECONDS_BY_MINUTES;
     result += time->tm_hour * SECONDS_BY_HOUR;
     result += (time->tm_mday - 1) * SECONDS_BY_DAY;
-    result += seconds_before_month[_rtc_is_leap_year(time->tm_year)][time->tm_mon];
+    result += seconds_before_month[_rtc_is_leap_year(time->tm_year, leap_year_support)][time->tm_mon];
+
+    /* Check if we are within valid range. */
+    if (time->tm_year == LAST_VALID_YEAR) {
+        if ((leap_year_support == RTC_FULL_LEAP_YEAR_SUPPORT && result > EDGE_TIMESTAMP_FULL_LEAP_YEAR_SUPPORT) ||
+            (leap_year_support == RTC_4_YEAR_LEAP_YEAR_SUPPORT && result > EDGE_TIMESTAMP_4_YEAR_LEAP_YEAR_SUPPORT)) {
+        return false;
+        }
+    }
 
     if (time->tm_year > 70) { 
-        // valid in the range [70:138] 
+        /* Valid in the range [70:206]. */
         uint32_t count_of_leap_days = ((time->tm_year - 1) / 4) - (70 / 4);
+        if (leap_year_support == RTC_FULL_LEAP_YEAR_SUPPORT) {
+            if (time->tm_year > 200) {
+                count_of_leap_days--; // 2100 is not a leap year
+            }
+        }
+
         result += (((time->tm_year - 70) * 365) + count_of_leap_days) * SECONDS_BY_DAY;
     }
 
-    if (result > INT32_MAX) { 
-        return (time_t) -1;
-    }
+    *seconds = result;
 
-    return result;
+    return true;
 }
 
-bool _rtc_localtime(time_t timestamp, struct tm* time_info) {
-    if (((int32_t) timestamp) < 0) { 
+bool _rtc_localtime(time_t timestamp, struct tm* time_info, rtc_leap_year_support_t leap_year_support) {
+    if (time_info == NULL) {
         return false;
-    } 
+    }
 
-    time_info->tm_sec = timestamp % 60;
-    timestamp = timestamp / 60;   // timestamp in minutes
-    time_info->tm_min = timestamp % 60;
-    timestamp = timestamp / 60;  // timestamp in hours
-    time_info->tm_hour = timestamp % 24;
-    timestamp = timestamp / 24;  // timestamp in days;
+    uint32_t seconds = (uint32_t)timestamp;
 
-    // compute the weekday
-    // The 1st of January 1970 was a Thursday which is equal to 4 in the weekday
-    // representation ranging from [0:6]
-    time_info->tm_wday = (timestamp + 4) % 7;
+    time_info->tm_sec = seconds % 60;
+    seconds = seconds / 60;   // timestamp in minutes
+    time_info->tm_min = seconds % 60;
+    seconds = seconds / 60;  // timestamp in hours
+    time_info->tm_hour = seconds % 24;
+    seconds = seconds / 24;  // timestamp in days;
 
-    // years start at 70
+    /* Compute the weekday.
+     * The 1st of January 1970 was a Thursday which is equal to 4 in the weekday representation ranging from [0:6].
+     */
+    time_info->tm_wday = (seconds + 4) % 7;
+
+    /* Years start at 70. */
     time_info->tm_year = 70;
     while (true) { 
-        if (_rtc_is_leap_year(time_info->tm_year) && timestamp >= 366) {
+        if (_rtc_is_leap_year(time_info->tm_year, leap_year_support) && seconds >= 366) {
             ++time_info->tm_year;
-            timestamp -= 366;
-        } else if (!_rtc_is_leap_year(time_info->tm_year) && timestamp >= 365) {
+            seconds -= 366;
+        } else if (!_rtc_is_leap_year(time_info->tm_year, leap_year_support) && seconds >= 365) {
             ++time_info->tm_year;
-            timestamp -= 365;
+            seconds -= 365;
         } else {
-            // the remaining days are less than a years
+            /* The remaining days are less than a years. */
             break;
         }
     }
 
-    time_info->tm_yday = timestamp;
+    time_info->tm_yday = seconds;
 
-    // convert days into seconds and find the current month
-    timestamp *= SECONDS_BY_DAY;
+    /* Convert days into seconds and find the current month. */
+    seconds *= SECONDS_BY_DAY;
     time_info->tm_mon = 11;
-    bool leap = _rtc_is_leap_year(time_info->tm_year);
+    bool leap = _rtc_is_leap_year(time_info->tm_year, leap_year_support);
     for (uint32_t i = 0; i < 12; ++i) {
-        if ((uint32_t) timestamp < seconds_before_month[leap][i]) {
+        if ((uint32_t) seconds < seconds_before_month[leap][i]) {
             time_info->tm_mon = i - 1;
             break;
         }
     }
 
-    // remove month from timestamp and compute the number of days.
-    // note: unlike other fields, days are not 0 indexed.
-    timestamp -= seconds_before_month[leap][time_info->tm_mon];
-    time_info->tm_mday = (timestamp / SECONDS_BY_DAY) + 1;
+    /* Remove month from timestamp and compute the number of days.
+     * Note: unlike other fields, days are not 0 indexed.
+     */
+    seconds -= seconds_before_month[leap][time_info->tm_mon];
+    time_info->tm_mday = (seconds / SECONDS_BY_DAY) + 1;
 
     return true;
 }

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/rtc_api.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/rtc_api.c
@@ -71,7 +71,11 @@ time_t rtc_read(void)
     timeinfo.tm_year = (ul_year - 1900);
 
     /* Convert to timestamp */
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
+
     return t;
 }
 
@@ -81,8 +85,9 @@ void rtc_write(time_t t)
         /* Initialize the RTC is not yet initialized */
         rtc_init();
     }
+
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
     uint32_t ul_hour, ul_minute, ul_second;

--- a/targets/TARGET_NUVOTON/TARGET_M451/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/rtc_api.c
@@ -94,7 +94,10 @@ time_t rtc_read(void)
     timeinfo.tm_sec  = rtc_datetime.u32Second;
 
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
 
     return t;
 }
@@ -104,10 +107,10 @@ void rtc_write(time_t t)
     if (! rtc_isenabled()) {
         rtc_init();
     }
-    
+
     // Convert timestamp to struct tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
@@ -96,7 +96,10 @@ time_t rtc_read(void)
     timeinfo.tm_sec  = rtc_datetime.u32Second;
 
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
 
     return t;
 }
@@ -109,7 +112,7 @@ void rtc_write(time_t t)
 
     // Convert timestamp to struct tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/rtc_api.c
@@ -94,7 +94,10 @@ time_t rtc_read(void)
     timeinfo.tm_sec  = rtc_datetime.u32Second;
 
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
 
     return t;
 }
@@ -104,10 +107,10 @@ void rtc_write(time_t t)
     if (! rtc_isenabled()) {
         rtc_init();
     }
-    
+
     // Convert timestamp to struct tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
@@ -94,7 +94,10 @@ time_t rtc_read(void)
     timeinfo.tm_sec  = rtc_datetime.u32Second;
 
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
 
     return t;
 }
@@ -104,10 +107,10 @@ void rtc_write(time_t t)
     if (! rtc_isenabled()) {
         rtc_init();
     }
-    
+
     // Convert timestamp to struct tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
 

--- a/targets/TARGET_NXP/TARGET_LPC176X/rtc_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/rtc_api.c
@@ -89,7 +89,10 @@ time_t rtc_read(void) {
     timeinfo.tm_year = LPC_RTC->YEAR - 1900;
     
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
     
     return t;
 }
@@ -97,10 +100,10 @@ time_t rtc_read(void) {
 void rtc_write(time_t t) {
     // Convert the time in to a tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
-    
+
     // Pause clock, and clear counter register (clears us count)
     LPC_RTC->CCR |= 2;
     

--- a/targets/TARGET_NXP/TARGET_LPC408X/rtc_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/rtc_api.c
@@ -88,7 +88,10 @@ time_t rtc_read(void) {
     timeinfo.tm_year = LPC_RTC->YEAR - 1900;
     
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
     
     return t;
 }
@@ -96,10 +99,10 @@ time_t rtc_read(void) {
 void rtc_write(time_t t) {
     // Convert the time in to a tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
-    
+
     // Pause clock, and clear counter register (clears us count)
     LPC_RTC->CCR |= 2;
     

--- a/targets/TARGET_NXP/TARGET_LPC43XX/rtc_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/rtc_api.c
@@ -102,7 +102,10 @@ time_t rtc_read(void) {
     timeinfo.tm_year = LPC_RTC->TIME[RTC_TIMETYPE_YEAR] - 1900;
     
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
     
     return t;
 }
@@ -110,10 +113,10 @@ time_t rtc_read(void) {
 void rtc_write(time_t t) {
     // Convert the time in to a tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
-    
+
     // Pause clock, and clear counter register (clears us count)
     LPC_RTC->CCR |= 2;
     

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/rtc_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/rtc_api.c
@@ -308,6 +308,7 @@ void rtc_write(time_t t) {
     if (_rtc_localtime(t, &timeinfo) == false) {
         return;
     }
+
     volatile uint16_t dummy_read;
 
     if (rtc_isenabled() != 0) {

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/rtc_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/rtc_api.c
@@ -70,7 +70,7 @@
 #define SHIFT_1BYTE      (8u)
 #define SHIFT_2BYTE      (16u)
 
-#define TIME_ERROR_VAL   (0xFFFFFFFFu)
+#define TIME_ERROR_VAL   (0u)
 
 static int rtc_dec8_to_hex(uint8_t dec_val, uint8_t offset, int *hex_val);
 static int rtc_dec16_to_hex(uint16_t dec_val, uint16_t offset, int *hex_val);
@@ -248,7 +248,9 @@ time_t rtc_read(void) {
 
     if (err == 0) {
         // Convert to timestamp
-        t = _rtc_mktime(&timeinfo);
+        if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
+            return TIME_ERROR_VAL;
+        }
     } else {
         // Error
         t = TIME_ERROR_VAL;
@@ -339,9 +341,10 @@ static int rtc_dec16_to_hex(uint16_t dec_val, uint16_t offset, int *hex_val) {
 void rtc_write(time_t t) {
 
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
+
     volatile uint16_t dummy_read;
 
     if (rtc_isenabled() != 0) {

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -241,7 +241,10 @@ time_t rtc_read(void)
     timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
-    time_t t = _rtc_mktime(&timeinfo);
+    time_t t;
+    if (_rtc_maketime(&timeinfo, &t, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
+        return 0;
+    }
 
     return t;
 }
@@ -255,7 +258,7 @@ void rtc_write(time_t t)
 
     // Convert the time into a tm
     struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo) == false) {
+    if (_rtc_localtime(t, &timeinfo, RTC_4_YEAR_LEAP_YEAR_SUPPORT) == false) {
         return;
     }
 


### PR DESCRIPTION
## Description
Add support for extended RTC.
Add tests for extended RTC.

Provide support to use whole 32-bit range (unsigned int) to hold time since UNIX epoch.
The supported time range is now from the 1st of January 1970 at 00:00:00 to the 7th of February 2106 at 06:28:15.
Add support for two types of RTC devices:
- RTCs which handles all leap years in the mentioned year range correctly. Leap year is determined by checking if the year counter value is divisible by 400, 100, and 4.
- RTCs which handles leap years correctly up to 2100. The RTC does a simple bit comparison to see if the two lowest order bits of the year counter are zero. In this case 2100 year will be considered incorrectly as a leap year, so the last valid point in time will be 28.02.2100 23:59:59 and next day will be 29.02.2100 (invalid). So after 28.02.2100 the day counter will be off by a day.

## Status
READY


## Migrations
YES

Modified API of _rtc_is_leap_year(), _rtc_mktime(), _rtc_localtime() functions.
Renamed _rtc_mktime() to _rtc_maketime().

Each function has additional parameter which informs if function is used for RTC which provides full leap year detection or not.