### PR TITLE
Nuvoton: TRNG_Get support 32 bytes unalignment

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
@@ -92,10 +92,10 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
         output += 32;
     }     
     if( length > *output_length ) {
-        trng_zeroize(tmpBuff, sizeof(tmpBuff));
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, (length - *output_length));
         *output_length = length;
+        trng_zeroize(tmpBuff, sizeof(tmpBuff));
     }
 
     return 0;

--- a/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
@@ -83,21 +83,20 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     unsigned char tmpBuff[32];
-    
-    *output_length = 0;
+    size_t cur_length = 0;
     
     for (unsigned i = 0; i < (length/32); i++) {
         trng_get(output);
-        *output_length += 32;
+        cur_length += 32;
         output += 32;
     }     
-    if( length > *output_length ) {
+    if( length > cur_length ) {
         trng_get(tmpBuff);
-        memcpy(output, &tmpBuff, (length - *output_length));
-        *output_length = length;
+        memcpy(output, &tmpBuff, (length - cur_length));
+        cur_length = length;
         trng_zeroize(tmpBuff, sizeof(tmpBuff));
     }
-
+    *output_length = cur_length;
     return 0;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
@@ -77,10 +77,10 @@ void trng_free(trng_t *obj)
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
     (void)obj;
-
+    unsigned char tmpBuff[32];
+        
     *output_length = 0;
     if (length < 32) {
-        unsigned char tmpBuff[32];
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, length);
         *output_length = length;
@@ -89,6 +89,11 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
             trng_get(output);
             *output_length += 32;
             output += 32;
+        }     
+        if( length > *output_length ) {
+            trng_get(tmpBuff);
+            memcpy(output, &tmpBuff, (length - *output_length));
+            *output_length = length;
         }
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/trng_api.c
@@ -28,6 +28,11 @@
 static volatile int  g_PRNG_done;
 volatile int  g_AES_done;
 
+/* Implementation that should never be optimized out by the compiler */
+static void trng_zeroize( void *v, size_t n ) {
+    volatile unsigned char *p = (unsigned char*)v; while( n-- ) *p++ = 0;
+}
+
 void CRYPTO_IRQHandler()
 {
     if (PRNG_GET_INT_FLAG()) {
@@ -78,23 +83,19 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     unsigned char tmpBuff[32];
-        
+    
     *output_length = 0;
-    if (length < 32) {
+    
+    for (unsigned i = 0; i < (length/32); i++) {
+        trng_get(output);
+        *output_length += 32;
+        output += 32;
+    }     
+    if( length > *output_length ) {
+        trng_zeroize(tmpBuff, sizeof(tmpBuff));
         trng_get(tmpBuff);
-        memcpy(output, &tmpBuff, length);
+        memcpy(output, &tmpBuff, (length - *output_length));
         *output_length = length;
-    } else {
-        for (unsigned i = 0; i < (length/32); i++) {
-            trng_get(output);
-            *output_length += 32;
-            output += 32;
-        }     
-        if( length > *output_length ) {
-            trng_get(tmpBuff);
-            memcpy(output, &tmpBuff, (length - *output_length));
-            *output_length = length;
-        }
     }
 
     return 0;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
@@ -82,18 +82,23 @@ void trng_free(trng_t *obj)
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
     (void)obj;
-
+    unsigned char tmpBuff[32];
+        
     *output_length = 0;
     if (length < 32) {
-        unsigned char tmpBuff[32];
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, length);
         *output_length = length;
     } else {
-        for (int i = 0; i < (length/32); i++) {
+        for (unsigned i = 0; i < (length/32); i++) {
             trng_get(output);
             *output_length += 32;
             output += 32;
+        }     
+        if( length > *output_length ) {
+            trng_get(tmpBuff);
+            memcpy(output, &tmpBuff, (length - *output_length));
+            *output_length = length;
         }
     }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
@@ -97,10 +97,10 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
         output += 32;
     }     
     if( length > *output_length ) {
-        trng_zeroize(tmpBuff, sizeof(tmpBuff));
         trng_get(tmpBuff);
         memcpy(output, &tmpBuff, (length - *output_length));
         *output_length = length;
+        trng_zeroize(tmpBuff, sizeof(tmpBuff));
     }
 
     return 0;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
@@ -30,6 +30,9 @@
 /*
  * Get Random number generator.
  */
+
+#define PRNG_KEY_SIZE  (0x20UL)
+
 static volatile int  g_PRNG_done;
 volatile int  g_AES_done;
 
@@ -87,18 +90,19 @@ void trng_free(trng_t *obj)
 int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
 {
     (void)obj;
-    unsigned char tmpBuff[32];
+    unsigned char tmpBuff[PRNG_KEY_SIZE];
     size_t cur_length = 0;
     
-    for (unsigned i = 0; i < (length/32); i++) {
+    while (length >= sizeof(tmpBuff)) {
         trng_get(output);
-        cur_length += 32;
-        output += 32;
-    }     
-    if( length > cur_length ) {
+        output += sizeof(tmpBuff);
+        cur_length += sizeof(tmpBuff);
+        length -= sizeof(tmpBuff);
+    }
+    if (length > 0) {
         trng_get(tmpBuff);
-        memcpy(output, &tmpBuff, (length - cur_length));
-        cur_length = length;
+        memcpy(output, tmpBuff, length);
+        cur_length += length;
         trng_zeroize(tmpBuff, sizeof(tmpBuff));
     }
     *output_length = cur_length;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/trng_api.c
@@ -88,21 +88,20 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     unsigned char tmpBuff[32];
-        
-    *output_length = 0;
+    size_t cur_length = 0;
     
     for (unsigned i = 0; i < (length/32); i++) {
         trng_get(output);
-        *output_length += 32;
+        cur_length += 32;
         output += 32;
     }     
-    if( length > *output_length ) {
+    if( length > cur_length ) {
         trng_get(tmpBuff);
-        memcpy(output, &tmpBuff, (length - *output_length));
-        *output_length = length;
+        memcpy(output, &tmpBuff, (length - cur_length));
+        cur_length = length;
         trng_zeroize(tmpBuff, sizeof(tmpBuff));
     }
-
+    *output_length = cur_length;
     return 0;
 }
  


### PR DESCRIPTION
## Description
This PR refines code with TRNG_Get, to let TRNG_Get() support 32 bytes unalignment on NUC472/M487 platforms.

## Related PRs
#5434
#5449 

## Test
Passed Mbed Cloud-Client-restricted(R1.2.4-LA) OTA test.


@0xc0170 
@Ronny-Liu 
@ccli8 
@samchuarm 