### PR TITLE
Fix for default test config file

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -145,6 +145,8 @@ if __name__ == '__main__':
                 args_error(parser, "argument --test-config contains invalid path or identifier")
         elif not options.app_config:
             config = TestConfig.get_default_config(mcu)
+            if os.path.exists(os.path.abspath(os.path.join("mbed_app.json", ".."))):
+                config = "mbed_app.json"
         else:
             config = options.app_config
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -30,7 +30,7 @@ from tools.config import ConfigException
 from tools.test_api import test_path_to_name, find_tests, get_test_config, print_tests, build_tests, test_spec_from_test_builds
 import tools.test_configs as TestConfig
 from tools.options import get_default_options_parser, extract_profile, extract_mcus
-from tools.build_api import build_project, build_library, get_config
+from tools.build_api import build_project, build_library
 from tools.build_api import print_build_memory_usage
 from tools.build_api import merge_build_data
 from tools.targets import TARGET_MAP
@@ -142,7 +142,7 @@ if __name__ == '__main__':
         if options.test_config:
             config = get_test_config(options.test_config, mcu)
             if not config:
-                args_error(parser, "argument --test-csonfig contains invalid path or identifier")
+                args_error(parser, "argument --test-config contains invalid path or identifier")
         elif not options.app_config:
             config = TestConfig.get_default_config(options.source_dir, mcu)
         else:

--- a/tools/test.py
+++ b/tools/test.py
@@ -30,7 +30,7 @@ from tools.config import ConfigException
 from tools.test_api import test_path_to_name, find_tests, get_test_config, print_tests, build_tests, test_spec_from_test_builds
 import tools.test_configs as TestConfig
 from tools.options import get_default_options_parser, extract_profile, extract_mcus
-from tools.build_api import build_project, build_library
+from tools.build_api import build_project, build_library, get_config
 from tools.build_api import print_build_memory_usage
 from tools.build_api import merge_build_data
 from tools.targets import TARGET_MAP
@@ -142,11 +142,9 @@ if __name__ == '__main__':
         if options.test_config:
             config = get_test_config(options.test_config, mcu)
             if not config:
-                args_error(parser, "argument --test-config contains invalid path or identifier")
+                args_error(parser, "argument --test-csonfig contains invalid path or identifier")
         elif not options.app_config:
-            config = TestConfig.get_default_config(mcu)
-            if os.path.exists(os.path.abspath(os.path.join("mbed_app.json", ".."))):
-                config = "mbed_app.json"
+            config = TestConfig.get_default_config(options.source_dir, mcu)
         else:
             config = options.app_config
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -144,7 +144,7 @@ if __name__ == '__main__':
             if not config:
                 args_error(parser, "argument --test-config contains invalid path or identifier")
         elif not options.app_config:
-            config = TestConfig.get_default_config(options.source_dir, mcu)
+            config = TestConfig.get_default_config(options.source_dir or ['.'], mcu)
         else:
             config = options.app_config
 

--- a/tools/test_configs/__init__.py
+++ b/tools/test_configs/__init__.py
@@ -2,6 +2,7 @@ from os.path import dirname, abspath, join, exists
 
 from tools.utils import json_file_to_dict
 from tools.targets import TARGET_MAP
+from tools.config import Config
 
 CONFIG_DIR = dirname(abspath(__file__))
 CONFIG_MAP = json_file_to_dict(join(CONFIG_DIR, "config_paths.json"))
@@ -34,8 +35,8 @@ def get_default_config(source_dir, target_name):
         if config_name == "NONE":
             return None
         return join(CONFIG_DIR, CONFIG_MAP[config_name])
-    elif any(exists(join(dir or ".", "mbed_app.json")) for dir in source_dir):
-        config = None
+    elif Config.find_app_config(source_dir):
+        return None
     elif (target_name in TARGET_MAP and 'LWIP' in TARGET_MAP[target_name].features):
         return join(CONFIG_DIR, CONFIG_MAP["ETHERNET"])
     else:

--- a/tools/test_configs/__init__.py
+++ b/tools/test_configs/__init__.py
@@ -1,4 +1,4 @@
-from os.path import dirname, abspath, join
+from os.path import dirname, abspath, join, exists
 
 from tools.utils import json_file_to_dict
 from tools.targets import TARGET_MAP
@@ -28,12 +28,14 @@ def get_config_path(conf_name, target_name):
     else:
         return None
 
-def get_default_config(target_name):
+def get_default_config(source_dir, target_name):
     if target_name in TARGET_CONFIGS:
         config_name = TARGET_CONFIGS[target_name]['default_test_configuration']
         if config_name == "NONE":
             return None
         return join(CONFIG_DIR, CONFIG_MAP[config_name])
+    elif any(exists(join(dir or ".", "mbed_app.json")) for dir in source_dir):
+        config = None
     elif (target_name in TARGET_MAP and 'LWIP' in TARGET_MAP[target_name].features):
         return join(CONFIG_DIR, CONFIG_MAP["ETHERNET"])
     else:


### PR DESCRIPTION
## Description

Fixes #5543

This change allows for `mbed test` to build with an `mbed_app.json` file by default if one exists in the project's root directory (i.e. for running the [ci-test-shield tests](https://github.com/ARMmbed/ci-test-shield)). However, if the `mbed_app.json` file is not in the root directory, then it's location needs to be specified in the command with the `--app-config` parameter.

## Steps to test or reproduce

**Before fix:**
If you run the [ci-test-shield tests](https://github.com/ARMmbed/ci-test-shield) with `mbed test -t GCC_ARM -m NUCLEO_F207ZG -n tests* --compile` without a specified `--app-config` you get the following errors related to the unspecified `mbed_app.json`:
```
        [Error] Mixed.cpp@68,22: 'MBED_CONF_APP_I2C_SDA' was not declared in this scope
        [Error] Mixed.cpp@68,44: 'MBED_CONF_APP_I2C_SCL' was not declared in this scope
        [Error] Mixed.cpp@68,66: 'MBED_CONF_APP_I2C_EEPROM_ADDR' was not declared in this scope
        ...
```

**After fix:**
If you run the [ci-test-shield tests](https://github.com/ARMmbed/ci-test-shield) with `mbed test -t GCC_ARM -m NUCLEO_F207ZG -n tests* --compile` without a specified `--app-config`, if there exists an `mbed_app.json` in the root directory of the project then the tests compile and run successfully.