### PR TITLE
Add missing decimal digits of Humidity and Pressure.

### DIFF
--- a/features/FEATURE_BLE/ble/services/EnvironmentalService.h
+++ b/features/FEATURE_BLE/ble/services/EnvironmentalService.h
@@ -65,7 +65,7 @@ public:
      * @brief   Update humidity characteristic.
      * @param   newHumidityVal New humidity measurement.
      */
-    void updateHumidity(HumidityType_t newHumidityVal)
+    void updateHumidity(float newHumidityVal)
     {
         humidity = (HumidityType_t) (newHumidityVal * 100);
         ble.gattServer().write(humidityCharacteristic.getValueHandle(), (uint8_t *) &humidity, sizeof(HumidityType_t));
@@ -75,7 +75,7 @@ public:
      * @brief   Update pressure characteristic.
      * @param   newPressureVal New pressure measurement.
      */
-    void updatePressure(PressureType_t newPressureVal)
+    void updatePressure(float newPressureVal)
     {
         pressure = (PressureType_t) (newPressureVal * 10);
         ble.gattServer().write(pressureCharacteristic.getValueHandle(), (uint8_t *) &pressure, sizeof(PressureType_t));


### PR DESCRIPTION
## Description

This is an old issue. [#4512](https://github.com/ARMmbed/mbed-os/issues/4512)
BLE EnvironmentalService sends out Humidity value and Pressure value missing decimal digits.

## Status

**Fixed**

## Modification

This PR changes 2 following input parameter types for keeping their decimal digits. 
from HumidityType_t (uint16_t) for humidity to float
from PressureType_t (uint32_t) for pressure to float

## Test APPs

The fix had been tested with following applications.
BLE GATT server on TY51822r3 using https://github.com/soramame21/BLE_Server_BME280
BLE Gatt Client on K64F using https://github.com/soramame21/BLEClient_mbedDevConn
Please verify com port print from BLEClient_mbedDevConn for received value of Humidity and Pressure at K64F.  