### PR TITLE
K64F Ethernet: avoid using NULL thread during init

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
@@ -140,7 +140,9 @@ static void k64f_tx_reclaim(struct k64f_enetdata *k64f_enet)
  */
 void enet_mac_rx_isr()
 {
-    osThreadFlagsSet(k64f_enetdata.thread, FLAG_RX);
+    if (k64f_enetdata.thread) {
+        osThreadFlagsSet(k64f_enetdata.thread, FLAG_RX);
+    }
 }
 
 void enet_mac_tx_isr()
@@ -755,6 +757,9 @@ err_t eth_arch_enetif_init(struct netif *netif)
 
   /* Worker thread */
   k64f_enetdata.thread = sys_thread_new("k64f_emac_thread", emac_thread, netif->state, THREAD_STACKSIZE, THREAD_PRIORITY)->id;
+
+  /* Trigger thread to deal with any RX packets that arrived before thread was started */
+  enet_mac_rx_isr();
 
   return ERR_OK;
 }


### PR DESCRIPTION
The K64F Ethernet driver installs an interrupt handler that sets thread
flags, and this could be called before the thread was initialised, so it
would use a NULL thread ID.

This triggers an RTX error-checking trap in debug builds, and could also
lead to other problems with received packets not being processed.

Adjusted so the RX interrupt handler does nothing if the thread isn't
initialised yet, and manually trigger a RX event flag after initialising
the thread in case any interrupts were ignored.

An alternative would have been to implement eth_arch_enable_interrupts,
but this mechanism is not present in the EMAC world - drivers will have
to start returning interrupts in their power up.

Fixes #5680
