### PR TITLE
Fix bug in K64F trng_api.c

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/trng_api.c
@@ -50,6 +50,7 @@ void trng_free(trng_t *obj)
  */
 static void trng_get_byte(unsigned char *byte)
 {
+    *byte = 0;
     size_t bit;
 
     /* 34.5 Steps 3-4-5: poll SR and read from OR when ready */


### PR DESCRIPTION
## Description

K64F `trng_get_byte` function assumed memory for byte was zero initialized. 

That means that [this line](https://github.com/sarahmarshy/mbed-os/blob/cefcb8cff31662553015da0dd32fc404ee623ec1/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/trng_api.c#L60) would OR random data with data existing in memory. All values will eventually reach 255 if called many times.

## Steps to test or reproduce
Use this test program to replicate the issue:
```c++

#include "mbed.h"

#define RANDOM_BUFF_SIZE 3                                                           /**< Random numbers buffer size. */

#include "hal/trng_api.h"

int main(void)
{
    uint32_t err_code;

    while (true)
    {
        trng_t trng_obj;
        trng_init(&trng_obj);
        uint8_t p_buff[RANDOM_BUFF_SIZE];
        size_t output_length;
        uint8_t length = trng_get_bytes(&trng_obj, p_buff, RANDOM_BUFF_SIZE, &output_length);
        printf("Random Vector:");
        for(uint8_t i = 0; i < RANDOM_BUFF_SIZE; i++)
        {
            printf(" %u",p_buff[i]);
        }
        printf("\r\n expected: %d length: %d",RANDOM_BUFF_SIZE, output_length);
        printf("\n\r");
        trng_free(&trng_obj);
        wait_ms(3000);
    }
}
```