### PR TITLE
STM32 UART init update

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -33,7 +33,7 @@
 #include "serial_api_hal.h"
 
 #if defined (TARGET_STM32F031K6)
-    #define UART_NUM (1
+    #define UART_NUM (1)
 #elif defined (TARGET_STM32F030R8) || defined (TARGET_STM32F051R8) || defined (TARGET_STM32F042K6)
     #define UART_NUM (2)
 #elif defined (TARGET_STM32F070RB) || defined (TARGET_STM32F072RB)

--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,128 +27,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_error.h"
-#include <string.h>
-#include "PeripheralPins.h"
+#include "serial_api_hal.h"
 
 #define UART_NUM (3)
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_ENABLE();
-        obj_s->index = 0;
-    }
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_ENABLE();
-        obj_s->index = 1;
-    }
-    if (obj_s->uart == UART_3) {
-        __HAL_RCC_USART3_FORCE_RESET();
-        __HAL_RCC_USART3_RELEASE_RESET();
-        __HAL_RCC_USART3_CLK_ENABLE();
-        obj_s->index = 2;
-    }
-
-    // Configure UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_DISABLE();
-    }
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_DISABLE();
-    }
-    if (obj_s->uart == UART_3) {
-        __HAL_RCC_USART3_FORCE_RESET();
-        __HAL_RCC_USART3_RELEASE_RESET();
-        __HAL_RCC_USART3_CLK_DISABLE();
-    }
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -687,7 +576,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -746,6 +635,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2016, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,215 +27,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include <string.h>
-#include "PeripheralPins.h"
-#include "mbed_error.h"
+#include "serial_api_hal.h"
 
-#define UART_NUM (8)
+#define UART_NUM (6)
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_ENABLE();
-            obj_s->index = 0;
-            break;
-
-        case UART_2:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_ENABLE();
-            obj_s->index = 1;
-            break;
-
-#if defined(USART3_BASE)
-        case UART_3:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_ENABLE();
-            obj_s->index = 2;
-            break;
-#endif
-#if defined(UART4_BASE)
-        case UART_4:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_ENABLE();
-            obj_s->index = 3;
-            break;
-#endif
-#if defined(UART5_BASE)
-        case UART_5:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_ENABLE();
-            obj_s->index = 4;
-            break;
-#endif
-#if defined(USART6_BASE)
-        case UART_6:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_ENABLE();
-            obj_s->index = 5;
-            break;
-#endif
-#if defined(UART7_BASE)
-        case UART_7:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_ENABLE();
-            obj_s->index = 6;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_ENABLE();
-            obj_s->index = 7;
-            break;
-#endif
-    }
-
-    // Configure the UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-    switch (obj_s->index) {
-        case 0:
-            __USART1_FORCE_RESET();
-            __USART1_RELEASE_RESET();
-            __USART1_CLK_DISABLE();
-            break;
-
-        case 1:
-            __USART2_FORCE_RESET();
-            __USART2_RELEASE_RESET();
-            __USART2_CLK_DISABLE();
-            break;
-
-#if defined(USART3_BASE)
-        case 2:
-            __USART3_FORCE_RESET();
-            __USART3_RELEASE_RESET();
-            __USART3_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART4_BASE)
-        case 3:
-            __UART4_FORCE_RESET();
-            __UART4_RELEASE_RESET();
-            __UART4_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART5_BASE)
-        case 4:
-            __UART5_FORCE_RESET();
-            __UART5_RELEASE_RESET();
-            __UART5_CLK_DISABLE();
-            break;
-#endif
-#if defined(USART6_BASE)
-        case 5:
-            __USART6_FORCE_RESET();
-            __USART6_RELEASE_RESET();
-            __USART6_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART7_BASE)
-        case 6:
-            __UART7_FORCE_RESET();
-            __UART7_RELEASE_RESET();
-            __UART7_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            __UART8_FORCE_RESET();
-            __UART8_RELEASE_RESET();
-            __UART8_CLK_DISABLE();
-            break;
-#endif
-    }
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -865,7 +667,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -924,6 +726,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,179 +27,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include <string.h>
-#include "PeripheralPins.h"
-#include "mbed_error.h"
+#include "serial_api_hal.h"
 
