### PR TITLE
Fix #5079. Support of call to mbedtls_x_finish without calling mbedtls_x_update

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
@@ -22,12 +22,10 @@
 
 #define MBEDTLS_AES_ALT
 
-/* FIXME: Don't enable SHA1, SHA256 and MD5 hardware acceleration until issue
- * #5079 is fixed. (https://github.com/ARMmbed/mbed-os/issues/5079) */
-/* #define MBEDTLS_SHA256_ALT */
+#define MBEDTLS_SHA256_ALT
 
-/* #define MBEDTLS_SHA1_ALT */
+#define MBEDTLS_SHA1_ALT
 
-/* #define MBEDTLS_MD5_ALT */
+#define MBEDTLS_MD5_ALT
 
 #endif /* MBEDTLS_DEVICE_H */

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.c
@@ -175,6 +175,12 @@ void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
             return; // Return error code here
         }
     }
+    /* The following test can happen when the input is empty, and mbedtls_md5_update has never been called */
+    if(ctx->hhash_md5.Phase == HAL_HASH_PHASE_READY) {
+        /* Select the MD5 mode and reset the HASH processor core, so that the HASH will be ready to compute
+            the message digest of a new message */
+        HASH->CR |= HASH_ALGOSELECTION_MD5 | HASH_CR_INIT;
+    }
     mbedtls_zeroize( ctx->sbuf, ST_MD5_BLOCK_SIZE);
     ctx->sbuf_len = 0;
     __HAL_HASH_START_DIGEST();

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.c
@@ -17,8 +17,8 @@
  *  limitations under the License.
  *
  */
-#if defined(MBEDTLS_MD5_C)
 #include "mbedtls/md5.h"
+#if defined(MBEDTLS_MD5_C)
 
 #if defined(MBEDTLS_MD5_ALT)
 #include "mbedtls/platform.h"

