### PR TITLE
BLE: Add function converting error codes into strings

### DIFF
--- a/features/FEATURE_BLE/ble/BLE.h
+++ b/features/FEATURE_BLE/ble/BLE.h
@@ -400,6 +400,15 @@ public:
      */
     const SecurityManager& securityManager() const;
 
+    /**
+     * Translate error code into a printable string.
+     *
+     * @param[in] error Error code returned by BLE functions.
+     *
+     * @return A pointer to a const string describing the error.
+     */
+    static const char* errorToString(ble_error_t error);
+
     /*
      * Deprecation alert!
      * All of the following are deprecated and may be dropped in a future

--- a/features/FEATURE_BLE/source/BLE.cpp
+++ b/features/FEATURE_BLE/source/BLE.cpp
@@ -31,6 +31,30 @@
 #include <toolchain.h>
 #endif
 
+static const char* error_strings[] = {
+    "BLE_ERROR_NONE: No error",
+    "BLE_ERROR_BUFFER_OVERFLOW: The requested action would cause a buffer overflow and has been aborted",
+    "BLE_ERROR_NOT_IMPLEMENTED: Requested a feature that isn't yet implement or isn't supported by the target HW",
+    "BLE_ERROR_PARAM_OUT_OF_RANGE: One of the supplied parameters is outside the valid range",
+    "BLE_ERROR_INVALID_PARAM: One of the supplied parameters is invalid",
+    "BLE_STACK_BUSY: The stack is busy",
+    "BLE_ERROR_INVALID_STATE: Invalid state",
+    "BLE_ERROR_NO_MEM: Out of Memory",
+    "BLE_ERROR_OPERATION_NOT_PERMITTED: The operation requested is not permitted",
+    "BLE_ERROR_INITIALIZATION_INCOMPLETE: The BLE subsystem has not completed its initialisation",
+    "BLE_ERROR_ALREADY_INITIALIZED: The BLE system has already been initialised",
+    "BLE_ERROR_UNSPECIFIED: Unknown error",
+    "BLE_ERROR_INTERNAL_STACK_FAILURE: The platform-specific stack failed"
+};
+
+const char* BLE::errorToString(ble_error_t error)
+{
+    if (error > BLE_ERROR_INTERNAL_STACK_FAILURE) {
+        return "Illegal error code";
+    }
+    return error_strings[error];
+}
+
 ble_error_t
 BLE::initImplementation(FunctionPointerWithContext<InitializationCompleteCallbackContext*> callback)
 {


### PR DESCRIPTION
## Description

To avoid duplication in applications and help developers this provides them with printable strings for ble error codes.

## Status

**READY**

## Migrations

NO