### PR TITLE
Shrink RTOS classes

### DIFF
--- a/rtos/EventFlags.cpp
+++ b/rtos/EventFlags.cpp
@@ -39,11 +39,11 @@ EventFlags::EventFlags(const char *name)
 void EventFlags::constructor(const char *name)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    memset(&_attr, 0, sizeof(_attr));
-    _attr.name = name ? name : "application_unnamed_event_flags";
-    _attr.cb_mem = &_obj_mem;
-    _attr.cb_size = sizeof(_obj_mem);
-    _id = osEventFlagsNew(&_attr);
+    osEventFlagsAttr_t attr;
+    attr.name = name ? name : "application_unnamed_event_flags";
+    attr.cb_mem = &_obj_mem;
+    attr.cb_size = sizeof(_obj_mem);
+    _id = osEventFlagsNew(&attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/EventFlags.h
+++ b/rtos/EventFlags.h
@@ -90,7 +90,6 @@ private:
     void constructor(const char *name = NULL);
     uint32_t wait(uint32_t flags, uint32_t opt, uint32_t timeout, bool clear);
     osEventFlagsId_t                _id;
-    osEventFlagsAttr_t              _attr;
     mbed_rtos_storage_event_flags_t _obj_mem;
 };
 

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -50,12 +50,12 @@ public:
     MemoryPool() {
         memset(_pool_mem, 0, sizeof(_pool_mem));
         memset(&_obj_mem, 0, sizeof(_obj_mem));
-        memset(&_attr, 0, sizeof(_attr));
-        _attr.mp_mem = _pool_mem;
-        _attr.mp_size = sizeof(_pool_mem);
-        _attr.cb_mem = &_obj_mem;
-        _attr.cb_size = sizeof(_obj_mem);
-        _id = osMemoryPoolNew(pool_sz, sizeof(T), &_attr);
+        osMemoryPoolAttr_t attr = { 0 };
+        attr.mp_mem = _pool_mem;
+        attr.mp_size = sizeof(_pool_mem);
+        attr.cb_mem = &_obj_mem;
+        attr.cb_size = sizeof(_obj_mem);
+        _id = osMemoryPoolNew(pool_sz, sizeof(T), &attr);
         MBED_ASSERT(_id);
     }
 
@@ -95,7 +95,6 @@ public:
 
 private:
     osMemoryPoolId_t             _id;
-    osMemoryPoolAttr_t           _attr;
     /* osMemoryPoolNew requires that pool block size is a multiple of 4 bytes. */
     char                         _pool_mem[((sizeof(T) + 3) & ~3) * pool_sz];
     mbed_rtos_storage_mem_pool_t _obj_mem;

--- a/rtos/Mutex.cpp
+++ b/rtos/Mutex.cpp
@@ -40,12 +40,12 @@ Mutex::Mutex(const char *name)
 void Mutex::constructor(const char *name)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    memset(&_attr, 0, sizeof(_attr));
-    _attr.name = name ? name : "aplication_unnamed_mutex";
-    _attr.cb_mem = &_obj_mem;
-    _attr.cb_size = sizeof(_obj_mem);
-    _attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
-    _id = osMutexNew(&_attr);
+    osMutexAttr_t attr = { 0 };
+    attr.name = name ? name : "aplication_unnamed_mutex";
+    attr.cb_mem = &_obj_mem;
+    attr.cb_size = sizeof(_obj_mem);
+    attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
+    _id = osMutexNew(&attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -82,7 +82,6 @@ private:
     void constructor(const char *name = NULL);
 
     osMutexId_t               _id;
-    osMutexAttr_t             _attr;
     mbed_rtos_storage_mutex_t _obj_mem;
 };
 

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -51,12 +51,12 @@ public:
     /** Create and initialize a message Queue. */
     Queue() {
         memset(&_obj_mem, 0, sizeof(_obj_mem));
-        memset(&_attr, 0, sizeof(_attr));
-        _attr.mq_mem = _queue_mem;
-        _attr.mq_size = sizeof(_queue_mem);
-        _attr.cb_mem = &_obj_mem;
-        _attr.cb_size = sizeof(_obj_mem);
-        _id = osMessageQueueNew(queue_sz, sizeof(T*), &_attr);
+        osMessageQueueAttr_t attr = { 0 };
+        attr.mq_mem = _queue_mem;
+        attr.mq_size = sizeof(_queue_mem);
+        attr.cb_mem = &_obj_mem;
+        attr.cb_size = sizeof(_obj_mem);
+        _id = osMessageQueueNew(queue_sz, sizeof(T*), &attr);
         MBED_ASSERT(_id);
     }
 
@@ -115,7 +115,6 @@ public:
 
 private:
     osMessageQueueId_t            _id;
-    osMessageQueueAttr_t          _attr;
     char                          _queue_mem[queue_sz * (sizeof(T*) + sizeof(mbed_rtos_storage_message_t))];
     mbed_rtos_storage_msg_queue_t _obj_mem;
 };

--- a/rtos/RtosTimer.cpp
+++ b/rtos/RtosTimer.cpp
@@ -31,10 +31,10 @@ namespace rtos {
 void RtosTimer::constructor(mbed::Callback<void()> func, os_timer_type type) {
     _function = func;
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    memset(&_attr, 0, sizeof(_attr));
-    _attr.cb_mem = &_obj_mem;
-    _attr.cb_size = sizeof(_obj_mem);
-    _id = osTimerNew((void (*)(void *))Callback<void()>::thunk, type, &_function, &_attr);
+    osTimerAttr_t attr = { 0 };
+    attr.cb_mem = &_obj_mem;
+    attr.cb_size = sizeof(_obj_mem);
+    _id = osTimerNew((void (*)(void *))Callback<void()>::thunk, type, &_function, &attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -157,7 +157,6 @@ private:
     void constructor(mbed::Callback<void()> func, os_timer_type type);
 
     osTimerId_t _id;
-    osTimerAttr_t _attr;
     mbed_rtos_storage_timer_t _obj_mem;
     mbed::Callback<void()> _function;
 };

--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -36,10 +36,10 @@ Semaphore::Semaphore(int32_t count, uint16_t max_count) {
 
 void Semaphore::constructor(int32_t count, uint16_t max_count) {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    memset(&_attr, 0, sizeof(_attr));
-    _attr.cb_mem = &_obj_mem;
-    _attr.cb_size = sizeof(_obj_mem);
-    _id = osSemaphoreNew(max_count, count, &_attr);
+    osSemaphoreAttr_t attr = { 0 };
+    attr.cb_mem = &_obj_mem;
+    attr.cb_size = sizeof(_obj_mem);
+    _id = osSemaphoreNew(max_count, count, &attr);
     MBED_ASSERT(_id != NULL);
 }
 

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -71,7 +71,6 @@ private:
     void constructor(int32_t count, uint16_t max_count);
 
     osSemaphoreId_t               _id;
-    osSemaphoreAttr_t             _attr;
     mbed_rtos_storage_semaphore_t _obj_mem;
 };
 


### PR DESCRIPTION
Various RTOS classes were storing their CMSIS-RTOS creation attribute
structure as a member, when it's not required after construction. Reduce
memory by eliminating this member.
