### PR TITLE
STM32: Ethernet: Workaround for STM32_F767 revA

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
@@ -46,6 +46,9 @@ static sys_mutex_t tx_lock_mutex;
 /* function */
 static void _eth_arch_rx_task(void *arg);
 static void _eth_arch_phy_task(void *arg);
+#if defined (TARGET_NUCLEO_F767ZI)
+static void _rmii_watchdog(void *arg);
+#endif
 
 #if LWIP_IPV4
 static err_t _eth_arch_netif_output_ipv4(struct netif *netif, struct pbuf *q, const ip4_addr_t *ipaddr);
@@ -372,6 +375,35 @@ static void _eth_arch_phy_task(void *arg)
     }
 }
 
+#if defined (TARGET_NUCLEO_F767ZI)
+/**
+ * workaround for the ETH RMII bug in STM32F769 Cut1.0
+ *
+ * \param[in] netif the lwip network interface structure
+ */
+static void _rmii_watchdog(void *arg)
+{
+    while(1) {
+        /* some good packets are received */
+        if (EthHandle.Instance->MMCRGUFCR > 0) {
+            /* RMII Init is OK - would need service to terminate or suspend
+             * the thread */
+            while(1) {
+                /*  don't do anything anymore */
+                osDelay(0xFFFFFFFF);
+            }
+        } else if (EthHandle.Instance->MMCRFCECR > 10) {
+            /* ETH received too many packets with CRC errors, resetting RMII */
+            SYSCFG->PMC &= ~SYSCFG_PMC_MII_RMII_SEL;
+            SYSCFG->PMC |= SYSCFG_PMC_MII_RMII_SEL;
+            EthHandle.Instance->MMCCR |= ETH_MMCCR_CR;
+        } else {
+            osDelay(100);
+        }
+    }
+}
+#endif
+
 /**
  * This function is the ethernet IPv4 packet send function. It calls
  * etharp_output after checking link status.
@@ -464,6 +496,10 @@ err_t eth_arch_enetif_init(struct netif *netif)
 
     /* initialize the hardware */
     _eth_arch_low_level_init(netif);
+
+#if defined (TARGET_NUCLEO_F767ZI)
+    sys_thread_new("stm32_rmii_watchdog", _rmii_watchdog, netif, DEFAULT_THREAD_STACKSIZE, osPriorityLow);
+#endif
 
     return ERR_OK;
 }


### PR DESCRIPTION
## Description

This is a proposed fix to #5294

On STM32 F767 rev A devices ,Ethernet peripheral had problems on RMII
interface, on MII this was not the case.

This commits implements a tentative workaround for the issue rerfered to
as Ethernet erroneous data received in RMII configuration in the Errata
sheet below:
http://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/23/a6/11/0b/30/24/46/a5/DM00257543/files/DM00257543.pdf/jcr:content/translations/en.DM00257543.pdf

Note that the issue has been fixed in 'Z' revision. of STM32 F767 MCUs.

## Status
**READY**


## Todos
- [x] Tests
```
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
| target                | platform_name | test suite                                                   | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 21.78              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 22.28              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 20.92              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 24.35              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.47              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 20.67              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 30.15              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 31.61              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 28.84              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 22.82              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 27.44              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 30.33              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 22.45              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 20.83              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 23.21              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 38.08              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 22.31              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 26.47              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 22.53              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 23.81              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 34.37              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 26.83              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 23.65              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 37.36              | default     |
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 24 OK

```