### PR TITLE
Greentea Wifi testcase fixes

### DIFF
--- a/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -28,19 +28,19 @@ void wifi_connect_params_valid_secure(void)
     WiFiInterface *wifi = get_interface();
 
     if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2) == NSAPI_ERROR_OK) {
-        TEST_PASS();
+        return;
     }
 
     if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2) == NSAPI_ERROR_OK) {
-        TEST_PASS();
+        return;
     }
 
     if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA) == NSAPI_ERROR_OK) {
-        TEST_PASS();
+        return;
     }
 
     if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WEP) == NSAPI_ERROR_OK) {
-        TEST_PASS();
+        return;
     }
 
     TEST_FAIL();

--- a/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -26,5 +26,22 @@ using namespace utest::v1;
 void wifi_connect_params_valid_secure(void)
 {
     WiFiInterface *wifi = get_interface();
-    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2));
+
+    if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA2) == NSAPI_ERROR_OK) {
+        TEST_PASS();
+    }
+
+    if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2) == NSAPI_ERROR_OK) {
+        TEST_PASS();
+    }
+
+    if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA) == NSAPI_ERROR_OK) {
+        TEST_PASS();
+    }
+
+    if(wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WEP) == NSAPI_ERROR_OK) {
+        TEST_PASS();
+    }
+
+    TEST_FAIL();
 }

--- a/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -33,6 +33,6 @@ void wifi_get_rssi(void)
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
 
-    TEST_ASSERT_INT8_WITHIN(-35, -65, wifi->get_rssi()); // -30 ... -100
+    TEST_ASSERT_INT8_WITHIN(-10, -100, wifi->get_rssi());
 }
 

--- a/TESTS/network/wifi/wifi_scan.cpp
+++ b/TESTS/network/wifi/wifi_scan.cpp
@@ -48,8 +48,7 @@ void wifi_scan(void)
         nsapi_security_t security = ap[i].get_security();
         int8_t rssi = ap[i].get_rssi();
         uint8_t ch = ap[i].get_channel();
-        TEST_ASSERT_NOT_EQUAL(0, strlen(ssid));
-        TEST_ASSERT_INT8_WITHIN(-35, -65, rssi);
+        TEST_ASSERT_INT8_WITHIN(-10, -100, rssi);
         if (strcmp(MBED_CONF_APP_WIFI_SECURE_SSID, ssid) == 0) {
             secure_found = true;
             TEST_ASSERT_EQUAL_INT(NSAPI_SECURITY_WPA2, security);

--- a/TESTS/network/wifi/wifi_set_credential.cpp
+++ b/TESTS/network/wifi/wifi_set_credential.cpp
@@ -40,6 +40,12 @@ void wifi_set_credential(void)
     error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_WPA_WPA2);
     TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
 
+    error = iface->set_credentials("OK", NULL, NSAPI_SECURITY_NONE);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WEP);
+    TEST_ASSERT((error == NSAPI_ERROR_OK) || (error == NSAPI_ERROR_UNSUPPORTED));
+
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA);
     TEST_ASSERT(error == NSAPI_ERROR_OK);
 
@@ -49,6 +55,9 @@ void wifi_set_credential(void)
     error = iface->set_credentials("OK", "12345678", NSAPI_SECURITY_WPA_WPA2);
     TEST_ASSERT(error == NSAPI_ERROR_OK);
 
-    error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni82", NSAPI_SECURITY_WPA2);
+    error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni", NSAPI_SECURITY_WPA2);
+    TEST_ASSERT(error == NSAPI_ERROR_OK);
+
+    error = iface->set_credentials("OK", "kUjd0PHHeAqaDoyfcDDEOvbyiVbYMpUHDukGoR6EJZnO5iLzWsfwiM9JQqOngni8", NSAPI_SECURITY_WPA2);
     TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
 }


### PR DESCRIPTION
## Description

Greentea testcase WIFI-SCAN fails arbitrarily
Greentea testcase WIFI-SET-CREDENTIAL doesn't try WEP with valid credentials
Greentea testcase WIFI-GET-RSSI uses arbitrary RSSI value limits
Greentea testcase WIFI-CONNECT-PARAMS-VALID-SECURE assumes WPA2

Testcases in question either have unnecessary expectations about signal quality or make unnecessary assumptions about security features available. Testcases also assume that max password length is 64 characters when 802.11 says it's 63.  We might have also access points with hidden SSIDs in vicinity but the scan test didn't like about those too much. This PR addresses all these issues.

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce

    ...\mbed-os> mbed test --compile -t ARM -m REALTEK_RTL8195AM --app-config .\TESTS\network\wifi\template_mbed_app.txt -n tests-network-wifi
    ...\mbed-os> mbedhtrun -f .\BUILD\tests\REALTEK_RTL8195AM\ARM\TESTS\network\wifi\wifi.bin -d X: -p COMY:9600