-#define UART_NUM (5)
+#if defined (TARGET_STM32F302x8) || defined (TARGET_STM32F303x8) || defined (TARGET_STM32F334x8)
+    #define UART_NUM (3)
+#else
+    #define UART_NUM (5) // max value
+#endif
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
-uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock + switch to SystemClock
-    if (obj_s->uart == UART_1) {
-        __USART1_FORCE_RESET();
-        __USART1_RELEASE_RESET();
-        __USART1_CLK_ENABLE();
-#if defined(RCC_USART1CLKSOURCE_SYSCLK) 
-        __HAL_RCC_USART1_CONFIG(RCC_USART1CLKSOURCE_SYSCLK);
-#endif
-        obj_s->index = 0;
-    }
-#if defined(USART2_BASE)
-    if (obj_s->uart == UART_2) {
-        __USART2_FORCE_RESET();
-        __USART2_RELEASE_RESET();
-        __USART2_CLK_ENABLE();
-#if defined(RCC_USART2CLKSOURCE_SYSCLK)
-        __HAL_RCC_USART2_CONFIG(RCC_USART2CLKSOURCE_SYSCLK);
-#endif
-        obj_s->index = 1;
-    }
-#endif
-#if defined(USART3_BASE)
-    if (obj_s->uart == UART_3) {
-        __USART3_FORCE_RESET();
-        __USART3_RELEASE_RESET();
-        __USART3_CLK_ENABLE();
-#if defined(RCC_USART3CLKSOURCE_SYSCLK)
-        __HAL_RCC_USART3_CONFIG(RCC_USART3CLKSOURCE_SYSCLK);
-#endif
-        obj_s->index = 2;
-    }
-#endif
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __UART4_FORCE_RESET();
-        __UART4_RELEASE_RESET();
-        __UART4_CLK_ENABLE();
-#if defined(RCC_UART4CLKSOURCE_SYSCLK)
-        __HAL_RCC_UART4_CONFIG(RCC_UART4CLKSOURCE_SYSCLK);
-#endif
-        obj_s->index = 3;
-    }
-#endif
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_UART5_FORCE_RESET();
-        __HAL_RCC_UART5_RELEASE_RESET();
-        __UART5_CLK_ENABLE();
-#if defined(RCC_UART5CLKSOURCE_SYSCLK)
-        __HAL_RCC_UART5_CONFIG(RCC_UART5CLKSOURCE_SYSCLK);
-#endif
-        obj_s->index = 4;
-    }
-#endif
-
-    // Configure the UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-    if (obj_s->uart == UART_1) {
-        __USART1_FORCE_RESET();
-        __USART1_RELEASE_RESET();
-        __USART1_CLK_DISABLE();
-    }
-    if (obj_s->uart == UART_2) {
-        __USART2_FORCE_RESET();
-        __USART2_RELEASE_RESET();
-        __USART2_CLK_DISABLE();
-    }
-#if defined(USART3_BASE)
-    if (obj_s->uart == UART_3) {
-        __USART3_FORCE_RESET();
-        __USART3_RELEASE_RESET();
-        __USART3_CLK_DISABLE();
-    }
-#endif
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __UART4_FORCE_RESET();
-        __UART4_RELEASE_RESET();
-        __UART4_CLK_DISABLE();
-    }
-#endif
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __UART5_FORCE_RESET();
-        __UART5_RELEASE_RESET();
-        __UART5_CLK_DISABLE();
-    }
-#endif
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
+static uart_irq_handler irq_handler;
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -785,7 +627,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -844,6 +686,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -40,10 +40,8 @@
     #define UART_NUM (6)
 #elif defined (TARGET_STM32F429xI) || defined (TARGET_STM32F439xI) || defined (TARGET_STM32F437xG) || defined (TARGET_STM32F469xI)
     #define UART_NUM (8)
-#elif defined (TARGET_STM32F413xH)
-    #define UART_NUM (10)
 #else
-    #define UART_NUM (10) // max value
+    #define UART_NUM (10) // max value // TARGET_STM32F413xH
 #endif
 
 uint32_t serial_irq_ids[UART_NUM] = {0};

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -28,241 +28,28 @@
  *******************************************************************************
  */
 
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
-
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include <string.h>
-#include "PeripheralPins.h"
-#include "mbed_error.h"
+#include "serial_api_hal.h"
 
