### PR TITLE
STM32: Extend Ethernet RMII workaround

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_STM/stm32xx_emac.c
@@ -46,7 +46,8 @@ static sys_mutex_t tx_lock_mutex;
 /* function */
 static void _eth_arch_rx_task(void *arg);
 static void _eth_arch_phy_task(void *arg);
-#if defined (TARGET_NUCLEO_F767ZI)
+#if defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx)\
+    || defined (STM32F779xx)
 static void _rmii_watchdog(void *arg);
 #endif
 
@@ -375,9 +376,10 @@ static void _eth_arch_phy_task(void *arg)
     }
 }
 
-#if defined (TARGET_NUCLEO_F767ZI)
+#if defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx)\
+    || defined (STM32F779xx)
 /**
- * workaround for the ETH RMII bug in STM32F769 Cut1.0
+ * workaround for the ETH RMII bug in STM32F76x and STM32F77x revA
  *
  * \param[in] netif the lwip network interface structure
  */
@@ -497,7 +499,8 @@ err_t eth_arch_enetif_init(struct netif *netif)
     /* initialize the hardware */
     _eth_arch_low_level_init(netif);
 
-#if defined (TARGET_NUCLEO_F767ZI)
+#if defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx)\
+    || defined (STM32F779xx)
     sys_thread_new("stm32_rmii_watchdog", _rmii_watchdog, netif, DEFAULT_THREAD_STACKSIZE, osPriorityLow);
 #endif
 


### PR DESCRIPTION
to all applicable devices part of F77x/F76x series.

This is an extension of #5411 and covers a comment that was done but could not be corrected in time before merge.

## Status

**READY**

## TESTS
Verified ok on DISCO_F769NI and NUCLEO_F767ZI

```
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
| target                | platform_name | test suite                                                   | result | elapsed_time (sec) | copy_method |
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 35.51              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 19.83              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 20.33              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 23.88              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.51              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 20.05              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 22.29              | default     |
| DISCO_F769NI-ARM      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 31.32              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 21.53              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 20.15              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 35.8               | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 29.34              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.97              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 20.86              | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 23.2               | default     |
| DISCO_F769NI-GCC_ARM  | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 31.65              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 26.93              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 19.67              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 21.48              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 29.28              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 26.08              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 26.63              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 23.23              | default     |
| DISCO_F769NI-IAR      | DISCO_F769NI  | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 30.94              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 34.9               | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 19.8               | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 20.72              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 37.75              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.26              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 19.67              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 37.63              | default     |
| NUCLEO_F767ZI-ARM     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 36.96              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 21.84              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 20.0               | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 21.37              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 23.23              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.55              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 20.4               | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 23.21              | default     |
| NUCLEO_F767ZI-GCC_ARM | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 33.59              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-connectivity       | OK     | 20.84              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-gethostbyname      | OK     | 25.62              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo           | OK     | 21.37              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_echo_parallel  | OK     | 22.92              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-tcp_hello_world    | OK     | 20.29              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_dtls_handshake | OK     | 19.91              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo           | OK     | 25.52              | default     |
| NUCLEO_F767ZI-IAR     | NUCLEO_F767ZI | features-feature_lwip-tests-mbedmicro-net-udp_echo_parallel  | OK     | 37.63              | default     |
+-----------------------+---------------+--------------------------------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 48 OK
```
