### PR TITLE
Make POSIX-like writes write everything when blocking

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -71,6 +71,12 @@ public:
 
     /** Write the contents of a buffer to a file
      *
+     *  Follows POSIX semantics:
+     *
+     * * if blocking, block until all data is written
+     * * if no data can be written, and non-blocking set, return -EAGAIN
+     * * if some data can be written, and non-blocking set, write partial
+     *
      *  @param buffer   The buffer to write from
      *  @param length   The number of bytes to write
      *  @return         The number of bytes written, negative error on failure

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -88,9 +88,9 @@ public:
      *  The socket must be connected to a remote host. Returns the number of
      *  bytes sent from the buffer.
      *
-     *  By default, send blocks until data is sent. If socket is set to
-     *  non-blocking or times out, NSAPI_ERROR_WOULD_BLOCK is returned
-     *  immediately.
+     *  By default, send blocks until all data is sent. If socket is set to
+     *  non-blocking or times out, a partial amount can be written.
+     *  NSAPI_ERROR_WOULD_BLOCK is returned if no data was written.
      *
      *  @param data     Buffer of data to send to the host
      *  @param size     Size of the buffer in bytes
@@ -104,9 +104,9 @@ public:
      *  The socket must be connected to a remote host. Returns the number of
      *  bytes received into the buffer.
      *
-     *  By default, recv blocks until data is sent. If socket is set to
-     *  non-blocking or times out, NSAPI_ERROR_WOULD_BLOCK is returned
-     *  immediately.
+     *  By default, recv blocks until some data is received. If socket is set to
+     *  non-blocking or times out, NSAPI_ERROR_WOULD_BLOCK can be returned to
+     *  indicate no data.
      *
      *  @param data     Destination buffer for data received from the host
      *  @param size     Size of the buffer in bytes

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -51,7 +51,7 @@ public:
      *  Devices acting as FileHandles should follow POSIX semantics:
      *
      *  * if no data is available, and non-blocking set return -EAGAIN
-     *  * if no data is available, and blocking set, wait until data is available
+     *  * if no data is available, and blocking set, wait until some data is available
      *  * If any data is available, call returns immediately
      *
      *  @param buffer   The buffer to read in to
@@ -61,6 +61,12 @@ public:
     virtual ssize_t read(void *buffer, size_t size) = 0;
 
     /** Write the contents of a buffer to a file
+     *
+     *  Devices acting as FileHandles should follow POSIX semantics:
+     *
+     * * if blocking, block until all data is written
+     * * if no data can be written, and non-blocking set, return -EAGAIN
+     * * if some data can be written, and non-blocking set, write partial
      *
      *  @param buffer   The buffer to write from
      *  @param size     The number of bytes to write 


### PR DESCRIPTION
FileHandle and TCPSocket both have POSIX-like write calls. Both of them only ever write as much as currently fits into the buffer or underlying stack in one go.

It would be advantageous if we were to follow the spirit of POSIX a bit more closely and make those write calls write everything when in blocking mode - POSIX does try to write everything when blocking, and only returns early if interrupted by a signal.

As we don't have signals, we can guarantee to always write everything when blocking (if no errors), and this could make callers' lives easier.

First commit here updates TCPSocket for testing. A commit for UARTSerial.cpp and FileHandle.h will follow.

See commit message for the TCPSocket for more excruciating detail and POSIX spec quotes.