### PR TITLE
Add memory barriers to STM32F7xx Ethernet

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_eth.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_eth.c
@@ -717,6 +717,8 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
     heth->TxDesc->Status |=ETH_DMATXDESC_FS|ETH_DMATXDESC_LS;
     /* Set frame size */
     heth->TxDesc->ControlBufferSize = (FrameLength & ETH_DMATXDESC_TBS1);
+    /* Ensure rest of descriptor is written to RAM before the OWN bit */
+    __DMB();
     /* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
     heth->TxDesc->Status |= ETH_DMATXDESC_OWN;
     /* Point to next descriptor */
@@ -746,6 +748,8 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
         heth->TxDesc->ControlBufferSize = (size & ETH_DMATXDESC_TBS1);
       }
       
+      /* Ensure rest of descriptor is written to RAM before the OWN bit */
+      __DMB();
       /* Set Own bit of the Tx descriptor Status: gives the buffer back to ETHERNET DMA */
       heth->TxDesc->Status |= ETH_DMATXDESC_OWN;
       /* point to next descriptor */
@@ -753,6 +757,9 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
     }
   }
   
+  /* Ensure all descriptors are written to RAM before checking transmitter status */
+  __DMB();
+
   /* When Tx Buffer unavailable flag is set: clear it and resume transmission */
   if (((heth->Instance)->DMASR & ETH_DMASR_TBUS) != (uint32_t)RESET)
   {


### PR DESCRIPTION
Pending official update from STM, add memory barriers to the Ethernet
HAL code for the STM32F7xx family.

Cortex-M7 has a merging write buffer that is not automatically flushed
by accesses to devices, so without these DMBs, we sometimes lose synch
with the transmitter.

The DMBs are architecturally needed in every version of this HAL, but
adding just to the STM32F7 version for now to clear test, as the
problem has only been observed on Cortex-M7-based devices.

Fixes #5622.

