### PR TITLE
Increase flash program granularity on Realtek RTL8195AM

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/flash_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/flash_api.c
@@ -56,7 +56,7 @@ uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
 
 uint32_t flash_get_page_size(const flash_t *obj)
 {
-    return FLASH_PAGE_SIZE;
+    return 1;
 }
 
 uint32_t flash_get_start_address(const flash_t *obj)


### PR DESCRIPTION
The Page size has been set to 1 byte instead of the previous 256.
Although 256 is the physical page size, the driver supports
writing 1 byte at a time.

