### PR TITLE
Unity framework : add float support in error print

### DIFF
--- a/features/frameworks/unity/unity/unity.h
+++ b/features/frameworks/unity/unity/unity.h
@@ -20,6 +20,8 @@ extern "C"
 #define UNITY_SUPPORT_64
 // support double precision floating point
 #define UNITY_INCLUDE_DOUBLE
+// support float values in error print
+#define UNITY_FLOAT_VERBOSE
 
 #include "unity_internals.h"
 


### PR DESCRIPTION
## Description
It is useful to get some information about FAIL tests.

This define adds the float support in the error prints

Ex before:
[1510238846.92][CONN][RXD] :316::FAIL: Values Not Within Delta

With the patch:
[1510238777.90][CONN][RXD] :316::FAIL: Expected 1.000000 Was 0.999424

Thx

## Status

**READY**
