### PR TITLE
Statically allocate ARMCC required mutex objects

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -45,12 +45,6 @@
 #error "OS Tickrate must be 1000 for system timing"
 #endif
 
-#if defined (__CC_ARM) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-/* ARM toolchain uses up to 8 static mutexes, any further mutexes will be allocated on the heap. */
-#define OS_MUTEX_OBJ_MEM            1
-#define OS_MUTEX_NUM                8
-#endif
-
 #if !defined(OS_STACK_WATERMARK) && (defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED)
 #define OS_STACK_WATERMARK          1
 #endif


### PR DESCRIPTION
This is fix for - https://github.com/ARMmbed/mbed-os/issues/5664
Previously we used OS_MUTEX_NUM define to pre-allocate Mutex objects for ARMCC libs. But that doesn't guarantee that they will be avaliable for ARMCC usage always as any other client can grab them before ARMCC lib requires that to be used/initialized. This change is to statically allocate memory for Mutex objects for ARMCC to ensure ARMCC have them when it needs. 