### PR TITLE
Remove destruction of WiFi interface in test runs

### DIFF
--- a/TESTS/network/wifi/get_interface.cpp
+++ b/TESTS/network/wifi/get_interface.cpp
@@ -50,8 +50,10 @@ WiFiInterface *get_interface()
 {
     static WiFiInterface *interface = NULL;
 
-    if (interface)
-        delete interface;
+    if (interface) {
+        interface->disconnect();
+        return interface;
+    }
 
 #if MBED_CONF_APP_WIFI_DRIVER == INTERNAL
     interface = new DRIVER();

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -58,6 +58,7 @@ utest::v1::status_t test_setup(const size_t number_of_cases) {
 // Test cases
 Case cases[] = {
     Case("WIFI-CONSTRUCTOR", wifi_constructor),
+    Case("WIFI-CONNECT-NOCREDENTIALS", wifi_connect_nocredentials),
     Case("WIFI-SET-CREDENTIAL", wifi_set_credential),
     Case("WIFI-SET-CHANNEL", wifi_set_channel),
 #if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
@@ -72,7 +73,6 @@ Case cases[] = {
     Case("WIFI-CONNECT-PARAMS-CHANNEL", wifi_connect_params_channel),
     Case("WIFI-CONNECT-PARAMS-CHANNEL-FAIL", wifi_connect_params_channel_fail),
 #endif
-    Case("WIFI-CONNECT-NOCREDENTIALS", wifi_connect_nocredentials),
 #if defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)
     Case("WIFI-CONNECT", wifi_connect),
 #endif


### PR DESCRIPTION
## Description

Most of our IP stacks don't allow removal of interfaces so
interface destructor can not reliably clean up. Therefore we
cannot rely its behaviours in test case.

Instead run interface->disconnect() in case interface was already
created.


## Status

**READY**

## Migrations

NO
