### PR TITLE
REALTEK_RTL8195AM Wifi driver - adds check of credentials validity

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -130,6 +130,25 @@ nsapi_error_t RTWInterface::set_dhcp(bool dhcp)
  */
 nsapi_error_t RTWInterface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
 {
+    if(!ssid) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    switch (security) {
+        case NSAPI_SECURITY_WPA:
+        case NSAPI_SECURITY_WPA2:
+        case NSAPI_SECURITY_WPA_WPA2:
+        case NSAPI_SECURITY_WEP:
+            if((strlen(pass) < 8) || (strlen(pass) > 63)) { // 802.11 password 8-63 characters
+                return NSAPI_ERROR_PARAMETER;
+            }
+            break;
+        case NSAPI_SECURITY_NONE:
+            break;
+        default:
+            return NSAPI_ERROR_PARAMETER;
+    }
+
     strncpy(_ssid, ssid, 255);
     strncpy(_pass, pass, 255);
     _security = security;


### PR DESCRIPTION
Adds checks that SSID is non-empty and that password is 8-63 characters
long when security is enabled

## Description

Enables checking of SSID and password validity when set_credentials() is called

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce

    ...\mbed-os> mbed test --compile -t ARM -m REALTEK_RTL8195AM --app-config .\TESTS\network\wifi\template_mbed_app.txt -n tests-network-wifi
    ...\mbed-os> mbedhtrun -f .\BUILD\tests\REALTEK_RTL8195AM\ARM\TESTS\network\wifi\wifi.bin -d X: -p COMY:9600
