### PR TITLE
Switch to using newlib-nano.

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -13,7 +13,7 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n"]
+               "-Wl,-n", "-specs=nano.specs"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-g", "-O0",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -12,7 +12,7 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n"]
+               "-Wl,-n", "-specs=nano.specs"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Os",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -12,7 +12,7 @@
         "ld": ["-Wl,--gc-sections", "-Wl,--wrap,main", "-Wl,--wrap,_malloc_r",
                "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r", "-Wl,--wrap,_memalign_r",
                "-Wl,--wrap,_calloc_r", "-Wl,--wrap,exit", "-Wl,--wrap,atexit",
-               "-Wl,-n"]
+               "-Wl,-n", "-specs=nano.specs"]
     },
     "ARMC6": {
         "common": ["-c", "--target=arm-arm-none-eabi", "-mthumb", "-Oz",


### PR DESCRIPTION
## Description

Reduce mbed-os code size by switching to newlib-nano. newlib-nano is intended for bare-metal platforms, like mbed-os. It has many space optimisations that will benefit mbedOS code size.

See here for more information: https://community.arm.com/iot/embedded/b/embedded-blog/posts/shrink-your-mcu-code-size-with-gcc-arm-embedded-4-7


## Status

**IN DEVELOPMENT**

## Migrations

Users **should not** notice any changes in APIs. More detail about changes is provided here: https://github.com/32bitmicro/newlib-nano-1.0/blob/master/newlib/README.nano and here: https://community.arm.com/tools/b/blog/posts/more-code-in-less-space-with-arm-compiler-6
