### PR TITLE
Remove unnecessary inclusion of an internal RTX header

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -24,7 +24,6 @@
 #include "platform/mbed_sleep.h"
 #include "TimerEvent.h"
 #include "lp_ticker_api.h"
-#include "rtx_core_cm.h"
 #include "mbed_critical.h"
 #include "mbed_assert.h"
 #include <new>


### PR DESCRIPTION

## Description

Remove unnecessary inclusion of `rtx_core_cm.h` from `mbed_rtx_idle.cpp`.

## Status

**READY**
