### PR TITLE
critical: fix set exclusive access if not yet defined

### DIFF
--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -24,6 +24,21 @@
 #include "platform/mbed_critical.h"
 #include "platform/mbed_toolchain.h"
 
+// if __EXCLUSIVE_ACCESS rtx macro not defined, we need to get this via own-set architecture macros
+#ifndef __EXCLUSIVE_ACCESS
+#ifndef MBED_EXCLUSIVE_ACCESS
+#if ((__ARM_ARCH_7M__      == 1U) || \
+    (__ARM_ARCH_7EM__     == 1U) || \
+    (__ARM_ARCH_8M_BASE__ == 1U) || \
+    (__ARM_ARCH_8M_MAIN__ == 1U)) || \
+    (__ARM_ARCH_7A__ == 1U)
+#define MBED_EXCLUSIVE_ACCESS      1U
+#else
+#define MBED_EXCLUSIVE_ACCESS      0U
+#endif
+#endif
+#endif
+
 static volatile uint32_t critical_section_reentrancy_counter = 0;
 
 bool core_util_are_interrupts_enabled(void)
@@ -90,7 +105,7 @@ void core_util_critical_section_exit(void)
     }
 }
 
-#if __EXCLUSIVE_ACCESS
+#if MBED_EXCLUSIVE_ACCESS
 
 /* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
 #if defined (__CC_ARM) 

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -25,17 +25,21 @@
 #include "platform/mbed_toolchain.h"
 
 // if __EXCLUSIVE_ACCESS rtx macro not defined, we need to get this via own-set architecture macros
-#ifndef __EXCLUSIVE_ACCESS
 #ifndef MBED_EXCLUSIVE_ACCESS
+#ifndef __EXCLUSIVE_ACCESS
 #if ((__ARM_ARCH_7M__      == 1U) || \
     (__ARM_ARCH_7EM__     == 1U) || \
     (__ARM_ARCH_8M_BASE__ == 1U) || \
     (__ARM_ARCH_8M_MAIN__ == 1U)) || \
     (__ARM_ARCH_7A__ == 1U)
 #define MBED_EXCLUSIVE_ACCESS      1U
-#else
+#elif (__ARM_ARCH_6M__ == 1U)
 #define MBED_EXCLUSIVE_ACCESS      0U
+#else
+#error "Unknown architecture for exclusive access"
 #endif
+#else 
+#define MBED_EXCLUSIVE_ACCESS __EXCLUSIVE_ACCESS
 #endif
 #endif
 


### PR DESCRIPTION
Fixes #5555 bug.
In case there is not yet defined __EXCLUSIVE_ACCESS, neither MBED_EXCLUSIVE_ACCESS that
we are introducing, use architecture macros to find out if MBED_EXCLUSIVE_ACCESS can be
enabled.

First I thought that these could be added to `CORE_LABELS` that we have in tools/targets/init file. That might be better placement, but @theotherjimmy did not like the proposal. If we add a new core, this would need to be defined. In this case it might be overlooked.