### PR TITLE
Ethernet tests update

### DIFF
--- a/TESTS/netsocket/gethostbyname/main.cpp
+++ b/TESTS/netsocket/gethostbyname/main.cpp
@@ -29,8 +29,8 @@ using namespace utest::v1;
 
 // Hostname for testing against
 // Must have A and AAAA records
-#ifndef MBED_DNS_TEST_HOST
-#define MBED_DNS_TEST_HOST "connector.mbed.com"
+#ifndef MBED_CONF_APP_DNS_TEST_HOST
+#define MBED_CONF_APP_DNS_TEST_HOST "connector.mbed.com"
 #endif
 
 
@@ -59,9 +59,9 @@ void net_bringup() {
 // DNS tests
 void test_dns_query() {
     SocketAddress addr;
-    int err = net->gethostbyname(MBED_DNS_TEST_HOST, &addr);
+    int err = net->gethostbyname(MBED_CONF_APP_DNS_TEST_HOST, &addr);
     printf("DNS: query \"%s\" => \"%s\"\n",
-            MBED_DNS_TEST_HOST, addr.get_ip_address());
+            MBED_CONF_APP_DNS_TEST_HOST, addr.get_ip_address());
 
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT((bool)addr);
@@ -70,9 +70,9 @@ void test_dns_query() {
 
 void test_dns_query_pref() {
     SocketAddress addr;
-    int err = net->gethostbyname(MBED_DNS_TEST_HOST, &addr, ip_pref);
+    int err = net->gethostbyname(MBED_CONF_APP_DNS_TEST_HOST, &addr, ip_pref);
     printf("DNS: query %s \"%s\" => \"%s\"\n",
-            ip_pref_repr, MBED_DNS_TEST_HOST, addr.get_ip_address());
+            ip_pref_repr, MBED_CONF_APP_DNS_TEST_HOST, addr.get_ip_address());
 
     TEST_ASSERT_EQUAL(0, err);
     TEST_ASSERT((bool)addr);

--- a/TESTS/netsocket/socket_sigio/main.cpp
+++ b/TESTS/netsocket/socket_sigio/main.cpp
@@ -29,11 +29,13 @@
 
 using namespace utest::v1;
 
+#ifndef MBED_CONF_APP_HTTP_SERVER_NAME
+#define MBED_CONF_APP_HTTP_SERVER_NAME "os.mbed.com"
+#define MBED_CONF_APP_HTTP_SERVER_FILE_PATH "/media/uploads/mbed_official/hello.txt"
+#endif
 
 namespace {
     // Test connection information
-    const char *HTTP_SERVER_NAME = "os.mbed.com";
-    const char *HTTP_SERVER_FILE_PATH = "/media/uploads/mbed_official/hello.txt";
     const int HTTP_SERVER_PORT = 80;
 #if defined(TARGET_VK_RZ_A1H)
     const int RECV_BUFFER_SIZE = 300;
@@ -97,12 +99,14 @@ void prep_buffer() {
     // We are constructing GET command like this:
     // GET http://developer.mbed.org/media/uploads/mbed_official/hello.txt HTTP/1.0\n\n
     strcpy(buffer, "GET http://");
-    strcat(buffer, HTTP_SERVER_NAME);
-    strcat(buffer, HTTP_SERVER_FILE_PATH);
+    strcat(buffer, MBED_CONF_APP_HTTP_SERVER_NAME);
+    strcat(buffer, MBED_CONF_APP_HTTP_SERVER_FILE_PATH);
     strcat(buffer, " HTTP/1.0\n\n");
 }
 
 void test_socket_attach() {
+    bool result = false;
+
     // Dispatch event queue
     Thread eventThread;
     EventQueue queue(4*EVENTS_EVENT_SIZE);
@@ -111,8 +115,8 @@ void test_socket_attach() {
     printf("TCP client IP Address is %s\r\n", net->get_ip_address());
 
     TCPSocket sock(net);
-    printf("HTTP: Connection to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
-    if (sock.connect(HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
+    printf("HTTP: Connection to %s:%d\r\n", MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT);
+    if (sock.connect(MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
         printf("HTTP: OK\r\n");
 
         prep_buffer();
@@ -122,10 +126,13 @@ void test_socket_attach() {
         sock.send(buffer, strlen(buffer));
         // wait for recv data
         recvd.wait();
+
+        result = true;
     } else {
         printf("HTTP: ERROR\r\n");
     }
     sock.close();
+    TEST_ASSERT_EQUAL(true, result);
 }
 
 void cb_fail() {
@@ -145,8 +152,8 @@ void test_socket_detach() {
     printf("TCP client IP Address is %s\r\n", net->get_ip_address());
 
     TCPSocket sock(net);
-    printf("HTTP: Connection to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
-    if (sock.connect(HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
+    printf("HTTP: Connection to %s:%d\r\n", MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT);
+    if (sock.connect(MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
         printf("HTTP: OK\r\n");
 
         prep_buffer();
@@ -172,8 +179,8 @@ void test_socket_reattach() {
     printf("TCP client IP Address is %s\r\n", net->get_ip_address());
 
     TCPSocket sock(net);
-    printf("HTTP: Connection to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
-    if (sock.connect(HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
+    printf("HTTP: Connection to %s:%d\r\n", MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT);
+    if (sock.connect(MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
         printf("HTTP: OK\r\n");
 
         prep_buffer();

--- a/TESTS/netsocket/tcp_hello_world/main.cpp
+++ b/TESTS/netsocket/tcp_hello_world/main.cpp
@@ -29,11 +29,13 @@
 
 using namespace utest::v1;
 
+#ifndef MBED_CONF_APP_HTTP_SERVER_NAME
+#define MBED_CONF_APP_HTTP_SERVER_NAME "os.mbed.com"
+#define MBED_CONF_APP_HTTP_SERVER_FILE_PATH "/media/uploads/mbed_official/hello.txt"
+#endif
 
 namespace {
     // Test connection information
-    const char *HTTP_SERVER_NAME = "os.mbed.com";
-    const char *HTTP_SERVER_FILE_PATH = "/media/uploads/mbed_official/hello.txt";
     const int HTTP_SERVER_PORT = 80;
 #if defined(TARGET_VK_RZ_A1H)
     const int RECV_BUFFER_SIZE = 300;
@@ -60,15 +62,15 @@ void test_tcp_hello_world() {
     printf("TCP client IP Address is %s\r\n", net->get_ip_address());
 
     TCPSocket sock(net);
-    printf("HTTP: Connection to %s:%d\r\n", HTTP_SERVER_NAME, HTTP_SERVER_PORT);
-    if (sock.connect(HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
+    printf("HTTP: Connection to %s:%d\r\n", MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT);
+    if (sock.connect(MBED_CONF_APP_HTTP_SERVER_NAME, HTTP_SERVER_PORT) == 0) {
         printf("HTTP: OK\r\n");
 
         // We are constructing GET command like this:
         // GET http://developer.mbed.org/media/uploads/mbed_official/hello.txt HTTP/1.0\n\n
         strcpy(buffer, "GET http://");
-        strcat(buffer, HTTP_SERVER_NAME);
-        strcat(buffer, HTTP_SERVER_FILE_PATH);
+        strcat(buffer, MBED_CONF_APP_HTTP_SERVER_NAME);
+        strcat(buffer, MBED_CONF_APP_HTTP_SERVER_FILE_PATH);
         strcat(buffer, " HTTP/1.0\n\n");
         // Send GET command
         sock.send(buffer, strlen(buffer));


### PR DESCRIPTION
## Description

Some tests have been updated:

tests-netsocket-gethostbyname:
-	MBED_DNS_TEST_HOST define is replaced by MBED_CONF_APP_DNS_TEST_HOST to allow user to change host name for local tests

tests-netsocket-udp_echo:
-	UUID lines are removed as they were not used
-	If MBED_CONF_APP_ECHO_SERVER_ADDR and MBED_CONF_APP_ECHO_SERVER_PORT are not defined (default case), test is using Greentea to get server information (code before OS 5.6.1 version)

tests-netsocket-tcp_echo:
-	UUID lines are removed as they were not used
-	If MBED_CONF_APP_ECHO_SERVER_ADDR and MBED_CONF_APP_ECHO_SERVER_PORT are not defined (default case), test is using Greentea to get server information (code before OS 5.6.1 version)
-	TCP_ECHO_PREFIX is no more a mandatory feature

tests-netsocket-tcp_hello_world:
-	HTTP_SERVER_NAME and HTTP_SERVER_FILE_PATH are replaced by MBED_CONF_APP_HTTP_SERVER_NAME and MBED_CONF_APP_HTTP_SERVER_FILE_PATH to allow user to make local tests

## Status

**READY**