-#define UART_NUM (10)
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+#if defined (TARGET_STM32F401xC) || defined (TARGET_STM32F401xE) || defined (TARGET_STM32F410xB) || defined (TARGET_STM32F411xE)
+    #define UART_NUM (3)
+#elif defined (TARGET_STM32F412xG)
+    #define UART_NUM (4)
+#elif defined (TARGET_STM32F407xG) || defined (TARGET_STM32F446xE)
+    #define UART_NUM (6)
+#elif defined (TARGET_STM32F429xI) || defined (TARGET_STM32F439xI) || defined (TARGET_STM32F437xG) || defined (TARGET_STM32F469xI)
+    #define UART_NUM (8)
+#elif defined (TARGET_STM32F413xH)
+    #define UART_NUM (10)
+#else
+    #define UART_NUM (10) // max value
+#endif
+
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_ENABLE();
-            obj_s->index = 0;
-            break;
-            
-        case UART_2:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_ENABLE();
-            obj_s->index = 1;
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_ENABLE();
-            obj_s->index = 2;
-            break;
-#endif
-#if defined(UART4_BASE)
-        case UART_4:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_ENABLE();
-            obj_s->index = 3;
-            break;
-#endif
-#if defined(UART5_BASE)
-        case UART_5:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_ENABLE();
-            obj_s->index = 4;
-            break;
-#endif
-#if defined(USART6_BASE)
-        case UART_6:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_ENABLE();
-            obj_s->index = 5;
-            break;
-#endif
-#if defined(UART7_BASE)
-        case UART_7:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_ENABLE();
-            obj_s->index = 6;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_ENABLE();
-            obj_s->index = 7;
-            break;
-#endif
-#if defined(UART9_BASE)
-        case UART_9:
-            __HAL_RCC_UART9_FORCE_RESET();
-            __HAL_RCC_UART9_RELEASE_RESET();
-            __HAL_RCC_UART9_CLK_ENABLE();
-            obj_s->index = 8;
-            break;
-#endif
-#if defined(UART10_BASE)
-        case UART_10:
-            __HAL_RCC_UART10_FORCE_RESET();
-            __HAL_RCC_UART10_RELEASE_RESET();
-            __HAL_RCC_UART10_CLK_ENABLE();
-            obj_s->index = 9;
-            break;
-#endif
-    }
-
-    // Configure the UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Reset UART and disable clock
-    switch (obj_s->index) {
-        case 0:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_DISABLE();
-            break;
-        case 1:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_DISABLE();
-            break;
-#if defined(USART3_BASE)
-        case 2:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART4_BASE)
-        case 3:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART5_BASE)
-        case 4:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_DISABLE();
-            break;
-#endif
-#if defined(USART6_BASE)
-        case 5:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART7_BASE)
-        case 6:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART8_BASE)
-        case 7:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART9_BASE)
-        case 8:
-            __HAL_RCC_UART9_FORCE_RESET();
-            __HAL_RCC_UART9_RELEASE_RESET();
-            __HAL_RCC_UART9_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART10_BASE)
-        case 9:
-            __HAL_RCC_UART10_FORCE_RESET();
-            __HAL_RCC_UART10_RELEASE_RESET();
-            __HAL_RCC_UART10_CLK_DISABLE();
-            break;
-#endif
-    }
-    
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -927,7 +714,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -986,6 +773,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,207 +27,16 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include <string.h>
-#include "PeripheralPins.h"
-#include "mbed_error.h"
+#include "serial_api_hal.h"
 
 #define UART_NUM (8)
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __HAL_RCC_USART1_FORCE_RESET();
-            __HAL_RCC_USART1_RELEASE_RESET();
-            __HAL_RCC_USART1_CLK_ENABLE();
-            obj_s->index = 0;
-            break;
-            
-        case UART_2:
-            __HAL_RCC_USART2_FORCE_RESET();
-            __HAL_RCC_USART2_RELEASE_RESET();
-            __HAL_RCC_USART2_CLK_ENABLE();
-            obj_s->index = 1;
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            __HAL_RCC_USART3_FORCE_RESET();
-            __HAL_RCC_USART3_RELEASE_RESET();
-            __HAL_RCC_USART3_CLK_ENABLE();
-            obj_s->index = 2;
-            break;
-#endif
-#if defined(UART4_BASE)
-        case UART_4:
-            __HAL_RCC_UART4_FORCE_RESET();
-            __HAL_RCC_UART4_RELEASE_RESET();
-            __HAL_RCC_UART4_CLK_ENABLE();
-            obj_s->index = 3;
-            break;
-#endif
-#if defined(UART5_BASE)
-        case UART_5:
-            __HAL_RCC_UART5_FORCE_RESET();
-            __HAL_RCC_UART5_RELEASE_RESET();
-            __HAL_RCC_UART5_CLK_ENABLE();
-            obj_s->index = 4;
-            break;
-#endif
-        case UART_6:
-            __HAL_RCC_USART6_FORCE_RESET();
-            __HAL_RCC_USART6_RELEASE_RESET();
-            __HAL_RCC_USART6_CLK_ENABLE();
-            obj_s->index = 5;
-            break;
-#if defined(UART7_BASE)
-        case UART_7:
-            __HAL_RCC_UART7_FORCE_RESET();
-            __HAL_RCC_UART7_RELEASE_RESET();
-            __HAL_RCC_UART7_CLK_ENABLE();
-            obj_s->index = 6;
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __HAL_RCC_UART8_FORCE_RESET();
-            __HAL_RCC_UART8_RELEASE_RESET();
-            __HAL_RCC_UART8_CLK_ENABLE();
-            obj_s->index = 7;
-            break;
-#endif
-    }
-
-    // Configure the UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Reset UART and disable clock
-    switch (obj_s->uart) {
-        case UART_1:
-            __USART1_FORCE_RESET();
-            __USART1_RELEASE_RESET();
-            __USART1_CLK_DISABLE();
-            break;
-        case UART_2:
-            __USART2_FORCE_RESET();
-            __USART2_RELEASE_RESET();
-            __USART2_CLK_DISABLE();
-            break;
-#if defined(USART3_BASE)
-        case UART_3:
-            __USART3_FORCE_RESET();
-            __USART3_RELEASE_RESET();
-            __USART3_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART4_BASE)
-        case UART_4:
-            __UART4_FORCE_RESET();
-            __UART4_RELEASE_RESET();
-            __UART4_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART5_BASE)
-        case UART_5:
-            __UART5_FORCE_RESET();
-            __UART5_RELEASE_RESET();
-            __UART5_CLK_DISABLE();
-            break;
-#endif
-        case UART_6:
-            __USART6_FORCE_RESET();
-            __USART6_RELEASE_RESET();
-            __USART6_CLK_DISABLE();
-            break;
-#if defined(UART7_BASE)
-        case UART_7:
-            __UART7_FORCE_RESET();
-            __UART7_RELEASE_RESET();
-            __UART7_CLK_DISABLE();
-            break;
-#endif
-#if defined(UART8_BASE)
-        case UART_8:
-            __UART8_FORCE_RESET();
-            __UART8_RELEASE_RESET();
-            __UART8_CLK_DISABLE();
-            break;
-#endif
-    }
-    
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-  
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -854,7 +663,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -913,6 +722,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,170 +27,23 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include <string.h>
-#include "PeripheralPins.h"
-#include "mbed_error.h"
+#include "serial_api_hal.h"
 
