### PR TITLE
Nanostack EFR32 flag fix

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_SL_RAIL/NanostackRfPhyEfr32.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/targets/TARGET_SL_RAIL/NanostackRfPhyEfr32.cpp
@@ -62,7 +62,7 @@ enum RFThreadSignal {
     SL_QUEUE_FULL       = (1 << 11),
 
     // ACK pend flag can be signalled in addition to RX_DONE
-    SL_ACK_PEND         = (1 << 31),
+    SL_ACK_PEND         = (1 << 30),
 };
 
 /*  Adaptor thread definitions */


### PR DESCRIPTION
Fixes the `SL_ACK_PEND` flag which is currently larger than `osRtxThreadFlagsLimit`, evaluated in `isrRtxThreadFlagsSet` at `rtx_thread.c:1491`.

This causes an `osErrorParameter` on receiving packets that require acknowledgements.