### PR TITLE
STM32 - CAN - Fix RTR position bit in TX mailbox register

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -277,9 +277,9 @@ int can_write(can_t *obj, CAN_Message msg, int cc)
 
     can->sTxMailBox[transmitmailbox].TIR &= CAN_TI0R_TXRQ;
     if (!(msg.format)) {
-      can->sTxMailBox[transmitmailbox].TIR |= ((msg.id << 21) | msg.type);
+      can->sTxMailBox[transmitmailbox].TIR |= ((msg.id << 21) | (msg.type << 1));
     } else {
-      can->sTxMailBox[transmitmailbox].TIR |= ((msg.id << 3) | CAN_ID_EXT | msg.type);
+      can->sTxMailBox[transmitmailbox].TIR |= ((msg.id << 3) | CAN_ID_EXT | (msg.type << 1));
     }
 
     /* Set up the DLC */


### PR DESCRIPTION
- Bug fix
- Target STM32, Peripheral CAN

## Description

The RTR bit that defines the type of CAN message (Data or Remote) was written as bit0 in CAN_TIxR (the CAN TX mailbox).
According to [Reference Manual](http://www.st.com/content/ccc/resource/technical/document/reference_manual/02/35/09/0c/4f/f7/40/03/DM00083560.pdf/files/DM00083560.pdf/jcr:content/translations/en.DM00083560.pdf) p. 1606 of STM32L476RG, also verified for STM32F103, STM32F302 (seems to be the same for all STM32 offering CAN: 

Bit 0 **TXRQ**: Transmit mailbox request
Set by software to request the transmission for the corresponding mailbox.
Cleared by hardware when the mailbox becomes emp

Bit 1 **RTR**: Remote transmission request
0: Data frame
1: Remote frame

The RTR bit has been shifted by 1 to the left in order to put it in the right place.

## Consequences

Bad behavior observed : Only Data message were sent, even if CAN::write(CANMessage msg) was called with a Remote-type message as argument.

After fix : Remote messages are correctly sent.
