### PR TITLE
SlicingBD: replace second constructor with default parameter

### DIFF
--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -17,17 +17,6 @@
 #include "SlicingBlockDevice.h"
 
 
-SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start)
-    : _bd(bd)
-    , _start_from_end(false), _start(start)
-    , _stop_from_end(true), _stop(0)
-{
-    if ((int64_t)_start < 0) {
-        _start_from_end = true;
-        _start = -_start;
-    }
-}
-
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t stop)
     : _bd(bd)
     , _start_from_end(false), _start(start)
@@ -38,7 +27,7 @@ SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr
         _start = -_start;
     }
 
-    if ((int64_t)_stop < 0) {
+    if ((int64_t)_stop <= 0) {
         _stop_from_end = true;
         _stop = -_stop;
     }

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -54,20 +54,12 @@ public:
      *  @param bd       Block device to back the SlicingBlockDevice
      *  @param start    Start block address to map to block 0, negative addresses
      *                  are calculated from the end of the underlying block device
-     *  @note This is the same as SlicingBlockDevice(bd, start, bd->size())
-     */
-    SlicingBlockDevice(BlockDevice *bd, bd_addr_t start);
-
-    /** Lifetime of the memory block device
-     *
-     *  @param bd       Block device to back the SlicingBlockDevice
-     *  @param start    Start block address to map to block 0, negative addresses
-     *                  are calculated from the end of the underlying block device
      *  @param end      End block address to mark the end of the block device,
      *                  this block is not mapped, negative addresses are
-     *                  calculated from the end of the underlying block device
+     *                  calculated from the end of the underlying block device.
+     *                  The default stops at end of the underlying block device.
      */
-    SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t end);
+    SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t end = 0);
 
     /** Lifetime of a block device
      */


### PR DESCRIPTION
Slightly simplifies the SlicingBlockDevice constructor setup. Example in the header still works correctly.

@geky 
