### PR TITLE
Add minimal debug info to release and develop profiles.

### DIFF
--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os"],
+                   "-fomit-frame-pointer", "-Os", "-g1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-Os", "-DNDEBUG"],
+                   "-fomit-frame-pointer", "-Os", "-DNDEBUG", "-g1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],
         "cxx": ["-std=gnu++98", "-fno-rtti", "-Wvla"],


### PR DESCRIPTION
This allows minimal debugging and allows tools like
[mbed-os-linker-report](https://github.com/armmbed/mbed-os-linker-report) to work properly.

Because debugging info is kept in .elf file and not flashed to device
there is no side effects to flash sizes.

