### PR TITLE
Fix PR5578

### DIFF
--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -17,6 +17,7 @@
 #define MBED_CIRCULARBUFFER_H
 
 #include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 
 namespace mbed {
 


### PR DESCRIPTION
Fix #5578 by including the header file that introduces `MBED_STATIC_ASSERT` macro.
