### PR TITLE
Complete mbed_retarget FileHandle rework

### DIFF
--- a/platform/FileHandle.cpp
+++ b/platform/FileHandle.cpp
@@ -33,9 +33,4 @@ off_t FileHandle::size()
     return size;
 }
 
-std::FILE *fdopen(FileHandle *fh, const char *mode)
-{
-    return mbed_fdopen(fh, mode);
-}
-
 } // namespace mbed

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -252,18 +252,6 @@ public:
     }
 };
 
-/** Not a member function
- *  This call is equivalent to posix fdopen().
- *  It associates a Stream to an already opened file descriptor (FileHandle)
- *
- *  @param fh       a pointer to an opened file descriptor
- *  @param mode     operation upon the file descriptor, e.g., 'wb+'
- *
- *  @returns        a pointer to std::FILE
-*/
-
-std::FILE *fdopen(FileHandle *fh, const char *mode);
-
 /**@}*/
 
 /**@}*/

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -2,7 +2,17 @@
     "name": "platform",
     "config": {
         "stdio-convert-newlines": {
-            "help": "Enable conversion to standard newlines on stdin/stdout",
+            "help": "Enable conversion to standard newlines on stdin/stdout/stderr",
+            "value": false
+        },
+
+        "stdio-convert-tty-newlines": {
+            "help": "Enable conversion to standard newlines on any tty FILE stream",
+            "value": false
+        },
+
+        "stdio-buffered-serial": {
+            "help": "Use UARTSerial driver to obtain buffered serial I/O on stdin/stdout/stderr. If false, unbuffered serial_getc and serial_putc are used directly.",
             "value": false
         },
 

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -28,8 +28,9 @@
 /* We can get the following standard types from sys/types for gcc, but we
  * need to define the types ourselves for the other compilers that normally
  * target embedded systems */
-typedef signed   int  ssize_t;     ///< Signed size type, usually encodes negative errors
-typedef signed   long off_t;       ///< Offset in a data stream
+typedef signed   int  ssize_t;  ///< Signed size type, usually encodes negative errors
+typedef signed   long off_t;    ///< Offset in a data stream
+typedef unsigned int  nfds_t;   ///< Number of file descriptors
 typedef unsigned long long fsblkcnt_t;  ///< Count of file system blocks
 #if defined(__ARMCC_VERSION) || !defined(__GNUC__)
 typedef unsigned int  mode_t;   ///< Mode for opening files
@@ -73,21 +74,6 @@ typedef mbed::DirHandle DIR;
 #else
 typedef struct Dir DIR;
 #endif
-
-#if __cplusplus
-extern "C" {
-#endif
-    DIR *opendir(const char*);
-    struct dirent *readdir(DIR *);
-    int closedir(DIR*);
-    void rewinddir(DIR*);
-    long telldir(DIR*);
-    void seekdir(DIR*, long);
-    int mkdir(const char *name, mode_t n);
-#if __cplusplus
-};
-#endif
-
 
 /* The intent of this section is to unify the errno error values to match
  * the POSIX definitions for the GCC_ARM, ARMCC and IAR compilers. This is
@@ -429,16 +415,6 @@ struct statvfs {
     unsigned long  f_namemax;  ///< Maximum filename length
 };
 
-#if __cplusplus
-extern "C" {
-#endif
-    int stat(const char *path, struct stat *st);
-    int statvfs(const char *path, struct statvfs *buf);
-#if __cplusplus
-};
-#endif
-
-
 /* The following are dirent.h definitions are declared here to garuntee
  * consistency where structure may be different with different toolchains
  */
@@ -457,6 +433,37 @@ enum {
     DT_LNK,     ///< This is a symbolic link.
     DT_SOCK,    ///< This is a UNIX domain socket.
 };
+
+struct pollfd {
+    int fd;
+    short events;
+    short revents;
+};
+
+#if __cplusplus
+extern "C" {
+#endif
+    int open(const char *path, int oflag, ...);
+    ssize_t write(int fildes, const void *buf, size_t nbyte);
+    ssize_t read(int fildes, void *buf, size_t nbyte);
+    off_t lseek(int fildes, off_t offset, int whence);
+    int isatty(int fildes);
+    int fsync(int fildes);
+    int fstat(int fh, struct stat *st);
+    int poll(struct pollfd fds[], nfds_t nfds, int timeout);
+    int close(int fildes);
+    int stat(const char *path, struct stat *st);
+    int statvfs(const char *path, struct statvfs *buf);
+    DIR *opendir(const char*);
+    struct dirent *readdir(DIR *);
+    int closedir(DIR*);
+    void rewinddir(DIR*);
+    long telldir(DIR*);
+    void seekdir(DIR*, long);
+    int mkdir(const char *name, mode_t n);
+#if __cplusplus
+};
+#endif
 
 /**@}*/
 

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -54,6 +54,10 @@ typedef unsigned int  gid_t;    ///< Group ID
 
 #define NAME_MAX 255    ///< Maximum size of a name in a file path
 
+#define STDIN_FILENO  0
+#define STDOUT_FILENO 1
+#define STDERR_FILENO 2
+
 #include <time.h>
 
 /** \addtogroup platform */
@@ -69,6 +73,46 @@ namespace mbed {
 
 class FileHandle;
 class DirHandle;
+
+/** Targets may implement this to change stdin, stdout, stderr.
+ *
+ * If the application hasn't provided mbed_override_console, this is called
+ * to give the target a chance to specify a FileHandle for the console.
+ *
+ * If this is not provided or returns NULL, the console will be:
+ *   - UARTSerial if configuration option "platform.stdio-buffered-serial" is
+ *     true and the target has DEVICE_SERIAL;
+ *   - Raw HAL serial via serial_getc and serial_putc if
+ *     "platform.stdio-buffered-serial" is false and the target has DEVICE_SERIAL;
+ *   - stdout/stderr will be a sink and stdin will input a stream of 0s if the
+ *     target does not have DEVICE_SERIAL.
+ *
+ * @param fd file descriptor - STDIN_FILENO, STDOUT_FILENO or STDERR_FILENO
+ * @return  pointer to FileHandle to override normal stream otherwise NULL
+ */
+FileHandle* mbed_target_override_console(int fd);
+
+/** Applications may implement this to change stdin, stdout, stderr.
+ *
+ * This hook gives the application a chance to specify a custom FileHandle
+ * for the console.
+ *
+ * If this is not provided or returns NULL, the console will be specified
+ * by mbed_target_override_console, else will default to serial - see
+ * mbed_target_override_console for more details.
+ *
+ * Example:
+ * @code
+ * FileHandle* mbed::mbed_override_console(int) {
+ *     static UARTSerial my_serial(D0, D1);
+ *     return &my_serial;
+ * }
+ * @endcode
+
+ * @param fd file descriptor - STDIN_FILENO, STDOUT_FILENO or STDERR_FILENO
+ * @return  pointer to FileHandle to override normal stream otherwise NULL
+ */
+FileHandle* mbed_override_console(int fd);
 
 }
 


### PR DESCRIPTION
To complete the move to POSIX-ness and FileHandle-ness, close the loop by reworking mbed_retarget.cpp so that everything is a `FileHandle`.

This adds:

* POSIX file APIs - `open`/`close`/`read`/`write`/`lseek`/`isatty`/`fsync`/`fstat`/`fdopen`/`poll`.
* The ability to have buffered `stdin`/`stdout` using `UARTSerial` with a simple JSON change.
* The ability for target or application to change stdin/stdout/stderr to be a custom `FileHandle` by overriding weak functions..
* The option of CRLF conversion for any `isatty()` stream, not just stdin/stdout/stderr.