--- a/features/mbedtls/targets/TARGET_STM/md5_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/md5_alt.c
@@ -127,41 +127,39 @@ void mbedtls_md5_process( mbedtls_md5_context *ctx, const unsigned char data[ST_
 void mbedtls_md5_update( mbedtls_md5_context *ctx, const unsigned char *input, size_t ilen )
 {
     size_t currentlen = ilen;
-    if (st_md5_restore_hw_context(ctx) != 1) {
-        return; // Return HASH_BUSY timout error here
-    }
-    // store mechanism to accumulate ST_MD5_BLOCK_SIZE bytes (512 bits) in the HW
-    if (currentlen == 0){ // only change HW status is size if 0
-        if(ctx->hhash_md5.Phase == HAL_HASH_PHASE_READY) {
-          /* Select the MD5 mode and reset the HASH processor core, so that the HASH will be ready to compute
-             the message digest of a new message */
-          HASH->CR |= HASH_ALGOSELECTION_MD5 | HASH_CR_INIT;
+    /* If ilen = 0 : do nothing */
+    if (currentlen != 0) {
+        if (st_md5_restore_hw_context(ctx) != 1) {
+            return; // Return HASH_BUSY timout error here
         }
-        ctx->hhash_md5.Phase = HAL_HASH_PHASE_PROCESS;
-    } else if (currentlen < (ST_MD5_BLOCK_SIZE - ctx->sbuf_len)) {
-        // only buffurize
-        memcpy(ctx->sbuf+ctx->sbuf_len, input, currentlen);
-        ctx->sbuf_len += currentlen;
-    } else {
-        // fill buffer and process it
-        memcpy(ctx->sbuf + ctx->sbuf_len, input, (ST_MD5_BLOCK_SIZE - ctx->sbuf_len));
-        currentlen -= (ST_MD5_BLOCK_SIZE - ctx->sbuf_len);
-        mbedtls_md5_process(ctx, ctx->sbuf);
-        // Process every input as long as it is %64 bytes, ie 512 bits
-        size_t iter = currentlen / ST_MD5_BLOCK_SIZE;
-        if (iter !=0) {
-            if (HAL_HASH_MD5_Accumulate(&ctx->hhash_md5, (uint8_t *)(input + ST_MD5_BLOCK_SIZE - ctx->sbuf_len), (iter * ST_MD5_BLOCK_SIZE)) != 0) {
-                return; // Return error code here
+
+        // store mechanism to accumulate ST_MD5_BLOCK_SIZE bytes (512 bits) in the HW
+        if (currentlen < (ST_MD5_BLOCK_SIZE - ctx->sbuf_len)) {
+            // only buffurize
+            memcpy(ctx->sbuf+ctx->sbuf_len, input, currentlen);
+            ctx->sbuf_len += currentlen;
+        } else {
+            // fill buffer and process it
+            memcpy(ctx->sbuf + ctx->sbuf_len, input, (ST_MD5_BLOCK_SIZE - ctx->sbuf_len));
+            currentlen -= (ST_MD5_BLOCK_SIZE - ctx->sbuf_len);
+            mbedtls_md5_process(ctx, ctx->sbuf);
+            // Process every input as long as it is %64 bytes, ie 512 bits
+            size_t iter = currentlen / ST_MD5_BLOCK_SIZE;
+            if (iter !=0) {
+                if (HAL_HASH_MD5_Accumulate(&ctx->hhash_md5, (uint8_t *)(input + ST_MD5_BLOCK_SIZE - ctx->sbuf_len), (iter * ST_MD5_BLOCK_SIZE)) != 0) {
+                    return; // Return error code here
+                }
+            }
+            // sbuf is completely accumulated, now copy up to 63 remaining bytes
+            ctx->sbuf_len = currentlen % ST_MD5_BLOCK_SIZE;
+            if (ctx->sbuf_len !=0) {
+                memcpy(ctx->sbuf, input + ilen - ctx->sbuf_len, ctx->sbuf_len);
             }
         }
-        // sbuf is completely accumulated, now copy up to 63 remaining bytes
-        ctx->sbuf_len = currentlen % ST_MD5_BLOCK_SIZE;
-        if (ctx->sbuf_len !=0) {
-            memcpy(ctx->sbuf, input + ilen - ctx->sbuf_len, ctx->sbuf_len);
+
+        if (st_md5_save_hw_context(ctx) != 1) {
+            return; // return HASH_BUSY timeout Error here
         }
-    }
-    if (st_md5_save_hw_context(ctx) != 1) {
-        return; // return HASH_BUSY timeout Error here
     }
 }
 
@@ -171,7 +169,7 @@ void mbedtls_md5_finish( mbedtls_md5_context *ctx, unsigned char output[16] )
         return; // Return HASH_BUSY timout error here
     }
     /* Last accumulation for extra bytes in sbuf_len */
-    /* This allows the HW flags to be in place in case mbedtls_sha256_update has not been called yet */
+    /* This sets HW flags in case mbedtls_md5_update has not been called yet */
     if (HAL_HASH_MD5_Accumulate(&ctx->hhash_md5, ctx->sbuf, ctx->sbuf_len) != 0) {
         return; // Return error code here
     }

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -174,6 +174,12 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
             return; // Return error code here
         }
     }
+    /* The following test can happen when the input is empty, and mbedtls_sha1_update has never been called */
+    if(ctx->hhash_sha1.Phase == HAL_HASH_PHASE_READY) {
+        /* Select the SHA1 mode and reset the HASH processor core, so that the HASH will be ready to compute
+           the message digest of a new message */
+        HASH->CR |= HASH_ALGOSELECTION_SHA1 | HASH_CR_INIT;
+    }
     mbedtls_zeroize(ctx->sbuf, ST_SHA1_BLOCK_SIZE);
     ctx->sbuf_len = 0;
     __HAL_HASH_START_DIGEST();

--- a/features/mbedtls/targets/TARGET_STM/sha1_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha1_alt.c
@@ -169,16 +169,10 @@ void mbedtls_sha1_finish( mbedtls_sha1_context *ctx, unsigned char output[20] )
         return; // Return HASH_BUSY timout error here
     }
 
-    if (ctx->sbuf_len > 0) {
-        if (HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, ctx->sbuf, ctx->sbuf_len) != 0) {
-            return; // Return error code here
-        }
-    }
-    /* The following test can happen when the input is empty, and mbedtls_sha1_update has never been called */
-    if(ctx->hhash_sha1.Phase == HAL_HASH_PHASE_READY) {
-        /* Select the SHA1 mode and reset the HASH processor core, so that the HASH will be ready to compute
-           the message digest of a new message */
-        HASH->CR |= HASH_ALGOSELECTION_SHA1 | HASH_CR_INIT;
+    /* Last accumulation for extra bytes in sbuf_len */
+    /* This allows the HW flags to be in place in case mbedtls_sha256_update has not been called yet */
+    if (HAL_HASH_SHA1_Accumulate(&ctx->hhash_sha1, ctx->sbuf, ctx->sbuf_len) != 0) {
+        return; // Return error code here
     }
     mbedtls_zeroize(ctx->sbuf, ST_SHA1_BLOCK_SIZE);
     ctx->sbuf_len = 0;

--- a/features/mbedtls/targets/TARGET_STM/sha256_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha256_alt.c
@@ -187,29 +187,18 @@ void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32
     if (st_sha256_restore_hw_context(ctx) != 1) {
         return; // Return HASH_BUSY timout error here
     }
-    if (ctx->sbuf_len > 0) {
-        if (ctx->is224 == 0) {
-            if (HAL_HASHEx_SHA256_Accumulate(&ctx->hhash_sha256, ctx->sbuf, ctx->sbuf_len) != 0) {
-                return; // Return error code here
-            }
-        } else {
-            if (HAL_HASHEx_SHA224_Accumulate(&ctx->hhash_sha256, ctx->sbuf, ctx->sbuf_len) != 0) {
-                return; // Return error code here
-            }
+    /* Last accumulation for extra bytes in sbuf_len */
+    /* This allows the HW flags to be in place in case mbedtls_sha256_update has not been called yet */
+    if (ctx->is224 == 0) {
+        if (HAL_HASHEx_SHA256_Accumulate(&ctx->hhash_sha256, ctx->sbuf, ctx->sbuf_len) != 0) {
+            return; // Return error code here
+        }
+    } else {
+        if (HAL_HASHEx_SHA224_Accumulate(&ctx->hhash_sha256, ctx->sbuf, ctx->sbuf_len) != 0) {
+            return; // Return error code here
         }
     }
-    /* The following test can happen when the input is empty, and mbedtls_sha256_update has never been called */
-    if(ctx->hhash_sha256.Phase == HAL_HASH_PHASE_READY) {
-        if (ctx->is224 == 0) {
-            /* Select the SHA256 mode and reset the HASH processor core, so that the HASH will be ready to compute
-           the message digest of a new message */
-            HASH->CR |= HASH_ALGOSELECTION_SHA256 | HASH_CR_INIT;
-        } else {
-            /* Select the SHA224 mode and reset the HASH processor core, so that the HASH will be ready to compute
-           the message digest of a new message */
-            HASH->CR |= HASH_ALGOSELECTION_SHA224 | HASH_CR_INIT;
-        }
-    }
+
     mbedtls_zeroize(ctx->sbuf, ST_SHA256_BLOCK_SIZE);
     ctx->sbuf_len = 0;
     __HAL_HASH_START_DIGEST();

--- a/features/mbedtls/targets/TARGET_STM/sha256_alt.c
+++ b/features/mbedtls/targets/TARGET_STM/sha256_alt.c
@@ -198,6 +198,18 @@ void mbedtls_sha256_finish( mbedtls_sha256_context *ctx, unsigned char output[32
             }
         }
     }
+    /* The following test can happen when the input is empty, and mbedtls_sha256_update has never been called */
+    if(ctx->hhash_sha256.Phase == HAL_HASH_PHASE_READY) {
+        if (ctx->is224 == 0) {
+            /* Select the SHA256 mode and reset the HASH processor core, so that the HASH will be ready to compute
+           the message digest of a new message */
+            HASH->CR |= HASH_ALGOSELECTION_SHA256 | HASH_CR_INIT;
+        } else {
+            /* Select the SHA224 mode and reset the HASH processor core, so that the HASH will be ready to compute
+           the message digest of a new message */
+            HASH->CR |= HASH_ALGOSELECTION_SHA224 | HASH_CR_INIT;
+        }
+    }
     mbedtls_zeroize(ctx->sbuf, ST_SHA256_BLOCK_SIZE);
     ctx->sbuf_len = 0;
     __HAL_HASH_START_DIGEST();


### PR DESCRIPTION
## Description
Fix #5079 
Support of call to mbedtls_x_finish without calling mbedtls_x_update.

## Status
**READY**
Before the PR: failure occurs in case of an empty input and mbedtls_xx_update is not called between xxx_start and xxx_finish

After this PR: 
- SHA1 / SHA256 / MD5 hardware acceleration is activated for STM32F439xI
- An empty input can be encrypted correctly even is the call to mbedtls_xxx_update has been omited

~~[] To do: test MD5, as it is not compiled in mbed-os (I could not find a way to activate it, can someone help me for this ?)~~ [edit 12.14.2017 -> MD5 link issue is now fixed.]


## Steps to test or reproduce

Use the test available in #5079
