### PR TITLE
Platform: Allow copy of non copyable objects

### DIFF
--- a/platform/NonCopyable.h
+++ b/platform/NonCopyable.h
@@ -16,6 +16,11 @@
 #ifndef MBED_NONCOPYABLE_H_
 #define MBED_NONCOPYABLE_H_
 
+#if (!defined(MBED_DEBUG) && (MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR == 0))
+#include "mbed_toolchain.h"
+#include "mbed_debug.h"
+#endif
+
 namespace mbed {
 
 /**
@@ -136,6 +141,10 @@ namespace mbed {
  * // empty base optimization can be applied B and C does not refer to the same
  * // kind of A. sizeof(C) == sizeof(B) == sizeof(int).
  * @endcode
+ *
+ * @note Compile time errors are disabled if the develop or the release profile
+ * is used. To override this behavior and force compile time errors in all profile
+ * set the configuration parameter "platform.force-non-copyable-error" to true.
  */
 template<typename T>
 class NonCopyable {
@@ -149,6 +158,39 @@ protected:
      */
     ~NonCopyable() { }
 
+#if (!defined(MBED_DEBUG) && (MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR == 0))
+    /**
+     * NonCopyable copy constructor.
+     *
+     * A compile time warning is issued when this function is used and a runtime
+     * warning is printed when the copy construction of the non copyable happens.
+     *
+     * If you see this warning, your code is probably doing something unspecified.
+     * Copy of non copyable resources can lead to resource leak and random error.
+     */
+    MBED_DEPRECATED("Invalid copy construction of a NonCopyable resource.")
+    NonCopyable(const NonCopyable&)
+    {
+        debug("Invalid copy construction of a NonCopyable resource: %s\r\n", MBED_PRETTY_FUNCTION);
+    }
+
+    /**
+     * NonCopyable copy assignment operator.
+     *
+     * A compile time warning is issued when this function is used and a runtime
+     * warning is printed when the copy construction of the non copyable happens.
+     *
+     * If you see this warning, your code is probably doing something unspecified.
+     * Copy of non copyable resources can lead to resource leak and random error.
+     */
+    MBED_DEPRECATED("Invalid copy assignment of a NonCopyable resource.")
+    NonCopyable& operator=(const NonCopyable&)
+    {
+        debug("Invalid copy assignment of a NonCopyable resource: %s\r\n", MBED_PRETTY_FUNCTION);
+        return *this;
+    }
+
+#else
 private:
     /**
      * Declare copy constructor as private, any attempt to copy construct
@@ -161,6 +203,7 @@ private:
      * a NonCopyable will fail at compile time.
      */
     NonCopyable& operator=(const NonCopyable&);
+#endif
 };
 
 } // namespace mbed

--- a/platform/NonCopyable.h
+++ b/platform/NonCopyable.h
@@ -16,153 +16,153 @@
 #ifndef MBED_NONCOPYABLE_H_
 #define MBED_NONCOPYABLE_H_
 
