### PR TITLE
Deprecate CallChain and InterruptManager

### DIFF
--- a/drivers/InterruptManager.cpp
+++ b/drivers/InterruptManager.cpp
@@ -16,6 +16,12 @@
 #include "cmsis.h"
 #if defined(NVIC_NUM_VECTORS)
 
+// Suppress deprecation warnings since this whole
+// class is deprecated already
+#include "mbed_toolchain.h"
+#undef MBED_DEPRECATED_SINCE
+#define MBED_DEPRECATED_SINCE(...)
+
 #include "drivers/InterruptManager.h"
 #include "platform/mbed_critical.h"
 #include <string.h>

--- a/drivers/InterruptManager.h
+++ b/drivers/InterruptManager.h
@@ -60,10 +60,14 @@ public:
      *
      *  @return the only instance of this class
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     static InterruptManager* get();
 
     /** Destroy the current instance of the interrupt manager
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     static void destroy();
 
     /** Add a handler for an interrupt at the end of the handler list
@@ -74,6 +78,8 @@ public:
      *  @returns
      *  The function object created for 'function'
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add_handler(void (*function)(void), IRQn_Type irq) {
         // Underlying call is thread safe
         return add_common(function, irq);
@@ -87,6 +93,8 @@ public:
      *  @returns
      *  The function object created for 'function'
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add_handler_front(void (*function)(void), IRQn_Type irq) {
         // Underlying call is thread safe
         return add_common(function, irq, true);
@@ -102,6 +110,8 @@ public:
      *  The function object created for 'tptr' and 'mptr'
      */
     template<typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add_handler(T* tptr, void (T::*mptr)(void), IRQn_Type irq) {
         // Underlying call is thread safe
         return add_common(tptr, mptr, irq);
@@ -117,6 +127,8 @@ public:
      *  The function object created for 'tptr' and 'mptr'
      */
     template<typename T>
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add_handler_front(T* tptr, void (T::*mptr)(void), IRQn_Type irq) {
         // Underlying call is thread safe
         return add_common(tptr, mptr, irq, true);
@@ -130,6 +142,8 @@ public:
      *  @returns
      *  true if the handler was found and removed, false otherwise
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     bool remove_handler(pFunctionPointer_t handler, IRQn_Type irq);
 
 private:

--- a/platform/CallChain.cpp
+++ b/platform/CallChain.cpp
@@ -1,3 +1,10 @@
+
+// Suppress deprecation warnings since this whole
+// class is deprecated already
+#include "mbed_toolchain.h"
+#undef MBED_DEPRECATED_SINCE
+#define MBED_DEPRECATED_SINCE(...)
+
 #include "platform/CallChain.h"
 #include "cmsis.h"
 #include "platform/mbed_critical.h"

--- a/platform/CallChain.h
+++ b/platform/CallChain.h
@@ -72,7 +72,12 @@ public:
      *
      *  @param size (optional) Initial size of the chain
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     CallChain(int size = 4);
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     virtual ~CallChain();
 
     /** Add a function at the end of the chain
@@ -82,6 +87,8 @@ public:
      *  @returns
      *  The function object created for 'func'
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add(Callback<void()> func);
 
     /** Add a function at the end of the chain
@@ -111,6 +118,8 @@ public:
      *  @returns
      *  The function object created for 'func'
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t add_front(Callback<void()> func);
 
     /** Add a function at the beginning of the chain
@@ -135,6 +144,8 @@ public:
 
     /** Get the number of functions in the chain
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     int size() const;
 
     /** Get a function object from the chain
@@ -144,6 +155,8 @@ public:
      *  @returns
      *  The function object at position 'i' in the chain
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t get(int i) const;
 
     /** Look for a function object in the call chain
@@ -153,10 +166,14 @@ public:
      *  @returns
      *  The index of the function object if found, -1 otherwise.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     int find(pFunctionPointer_t f) const;
 
     /** Clear the call chain (remove all functions in the chain).
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     void clear();
 
     /** Remove a function object from the chain
@@ -166,15 +183,24 @@ public:
      *  @returns
      *  true if the function object was found and removed, false otherwise.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     bool remove(pFunctionPointer_t f);
 
     /** Call all the functions in the chain in sequence
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     void call();
 
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     void operator ()(void) {
         call();
     }
+
+    MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
+        "public API of mbed-os and is being removed in the future.")
     pFunctionPointer_t operator [](int i) const {
         return get(i);
     }


### PR DESCRIPTION
Deprecate the CallChain and InterruptManager classes since these are dead code which is not part of mbed-os's public API.
