### PR TITLE
Enable IAR export for EV_COG_AD3029LZ and EV_COG_AD4050LZ

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -245,5 +245,11 @@
         "OGChipSelectEditMenu": "TMPM066FWUG\tToshiba TMPM066FWUG",
         "GFPUCoreSlave": 21,
         "GBECoreSlave": 21
+    },
+    "ADuCM3029": {
+        "OGChipSelectEditMenu": "ADuCM3029\tAnalogDevices ADuCM3029"
+    },
+    "ADuCM4050": {
+        "OGChipSelectEditMenu": "ADuCM4050\tAnalogDevices ADuCM4050"
     }
 }


### PR DESCRIPTION
## Description

 - ADuCM3029 is the MCU name for EV_COG_AD3029LZ
 - ADuCM4050 is the MCU name for EV_COG_AD4050LZ

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce

mbed export -i iar -m EV_COG_AD3029LZ
mbed export -i iar -m EV_COG_AD4050LZ
