### PR TITLE
Support Wunderbar IoT kit target 

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PeripheralNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PeripheralNames.h
@@ -1,0 +1,137 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    OSC32KCLK = 0,
+} RTCName;
+
+typedef enum {
+    UART_0 = 0,
+    UART_1 = 1,
+    UART_2 = 2,
+    UART_3 = 3,
+    UART_4 = 4,
+} UARTName;
+
+#define STDIO_UART_TX     NC
+#define STDIO_UART_RX     NC
+#define STDIO_UART        UART_4
+
+typedef enum {
+    I2C_0 = 0,
+    I2C_1 = 1,
+    I2C_2 = 2,
+} I2CName;
+
+#define TPM_SHIFT   8
+typedef enum {
+    PWM_1  = (0 << TPM_SHIFT) | (0),  // FTM0 CH0
+    PWM_2  = (0 << TPM_SHIFT) | (1),  // FTM0 CH1
+    PWM_3  = (0 << TPM_SHIFT) | (2),  // FTM0 CH2
+    PWM_4  = (0 << TPM_SHIFT) | (3),  // FTM0 CH3
+    PWM_5  = (0 << TPM_SHIFT) | (4),  // FTM0 CH4
+    PWM_6  = (0 << TPM_SHIFT) | (5),  // FTM0 CH5
+    PWM_7  = (0 << TPM_SHIFT) | (6),  // FTM0 CH6
+    PWM_8  = (0 << TPM_SHIFT) | (7),  // FTM0 CH7
+    PWM_9  = (1 << TPM_SHIFT) | (0),  // FTM1 CH0
+    PWM_10 = (1 << TPM_SHIFT) | (1),  // FTM1 CH1
+    PWM_11 = (1 << TPM_SHIFT) | (2),  // FTM1 CH2
+    PWM_12 = (1 << TPM_SHIFT) | (3),  // FTM1 CH3
+    PWM_13 = (1 << TPM_SHIFT) | (4),  // FTM1 CH4
+    PWM_14 = (1 << TPM_SHIFT) | (5),  // FTM1 CH5
+    PWM_15 = (1 << TPM_SHIFT) | (6),  // FTM1 CH6
+    PWM_16 = (1 << TPM_SHIFT) | (7),  // FTM1 CH7
+    PWM_17 = (2 << TPM_SHIFT) | (0),  // FTM2 CH0
+    PWM_18 = (2 << TPM_SHIFT) | (1),  // FTM2 CH1
+    PWM_19 = (2 << TPM_SHIFT) | (2),  // FTM2 CH2
+    PWM_20 = (2 << TPM_SHIFT) | (3),  // FTM2 CH3
+    PWM_21 = (2 << TPM_SHIFT) | (4),  // FTM2 CH4
+    PWM_22 = (2 << TPM_SHIFT) | (5),  // FTM2 CH5
+    PWM_23 = (2 << TPM_SHIFT) | (6),  // FTM2 CH6
+    PWM_24 = (2 << TPM_SHIFT) | (7),  // FTM2 CH7
+    PWM_25 = (3 << TPM_SHIFT) | (0),  // FTM3 CH0
+    PWM_26 = (3 << TPM_SHIFT) | (1),  // FTM3 CH1
+    PWM_27 = (3 << TPM_SHIFT) | (2),  // FTM3 CH2
+    PWM_28 = (3 << TPM_SHIFT) | (3),  // FTM3 CH3
+    PWM_29 = (3 << TPM_SHIFT) | (4),  // FTM3 CH4
+    PWM_30 = (3 << TPM_SHIFT) | (5),  // FTM3 CH5
+    PWM_31 = (3 << TPM_SHIFT) | (6),  // FTM3 CH6
+    PWM_32 = (3 << TPM_SHIFT) | (7),  // FTM3 CH7
+} PWMName;
+
+#define ADC_INSTANCE_SHIFT           8
+#define ADC_B_CHANNEL_SHIFT          5
+typedef enum {
+    ADC0_SE4b = (0 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 4,
+    ADC0_SE5b = (0 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 5,
+    ADC0_SE6b = (0 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 6,
+    ADC0_SE7b = (0 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 7,
+    ADC0_SE8  = (0 << ADC_INSTANCE_SHIFT) | 8,
+    ADC0_SE9  = (0 << ADC_INSTANCE_SHIFT) | 9,
+    ADC0_SE12 = (0 << ADC_INSTANCE_SHIFT) | 12,
+    ADC0_SE13 = (0 << ADC_INSTANCE_SHIFT) | 13,
+    ADC0_SE14 = (0 << ADC_INSTANCE_SHIFT) | 14,
+    ADC0_SE15 = (0 << ADC_INSTANCE_SHIFT) | 15,
+    ADC0_SE16 = (0 << ADC_INSTANCE_SHIFT) | 16,
+    ADC0_SE17 = (0 << ADC_INSTANCE_SHIFT) | 17,
+    ADC0_SE18 = (0 << ADC_INSTANCE_SHIFT) | 18,
+    ADC0_SE21 = (0 << ADC_INSTANCE_SHIFT) | 21,
+    ADC0_SE22 = (0 << ADC_INSTANCE_SHIFT) | 22,
+    ADC0_SE23 = (0 << ADC_INSTANCE_SHIFT) | 23,
+    ADC1_SE4a = (1 << ADC_INSTANCE_SHIFT) | 4,
+    ADC1_SE5a = (1 << ADC_INSTANCE_SHIFT) | 5,
+    ADC1_SE6a = (1 << ADC_INSTANCE_SHIFT) | 6,
+    ADC1_SE7a = (1 << ADC_INSTANCE_SHIFT) | 7,
+    ADC1_SE4b = (1 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 4,
+    ADC1_SE5b = (1 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 5,
+    ADC1_SE6b = (1 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 6,
+    ADC1_SE7b = (1 << ADC_INSTANCE_SHIFT) | (1 << ADC_B_CHANNEL_SHIFT) | 7,
+    ADC1_SE8  = (1 << ADC_INSTANCE_SHIFT) | 8,
+    ADC1_SE9  = (1 << ADC_INSTANCE_SHIFT) | 9,
+    ADC1_SE12 = (1 << ADC_INSTANCE_SHIFT) | 12,
+    ADC1_SE13 = (1 << ADC_INSTANCE_SHIFT) | 13,
+    ADC1_SE14 = (1 << ADC_INSTANCE_SHIFT) | 14,
+    ADC1_SE15 = (1 << ADC_INSTANCE_SHIFT) | 15,
+    ADC1_SE16 = (1 << ADC_INSTANCE_SHIFT) | 16,
+    ADC1_SE17 = (1 << ADC_INSTANCE_SHIFT) | 17,
+    ADC1_SE18 = (1 << ADC_INSTANCE_SHIFT) | 18,
+    ADC1_SE23 = (1 << ADC_INSTANCE_SHIFT) | 23,
+} ADCName;
+
+typedef enum {
+    DAC_0 = 0
+} DACName;
+
+
+typedef enum {
+    SPI_0 = 0,
+    SPI_1 = 1,
+    SPI_2 = 2,
+} SPIName;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PeripheralPins.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PeripheralPins.c
@@ -1,0 +1,242 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "PeripheralPins.h"
+
+/************RTC***************/
+const PinMap PinMap_RTC[] = {
+    {NC, OSC32KCLK, 0},
+};
+
+/************ADC***************/
+const PinMap PinMap_ADC[] = {
+    {PTA17, ADC1_SE17, 0},
+    {PTB0 , ADC0_SE8 , 0},
+    {PTB1 , ADC0_SE9 , 0},
+    {PTB2 , ADC0_SE12, 0},
+    {PTB3 , ADC0_SE13, 0},
+    {PTB6 , ADC1_SE12, 0},
+    {PTB7 , ADC1_SE13, 0},
+    {PTB10, ADC1_SE14, 0},
+    {PTB11, ADC1_SE15, 0},
+    {PTC0 , ADC0_SE14, 0},
+    {PTC1 , ADC0_SE15, 0},
+    {PTC2,  ADC0_SE4b, 0},
+    {PTC8,  ADC1_SE4b, 0},
+    {PTC9,  ADC1_SE5b, 0},
+    {PTC10, ADC1_SE6b, 0},
+    {PTC11, ADC1_SE7b, 0},
+    {PTD1,  ADC0_SE5b, 0},
+    {PTD5,  ADC0_SE6b, 0},
+    {PTD6,  ADC0_SE7b, 0},
+    {PTE0,  ADC1_SE4a, 0},
+    {PTE1,  ADC1_SE5a, 0},
+    {PTE2,  ADC1_SE6a, 0},
+    {PTE3,  ADC1_SE7a, 0},
+    //{PTE24, ADC0_SE17, 0}, //I2C pull up
+    //{PTE25, ADC0_SE18, 0}, //I2C pull up
+    {NC   , NC       , 0}
+};
+
+/************DAC***************/
+const PinMap PinMap_DAC[] = {
+    {DAC0_OUT, DAC_0, 0},
+    {NC      , NC   , 0}
+};
+
+/************I2C***************/
+const PinMap PinMap_I2C_SDA[] = {
+    {PTE25, I2C_0, 5},
+    {PTB1 , I2C_0, 2},
+    {PTB3 , I2C_0, 2},
+    {PTC11, I2C_1, 2},
+    {PTA13, I2C_2, 5},
+    {PTD3 , I2C_0, 7},
+    {PTE0 , I2C_1, 6},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_I2C_SCL[] = {
+    {PTE24, I2C_0, 5},
+    {PTB0 , I2C_0, 2},
+    {PTB2 , I2C_0, 2},
+    {PTC10, I2C_1, 2},
+    {PTA12, I2C_2, 5},
+    {PTA14, I2C_2, 5},
+    {PTD2 , I2C_0, 7},
+    {PTE1 , I2C_1, 6},
+    {NC   , NC   , 0}
+};
+
+/************UART***************/
+const PinMap PinMap_UART_TX[] = {
+    {PTB17, UART_0, 3},
+    {PTC17, UART_3, 3},
+    {PTD7 , UART_0, 3},
+    {PTD3 , UART_2, 3},
+    {PTC4 , UART_1, 3},
+    {PTC15, UART_4, 3},
+    {PTB11, UART_3, 3},
+    {PTA14, UART_0, 3},
+    {PTE24, UART_4, 3},
+    {PTE4 , UART_3, 3},
+    {PTE0,  UART_1, 3},
+    {NC  ,  NC    , 0}
+};
+
+const PinMap PinMap_UART_RX[] = {
+    {PTB16, UART_0, 3},
+    {PTE1 , UART_1, 3},
+    {PTE5 , UART_3, 3},
+    {PTE25, UART_4, 3},
+    {PTA15, UART_0, 3},
+    {PTC16, UART_3, 3},
+    {PTB10, UART_3, 3},
+    {PTC3 , UART_1, 3},
+    {PTC14, UART_4, 3},
+    {PTD2 , UART_2, 3},
+    {PTD6 , UART_0, 3},
+    {NC  ,  NC    , 0}
+};
+
+const PinMap PinMap_UART_CTS[] = {
+    {PTB13, UART_3, 2},
+    {PTE2 , UART_1, 3},
+    {PTE6 , UART_3, 3},
+    {PTE26, UART_4, 3},
+    {PTA0 , UART_0, 2},
+    {PTA16, UART_0, 3},
+    {PTB3 , UART_0, 3},
+    {PTB9 , UART_3, 3},
+    {PTC2 , UART_1, 3},
+    {PTC13, UART_4, 3},
+    {PTC19, UART_3, 3},
+    {PTD1 , UART_2, 3},
+    {PTD5 , UART_0, 3},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_UART_RTS[] = {
+    {PTB12, UART_3, 2},
+    {PTE3 , UART_1, 3},
+    {PTE7 , UART_3, 3},
+    {PTE27, UART_4, 3},
+    {PTA17, UART_0, 3},
+    {PTB8 , UART_3, 3},
+    {PTC1 , UART_1, 3},
+    {PTC12, UART_4, 3},
+    {PTC18, UART_3, 3},
+    {PTD0 , UART_2, 3},
+    {PTD4 , UART_0, 3},
+    {PTA3 , UART_0, 2},
+    {PTB2 , UART_0, 3},
+    {NC   , NC    , 0}
+};
+
+/************SPI***************/
+const PinMap PinMap_SPI_SCLK[] = {
+    {PTD1 , SPI_0, 2},
+    {PTE2 , SPI_1, 2},
+    {PTA15, SPI_0, 2},
+    {PTB11, SPI_1, 2},
+    {PTB21, SPI_2, 2},
+    {PTC5 , SPI_0, 2},
+    {PTD5 , SPI_1, 7},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_MOSI[] = {
+    {PTD2 , SPI_0, 2},
+    {PTE1 , SPI_1, 2},
+    {PTE3 , SPI_1, 7},
+    {PTA16, SPI_0, 2},
+    {PTB16, SPI_1, 2},
+    {PTB22, SPI_2, 2},
+    {PTC6 , SPI_0, 2},
+    {PTD6 , SPI_1, 7},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_MISO[] = {
+    {PTD3 , SPI_0, 2},
+    {PTE1 , SPI_1, 7},
+    {PTE3 , SPI_1, 2},
+    {PTA17, SPI_0, 2},
+    {PTB17, SPI_1, 2},
+    {PTB23, SPI_2, 2},
+    {PTC7 , SPI_0, 2},
+    {PTD7 , SPI_1, 7},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_SSEL[] = {
+    {PTD0 , SPI_0, 2},
+    {PTE4 , SPI_1, 2},
+    {PTA14, SPI_0, 2},
+    {PTB10, SPI_1, 2},
+    {PTB20, SPI_2, 2},
+    {PTC4 , SPI_0, 2},
+    {PTD4 , SPI_1, 7},
+    {NC   , NC   , 0}
+};
+
+/************PWM***************/
+const PinMap PinMap_PWM[] = {
+    {PTA0 , PWM_6 , 3},
+    {PTA1 , PWM_7 , 3},
+    {PTA2 , PWM_8 , 3},
+    {PTA3 , PWM_1 , 3},
+    {PTA4 , PWM_2 , 3},
+    {PTA5 , PWM_3 , 3},
+    {PTA6 , PWM_4 , 3},
+    {PTA7 , PWM_5 , 3},
+    {PTA8 , PWM_9 , 3},
+    {PTA9 , PWM_10, 3},
+    {PTA10, PWM_17, 3},
+    {PTA11, PWM_18, 3},
+    {PTA12, PWM_9 , 3},
+    {PTA13, PWM_10, 3},
+
+    {PTB0 , PWM_9 , 3},
+    {PTB1 , PWM_10, 3},
+    {PTB18, PWM_17, 3},
+    {PTB19, PWM_18, 3},
+
+    {PTC1 , PWM_1 , 4},
+    {PTC2 , PWM_2 , 4},
+    {PTC3 , PWM_3 , 4},
+    {PTC4 , PWM_4 , 4},
+    {PTC5 , PWM_3 , 7},
+    {PTC8 , PWM_29, 3},
+    {PTC9 , PWM_30, 3},
+    {PTC10, PWM_31, 3},
+    {PTC11, PWM_32, 3},
+
+    {PTD0 , PWM_25, 4},
+    {PTD1 , PWM_26, 4},
+    {PTD2 , PWM_27, 4},
+    {PTD3 , PWM_28, 4},
+    {PTD4 , PWM_5 , 4},
+    {PTD5 , PWM_6 , 4},
+    {PTD6 , PWM_7 , 4},
+    {PTD4 , PWM_5 , 4},
+    {PTD7 , PWM_8 , 4},
+
+    {PTE5 , PWM_25, 6},
+    {PTE6 , PWM_26, 6},
+
+    {NC   , NC    , 0}
+};

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/PinNames.h
@@ -1,0 +1,241 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define GPIO_PORT_SHIFT 12
+
+typedef enum {
+    PTA0  = (0 << GPIO_PORT_SHIFT | 0 ),
+    PTA1  = (0 << GPIO_PORT_SHIFT | 1 ),
+    PTA2  = (0 << GPIO_PORT_SHIFT | 2 ),
+    PTA3  = (0 << GPIO_PORT_SHIFT | 3 ),
+    PTA4  = (0 << GPIO_PORT_SHIFT | 4 ),
+    PTA5  = (0 << GPIO_PORT_SHIFT | 5 ),
+    PTA6  = (0 << GPIO_PORT_SHIFT | 6 ),
+    PTA7  = (0 << GPIO_PORT_SHIFT | 7 ),
+    PTA8  = (0 << GPIO_PORT_SHIFT | 8 ),
+    PTA9  = (0 << GPIO_PORT_SHIFT | 9 ),
+    PTA10 = (0 << GPIO_PORT_SHIFT | 10),
+    PTA11 = (0 << GPIO_PORT_SHIFT | 11),
+    PTA12 = (0 << GPIO_PORT_SHIFT | 12),
+    PTA13 = (0 << GPIO_PORT_SHIFT | 13),
+    PTA14 = (0 << GPIO_PORT_SHIFT | 14),
+    PTA15 = (0 << GPIO_PORT_SHIFT | 15),
+    PTA16 = (0 << GPIO_PORT_SHIFT | 16),
+    PTA17 = (0 << GPIO_PORT_SHIFT | 17),
+    PTA18 = (0 << GPIO_PORT_SHIFT | 18),
+    PTA19 = (0 << GPIO_PORT_SHIFT | 19),
+    PTA20 = (0 << GPIO_PORT_SHIFT | 20),
+    PTA21 = (0 << GPIO_PORT_SHIFT | 21),
+    PTA22 = (0 << GPIO_PORT_SHIFT | 22),
+    PTA23 = (0 << GPIO_PORT_SHIFT | 23),
+    PTA24 = (0 << GPIO_PORT_SHIFT | 24),
+    PTA25 = (0 << GPIO_PORT_SHIFT | 25),
+    PTA26 = (0 << GPIO_PORT_SHIFT | 26),
+    PTA27 = (0 << GPIO_PORT_SHIFT | 27),
+    PTA28 = (0 << GPIO_PORT_SHIFT | 28),
+    PTA29 = (0 << GPIO_PORT_SHIFT | 29),
+    PTA30 = (0 << GPIO_PORT_SHIFT | 30),
+    PTA31 = (0 << GPIO_PORT_SHIFT | 31),
+    PTB0  = (1 << GPIO_PORT_SHIFT | 0 ),
+    PTB1  = (1 << GPIO_PORT_SHIFT | 1 ),
+    PTB2  = (1 << GPIO_PORT_SHIFT | 2 ),
+    PTB3  = (1 << GPIO_PORT_SHIFT | 3 ),
+    PTB4  = (1 << GPIO_PORT_SHIFT | 4 ),
+    PTB5  = (1 << GPIO_PORT_SHIFT | 5 ),
+    PTB6  = (1 << GPIO_PORT_SHIFT | 6 ),
+    PTB7  = (1 << GPIO_PORT_SHIFT | 7 ),
+    PTB8  = (1 << GPIO_PORT_SHIFT | 8 ),
+    PTB9  = (1 << GPIO_PORT_SHIFT | 9 ),
+    PTB10 = (1 << GPIO_PORT_SHIFT | 10),
+    PTB11 = (1 << GPIO_PORT_SHIFT | 11),
+    PTB12 = (1 << GPIO_PORT_SHIFT | 12),
+    PTB13 = (1 << GPIO_PORT_SHIFT | 13),
+    PTB14 = (1 << GPIO_PORT_SHIFT | 14),
+    PTB15 = (1 << GPIO_PORT_SHIFT | 15),
+    PTB16 = (1 << GPIO_PORT_SHIFT | 16),
+    PTB17 = (1 << GPIO_PORT_SHIFT | 17),
+    PTB18 = (1 << GPIO_PORT_SHIFT | 18),
+    PTB19 = (1 << GPIO_PORT_SHIFT | 19),
+    PTB20 = (1 << GPIO_PORT_SHIFT | 20),
+    PTB21 = (1 << GPIO_PORT_SHIFT | 21),
+    PTB22 = (1 << GPIO_PORT_SHIFT | 22),
+    PTB23 = (1 << GPIO_PORT_SHIFT | 23),
+    PTB24 = (1 << GPIO_PORT_SHIFT | 24),
+    PTB25 = (1 << GPIO_PORT_SHIFT | 25),
+    PTB26 = (1 << GPIO_PORT_SHIFT | 26),
+    PTB27 = (1 << GPIO_PORT_SHIFT | 27),
+    PTB28 = (1 << GPIO_PORT_SHIFT | 28),
+    PTB29 = (1 << GPIO_PORT_SHIFT | 29),
+    PTB30 = (1 << GPIO_PORT_SHIFT | 30),
+    PTB31 = (1 << GPIO_PORT_SHIFT | 31),
+    PTC0  = (2 << GPIO_PORT_SHIFT | 0 ),
+    PTC1  = (2 << GPIO_PORT_SHIFT | 1 ),
+    PTC2  = (2 << GPIO_PORT_SHIFT | 2 ),
+    PTC3  = (2 << GPIO_PORT_SHIFT | 3 ),
+    PTC4  = (2 << GPIO_PORT_SHIFT | 4 ),
+    PTC5  = (2 << GPIO_PORT_SHIFT | 5 ),
+    PTC6  = (2 << GPIO_PORT_SHIFT | 6 ),
+    PTC7  = (2 << GPIO_PORT_SHIFT | 7 ),
+    PTC8  = (2 << GPIO_PORT_SHIFT | 8 ),
+    PTC9  = (2 << GPIO_PORT_SHIFT | 9 ),
+    PTC10 = (2 << GPIO_PORT_SHIFT | 10),
+    PTC11 = (2 << GPIO_PORT_SHIFT | 11),
+    PTC12 = (2 << GPIO_PORT_SHIFT | 12),
+    PTC13 = (2 << GPIO_PORT_SHIFT | 13),
+    PTC14 = (2 << GPIO_PORT_SHIFT | 14),
+    PTC15 = (2 << GPIO_PORT_SHIFT | 15),
+    PTC16 = (2 << GPIO_PORT_SHIFT | 16),
+    PTC17 = (2 << GPIO_PORT_SHIFT | 17),
+    PTC18 = (2 << GPIO_PORT_SHIFT | 18),
+    PTC19 = (2 << GPIO_PORT_SHIFT | 19),
+    PTC20 = (2 << GPIO_PORT_SHIFT | 20),
+    PTC21 = (2 << GPIO_PORT_SHIFT | 21),
+    PTC22 = (2 << GPIO_PORT_SHIFT | 22),
+    PTC23 = (2 << GPIO_PORT_SHIFT | 23),
+    PTC24 = (2 << GPIO_PORT_SHIFT | 24),
+    PTC25 = (2 << GPIO_PORT_SHIFT | 25),
+    PTC26 = (2 << GPIO_PORT_SHIFT | 26),
+    PTC27 = (2 << GPIO_PORT_SHIFT | 27),
+    PTC28 = (2 << GPIO_PORT_SHIFT | 28),
+    PTC29 = (2 << GPIO_PORT_SHIFT | 29),
+    PTC30 = (2 << GPIO_PORT_SHIFT | 30),
+    PTC31 = (2 << GPIO_PORT_SHIFT | 31),
+    PTD0  = (3 << GPIO_PORT_SHIFT | 0 ),
+    PTD1  = (3 << GPIO_PORT_SHIFT | 1 ),
+    PTD2  = (3 << GPIO_PORT_SHIFT | 2 ),
+    PTD3  = (3 << GPIO_PORT_SHIFT | 3 ),
+    PTD4  = (3 << GPIO_PORT_SHIFT | 4 ),
+    PTD5  = (3 << GPIO_PORT_SHIFT | 5 ),
+    PTD6  = (3 << GPIO_PORT_SHIFT | 6 ),
+    PTD7  = (3 << GPIO_PORT_SHIFT | 7 ),
+    PTD8  = (3 << GPIO_PORT_SHIFT | 8 ),
+    PTD9  = (3 << GPIO_PORT_SHIFT | 9 ),
+    PTD10 = (3 << GPIO_PORT_SHIFT | 10),
+    PTD11 = (3 << GPIO_PORT_SHIFT | 11),
+    PTD12 = (3 << GPIO_PORT_SHIFT | 12),
+    PTD13 = (3 << GPIO_PORT_SHIFT | 13),
+    PTD14 = (3 << GPIO_PORT_SHIFT | 14),
+    PTD15 = (3 << GPIO_PORT_SHIFT | 15),
+    PTD16 = (3 << GPIO_PORT_SHIFT | 16),
+    PTD17 = (3 << GPIO_PORT_SHIFT | 17),
+    PTD18 = (3 << GPIO_PORT_SHIFT | 18),
+    PTD19 = (3 << GPIO_PORT_SHIFT | 19),
+    PTD20 = (3 << GPIO_PORT_SHIFT | 20),
+    PTD21 = (3 << GPIO_PORT_SHIFT | 21),
+    PTD22 = (3 << GPIO_PORT_SHIFT | 22),
+    PTD23 = (3 << GPIO_PORT_SHIFT | 23),
+    PTD24 = (3 << GPIO_PORT_SHIFT | 24),
+    PTD25 = (3 << GPIO_PORT_SHIFT | 25),
+    PTD26 = (3 << GPIO_PORT_SHIFT | 26),
+    PTD27 = (3 << GPIO_PORT_SHIFT | 27),
+    PTD28 = (3 << GPIO_PORT_SHIFT | 28),
+    PTD29 = (3 << GPIO_PORT_SHIFT | 29),
+    PTD30 = (3 << GPIO_PORT_SHIFT | 30),
+    PTD31 = (3 << GPIO_PORT_SHIFT | 31),
+    PTE0  = (4 << GPIO_PORT_SHIFT | 0 ),
+    PTE1  = (4 << GPIO_PORT_SHIFT | 1 ),
+    PTE2  = (4 << GPIO_PORT_SHIFT | 2 ),
+    PTE3  = (4 << GPIO_PORT_SHIFT | 3 ),
+    PTE4  = (4 << GPIO_PORT_SHIFT | 4 ),
+    PTE5  = (4 << GPIO_PORT_SHIFT | 5 ),
+    PTE6  = (4 << GPIO_PORT_SHIFT | 6 ),
+    PTE7  = (4 << GPIO_PORT_SHIFT | 7 ),
+    PTE8  = (4 << GPIO_PORT_SHIFT | 8 ),
+    PTE9  = (4 << GPIO_PORT_SHIFT | 9 ),
+    PTE10 = (4 << GPIO_PORT_SHIFT | 10),
+    PTE11 = (4 << GPIO_PORT_SHIFT | 11),
+    PTE12 = (4 << GPIO_PORT_SHIFT | 12),
+    PTE13 = (4 << GPIO_PORT_SHIFT | 13),
+    PTE14 = (4 << GPIO_PORT_SHIFT | 14),
+    PTE15 = (4 << GPIO_PORT_SHIFT | 15),
+    PTE16 = (4 << GPIO_PORT_SHIFT | 16),
+    PTE17 = (4 << GPIO_PORT_SHIFT | 17),
+    PTE18 = (4 << GPIO_PORT_SHIFT | 18),
+    PTE19 = (4 << GPIO_PORT_SHIFT | 19),
+    PTE20 = (4 << GPIO_PORT_SHIFT | 20),
+    PTE21 = (4 << GPIO_PORT_SHIFT | 21),
+    PTE22 = (4 << GPIO_PORT_SHIFT | 22),
+    PTE23 = (4 << GPIO_PORT_SHIFT | 23),
+    PTE24 = (4 << GPIO_PORT_SHIFT | 24),
+    PTE25 = (4 << GPIO_PORT_SHIFT | 25),
+    PTE26 = (4 << GPIO_PORT_SHIFT | 26),
+    PTE27 = (4 << GPIO_PORT_SHIFT | 27),
+    PTE28 = (4 << GPIO_PORT_SHIFT | 28),
+    PTE29 = (4 << GPIO_PORT_SHIFT | 29),
+    PTE30 = (4 << GPIO_PORT_SHIFT | 30),
+    PTE31 = (4 << GPIO_PORT_SHIFT | 31),
+
+    LED_RED   = PTA29,
+
+    // mbed original LED naming
+    LED1 = LED_RED,
+
+    //Push buttons
+    SW2 = PTD8,
+
+    // USB Pins
+    WIFI_TX = PTD7,
+    WIFI_RX = PTD6,
+
+    WIFIPD = PTD5,
+
+    DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
+
+    // SPI pins
+    MOSI = PTA16,
+    MISO = PTA17,
+    SCLK = PTA15,
+    SSEL = PTA14,
+    // External interrupt from SPI Slave
+    SPI_EXT_INT = PTA10,
+    NRF_MCU_GP2 = PTA13,
+    // Controling nordic BLE module
+    NRF_NRESET = PTE24,
+    NRF_SWCLK = PTC1,
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    // Wunderbar _does not_ have STDIO UART! Use USB CDC instead
+    USBTX = NC,
+    USBRX = NC
+} PinName;
+
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp   = 2,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/device.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/device.h
@@ -1,0 +1,33 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_ID_LENGTH       24
+
+#include "objects.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+    extern void resetWifi();
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/fsl_clock_config.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/fsl_clock_config.c
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "fsl_common.h"
+#include "fsl_smc.h"
+#include "fsl_clock_config.h"
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+/*! @brief Clock configuration structure. */
+typedef struct _clock_config
+{
+    mcg_config_t mcgConfig;       /*!< MCG configuration.      */
+    sim_clock_config_t simConfig; /*!< SIM configuration.      */
+    osc_config_t oscConfig;       /*!< OSC configuration.      */
+    uint32_t coreClock;           /*!< core clock frequency.   */
+} clock_config_t;
+
+/*******************************************************************************
+ * Variables
+ ******************************************************************************/
+/* System clock frequency. */
+extern uint32_t SystemCoreClock;
+
+/* Configuration for enter VLPR mode. Core clock = 4MHz. */
+const clock_config_t g_defaultClockConfigVlpr = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModeBLPI,            /* Work in BLPI mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /*  MCGIRCLK enable. */
+            .ircs = kMCG_IrcFast,                /* Select IRC4M. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 0U,
+            .drs = kMCG_DrsLow,         /* Low frequency range. */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25%. */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC. */
+
+            .pll0Config =
+                {
+                    .enableMode = 0U, /* Don't eanble PLL. */
+                    .prdiv = 0U,
+                    .vdiv = 0U,
+                },
+        },
+    .simConfig =
+        {
+            .pllFllSel = 3U,        /* PLLFLLSEL select IRC48MCLK. */
+            .er32kSrc = 2U,         /* ERCLK32K selection, use RTC. */
+            .clkdiv1 = 0x00040000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig = {.freq = BOARD_XTAL0_CLK_HZ,
+                  .capLoad = 0,
+                  .workMode = kOSC_ModeOscLowPower,
+                  .oscerConfig =
+                      {
+                          .enableMode = kOSC_ErClkEnable,
+#if (defined(FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER) && FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER)
+                          .erclkDiv = 0U,
+#endif
+                      }},
+    .coreClock = 4000000U, /* Core clock frequency */
+};
+
+/* Configuration for enter RUN mode. Core clock = 120MHz. */
+const clock_config_t g_defaultClockConfigRun = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModePEE,             /* Work in PEE mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcSlow,                /* Select IRC32k.*/
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+            .frdiv = 3U,
+            .drs = kMCG_DrsLow,         /* Low frequency range. */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25%. */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC. */
+
+            .pll0Config =
+                {
+                    .enableMode = 0U, .prdiv = 0x2U, .vdiv = 0x6U,
+                },
+        },
+    .simConfig =
+        {
+            .pllFllSel = 1U,        /* PLLFLLSEL select PLL. */
+            .er32kSrc = 2U,         /* ERCLK32K selection, use RTC. */
+            .clkdiv1 = 0x01240000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig = {.freq = BOARD_XTAL0_CLK_HZ,
+                  .capLoad = 0,
+                  .workMode = kOSC_ModeOscLowPower,
+                  .oscerConfig =
+                      {
+                          .enableMode = kOSC_ErClkEnable,
+#if (defined(FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER) && FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER)
+                          .erclkDiv = 0U,
+#endif
+                      }},
+    .coreClock = 120000000U, /* Core clock frequency */
+};
+
+/* Configuration for HSRUN mode. Core clock = 120MHz. */
+const clock_config_t g_defaultClockConfigHsrun = {
+    .mcgConfig =
+        {
+            .mcgMode = kMCG_ModePEE,             /* Work in PEE mode. */
+            .irclkEnableMode = kMCG_IrclkEnable, /* MCGIRCLK enable. */
+            .ircs = kMCG_IrcSlow,                /* Select IRC32k. */
+            .fcrdiv = 0U,                        /* FCRDIV is 0. */
+
+            .frdiv = 3U,
+            .drs = kMCG_DrsLow,         /* Low frequency range. */
+            .dmx32 = kMCG_Dmx32Default, /* DCO has a default range of 25%. */
+            .oscsel = kMCG_OscselOsc,   /* Select OSC. */
+
+            .pll0Config =
+                {
+                    .enableMode = 0U, .prdiv = 0x2U, .vdiv = 0x6U,
+                },
+        },
+    .simConfig =
+        {
+            .pllFllSel = 1U,        /* PLLFLLSEL select PLL. */
+            .er32kSrc = 2U,         /* ERCLK32K selection, use RTC. */
+            .clkdiv1 = 0x01240000U, /* SIM_CLKDIV1. */
+        },
+    .oscConfig = {.freq = BOARD_XTAL0_CLK_HZ,
+                  .capLoad = 0,
+                  .workMode = kOSC_ModeOscLowPower,
+                  .oscerConfig =
+                      {
+                          .enableMode = kOSC_ErClkEnable,
+#if (defined(FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER) && FSL_FEATURE_OSC_HAS_EXT_REF_CLOCK_DIVIDER)
+                          .erclkDiv = 0U,
+#endif
+                      }},
+    .coreClock = 120000000U, /* Core clock frequency */
+};
+
+/*******************************************************************************
+ * Code
+ ******************************************************************************/
+/*
+ * How to setup clock using clock driver functions:
+ *
+ * 1. CLOCK_SetSimSafeDivs, to make sure core clock, bus clock, flexbus clock
+ *    and flash clock are in allowed range during clock mode switch.
+ *
+ * 2. Call CLOCK_Osc0Init to setup OSC clock, if it is used in target mode.
+ *
+ * 3. Set MCG configuration, MCG includes three parts: FLL clock, PLL clock and
+ *    internal reference clock(MCGIRCLK). Follow the steps to setup:
+ *
+ *    1). Call CLOCK_BootToXxxMode to set MCG to target mode.
+ *
+ *    2). If target mode is FBI/BLPI/PBI mode, the MCGIRCLK has been configured
+ *        correctly. For other modes, need to call CLOCK_SetInternalRefClkConfig
+ *        explicitly to setup MCGIRCLK.
+ *
+ *    3). Don't need to configure FLL explicitly, because if target mode is FLL
+ *        mode, then FLL has been configured by the function CLOCK_BootToXxxMode,
+ *        if the target mode is not FLL mode, the FLL is disabled.
+ *
+ *    4). If target mode is PEE/PBE/PEI/PBI mode, then the related PLL has been
+ *        setup by CLOCK_BootToXxxMode. In FBE/FBI/FEE/FBE mode, the PLL could
+ *        be enabled independently, call CLOCK_EnablePll0 explicitly in this case.
+ *
+ * 4. Call CLOCK_SetSimConfig to set the clock configuration in SIM.
+ */
+
+void CLOCK_CONFIG_SetFllExtRefDiv(uint8_t frdiv)
+{
+    MCG->C1 = ((MCG->C1 & ~MCG_C1_FRDIV_MASK) | MCG_C1_FRDIV(frdiv));
+}
+
+void BOARD_BootClockVLPR(void)
+{
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_BootToBlpiMode(g_defaultClockConfigVlpr.mcgConfig.fcrdiv, g_defaultClockConfigVlpr.mcgConfig.ircs,
+                         g_defaultClockConfigVlpr.mcgConfig.irclkEnableMode);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigVlpr.simConfig);
+
+    SystemCoreClock = g_defaultClockConfigVlpr.coreClock;
+
+    SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
+    SMC_SetPowerModeVlpr(SMC, true);
+    while (SMC_GetPowerModeState(SMC) != kSMC_PowerStateVlpr)
+    {
+    }
+}
+
+void BOARD_BootClockRUN(void)
+{
+    CLOCK_SetSimSafeDivs();
+
+    CLOCK_InitOsc0(&g_defaultClockConfigRun.oscConfig);
+    CLOCK_SetXtal0Freq(BOARD_XTAL0_CLK_HZ);
+
+    CLOCK_SetInternalRefClkConfig(g_defaultClockConfigRun.mcgConfig.irclkEnableMode,
+                                  g_defaultClockConfigRun.mcgConfig.ircs,
+                                  g_defaultClockConfigRun.mcgConfig.fcrdiv);
+    CLOCK_CONFIG_SetFllExtRefDiv(g_defaultClockConfigRun.mcgConfig.frdiv);
+
+    CLOCK_BootToPeeMode(g_defaultClockConfigRun.mcgConfig.oscsel,
+                        kMCG_PllClkSelPll0,
+                        &g_defaultClockConfigRun.mcgConfig.pll0Config);
+
+    CLOCK_SetSimConfig(&g_defaultClockConfigRun.simConfig);
+    SystemCoreClock = g_defaultClockConfigRun.coreClock;
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/fsl_clock_config.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/fsl_clock_config.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#ifndef _CLOCK_CONFIG_H_
+#define _CLOCK_CONFIG_H_
+
+/*******************************************************************************
+ * Definitions
+ ******************************************************************************/
+#define BOARD_XTAL0_CLK_HZ 12000000UL
+#define BOARD_XTAL32K_CLK_HZ 32768U
+
+/*******************************************************************************
+ * API
+ ******************************************************************************/
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus*/
+
+void BOARD_BootClockVLPR(void);
+void BOARD_BootClockRUN(void);
+
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus*/
+
+#endif /* _CLOCK_CONFIG_H_ */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_WUNDERBAR/mbed_overrides.c
@@ -1,0 +1,52 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+#include "pinmap.h"
+#include "fsl_clock_config.h"
+
+// called before main - implement here if board needs it otherwise, let
+//  the application override this if necessary
+void mbed_sdk_init()
+{
+    BOARD_BootClockRUN();
+}
+
+// Enable the RTC oscillator if available on the board
+void rtc_setup_oscillator(RTC_Type *base)
+{
+    /* Enable the RTC oscillator */
+    RTC->CR |= RTC_CR_OSCE_MASK;
+}
+
+// Change the NMI pin to an input. This allows NMI pin to
+//  be used as a low power mode wakeup.  The application will
+//  need to change the pin back to NMI_b or wakeup only occurs once!
+void NMI_Handler(void)
+{
+    gpio_t gpio;
+    gpio_init_in(&gpio, PTA4);
+}
+
+void getCpuId(uint32_t* part0,
+              uint32_t* part1,
+              uint32_t* part2,
+              uint32_t* part3)
+{
+    *part0 = SIM->UIDH;
+    *part1 = SIM->UIDMH;
+    *part2 = SIM->UIDML;
+    *part3 = SIM->UIDL;
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_GCC_ARM/MK24FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_GCC_ARM/MK24FN1M0xxx12.ld
@@ -56,6 +56,13 @@ __ram_vector_table__ = 1;
 __stack_size__ = 0x8000;
 __heap_size__ = 0x10000;
 
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
 HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
 M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
@@ -63,9 +70,9 @@ M_VECTOR_RAM_SIZE = DEFINED(__ram_vector_table__) ? 0x0400 : 0x0;
 /* Specify the memory areas */
 MEMORY
 {
-  m_interrupts          (RX)  : ORIGIN = 0x00000000, LENGTH = 0x00000400
-  m_flash_config        (RX)  : ORIGIN = 0x00000400, LENGTH = 0x00000010
-  m_text                (RX)  : ORIGIN = 0x00000410, LENGTH = 0x000FFBF0
+  m_interrupts          (RX)  : ORIGIN = MBED_APP_START, LENGTH = 0x400
+  m_flash_config        (RX)  : ORIGIN = MBED_APP_START + 0x400, LENGTH = 0x10
+  m_text                (RX)  : ORIGIN = MBED_APP_START + 0x410, LENGTH = MBED_APP_SIZE - 0x410
   m_data                (RW)  : ORIGIN = 0x1FFF0000, LENGTH = 0x00010000
   m_data_2              (RW)  : ORIGIN = 0x20000000, LENGTH = 0x00030000
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/system_MK24F12.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/system_MK24F12.h
@@ -112,8 +112,11 @@ extern "C" {
 #endif
 
 /* Define clock source values */
-
+#ifdef TARGET_WUNDERBAR
+#define CPU_XTAL_CLK_HZ                12000000u           /* Value of the external crystal or oscillator clock frequency in Hz */
+#else
 #define CPU_XTAL_CLK_HZ                50000000u           /* Value of the external crystal or oscillator clock frequency in Hz */
+#endif
 #define CPU_XTAL32k_CLK_HZ             32768u              /* Value of the external 32k crystal or oscillator clock frequency in Hz */
 #define CPU_INT_SLOW_CLK_HZ            32768u              /* Value of the slow internal oscillator clock frequency in Hz  */
 #define CPU_INT_FAST_CLK_HZ            4000000u            /* Value of the fast internal oscillator clock frequency in Hz  */

--- a/targets/TARGET_Freescale/mbed_rtx.h
+++ b/targets/TARGET_Freescale/mbed_rtx.h
@@ -113,6 +113,12 @@
 #define INITIAL_SP              (0x20030000UL)
 #endif
 
+#elif defined(TARGET_WUNDERBAR)
+
+#ifndef INITIAL_SP
+#define INITIAL_SP              (0x20030000UL)
+#endif
+
 #endif
 
 #endif  // MBED_MBED_RTX_H

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3520,5 +3520,15 @@
         "device_name": "TMPM066FWUG",
         "detect_code": ["7011"],
         "release_versions": ["5"]
+    },
+    "WUNDERBAR": {
+        "inherits": ["MCU_K24F1M"],
+        "release_versions": ["5"],
+        "OUTPUT_EXT": "hex"
+    },
+    "WUNDERBAR_APP_BIN": {
+        "inherits": ["WUNDERBAR"],
+        "OUTPUT_EXT": "bin",
+        "bootloader_supported": true
     }
 }


### PR DESCRIPTION
## Description

[Wunderbar IoT kit](https://github.com/relayr/wunderbar-hardware) target based on TARGET_MCU_K24F1M

Change introduces two build targets:
- WUNDERBAR_APP_BIN for use with Wundrbar default DFU bootloader
- WUNDERBAR for standalone (no bootloader) use 

## Status

**READY**

## Todos

- [ ] Tests