-#define UART_NUM (5)
+#if defined (TARGET_STM32L011K4) || defined (TARGET_STM32L031K6)
+    #define UART_NUM (2)
+#elif defined (TARGET_STM32L053x8)
+    #define UART_NUM (3)
+#else
+    #define UART_NUM (5)
+#endif
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable UART clock
-#if defined(USART1_BASE)
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_ENABLE();
-        obj_s->index = 0;
-    }
-#endif
-
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_ENABLE();
-        obj_s->index = 1;
-    }
-
-    if (obj_s->uart == LPUART_1) {
-        __HAL_RCC_LPUART1_FORCE_RESET();
-        __HAL_RCC_LPUART1_RELEASE_RESET();
-        __HAL_RCC_LPUART1_CLK_ENABLE();
-        obj_s->index = 2;
-    }
-
-#if defined(USART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __HAL_RCC_USART4_FORCE_RESET();
-        __HAL_RCC_USART4_RELEASE_RESET();
-        __HAL_RCC_USART4_CLK_ENABLE();
-        obj_s->index = 3;
-    }
-#endif
-
-#if defined(USART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_USART5_FORCE_RESET();
-        __HAL_RCC_USART5_RELEASE_RESET();
-        __HAL_RCC_USART5_CLK_ENABLE();
-        obj_s->index = 4;
-    }
-#endif
-
-    // Configure the UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-#if defined(USART1_BASE)
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_DISABLE();
-    }
-#endif
-
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_DISABLE();
-    }
-
-    if (obj_s->uart == LPUART_1) {
-        __HAL_RCC_LPUART1_FORCE_RESET();
-        __HAL_RCC_LPUART1_RELEASE_RESET();
-        __HAL_RCC_LPUART1_CLK_DISABLE();
-    }
-
-#if defined(USART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __HAL_RCC_USART4_FORCE_RESET();
-        __HAL_RCC_USART4_RELEASE_RESET();
-        __HAL_RCC_USART4_CLK_DISABLE();
-    }
-#endif
-
-#if defined(USART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_USART5_FORCE_RESET();
-        __HAL_RCC_USART5_RELEASE_RESET();
-        __HAL_RCC_USART5_CLK_DISABLE();
-    }
-#endif
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -761,7 +614,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -820,6 +673,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2014, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,159 +27,17 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_error.h"
-#include <string.h>
-#include "PeripheralPins.h"
+#include "serial_api_hal.h"
 
 #define UART_NUM (5)
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_ENABLE();
-        obj_s->index = 0;
-    }
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_ENABLE();
-        obj_s->index = 1;
-    }
-    if (obj_s->uart == UART_3) {
-        __HAL_RCC_USART3_FORCE_RESET();
-        __HAL_RCC_USART3_RELEASE_RESET();
-        __HAL_RCC_USART3_CLK_ENABLE();
-        obj_s->index = 2;
-    }
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __HAL_RCC_UART4_FORCE_RESET();
-        __HAL_RCC_UART4_RELEASE_RESET();
-        __HAL_RCC_UART4_CLK_ENABLE();
-        obj_s->index = 3;
-    }
-#endif
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_UART5_FORCE_RESET();
-        __HAL_RCC_UART5_RELEASE_RESET();
-        __HAL_RCC_UART5_CLK_ENABLE();
-        obj_s->index = 4;
-    }
-#endif
-
-    // Configure UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-    if (obj_s->uart == UART_1) {
-        __USART1_FORCE_RESET();
-        __USART1_RELEASE_RESET();
-        __USART1_CLK_DISABLE();
-    }
-    if (obj_s->uart == UART_2) {
-        __USART2_FORCE_RESET();
-        __USART2_RELEASE_RESET();
-        __USART2_CLK_DISABLE();
-    }
-    if (obj_s->uart == UART_3) {
-        __USART3_FORCE_RESET();
-        __USART3_RELEASE_RESET();
-        __USART3_CLK_DISABLE();
-    }
-
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __UART4_FORCE_RESET();
-        __UART4_RELEASE_RESET();
-        __UART4_CLK_DISABLE();
-    }
-#endif
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __UART5_FORCE_RESET();
-        __UART5_RELEASE_RESET();
-        __UART5_CLK_DISABLE();
-    }
-#endif
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -752,7 +610,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -811,6 +669,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,186 +27,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
 
 #if DEVICE_SERIAL
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_error.h"
-#include <string.h>
-#include "PeripheralPins.h"
+#include "serial_api_hal.h"
 
