### PR TITLE
lwip: fix socket behaviour

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -287,7 +287,7 @@ static bool mbed_lwip_is_local_addr(const ip_addr_t *ip_addr)
         if (IP_IS_V6(ip_addr)) {
             for (int i = 0; i < LWIP_IPV6_NUM_ADDRESSES; i++) {
                 if (ip6_addr_isvalid(netif_ip6_addr_state(netif, i)) &&
-                    ip6_addr_cmp(netif_ip6_addr(netif, i), ip_addr)) {
+                    ip6_addr_cmp(netif_ip6_addr(netif, i), ip_2_ip6(ip_addr))) {
                     return true;
                 }
             }
@@ -297,7 +297,7 @@ static bool mbed_lwip_is_local_addr(const ip_addr_t *ip_addr)
 #if LWIP_IPV4
         if (IP_IS_V4(ip_addr)) {
             if (!ip4_addr_isany(netif_ip4_addr(netif)) &&
-                ip4_addr_cmp(netif_ip_addr4(netif), ip_addr)) {
+                ip4_addr_cmp(netif_ip4_addr(netif), ip_2_ip4(ip_addr))) {
                 return true;
             }
         }


### PR DESCRIPTION
Return NSAPI_ERROR_PARAMETER when:
Binding to a non-local address
Socket listen() is called without calling bind() first
Socket accept() is called without calling listen() first
