### PR TITLE
Patch for an Uart issue in ISR

### DIFF
--- a/drivers/Serial.cpp
+++ b/drivers/Serial.cpp
@@ -57,7 +57,7 @@ int Serial::putc(int c) {
 	}
 	else
 	{
-		return _base_putc(c);
+        return _base_putc(c);
 	}
 }
 

--- a/drivers/Serial.cpp
+++ b/drivers/Serial.cpp
@@ -15,6 +15,7 @@
  */
 #include "drivers/Serial.h"
 #include "platform/mbed_wait_api.h"
+#include "platform/mbed_critical.h"
 
 #if DEVICE_SERIAL
 
@@ -36,12 +37,42 @@ int Serial::_putc(int c) {
     return _base_putc(c);
 }
 
+int Serial::getc() {
+    // Mutex is already held
+	if(!core_util_is_isr_active())
+	{
+        return Stream::getc();
+	}
+	else
+	{
+        return _base_getc();
+	}
+}
+
+int Serial::putc(int c) {
+    // Mutex is already held
+	if(!core_util_is_isr_active())
+	{
+        return Stream::putc(c);
+	}
+	else
+	{
+		return _base_putc(c);
+	}
+}
+
 void Serial::lock() {
-    _mutex.lock();
+	if(!core_util_is_isr_active())
+	{
+        _mutex.lock();
+	}
 }
 
 void Serial::unlock() {
-    _mutex.unlock();
+	if(!core_util_is_isr_active())
+	{
+        _mutex.unlock();
+	}
 }
 
 } // namespace mbed

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -98,8 +98,8 @@ public:
     {
         return SerialBase::writeable();
     }
-    virtual int getc();
-    virtual int putc(int c);
+    int getc();
+    int putc(int c);
 
 protected:
     virtual int _getc();

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -98,6 +98,8 @@ public:
     {
         return SerialBase::writeable();
     }
+    virtual int getc();
+    virtual int putc(int c);
 
 protected:
     virtual int _getc();

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -56,7 +56,7 @@ void SerialBase::format(int bits, Parity parity, int stop_bits) {
 int SerialBase::readable() {
     lock();
     int ret = 0;
-	ret = serial_readable(&_serial);
+    ret = serial_readable(&_serial);
     unlock();
     return ret;
 }
@@ -65,7 +65,7 @@ int SerialBase::readable() {
 int SerialBase::writeable() {
     lock();
     int ret = 0;
-	ret = serial_writable(&_serial);
+    ret = serial_writable(&_serial);
     unlock();
     return ret;
 }

--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -55,7 +55,8 @@ void SerialBase::format(int bits, Parity parity, int stop_bits) {
 
 int SerialBase::readable() {
     lock();
-    int ret = serial_readable(&_serial);
+    int ret = 0;
+	ret = serial_readable(&_serial);
     unlock();
     return ret;
 }
@@ -63,7 +64,8 @@ int SerialBase::readable() {
 
 int SerialBase::writeable() {
     lock();
-    int ret = serial_writable(&_serial);
+    int ret = 0;
+	ret = serial_writable(&_serial);
     unlock();
     return ret;
 }


### PR DESCRIPTION
## Description

Changes:
    1. SerialBase.cpp: the change of separating initialization of 'ret' is to avoid the compiler optimizing it. It is observed that on ublox EVK NINA-B1, 'ret' is always returning false as it has been optimized.
    2. Serial.cpp/Serial.h: the change is to avoid calling mutex lock/unlock and accessing file in ISR context.

    Note: there's risk that with this patch putc/getc will behave differently in ISR and non-ISR context. Further discussions required.
###         note:
           observed in ublox EVK NINA-B1: 
               **Mutex 0x20005690 error -6: Not allowed in ISR context** (occurred in Serial::lock() and Serial::unlock())
               **Error - reading from a file in an ISR or critical section** (occurred in Stream::getc() and Stream::putc() )

reference issue : https://github.com/ARMmbed/mbed-os/issues/4686

## Status

IN DEVELOPMENT

## Migrations

Serial class will have its own instance of putc() and getc() implementations.

## Todos

- [v] Tests

## Deploy notes

No changes required.

