### PR TITLE
Beetle BLE: Fix variable length GATT attribute

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_ARM_SSG/TARGET_BEETLE/source/ArmGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_ARM_SSG/TARGET_BEETLE/source/ArmGattServer.cpp
@@ -130,6 +130,9 @@ ble_error_t ArmGattServer::addService(GattService &service)
         currAtt->pLen = p_char->getValueAttribute().getLengthPtr();
         currAtt->maxLen = p_char->getValueAttribute().getMaxLength();
         currAtt->settings = ATTS_SET_WRITE_CBACK | ATTS_SET_READ_CBACK;
+        if (p_char->getValueAttribute().hasVariableLength()) {
+            currAtt->settings |= ATTS_SET_VARIABLE_LEN;
+        }
         if (p_char->getValueAttribute().getUUID().shortOrLong() == UUID::UUID_TYPE_LONG) {
             currAtt->settings |= ATTS_SET_UUID_128;
         }


### PR DESCRIPTION
## Description
Variable length flag was lost during attribute settings,
so variable length GATT attributes should have been set
to the predefined maximum length.
This fixes issue #86.