### PR TITLE
Fix fatal parameter error when deleting/terminating Thread object

### DIFF
--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -129,7 +129,11 @@ osStatus Thread::terminate() {
     _tid = (osThreadId_t)NULL;
     if (!_finished) {
         _finished = true;
-        ret = osThreadTerminate(local_id);
+        // if local_id == 0 Thread was not started in first place
+        // and does not have to be terminated
+        if(local_id != 0) {
+            ret = osThreadTerminate(local_id);
+        }
     }
     _mutex.unlock();
     return ret;

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -131,7 +131,7 @@ osStatus Thread::terminate() {
         _finished = true;
         // if local_id == 0 Thread was not started in first place
         // and does not have to be terminated
-        if(local_id != 0) {
+        if (local_id != 0) {
             ret = osThreadTerminate(local_id);
         }
     }


### PR DESCRIPTION
## Description

Call to osThreadTerminate is guarded by local_id != 0 check, to avoid parameter error fault when deleting or terminating Thread object that was not started.

## Status

**READY**

## Migrations

NO

## Todos

- [ ] Tests

## Steps to test or reproduce

On any target (tested with FRDM-K64F):
```
#include "mbed.h"

RawSerial output(USBTX, USBRX);

int main(int argc, char **argv)
{
    output.baud(115200);

    output.printf("\r\nStarting mbed\r\n");

    {
        rtos::Thread dummyToTriggerError(osPriorityNormal, 0x500);
    }

    while(1);
}
```

output:
```
Starting mbed
Thread 0x0 error -4: Parameter error
```

