### PR TITLE
Eliminate warnings in MBED_ASSERT usage in Release variant

### DIFF
--- a/platform/mbed_assert.h
+++ b/platform/mbed_assert.h
@@ -48,6 +48,7 @@ void mbed_assert_internal(const char *expr, const char *file, int line);
  *
  *  @note
  *  Use of MBED_ASSERT is limited to Debug and Develop builds.
+ *  The expression will be also evaluated on Release, but the condition will have no effect
  *
  *  @code
  *
@@ -57,15 +58,22 @@ void mbed_assert_internal(const char *expr, const char *file, int line);
  *  @endcode
  */
 #ifdef NDEBUG
-#define MBED_ASSERT(expr) ((void)0)
+
+#define MBED_ASSERT(expr)                                \
+do {                                                     \
+    if (!(expr)) {                                       \
+    }                                                    \
+} while (0)
 
 #else
+
 #define MBED_ASSERT(expr)                                \
 do {                                                     \
     if (!(expr)) {                                       \
         mbed_assert_internal(#expr, __FILE__, __LINE__); \
     }                                                    \
 } while (0)
+
 #endif
 
 


### PR DESCRIPTION
* On current implementation, the below code will issue a warning on Release variant for unused variable:
_int status = foo();_
_MBED_ASSERT(status == OK);_

* Also, the below code cannot be used on Release since foo() will not be invoked:
_MBED_ASSERT(foo() == OK);_
