### PR TITLE
STM32: Add USB Device on DISCO_F429ZI

### DIFF
--- a/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
+++ b/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
@@ -27,7 +27,8 @@
 #define TARGET_DISCO_F746NG_OTG_HS
 #endif
 
-#if defined(TARGET_DISCO_F769NI) || \
+#if defined(TARGET_DISCO_F429ZI) || \
+    defined(TARGET_DISCO_F769NI) || \
     defined(TARGET_DISCO_F746NG_OTG_HS)
 #define USBHAL_IRQn  OTG_HS_IRQn
 #else
@@ -101,6 +102,11 @@ USBHAL::USBHAL(void) {
     hpcd.Init.phy_itface = PCD_PHY_ULPI;
     hpcd.Init.Sof_enable = 0;
     hpcd.Init.speed = PCD_SPEED_HIGH;
+#elif defined(TARGET_DISCO_F429ZI)
+    hpcd.Instance = USB_OTG_HS;
+    hpcd.Init.phy_itface = PCD_PHY_EMBEDDED;
+    hpcd.Init.Sof_enable = 0;
+    hpcd.Init.speed = PCD_SPEED_HIGH;
 #else
     hpcd.Instance = USB_OTG_FS;
     hpcd.Init.phy_itface = PCD_PHY_EMBEDDED;
@@ -150,6 +156,13 @@ USBHAL::USBHAL(void) {
     pin_function(PA_10, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_PULLUP, GPIO_AF10_OTG_FS)); // ID
     pin_function(PA_8, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS));  // SOF
     __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+#elif defined(TARGET_DISCO_F429ZI)
+    __HAL_RCC_GPIOB_CLK_ENABLE();
+    pin_function(PB_14, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF12_OTG_HS_FS)); // DM
+    pin_function(PB_15, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF12_OTG_HS_FS)); // DP
+    pin_function(PB_13, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0)); // VBUS
+    __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
 
 #elif defined(TARGET_DISCO_L475VG_IOT01A) || \
       defined(TARGET_DISCO_L476VG)

--- a/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_STM32.h
+++ b/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_STM32.h
@@ -28,6 +28,7 @@
     defined(TARGET_NUCLEO_F767ZI) || \
     defined(TARGET_NUCLEO_F746ZG) || \
     defined(TARGET_DISCO_F407VG) || \
+    defined(TARGET_DISCO_F429ZI) || \
     defined(TARGET_DISCO_F469NI) || \
     defined(TARGET_DISCO_F746NG) || \
     defined(TARGET_DISCO_F769NI) || \

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1525,7 +1525,7 @@
                 "macro_name": "CLOCK_SOURCE_USB"
             }
         },
-        "macros_add": ["RTC_LSI=1", "USBHOST_OTHER"],
+        "macros_add": ["RTC_LSI=1", "USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F429ZI"


### PR DESCRIPTION
## Description
Add support of USB Device on the DISCO_F429ZI board.

Tested OK with USB_1 test.

## Status
**READY**

## Migrations
NO
