### PR TITLE
Add IAR exporter for STM32L475VG (mcu of DISCO_L475VG_IOT01A)

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -2,6 +2,9 @@
     "STM32L476VG": {
         "OGChipSelectEditMenu": "STM32L476VG\tST STM32L476VG"
     },
+    "STM32L475VG": {
+        "OGChipSelectEditMenu": "STM32L475VG\tST STM32L475VG"
+    },
     "LPC11U24FBD48/401": {
         "OGChipSelectEditMenu": "LPC11U24FBD64_401\tNXP LPC11U24FBD64_401"
     },


### PR DESCRIPTION
## Description

The `mbed export -i IAR -m DISCO_L475VG_IOT01A` command is failing.
With this PR, it is supported.

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce
before:
`mbed export -i IAR -m DISCO_L475VG_IOT01A` gives
```
project.py: error: DISCO_L475VG_IOT01A not supported by iar
[mbed] ERROR: "c:\python27\python.exe" returned error code 2.
```
after:
it works