### PR TITLE
DISCO_F746NG: add usp_speed configuration

### DIFF
--- a/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
+++ b/features/unsupported/USBDevice/targets/TARGET_STM/USBHAL_IP_OTGFSHS.h
@@ -18,13 +18,12 @@
 #ifndef USBHAL_IP_OTGFSHS_H
 #define USBHAL_IP_OTGFSHS_H
 
-//==================================================================
-// This board has both USB OTG FS and HS connectors.
-// Select one line only.
-//==================================================================
 #if defined(TARGET_DISCO_F746NG)
-//#define TARGET_DISCO_F746NG_OTG_FS
+#if (MBED_CONF_TARGET_USB_SPEED == 1) // Defined in json configuration file
 #define TARGET_DISCO_F746NG_OTG_HS
+#else
+#define TARGET_DISCO_F746NG_OTG_FS
+#endif
 #endif
 
 #if defined(TARGET_DISCO_F429ZI) || \

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1592,6 +1592,10 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "usb_speed": {
+                "help": "Select the USB connector (0=FullSpeed, 1=HighSpeed))",
+                "value": "1"
             }
         },
         "detect_code": ["0815"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1594,7 +1594,7 @@
                 "macro_name": "CLOCK_SOURCE"
             },
             "usb_speed": {
-                "help": "Select the USB connector (0=FullSpeed, 1=HighSpeed))",
+                "help": "Select the USB speed/connector (0=FullSpeed, 1=HighSpeed)",
                 "value": "1"
             }
         },


### PR DESCRIPTION
## Description
Add a new `usb_speed` configuration in targets.json in order to select between the FS or HS USB connectors present on the board.

## Status
**READY**

## Migrations
NO