### PR TITLE
Add presentation format descriptor support for nRF5x

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.cpp
@@ -210,6 +210,8 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      bool                      has_variable_len,
                                      const uint8_t            *userDescriptionDescriptorValuePtr,
                                      uint16_t                  userDescriptionDescriptorValueLen,
+                                     const uint8_t            *presentationFormatDescriptorValuePtr,
+                                     uint16_t                  presentationFormatDescriptorValueLen,
                                      bool                      readAuthorization,
                                      bool                      writeAuthorization,
                                      ble_gatts_char_handles_t *p_char_handle)
@@ -237,6 +239,11 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
         char_md.p_char_user_desc        = const_cast<uint8_t *>(userDescriptionDescriptorValuePtr);
         char_md.char_user_desc_max_size = userDescriptionDescriptorValueLen;
         char_md.char_user_desc_size     = userDescriptionDescriptorValueLen;
+    }
+    if ((presentationFormatDescriptorValueLen > 0) && (presentationFormatDescriptorValuePtr != NULL)) {
+        ASSERT_TRUE( sizeof(ble_gatts_char_pf_t) == sizeof(GattCharacteristic::PresentationFormat_t), ERROR_INVALID_PARAM );
+        ASSERT_TRUE( presentationFormatDescriptorValueLen == sizeof(GattCharacteristic::PresentationFormat_t), ERROR_INVALID_PARAM );
+        char_md.p_char_pf = const_cast<ble_gatts_char_pf_t *>(reinterpret_cast<const ble_gatts_char_pf_t *>(presentationFormatDescriptorValuePtr));
     }
 
     /* Attribute declaration */

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
@@ -52,6 +52,8 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      bool                      has_variable_len,
                                      const uint8_t            *userDescriptionDescriptorValuePtr,
                                      uint16_t                  userDescriptionDescriptorValueLen,
+                                     const uint8_t            *presentationFormatDescriptorValuePtr,
+                                     uint16_t                  presentationFormatDescriptorValueLen,
                                      bool                      readAuthorization,
                                      bool                      writeAuthorization,
                                      ble_gatts_char_handles_t *p_char_handle);


### PR DESCRIPTION
Notes:
- Have agreed to contributor agreement on mbed site (user: dschuler)

## Description

Looking through the mbed BTLE sources, I can find the characteristic presentation format descriptor, BLE_UUID_DESCRIPTOR_CHAR_PRESENTATION_FORMAT, as well as a struct to hold the format in GattCharacteristic::PresentationFormat_t. However, when I add this descriptor to a characteristic and test using Nordic's NRF52 DK board, the descriptor does not appear.

Nordic seems to handle this presentation format differently from other descriptors, along with BLE_UUID_DESCRIPTOR_CHAR_USER_DESC. So, here I added a code path to handle the presentation format the similarly. Tested again on the NRF52 DK, everything appears to be working well.

## Status

**READY**

## Migrations

This does not change any APIs or behavior, but should allow a user to pass a characteristic presentation format descriptor, which was not possible before.

## Related PRs

No related PRs.

## Todos

- [ ] Tests
- [ ] Documentation

I will create another PR with sample code to use the characteristic presentation format.

## Deploy notes

Nothing needs to be done to deploy these changes.

## Steps to test or reproduce

To test if this PR works, create a descriptor of type BLE_UUID_DESCRIPTOR_CHAR_PRESENTATION_FORMAT - without these changes, the descriptor will not appear on a Nordic NRF52 target. I assume the NRF51 target will have a similar issue, but I had some unrelated probles getting the NRF51 dongle to work so can't currently test changes to NRF51.


