### PR TITLE
STM32 Flash 2MB GetSector fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
@@ -145,7 +145,6 @@ int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, 
 
 uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
 {
-    
     if ((address >= (FLASH_BASE + FLASH_SIZE)) || (address < FLASH_BASE)) {
         return MBED_FLASH_INVALID_SIZE;
     }
@@ -165,7 +164,7 @@ uint32_t flash_get_start_address(const flash_t *obj)
 }
 uint32_t flash_get_size(const flash_t *obj)
 {
-    return FLASH_SIZE;    
+    return FLASH_SIZE;
 }
 
 /**
@@ -175,7 +174,7 @@ uint32_t flash_get_size(const flash_t *obj)
   */
 static uint32_t GetSector(uint32_t address)
 {
-    uint32_t sector = 0; 
+    uint32_t sector = 0;
     uint32_t tmp = address - ADDR_FLASH_SECTOR_0;
     /* This function supports 1Mb and 2Mb flash sizes */
 #if defined(ADDR_FLASH_SECTOR_16)
@@ -191,14 +190,14 @@ static uint32_t GetSector(uint32_t address)
     }
 #if defined(ADDR_FLASH_SECTOR_5)
     else if (address < ADDR_FLASH_SECTOR_5) { //64k sector size
-        sector += FLASH_SECTOR_4; 
+        sector += FLASH_SECTOR_4;
     } else {
         sector += 4 + (tmp >>17);
     }
 #else
     // In case ADDR_FLASH_SECTOR_5 is not defined, sector 4 is the last one.
     else { //64k sector size
-        sector += FLASH_SECTOR_4; 
+        sector += FLASH_SECTOR_4;
     }
 #endif
     return sector;
@@ -227,7 +226,7 @@ if((Sector == FLASH_SECTOR_0) || (Sector == FLASH_SECTOR_1) || (Sector == FLASH_
         sectorsize = 64 * 1024;
     } else {
         sectorsize = 128 * 1024;
-    }  
+    }
     return sectorsize;
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
@@ -180,8 +180,10 @@ static uint32_t GetSector(uint32_t address)
     /* This function supports 1Mb and 2Mb flash sizes */
 #if defined(ADDR_FLASH_SECTOR_16)
     if (address & 0x100000) { // handle 2nd bank
+        /*  Sector will be at least 12 */
         sector = FLASH_SECTOR_12;
-        tmp = address - ADDR_FLASH_SECTOR_12;
+        tmp -= 0x100000;
+        address -= 0x100000;
     }
 #endif
     if (address < ADDR_FLASH_SECTOR_4) { // 16k sectorsize


### PR DESCRIPTION
## Description
This is a fix to issue #5450 
The GetSector computation for 2MB flash topology was erroneous, and is fixed in this PR.

## Status
**READY**

## Tests 

- [ ] Test case from issue
With the fix, the test program shared in the issue now outputs the expected data..
```
ram
Sector at  0x8000000 of size 16384
Sector at  0x8004000 of size 16384
Sector at  0x8008000 of size 16384
Sector at  0x800c000 of size 16384
Sector at  0x8010000 of size 65536
Sector at  0x8020000 of size 131072
Sector at  0x8040000 of size 131072
Sector at  0x8060000 of size 131072
Sector at  0x8080000 of size 131072
Sector at  0x80a0000 of size 131072
Sector at  0x80c0000 of size 131072
Sector at  0x80e0000 of size 131072
Sector at  0x8100000 of size 16384
Sector at  0x8104000 of size 16384
Sector at  0x8108000 of size 16384
Sector at  0x810c000 of size 16384
Sector at  0x8110000 of size 65536
Sector at  0x8120000 of size 131072
Sector at  0x8140000 of size 131072
Sector at  0x8160000 of size 131072
Sector at  0x8180000 of size 131072
Sector at  0x81a0000 of size 131072
Sector at  0x81c0000 of size 131072
Sector at  0x81e0000 of size 131072

End of program
```

- [ ] Non regression tests

Ongoing
