### PR TITLE
STM32: Add support of CAN3

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f0xx_hal.h"
+#include "stm32f0xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM    1 // Number of CAN peripherals present in the STM32 serie
+#define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN1_IRQ_RX_IRQN        CEC_CAN_IRQn
 #define CAN1_IRQ_RX_VECT        CAN_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F1/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f1.h"
+#include "stm32f1xx.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/TARGET_STM32F1/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f1xx_hal.h"
+#include "stm32f1.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM    1 // Number of CAN peripherals present in the STM32 serie
+#define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN1_IRQ_RX_IRQN        CAN1_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN1_RX0_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F2/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f2xx_hal.h"
+#include "stm32f2xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie (1 or 2)
+#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN1_IRQ_RX_IRQN        CAN1_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN1_RX0_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F3/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f3xx_hal.h"
+#include "stm32f3xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM    1 // Number of CAN peripherals present in the STM32 serie
+#define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN1_IRQ_RX_IRQN        CAN_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN_RX0_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f4xx_hal.h"
+#include "stm32f4xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,9 +25,9 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(STM32F413xx)
+#if defined(CAN3_BASE)
 
-#define CAN_NUM 3
+#define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN3_IRQ_RX_IRQN        CAN3_RX0_IRQn
 #define CAN3_IRQ_RX_VECT        CAN3_RX0_IRQHandler
@@ -42,7 +42,7 @@ extern "C" {
 
 #else
 
-#define CAN_NUM 2
+#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie
 
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -25,7 +25,26 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie (1 or 2)
+#if defined(STM32F413xx)
+
+#define CAN_NUM 3
+
+#define CAN3_IRQ_RX_IRQN        CAN3_RX0_IRQn
+#define CAN3_IRQ_RX_VECT        CAN3_RX0_IRQHandler
+#define CAN3_IRQ_TX_IRQN        CAN3_TX_IRQn
+#define CAN3_IRQ_TX_VECT        CAN3_TX_IRQHandler
+#define CAN3_IRQ_ERROR_IRQN     CAN3_SCE_IRQn
+#define CAN3_IRQ_ERROR_VECT     CAN3_SCE_IRQHandler
+#define CAN3_IRQ_PASSIVE_IRQN   CAN3_SCE_IRQn
+#define CAN3_IRQ_PASSIVE_VECT   CAN3_SCE_IRQHandler
+#define CAN3_IRQ_BUS_IRQN       CAN3_SCE_IRQn
+#define CAN3_IRQ_BUS_VECT       CAN3_SCE_IRQHandler
+
+#else
+
+#define CAN_NUM 2
+
+#endif
 
 #define CAN1_IRQ_RX_IRQN        CAN1_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN1_RX0_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(CAN3_BASE)
+#if defined(CAN3_BASE) && defined(CAN_3)
 
 #define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -25,7 +25,26 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie (1 or 2)
+#if defined(STM32F767xx)
+
+#define CAN_NUM 3
+
+#define CAN3_IRQ_RX_IRQN        CAN3_RX0_IRQn
+#define CAN3_IRQ_RX_VECT        CAN3_RX0_IRQHandler
+#define CAN3_IRQ_TX_IRQN        CAN3_TX_IRQn
+#define CAN3_IRQ_TX_VECT        CAN3_TX_IRQHandler
+#define CAN3_IRQ_ERROR_IRQN     CAN3_SCE_IRQn
+#define CAN3_IRQ_ERROR_VECT     CAN3_SCE_IRQHandler
+#define CAN3_IRQ_PASSIVE_IRQN   CAN3_SCE_IRQn
+#define CAN3_IRQ_PASSIVE_VECT   CAN3_SCE_IRQHandler
+#define CAN3_IRQ_BUS_IRQN       CAN3_SCE_IRQn
+#define CAN3_IRQ_BUS_VECT       CAN3_SCE_IRQHandler
+
+#else
+
+#define CAN_NUM 2
+
+#endif
 
 #define CAN1_IRQ_RX_IRQN        CAN1_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN1_RX0_IRQHandler

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(CAN3_BASE)
+#if defined(CAN3_BASE) && defined(CAN_3)
 
 #define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32f7xx_hal.h"
+#include "stm32f7xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,9 +25,9 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(STM32F767xx)
+#if defined(CAN3_BASE)
 
-#define CAN_NUM 3
+#define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN3_IRQ_RX_IRQN        CAN3_RX0_IRQn
 #define CAN3_IRQ_RX_VECT        CAN3_RX0_IRQHandler
@@ -42,7 +42,7 @@ extern "C" {
 
 #else
 
-#define CAN_NUM 2
+#define CAN_NUM 2 // Number of CAN peripherals present in the STM32 serie
 
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32L4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/can_device.h
@@ -17,7 +17,7 @@
 #define MBED_CAN_DEVICE_H
 
 #include "cmsis.h"
-#include "stm32l4xx_hal.h"
+#include "stm32l4xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#define CAN_NUM    1 // Number of CAN peripherals present in the STM32 serie
+#define CAN_NUM 1 // Number of CAN peripherals present in the STM32 serie
 
 #define CAN1_IRQ_RX_IRQN        CAN1_RX0_IRQn
 #define CAN1_IRQ_RX_VECT        CAN1_RX0_IRQHandler

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -57,11 +57,17 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
         __HAL_RCC_CAN1_CLK_ENABLE();
         obj->index = 0;
     }
-#if defined(CAN2_BASE) && (CAN_NUM == 2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     else if (can == CAN_2) {
         __HAL_RCC_CAN1_CLK_ENABLE(); // needed to set filters
         __HAL_RCC_CAN2_CLK_ENABLE();
         obj->index = 1;
+    }
+#endif
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
+    else if (can == CAN_3) {
+        __HAL_RCC_CAN3_CLK_ENABLE();
+        obj->index = 2;
     }
 #endif
     else {
@@ -126,11 +132,18 @@ void can_free(can_t *obj)
         __HAL_RCC_CAN1_RELEASE_RESET();
         __HAL_RCC_CAN1_CLK_DISABLE();
     }
