### PR TITLE
Fixed mutex assert in armcc fopen and related memory leak

### DIFF
--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.c
@@ -609,27 +609,33 @@ __WEAK int _mutex_initialize(mutex *m) {
 }
 
 // Acquire mutex
+#if !defined(__ARMCC_VERSION) || __ARMCC_VERSION < 6010050
 __USED
+#endif
 void _mutex_acquire(mutex *m);
-void _mutex_acquire(mutex *m) {
+__WEAK void _mutex_acquire(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexAcquire(*m, osWaitForever);
   }
 }
 
 // Release mutex
+#if !defined(__ARMCC_VERSION) || __ARMCC_VERSION < 6010050
 __USED
+#endif
 void _mutex_release(mutex *m);
-void _mutex_release(mutex *m) {
+__WEAK void _mutex_release(mutex *m) {
   if (os_kernel_is_active()) {
     osMutexRelease(*m);
   }
 }
 
 // Free mutex
+#if !defined(__ARMCC_VERSION) || __ARMCC_VERSION < 6010050
 __USED
+#endif
 void _mutex_free(mutex *m);
-void _mutex_free(mutex *m) {
+__WEAK void _mutex_free(mutex *m) {
   osMutexDelete(*m);
 }
 


### PR DESCRIPTION
armcc fopen allocated a mutex using the retargeted system-level _mutex_initialize function. Interestingly, malloc also uses this same _mutex_initialization function, which prevents a full solution relying on malloc. The solution previously implemented involved using the rtx mutex pool for the first 8 mutexes, then falling back on malloc.

The previous implementation relied on osMutexNew returning an error on out-of-memory. An unrelated change causes osMutexNew to instead assert (except for release mode). This meant if you exceed 8 system- level mutexes in armcc you will hit an assert. Since the filesystem code can call fopen an unlimited number of times, this is a problem.

Solution is to keep track of which static mutexes we've allocated, so we know before calling osMutexNew if we need to call malloc.

Also _mutex_free never deallocated the malloced mutexes, which would cause fopen to leak memory.

cc @c1728p9, @deepikabhavnani, @bulislaw 