### PR TITLE
C030 Battery Charger Voltage Fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.cpp
@@ -1,0 +1,33 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "battery_charger_i2c.h"
+
+BatteryChargerI2c::BatteryChargerI2c(PinName sda, PinName scl):_i2c(), _hz(100000) {
+    i2c_init(&_i2c, sda, scl);
+}
+
+bool BatteryChargerI2c::read_from_i2c(int i2c_address, char* data_read, int length)
+{
+    int bytes_read = i2c_read(&_i2c, i2c_address, data_read, length, 1);
+    return (length == bytes_read);
+}
+
+bool BatteryChargerI2c::write_to_i2c(int i2c_address, const char* data_write, int length)
+{
+    int bytes_written = i2c_write(&_i2c, i2c_address, data_write, length, 1);
+    return (length == bytes_written);
+}

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.cpp
@@ -16,7 +16,8 @@
 
 #include "battery_charger_i2c.h"
 
-BatteryChargerI2c::BatteryChargerI2c(PinName sda, PinName scl):_i2c(), _hz(100000) {
+BatteryChargerI2c::BatteryChargerI2c(PinName sda, PinName scl):_i2c(), _hz(100000)
+{
     i2c_init(&_i2c, sda, scl);
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.h
@@ -1,3 +1,19 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef BATTERY_CHARGER_I2C
 #define BATTERY_CHARGER_I2C
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/battery_charger_i2c.h
@@ -1,0 +1,27 @@
+#ifndef BATTERY_CHARGER_I2C
+#define BATTERY_CHARGER_I2C
+
+#include "hal/i2c_api.h"
+
+#ifdef __cplusplus
+extern"C"{
+#endif
+
+class BatteryChargerI2c{
+
+public:
+    BatteryChargerI2c(PinName sda, PinName scl);
+    bool read_from_i2c(int i2c_address, char *data_read, int length);
+    bool write_to_i2c(int i2c_address, const char *data_write, int length);
+    virtual ~BatteryChargerI2c() {}
+
+private:
+    i2c_t _i2c;
+    int   _hz;
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //BATTERY_CHARGER_I2C

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.cpp
@@ -1,0 +1,48 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "min_battery_voltage.h"
+#include "battery_charger_i2c.h"
+
+/** Defining HAL_MspInit strong function
+ * in user defined file as described in documentation
+ */
+
+void HAL_MspInit(void)
+{
+	set_minimum_battery_voltage();
+}
+
+void set_minimum_battery_voltage()
+{
+    char data_write[2] = {0};
+    char data_read;
+    BatteryChargerI2c i2c_object(I2C_SDA_B, I2C_SCL_B);
+
+    if (i2c_object.write_to_i2c(BQ24295_I2C_ADDRESS,&data_write[0] , 1)){
+        i2c_object.read_from_i2c(BQ24295_I2C_ADDRESS, &data_read, 1);
+        data_read = data_read & MIN_BATTERY_VOLTAGE_MASK;
+        data_write[0] = 0x0;
+        data_write[1] = data_read;
+        if (i2c_object.write_to_i2c(BQ24295_I2C_ADDRESS,&data_write[0] , 2)){
+            //Battery Voltage is set to 3880mV
+            }
+        }
+    else{
+        // Minimum battery voltage could not be set.  This is not a critical error, no need to stop execution
+        // It simply means that longer cabling or USB ports with lower output voltages may cause problems.
+    }
+}

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.h
@@ -1,0 +1,21 @@
+#ifndef MIN_BATTERY_VOLTAGE_H
+#define MIN_BATTERY_VOLTAGE_H
+
+#ifdef __cplusplus
+extern"C"{
+#endif
+
+#define BQ24295_I2C_ADDRESS (0x6B << 1)
+#define MIN_BATTERY_VOLTAGE_MASK (0x87)
+
+/** Initializes an instance of class BatteryChargerI2c which is using the STM HAL I2C APIs
+ *  This allows longer USB cables or USB ports with lower output voltages to power the board correctly.
+ */
+
+void set_minimum_battery_voltage(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif	// MIN_BATTERY_VOLTAGE_H

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.h
@@ -1,3 +1,19 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef MIN_BATTERY_VOLTAGE_H
 #define MIN_BATTERY_VOLTAGE_H
 


### PR DESCRIPTION
## Description

This is a fix for on board BQ24295 battery charger on UBLOX C030 application board. This allows longer USB cables or USB ports with lower output voltages to power the board correctly. An I2C interface is used to set the battery voltage in boot sequence. 

## Status

**READY**

- Tested on UBLOX_C030 application boards using the battery charger driver
- New files introduced in vendor specific TARGET_UBLOX_C030 folder
