### PR TITLE
DISCO_L072CZ_LRWAN1: HSE clock configuration improvement

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/system_clock.c
@@ -200,11 +200,9 @@ uint8_t SetSysClock_PLL_HSE(uint8_t bypass)
     // Output clock on MCO1 pin(PA8) for debugging purpose
     if (bypass == 0) { // Xtal used
         HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_2); // 16 MHz
-        //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_2); // 4 MHz
     }
     else { // External clock used
         HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_4); // 8 MHz
-        //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSE, RCC_MCODIV_4); // 2 MHz
     }
 #endif
 
@@ -278,7 +276,6 @@ uint8_t SetSysClock_PLL_HSI(void)
 #ifdef DEBUG_MCO
     // Output clock on MCO1 pin(PA8) for debugging purpose
     HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_SYSCLK, RCC_MCODIV_1); // 32 MHz (not precise due to HSI not calibrated)
-    //HAL_RCC_MCOConfig(RCC_MCO1, RCC_MCO1SOURCE_HSI, RCC_MCODIV_1); // 16 MHz (not precise due to HSI not calibrated)
 #endif
 
     return 1; // OK

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1551,7 +1551,7 @@
         "macros": ["RTC_LSI=1"],
         "config": {
             "clock_source": {
-                "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
+                "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             }


### PR DESCRIPTION
## Description
- Align the SetSysClock_PLL_HSE function with SetSysClock_PLL_HSI
- Minor change concerning the MCO pin output used for debug
- Add a comment in target.json for the HSE clock configuration

## Status
**READY**

## Migrations
NO

