### PR TITLE
STM32: Add USB Device on DISCO_F413ZH

### DIFF
--- a/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
+++ b/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
@@ -147,6 +147,7 @@ USBHAL::USBHAL(void) {
     defined(TARGET_NUCLEO_F767ZI) || \
     defined(TARGET_NUCLEO_F746ZG) || \
     defined(TARGET_DISCO_F407VG) || \
+    defined(TARGET_DISCO_F413ZH) || \
     defined(TARGET_DISCO_F469NI) || \
     defined(TARGET_DISCO_F746NG_OTG_FS)
     __HAL_RCC_GPIOA_CLK_ENABLE();

--- a/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_STM32.h
+++ b/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_STM32.h
@@ -28,6 +28,7 @@
     defined(TARGET_NUCLEO_F767ZI) || \
     defined(TARGET_NUCLEO_F746ZG) || \
     defined(TARGET_DISCO_F407VG) || \
+    defined(TARGET_DISCO_F413ZH) || \
     defined(TARGET_DISCO_F429ZI) || \
     defined(TARGET_DISCO_F469NI) || \
     defined(TARGET_DISCO_F746NG) || \


### PR DESCRIPTION
## Description
Add support of USB Device on DISCO_F413ZH platform.

Tested OK with USB_1 test.

## Status
**READY**

## Migrations
NO
