### PR TITLE
ONSEMI: Fix a few issues related to I2C

### DIFF
--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c.h
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c.h
@@ -48,7 +48,6 @@
 #define I2C_SPEED_400K_AT_8MHZ     (uint8_t)0x03
 #define I2C_SPEED_400K_AT_16MHZ    (uint8_t)0x08
 
-
 /* I2C commands */
 #define I2C_CMD_NULL          0x00
 #define I2C_CMD_WDAT0         0x10
@@ -93,7 +92,10 @@
 #define I2C_API_STATUS_SUCCESS    0
 #define PAD_REG_ADRS_BYTE_SIZE    4
 
-#define SEND_COMMAND(cmd)  while(!I2C_FIFO_EMPTY); wait_us(1); obj->membase->CMD_REG = cmd;
+// The wait_us(0) command is needed so the I2C state machines have enough
+// time for data to settle across all clock domain crossings in their
+// synchronizers, both directions.
+#define SEND_COMMAND(cmd) wait_us(0); obj->membase->CMD_REG = cmd; wait_us(0);
 
 /** Init I2C device.
  * @details

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/i2c_api.c
@@ -169,9 +169,7 @@ int i2c_byte_write(i2c_t *obj, int data)
         return Count;
     }
 
-    while(obj->membase->STATUS.WORD & I2C_STATUS_CMD_FIFO_OFL_BIT); /* Wait till command overflow ends */
-
-    if(obj->membase->STATUS.WORD & I2C_STATUS_BUS_ERR_BIT) {
+    if(I2C_BUS_ERR_CHECK) {
         /* Bus error means NAK received */
         return 0;
     } else {


### PR DESCRIPTION
Three main issues were found and corrected:
1) The 0x13 special case section in write data in ncs36510_i2c.c didn't have a write++ command.
2) In the same write function, the WDAT8 command was put before the 0x13 section and this is not correct
3) Needed to add wait_us(0) before and after the register writes for apparent clock domain crossing delay times until registers are stable in HW

There were also a handful of other tweaks related to general code maintenance and moving some status register checks to the proper locations.

## Description
This pull request addresses some I2C issues that were found by CI test shield and by a customer.  This pull request solves #5007 and #3511.

## Status
Fully tested by extensive ON Semiconductor tests based on CI test shield hardware as well as fully verified on CI test shield with CI test shield tests for I2C.

@jacobjohnson-ON 
@maclobdell 