-#define UART_NUM (6)
+#if defined (TARGET_STM32L432xC)
+    #define UART_NUM (3)
+#else
+    #define UART_NUM (6) // max value
+#endif
 
-static uint32_t serial_irq_ids[UART_NUM] = {0};
+uint32_t serial_irq_ids[UART_NUM] = {0};
 UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
-
-int stdio_uart_inited = 0;
-serial_t stdio_uart;
-
-void serial_init(serial_t *obj, PinName tx, PinName rx)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    
-    // Determine the UART to use (UART_1, UART_2, ...)
-    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
-    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
-
-    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
-    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
-    MBED_ASSERT(obj_s->uart != (UARTName)NC);
-
-    // Enable USART clock
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_ENABLE();
-        obj_s->index = 0;
-    }
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_ENABLE();
-        obj_s->index = 1;
-    }
-
-#if defined(USART3_BASE)
-    if (obj_s->uart == UART_3) {
-        __HAL_RCC_USART3_FORCE_RESET();
-        __HAL_RCC_USART3_RELEASE_RESET();
-        __HAL_RCC_USART3_CLK_ENABLE();
-        obj_s->index = 2;
-    }
-#endif
-
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __HAL_RCC_UART4_FORCE_RESET();
-        __HAL_RCC_UART4_RELEASE_RESET();
-        __HAL_RCC_UART4_CLK_ENABLE();
-        obj_s->index = 3;
-    }
-#endif
-
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_UART5_FORCE_RESET();
-        __HAL_RCC_UART5_RELEASE_RESET();
-        __HAL_RCC_UART5_CLK_ENABLE();
-        obj_s->index = 4;
-    }
-#endif
-
-#if defined(LPUART1_BASE)
-    if (obj_s->uart == LPUART_1) {
-        __HAL_RCC_LPUART1_FORCE_RESET();
-        __HAL_RCC_LPUART1_RELEASE_RESET();
-        __HAL_RCC_LPUART1_CLK_ENABLE();
-        obj_s->index = 5;
-    }
-#endif
-
-    // Configure UART pins
-    pinmap_pinout(tx, PinMap_UART_TX);
-    pinmap_pinout(rx, PinMap_UART_RX);
-    
-    if (tx != NC) {
-        pin_mode(tx, PullUp);
-    }
-    if (rx != NC) {
-        pin_mode(rx, PullUp);
-    }
-
-    // Configure UART
-    obj_s->baudrate = 9600;
-    obj_s->databits = UART_WORDLENGTH_8B;
-    obj_s->stopbits = UART_STOPBITS_1;
-    obj_s->parity   = UART_PARITY_NONE;
-    
-#if DEVICE_SERIAL_FC
-    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
-#endif
-
-    obj_s->pin_tx = tx;
-    obj_s->pin_rx = rx;
-
-    init_uart(obj);
-
-    // For stdio management
-    if (obj_s->uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
-}
-
-void serial_free(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-      
-    // Reset UART and disable clock
-    if (obj_s->uart == UART_1) {
-        __HAL_RCC_USART1_FORCE_RESET();
-        __HAL_RCC_USART1_RELEASE_RESET();
-        __HAL_RCC_USART1_CLK_DISABLE();
-    }
-
-    if (obj_s->uart == UART_2) {
-        __HAL_RCC_USART2_FORCE_RESET();
-        __HAL_RCC_USART2_RELEASE_RESET();
-        __HAL_RCC_USART2_CLK_DISABLE();
-    }
-
-#if defined(USART3_BASE)
-    if (obj_s->uart == UART_3) {
-        __HAL_RCC_USART3_FORCE_RESET();
-        __HAL_RCC_USART3_RELEASE_RESET();
-        __HAL_RCC_USART3_CLK_DISABLE();
-    }
-#endif
-
-#if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        __HAL_RCC_UART4_FORCE_RESET();
-        __HAL_RCC_UART4_RELEASE_RESET();
-        __HAL_RCC_UART4_CLK_DISABLE();
-    }
-#endif
-
-#if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        __HAL_RCC_UART5_FORCE_RESET();
-        __HAL_RCC_UART5_RELEASE_RESET();
-        __HAL_RCC_UART5_CLK_DISABLE();
-    }
-#endif
-
-#if defined(LPUART1_BASE)
-    if (obj_s->uart == LPUART_1) {
-        __HAL_RCC_LPUART1_FORCE_RESET();
-        __HAL_RCC_LPUART1_RELEASE_RESET();
-        __HAL_RCC_LPUART1_CLK_DISABLE();
-    }
-#endif
-
-    // Configure GPIOs
-    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
-
-    serial_irq_ids[obj_s->index] = 0;
-}
-
-void serial_baud(serial_t *obj, int baudrate)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-
-    obj_s->baudrate = baudrate;
-    init_uart(obj);
-}
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -804,7 +639,7 @@ void serial_rx_abort_asynch(serial_t *obj)
     }
 }
 
