### PR TITLE
fix TRUE/FALSE redefinition issue

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
@@ -125,7 +125,9 @@ typedef enum {
     // Button naming
     SW1 = PC_12,
     SW2 = PC_13,
-    
+
+    BUTTON1 = SW1,
+  
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
@@ -32511,8 +32511,13 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define NULL           (0)      ///< NULL pointer
 #endif
 
+#ifndef TRUE
 #define TRUE           (1)      ///< Boolean true, define to use in API parameters or return value
+#endif
+
+#ifndef FALSE
 #define FALSE          (0)      ///< Boolean false, define to use in API parameters or return value
+#endif
 
 #define ENABLE         (1)      ///< Enable, define to use in API parameters
 #define DISABLE        (0)      ///< Disable, define to use in API parameters


### PR DESCRIPTION
There is compile error when building NUVOTON NUC472 target.  TRUE/FALSE are complained redefined.