### PR TITLE
Fixed lwip k64f ethernet driver ipv6 multicast groups

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
@@ -246,6 +246,16 @@ static err_t low_level_init(struct netif *netif)
   config.txAccelerConfig = kENET_TxAccelIsShift16Enabled;
   config.rxAccelerConfig = kENET_RxAccelisShift16Enabled | kENET_RxAccelMacCheckEnabled;
   ENET_Init(ENET, &g_handle, &config, &buffCfg, netif->hwaddr, sysClock);
+
+#if defined(TOOLCHAIN_ARM)
+#if defined(__OPTIMISE_TIME) && (__ARMCC_VERSION < 5060750)
+  /* Add multicast groups
+     work around for https://github.com/ARMmbed/mbed-os/issues/4372 */
+  ENET->GAUR = 0xFFFFFFFFu;
+  ENET->GALR = 0xFFFFFFFFu;
+#endif
+#endif
+
   ENET_SetCallback(&g_handle, ethernet_callback, netif);
   ENET_ActiveRead(ENET);
 


### PR DESCRIPTION
## Description

Added a work around to lwip k64f ethernet Ipv6 multicast groups handling.

This is a work around for problem described in:

https://github.com/ARMmbed/mbed-os/issues/4372

## Status

READY

## Migrations

NO

## Related PRs

None

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

None

## Steps to test or reproduce

None
