### PR TITLE
Deprecate Stream and Serial

### DIFF
--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -106,7 +106,10 @@ protected:
     virtual void unlock();
 
     PlatformMutex _mutex;
-};
+}
+MBED_DEPRECATED_SINCE("mbed-os-5.8",
+                      "Use UARTSerial instead - it provides buffering, better blocking, and correct POSIX-like FileHandle semantics. "
+                      "Use fdopen on a UARTSerial object to get a FILE * for <stdio.h> calls.");
 
 } // namespace mbed
 

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -83,7 +83,10 @@ protected:
     virtual void unlock() {
         // Stub
     }
-};
+}
+MBED_DEPRECATED_SINCE("mbed-os-5.8",
+                      "Stream does not conform to current POSIX-like FileHandle semantics - implement FileHandle directly. "
+                      "Users of FileHandles can use fdopen() to get a FILE * for <stdio.h> calls.");
 /**@}*/
 
 /**@}*/


### PR DESCRIPTION
`Serial` is replaced by `UARTSerial` - this provides the necessary buffers
to use serial reliably for input from non-interrupt contexts, and avoid
excess spinning waiting for TX buffer space.

(Historically, anyone using `Serial` but needing input has done so by
bypassing its stdio-based calls, and instead making calls
to the underlying `SerialBase` from interrupt, as the stdio input calls
do not work reliably from threads due to lack of buffering, and can't
be used from interrupts. This reliance on the underlying implementation
means it wasn't possible to add buffering in a backwards-compatible
fashion, hence the distinct `UARTSerial`).

Because it no longer uses `Stream`, use of `UARTSerial` no longer
necessarily forces pulling in the C library stdio system.

`Stream` is replaced by drivers implementing `FileHandle` directly, and
applications using `fdopen(FileHandle *)` to get a `FILE *` to use full
C/C++ stream features. This avoids being locked into an odd design
pattern whereby the class works at 2 layers:

   * Application - uses Stream-based driver
   * Stream - uses <stdio.h> `FILE`
   * C library - Implements `FILE`, uses `FileHandle`
   * Stream - implements `FileHandle`, uses virtual `_getc/_putc`
   * Derived-from-Stream (eg Serial) - implements `_getc/_putc`

Stream's implementation of FileHandle on a simple blocking _getc/_putc
cannot be usefully extended to the fuller FileHandle API required for
real-life use like PPP or `ATCmdParser`.

The revised setup now looks like:

   * Application - uses `FILE`
   * C library - Implements `FILE`, uses `FileHandle`
   * Driver - Implements `FileHandle`

What we lose is the syntactical sugar that allowed you to do

    Serial serial(RX, TX, 115200);
    serial.printf("Hello");

Instead, you now must do

    UARTSerial serial(RX, TX, 115200);
    FILE *out = fdopen(&serial, "w");
    fprintf(out, "Hello");
