### PR TITLE
STM32: SPI 3 wires mode not supported in SPI slave

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -29,6 +29,7 @@
  */
 #include "mbed_assert.h"
 #include "mbed_error.h"
+#include "mbed_debug.h"
 #include "spi_api.h"
 
 #if DEVICE_SPI
@@ -285,6 +286,16 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
     }
 
     handle->Init.Mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
+
+    if (slave && (handle->Init.Direction == SPI_DIRECTION_1LINE)) {
+        /*  SPI slave implemtation in MBED does not support the 3 wires SPI.
+         *  (e.g. when MISO is not connected). So we're forcing slave in
+         *  2LINES mode. As MISO is not connected, slave will only read
+         *  from master, and cannot write to it. Inform user.
+         */
+        debug("3 wires SPI slave not supported - slave will only read\r\n");
+        handle->Init.Direction = SPI_DIRECTION_2LINES;
+    }
 
     init_spi(obj);
 }


### PR DESCRIPTION
This patch handles the case of SPI slave mode without MISO (NC).
In case MISO is not connected, we consider that SPI will be configured in
3 wires mode (CLK / MOSI / CS, but no MISO). In this case, the MOSI line
is bi-directional : SPI_DIRECTION_1LINE.

But as this is not supported yet in slave mode, we force it to
SPI_DIRECTION_2LINES. In this case slave SPI will receive data on MOSI
but nothing will be sent back to master as MISO is not connected.

This FIX addresses the issue reported in: #5554