### PR TITLE
ncs36510: fire interrupt correct timer fix

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
@@ -130,7 +130,8 @@ uint32_t us_ticker_read()
 
 void us_ticker_fire_interrupt(void)
 {
-    NVIC_SetPendingIRQ(Tim0_IRQn);
+    us_ticker_target = 0;
+    NVIC_SetPendingIRQ(Tim1_IRQn);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Use Timer1, it is used for us ticker isr handling. Plus reset target counter,
that should be 0, go to upper ticker isr handler immediately.

Found during #5307

cc @maciejbocianski @danclement @jacobjohnson-ON 