### PR TITLE
Support bootloader for DISCO_F429ZI

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1528,7 +1528,8 @@
         "macros_add": ["RTC_LSI=1", "USBHOST_OTHER"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F429ZI"
+        "device_name": "STM32F429ZI",
+        "bootloader_supported": true
     },
     "DISCO_F469NI": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
## Description

Support bootloader for DISCO_F429ZI
It's tested using following environment.
- ARMmbed/mbed-cloud-client-example-internal with esp8266.
- mbed-cloud-sdk-javascript-quickstart

## Related PRs
https://github.com/ARMmbed/mbed-cloud-client-example-internal/pull/209
https://github.com/ARMmbed/mbed-bootloader-internal/pull/72
https://github.com/ARMmbed/sd-driver/pull/73

