### PR TITLE
Network interface: Add status callback register

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -24,10 +24,9 @@ EthernetInterface::EthernetInterface() :
     _ip_address(), 
     _netmask(), 
     _gateway(),
+    _connection_status_cb(NULL),
     _connect_status(NSAPI_STATUS_DISCONNECTED)
 {
-    set_blocking(true);
-    attach(NULL);
 }
 
 

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -26,8 +26,8 @@ EthernetInterface::EthernetInterface() :
     _gateway()
 {
 }
-Callback<void(connection_status_t, int)> EthernetInterface::_connection_status_cb = NULL;
-connection_status_t EthernetInterface::_connect_status = DISCONNECTED;
+Callback<void(nsapi_connection_status_t, int)> EthernetInterface::_connection_status_cb = NULL;
+nsapi_connection_status_t EthernetInterface::_connect_status = NSAPI_STATUS_DISCONNECTED;
 
 nsapi_error_t EthernetInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
 {
@@ -101,13 +101,13 @@ NetworkStack *EthernetInterface::get_stack()
     return nsapi_create_stack(&lwip_stack);
 }
 
-void EthernetInterface::register_status_callback(
-    Callback<void(connection_status_t, int)> status_cb)
+void EthernetInterface::attach(
+    Callback<void(nsapi_connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }
 
-connection_status_t EthernetInterface::get_connection_status()
+nsapi_connection_status_t EthernetInterface::get_connection_status()
 {
     return _connect_status;
 }
@@ -116,7 +116,7 @@ void EthernetInterface::netif_status_irq(struct netif *lwip_netif)
 {
     mbed_lwip_netif_status_irq(lwip_netif);
 
-    connection_status_t previous_status = _connect_status;
+    nsapi_connection_status_t previous_status = _connect_status;
     _connect_status = mbed_lwip_netif_status_check();
 
     if (_connection_status_cb && _connect_status != previous_status) {

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -105,7 +105,7 @@ void EthernetInterface::attach(
     Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     _connection_status_cb = status_cb;
-    mbed_lwip_attach(netif_status_irq, this);
+    mbed_lwip_attach(netif_status_cb, this);
 }
 
 nsapi_connection_status_t EthernetInterface::get_connection_status() const
@@ -113,7 +113,7 @@ nsapi_connection_status_t EthernetInterface::get_connection_status() const
     return _connect_status;
 }
 
-void EthernetInterface::netif_status_irq(void *ethernet_if_ptr, 
+void EthernetInterface::netif_status_cb(void *ethernet_if_ptr, 
     nsapi_event_t reason, intptr_t parameter) 
 {
     EthernetInterface *eth_ptr = static_cast<EthernetInterface*>(ethernet_if_ptr);

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.cpp
@@ -26,8 +26,8 @@ EthernetInterface::EthernetInterface() :
     _gateway()
 {
 }
-Callback<void(ConnectionStatusType, int)> EthernetInterface::_connection_status_cb = NULL;
-ConnectionStatusType EthernetInterface::_connect_status = DISCONNECTED;
+Callback<void(connection_status_t, int)> EthernetInterface::_connection_status_cb = NULL;
+connection_status_t EthernetInterface::_connect_status = DISCONNECTED;
 
 nsapi_error_t EthernetInterface::set_network(const char *ip_address, const char *netmask, const char *gateway)
 {
@@ -102,12 +102,12 @@ NetworkStack *EthernetInterface::get_stack()
 }
 
 void EthernetInterface::register_status_callback(
-    Callback<void(ConnectionStatusType, int)> status_cb)
+    Callback<void(connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }
 
-ConnectionStatusType EthernetInterface::get_connection_status()
+connection_status_t EthernetInterface::get_connection_status()
 {
     return _connect_status;
 }
@@ -116,7 +116,7 @@ void EthernetInterface::netif_status_irq(struct netif *lwip_netif)
 {
     mbed_lwip_netif_status_irq(lwip_netif);
 
-    ConnectionStatusType previous_status = _connect_status;
+    connection_status_t previous_status = _connect_status;
     _connect_status = mbed_lwip_netif_status_check();
 
     if (_connection_status_cb && _connect_status != previous_status) {

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -135,7 +135,7 @@ protected:
 
     Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
-    static void netif_status_irq(void *, nsapi_event_t, intptr_t);
+    static void netif_status_cb(void *, nsapi_event_t, intptr_t);
 };
 
 

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -100,6 +100,18 @@ public:
      */
     virtual const char *get_gateway();
 
+    /** Register callback for status reporting
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual ConnectionStatusType get_connection_status();
+
 protected:
     /** Provide access to the underlying stack
      *
@@ -111,6 +123,12 @@ protected:
     char _ip_address[IPADDR_STRLEN_MAX];
     char _netmask[NSAPI_IPv4_SIZE];
     char _gateway[NSAPI_IPv4_SIZE];
+
+
+    static Callback<void(ConnectionStatusType, int)> _connection_status_cb;
+    static void netif_status_irq(struct netif *);
+    static ConnectionStatusType _connect_status;
+
 };
 
 

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -104,13 +104,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
-     *  @return         The connection status according to connection_status_t
+     *  @return         The connection status according to nsapi_connection_status_t
      */
-    virtual connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status();
 
 protected:
     /** Provide access to the underlying stack
@@ -125,9 +125,9 @@ protected:
     char _gateway[NSAPI_IPv4_SIZE];
 
 
-    static Callback<void(connection_status_t, int)> _connection_status_cb;
+    static Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
     static void netif_status_irq(struct netif *);
-    static connection_status_t _connect_status;
+    static nsapi_connection_status_t _connect_status;
 
 };
 

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -104,13 +104,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
+    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
-     *  @return         The connection status according to ConnectionStatusType
+     *  @return         The connection status according to connection_status_t
      */
-    virtual ConnectionStatusType get_connection_status();
+    virtual connection_status_t get_connection_status();
 
 protected:
     /** Provide access to the underlying stack
@@ -125,9 +125,9 @@ protected:
     char _gateway[NSAPI_IPv4_SIZE];
 
 
-    static Callback<void(ConnectionStatusType, int)> _connection_status_cb;
+    static Callback<void(connection_status_t, int)> _connection_status_cb;
     static void netif_status_irq(struct netif *);
-    static ConnectionStatusType _connect_status;
+    static connection_status_t _connect_status;
 
 };
 

--- a/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
+++ b/features/FEATURE_LWIP/lwip-interface/EthernetInterface.h
@@ -104,13 +104,21 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to nsapi_connection_status_t
      */
-    virtual nsapi_connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status() const;
+
+    /** Set blocking status of connect() which by default should be blocking
+     *
+     *  @param blocking true if connect is blocking
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t set_blocking(bool blocking);
+
 
 protected:
     /** Provide access to the underlying stack
@@ -125,10 +133,9 @@ protected:
     char _gateway[NSAPI_IPv4_SIZE];
 
 
-    static Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
-    static void netif_status_irq(struct netif *);
-    static nsapi_connection_status_t _connect_status;
-
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    nsapi_connection_status_t _connect_status;
+    static void netif_status_irq(void *, nsapi_event_t, intptr_t);
 };
 
 

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/netif.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/netif.h
@@ -48,6 +48,7 @@
 #include "lwip/def.h"
 #include "lwip/pbuf.h"
 #include "lwip/stats.h"
+#include "nsapi_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -196,6 +197,9 @@ typedef err_t (*netif_output_ip6_fn)(struct netif *netif, struct pbuf *p,
 typedef err_t (*netif_linkoutput_fn)(struct netif *netif, struct pbuf *p);
 /** Function prototype for netif status- or link-callback functions. */
 typedef void (*netif_status_callback_fn)(struct netif *netif);
+/** Function prototype for netif client status callback functions. */
+typedef void (*netif_client_status_callback_fn)(void* ethernet_if_ptr, 
+    nsapi_event_t reason, intptr_t parameter);
 #if LWIP_IPV4 && LWIP_IGMP
 /** Function prototype for netif igmp_mac_filter functions */
 typedef err_t (*netif_igmp_mac_filter_fn)(struct netif *netif,
@@ -271,6 +275,16 @@ struct netif {
   /** This function is called when the netif state is set to up or down
    */
   netif_status_callback_fn status_callback;
+  /** This is a pointer to an Ethernet IF, whose callback will be called in case
+   *  of network connection status changes
+   */
+  void *status_cb_handle;
+  /** This function is called when the netif state is set to up or down
+   */
+  netif_client_status_callback_fn client_callback;
+  /** The blocking status of the if
+   */
+  u8_t blocking;  
 #endif /* LWIP_NETIF_STATUS_CALLBACK */
 #if LWIP_NETIF_LINK_CALLBACK
   /** This function is called when the netif link is set to up or down

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/netif.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/netif.h
@@ -48,7 +48,6 @@
 #include "lwip/def.h"
 #include "lwip/pbuf.h"
 #include "lwip/stats.h"
-#include "nsapi_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -197,9 +196,6 @@ typedef err_t (*netif_output_ip6_fn)(struct netif *netif, struct pbuf *p,
 typedef err_t (*netif_linkoutput_fn)(struct netif *netif, struct pbuf *p);
 /** Function prototype for netif status- or link-callback functions. */
 typedef void (*netif_status_callback_fn)(struct netif *netif);
-/** Function prototype for netif client status callback functions. */
-typedef void (*netif_client_status_callback_fn)(void* ethernet_if_ptr, 
-    nsapi_event_t reason, intptr_t parameter);
 #if LWIP_IPV4 && LWIP_IGMP
 /** Function prototype for netif igmp_mac_filter functions */
 typedef err_t (*netif_igmp_mac_filter_fn)(struct netif *netif,
@@ -275,16 +271,6 @@ struct netif {
   /** This function is called when the netif state is set to up or down
    */
   netif_status_callback_fn status_callback;
-  /** This is a pointer to an Ethernet IF, whose callback will be called in case
-   *  of network connection status changes
-   */
-  void *status_cb_handle;
-  /** This function is called when the netif state is set to up or down
-   */
-  netif_client_status_callback_fn client_callback;
-  /** The blocking status of the if
-   */
-  u8_t blocking;  
 #endif /* LWIP_NETIF_STATUS_CALLBACK */
 #if LWIP_NETIF_LINK_CALLBACK
   /** This function is called when the netif link is set to up or down

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -736,9 +736,9 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
     // Check if we've already connected
  
     if (lwip_connected == NSAPI_STATUS_GLOBAL_UP) {
-        return NSAPI_ERROR_PARAMETER;
+        return NSAPI_ERROR_IS_CONNECTED;
     } else if (lwip_connected == NSAPI_STATUS_CONNECTING) {
-        return NSAPI_ERROR_IN_PROGRESS;
+        return NSAPI_ERROR_ALREADY;
     }
 
     lwip_connected = NSAPI_STATUS_CONNECTING;
@@ -858,10 +858,6 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
                 if (ppp) {
                     ppp_lwip_disconnect();
                 }
-                lwip_connected = NSAPI_STATUS_DISCONNECTED;
-                if (lwip_client_callback) {
-                    lwip_client_callback(lwip_status_cb_handle, NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
-                }
                 return NSAPI_ERROR_NO_CONNECTION;
             }
         }
@@ -878,10 +874,6 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
             if (sys_arch_sem_wait(&lwip_netif_has_any_addr, DHCP_TIMEOUT * 1000) == SYS_ARCH_TIMEOUT) {
                 if (ppp) {
                     ppp_lwip_disconnect();
-                }
-                lwip_connected = NSAPI_STATUS_DISCONNECTED;
-                if (lwip_client_callback) {
-                    lwip_client_callback(lwip_status_cb_handle, NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
                 }
                 return NSAPI_ERROR_DHCP_FAILURE;
             }

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -474,7 +474,7 @@ void mbed_lwip_netif_status_irq(struct netif *lwip_netif)
     }
 }
 
-ConnectionStatusType mbed_lwip_netif_status_check(void)
+connection_status_t mbed_lwip_netif_status_check(void)
 {
     if (netif_is_up(&lwip_netif)) {
         return GLOBAL_UP;

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -474,12 +474,12 @@ void mbed_lwip_netif_status_irq(struct netif *lwip_netif)
     }
 }
 
-connection_status_t mbed_lwip_netif_status_check(void)
+nsapi_connection_status_t mbed_lwip_netif_status_check(void)
 {
     if (netif_is_up(&lwip_netif)) {
-        return GLOBAL_UP;
+        return NSAPI_STATUS_GLOBAL_UP;
     } else {
-        return DISCONNECTED;
+        return NSAPI_STATUS_DISCONNECTED;
     }
 }
 

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -31,7 +31,7 @@ extern "C" {
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
 nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac);
 void mbed_lwip_netif_status_irq(struct netif *lwip_netif);
-ConnectionStatusType mbed_lwip_netif_status_check(void);
+connection_status_t mbed_lwip_netif_status_check(void);
 nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
 nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
     const nsapi_ip_stack_t stack);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -31,7 +31,7 @@ extern "C" {
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
 nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac);
 void mbed_lwip_netif_status_irq(struct netif *lwip_netif);
-connection_status_t mbed_lwip_netif_status_check(void);
+nsapi_connection_status_t mbed_lwip_netif_status_check(void);
 nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
 nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
     const nsapi_ip_stack_t stack);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -20,7 +20,6 @@
 #include "nsapi.h"
 #include "emac_api.h"
 #include "lwip/opt.h"
-#include "nsapi_types.h"
 #include "netif.h"
 #ifdef __cplusplus
 extern "C" {
@@ -35,11 +34,11 @@ nsapi_connection_status_t mbed_lwip_netif_status_check(void);
 nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
 nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
     const nsapi_ip_stack_t stack);
-nsapi_error_t mbed_lwip_bringup_3(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
-    const nsapi_ip_stack_t stack, netif_status_callback_fn status_cb);
+typedef netif_client_status_callback_fn mbed_lwip_client_callback;
+void mbed_lwip_attach(mbed_lwip_client_callback status_cb, void *status_cb_handle);
+void mbed_lwip_set_blocking(u8_t blocking);
 nsapi_error_t mbed_lwip_bringdown(void);
 nsapi_error_t mbed_lwip_bringdown_2(bool ppp);
-
 const char *mbed_lwip_get_mac_address(void);
 char *mbed_lwip_get_ip_address(char *buf, nsapi_size_t buflen);
 char *mbed_lwip_get_netmask(char *buf, nsapi_size_t buflen);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -29,14 +29,13 @@ extern "C" {
 // drivers attach through these.
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
 nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac);
-void mbed_lwip_netif_status_irq(struct netif *lwip_netif);
 nsapi_connection_status_t mbed_lwip_netif_status_check(void);
 nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
 nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
     const nsapi_ip_stack_t stack);
-typedef netif_client_status_callback_fn mbed_lwip_client_callback;
+typedef void (*mbed_lwip_client_callback)(void *ethernet_if_ptr, nsapi_event_t reason, intptr_t parameter);
 void mbed_lwip_attach(mbed_lwip_client_callback status_cb, void *status_cb_handle);
-void mbed_lwip_set_blocking(u8_t blocking);
+void mbed_lwip_set_blocking(bool blocking);
 nsapi_error_t mbed_lwip_bringdown(void);
 nsapi_error_t mbed_lwip_bringdown_2(bool ppp);
 const char *mbed_lwip_get_mac_address(void);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.h
@@ -20,6 +20,8 @@
 #include "nsapi.h"
 #include "emac_api.h"
 #include "lwip/opt.h"
+#include "nsapi_types.h"
+#include "netif.h"
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -28,8 +30,13 @@ extern "C" {
 // drivers attach through these.
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac);
 nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac);
+void mbed_lwip_netif_status_irq(struct netif *lwip_netif);
+ConnectionStatusType mbed_lwip_netif_status_check(void);
 nsapi_error_t mbed_lwip_bringup(bool dhcp, const char *ip, const char *netmask, const char *gw);
-nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, const nsapi_ip_stack_t stack);
+nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
+    const nsapi_ip_stack_t stack);
+nsapi_error_t mbed_lwip_bringup_3(bool dhcp, bool ppp, const char *ip, const char *netmask, const char *gw, 
+    const nsapi_ip_stack_t stack, netif_status_callback_fn status_cb);
 nsapi_error_t mbed_lwip_bringdown(void);
 nsapi_error_t mbed_lwip_bringdown_2(bool ppp);
 

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -225,7 +225,6 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
     if (connection_status_cb) {
         connection_status_cb(NetworkInterface::down);
     }
-
 }
 
 static void handle_modem_hangup()

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -59,7 +59,7 @@ static bool ppp_active = false;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
-static Callback<void(nsapi_error_t)> connection_status_cb;
+static Callback<void(NetworkInterface::ConnectionStatusType)> connection_status_cb;
 
 static EventQueue *prepare_event_queue()
 {
@@ -207,8 +207,10 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
     }
 
     if (err_code == PPPERR_NONE) {
-        /* suppress generating a callback event for connection up
-         * Because connect() call is blocking, why wait for a callback */
+        /* status changes have to be reported */
+        if (connection_status_cb) {
+            connection_status_cb(NetworkInterface::global_up);
+        }
         return;
     }
 
@@ -221,8 +223,9 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
 
     /* Alright, PPP interface is down, we need to notify upper layer */
     if (connection_status_cb) {
-        connection_status_cb(mapped_err_code);
+        connection_status_cb(NetworkInterface::down);
     }
+
 }
 
 static void handle_modem_hangup()
@@ -351,7 +354,7 @@ nsapi_error_t nsapi_ppp_error_code()
     return connect_error_code;
 }
 
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_error_t)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(NetworkInterface::ConnectionStatusType)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
 {
     if (my_stream) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -59,7 +59,7 @@ static bool ppp_active = false;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
-static Callback<void(NetworkInterface::ConnectionStatusType)> connection_status_cb;
+static Callback<void(ConnectionStatusType, int)> connection_status_cb;
 
 static EventQueue *prepare_event_queue()
 {
@@ -209,7 +209,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
     if (err_code == PPPERR_NONE) {
         /* status changes have to be reported */
         if (connection_status_cb) {
-            connection_status_cb(NetworkInterface::global_up);
+            connection_status_cb(GLOBAL_UP, 0);
         }
         return;
     }
@@ -223,7 +223,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
 
     /* Alright, PPP interface is down, we need to notify upper layer */
     if (connection_status_cb) {
-        connection_status_cb(NetworkInterface::down);
+        connection_status_cb(DISCONNECTED, 0);
     }
 }
 
@@ -353,7 +353,7 @@ nsapi_error_t nsapi_ppp_error_code()
     return connect_error_code;
 }
 
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(NetworkInterface::ConnectionStatusType)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(ConnectionStatusType, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
 {
     if (my_stream) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -59,7 +59,7 @@ static bool ppp_active = false;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
-static Callback<void(connection_status_t, int)> connection_status_cb;
+static Callback<void(nsapi_connection_status_t, int)> connection_status_cb;
 
 static EventQueue *prepare_event_queue()
 {
@@ -209,7 +209,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
     if (err_code == PPPERR_NONE) {
         /* status changes have to be reported */
         if (connection_status_cb) {
-            connection_status_cb(GLOBAL_UP, 0);
+            connection_status_cb(NSAPI_STATUS_GLOBAL_UP, 0);
         }
         return;
     }
@@ -223,7 +223,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
 
     /* Alright, PPP interface is down, we need to notify upper layer */
     if (connection_status_cb) {
-        connection_status_cb(DISCONNECTED, 0);
+        connection_status_cb(NSAPI_STATUS_DISCONNECTED, 0);
     }
 }
 
@@ -353,7 +353,7 @@ nsapi_error_t nsapi_ppp_error_code()
     return connect_error_code;
 }
 
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(connection_status_t, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_connection_status_t, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
 {
     if (my_stream) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -59,7 +59,7 @@ static bool ppp_active = false;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
-static Callback<void(ConnectionStatusType, int)> connection_status_cb;
+static Callback<void(connection_status_t, int)> connection_status_cb;
 
 static EventQueue *prepare_event_queue()
 {
@@ -353,7 +353,7 @@ nsapi_error_t nsapi_ppp_error_code()
     return connect_error_code;
 }
 
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(ConnectionStatusType, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(connection_status_t, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
 {
     if (my_stream) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -59,7 +59,7 @@ static bool ppp_active = false;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
-static Callback<void(nsapi_connection_status_t, int)> connection_status_cb;
+static Callback<void(nsapi_event_t, intptr_t)> connection_status_cb;
 
 static EventQueue *prepare_event_queue()
 {
@@ -209,7 +209,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
     if (err_code == PPPERR_NONE) {
         /* status changes have to be reported */
         if (connection_status_cb) {
-            connection_status_cb(NSAPI_STATUS_GLOBAL_UP, 0);
+            connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_GLOBAL_UP);
         }
         return;
     }
@@ -223,7 +223,7 @@ static void ppp_link_status(ppp_pcb *pcb, int err_code, void *ctx)
 
     /* Alright, PPP interface is down, we need to notify upper layer */
     if (connection_status_cb) {
-        connection_status_cb(NSAPI_STATUS_DISCONNECTED, 0);
+        connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
     }
 }
 
@@ -353,7 +353,13 @@ nsapi_error_t nsapi_ppp_error_code()
     return connect_error_code;
 }
 
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_connection_status_t, int)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
+nsapi_error_t nsapi_ppp_set_blocking(bool blocking)
+{
+    mbed_lwip_set_blocking(blocking);
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_event_t, intptr_t)> cb, const char *uname, const char *password, const nsapi_ip_stack_t stack)
 {
     if (my_stream) {
         return NSAPI_ERROR_PARAMETER;

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -62,6 +62,19 @@ public:
      * */
     void mesh_network_handler(mesh_connection_status_t status);
 
+    /** Register callback for status reporting
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual ConnectionStatusType get_connection_status();
+
+
 protected:
     MeshInterfaceNanostack();
     MeshInterfaceNanostack(NanostackPhy *phy);
@@ -86,6 +99,9 @@ protected:
     char ip_addr_str[40];
     char mac_addr_str[24];
     Semaphore connect_semaphore;
+
+    Callback<void(ConnectionStatusType, int)> _connection_status_cb;
+    ConnectionStatusType _connect_status;
 };
 
 #endif /* MESHINTERFACENANOSTACK_H */

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -66,14 +66,20 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual nsapi_connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status() const;
 
+    /** Set blocking status of connect() which by default should be blocking
+     *
+     *  @param blocking true if connect is blocking
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t set_blocking(bool blocking);
 
 protected:
     MeshInterfaceNanostack();
@@ -100,8 +106,9 @@ protected:
     char mac_addr_str[24];
     Semaphore connect_semaphore;
 
-    Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
+    bool _blocking;
 };
 
 #endif /* MESHINTERFACENANOSTACK_H */

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -66,13 +66,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status();
 
 
 protected:
@@ -100,8 +100,8 @@ protected:
     char mac_addr_str[24];
     Semaphore connect_semaphore;
 
-    Callback<void(connection_status_t, int)> _connection_status_cb;
-    connection_status_t _connect_status;
+    Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
+    nsapi_connection_status_t _connect_status;
 };
 
 #endif /* MESHINTERFACENANOSTACK_H */

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -66,13 +66,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
+    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual ConnectionStatusType get_connection_status();
+    virtual connection_status_t get_connection_status();
 
 
 protected:
@@ -100,8 +100,8 @@ protected:
     char mac_addr_str[24];
     Semaphore connect_semaphore;
 
-    Callback<void(ConnectionStatusType, int)> _connection_status_cb;
-    ConnectionStatusType _connect_status;
+    Callback<void(connection_status_t, int)> _connection_status_cb;
+    connection_status_t _connect_status;
 };
 
 #endif /* MESHINTERFACENANOSTACK_H */

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -17,6 +17,8 @@
 #include "MeshInterfaceNanostack.h"
 #include "NanostackInterface.h"
 #include "mesh_system.h"
+#include "net_interface.h"
+
 
 MeshInterfaceNanostack::MeshInterfaceNanostack()
     : phy(NULL), _network_interface_id(-1), _device_id(-1), eui64(),
@@ -52,10 +54,16 @@ void MeshInterfaceNanostack::mesh_network_handler(mesh_connection_status_t statu
 
     nanostack_unlock();
 
+
     ConnectionStatusType previous_status = _connect_status;
 
     if (status == MESH_CONNECTED) {
-        _connect_status = GLOBAL_UP;
+        uint8_t temp_ipv6[16];
+        if (arm_net_address_get(_network_interface_id, ADDR_IPV6_GP, temp_ipv6)) {
+            _connect_status = GLOBAL_UP;
+        } else {
+            _connect_status = LOCAL_UP;
+        }
     } else {
         _connect_status = DISCONNECTED;
     }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -23,7 +23,7 @@
 MeshInterfaceNanostack::MeshInterfaceNanostack()
     : phy(NULL), _network_interface_id(-1), _device_id(-1), eui64(),
       ip_addr_str(), mac_addr_str(), connect_semaphore(0), 
-      _connection_status_cb(NULL), _connect_status(DISCONNECTED)
+      _connection_status_cb(NULL), _connect_status(NSAPI_STATUS_DISCONNECTED)
 {
     // Nothing to do
 }
@@ -55,17 +55,17 @@ void MeshInterfaceNanostack::mesh_network_handler(mesh_connection_status_t statu
     nanostack_unlock();
 
 
-    connection_status_t previous_status = _connect_status;
+    nsapi_connection_status_t previous_status = _connect_status;
 
     if (status == MESH_CONNECTED) {
         uint8_t temp_ipv6[16];
         if (arm_net_address_get(_network_interface_id, ADDR_IPV6_GP, temp_ipv6)) {
-            _connect_status = GLOBAL_UP;
+            _connect_status = NSAPI_STATUS_GLOBAL_UP;
         } else {
-            _connect_status = LOCAL_UP;
+            _connect_status = NSAPI_STATUS_LOCAL_UP;
         }
     } else {
-        _connect_status = DISCONNECTED;
+        _connect_status = NSAPI_STATUS_DISCONNECTED;
     }
 
     if (_connection_status_cb && _connect_status != previous_status) {
@@ -115,13 +115,13 @@ const char *MeshInterfaceNanostack::get_mac_address()
     return mac_addr_str;
 }
 
-connection_status_t MeshInterfaceNanostack::get_connection_status()
+nsapi_connection_status_t MeshInterfaceNanostack::get_connection_status()
 {
     return _connect_status;
 }
 
-void MeshInterfaceNanostack::register_status_callback(
-    Callback<void(connection_status_t, int)> status_cb)
+void MeshInterfaceNanostack::attach(
+    Callback<void(nsapi_connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -55,7 +55,7 @@ void MeshInterfaceNanostack::mesh_network_handler(mesh_connection_status_t statu
     nanostack_unlock();
 
 
-    ConnectionStatusType previous_status = _connect_status;
+    connection_status_t previous_status = _connect_status;
 
     if (status == MESH_CONNECTED) {
         uint8_t temp_ipv6[16];
@@ -115,13 +115,13 @@ const char *MeshInterfaceNanostack::get_mac_address()
     return mac_addr_str;
 }
 
-ConnectionStatusType MeshInterfaceNanostack::get_connection_status()
+connection_status_t MeshInterfaceNanostack::get_connection_status()
 {
     return _connect_status;
 }
 
 void MeshInterfaceNanostack::register_status_callback(
-    Callback<void(ConnectionStatusType, int)> status_cb)
+    Callback<void(connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -43,10 +43,12 @@ int ThreadInterface::connect()
     // -routers will create new network and get local connectivity
     // -end devices will get connectivity once attached to existing network
     // -devices without network settings gets connectivity once commissioned and attached to network
-    int32_t count = connect_semaphore.wait(osWaitForever);
+    if (_blocking) {
+        int32_t count = connect_semaphore.wait(osWaitForever);
 
-    if (count <= 0) {
-        return NSAPI_ERROR_DHCP_FAILURE; // sort of...
+        if (count <= 0) {
+            return NSAPI_ERROR_DHCP_FAILURE; // sort of...
+        }
     }
     return 0;
 }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -43,10 +43,18 @@ int ThreadInterface::connect()
     // -routers will create new network and get local connectivity
     // -end devices will get connectivity once attached to existing network
     // -devices without network settings gets connectivity once commissioned and attached to network
+    _connect_status = NSAPI_STATUS_CONNECTING;
+    if (_connection_status_cb) {
+        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_CONNECTING);
+    }
     if (_blocking) {
         int32_t count = connect_semaphore.wait(osWaitForever);
 
         if (count <= 0) {
+            _connect_status = NSAPI_STATUS_DISCONNECTED;
+            if (_connection_status_cb) {
+                _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
+            }
             return NSAPI_ERROR_DHCP_FAILURE; // sort of...
         }
     }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -14,6 +14,12 @@ nsapi_error_t ThreadInterface::initialize(NanostackRfPhy *phy)
 
 int ThreadInterface::connect()
 {
+    if (_connect_status == NSAPI_STATUS_GLOBAL_UP || _connect_status == NSAPI_STATUS_LOCAL_UP) {
+        return NSAPI_ERROR_IS_CONNECTED;
+    } else if (_connect_status == NSAPI_STATUS_CONNECTING) {
+        return NSAPI_ERROR_ALREADY;
+    }
+
     nanostack_lock();
 
     if (register_phy() < 0) {
@@ -51,10 +57,6 @@ int ThreadInterface::connect()
         int32_t count = connect_semaphore.wait(osWaitForever);
 
         if (count <= 0) {
-            _connect_status = NSAPI_STATUS_DISCONNECTED;
-            if (_connection_status_cb) {
-                _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, NSAPI_STATUS_DISCONNECTED);
-            }
             return NSAPI_ERROR_DHCP_FAILURE; // sort of...
         }
     }

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -65,13 +65,13 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
     return get_stack()->add_dns_server(address);
 }
 
-void NetworkInterface::register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb)
+void NetworkInterface::register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb)
 {
 }
 
-NetworkInterface::ConnectionStatusType NetworkInterface::get_connection_status()
+ConnectionStatusType NetworkInterface::get_connection_status()
 {
-    return undefined;
+    return UNDEFINED;
 }
 
 nsapi_error_t NetworkInterface::set_blocking(bool blocking)

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -65,13 +65,13 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
     return get_stack()->add_dns_server(address);
 }
 
-void NetworkInterface::register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb)
+void NetworkInterface::attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb)
 {
 }
 
-connection_status_t NetworkInterface::get_connection_status()
+nsapi_connection_status_t NetworkInterface::get_connection_status()
 {
-    return UNDEFINED;
+    return NSAPI_STATUS_UNDEFINED;
 }
 
 nsapi_error_t NetworkInterface::set_blocking(bool blocking)

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -65,11 +65,11 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
     return get_stack()->add_dns_server(address);
 }
 
-void NetworkInterface::register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb)
+void NetworkInterface::register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb)
 {
 }
 
-ConnectionStatusType NetworkInterface::get_connection_status()
+connection_status_t NetworkInterface::get_connection_status()
 {
     return UNDEFINED;
 }

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -65,11 +65,11 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
     return get_stack()->add_dns_server(address);
 }
 
-void NetworkInterface::attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb)
+void NetworkInterface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
 }
 