-#if defined(CAN2_BASE) && (CAN_NUM == 2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     if (can == CAN_2) {
         __HAL_RCC_CAN2_FORCE_RESET();
         __HAL_RCC_CAN2_RELEASE_RESET();
         __HAL_RCC_CAN2_CLK_DISABLE();
+    }
+#endif
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
+    if (can == CAN_3) {
+        __HAL_RCC_CAN3_FORCE_RESET();
+        __HAL_RCC_CAN3_RELEASE_RESET();
+        __HAL_RCC_CAN3_CLK_DISABLE();
     }
 #endif
 }
@@ -549,7 +562,7 @@ void CAN1_SCE_IRQHandler(void)
 {
     can_irq(CAN_1, 0);
 }
-#if defined(CAN2_BASE) && (CAN_NUM == 2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
 void CAN2_RX0_IRQHandler(void)
 {
     can_irq(CAN_2, 1);
@@ -562,7 +575,21 @@ void CAN2_SCE_IRQHandler(void)
 {
     can_irq(CAN_2, 1);
 }
-#endif // defined(CAN2_BASE) && (CAN_NUM == 2)
+#endif
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
+void CAN3_RX0_IRQHandler(void)
+{
+    can_irq(CAN_3, 1);
+}
+void CAN3_TX_IRQHandler(void)
+{
+    can_irq(CAN_3, 1);
+}
+void CAN3_SCE_IRQHandler(void)
+{
+    can_irq(CAN_3, 1);
+}
+#endif
 #endif // else
 
 void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
@@ -603,7 +630,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
                 return;
         }
     }
