### PR TITLE
semaphore test: fix out of memory problem for NUCLEO_F070RB

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -30,7 +30,7 @@ using namespace utest::v1;
 #define SEM_CHANGES      100
 #define SHORT_WAIT       5
 
-#define THREAD_STACK_SIZE 512
+#define THREAD_STACK_SIZE 320 /* larger stack cause out of heap memory on some 16kB RAM boards in multi thread test*/
 
 Semaphore two_slots(SEMAPHORE_SLOTS);
 


### PR DESCRIPTION
## Description
This test cause out of memory error ("Operator new[] out of memory") when run on NUCLEO_F070RB with GCC_ARM compiler

Thread stack was changed from 512B to 320B to reduce heap usage


## Status
**READY**


## Migrations
NO