-namespace mbed { 
+namespace mbed {
 
 /**
- * Inheriting from this class autogeneration of copy construction and copy 
- * assignement operations. 
- * 
- * Classes which are not value type should inherit privately from this class 
- * to avoid generation of invalid copy constructor or copy assignement operator
- * which can lead to unoticeable programming errors. 
- * 
- * As an example consider the following signature: 
- * 
- * @code
- * class Resource; 
+ * Inheriting from this class autogeneration of copy construction and copy
+ * assignement operations.
  *
- * class Foo { 
- * public:     
+ * Classes which are not value type should inherit privately from this class
+ * to avoid generation of invalid copy constructor or copy assignement operator
+ * which can lead to unoticeable programming errors.
+ *
+ * As an example consider the following signature:
+ *
+ * @code
+ * class Resource;
+ *
+ * class Foo {
+ * public:
  *   Foo() : _resource(new Resource()) { }
- *   ~Foo() { delete _resource; } 
+ *   ~Foo() { delete _resource; }
  * private:
  *   Resource* _resource;
  * }
- * 
+ *
  * Foo get_foo();
- * 
+ *
  * Foo foo = get_foo();
- * @endcode 
- * 
- * There is a bug in this function, it returns a temporary value which will be 
- * byte copied into foo then destroyed. Unfortunately, internaly the Foo class 
- * manage a pointer to a Resource object. This pointer will be released when the 
- * temporary is destroyed and foo will manage a pointer to an already released 
+ * @endcode
+ *
+ * There is a bug in this function, it returns a temporary value which will be
+ * byte copied into foo then destroyed. Unfortunately, internaly the Foo class
+ * manage a pointer to a Resource object. This pointer will be released when the
+ * temporary is destroyed and foo will manage a pointer to an already released
  * Resource.
- * 
- * Two issues has to be fixed in the example above: 
- *   - Function signature has to be changed to reflect the fact that Foo 
- *     instances cannot be copied. In that case accessor should return a 
- *     reference to give access to objects already existing and managed. 
+ *
+ * Two issues has to be fixed in the example above:
+ *   - Function signature has to be changed to reflect the fact that Foo
+ *     instances cannot be copied. In that case accessor should return a
+ *     reference to give access to objects already existing and managed.
  *     Generator on the other hand should return a pointer to the created object.
- * 
- * @code 
+ *
+ * @code
  * // return a reference to an already managed Foo instance
- * Foo& get_foo(); 
+ * Foo& get_foo();
  * Foo& foo = get_foo();
- * 
+ *
  * // create a new Foo instance
  * Foo* make_foo();
  * Foo* m = make_foo();
  * @endcode
- * 
- *   - Copy constructor and copy assignement operator has to be made private 
- *     in the Foo class. It prevents unwanted copy of Foo objects. This can be 
- *     done by declaring copy constructor and copy assignement in the private 
+ *
+ *   - Copy constructor and copy assignement operator has to be made private
+ *     in the Foo class. It prevents unwanted copy of Foo objects. This can be
+ *     done by declaring copy constructor and copy assignement in the private
  *     section of the Foo class.
- *     
- * @code 
- * class Foo { 
- * public:     
+ *
+ * @code
+ * class Foo {
+ * public:
  *   Foo() : _resource(new Resource()) { }
- *   ~Foo() { delete _resource; } 
+ *   ~Foo() { delete _resource; }
  * private:
- *   // disallow copy operations 
+ *   // disallow copy operations
  *   Foo(const Foo&);
  *   Foo& operator=(const Foo&);
- *   // data members 
+ *   // data members
  *   Resource* _resource;
  * }
  * @endcode
- * 
- * Another solution is to inherit privately from the NonCopyable class. 
- * It reduces the boiler plate needed to avoid copy operations but more 
+ *
+ * Another solution is to inherit privately from the NonCopyable class.
+ * It reduces the boiler plate needed to avoid copy operations but more
  * importantly it clarifies the programer intent and the object semantic.
  *
- * class Foo : private NonCopyable<Foo> { 
- * public:     
+ * class Foo : private NonCopyable<Foo> {
+ * public:
  *   Foo() : _resource(new Resource()) { }
- *   ~Foo() { delete _resource; } 
+ *   ~Foo() { delete _resource; }
  * private:
  *   Resource* _resource;
  * }
- * 
- * @tparam T The type that should be made non copyable. It prevent cases where 
- * the empty base optimization cannot be applied and therefore ensure that the 
- * cost of this semantic sugar is null. 
- * 
- * As an example, the empty base optimization is prohibited if one of the empty 
- * base class is also a base type of the first non static data member: 
- * 
- * @code 
+ *
+ * @tparam T The type that should be made non copyable. It prevent cases where
+ * the empty base optimization cannot be applied and therefore ensure that the
+ * cost of this semantic sugar is null.
+ *
+ * As an example, the empty base optimization is prohibited if one of the empty
+ * base class is also a base type of the first non static data member:
+ *
+ * @code
  * struct A { };
- * struct B : A { 
+ * struct B : A {
  *    int foo;
  * };
  * // thanks to empty base optimization, sizeof(B) == sizeof(int)
- * 
- * struct C : A { 
+ *
+ * struct C : A {
  *   B b;
  * };
- * 
+ *
  * // empty base optimization cannot be applied here because A from C and A from
- * // B shall have a different address. In that case, with the alignement 
+ * // B shall have a different address. In that case, with the alignement
  * // sizeof(C) == 2* sizeof(int)
  * @endcode
- * 
- * The solution to that problem is to templatize the empty class to makes it 
- * unique to the type it is applied to: 
- * 
- * @code 
+ *
+ * The solution to that problem is to templatize the empty class to makes it
+ * unique to the type it is applied to:
+ *
+ * @code
  * template<typename T>
  * struct A<T> { };
- * struct B : A<B> { 
+ * struct B : A<B> {
  *    int foo;
  * };
- * struct C : A<C> { 
+ * struct C : A<C> {
  *   B b;
  * };
- * 
- * // empty base optimization can be applied B and C does not refer to the same 
+ *
+ * // empty base optimization can be applied B and C does not refer to the same
  * // kind of A. sizeof(C) == sizeof(B) == sizeof(int).
  * @endcode
  */
 template<typename T>
-class NonCopyable { 
+class NonCopyable {
 protected:
-    /** 
+    /**
      * Disalow construction of NonCopyable objects from outside of its hierarchy.
      */
     NonCopyable() { }
-    /** 
+    /**
      * Disalow destruction of NonCopyable objects from outside of its hierarchy.
      */
     ~NonCopyable() { }
 
-private: 
+private:
     /**
-     * Declare copy constructor as private, any attempt to copy construct 
+     * Declare copy constructor as private, any attempt to copy construct
      * a NonCopyable will fail at compile time.
      */
     NonCopyable(const NonCopyable&);
 
     /**
-     * Declare copy assignement operator as private, any attempt to copy assign 
+     * Declare copy assignement operator as private, any attempt to copy assign
      * a NonCopyable will fail at compile time.
      */
     NonCopyable& operator=(const NonCopyable&);
 };
 
-} // namespace mbed 
+} // namespace mbed
 
 #endif /* MBED_NONCOPYABLE_H_ */

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -19,6 +19,11 @@
         "default-serial-baud-rate": {
             "help": "Default baud rate for a Serial or RawSerial instance (if not specified in the constructor)",
             "value": 9600
+        },
+
+        "force-non-copyable-error": {
+            "help": "Force compile time error when a NonCopyable object is copied",
+            "value": false
         }
     },
     "target_overrides": {

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -5,7 +5,7 @@
  * \defgroup platform_toolchain Toolchain functions
  * @{
  */
- 
+
 /* mbed Microcontroller Library
  * Copyright (c) 2006-2013 ARM Limited
  *
@@ -63,7 +63,7 @@
  *
  *  @note
  *  IAR does not support alignment greater than word size on the stack
- *  
+ *
  *  @code
  *  #include "mbed_toolchain.h"
  *
@@ -125,16 +125,16 @@
  *  should contain a regular function declaration to insure the function is emitted.
  *  A function marked weak will not be emitted if an alternative non-weak
  *  implementation is defined.
- *  
+ *
  *  @note
  *  Weak functions are not friendly to making code re-usable, as they can only
  *  be overridden once (and if they are multiply overridden the linker will emit
  *  no warning). You should not normally use weak symbols as part of the API to
  *  re-usable modules.
- *  
+ *
  *  @code
  *  #include "mbed_toolchain.h"
- *  
+ *
  *  MBED_WEAK void foo() {
  *      // a weak implementation of foo that can be overriden by a definition
  *      // without  __weak
@@ -173,9 +173,9 @@
  *
  *  @code
  *  #include "mbed_toolchain.h"
- *  
+ *
  *  MBED_NOINLINE void foo() {
- *  
+ *
  *  }
  *  @endcode
  */
@@ -195,9 +195,9 @@
  *
  *  @code
  *  #include "mbed_toolchain.h"
- *  
+ *
  *  MBED_FORCEINLINE void foo() {
- *  
+ *
  *  }
  *  @endcode
  */
@@ -216,7 +216,7 @@
  *
  *  @code
  *  #include "mbed_toolchain.h"
- *  
+ *
  *  MBED_NORETURN void foo() {
  *      // must never return
  *      while (1) {}
@@ -266,7 +266,7 @@
  *
  *  @code
  *  #include "mbed_toolchain.h"
- *  
+ *
  *  MBED_DEPRECATED("don't foo any more, bar instead")
  *  void foo(int arg);
  *  @endcode

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -330,6 +330,20 @@
 #endif
 #endif
 
+/**
+ * Macro expanding to a string literal of the enclosing function name.
+ *
+ * The string returned takes into account language specificity and yield human
+ * readable content.
+ *
+ * As an example, if the macro is used within a C++ function then the string
+ * literal containing the function name will contain the complete signature of
+ * the function - including template parameters - and namespace qualifications.
+ */
+#ifndef MBED_PRETTY_FUNCTION
+#define MBED_PRETTY_FUNCTION __PRETTY_FUNCTION__
+#endif
+
 #ifndef MBED_PRINTF
 #if defined(__GNUC__) || defined(__CC_ARM)
 #define MBED_PRINTF(format_idx, first_param_idx) __attribute__ ((__format__(__printf__, format_idx, first_param_idx)))


### PR DESCRIPTION
## Description

~~This patch adds the compile time configuration "non-copyable-warning" to mbed platform library. When this configuration flag is set to true, compile time errors resulting of the copy of a NonCopyable object are transformed into compile time and runtime warning.~~

~~This may be useful for *functional* legacy code that erroneously copy non copyable resources. It is highly encouraged to fix non complying code; copy of objects not designed to be copied may lead to resources leak, operation on invalid memory location as well as random malfunctioning.~~

This patch turns compile time errors resulting of the copy of a NonCopyable object into compile time and runtime warnings when the code is compiled with the develop or release profile. The compile time error is still issued when the code is compiled with the debug profile. 

Compile time error can be enforced by setting the compile time configuration "force-non-copyable-error" to true.

This patch also adds the macro `MBED_PRETTY_FUNCTION` which yield the string literal of the enclosing function signature. 

## Status

**READY**

## Migrations

NO


