### PR TITLE
STM32: Fix issues with CAN_2 and CAN_3 declarations + correct filter number

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/can_device.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE)
 
 #define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PeripheralNames.h
@@ -94,7 +94,8 @@ typedef enum {
 
 typedef enum {
     CAN_1 = (int)CAN1_BASE,
-    CAN_2 = (int)CAN2_BASE
+    CAN_2 = (int)CAN2_BASE,
+    CAN_3 = (int)CAN3_BASE
 } CANName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_STM/TARGET_STM32F7/can_device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/can_device.h
@@ -25,7 +25,7 @@ extern "C" {
 
 #ifdef DEVICE_CAN
 
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE)
 
 #define CAN_NUM 3 // Number of CAN peripherals present in the STM32 serie
 

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -103,7 +103,14 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
 
     can_registers_init(obj);
 
+    /* Bits 27:14 are available for dual CAN configuration and are reserved for
+       single CAN configuration */
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
+    uint32_t filter_number = (can == CAN_1 || can == CAN_3) ? 0 : 14;
+#else
     uint32_t filter_number = (can == CAN_1) ? 0 : 14;
+#endif
+
     can_filter(obj, 0, 0, CANStandard, filter_number);
 }
 
@@ -579,15 +586,15 @@ void CAN2_SCE_IRQHandler(void)
 #if defined(CAN3_BASE) && (CAN_NUM > 2)
 void CAN3_RX0_IRQHandler(void)
 {
-    can_irq(CAN_3, 1);
+    can_irq(CAN_3, 2);
 }
 void CAN3_TX_IRQHandler(void)
 {
-    can_irq(CAN_3, 1);
+    can_irq(CAN_3, 2);
 }
 void CAN3_SCE_IRQHandler(void)
 {
-    can_irq(CAN_3, 1);
+    can_irq(CAN_3, 2);
 }
 #endif
 #endif // else

--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -57,14 +57,14 @@ void can_init_freq (can_t *obj, PinName rd, PinName td, int hz)
         __HAL_RCC_CAN1_CLK_ENABLE();
         obj->index = 0;
     }
-#if defined(CAN2_BASE) && defined(CAN_2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     else if (can == CAN_2) {
         __HAL_RCC_CAN1_CLK_ENABLE(); // needed to set filters
         __HAL_RCC_CAN2_CLK_ENABLE();
         obj->index = 1;
     }
 #endif
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
     else if (can == CAN_3) {
         __HAL_RCC_CAN3_CLK_ENABLE();
         obj->index = 2;
@@ -132,14 +132,14 @@ void can_free(can_t *obj)
         __HAL_RCC_CAN1_RELEASE_RESET();
         __HAL_RCC_CAN1_CLK_DISABLE();
     }
-#if defined(CAN2_BASE) && defined(CAN_2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     if (can == CAN_2) {
         __HAL_RCC_CAN2_FORCE_RESET();
         __HAL_RCC_CAN2_RELEASE_RESET();
         __HAL_RCC_CAN2_CLK_DISABLE();
     }
 #endif
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
     if (can == CAN_3) {
         __HAL_RCC_CAN3_FORCE_RESET();
         __HAL_RCC_CAN3_RELEASE_RESET();
@@ -562,7 +562,7 @@ void CAN1_SCE_IRQHandler(void)
 {
     can_irq(CAN_1, 0);
 }
-#if defined(CAN2_BASE) && defined(CAN_2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
 void CAN2_RX0_IRQHandler(void)
 {
     can_irq(CAN_2, 1);
@@ -576,7 +576,7 @@ void CAN2_SCE_IRQHandler(void)
     can_irq(CAN_2, 1);
 }
 #endif
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
 void CAN3_RX0_IRQHandler(void)
 {
     can_irq(CAN_3, 1);
@@ -630,7 +630,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
                 return;
         }
     }
-#if defined(CAN2_BASE) && defined(CAN_2)
+#if defined(CAN2_BASE) && (CAN_NUM > 1)
     else if ((CANName) can == CAN_2) {
         switch (type) {
             case IRQ_RX:
@@ -663,7 +663,7 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
         }
     }
 #endif
-#if defined(CAN3_BASE) && defined(CAN_3)
+#if defined(CAN3_BASE) && (CAN_NUM > 2)
     else if ((CANName) can == CAN_3) {
         switch (type) {
             case IRQ_RX:
@@ -711,4 +711,3 @@ void can_irq_set(can_t *obj, CanIrqType type, uint32_t enable)
 }
 
 #endif // DEVICE_CAN
-


### PR DESCRIPTION
## Description
- Replace test of CAN_2/CAN_3 with CAN_NUM test. This should solve issue #5668 
- Correct filter number and IRQ index for CAN_3. Pick the work done in PR #5667

## Status
**READY**

## Migrations
NO

## Related PRs
#5667

CC @adamheinrich
