### PR TITLE
 DISCO_L072CZ_LRWAN1 can use LSE from LORA module

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_ARM_MICRO/stm32l072xz.sct
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_ARM_MICRO/stm32l072xz.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32L073RZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
+; STM32L072CZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
 LR_IROM1 0x08000000 0x30000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x30000  {  ; load address = execution address

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_ARM_STD/stm32l072xz.sct
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L072CZ_LRWAN1/device/TOOLCHAIN_ARM_STD/stm32l072xz.sct
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32L073RZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
+; STM32L072CZ: 192KB FLASH (0x30000) + 20KB RAM (0x5000)
 LR_IROM1 0x08000000 0x30000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x30000  {  ; load address = execution address

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1559,7 +1559,6 @@
         "core": "Cortex-M0+",
         "extra_labels_add": ["STM32L0", "STM32L072CZ", "STM32L072xx"],
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "macros": ["RTC_LSI=1"],
         "config": {
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",


### PR DESCRIPTION
## Description

DISCO_L072CZ_LRWAN1 can use LSE from LORA module

## Status

**READY**

## Test Result

+-------------------------+---------------------+-------------------------+----------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name       | test suite              | test case                        | passed | failed | result | elapsed_time (sec) |
+-------------------------+---------------------+-------------------------+----------------------------------+--------+--------+--------+--------------------+
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_drivers-rtc  | RTC strftime                     | 1      | 0      | OK     | 10.93              |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-rtc_time | mk time                          | 1      | 0      | OK     | 24.04              |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-rtc_time | test is leap year                | 1      | 0      | OK     | 0.04               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-rtc_time | test local time                  | 1      | 0      | OK     | 58.11              |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-rtc_time | test local time limits           | 1      | 0      | OK     | 0.05               |
| DISCO_L072CZ_LRWAN1-ARM | DISCO_L072CZ_LRWAN1 | tests-mbed_hal-rtc_time | test mk time out of range values | 1      | 0      | OK     | 0.06               |
+-------------------------+---------------------+-------------------------+----------------------------------+--------+--------+--------+--------------------+


