### PR TITLE
ADI: Add ARMC6 compatible code

### DIFF
--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/device/startup_ADuCM3029.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/device/startup_ADuCM3029.c
@@ -45,7 +45,7 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *****************************************************************************/
 #include <stdint.h>
-#ifdef __CC_ARM
+#ifdef __ARMCC_VERSION
 #include <rt_misc.h>
 #endif
 #include <cmsis.h>
@@ -61,8 +61,8 @@ extern void SramInit(void);
 /*----------------------------------------------------------------------------
   Checksum options
  *----------------------------------------------------------------------------*/
- #if defined (__CC_ARM)
-__attribute__ ((at(0x000001A0u)))
+#if defined (__ARMCC_VERSION)
+__attribute__((section(".ARM.__at_0x000001A0")))
 #elif defined( __ICCARM__)
 __root
 #endif /* __ICCARM__ */
@@ -151,7 +151,7 @@ const pFunc SECTION_PLACE(IVT_NAME[104],VECTOR_SECTION) =
 /*----------------------------------------------------------------------------
 * Initialize .bss and .data for GNU
 *----------------------------------------------------------------------------*/
-#if defined( __GNUC__) && !defined (__CC_ARM)
+#if defined( __GNUC__) && !defined (__ARMCC_VERSION)
 void zero_bss(void)
 {
     uint32_t *pSrc, *pDest;
@@ -248,7 +248,7 @@ void Reset_Handler(void)
        may reside in DSRAM bank B. */
     SramInit();
 
-#if defined(__GNUC__) && !defined (__CC_ARM)
+#if defined(__GNUC__) && !defined (__ARMCC_VERSION)
     /* Clear the bss section for GCC build only */
     zero_bss();
 #endif
@@ -263,7 +263,7 @@ void Reset_Handler(void)
 /*----------------------------------------------------------------------------
   Default Handler for Exceptions / Interrupts
  *----------------------------------------------------------------------------*/
-#if defined(__CC_ARM) || defined (__GNUC__)
+#if defined(__ARMCC_VERSION) || defined (__GNUC__)
 void Default_Handler(void)
 {
     while(1);

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/device/startup_ADuCM3029.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/device/startup_ADuCM3029.h
@@ -63,16 +63,14 @@ RESET_EXCPT_HNDLR
 
 #define VECTOR_SECTION                 ".vectors"
 
-#ifdef __CC_ARM
-extern unsigned Image$$ADUCM_HEAP$$Base[];
-extern unsigned Image$$ADUCM_HEAP$$ZI$$Limit[];
+#ifdef __ARMCC_VERSION
 void Default_Handler(void);
-#define SECTION_NAME(sectionname)      __attribute__ ((section(sectionname)))
-#define SECTION_PLACE(def,sectionname) def __attribute__ ((section(sectionname)))
+#define SECTION_NAME(sectionname)      __attribute__((section(sectionname)))
+#define SECTION_PLACE(def,sectionname) def __attribute__((section(sectionname)))
 #define IVT_NAME                       __Vectors
 #define RESET_EXCPT_HNDLR              __main
 #define COMPILER_NAME                  "ARMCC"
-#define WEAK_FUNCTION(x)               void x (void) __attribute__ ((weak, alias("Default_Handler")));
+#define WEAK_FUNCTION(x)               void x (void) __attribute__((weak, alias("Default_Handler")));
 
 #elif defined(__ICCARM__)
 #pragma diag_suppress=Pm093,Pm140

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_api.c
@@ -46,9 +46,12 @@
 
 #define MUX_FUNC_0 0x0
 #define NUM_GPIO_PORTS 4
-
-extern uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
-extern uint8_t gpio_initialized;
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+extern uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
+extern uint8_t  gpio_initialized;
 
 static uint16_t gpio_oen[NUM_GPIO_PORTS] = {0};
 static uint16_t gpio_output_val[NUM_GPIO_PORTS] = {0};

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_dev_mem.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_dev_mem.c
@@ -39,9 +39,12 @@
  ******************************************************************************/
 
 #include <drivers/gpio/adi_gpio.h>
-
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
 // ADI GPIO device driver state memory. Only one state memory is required globally.
-uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
+uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
 
 // Flag to indicate whether the GPIO driver has been initialized
-uint8_t gpio_initialized = 0;
+uint8_t  gpio_initialized = 0;

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_irq_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/gpio_irq_api.c
@@ -53,9 +53,12 @@ typedef struct {
     gpio_irq_event event;
     uint8_t int_enable;
 } gpio_chan_info_t;
-
-extern uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
-extern uint8_t gpio_initialized;
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+extern uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
+extern uint8_t  gpio_initialized;
 static gpio_chan_info_t channel_ids[MAX_GPIO_PORTS][MAX_GPIO_LINES];
 static gpio_irq_handler irq_handler = NULL;
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/i2c_api.c
@@ -57,7 +57,11 @@
 int adi_i2c_memtype = 0;
 #endif
 #else
-static uint8_t          i2c_Mem[ADI_I2C_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_I2C_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+static uint32_t         i2c_Mem[(ADI_I2C_MEMORY_SIZE + 3)/4];
 static ADI_I2C_HANDLE   i2c_Handle;
 #if defined(ADI_DEBUG)
 #warning "BUILD_I2C_MI_DYNAMIC is NOT defined.  Memory allocation for I2C will be static"
@@ -72,7 +76,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     uint32_t        i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
     uint32_t        i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
     ADI_I2C_HANDLE  *pI2C_Handle;
-    uint8_t         *I2C_Mem;
+    uint32_t        *I2C_Mem;
     ADI_I2C_RESULT  I2C_Return = ADI_I2C_SUCCESS;
     uint32_t        I2C_DevNum = I2C_0;     /* ADuCM3029 only has 1 I2C port */
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/objects.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/objects.h
@@ -79,7 +79,11 @@ struct i2c_s {
     ADI_I2C_HANDLE  *pI2C_Handle;
 #if defined(BUILD_I2C_MI_DYNAMIC)
     ADI_I2C_HANDLE  I2C_Handle;
-    uint8_t         I2C_Mem[ADI_I2C_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_I2C_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+    uint32_t        I2C_Mem[(ADI_I2C_MEMORY_SIZE + 3)/4];
 #endif
 };
 
@@ -90,7 +94,11 @@ struct spi_s {
     ADI_SPI_HANDLE  *pSPI_Handle;
 #if defined(BUILD_SPI_MI_DYNAMIC)
     ADI_SPI_HANDLE  SPI_Handle;
-    uint8_t         SPI_Mem[ADI_SPI_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_SPI_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+    uint32_t        SPI_Mem[(ADI_SPI_MEMORY_SIZE + 3)/4];
 #endif
 };
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/rtc_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/rtc_api.c
@@ -46,7 +46,11 @@
 #include "adi_pwr.h"
 
 #define RTC_DEVICE_NUM    0
-static uint8_t aRtcDevMem0[ADI_RTC_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_RTC_DEVICE Instance memory containing memory pointer should guarantee
+   4 byte alignmnet.
+ *******************************************************************************/
+static uint32_t       aRtcDevMem0[(ADI_RTC_MEMORY_SIZE + 3)/4];
 static ADI_RTC_HANDLE hDevice0 = NULL;
 
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/spi_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/spi_api.c
@@ -59,12 +59,16 @@
 int adi_spi_memtype = 0;
 #endif
 #else
+/*******************************************************************************
+   ADI_SPI_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
 ADI_SPI_HANDLE      spi_Handle0;
-uint8_t             spi_Mem0[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3)/4];
 ADI_SPI_HANDLE      spi_Handle1;
-uint8_t             spi_Mem1[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3)/4];
 ADI_SPI_HANDLE      spi_Handle2;
-uint8_t             spi_Mem2[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3)/4];
 #if defined(ADI_DEBUG)
 #warning "BUILD_SPI_MI_DYNAMIC is NOT defined.  Memory allocation for SPI will be static"
 int adi_spi_memtype = 1;
@@ -92,7 +96,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
     ADI_SPI_HANDLE      *pSPI_Handle;
-    uint8_t             *SPI_Mem;
+    uint32_t            *SPI_Mem;
     ADI_SPI_RESULT      SPI_Return = ADI_SPI_SUCCESS;
     uint32_t            nDeviceNum = 0;
     ADI_SPI_CHIP_SELECT spi_cs = ADI_SPI_CS_NONE;

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
@@ -55,7 +55,7 @@
 #define TRNG_PRESCALER  2
 
 /* RNG Device memory */
-static uint8_t RngDevMem[ADI_RNG_MEMORY_SIZE];
+static uint32_t RngDevMem[(ADI_RNG_MEMORY_SIZE + 3)/4];
 
 void trng_init(trng_t *obj)
 {

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/trng_api.c
@@ -54,7 +54,14 @@
 #define TRNG_CNT_VAL    4095
 #define TRNG_PRESCALER  2
 
-/* RNG Device memory */
+/*******************************************************************************
+   RNG Device memory is the instance of ADI_RNG_DEV_DATA_TYPE that contains
+   pointers and requires 4 byte alignment. The use of uint8_t may cause memory
+   access fault for some compilers which are not configured to handle unaligned
+   accesses to SRAM. The size in uint8_t for RngDevMem is ADI_RNG_MEMORY_SIZE.
+   The size in uint32_t for RngDevMem is recalculated to be
+   (ADI_RNG_MEMORY_SIZE + 3)/4.
+ *******************************************************************************/
 static uint32_t RngDevMem[(ADI_RNG_MEMORY_SIZE + 3)/4];
 
 void trng_init(trng_t *obj)

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/ADuCM3029_typedefs.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/ADuCM3029_typedefs.h
@@ -62,10 +62,6 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #pragma diag_suppress=Pm008,Pm093
 #endif /* __ICCARM__ */
 
-#if defined (__CC_ARM)
-#pragma anon_unions
-#endif /* __CC_ARM */
-
 #define __ADI_NO_DECL_STRUCT_ADI_CRYPT_CFG_t__
 
 #include <sys/ADuCM302x_typedefs.h>

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/crypto/adi_crypto.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/crypto/adi_crypto.c
@@ -123,7 +123,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define __ADI_BYTE_SWAP(X)                        __REV(X)
 #elif defined (__GNUC__)
 #define __ADI_BYTE_SWAP(X)                        __builtin_bswap32(X)
-#elif defined (__CC_ARM)
+#elif defined (__ARMCC_VERSION)
 #define __ADI_BYTE_SWAP(X)                        __rev(X)
 #else
 #error "This toolchain is not supported"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/dma/adi_dma.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/dma/adi_dma.c
@@ -272,7 +272,7 @@ ADI_DMA_RESULT adi_dma_RegisterCallback (
 /* ARM Cortex-M3/M4, GNU-ARM compiler */
 #define ADI_CLZ(X)     __builtin_clz(X)
 
-#elif defined(__CC_ARM)
+#elif defined(__ARMCC_VERSION)
 
 /* ARM Cortex-M3/M4, Keil compiler */
 #define ADI_CLZ(X)    __clz(X)

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/drivers/general/adi_drivers_general.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/drivers/general/adi_drivers_general.h
@@ -82,10 +82,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   #define ADI_ALIGNED_ATTRIBUTE(num)
   #define ADI_ALIGNED_PRAGMA(num) PRAGMA(data_alignment=num) 
   #define ADI_UNUSED_ATTRIBUTE
-#elif defined (__CC_ARM)
+#elif defined (__ARMCC_VERSION)
   /* Keil uses a decorator which is placed in the same position as pragmas */
   #define ADI_ALIGNED_ATTRIBUTE(num)
-  #define ADI_ALIGNED_PRAGMA(num) __align(##num)
+  #define ADI_ALIGNED_PRAGMA(num) __attribute__((aligned(num)))
   #define ADI_UNUSED_ATTRIBUTE ATTRIBUTE(unused)
 #else
 #error "Toolchain not supported"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/sys/ADuCM302x_device.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/sys/ADuCM302x_device.h
@@ -25,12 +25,6 @@
 /* pickup register bitfield and bit masks */
 #include "ADuCM302x_typedefs.h"
 
-#if defined ( __CC_ARM   )
-#pragma push
-#pragma anon_unions
-#endif
-
-
 #ifndef __IO
 #ifdef __cplusplus
 #define     __I     volatile      /* read-only */
@@ -1208,10 +1202,5 @@ typedef enum
 #if defined (_MISRA_RULES)
 #pragma diag(pop)
 #endif /* _MISRA_RULES */
-
-
-#if defined (__CC_ARM)
-#pragma pop
-#endif 
 
 #endif

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/sys/ADuCM302x_typedefs.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/bsp/sys/ADuCM302x_typedefs.h
@@ -22,12 +22,6 @@
 #include <stdint.h>
 #endif /* _LANGUAGE_C */
 
-#if defined ( __CC_ARM   )
-#pragma push
-#pragma anon_unions
-#endif
-
-
 #if defined (_MISRA_RULES)
 /*
   anonymous unions violate ISO 9899:1990 and therefore MISRA Rule 1.1.
@@ -9555,10 +9549,5 @@ typedef struct _ADI_NVIC_INTCID3_t {
 #if defined (_MISRA_RULES)
 #pragma diag(pop)
 #endif /* _MISRA_RULES */
-
-
-#if defined (__CC_ARM)
-#pragma pop
-#endif 
 
 #endif

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/device/startup_ADuCM4050.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/device/startup_ADuCM4050.c
@@ -44,7 +44,7 @@ NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  *****************************************************************************/
-#ifdef __CC_ARM
+#ifdef __ARMCC_VERSION
 #include <stdint.h>
 #include <rt_misc.h>
 #endif
@@ -55,8 +55,8 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*----------------------------------------------------------------------------
   Checksum options
  *----------------------------------------------------------------------------*/
-#if defined (__CC_ARM)
-__attribute__ ((at(0x000001A0u)))
+#if defined (__ARMCC_VERSION)
+__attribute__((section(".ARM.__at_0x000001A0")))
 #elif defined(__ICCARM__)
 __root
 #endif
@@ -155,7 +155,7 @@ const pFunc SECTION_PLACE(IVT_NAME[104],VECTOR_SECTION) = {
 /*----------------------------------------------------------------------------
 * Initialize .bss and .data for GNU
 *----------------------------------------------------------------------------*/
-#if defined( __GNUC__) && !defined (__CC_ARM)
+#if defined( __GNUC__) && !defined (__ARMCC_VERSION)
 void zero_bss(void)
 {
     uint32_t *pSrc, *pDest;
@@ -251,7 +251,7 @@ void Reset_Handler(void)
     /* Initialize SRAM configuration. */
     SramInit();
 
-#if defined(__GNUC__) && !defined (__CC_ARM)
+#if defined(__GNUC__) && !defined (__ARMCC_VERSION)
     zero_bss();
 #endif
 
@@ -265,7 +265,7 @@ void Reset_Handler(void)
 /*----------------------------------------------------------------------------
   Default Handler for Exceptions / Interrupts
  *----------------------------------------------------------------------------*/
-#if defined(__CC_ARM) || defined (__GNUC__)
+#if defined(__ARMCC_VERSION) || defined (__GNUC__)
 void Default_Handler(void)
 {
     while(1);

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/device/startup_ADuCM4050.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/device/startup_ADuCM4050.h
@@ -63,16 +63,14 @@ RESET_EXCPT_HNDLR
 
 #include <adi_types.h>
 #define VECTOR_SECTION                 ".vectors"
-#ifdef __CC_ARM
-extern unsigned Image$$ADUCM_HEAP$$Base[];
-extern unsigned Image$$ADUCM_HEAP$$ZI$$Limit[];
+#ifdef __ARMCC_VERSION
 void Default_Handler(void);
-#define SECTION_NAME(sectionname)      __attribute__ ((section(sectionname)))
-#define SECTION_PLACE(def,sectionname) def __attribute__ ((section(sectionname)))
+#define SECTION_NAME(sectionname)      __attribute__((section(sectionname)))
+#define SECTION_PLACE(def,sectionname) def __attribute__((section(sectionname)))
 #define IVT_NAME                       __Vectors
 #define RESET_EXCPT_HNDLR              __main
 #define COMPILER_NAME                  "ARMCC"
-#define WEAK_FUNCTION(x)               void x (void) __attribute__ ((weak, alias("Default_Handler")));
+#define WEAK_FUNCTION(x)               void x (void) __attribute__((weak, alias("Default_Handler")));
 #elif defined(__ICCARM__)
 /*
 * IAR MISRA C 2004 error suppressions:

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_api.c
@@ -46,9 +46,12 @@
 
 #define MUX_FUNC_0 0x0
 #define NUM_GPIO_PORTS 4
-
-extern uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
-extern uint8_t gpio_initialized;
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+extern uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
+extern uint8_t  gpio_initialized;
 
 static uint16_t gpio_oen[NUM_GPIO_PORTS] = {0};
 static uint16_t gpio_output_val[NUM_GPIO_PORTS] = {0};

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_dev_mem.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_dev_mem.c
@@ -39,9 +39,12 @@
  ******************************************************************************/
 
 #include <drivers/gpio/adi_gpio.h>
-
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
 // ADI GPIO device driver state memory. Only one state memory is required globally.
-uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
+uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE +3)/4];
 
 // Flag to indicate whether the GPIO driver has been initialized
-uint8_t gpio_initialized = 0;
+uint8_t  gpio_initialized = 0;

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/gpio_irq_api.c
@@ -52,9 +52,12 @@ typedef struct {
     gpio_irq_event event;
     uint8_t int_enable;
 } gpio_chan_info_t;
-
-extern uint8_t gpioMemory[ADI_GPIO_MEMORY_SIZE];
-extern uint8_t gpio_initialized;
+/*******************************************************************************
+   ADI_GPIO_DEV_DATA Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+extern uint32_t gpioMemory[(ADI_GPIO_MEMORY_SIZE + 3)/4];
+extern uint8_t  gpio_initialized;
 static gpio_chan_info_t channel_ids[MAX_GPIO_PORTS][MAX_GPIO_LINES];
 static gpio_irq_handler irq_handler = NULL;
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/i2c_api.c
@@ -57,7 +57,11 @@
 int adi_i2c_memtype = 0;
 #endif
 #else
-static uint8_t          i2c_Mem[ADI_I2C_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_I2C_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+static uint32_t         i2c_Mem[(ADI_I2C_MEMORY_SIZE + 3)/4];
 static ADI_I2C_HANDLE   i2c_Handle;
 #if defined(ADI_DEBUG)
 #warning "BUILD_I2C_MI_DYNAMIC is NOT defined.  Memory allocation for I2C will be static"
@@ -72,7 +76,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     uint32_t        i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
     uint32_t        i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
     ADI_I2C_HANDLE  *pI2C_Handle;
-    uint8_t         *I2C_Mem;
+    uint32_t        *I2C_Mem;
     ADI_I2C_RESULT  I2C_Return = ADI_I2C_SUCCESS;
     uint32_t        I2C_DevNum = I2C_0;     /* ADuCM4050 only has 1 I2C port */
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/objects.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/objects.h
@@ -79,7 +79,11 @@ struct i2c_s {
     ADI_I2C_HANDLE  *pI2C_Handle;
 #if defined(BUILD_I2C_MI_DYNAMIC)
     ADI_I2C_HANDLE  I2C_Handle;
-    uint8_t         I2C_Mem[ADI_I2C_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_I2C_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+    uint32_t        I2C_Mem[(ADI_I2C_MEMORY_SIZE + 3)/4];
 #endif
 };
 
@@ -90,7 +94,11 @@ struct spi_s {
     ADI_SPI_HANDLE  *pSPI_Handle;
 #if defined(BUILD_SPI_MI_DYNAMIC)
     ADI_SPI_HANDLE  SPI_Handle;
-    uint8_t         SPI_Mem[ADI_SPI_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_SPI_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
+    uint32_t        SPI_Mem[(ADI_SPI_MEMORY_SIZE + 3)/4];
 #endif
 };
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/rtc_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/rtc_api.c
@@ -46,7 +46,11 @@
 #include "adi_pwr.h"
 
 #define RTC_DEVICE_NUM    0
-static uint8_t aRtcDevMem0[ADI_RTC_MEMORY_SIZE];
+/*******************************************************************************
+   ADI_RTC_DEVICE Instance memory containing memory pointer should guarantee
+   4 byte alignmnet.
+ *******************************************************************************/
+static uint32_t       aRtcDevMem0[(ADI_RTC_MEMORY_SIZE + 3)/4];
 static ADI_RTC_HANDLE hDevice0 = NULL;
 
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/spi_api.c
@@ -61,12 +61,16 @@
 int adi_spi_memtype = 0;
 #endif
 #else
+/*******************************************************************************
+   ADI_SPI_DEV_DATA_TYPE Instance memory containing memory pointer should
+   guarantee 4 byte alignmnet.
+ *******************************************************************************/
 ADI_SPI_HANDLE      spi_Handle0;
-uint8_t             spi_Mem0[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem0[(ADI_SPI_MEMORY_SIZE + 3)/4];
 ADI_SPI_HANDLE      spi_Handle1;
-uint8_t             spi_Mem1[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem1[(ADI_SPI_MEMORY_SIZE + 3)/4];
 ADI_SPI_HANDLE      spi_Handle2;
-uint8_t             spi_Mem2[ADI_SPI_MEMORY_SIZE];
+uint32_t            spi_Mem2[(ADI_SPI_MEMORY_SIZE + 3)/4];
 #if defined(ADI_DEBUG)
 #warning "BUILD_SPI_MI_DYNAMIC is NOT defined.  Memory allocation for SPI will be static"
 int adi_spi_memtype = 1;
@@ -94,7 +98,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_data = pinmap_merge(spi_mosi, spi_miso);
     uint32_t spi_cntl = pinmap_merge(spi_sclk, spi_ssel);
     ADI_SPI_HANDLE      *pSPI_Handle;
-    uint8_t             *SPI_Mem;
+    uint32_t            *SPI_Mem;
     ADI_SPI_RESULT      SPI_Return = ADI_SPI_SUCCESS;
     uint32_t            nDeviceNum = 0;
     ADI_SPI_CHIP_SELECT spi_cs = ADI_SPI_CS_NONE;

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/crypto/adi_crypto.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/crypto/adi_crypto.c
@@ -121,7 +121,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #define __ADI_BYTE_SWAP(X)                        __REV(X)
 #elif defined (__GNUC__)
 #define __ADI_BYTE_SWAP(X)                        __builtin_bswap32(X)
-#elif defined (__CC_ARM)
+#elif defined (__ARMCC_VERSION)
 #define __ADI_BYTE_SWAP(X)                        __rev(X)
 #else
 #error "This toolchain is not supported"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/dma/adi_dma.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/dma/adi_dma.c
@@ -272,7 +272,7 @@ ADI_DMA_RESULT adi_dma_RegisterCallback (
 /* ARM Cortex-M3/M4, GNU-ARM compiler */
 #define ADI_CLZ(X)     __builtin_clz(X)
 
-#elif defined(__CC_ARM)
+#elif defined(__ARMCC_VERSION)
 
 /* ARM Cortex-M3/M4, Keil compiler */
 #define ADI_CLZ(X)    __clz(X)

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/drivers/general/adi_drivers_general.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/drivers/general/adi_drivers_general.h
@@ -82,10 +82,10 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   #define ADI_ALIGNED_ATTRIBUTE(num)
   #define ADI_ALIGNED_PRAGMA(num) PRAGMA(data_alignment=num) 
   #define ADI_UNUSED_ATTRIBUTE
-#elif defined (__CC_ARM)
+#elif defined (__ARMCC_VERSION)
   /* Keil uses a decorator which is placed in the same position as pragmas */
   #define ADI_ALIGNED_ATTRIBUTE(num)
-  #define ADI_ALIGNED_PRAGMA(num) __align(##num)
+  #define ADI_ALIGNED_PRAGMA(num) __attribute__((aligned(num)))
   #define ADI_UNUSED_ATTRIBUTE ATTRIBUTE(unused)
 #else
 #error "Toolchain not supported"

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/sys/adi_ADuCM4050_device.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/sys/adi_ADuCM4050_device.h
@@ -25,12 +25,6 @@
 /* pickup register bitfield and bit masks */
 #include "adi_ADuCM4050_typedefs.h"
 
-#if defined ( __CC_ARM   )
-#pragma push
-#pragma anon_unions
-#endif
-
-
 #ifndef __IO
 #ifdef __cplusplus
 #define     __I     volatile      /* read-only */
@@ -1329,10 +1323,5 @@ typedef enum
 #if defined (_MISRA_RULES)
 #pragma diag(pop)
 #endif /* _MISRA_RULES */
-
-
-#if defined (__CC_ARM)
-#pragma pop
-#endif 
 
 #endif

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/sys/adi_ADuCM4050_typedefs.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/sys/adi_ADuCM4050_typedefs.h
@@ -22,12 +22,6 @@
 #include <stdint.h>
 #endif /* _LANGUAGE_C */
 
-#if defined ( __CC_ARM   )
-#pragma push
-#pragma anon_unions
-#endif
-
-
 #if defined (_MISRA_RULES)
 /*
   anonymous unions violate ISO 9899:1990 and therefore MISRA Rule 1.1.
@@ -11243,10 +11237,5 @@ typedef struct _ADI_NVIC_INTCID3_t {
 #if defined (_MISRA_RULES)
 #pragma diag(pop)
 #endif /* _MISRA_RULES */
-
-
-#if defined (__CC_ARM)
-#pragma pop
-#endif 
 
 #endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -622,7 +622,7 @@
     },
     "EV_COG_AD4050LZ": {
         "inherits": ["Target"],
-        "core": "Cortex-M4",
+        "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "macros": ["__ADUCM4050__", "EV_COG_AD4050LZ"],
         "extra_labels": ["Analog_Devices", "ADUCM4X50", "ADUCM4050", "EV_COG_AD4050LZ", "FLASH_CMSIS_ALGO"],


### PR DESCRIPTION
## Description

Apply changes to be compatible for IAR 7 and 8, GCC 4, 5 and 6, ARM 5 and 6 tool chain.
Enable EV_COG_AD4050LZ FPU option.
GreenTea Full pass for EV_COG_AD3029LZ and EV_COG_AD4050LZ single boards.

## Status

**READY**

## Migrations

NO

## Related PRs

feature-armc6 | #5560
master | #5541
master | #5144
master | #5137