-#endif
+#endif /* DEVICE_SERIAL_ASYNCH */
 
 #if DEVICE_SERIAL_FC
 
@@ -863,6 +698,6 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     init_uart(obj);
 }
 
-#endif
+#endif /* DEVICE_SERIAL_FC */
 
-#endif
+#endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2015, STMicroelectronics
+ * Copyright (c) 2017, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -27,15 +27,369 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *******************************************************************************
  */
-#include "mbed_assert.h"
-#include "mbed_error.h"
-#include "serial_api.h"
-#include "serial_api_hal.h"
-#include "PeripheralPins.h"
 
 #if DEVICE_SERIAL
 
-void init_uart(serial_t *obj)
+#include "serial_api_hal.h"
+
+int stdio_uart_inited = 0; // used in platform/mbed_board.c and platform/mbed_retarget.cpp
+serial_t stdio_uart;
+
+extern UART_HandleTypeDef uart_handlers[];
+extern uint32_t serial_irq_ids[];
+
+void serial_init(serial_t *obj, PinName tx, PinName rx)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+    int IndexNumber = 0;
+
+    // Determine the UART to use (UART_1, UART_2, ...)
+    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
+    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
+
+    // Get the peripheral name (UART_1, UART_2, ...) from the pin and assign it to the object
+    obj_s->uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
+    MBED_ASSERT(obj_s->uart != (UARTName)NC);
+
+    // Enable USART clock
+#if defined(USART1_BASE)
+    if (obj_s->uart == UART_1) {
+        __HAL_RCC_USART1_FORCE_RESET();
+        __HAL_RCC_USART1_RELEASE_RESET();
+        __HAL_RCC_USART1_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined (USART2_BASE)
+    if (obj_s->uart == UART_2) {
+        __HAL_RCC_USART2_FORCE_RESET();
+        __HAL_RCC_USART2_RELEASE_RESET();
+        __HAL_RCC_USART2_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART3_BASE)
+    if (obj_s->uart == UART_3) {
+        __HAL_RCC_USART3_FORCE_RESET();
+        __HAL_RCC_USART3_RELEASE_RESET();
+        __HAL_RCC_USART3_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART4_BASE)
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_UART4_FORCE_RESET();
+        __HAL_RCC_UART4_RELEASE_RESET();
+        __HAL_RCC_UART4_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART4_BASE)
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_USART4_FORCE_RESET();
+        __HAL_RCC_USART4_RELEASE_RESET();
+        __HAL_RCC_USART4_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART5_BASE)
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_UART5_FORCE_RESET();
+        __HAL_RCC_UART5_RELEASE_RESET();
+        __HAL_RCC_UART5_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART5_BASE)
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_USART5_FORCE_RESET();
+        __HAL_RCC_USART5_RELEASE_RESET();
+        __HAL_RCC_USART5_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART6_BASE)
+    if (obj_s->uart == UART_6) {
+        __HAL_RCC_USART6_FORCE_RESET();
+        __HAL_RCC_USART6_RELEASE_RESET();
+        __HAL_RCC_USART6_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART7_BASE)
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_UART7_FORCE_RESET();
+        __HAL_RCC_UART7_RELEASE_RESET();
+        __HAL_RCC_UART7_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART7_BASE)
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_USART7_FORCE_RESET();
+        __HAL_RCC_USART7_RELEASE_RESET();
+        __HAL_RCC_USART7_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART8_BASE)
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_UART8_FORCE_RESET();
+        __HAL_RCC_UART8_RELEASE_RESET();
+        __HAL_RCC_UART8_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(USART8_BASE)
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_USART8_FORCE_RESET();
+        __HAL_RCC_USART8_RELEASE_RESET();
+        __HAL_RCC_USART8_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART9_BASE)
+    if (obj_s->uart == UART_9) {
+        __HAL_RCC_UART9_FORCE_RESET();
+        __HAL_RCC_UART9_RELEASE_RESET();
+        __HAL_RCC_UART9_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+#if defined(UART10_BASE)
+    if (obj_s->uart == UART_10) {
+        __HAL_RCC_UART10_FORCE_RESET();
+        __HAL_RCC_UART10_RELEASE_RESET();
+        __HAL_RCC_UART10_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+
+#if defined(LPUART1_BASE)
+    if (obj_s->uart == LPUART_1) {
+        __HAL_RCC_LPUART1_FORCE_RESET();
+        __HAL_RCC_LPUART1_RELEASE_RESET();
+        __HAL_RCC_LPUART1_CLK_ENABLE();
+        obj_s->index = IndexNumber;
+    }
+    IndexNumber++;
+#endif
+
+    // Configure UART pins
+    pinmap_pinout(tx, PinMap_UART_TX);
+    pinmap_pinout(rx, PinMap_UART_RX);
+
+    if (tx != NC) {
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        pin_mode(rx, PullUp);
+    }
+
+    // Configure UART
+    obj_s->baudrate = 9600; // baudrate default value
+    if (obj_s->uart == STDIO_UART) {
+#if MBED_CONF_PLATFORM_STDIO_BAUD_RATE
+        obj_s->baudrate = MBED_CONF_PLATFORM_STDIO_BAUD_RATE; // baudrate takes value from platform/mbed_lib.json
+#endif /* MBED_CONF_PLATFORM_STDIO_BAUD_RATE */
+    }
+    else {
+#if MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE
+        obj_s->baudrate = MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE; // baudrate takes value from platform/mbed_lib.json
+#endif /* MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE */
+    }
+    obj_s->databits = UART_WORDLENGTH_8B;
+    obj_s->stopbits = UART_STOPBITS_1;
+    obj_s->parity   = UART_PARITY_NONE;
+
+#if DEVICE_SERIAL_FC
+    obj_s->hw_flow_ctl = UART_HWCONTROL_NONE;
+#endif
+
+    obj_s->pin_tx = tx;
+    obj_s->pin_rx = rx;
+
+    init_uart(obj); /* init_uart will be called again in serial_baud function, so don't worry if init_uart returns HAL_ERROR */
+
+    // For stdio management
+    if (obj_s->uart == STDIO_UART) { // STDIO_UART defined in PeripheralNames.h
+        stdio_uart_inited = 1;
+        memcpy(&stdio_uart, obj, sizeof(serial_t));
+    }
+}
+
+void serial_free(serial_t *obj)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+
+    // Reset UART and disable clock
+#if defined(USART1_BASE)
+    if (obj_s->uart == UART_1) {
+        __HAL_RCC_USART1_FORCE_RESET();
+        __HAL_RCC_USART1_RELEASE_RESET();
+        __HAL_RCC_USART1_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART2_BASE)
+    if (obj_s->uart == UART_2) {
+        __HAL_RCC_USART2_FORCE_RESET();
+        __HAL_RCC_USART2_RELEASE_RESET();
+        __HAL_RCC_USART2_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART3_BASE)
+    if (obj_s->uart == UART_3) {
+        __HAL_RCC_USART3_FORCE_RESET();
+        __HAL_RCC_USART3_RELEASE_RESET();
+        __HAL_RCC_USART3_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART4_BASE)
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_UART4_FORCE_RESET();
+        __HAL_RCC_UART4_RELEASE_RESET();
+        __HAL_RCC_UART4_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART4_BASE)
+    if (obj_s->uart == UART_4) {
+        __HAL_RCC_USART4_FORCE_RESET();
+        __HAL_RCC_USART4_RELEASE_RESET();
+        __HAL_RCC_USART4_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART5_BASE)
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_UART5_FORCE_RESET();
+        __HAL_RCC_UART5_RELEASE_RESET();
+        __HAL_RCC_UART5_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART5_BASE)
+    if (obj_s->uart == UART_5) {
+        __HAL_RCC_USART5_FORCE_RESET();
+        __HAL_RCC_USART5_RELEASE_RESET();
+        __HAL_RCC_USART5_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART6_BASE)
+    if (obj_s->uart == UART_6) {
+        __HAL_RCC_USART6_FORCE_RESET();
+        __HAL_RCC_USART6_RELEASE_RESET();
+        __HAL_RCC_USART6_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART7_BASE)
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_UART7_FORCE_RESET();
+        __HAL_RCC_UART7_RELEASE_RESET();
+        __HAL_RCC_UART7_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART7_BASE)
+    if (obj_s->uart == UART_7) {
+        __HAL_RCC_USART7_FORCE_RESET();
+        __HAL_RCC_USART7_RELEASE_RESET();
+        __HAL_RCC_USART7_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART8_BASE)
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_UART8_FORCE_RESET();
+        __HAL_RCC_UART8_RELEASE_RESET();
+        __HAL_RCC_UART8_CLK_DISABLE();
+    }
+#endif
+
+#if defined(USART8_BASE)
+    if (obj_s->uart == UART_8) {
+        __HAL_RCC_USART8_FORCE_RESET();
+        __HAL_RCC_USART8_RELEASE_RESET();
+        __HAL_RCC_USART8_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART9_BASE)
+    if (obj_s->uart == UART_9) {
+        __HAL_RCC_UART9_FORCE_RESET();
+        __HAL_RCC_UART9_RELEASE_RESET();
+        __HAL_RCC_UART9_CLK_DISABLE();
+    }
+#endif
+
+#if defined(UART10_BASE)
+    if (obj_s->uart == UART_10) {
+        __HAL_RCC_UART10_FORCE_RESET();
+        __HAL_RCC_UART10_RELEASE_RESET();
+        __HAL_RCC_UART10_CLK_DISABLE();
+    }
+#endif
+
+#if defined(LPUART1_BASE)
+    if (obj_s->uart == LPUART_1) {
+        __HAL_RCC_LPUART1_FORCE_RESET();
+        __HAL_RCC_LPUART1_RELEASE_RESET();
+        __HAL_RCC_LPUART1_CLK_DISABLE();
+    }
+#endif
+
+    // Configure GPIOs
+    pin_function(obj_s->pin_tx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+    pin_function(obj_s->pin_rx, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, 0));
+
+    serial_irq_ids[obj_s->index] = 0;
+}
+
+void serial_baud(serial_t *obj, int baudrate)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+
+    obj_s->baudrate = baudrate;
+    if (init_uart(obj) != HAL_OK) {
+        debug("Cannot initialize UART with baud rate %u\n", baudrate);
+        /* Note that LPUART clock source must be in the range [3 x baud rate, 4096 x baud rate], check Ref Manual */
+    }
+}
+
+HAL_StatusTypeDef init_uart(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
@@ -64,9 +418,7 @@ void init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
-    if (HAL_UART_Init(huart) != HAL_OK) {
-        error("Cannot initialize UART\n");
-    }
+    return HAL_UART_Init(huart);
 }
 
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)

