### PR TITLE
lp_timer test : add a minimum delta value

### DIFF
--- a/TESTS/mbed_drivers/lp_timer/main.cpp
+++ b/TESTS/mbed_drivers/lp_timer/main.cpp
@@ -51,13 +51,17 @@ extern uint32_t SystemCoreClock;
  *   For K64F          DELTA = (80000 / 120000000) * 1000000 = 666[us]
  *   For NUCLEO_F070RB DELTA = (80000 /  48000000) * 1000000 = 1666[us]
  *   For NRF51_DK      DELTA = (80000 /  16000000) * 1000000 = 5000[us]
+ *
+ * As low power timer cannot be too much accurate, this DELTA should not be more precise than 500us,
+ * which corresponds to a maximum CPU clock around 130MHz
  */
 #define US_PER_SEC       1000000
 #define US_PER_MSEC      1000
 #define TOLERANCE_FACTOR 80000.0f
 #define US_FACTOR        1000000.0f
+#define CLOCK_MAX        130000000
 
-static const int delta_sys_clk_us = ((int) (TOLERANCE_FACTOR / (float) SystemCoreClock * US_FACTOR));
+static const int delta_sys_clk_us = (SystemCoreClock < CLOCK_MAX? ((int) (TOLERANCE_FACTOR / (float) SystemCoreClock * US_FACTOR)):((int) (TOLERANCE_FACTOR / (float) CLOCK_MAX * US_FACTOR)));
 
 /* When test performs time measurement using Timer in sequence, then measurement error accumulates
  * in the successive attempts. */


### PR DESCRIPTION
## Description

In tests-mbed_drivers-lp_timer, since low power timer is less accurate than regular timer,
there is a delta time based on CPU clock frequency.

For ex, STM32F7 has a system core clock set to 216MHz, then delta time is only 370us.
With the current formula, we think that this delta time is too aggressive for high frequency targets.

So we propose to set a kind of minimum delta time around 500us.

Thx

## Status

**READY**

