### PR TITLE
Realtek RTL8195AM A3 fix

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
@@ -50,6 +50,7 @@ typedef enum {
     PIN_OUTPUT
 } PinDirection;
 
+
 typedef enum {
     PA_0  = (PORT_A<<4|0),
     PA_1  = (PORT_A<<4|1),
@@ -158,7 +159,7 @@ typedef enum {
     PK_5  = (PORT_K<<4|5),
     PK_6  = (PORT_K<<4|6),
     /* unavailable pins */
-//    PK_7  = (PORT_K<<4|7),
+    //    PK_7  = (PORT_K<<4|7),
 
     AD_1  = (PORT_V<<4|1),
     AD_2  = (PORT_V<<4|2),
@@ -166,34 +167,9 @@ typedef enum {
 
     DA_0  = (PORT_U<<4|0),
     DA_1  = (PORT_U<<4|1),
-    
-    // Arduino connector namings
 
-    A0          = AD_2,//A0 and A1 are connected
-    A1          = AD_2,
-    A2          = AD_3,
-    
-    D0          = PA_6,
-    D1          = PA_7,
-    D2          = PA_5,
-    D3          = PD_4,
-    D4          = PD_5,
-    D5          = PA_4,
-    D6          = PA_3,
-    D7          = PA_2,
-    D8          = PB_4,
-    D9          = PB_5,
-    D10         = PC_0,
-    D11         = PC_2,
-    D12         = PC_3,
-    D13         = PC_1,
-    D14         = PB_3,
-    D15         = PB_2,
-    
-    D16         = PA_1,
-    D17         = PA_0,
-    D18         = PE_5,
-
+    // Not connected
+    NC = (uint32_t)0xFFFFFFFF,
 
     // Generic signals namings
     /* LED1~4 are defined as alias of GPIO pins, they are not the LEDs on board*/
@@ -213,8 +189,35 @@ typedef enum {
     SPI_CS      = PC_0,
     PWM_OUT     = PD_4,
 
-    // Not connected
-    NC = (uint32_t)0xFFFFFFFF
+    // Arduino connector namings
+
+    A0          = AD_2,//A0 and A1 are connected
+    A1          = AD_2,
+    A2          = AD_3,
+    A3          = NC,
+    A4          = NC,
+    A5          = NC,
+
+    D0          = PA_6,
+    D1          = PA_7,
+    D2          = PA_5,
+    D3          = PD_4,
+    D4          = PD_5,
+    D5          = PA_4,
+    D6          = PA_3,
+    D7          = PA_2,
+    D8          = PB_4,
+    D9          = PB_5,
+    D10         = PC_0,
+    D11         = PC_2,
+    D12         = PC_3,
+    D13         = PC_1,
+    D14         = PB_3,
+    D15         = PB_2,
+    D16         = PA_1,
+    D17         = PA_0,
+    D18         = PE_5
+
 } PinName;
 
 typedef enum {


### PR DESCRIPTION
## Description

Based on the Mbed OS website the A3 is connected to "DAC", however there
is no define for DAC. In order to get the Realtek RTL8195AM to even compile
with mbed-os-example-client now, we must have the A3 defined - it is one of
the standard Arduino header pins. Therefore, setting it as NC.

Realtek will hopefully push a proper fix sooner or later, if there is a
more meaningful define for the A3 pin. They do state however that the
A0-A3 pins are not GPIO capable anyway.

Ref: https://os.mbed.com/platforms/Realtek-RTL8195AM/

Notes:
- Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
- This is just a template, so feel free to use/remove the unnecessary things


## Status

**READY**

With the caveat that Realtek might want to map A3 into something else than NC. But than can / should come as a separate PR in order to unblock us now.

## Migrations

NO

## Related PRs

## Todos

- [ ] Tests
- [ ] Documentation
