### PR TITLE
Fix bug for issue:  initial pin value not retained

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
@@ -33,7 +33,6 @@
 typedef struct {
     bool         used_as_gpio : 1;
     PinDirection direction    : 1;
-    bool         init_high    : 1;
     PinMode      pull         : 2;
     bool         used_as_irq  : 1;
     bool         irq_fall     : 1;
@@ -156,7 +155,7 @@ static void gpio_apply_config(uint8_t pin)
         }
         else {
             // Configure as output.
-            nrf_drv_gpiote_out_config_t cfg = GPIOTE_CONFIG_OUT_SIMPLE(m_gpio_cfg[pin].init_high);
+            nrf_drv_gpiote_out_config_t cfg = GPIOTE_CONFIG_OUT_SIMPLE(nrf_gpio_pin_out_read(pin));
             nrf_drv_gpiote_out_init(pin, &cfg);
         }
         m_gpio_initialized |= ((gpio_mask_t)1UL << pin);


### PR DESCRIPTION
For api usage like DigitalOut led(LED1, 1) the hal function gpio_write()
sets the output before f. gpio_mode() is called. gpio_mode() clears the
output as it take never writen parameters (gpio_cfg_t.init_hight).

This patch use internal hardware register of GPIO output instedad of above paramiter latch
for retaining proper writen state.

Fix for https://github.com/ARMmbed/mbed-os/issues/5462#issuecomment-343127875