### PR TITLE
Feature QSPI: add disabled flag to format phases

### DIFF
--- a/drivers/QSPI.cpp
+++ b/drivers/QSPI.cpp
@@ -36,7 +36,7 @@ QSPI::QSPI(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, Pin
     _address_width = QSPI_CFG_BUS_SINGLE;
     _address_size = QSPI_CFG_ADDR_SIZE_24;
     _alt_width = QSPI_CFG_BUS_SINGLE;
-    _alt_size = QSPI_CFG_ALT_SIZE_NONE;
+    _alt_size = QSPI_CFG_ALT_SIZE_8;
     _data_width = QSPI_CFG_BUS_SINGLE;
     _num_dummy_cycles = 0;
     _mode = 0;
@@ -253,8 +253,9 @@ void QSPI::_build_qspi_command(int instruction, int address, int alt)
     _qspi_command.instruction.bus_width = _inst_width;
     if (instruction != -1) {
         _qspi_command.instruction.value = instruction;
+        _qspi_command.instruction.disabled = false;
     } else {
-        _qspi_command.instruction.value = 0;
+        _qspi_command.instruction.disabled = true;
     }
 
     //Set up address phase parameters
@@ -262,8 +263,9 @@ void QSPI::_build_qspi_command(int instruction, int address, int alt)
     _qspi_command.address.size = _address_size;
     if (address != -1) {
         _qspi_command.address.value = address;
+        _qspi_command.address.disabled = false;
     } else {
-        _qspi_command.address.size = QSPI_CFG_ADDR_SIZE_NONE;
+        _qspi_command.address.disabled = true;
     }
 
     //Set up alt phase parameters
@@ -271,9 +273,9 @@ void QSPI::_build_qspi_command(int instruction, int address, int alt)
     _qspi_command.alt.size = _alt_size;
     if (alt != -1) {
         _qspi_command.alt.value = alt; 
+        _qspi_command.alt.disabled = false;
     } else {
-        //In the case alt phase is absent, set the alt size to be NONE
-        _qspi_command.alt.size = QSPI_CFG_ALT_SIZE_NONE;
+        _qspi_command.alt.disabled = true;
     }
     
     _qspi_command.dummy_count = _num_dummy_cycles;

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -83,9 +83,9 @@ public:
      *
      *  @param inst_width Bus width used by instruction phase(Valid values are 1,2,4)
      *  @param address_width Bus width used by address phase(Valid values are 1,2,4)
-     *  @param address_size Size in bits used by address phase(Valid values are NONE,8,16,24,32)
+     *  @param address_size Size in bits used by address phase(Valid values are 8,16,24,32)
      *  @param alt_width Bus width used by alt phase(Valid values are 1,2,4)
-     *  @param alt_size Size in bits used by alt phase(Valid values are NONE,8,16,24,32)
+     *  @param alt_size Size in bits used by alt phase(Valid values are 8,16,24,32)
      *  @param data_width Bus width used by data phase(Valid values are 1,2,4)
      *  @param dummy_cycles Number of dummy clock cycles to be used after alt phase
      *  @param mode Mode specifies the SPI mode(Mode=0 uses CPOL=0, CPHA=0, Mode=1 uses CPOL=1, CPHA=1)

--- a/hal/qspi_api.h
+++ b/hal/qspi_api.h
@@ -20,6 +20,7 @@
 #define MBED_QSPI_API_H
 
 #include "device.h"
+#include <stdbool.h>
 
 #if DEVICE_QSPI
 
@@ -49,7 +50,6 @@ typedef enum qspi_bus_width {
 /** Address size
  */
 typedef enum qspi_address_size {
-    QSPI_CFG_ADDR_SIZE_NONE,
     QSPI_CFG_ADDR_SIZE_8,
     QSPI_CFG_ADDR_SIZE_16,
     QSPI_CFG_ADDR_SIZE_24,
@@ -59,7 +59,6 @@ typedef enum qspi_address_size {
 /** Alternative size
  */
 typedef enum qspi_alt_size {
-    QSPI_CFG_ALT_SIZE_NONE,
     QSPI_CFG_ALT_SIZE_8,
     QSPI_CFG_ALT_SIZE_16,
     QSPI_CFG_ALT_SIZE_24,
@@ -74,16 +73,19 @@ typedef struct qspi_command {
     struct {
         qspi_bus_width_t bus_width; /**< Bus width for the instruction >*/
         uint8_t value;  /**< Instruction value >*/
+        bool disabled; /**< Instruction phase skipped if disabled is set to true >*/
     } instruction;
     struct {
         qspi_bus_width_t bus_width; /**< Bus width for the address >*/
         qspi_address_size_t size; /**< Address size >*/
         uint32_t value; /**< Address value >*/
+        bool disabled; /**< Address phase skipped if disabled is set to true >*/
     }  address;
     struct {
         qspi_bus_width_t bus_width; /**< Bus width for alternative  >*/
         qspi_alt_size_t size; /**< Alternative size >*/
         uint32_t value; /**< Alternative value >*/
+        bool disabled; /**< Alternative phase skipped if disabled is set to true >*/
     } alt;
     uint8_t dummy_count; /**< Dummy cycles count >*/
     struct {


### PR DESCRIPTION
To be able to skip any phase in the format, use bus width set to NONE. Previously this
was done via SIZE definitions, this however did not provide flexibility to skip instruction phase
or data (as all of them can be done via 0-4 lines).

This way any format phase can be skipped if bus width is set to NONE.

@SenRamakri Please review