-#if defined(CAN2_BASE) && (CAN_NUM == 2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     else if ((CANName) can == CAN_2) {
         switch (type) {
             case IRQ_RX:
@@ -630,6 +657,39 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
                 ier = CAN_IT_BOF;
                 irq_n = CAN2_IRQ_BUS_IRQN;
                 vector = (uint32_t)&CAN2_IRQ_BUS_VECT;
+                break;
+            default:
+                return;
+        }
+    }
+#endif
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
+    else if ((CANName) can == CAN_3) {
+        switch (type) {
+            case IRQ_RX:
+                ier = CAN_IT_FMP0;
+                irq_n = CAN3_IRQ_RX_IRQN;
+                vector = (uint32_t)&CAN3_IRQ_RX_VECT;
+                break;
+            case IRQ_TX:
+                ier = CAN_IT_TME;
+                irq_n = CAN3_IRQ_TX_IRQN;
+                vector = (uint32_t)&CAN3_IRQ_TX_VECT;
+                break;
+            case IRQ_ERROR:
+                ier = CAN_IT_ERR;
+                irq_n = CAN3_IRQ_ERROR_IRQN;
+                vector = (uint32_t)&CAN3_IRQ_ERROR_VECT;
+                break;
+            case IRQ_PASSIVE:
+                ier = CAN_IT_EPV;
+                irq_n = CAN3_IRQ_PASSIVE_IRQN;
+                vector = (uint32_t)&CAN3_IRQ_PASSIVE_VECT;
+                break;
+            case IRQ_BUS:
+                ier = CAN_IT_BOF;
+                irq_n = CAN3_IRQ_BUS_IRQN;
+                vector = (uint32_t)&CAN3_IRQ_BUS_VECT;
                 break;
             default:
                 return;

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -57,14 +57,14 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
         __HAL_RCC_CAN1_CLK_ENABLE();
         obj->index = 0;
     }
-#if defined(CAN2_BASE) && (CAN_NUM > 1)
+#if defined(CAN2_BASE) && defined(CAN_2)
     else if (can == CAN_2) {
         __HAL_RCC_CAN1_CLK_ENABLE(); // needed to set filters
         __HAL_RCC_CAN2_CLK_ENABLE();
         obj->index = 1;
     }
 #endif
-#if defined(CAN3_BASE) && (CAN_NUM > 2)
+#if defined(CAN3_BASE) && defined(CAN_3)
     else if (can == CAN_3) {
         __HAL_RCC_CAN3_CLK_ENABLE();
         obj->index = 2;
@@ -132,14 +132,14 @@ void can_free(can_t *obj)
         __HAL_RCC_CAN1_RELEASE_RESET();
         __HAL_RCC_CAN1_CLK_DISABLE();
     }
-#if defined(CAN2_BASE) && (CAN_NUM > 1)
+#if defined(CAN2_BASE) && defined(CAN_2)
     if (can == CAN_2) {
         __HAL_RCC_CAN2_FORCE_RESET();
         __HAL_RCC_CAN2_RELEASE_RESET();
         __HAL_RCC_CAN2_CLK_DISABLE();
     }
 #endif
-#if defined(CAN3_BASE) && (CAN_NUM > 2)
+#if defined(CAN3_BASE) && defined(CAN_3)
     if (can == CAN_3) {
         __HAL_RCC_CAN3_FORCE_RESET();
         __HAL_RCC_CAN3_RELEASE_RESET();
@@ -562,7 +562,7 @@ void CAN1_SCE_IRQHandler(void)
 {
     can_irq(CAN_1, 0);
 }
-#if defined(CAN2_BASE) && (CAN_NUM > 1)
+#if defined(CAN2_BASE) && defined(CAN_2)
 void CAN2_RX0_IRQHandler(void)
 {
     can_irq(CAN_2, 1);
@@ -576,7 +576,7 @@ void CAN2_SCE_IRQHandler(void)
     can_irq(CAN_2, 1);
 }
 #endif
-#if defined(CAN3_BASE) && (CAN_NUM > 2)
+#if defined(CAN3_BASE) && defined(CAN_3)
 void CAN3_RX0_IRQHandler(void)
 {
     can_irq(CAN_3, 1);
@@ -630,7 +630,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
                 return;
         }
     }
-#if defined(CAN2_BASE) && (CAN_NUM > 1)
+#if defined(CAN2_BASE) && defined(CAN_2)
     else if ((CANName) can == CAN_2) {
         switch (type) {
             case IRQ_RX:
@@ -663,7 +663,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
         }
     }
 #endif
-#if defined(CAN3_BASE) && (CAN_NUM > 2)
+#if defined(CAN3_BASE) && defined(CAN_3)
     else if ((CANName) can == CAN_3) {
         switch (type) {
             case IRQ_RX:


### PR DESCRIPTION
## Description
Add support of CAN3. Previously only CAN1 and CAN2 were supported.

Tested OK with a TX/RX loop program using a NUCLEO_F767ZI (CAN_RX) and NUCLEO_F446RE (CAN_TX).

Fix issue #5484 

## Status
**READY**

## Migrations
NO

