### PR TITLE
CriticalSectionLock class improvement

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -89,6 +89,7 @@
 #include "platform/FileSystemHandle.h"
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
+#include "platform/ScopedLock.h"
 #include "platform/CriticalSectionLock.h"
 #include "platform/DeepSleepLock.h"
 

--- a/platform/ScopedLock.h
+++ b/platform/ScopedLock.h
@@ -1,0 +1,87 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_SCOPEDLOCK_H
+#define MBED_SCOPEDLOCK_H
+
+#include "platform/NonCopyable.h"
+
+namespace mbed {
+
+/** \addtogroup platform */
+/** @{*/
+/**
+ * \defgroup platform_ScopedLock ScopedLock functions
+ * @{
+ */
+
+/** RAII-style mechanism for owning a lock of Lockable object for the duration of a scoped block
+ *
+ * @tparam Lockable The type implementing BasicLockable concept
+ *
+ * @note For type Lockable to be BasicLockable the following conditions have to be satisfied:
+ *        - has public member function @a lock which blocks until a lock can be obtained for the current execution context
+ *        - has public member function @a unlock which releases the lock
+ *
+ * Usage:
+ *
+ * Example with rtos::Mutex
+ *
+ * @code
+ * void foo(Mutex &m) {
+ *     ScopedLock<Mutex> lock(m);
+ *     // Code in this block will be protected by Mutex lock
+ * }
+ * @endcode
+ *
+ *
+ * More generic example
+ *
+ * @code
+ * template<typename Lockable>
+ * void foo(Lockable& lockable) {
+ *     ScopedLock<Lockable> lock(lockable);
+ *     // Code in this block will run under lock
+ * }
+ * @endcode
+ */
+template <typename Lockable>
+class ScopedLock : private NonCopyable<ScopedLock<Lockable> > {
+public:
+    /** Locks given locable object
+     *
+     * @param lockable reference to the instance of Lockable object
+     * @note lockable object should outlive the ScopedLock object
+     */
+    ScopedLock(Lockable& lockable): _lockable(lockable)
+    {
+        _lockable.lock();
+    }
+
+    ~ScopedLock()
+    {
+        _lockable.unlock();
+    }
+private:
+    Lockable& _lockable;
+};
+
+/**@}*/
+
+/**@}*/
+
+} // embed
+
+#endif // MBED_SCOPEDLOCK_H

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -28,15 +28,30 @@
 #include "mbed_rtos_storage.h"
 
 #include "platform/NonCopyable.h"
+#include "platform/ScopedLock.h"
 
 namespace rtos {
 /** \addtogroup rtos */
 /** @{*/
+
+class Mutex;
+/** Typedef for the mutex lock
+ *
+ * Usage:
+ * @code
+ * void foo(Mutex &m) {
+ *     ScopedMutexLock lock(m);
+ *     // Code in this block will be protected by Mutex lock
+ * }
+ * @endcode
+ */
+typedef mbed::ScopedLock<Mutex> ScopedMutexLock;
+
 /**
  * \defgroup rtos_Mutex Mutex class
  * @{
  */
- 
+
 /** The Mutex class is used to synchronize the execution of threads.
  This is for example used to protect access to a shared resource.
 


### PR DESCRIPTION
## Description
Several improvements added to make it more versatile:
- creation in not locked state: to allow more meaningful `lock/unlock` usage (see example below)
- store lock state to prevent erroneous lock usage

```
{
   CriticalSectionLock cs(false);
   // some code here

   cs.lock();
      // Code in this block will run with interrupts disabled
   cs.unlock();
   // interrupts will be restored to their previous state

   cs.lock();
      // Code in this block will run with interrupts disabled
   cs.unlock();
   // interrupts will be restored to their previous state
}
```

## Status

**READY**

## Migrations
NO