### PR TITLE
test: realtek net config default  to none

### DIFF
--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -8,7 +8,7 @@
         "test_configurations": ["ETHERNET"]
     },
     "REALTEK_RTL8195AM": {
-        "default_test_configuration": "REALTEK_WIFI",
+        "default_test_configuration": "NONE",
         "test_configurations": ["REALTEK_WIFI"]
     }
 }


### PR DESCRIPTION
Changing this to none as result of build failures. Wifi needs own configuration
per an enviroment. By setting this to none, net wifi tests are skipped for Realtek platform (skipped build, otherwise failures expected).

See https://github.com/ARMmbed/mbed-os/pull/5291 that enabled this. 

@SenRamakri @SeppoTakalo

Note for @adbridge @theotherjimmy We shall rerun CI prior the integration for changes that are at least a week older or more - to get uptodate results to avoid failures like this one (happens seldomly but happens)