--- a/targets/TARGET_STM/serial_api_hal.h
+++ b/targets/TARGET_STM/serial_api_hal.h
@@ -32,7 +32,14 @@
 #define MBED_SERIAL_API_HAL_H
 
 #include "serial_api.h"
+#include <string.h>
+#include "mbed_assert.h"
+#include "mbed_debug.h"
+#include "mbed_error.h"
 
+// #include "cmsis.h"
+// #include "pinmap.h"
+#include "PeripheralPins.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,14 +54,12 @@ extern "C" {
     #define SERIAL_S(obj) (obj)
 #endif
 
-extern UART_HandleTypeDef uart_handlers[];
-
 
 /** Initialize and configure the UART peripheral
  *
  * @param obj       The serial object containing the configuration
  */
-void init_uart(serial_t *obj);
+HAL_StatusTypeDef init_uart(serial_t *obj);
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/serial_api_hal.h
+++ b/targets/TARGET_STM/serial_api_hal.h
@@ -37,8 +37,6 @@
 #include "mbed_debug.h"
 #include "mbed_error.h"
 
-// #include "cmsis.h"
-// #include "pinmap.h"
 #include "PeripheralPins.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
## Description

- serial_init, serial_free and serial_baud functions moved from serial_device.c (specific to each STM32 family) to serial_api.c (common STM32 file)

- default baudrate value was hardcoded to 9600
  - Value is set now to MBED_CONF_PLATFORM_STDIO_BAUD_RATE for STDIO
  - Value is set now to MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE for other use

- UART init will not be stopped before calling serial_baud function

- for LPUART, init procedure can update the clock source depending on expected baudrate

This should close #5389 issue

## Status

**READY**

## Tests

OS2 and OS5 tests verified for all STM32 targets
