### PR TITLE
Allow 6LoWPAN applications to leave out channel specification.

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed_lib.json
@@ -3,9 +3,9 @@
     "config": {
         "heap-size": 32500,
         "use-malloc-for-heap": false,
-        "6lowpan-nd-channel-mask": "(1<<12)",
+        "6lowpan-nd-channel-mask": "0x7fff800",
         "6lowpan-nd-channel-page": 0,
-        "6lowpan-nd-channel": 12,
+        "6lowpan-nd-channel": 0,
         "6lowpan-nd-panid-filter": "0xffff",
         "6lowpan-nd-security-mode": "NONE",
         "6lowpan-nd-psk-key-id": 1,

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/nd_tasklet.c
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/nd_tasklet.c
@@ -106,7 +106,7 @@ static void initialize_channel_list(void)
 
     tr_debug("Channel: %ld", channel);
     tr_debug("Channel page: %d", tasklet_data_ptr->channel_list.channel_page);
-    tr_debug("Channel mask: %ld", tasklet_data_ptr->channel_list.channel_mask[word_index]);
+    tr_debug("Channel mask: 0x%.8lx", tasklet_data_ptr->channel_list.channel_mask[word_index]);
 }
 
 /*

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/thread_tasklet.c
@@ -274,8 +274,8 @@ void thread_tasklet_configure_and_connect_to_network(void)
     thread_tasklet_data_ptr->channel_list.channel_mask[0] = MBED_CONF_MBED_MESH_API_THREAD_CONFIG_CHANNEL_MASK;
     
     TRACE_DETAIL("channel page: %d", thread_tasklet_data_ptr->channel_list.channel_page);
-    TRACE_DETAIL("channel mask: %d", (int)thread_tasklet_data_ptr->channel_list.channel_mask[0]);
-          
+    TRACE_DETAIL("channel mask: 0x%.8lx", thread_tasklet_data_ptr->channel_list.channel_mask[0]);
+
     // PSKd
     const char PSKd[] = MBED_CONF_MBED_MESH_API_THREAD_PSKD;
     MBED_ASSERT(sizeof(PSKd) > 5 && sizeof(PSKd) < 33);


### PR DESCRIPTION
When specifying a full channel mask in .lib and setting the channel
to zero, device does proper channel scan.

For Thread, channel must be specified for router.
Sleepy devices don't respect the channel settings but do a full channel
scan at the start.

+ Modified the channel mask print to use hex.

Please review: @artokin @mikter 