### PR TITLE
NUCLEO_L432KC: Fixed async serial

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -491,9 +491,11 @@ static IRQn_Type serial_get_irq_n(serial_t *obj)
             irq_n = USART2_IRQn;
             break;
 
+#if defined(UART3_BASE)
         case 2:
             irq_n = USART3_IRQn;
             break;
+#endif
 #if defined(UART4_BASE)
         case 3:
             irq_n = UART4_IRQn;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1379,7 +1379,7 @@
             }
         },
         "detect_code": ["0770"],
-        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_FC", "CAN", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L432KC"
     },


### PR DESCRIPTION
## Description

In targets.json there is no SERIAL_ASYNC defined for the NUCLEO_L432KC developer board.
When adding this option, a bug in targets/TARGET_STM/TARGET_STM32L4 was encountered which was leading to compile errors.
