### PR TITLE
Add device_name for TB_SENSE_12.

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2870,6 +2870,7 @@
     },
 	"TB_SENSE_12": {
         "inherits": ["EFR32MG12P332F1024GL125"],
+        "device_name": "EFR32MG12P332F1024GL125",
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -394,7 +394,7 @@
               <MiscControls>{{asm_flags}}</MiscControls>
               <Define></Define>
               <Undefine></Undefine>
-              <IncludePath>{{include_paths}}</IncludePath>
+              <IncludePath></IncludePath>
             </VariousControls>
           </Aads>
           <LDads>


### PR DESCRIPTION
## Description
device_name key is required to add Cloud Client support / enable bootloader support for this target.

## Status

**READY**

## Deploy notes

None.