### PR TITLE
Fixing for greentea test mbed-os-tests-netsocket-connectivity

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -594,11 +594,13 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
 // Backwards compatibility with people using DEVICE_EMAC
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
 {
-    nsapi_error_t ret;
+    nsapi_error_t ret = NSAPI_ERROR_OK;
     mbed_lwip_core_init();
-    ret = mbed_lwip_emac_init(emac);
-    if (ret == NSAPI_ERROR_OK) {
-        netif_inited = true;
+    if(netif_inited == false){
+        ret = mbed_lwip_emac_init(emac);
+        if (ret == NSAPI_ERROR_OK) {
+            netif_inited = true;
+        }
     }
     return ret;
 }

--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -594,13 +594,11 @@ nsapi_error_t mbed_lwip_emac_init(emac_interface_t *emac)
 // Backwards compatibility with people using DEVICE_EMAC
 nsapi_error_t mbed_lwip_init(emac_interface_t *emac)
 {
-    nsapi_error_t ret = NSAPI_ERROR_OK;
+    nsapi_error_t ret;
     mbed_lwip_core_init();
-    if(netif_inited == false){
-        ret = mbed_lwip_emac_init(emac);
-        if (ret == NSAPI_ERROR_OK) {
-            netif_inited = true;
-        }
+    ret = mbed_lwip_emac_init(emac);
+    if (ret == NSAPI_ERROR_OK) {
+        netif_inited = true;
     }
     return ret;
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -36,6 +36,8 @@ typedef struct _wifi_scan_hdl {
 
 #define MAX_SCAN_TIMEOUT (15000)
 
+static bool _inited = false;
+
 static rtw_result_t scan_result_handler( rtw_scan_handler_result_t* malloced_scan_result )
 {
     wifi_scan_hdl *scan_handler = (wifi_scan_hdl *)malloced_scan_result->user_data;
@@ -97,11 +99,14 @@ RTWInterface::RTWInterface(bool debug)
         return;
     }
     emac->ops.power_up(emac);
-    ret = mbed_lwip_init(emac);
-    if (ret != 0) {
-        printf("Error init RTWInterface!(%d)\r\n", ret);
-        return;
-    }
+	if (_inited == false) {
+    	ret = mbed_lwip_init(emac);
+    	if (ret != 0) {
+        	printf("Error init RTWInterface!(%d)\r\n", ret);
+        	return;
+    	}
+		_inited = true;
+	}
 }
 
 RTWInterface::~RTWInterface()
@@ -228,8 +233,9 @@ nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
 nsapi_error_t RTWInterface::disconnect()
 {
     char essid[33];
-
+	
     wlan_emac_link_change(false);
+	mbed_lwip_bringdown();
     if(wifi_is_connected_to_ap() != RTW_SUCCESS)
         return NSAPI_ERROR_NO_CONNECTION;
     if(wifi_disconnect()<0){        

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -43,9 +43,9 @@ static rtw_result_t scan_result_handler( rtw_scan_handler_result_t* malloced_sca
     wifi_scan_hdl *scan_handler = (wifi_scan_hdl *)malloced_scan_result->user_data;
     if (malloced_scan_result->scan_complete != RTW_TRUE) {
         if(scan_handler->ap_details && scan_handler->scan_num > scan_handler->ap_num){
-            nsapi_wifi_ap_t ap;    
+            nsapi_wifi_ap_t ap;
             rtw_scan_result_t* record = &malloced_scan_result->ap_details;
-            record->SSID.val[record->SSID.len] = 0; /* Ensure the SSID is null terminated */    
+            record->SSID.val[record->SSID.len] = 0; /* Ensure the SSID is null terminated */
             memset((void*)&ap, 0x00, sizeof(nsapi_wifi_ap_t));
             memcpy(ap.ssid, record->SSID.val, record->SSID.len);
             memcpy(ap.bssid, record->BSSID.octet, 6);
@@ -90,7 +90,7 @@ RTWInterface::RTWInterface(bool debug)
 {
     emac_interface_t *emac;
     int ret;
-    extern u32 GlobalDebugEnable; 
+    extern u32 GlobalDebugEnable;
 
     GlobalDebugEnable = debug?1:0;
     emac = wlan_emac_init_interface();
@@ -99,13 +99,13 @@ RTWInterface::RTWInterface(bool debug)
         return;
     }
     emac->ops.power_up(emac);
-	if (_inited == false) {
+    if (_inited == false) {
         ret = mbed_lwip_init(emac);
         if (ret != 0) {
             printf("Error init RTWInterface!(%d)\r\n", ret);
             return;
         }
-	    _inited = true;
+        _inited = true;
     }
 }
 
@@ -163,7 +163,7 @@ nsapi_error_t RTWInterface::connect()
             break;
         case NSAPI_SECURITY_NONE:
             sec = RTW_SECURITY_OPEN;
-            break;            
+            break;
         default:
             return NSAPI_ERROR_PARAMETER;
     }
@@ -172,7 +172,7 @@ nsapi_error_t RTWInterface::connect()
         uint8_t pscan_config = PSCAN_ENABLE;
         wifi_set_pscan_chan(&_channel, &pscan_config, 1);
     }
-    
+
     ret = wifi_connect(_ssid, sec, _pass, strlen(_ssid), strlen(_pass), 0, (void *)NULL);
     if (ret != RTW_SUCCESS) {
         printf("failed: %d\r\n", ret);
@@ -223,7 +223,7 @@ int8_t RTWInterface::get_rssi()
 }
 
 nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
-                           nsapi_security_t security, uint8_t channel)
+                            nsapi_security_t security, uint8_t channel)
 {
     set_credentials(ssid, pass, security);
     set_channel(channel);
@@ -233,12 +233,12 @@ nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
 nsapi_error_t RTWInterface::disconnect()
 {
     char essid[33];
-	
+
     wlan_emac_link_change(false);
-	mbed_lwip_bringdown();
+    mbed_lwip_bringdown();
     if(wifi_is_connected_to_ap() != RTW_SUCCESS)
         return NSAPI_ERROR_NO_CONNECTION;
-    if(wifi_disconnect()<0){        
+    if(wifi_disconnect()<0){
         return NSAPI_ERROR_DEVICE_ERROR;
     }
     while(1){

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -100,13 +100,13 @@ RTWInterface::RTWInterface(bool debug)
     }
     emac->ops.power_up(emac);
 	if (_inited == false) {
-    	ret = mbed_lwip_init(emac);
-    	if (ret != 0) {
-        	printf("Error init RTWInterface!(%d)\r\n", ret);
-        	return;
-    	}
-		_inited = true;
-	}
+        ret = mbed_lwip_init(emac);
+        if (ret != 0) {
+            printf("Error init RTWInterface!(%d)\r\n", ret);
+            return;
+        }
+	    _inited = true;
+    }
 }
 
 RTWInterface::~RTWInterface()

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -228,9 +228,8 @@ nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
 nsapi_error_t RTWInterface::disconnect()
 {
     char essid[33];
-	
+
     wlan_emac_link_change(false);
-	mbed_lwip_bringdown();
     if(wifi_is_connected_to_ap() != RTW_SUCCESS)
         return NSAPI_ERROR_NO_CONNECTION;
     if(wifi_disconnect()<0){        

--- a/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/RTWInterface.cpp
@@ -228,8 +228,9 @@ nsapi_error_t RTWInterface::connect(const char *ssid, const char *pass,
 nsapi_error_t RTWInterface::disconnect()
 {
     char essid[33];
-
+	
     wlan_emac_link_change(false);
+	mbed_lwip_bringdown();
     if(wifi_is_connected_to_ap() != RTW_SUCCESS)
         return NSAPI_ERROR_NO_CONNECTION;
     if(wifi_disconnect()<0){        


### PR DESCRIPTION
Fix in lwip_stack to pass greentea test for Realtek RTL8195A platform

Notes:
- Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).

## Description
This is a fix in the lwip stack to ensure that the netif is not being initialized twice. In the earlier version the netif was being inialized twice and hence the test "bring the network up and down twice" was faling.

## Status

**READY**

## Migrations

No other changes other than in lwip_stack.c

## Related PRs

None

## Todos

- [X ] Tests. (Tested with latest mbed-os and mbedgt)
- [ ] Documentation [N/A]

## Deploy notes

No change in build/test environment needed.

## Steps to test or reproduce

download and run the greentea test corresponding to the test using the command

mbed test -n mbed-os-tests-netsocket-connectivity --test-config Realtek_wifi

Before running the command make sure to input the wi-fi credentials in mbed-os\tools\test_configs\RealtekInterface.json