-nsapi_connection_status_t NetworkInterface::get_connection_status()
+nsapi_connection_status_t NetworkInterface::get_connection_status() const
 {
     return NSAPI_STATUS_UNDEFINED;
 }

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -71,7 +71,7 @@ void NetworkInterface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> stat
 
 nsapi_connection_status_t NetworkInterface::get_connection_status() const
 {
-    return NSAPI_STATUS_UNDEFINED;
+    return NSAPI_STATUS_ERROR_UNSUPPORTED;
 }
 
 nsapi_error_t NetworkInterface::set_blocking(bool blocking)

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -65,3 +65,17 @@ nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
     return get_stack()->add_dns_server(address);
 }
 
+void NetworkInterface::register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb)
+{
+}
+
+NetworkInterface::ConnectionStatusType NetworkInterface::get_connection_status()
+{
+    return undefined;
+}
+
+nsapi_error_t NetworkInterface::set_blocking(bool blocking)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -19,6 +19,7 @@
 
 #include "netsocket/nsapi_types.h"
 #include "netsocket/SocketAddress.h"
+#include "Callback.h"
 
 // Predeclared class
 class NetworkStack;
@@ -31,6 +32,11 @@ class NetworkStack;
  */
 class NetworkInterface {
 public:
+
+    enum ConnectionStatusType {
+        down, local_up, global_up, undefined
+    };
+
     virtual ~NetworkInterface() {};
 
     /** Get the local MAC address
@@ -125,6 +131,26 @@ public:
      *  @return         0 on success, negative error code on failure
      */
     virtual nsapi_error_t add_dns_server(const SocketAddress &address);
+
+    /** Register callback for status reporting
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb) = 0;
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual ConnectionStatusType get_connection_status() = 0;
+
+    /** Set blocking status of connect()
+     *
+     *  @param blocking true if connect is blocking
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t set_blocking(bool blocking);
+
 
 protected:
     friend class Socket;

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -33,9 +33,7 @@ class NetworkStack;
 class NetworkInterface {
 public:
 
-    enum ConnectionStatusType {
-        down, local_up, global_up, undefined
-    };
+
 
     virtual ~NetworkInterface() {};
 
@@ -136,7 +134,7 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb);
+    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
 
     /** Get the connection status
      *

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -134,15 +134,15 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual nsapi_connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status() const;
 
-    /** Set blocking status of connect()
+    /** Set blocking status of connect() which by default should be blocking
      *
      *  @param blocking true if connect is blocking
      *  @return         0 on success, negative error code on failure

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -136,13 +136,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb) = 0;
+    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual ConnectionStatusType get_connection_status() = 0;
+    virtual ConnectionStatusType get_connection_status();
 
     /** Set blocking status of connect()
      *

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -134,13 +134,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
+    virtual void attach(mbed::Callback<void(nsapi_connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status();
 
     /** Set blocking status of connect()
      *

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -134,13 +134,13 @@ public:
      *
      *  @param status_cb The callback for status changes
      */
-    virtual void register_status_callback(mbed::Callback<void(ConnectionStatusType, int)> status_cb);
+    virtual void register_status_callback(mbed::Callback<void(connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to ConnectionStatusType
      */
-    virtual ConnectionStatusType get_connection_status();
+    virtual connection_status_t get_connection_status();
 
     /** Set blocking status of connect()
      *

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -58,7 +58,6 @@ static bool set_sim_pin_check_request;
 static bool change_pin;
 static device_info dev_info;
 
-
 static void parser_abort(ATCmdParser *at)
 {
     at->abort();
@@ -317,7 +316,6 @@ void PPPCellularInterface::ppp_status_cb(ConnectionStatusType status)
         _connection_status_cb(_connect_status);
     }
 }
-
 
 /**
  * Public API. Sets up the flag for the driver to enable or disable SIM pin check
@@ -578,7 +576,6 @@ nsapi_error_t PPPCellularInterface::connect()
         return NSAPI_ERROR_IS_CONNECTED;
     }
 
-
     do {
         retry_init:
 
@@ -618,7 +615,6 @@ nsapi_error_t PPPCellularInterface::connect()
                 apn_config = apnconfig(dev_info.imsi);
             }
 #endif
-
 
             /* Check if user want skip SIM pin checking on boot up */
             if (set_sim_pin_check_request) {

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -264,7 +264,7 @@ PPPCellularInterface::PPPCellularInterface(FileHandle *fh, bool debug)
     _debug_trace_on = debug;
     _stack = DEFAULT_STACK;
     _connection_status_cb = NULL;
-    _ppp_cb = Callback<void(ConnectionStatusType, int)>(this, &PPPCellularInterface::ppp_status_cb);
+    _ppp_cb = Callback<void(connection_status_t, int)>(this, &PPPCellularInterface::ppp_status_cb);
     _connect_status = DISCONNECTED;
     dev_info.reg_status_csd = CSD_NOT_REGISTERED_NOT_SEARCHING;
     dev_info.reg_status_psd = PSD_NOT_REGISTERED_NOT_SEARCHING;
@@ -306,9 +306,9 @@ void PPPCellularInterface::modem_debug_on(bool on)
     _debug_trace_on = on;
 }
 
-void PPPCellularInterface::ppp_status_cb(ConnectionStatusType status, int parameter)
+void PPPCellularInterface::ppp_status_cb(connection_status_t status, int parameter)
 {
-    ConnectionStatusType previous_status = _connect_status;
+    connection_status_t previous_status = _connect_status;
 
     _connect_status = status;
 
@@ -806,12 +806,12 @@ NetworkStack *PPPCellularInterface::get_stack()
 
 
 void PPPCellularInterface::register_status_callback(
-    Callback<void(ConnectionStatusType, int)> status_cb)
+    Callback<void(connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }
 
-ConnectionStatusType PPPCellularInterface::get_connection_status()
+connection_status_t PPPCellularInterface::get_connection_status()
 {
     return _connect_status;
 }

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -264,8 +264,8 @@ PPPCellularInterface::PPPCellularInterface(FileHandle *fh, bool debug)
     _debug_trace_on = debug;
     _stack = DEFAULT_STACK;
     _connection_status_cb = NULL;
-    _ppp_cb = Callback<void(connection_status_t, int)>(this, &PPPCellularInterface::ppp_status_cb);
-    _connect_status = DISCONNECTED;
+    _ppp_cb = Callback<void(nsapi_connection_status_t, int)>(this, &PPPCellularInterface::ppp_status_cb);
+    _connect_status = NSAPI_STATUS_DISCONNECTED;
     dev_info.reg_status_csd = CSD_NOT_REGISTERED_NOT_SEARCHING;
     dev_info.reg_status_psd = PSD_NOT_REGISTERED_NOT_SEARCHING;
 }
@@ -306,9 +306,9 @@ void PPPCellularInterface::modem_debug_on(bool on)
     _debug_trace_on = on;
 }
 
-void PPPCellularInterface::ppp_status_cb(connection_status_t status, int parameter)
+void PPPCellularInterface::ppp_status_cb(nsapi_connection_status_t status, int parameter)
 {
-    connection_status_t previous_status = _connect_status;
+    nsapi_connection_status_t previous_status = _connect_status;
 
     _connect_status = status;
 
@@ -406,7 +406,7 @@ bool PPPCellularInterface::nwk_registration(uint8_t nwk_type)
 
 bool PPPCellularInterface::is_connected()
 {
-    if (_connect_status == DISCONNECTED) {
+    if (_connect_status == NSAPI_STATUS_DISCONNECTED) {
         return false;
     } else {
         return true;
@@ -572,7 +572,7 @@ nsapi_error_t PPPCellularInterface::connect()
     bool did_init = false;
     const char *apn_config = NULL;
 
-    if (_connect_status != DISCONNECTED) {
+    if (_connect_status != NSAPI_STATUS_DISCONNECTED) {
         return NSAPI_ERROR_IS_CONNECTED;
     }
 
@@ -694,7 +694,7 @@ nsapi_error_t PPPCellularInterface::connect()
          * mbed_ppp_init() is a blocking call, it will block until
          * connected, or timeout after 30 seconds*/
         retcode = nsapi_ppp_connect(_fh, _ppp_cb, _uname, _pwd, _stack);
-    } while (_connect_status == DISCONNECTED && apn_config && *apn_config);
+    } while (_connect_status == NSAPI_STATUS_DISCONNECTED && apn_config && *apn_config);
 
     return retcode;
 }
@@ -805,13 +805,13 @@ NetworkStack *PPPCellularInterface::get_stack()
 }
 
 
-void PPPCellularInterface::register_status_callback(
-    Callback<void(connection_status_t, int)> status_cb)
+void PPPCellularInterface::attach(
+    Callback<void(nsapi_connection_status_t, int)> status_cb)
 {
     _connection_status_cb = status_cb;
 }
 
-connection_status_t PPPCellularInterface::get_connection_status()
+nsapi_connection_status_t PPPCellularInterface::get_connection_status()
 {
     return _connect_status;
 }

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -404,11 +404,7 @@ bool PPPCellularInterface::nwk_registration(uint8_t nwk_type)
 
 bool PPPCellularInterface::is_connected()
 {
-    if (_connect_status == NSAPI_STATUS_GLOBAL_UP || _connect_status == NSAPI_STATUS_LOCAL_UP) {
-        return true;
-    } else {
-        return false;
-    } 
+    return (_connect_status == NSAPI_STATUS_GLOBAL_UP || _connect_status == NSAPI_STATUS_LOCAL_UP);
 }
 
 // Get the SIM card going.
@@ -570,10 +566,10 @@ nsapi_error_t PPPCellularInterface::connect()
     bool did_init = false;
     const char *apn_config = NULL;
 
-    if (_connect_status == NSAPI_STATUS_GLOBAL_UP || _connect_status == NSAPI_STATUS_LOCAL_UP) {
+    if (is_connected()) {
         return NSAPI_ERROR_IS_CONNECTED;
     } else if (_connect_status == NSAPI_STATUS_CONNECTING) {
-        return NSAPI_ERROR_IN_PROGRESS;
+        return NSAPI_ERROR_ALREADY;
     } 
 
     _connect_status = NSAPI_STATUS_CONNECTING;
@@ -729,12 +725,7 @@ nsapi_error_t PPPCellularInterface::connect()
  */
 nsapi_error_t PPPCellularInterface::disconnect()
 {
-    nsapi_error_t ret = nsapi_ppp_disconnect(_fh);
-    if (ret == NSAPI_ERROR_OK) {
-        return NSAPI_ERROR_OK;
-    }
-
-    return ret;
+    return nsapi_ppp_disconnect(_fh);
 }
 
 const char *PPPCellularInterface::get_ip_address()

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -240,20 +240,20 @@ public:
      *
      *  @param status   connection status of the link
      */
-    virtual void ppp_status_cb(connection_status_t, int);
+    virtual void ppp_status_cb(nsapi_connection_status_t, int);
 
     /** Register callback for status reporting
      *
      *  @param status_cb The callback for status changes
-     *  @return          The connection status according to connection_status_t
+     *  @return          The connection status according to nsapi_connection_status_t
      */
-    virtual void register_status_callback(Callback<void(connection_status_t, int)> status_cb);
+    virtual void attach(Callback<void(nsapi_connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
-     *  @return         The connection status according to connection_status_t
+     *  @return         The connection status according to nsapi_connection_status_t
      */
-    virtual connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status();
 
 private:
     FileHandle *_fh;
@@ -265,9 +265,9 @@ private:
     const char *_pwd;
     bool _debug_trace_on;
     nsapi_ip_stack_t _stack;
-    Callback<void(connection_status_t, int)> _ppp_cb;
-    Callback<void(connection_status_t, int)> _connection_status_cb;
-    connection_status_t _connect_status;
+    Callback<void(nsapi_connection_status_t, int)> _ppp_cb;
+    Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
+    nsapi_connection_status_t _connect_status;
     void base_initialization();
     void setup_at_parser();
     void shutdown_at_parser();

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -165,7 +165,6 @@ public:
      *  the lookup table then the driver tries to resort to default APN settings.
      *
      *  Preferred method is to setup APN using 'set_credentials()' API.
-     *
      *  @return         0 on success, negative error code on failure
      */
     virtual nsapi_error_t connect();
@@ -353,7 +352,6 @@ protected:
      * @return true if registration is successful
      */
     bool nwk_registration(uint8_t nwk_type=PACKET_SWITCHED);
-
 
 };
 

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -268,7 +268,6 @@ private:
     Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
     bool _connect_is_blocking;
-    nsapi_error_t _nonblocking_status; 
     void base_initialization();
     void setup_at_parser();
     void shutdown_at_parser();

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -236,24 +236,24 @@ public:
      */
     void modem_debug_on(bool on);
 
-    /** PPP connection status callback
-     *
-     *  @param status   connection status of the link
-     */
-    virtual void ppp_status_cb(nsapi_connection_status_t, int);
-
     /** Register callback for status reporting
      *
      *  @param status_cb The callback for status changes
-     *  @return          The connection status according to nsapi_connection_status_t
      */
-    virtual void attach(Callback<void(nsapi_connection_status_t, int)> status_cb);
+    virtual void attach(Callback<void(nsapi_event_t, intptr_t)> status_cb);
 
     /** Get the connection status
      *
      *  @return         The connection status according to nsapi_connection_status_t
      */
-    virtual nsapi_connection_status_t get_connection_status();
+    virtual nsapi_connection_status_t get_connection_status() const;
+
+    /** Set blocking status of connect() which by default should be blocking
+     *
+     *  @param blocking true if connect is blocking
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t set_blocking(bool blocking);
 
 private:
     FileHandle *_fh;
@@ -265,16 +265,18 @@ private:
     const char *_pwd;
     bool _debug_trace_on;
     nsapi_ip_stack_t _stack;
-    Callback<void(nsapi_connection_status_t, int)> _ppp_cb;
-    Callback<void(nsapi_connection_status_t, int)> _connection_status_cb;
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
+    bool _connect_is_blocking;
+    nsapi_error_t _nonblocking_status; 
     void base_initialization();
     void setup_at_parser();
     void shutdown_at_parser();
     nsapi_error_t initialize_sim_card();
     nsapi_error_t setup_context_and_credentials();
     bool power_up();
-    void power_down();
+    void power_down(); 
+    void ppp_status_cb(nsapi_event_t, intptr_t);
 
 protected:
     /** Enable or disable hang-up detection

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -240,20 +240,20 @@ public:
      *
      *  @param status   connection status of the link
      */
-    virtual void ppp_status_cb(ConnectionStatusType, int);
+    virtual void ppp_status_cb(connection_status_t, int);
 
     /** Register callback for status reporting
      *
      *  @param status_cb The callback for status changes
-     *  @return          The connection status according to ConnectionStatusType
+     *  @return          The connection status according to connection_status_t
      */
-    virtual void register_status_callback(Callback<void(ConnectionStatusType, int)> status_cb);
+    virtual void register_status_callback(Callback<void(connection_status_t, int)> status_cb);
 
     /** Get the connection status
      *
-     *  @return         The connection status according to ConnectionStatusType
+     *  @return         The connection status according to connection_status_t
      */
-    virtual ConnectionStatusType get_connection_status();
+    virtual connection_status_t get_connection_status();
 
 private:
     FileHandle *_fh;
@@ -265,9 +265,9 @@ private:
     const char *_pwd;
     bool _debug_trace_on;
     nsapi_ip_stack_t _stack;
-    Callback<void(ConnectionStatusType, int)> _ppp_cb;
-    Callback<void(ConnectionStatusType, int)> _connection_status_cb;
-    ConnectionStatusType _connect_status;
+    Callback<void(connection_status_t, int)> _ppp_cb;
+    Callback<void(connection_status_t, int)> _connection_status_cb;
+    connection_status_t _connect_status;
     void base_initialization();
     void setup_at_parser();
     void shutdown_at_parser();

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -240,15 +240,14 @@ public:
      *
      *  @param status   connection status of the link
      */
-    virtual void ppp_status_cb(ConnectionStatusType status);
+    virtual void ppp_status_cb(ConnectionStatusType, int);
 
     /** Register callback for status reporting
      *
      *  @param status_cb The callback for status changes
      *  @return          The connection status according to ConnectionStatusType
      */
-    typedef NetworkInterface::ConnectionStatusType ConnectionStatusType;
-    virtual void register_status_callback(Callback<void(ConnectionStatusType)> status_cb);
+    virtual void register_status_callback(Callback<void(ConnectionStatusType, int)> status_cb);
 
     /** Get the connection status
      *
@@ -266,8 +265,8 @@ private:
     const char *_pwd;
     bool _debug_trace_on;
     nsapi_ip_stack_t _stack;
-    Callback<void(ConnectionStatusType)> _ppp_cb;
-    Callback<void(ConnectionStatusType)> _connection_status_cb;
+    Callback<void(ConnectionStatusType, int)> _ppp_cb;
+    Callback<void(ConnectionStatusType, int)> _connection_status_cb;
     ConnectionStatusType _connect_status;
     void base_initialization();
     void setup_at_parser();

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -40,7 +40,7 @@ NetworkStack *nsapi_ppp_get_stack();
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_error_t)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(NetworkInterface::ConnectionStatusType)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -40,7 +40,7 @@ NetworkStack *nsapi_ppp_get_stack();
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(ConnectionStatusType, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(connection_status_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -47,7 +47,7 @@ nsapi_error_t nsapi_ppp_set_blocking(bool blocking);
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_event_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_event_t, intptr_t)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -40,7 +40,7 @@ NetworkStack *nsapi_ppp_get_stack();
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(NetworkInterface::ConnectionStatusType)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(ConnectionStatusType, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -29,6 +29,13 @@ namespace mbed {
  */
 NetworkStack *nsapi_ppp_get_stack();
 
+/** Set connection blocking parameter
+ *
+ *  @param blocking     True if connection is blocking
+ *
+ *  @return             0 on success, negative error code on failure
+ */
+nsapi_error_t nsapi_ppp_set_blocking(bool blocking);
 
 /** Connect to a PPP pipe
  *
@@ -40,7 +47,7 @@ NetworkStack *nsapi_ppp_get_stack();
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_connection_status_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_event_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_ppp.h
+++ b/features/netsocket/nsapi_ppp.h
@@ -40,7 +40,7 @@ NetworkStack *nsapi_ppp_get_stack();
  *
  *  @return             0 on success, negative error code on failure
  */
-nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(connection_status_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
+nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_connection_status_t, int)> status_cb=0, const char *uname=0, const char *pwd=0, const nsapi_ip_stack_t stack=DEFAULT_STACK);
 
 /** Close a PPP connection
  *

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -68,19 +68,16 @@ enum nsapi_error {
     NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
     NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
     NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
-    NSAPI_STATUS_UNDEFINED          = -3001     /*!< error situation */
+    NSAPI_STATUS_ERROR_UNSUPPORTED  = -3001
 } nsapi_connection_status_t;
 
 
-/** Enum of event types
- *
- *  Valid error codes have negative values.
+/** Enum of event types, this is always accompanied with a parameter of type nsapi_connection_status_t
  *
  *  @enum nsapi_event
  */
  typedef enum nsapi_event {
-    NSAPI_EVENT_CONNECTION_STATUS_CHANGE    = 0,        /*!< network connection status has changed */
-    NSAPI_EVENT_UNDEFINED                   = -3001     /*!< error situation */
+    NSAPI_EVENT_CONNECTION_STATUS_CHANGE    = 0        /*!< network connection status has changed */
 } nsapi_event_t;
 
 

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -56,6 +56,14 @@ enum nsapi_error {
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
 };
 
+ typedef enum  {
+    DISCONNECTED, 
+    LOCAL_UP, 
+    GLOBAL_UP, 
+    UNDEFINED
+} ConnectionStatusType;
+
+
 /** Type used to represent error codes
  *
  *  This is a separate type from enum nsapi_error to avoid breaking

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -56,12 +56,12 @@ enum nsapi_error {
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
 };
 
- typedef enum  {
+ typedef enum connection_status {
     DISCONNECTED, 
     LOCAL_UP, 
     GLOBAL_UP, 
     UNDEFINED
-} ConnectionStatusType;
+} connection_status_t;
 
 
 /** Type used to represent error codes

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -68,16 +68,19 @@ enum nsapi_error {
     NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
     NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
     NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
-    NSAPI_STATUS_ERROR_UNSUPPORTED  = -3001
+    NSAPI_STATUS_ERROR_UNSUPPORTED  = NSAPI_ERROR_UNSUPPORTED
 } nsapi_connection_status_t;
 
 
-/** Enum of event types, this is always accompanied with a parameter of type nsapi_connection_status_t
+/** Enum of event types
+ * 
+ *  Event callbacks are accompanied with an event-dependent parameter passed as an intptr_t.
  *
  *  @enum nsapi_event
  */
  typedef enum nsapi_event {
-    NSAPI_EVENT_CONNECTION_STATUS_CHANGE    = 0        /*!< network connection status has changed */
+    NSAPI_EVENT_CONNECTION_STATUS_CHANGE = 0, /*!< network connection status has changed, the parameter = new status (nsapi_connection_status_t) */
+    NSAPI_EVENT_SOME_FUTURE_EVENT        = 1  /*!< something else has happened, the parameter = time in milliseconds */
 } nsapi_event_t;
 
 

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -79,8 +79,7 @@ enum nsapi_error {
  *  @enum nsapi_event
  */
  typedef enum nsapi_event {
-    NSAPI_EVENT_CONNECTION_STATUS_CHANGE = 0, /*!< network connection status has changed, the parameter = new status (nsapi_connection_status_t) */
-    NSAPI_EVENT_SOME_FUTURE_EVENT        = 1  /*!< something else has happened, the parameter = time in milliseconds */
+    NSAPI_EVENT_CONNECTION_STATUS_CHANGE = 0 /*!< network connection status has changed, the parameter = new status (nsapi_connection_status_t) */
 } nsapi_event_t;
 
 

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -56,6 +56,7 @@ enum nsapi_error {
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
 };
 
+
 /** Enum of connection status types
  *
  *  Valid error codes have negative values.
@@ -68,6 +69,18 @@ enum nsapi_error {
     NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
     NSAPI_STATUS_UNDEFINED          = -3001     /*!< error situation */
 } nsapi_connection_status_t;
+
+
+/** Enum of event types
+ *
+ *  Valid error codes have negative values.
+ *
+ *  @enum nsapi_event
+ */
+ typedef enum nsapi_event {
+    NSAPI_EVENT_CONNECTION_STATUS_CHANGE    = 0,        /*!< network connection status has changed */
+    NSAPI_EVENT_UNDEFINED                   = -3001     /*!< error situation */
+} nsapi_event_t;
 
 
 /** Type used to represent error codes

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -67,6 +67,7 @@ enum nsapi_error {
     NSAPI_STATUS_LOCAL_UP           = 0,        /*!< local IP address set */
     NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
     NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
+    NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
     NSAPI_STATUS_UNDEFINED          = -3001     /*!< error situation */
 } nsapi_connection_status_t;
 

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -56,12 +56,12 @@ enum nsapi_error {
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
 };
 
- typedef enum connection_status {
-    DISCONNECTED, 
-    LOCAL_UP, 
-    GLOBAL_UP, 
-    UNDEFINED
-} connection_status_t;
+ typedef enum nsapi_connection_status {
+    NSAPI_STATUS_DISCONNECTED,             /*!< no connection to network */
+    NSAPI_STATUS_LOCAL_UP,                 /*!< local IP address set */
+    NSAPI_STATUS_GLOBAL_UP,                /*!< global IP address set */
+    NSAPI_STATUS_UNDEFINED                 /*!< error situation */
+} nsapi_connection_status_t;
 
 
 /** Type used to represent error codes

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -56,11 +56,17 @@ enum nsapi_error {
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
 };
 
+/** Enum of connection status types
+ *
+ *  Valid error codes have negative values.
+ *
+ *  @enum nsapi_connection_status
+ */
  typedef enum nsapi_connection_status {
-    NSAPI_STATUS_DISCONNECTED,             /*!< no connection to network */
-    NSAPI_STATUS_LOCAL_UP,                 /*!< local IP address set */
-    NSAPI_STATUS_GLOBAL_UP,                /*!< global IP address set */
-    NSAPI_STATUS_UNDEFINED                 /*!< error situation */
+    NSAPI_STATUS_LOCAL_UP           = 0,        /*!< local IP address set */
+    NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
+    NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
+    NSAPI_STATUS_UNDEFINED          = -3001     /*!< error situation */
 } nsapi_connection_status_t;
 
 


### PR DESCRIPTION
## Description

This adds connection status callback registering, and connection status reporting to NetworkInterface, and implementation of these to CellularInterface, mesh and ethernet interfaces

## Status

**READY**

## Migrations

YES

In NetworkInterface new APIs:
-attach() for connection status callback registering
-get_connection_status()
-set_blocking()

In PPPCellularInterface:
-connection_status_cb() removed

## Related PRs

## Todos

-  Documentation needs to be updated

## Deploy notes

## Steps to test or reproduce

