### PR TITLE
M487: Fix premature lp_ticker interrupt

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -103,8 +103,6 @@ void lp_ticker_init(void)
 
     // Schedule wakeup to match semantics of lp_ticker_get_compare_match()
     lp_ticker_set_interrupt(wakeup_tick);
-
-
 }
 
 timestamp_t lp_ticker_read()
@@ -146,9 +144,9 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
     uint32_t delta = timestamp - lp_ticker_read();
     wakeup_tick = timestamp;
-    
+
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    
+
     cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
     lp_ticker_arm_cd();
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -144,21 +144,13 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t now = lp_ticker_read();
+    uint32_t delta = timestamp - lp_ticker_read();
     wakeup_tick = timestamp;
-
+    
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-
-    int delta = (int) (timestamp - now);
-    if (delta > 0) {
-        cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
-        lp_ticker_arm_cd();
-    } else {
-        // NOTE: With lp_ticker_fire_interrupt() introduced, upper layer would handle past event case.
-        //       This code fragment gets redundant, but it is still kept here for backward-compatible.
-        void lp_ticker_fire_interrupt(void);
-        lp_ticker_fire_interrupt();
-    }
+    
+    cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
+    lp_ticker_arm_cd();
 }
 
 void lp_ticker_fire_interrupt(void)

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -146,17 +146,10 @@ void us_ticker_clear_interrupt(void)
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    int delta = (int) (timestamp - us_ticker_read());
-    if (delta > 0) {
-        cd_major_minor_us = delta * US_PER_TICK;
-        us_ticker_arm_cd();
-    } else {
-        // NOTE: With us_ticker_fire_interrupt() introduced, upper layer would handle past event case.
-        //       This code fragment gets redundant, but it is still kept here for backward-compatible.
-        void us_ticker_fire_interrupt(void);
-        us_ticker_fire_interrupt();
-    }
+    
+    uint32_t delta = timestamp - us_ticker_read();
+    cd_major_minor_us = delta * US_PER_TICK;
+    us_ticker_arm_cd();
 }
 
 void us_ticker_fire_interrupt(void)

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -146,7 +146,7 @@ void us_ticker_clear_interrupt(void)
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    
+
     uint32_t delta = timestamp - us_ticker_read();
     cd_major_minor_us = delta * US_PER_TICK;
     us_ticker_arm_cd();


### PR DESCRIPTION
## Description
This PR fixes premature lp_ticker interrupt issue on **NUMAKER_PFM_M487** target.

## Related PRs
https://github.com/ARMmbed/mbed-os/pull/5366
This PR is the resend of the above due to **abuse flag** issue on travis CI.
