### PR TITLE
NUMAKER_PFM: TRNG_Get() support 32 bytes unalignment

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/device/M480.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/M480.h
@@ -35908,8 +35908,12 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define NULL           (0)      ///< NULL pointer
 #endif
 
+#ifndef TRUE
 #define TRUE           (1UL)      ///< Boolean true, define to use in API parameters or return value
+#endif
+#ifndef FALSE
 #define FALSE          (0UL)      ///< Boolean false, define to use in API parameters or return value
+#endif
 
 #define ENABLE         (1UL)      ///< Enable, define to use in API parameters
 #define DISABLE        (0UL)      ///< Disable, define to use in API parameters

--- a/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
@@ -77,10 +77,10 @@ void trng_free(trng_t *obj)
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
     (void)obj;
-
+    unsigned char tmpBuff[32];
+        
     *output_length = 0;
     if (length < 32) {
-        unsigned char tmpBuff[32];
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, length);
         *output_length = length;
@@ -89,6 +89,11 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
             trng_get(output);
             *output_length += 32;
             output += 32;
+        }     
+        if( length > *output_length ) {
+            trng_get(tmpBuff);
+            memcpy(output, &tmpBuff, (length - *output_length));
+            *output_length = length;
         }
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/Nano100Series.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/Nano100Series.h
@@ -11831,8 +11831,12 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define NULL           (0)      ///< NULL pointer
 #endif
 
+#ifndef TRUE
 #define TRUE           (1)      ///< Boolean true, define to use in API parameters or return value
+#endif
+#ifndef FALSE
 #define FALSE          (0)      ///< Boolean false, define to use in API parameters or return value
+#endif
 
 #define ENABLE         (1)      ///< Enable, define to use in API parameters
 #define DISABLE        (0)      ///< Disable, define to use in API parameters

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
@@ -32511,8 +32511,12 @@ typedef volatile unsigned long  vu32;       ///< Define 32-bit unsigned volatile
 #define NULL           (0)      ///< NULL pointer
 #endif
 
+#ifndef TRUE
 #define TRUE           (1)      ///< Boolean true, define to use in API parameters or return value
+#endif
+#ifndef FALSE
 #define FALSE          (0)      ///< Boolean false, define to use in API parameters or return value
+#endif
 
 #define ENABLE         (1)      ///< Enable, define to use in API parameters
 #define DISABLE        (0)      ///< Disable, define to use in API parameters

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
@@ -82,18 +82,23 @@ void trng_free(trng_t *obj)
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
     (void)obj;
-
+    unsigned char tmpBuff[32];
+        
     *output_length = 0;
     if (length < 32) {
-        unsigned char tmpBuff[32];
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, length);
         *output_length = length;
     } else {
-        for (int i = 0; i < (length/32); i++) {
+        for (unsigned i = 0; i < (length/32); i++) {
             trng_get(output);
             *output_length += 32;
             output += 32;
+        }     
+        if( length > *output_length ) {
+            trng_get(tmpBuff);
+            memcpy(output, &tmpBuff, (length - *output_length));
+            *output_length = length;
         }
     }
 


### PR DESCRIPTION
## Description
This PR refines code with TRNG_Get and compiler redefinition warnings. It includes the following modifications:
    1. NUC472/M487:  TRNG_Get() support 32 bytes unalignment
    2. NUC472/M487/NANO130: Fix TRUE/FALSE redefinition issue

## Related PRs
#5438 
#5434

## Test
Passed Mbed Cloud-Client-restricted(R1.2.4-LA) OTA test.


@0xc0170 
@Ronny-Liu 
@ccli8 
@samchuarm 