### PR TITLE
Build failed as code section was not included in map.

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -274,9 +274,13 @@ class MemapParser(object):
                     section = '.data'
                 elif test_re_armcc.group(3) == 'Zero':
                     section = '.bss'
+                elif test_re_armcc.group(3) == 'Code':
+                    section = '.text'
                 else:
-                    print "Malformed input found when parsing armcc map: %s" %\
-                          line
+                    print "Malformed input found when parsing armcc map: %s, %r" %\
+                          (line, test_re_armcc.groups())
+
+                    return ["", 0, ""]
 
             # check name of object or library
             object_name = self.parse_object_name_armcc(\


### PR DESCRIPTION
Build failed as code section was not included while generation of map file. 
Fix by @theotherjimmy 

Resolution was added as part of secure support, since that PR is delayed picking up mbed-os issues separately.