### PR TITLE
race test: fix out of memory problem for NUCLEO_F070RB

### DIFF
--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -68,21 +68,18 @@ static void main_class_race()
 void test_case_func_race()
 {
     Callback<void()> cb(main_func_race);
-    Thread *t1 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
-    Thread *t2 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
+    Thread t1(osPriorityNormal, TEST_STACK_SIZE);
+    Thread t2(osPriorityNormal, TEST_STACK_SIZE);
 
     // Start start first thread
-    t1->start(cb);
+    t1.start(cb);
     // Start second thread while the first is inside the constructor
     Thread::wait(250);
-    t2->start(cb);
+    t2.start(cb);
 
     // Wait for the threads to finish
-    t1->join();
-    t2->join();
-
-    delete t1;
-    delete t2;
+    t1.join();
+    t2.join();
 
     TEST_ASSERT_EQUAL_UINT32(1, instance_count);
 
@@ -93,21 +90,18 @@ void test_case_func_race()
 void test_case_class_race()
 {
     Callback<void()> cb(main_class_race);
-    Thread *t1 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
-    Thread *t2 = new Thread(osPriorityNormal, TEST_STACK_SIZE);
+    Thread t1(osPriorityNormal, TEST_STACK_SIZE);
+    Thread t2(osPriorityNormal, TEST_STACK_SIZE);
 
     // Start start first thread
-    t1->start(cb);
+    t1.start(cb);
     // Start second thread while the first is inside the constructor
     Thread::wait(250);
-    t2->start(cb);
+    t2.start(cb);
 
     // Wait for the threads to finish
-    t1->join();
-    t2->join();
-
-    delete t1;
-    delete t2;
+    t1.join();
+    t2.join();
 
     TEST_ASSERT_EQUAL_UINT32(1, instance_count);
 


### PR DESCRIPTION
## Description
This test cause out of memory error ("Operator new[] out of memory") when run on NUCLEO_F070RB with GCC_ARM compiler

Since there is no need to place `Thread` objects on heap, it was moved from heap to main stack.
In the result more heap memory is available for test purpose and "out of memory" problem doesn't occur anymore


## Status
**READY**


## Migrations
NO