### PR TITLE
nordic: fix tx/rx pins macro - casting the values

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/PeripheralNames.h
@@ -22,8 +22,8 @@
 extern "C" {
 #endif
 
-#define STDIO_UART_TX     TX_PIN_NUMBER
-#define STDIO_UART_RX     RX_PIN_NUMBER
+#define STDIO_UART_TX     (PinName)TX_PIN_NUMBER
+#define STDIO_UART_RX     (PinName)RX_PIN_NUMBER
 #define STDIO_UART        UART_0
 
 typedef enum {

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/PeripheralNames.h
@@ -45,8 +45,8 @@
 extern "C" {
 #endif
 
-#define STDIO_UART_TX     TX_PIN_NUMBER
-#define STDIO_UART_RX     RX_PIN_NUMBER
+#define STDIO_UART_TX     (PinName)TX_PIN_NUMBER
+#define STDIO_UART_RX     (PinName)RX_PIN_NUMBER
 #define STDIO_UART        UART_0
 
 typedef enum {

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/PeripheralNames.h
@@ -45,8 +45,8 @@
 extern "C" {
 #endif
 
-#define STDIO_UART_TX     TX_PIN_NUMBER
-#define STDIO_UART_RX     RX_PIN_NUMBER
+#define STDIO_UART_TX     (PinName)TX_PIN_NUMBER
+#define STDIO_UART_RX     (PinName)RX_PIN_NUMBER
 #define STDIO_UART        UART_0
 
 typedef enum {

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/PeripheralNames.h
@@ -45,8 +45,8 @@
 extern "C" {
 #endif
 
-#define STDIO_UART_TX     TX_PIN_NUMBER
-#define STDIO_UART_RX     RX_PIN_NUMBER
+#define STDIO_UART_TX     (PinName)TX_PIN_NUMBER
+#define STDIO_UART_RX     (PinName)RX_PIN_NUMBER
 #define STDIO_UART        UART_0
 
 typedef enum


### PR DESCRIPTION
RX/TX_PIN_NUMBER are defined as integers in the nordic header files. In the PinNames, they are
redefined. Use casting to make types correct.

This is the error I have experienced on one feature branch, when we added some definition in the objects.h from nordic (thus includes were changed):

```
[Error] mbed_retarget.cpp@123,58: invalid conversion from 'int' to 'PinName' [-fpermissive]
[Error] mbed_retarget.cpp@123,58: invalid conversion from 'int' to 'PinName' [-fpermissive]
```

Why TX_PIN_NUMBER is redefined in the PinNames? Should PinName::TX_PIN_NUMBER  be removed, to not cause this confusion? macro vs enum.

@ARMmbed/team-nordic please review, advise how to resolve the error I have experienced. Open to suggestions