### PR TITLE
Revert "Shrink RTOS classes"

### DIFF
--- a/rtos/EventFlags.cpp
+++ b/rtos/EventFlags.cpp
@@ -39,11 +39,11 @@ EventFlags::EventFlags(const char *name)
 void EventFlags::constructor(const char *name)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osEventFlagsAttr_t attr;
-    attr.name = name ? name : "application_unnamed_event_flags";
-    attr.cb_mem = &_obj_mem;
-    attr.cb_size = sizeof(_obj_mem);
-    _id = osEventFlagsNew(&attr);
+    memset(&_attr, 0, sizeof(_attr));
+    _attr.name = name ? name : "application_unnamed_event_flags";
+    _attr.cb_mem = &_obj_mem;
+    _attr.cb_size = sizeof(_obj_mem);
+    _id = osEventFlagsNew(&_attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/EventFlags.h
+++ b/rtos/EventFlags.h
@@ -94,6 +94,7 @@ private:
     void constructor(const char *name = NULL);
     uint32_t wait(uint32_t flags, uint32_t opt, uint32_t timeout, bool clear);
     osEventFlagsId_t                _id;
+    osEventFlagsAttr_t              _attr;
     mbed_rtos_storage_event_flags_t _obj_mem;
 };
 

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -54,12 +54,12 @@ public:
     MemoryPool() {
         memset(_pool_mem, 0, sizeof(_pool_mem));
         memset(&_obj_mem, 0, sizeof(_obj_mem));
-        osMemoryPoolAttr_t attr = { 0 };
-        attr.mp_mem = _pool_mem;
-        attr.mp_size = sizeof(_pool_mem);
-        attr.cb_mem = &_obj_mem;
-        attr.cb_size = sizeof(_obj_mem);
-        _id = osMemoryPoolNew(pool_sz, sizeof(T), &attr);
+        memset(&_attr, 0, sizeof(_attr));
+        _attr.mp_mem = _pool_mem;
+        _attr.mp_size = sizeof(_pool_mem);
+        _attr.cb_mem = &_obj_mem;
+        _attr.cb_size = sizeof(_obj_mem);
+        _id = osMemoryPoolNew(pool_sz, sizeof(T), &_attr);
         MBED_ASSERT(_id);
     }
 
@@ -99,6 +99,7 @@ public:
 
 private:
     osMemoryPoolId_t             _id;
+    osMemoryPoolAttr_t           _attr;
     /* osMemoryPoolNew requires that pool block size is a multiple of 4 bytes. */
     char                         _pool_mem[((sizeof(T) + 3) & ~3) * pool_sz];
     mbed_rtos_storage_mem_pool_t _obj_mem;

--- a/rtos/Mutex.cpp
+++ b/rtos/Mutex.cpp
@@ -40,12 +40,12 @@ Mutex::Mutex(const char *name)
 void Mutex::constructor(const char *name)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osMutexAttr_t attr = { 0 };
-    attr.name = name ? name : "aplication_unnamed_mutex";
-    attr.cb_mem = &_obj_mem;
-    attr.cb_size = sizeof(_obj_mem);
-    attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
-    _id = osMutexNew(&attr);
+    memset(&_attr, 0, sizeof(_attr));
+    _attr.name = name ? name : "aplication_unnamed_mutex";
+    _attr.cb_mem = &_obj_mem;
+    _attr.cb_size = sizeof(_obj_mem);
+    _attr.attr_bits = osMutexRecursive | osMutexPrioInherit | osMutexRobust;
+    _id = osMutexNew(&_attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -86,6 +86,7 @@ private:
     void constructor(const char *name = NULL);
 
     osMutexId_t               _id;
+    osMutexAttr_t             _attr;
     mbed_rtos_storage_mutex_t _obj_mem;
 };
 /** @}*/

--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -55,12 +55,12 @@ public:
     /** Create and initialize a message Queue. */
     Queue() {
         memset(&_obj_mem, 0, sizeof(_obj_mem));
-        osMessageQueueAttr_t attr = { 0 };
-        attr.mq_mem = _queue_mem;
-        attr.mq_size = sizeof(_queue_mem);
-        attr.cb_mem = &_obj_mem;
-        attr.cb_size = sizeof(_obj_mem);
-        _id = osMessageQueueNew(queue_sz, sizeof(T*), &attr);
+        memset(&_attr, 0, sizeof(_attr));
+        _attr.mq_mem = _queue_mem;
+        _attr.mq_size = sizeof(_queue_mem);
+        _attr.cb_mem = &_obj_mem;
+        _attr.cb_size = sizeof(_obj_mem);
+        _id = osMessageQueueNew(queue_sz, sizeof(T*), &_attr);
         MBED_ASSERT(_id);
     }
 
@@ -119,6 +119,7 @@ public:
 
 private:
     osMessageQueueId_t            _id;
+    osMessageQueueAttr_t          _attr;
     char                          _queue_mem[queue_sz * (sizeof(T*) + sizeof(mbed_rtos_storage_message_t))];
     mbed_rtos_storage_msg_queue_t _obj_mem;
 };

--- a/rtos/RtosTimer.cpp
+++ b/rtos/RtosTimer.cpp
@@ -31,10 +31,10 @@ namespace rtos {
 void RtosTimer::constructor(mbed::Callback<void()> func, os_timer_type type) {
     _function = func;
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osTimerAttr_t attr = { 0 };
-    attr.cb_mem = &_obj_mem;
-    attr.cb_size = sizeof(_obj_mem);
-    _id = osTimerNew((void (*)(void *))Callback<void()>::thunk, type, &_function, &attr);
+    memset(&_attr, 0, sizeof(_attr));
+    _attr.cb_mem = &_obj_mem;
+    _attr.cb_size = sizeof(_obj_mem);
+    _id = osTimerNew((void (*)(void *))Callback<void()>::thunk, type, &_function, &_attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/RtosTimer.h
+++ b/rtos/RtosTimer.h
@@ -161,6 +161,7 @@ private:
     void constructor(mbed::Callback<void()> func, os_timer_type type);
 
     osTimerId_t _id;
+    osTimerAttr_t _attr;
     mbed_rtos_storage_timer_t _obj_mem;
     mbed::Callback<void()> _function;
 };

--- a/rtos/Semaphore.cpp
+++ b/rtos/Semaphore.cpp
@@ -36,10 +36,10 @@ Semaphore::Semaphore(int32_t count, uint16_t max_count) {
 
 void Semaphore::constructor(int32_t count, uint16_t max_count) {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osSemaphoreAttr_t attr = { 0 };
-    attr.cb_mem = &_obj_mem;
-    attr.cb_size = sizeof(_obj_mem);
-    _id = osSemaphoreNew(max_count, count, &attr);
+    memset(&_attr, 0, sizeof(_attr));
+    _attr.cb_mem = &_obj_mem;
+    _attr.cb_size = sizeof(_obj_mem);
+    _id = osSemaphoreNew(max_count, count, &_attr);
     MBED_ASSERT(_id != NULL);
 }
 

--- a/rtos/Semaphore.h
+++ b/rtos/Semaphore.h
@@ -75,6 +75,7 @@ private:
     void constructor(int32_t count, uint16_t max_count);
 
     osSemaphoreId_t               _id;
+    osSemaphoreAttr_t             _attr;
     mbed_rtos_storage_semaphore_t _obj_mem;
 };
 /** @}*/


### PR DESCRIPTION
An obscure  binary breakage was detected within this commit which broke the ODIN board (5.6 branch)

This reverts commit 781c0c7105077711a1707bd64e42dfcb81265a7f.

