### PR TITLE
platform: make C++ allocation wrappers log the correct caller address

### DIFF
--- a/platform/mbed_alloc_wrappers.cpp
+++ b/platform/mbed_alloc_wrappers.cpp
@@ -81,12 +81,18 @@ extern "C" {
     void * __real__realloc_r(struct _reent * r, void * ptr, size_t size);
     void __real__free_r(struct _reent * r, void * ptr);
     void* __real__calloc_r(struct _reent * r, size_t nmemb, size_t size);
+    void* malloc_wrapper(struct _reent * r, size_t size, void * caller);
+    void free_wrapper(struct _reent * r, void * ptr, void* caller);
 }
 
 // TODO: memory tracing doesn't work with uVisor enabled.
 #if !defined(FEATURE_UVISOR)
 
 extern "C" void * __wrap__malloc_r(struct _reent * r, size_t size) {
+    return malloc_wrapper(r, size, MBED_CALLER_ADDR());
+}
+
+extern "C" void * malloc_wrapper(struct _reent * r, size_t size, void * caller) {
     void *ptr = NULL;
 #ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
@@ -111,7 +117,7 @@ extern "C" void * __wrap__malloc_r(struct _reent * r, size_t size) {
     ptr = __real__malloc_r(r, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
 #ifdef MBED_MEM_TRACING_ENABLED
-    mbed_mem_trace_malloc(ptr, size, MBED_CALLER_ADDR());
+    mbed_mem_trace_malloc(ptr, size, caller);
     mbed_mem_trace_unlock();
 #endif // #ifdef MBED_MEM_TRACING_ENABLED
     return ptr;
@@ -160,6 +166,10 @@ extern "C" void * __wrap__realloc_r(struct _reent * r, void * ptr, size_t size) 
 }
 
 extern "C" void __wrap__free_r(struct _reent * r, void * ptr) {
+    free_wrapper(r, ptr, MBED_CALLER_ADDR());
+}
+
+extern "C" void free_wrapper(struct _reent * r, void * ptr, void * caller) {
 #ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
@@ -177,7 +187,7 @@ extern "C" void __wrap__free_r(struct _reent * r, void * ptr) {
     __real__free_r(r, ptr);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
 #ifdef MBED_MEM_TRACING_ENABLED
-    mbed_mem_trace_free(ptr, MBED_CALLER_ADDR());
+    mbed_mem_trace_free(ptr, caller);
     mbed_mem_trace_unlock();
 #endif // #ifdef MBED_MEM_TRACING_ENABLED
 }

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1068,7 +1068,53 @@ void operator delete[](void *ptr)
     free_wrapper(ptr, MBED_CALLER_ADDR());
 }
 
+#elif defined(MBED_MEM_TRACING_ENABLED) && defined(__GNUC__)
+
+#include <reent.h>
+
+extern "C" void* malloc_wrapper(struct _reent * r, size_t size, void * caller);
+extern "C" void free_wrapper(struct _reent * r, void * ptr, void * caller);
+
+void *operator new(std::size_t count)
+{
+    void *buffer = malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
+    if (NULL == buffer) {
+        error("Operator new out of memory\r\n");
+    }
+    return buffer;
+}
+
+void *operator new[](std::size_t count)
+{
+    void *buffer = malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
+    if (NULL == buffer) {
+        error("Operator new[] out of memory\r\n");
+    }
+    return buffer;
+}
+
+void *operator new(std::size_t count, const std::nothrow_t& tag)
+{
+    return malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
+}
+
+void *operator new[](std::size_t count, const std::nothrow_t& tag)
+{
+    return malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
+}
+
+void operator delete(void *ptr)
+{
+    free_wrapper(_REENT, ptr, MBED_CALLER_ADDR());
+}
+
+void operator delete[](void *ptr)
+{
+    free_wrapper(_REENT, ptr, MBED_CALLER_ADDR());
+}
+
 #else
+
 void *operator new(std::size_t count)
 {
     void *buffer = malloc(count);


### PR DESCRIPTION
## Description

The C++ "operator new" and "operator delete" (and their array
variants) were logging the the caller address wrong. In practice
if one used "operator new", the logged caller address pointed
to mbed_retarget.cpp, not to the client. Fix this by exposing
the alloc wrappers to the the retarget.

Note: this fixes only the ARMCC variants, as the GCC ones have
different different API and implementation.

Related mbed-os issue: https://github.com/ARMmbed/mbed-os/issues/5221

## Status

**IN DEVELOPMENT**, GCC should also be fixed.

## Migrations

NO

## Related PRs


## Todos

- [x] Tests
- [ ] Documentation

## Deploy notes

Note: the GCC target is equally broken, but this PR is not fixing that.

## Steps to test or reproduce
Test code
```
class test_class
{
public:
    uint32_t member;
};

static void do_the_test()
{
    void *mem_malloc = malloc(100);
    void *mem_calloc = calloc(60, 2);
    test_class* cpp_new_obj = new test_class;
    uint8_t* cpp_new_array = new uint8_t[200];
    delete cpp_new_obj;
    delete[] cpp_new_array;
    free(mem_calloc);
    free(mem_malloc);
}
```