### PR TITLE
STM32: HAL smartcard, fix memory corruption in Receive

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_smartcard.c
@@ -500,7 +500,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *
   */
 HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint16_t* tmp;
   uint32_t tickstart = 0U;
   
   if(hsc->RxState == HAL_SMARTCARD_STATE_READY)
@@ -530,8 +529,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *p
       {
         return HAL_TIMEOUT;
       }
-      tmp = (uint16_t*) pData;
-      *tmp = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
+      *pData = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
       pData +=1U;
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_smartcard.c
@@ -496,7 +496,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *
   */
 HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint16_t* tmp;
   uint32_t tickstart = 0U;
   
   if(hsc->RxState == HAL_SMARTCARD_STATE_READY) 
@@ -526,8 +525,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *p
       {
         return HAL_TIMEOUT;
       }
-      tmp = (uint16_t*) pData;
-      *tmp = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
+      *pData = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
       pData +=1U;
     }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_smartcard.c
@@ -497,7 +497,6 @@ HAL_StatusTypeDef HAL_SMARTCARD_Transmit(SMARTCARD_HandleTypeDef *hsc, uint8_t *
   */
 HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *pData, uint16_t Size, uint32_t Timeout)
 {
-  uint16_t* tmp;
   uint32_t tickstart = 0U;
   
   if(hsc->RxState == HAL_SMARTCARD_STATE_READY) 
@@ -527,8 +526,7 @@ HAL_StatusTypeDef HAL_SMARTCARD_Receive(SMARTCARD_HandleTypeDef *hsc, uint8_t *p
       {
         return HAL_TIMEOUT;
       }
-      tmp = (uint16_t*) pData;
-      *tmp = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
+      *pData = (uint8_t)(hsc->Instance->DR & (uint8_t)0xFF);
       pData +=1U;
     }
 


### PR DESCRIPTION
This is a follow-up of PR #5303. In order to avoid losing that was proposed in #5303 but that could not be merged as it is we are proposing this new PR. We are taking only the fix part, and leaving behind application related changes.

Proposal: close #5303 and use this PR instead. 

## Description of fix

Re-casting with tmp the uint8_t* pData pointer to uint16_t* brings a
memory corruption and typically can corrupt the size parameter. This
is fixed with this commit.

STM32 Internal ticket reference : 39116

