### PR TITLE
mail test: fix out of memory problem for NUCLEO_F070RB

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -25,7 +25,7 @@
 
 using namespace utest::v1;
 
-#define THREAD_STACK_SIZE   384 /* larger stack cause out of memory on some 16kB RAM boards in multi thread test*/
+#define THREAD_STACK_SIZE   320 /* larger stack cause out of heap memory on some 16kB RAM boards in multi thread test*/
 #define QUEUE_SIZE          16
 #define THREAD_1_ID         1
 #define THREAD_2_ID         2


### PR DESCRIPTION
## Description
This test cause out of memory error ("Operator new[] out of memory") when run on NUCLEO_F070RB with GCC_ARM compiler

Thread stack was changed from 384B to 320B to reduce heap usage


## Status
**READY**


## Migrations
NO