### PR TITLE
Protect local static object construction in ARMCC

### DIFF
--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -58,11 +58,13 @@ static SingletonPtr<TestClass> test_class;
 static void main_func_race()
 {
     get_test_class();
+    TEST_ASSERT_EQUAL_UINT32(1, instance_count);
 }
 
 static void main_class_race()
 {
     test_class->do_something();
+    TEST_ASSERT_EQUAL_UINT32(1, instance_count);
 }
 
 void test_case_func_race()

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -977,6 +977,10 @@ extern "C" void __env_unlock( struct _reent *_r )
     __rtos_env_unlock(_r);
 }
 
+#endif
+
+#if defined (__GNUC__) || defined(__CC_ARM) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
+
 #define CXA_GUARD_INIT_DONE             (1 << 0)
 #define CXA_GUARD_INIT_IN_PROGRESS      (1 << 1)
 #define CXA_GUARD_MASK                  (CXA_GUARD_INIT_DONE | CXA_GUARD_INIT_IN_PROGRESS)


### PR DESCRIPTION
Implement the functions __cxa_guard_acquire, __cxa_guard_release and __cxa_guard_abort for ARMCC so local static object construction is thread safe. Also update the race test to properly detect this bug.