### PR TITLE
Remove pointless null check in operator delete

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1045,15 +1045,11 @@ void *operator new[](std::size_t count, const std::nothrow_t& tag)
 
 void operator delete(void *ptr)
 {
-    if (ptr != NULL) {
-        free(ptr);
-    }
+    free(ptr);
 }
 void operator delete[](void *ptr)
 {
-    if (ptr != NULL) {
-        free(ptr);
-    }
+    free(ptr);
 }
 
 /* @brief   standard c library clock() function.


### PR DESCRIPTION
free() checks for NULL, no need to add another check.

Micro-optimisation tweak - not for patch.