### PR TITLE
Increase flash size on Realtek RTL8195AM

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/flash_ext.h
@@ -24,7 +24,7 @@ extern "C" {
 #endif
 
 #define FLASH_PAGE_SIZE 256
-#define FLASH_SIZE        0x100000
+#define FLASH_SIZE        0x200000
 #define FLASH_OFS_START   0x0
 #define FLASH_OFS_END     (FLASH_OFS_START + FLASH_SIZE)
 


### PR DESCRIPTION
The Realtek RTL8195AM has 2 MiB of external flash. This change
enables the FlashIAP driver to gain access to the full flash.

