### PR TITLE
Add tests for Watchdog HAL API

### DIFF
--- a/TESTS/host_tests/sync_on_reset.py
+++ b/TESTS/host_tests/sync_on_reset.py
@@ -1,0 +1,72 @@
+"""
+mbed SDK
+Copyright (c) 2017 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import time
+from mbed_host_tests import BaseHostTest
+
+DEFAULT_CYCLE_PERIOD = 4.0
+
+MSG_VALUE_DUMMY = '0'
+MSG_KEY_DEVICE_READY = 'ready'
+MSG_KEY_START_CASE = 'start_case'
+MSG_KEY_DEVICE_RESET = 'reset_on_case_teardown'
+MSG_KEY_SYNC = '__sync'
+
+
+class SyncOnReset(BaseHostTest):
+    """Host side test that handles device reset during case teardown.
+
+    Given a device that performs a reset during a test case teardown.
+    When the device notifies the host about the reset.
+    Then the host:
+    * keeps track of the test case index of the current test suite,
+    * performs a dev-host handshake,
+    * advances the test suite to next test case.
+
+    Note:
+    Developed for a watchdog test, so that it can be run on devices that
+    do not support watchdog timeout updates after the initial setup.
+    As a solution, after testing watchdog with one set of settings, the
+    device performs a reset and notifies the host with the test case number,
+    so that the test suite may be advanced once the device boots again.
+    """
+
+    def __init__(self):
+        super(SyncOnReset, self).__init__()
+        self.test_case_num = 0
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+
+    def setup(self):
+        self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
+        self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_device_reset)
+
+    def cb_device_ready(self, key, value, timestamp):
+        """Advance the device test suite to the next test case."""
+        self.send_kv(MSG_KEY_START_CASE, self.test_case_num)
+
+    def cb_device_reset(self, key, value, timestamp):
+        """Wait for the device to boot and perform a handshake.
+
+        Additionally, keep track of the last test case number.
+        """
+        try:
+            self.test_case_num = int(value)
+        except ValueError:
+            pass
+        self.test_case_num += 1
+        time.sleep(self.program_cycle_s)
+        self.send_kv(MSG_KEY_SYNC, MSG_VALUE_DUMMY)

--- a/TESTS/host_tests/watchdog_reset.py
+++ b/TESTS/host_tests/watchdog_reset.py
@@ -1,0 +1,96 @@
+"""
+mbed SDK
+Copyright (c) 2017 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+import collections
+import threading
+from mbed_host_tests import BaseHostTest
+
+TestCaseData = collections.namedtuple('TestCaseData', ['index', 'data_to_send'])
+
+DEFAULT_CYCLE_PERIOD = 4.0
+
+MSG_VALUE_DUMMY = '0'
+CASE_DATA_INVALID = 0xffffffff
+CASE_DATA_PHASE2_OK = 0xfffffffe
+
+MSG_KEY_SYNC = '__sync'
+MSG_KEY_DEVICE_READY = 'ready'
+MSG_KEY_START_CASE = 'start_case'
+MSG_KEY_DEVICE_RESET = 'dev_reset'
+
+
+class WatchdogReset(BaseHostTest):
+    """Host side test that handles device reset.
+
+    Given a device with a watchdog timer started.
+    When the device notifies the host about an incoming reset.
+    Then the host:
+    * keeps track of the test case index of the current test suite,
+    * performs a dev-host handshake.
+    """
+
+    def __init__(self):
+        super(WatchdogReset, self).__init__()
+        self.current_case = TestCaseData(0, CASE_DATA_INVALID)
+        self.__handshake_timer = None
+        cycle_s = self.get_config_item('program_cycle_s')
+        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
+
+    def handshake_timer_start(self, seconds=1.0):
+        """Start a new handshake timer.
+
+        Perform a dev-host handshake by sending a sync message.
+        """
+        self.__handshake_timer = threading.Timer(seconds, self.send_kv,
+                                                 [MSG_KEY_SYNC, MSG_VALUE_DUMMY])
+        self.__handshake_timer.start()
+
+    def handshake_timer_cancel(self):
+        """Cancel the current handshake timer."""
+        try:
+            self.__handshake_timer.cancel()
+        except AttributeError:
+            pass
+        finally:
+            self.__handshake_timer = None
+
+    def setup(self):
+        self.register_callback(MSG_KEY_DEVICE_READY, self.cb_device_ready)
+        self.register_callback(MSG_KEY_DEVICE_RESET, self.cb_device_reset)
+
+    def teardown(self):
+        self.handshake_timer_cancel()
+
+    def cb_device_ready(self, key, value, timestamp):
+        """Advance the device test suite to a proper test case.
+
+        Additionally, send test case data to the device.
+        """
+        self.handshake_timer_cancel()
+        msg_value = '{0.index:02x},{0.data_to_send:08x}'.format(self.current_case)
+        self.send_kv(MSG_KEY_START_CASE, msg_value)
+
+    def cb_device_reset(self, key, value, timestamp):
+        """Keep track of the test case number.
+
+        Also set a new handshake timeout, so when the device gets
+        restarted by the watchdog, the communication will be restored
+        by the __handshake_timer.
+        """
+        self.handshake_timer_cancel()
+        case_num, dev_reset_delay_ms = (int(i, base=16) for i in value.split(','))
+        self.current_case = TestCaseData(case_num, CASE_DATA_PHASE2_OK)
+        self.handshake_timer_start(self.program_cycle_s + dev_reset_delay_ms / 1000.0)

--- a/TESTS/mbed_drivers/watchdog/Watchdog_tests.h
+++ b/TESTS/mbed_drivers/watchdog/Watchdog_tests.h
@@ -1,0 +1,108 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @addtogroup drivers_watchdog_tests
+ * @{
+ */
+
+#ifndef MBED_DRIVERS_WATCHDOG_TESTS_H
+#define MBED_DRIVERS_WATCHDOG_TESTS_H
+
+#if DEVICE_WATCHDOG
+
+/** Test max_timeout is valid
+ *
+ * Given a device supporting Watchdog driver API
+ * When @a Watchdog::max_timeout() is called
+ * Then the returned value is greater than 1
+ */
+void test_max_timeout_is_valid();
+
+/** Test watchdog can be stopped
+ *
+ * Given a platform with a support for disabling a running watchdog
+ * When watchdog is not running and @a Watchdog::stop() is called
+ * Then WATCHDOG_STATUS_OK is returned
+ * When watchdog is running
+ *     and @a Watchdog::stop() is called before timeout
+ * Then WATCHDOG_STATUS_OK is returned
+ *     and watchdog does not reset the device
+ * When watchdog has already been stopped and @a Watchdog::stop() is called
+ * Then WATCHDOG_STATUS_OK is returned
+ */
+void test_stop();
+
+/** Test restart watchdog multiple times
+ *
+ * Given @a max_timeout value returned by @a Watchdog::max_timeout()
+ *     and @a Watchdog::start() called multiple times
+ * When @a timeout is set to max_timeout - delta
+ * Then return value of @a Watchdog::start() is @a WATCHDOG_STATUS_OK
+ *     and @a Watchdog::reload_value() returns max_timeout - delta
+ * When @a timeout is set to max_timeout
+ * Then return value of @a Watchdog::start() is @a WATCHDOG_STATUS_OK
+ *     and @a Watchdog::reload_value() returns max_timeout
+ * When @a timeout is set to max_timeout + delta
+ * Then return value of @a Watchdog::start() is @a WATCHDOG_STATUS_INVALID_ARGUMENT
+ *     and @a Watchdog::reload_value() returns previously set value (max_timeout)
+ * When @a timeout is set to 0
+ * Then return value of @a Watchdog::start() is @a WATCHDOG_STATUS_INVALID_ARGUMENT
+ *     and @a Watchdog::reload_value() returns previously set value (max_timeout)
+ */
+void test_restart();
+
+/** Test start with 0 ms
+ *
+ * Given a device supporting Watchdog driver API
+ * When @a timeout is set to 0 ms
+ * Then return value of Watchdog::start() is @a WATCHDOG_STATUS_INVALID_ARGUMENT
+ */
+void test_start_zero();
+
+/** Test start with a valid config
+ *
+ * Given a device supporting Watchdog driver API
+ * When @a timeout is set to value X within platform's timeout range
+ * Then return value of Watchdog::start() is @a WATCHDOG_STATUS_OK
+ *     and @a Watchdog::reload_value() returns X
+ */
+template<uint32_t timeout_ms>
+void test_start();
+
+/** Test start with a max_timeout
+ *
+ * Given @a max_timeout value returned by @a Watchdog::max_timeout()
+ * When @a timeout is set to max_timeout
+ * Then return value of Watchdog::start() is @a WATCHDOG_STATUS_OK
+ *     and @a Watchdog::reload_value() returns max_timeout
+ */
+void test_start_max_timeout();
+
+/** Test start with a timeout value exceeding max_timeout
+ *
+ * Given a device supporting Watchdog driver API
+ * When @a timeout is set to max_timeout + 1
+ * Then return value of Watchdog::start() is @a WATCHDOG_STATUS_INVALID_ARGUMENT
+ */
+void test_start_max_timeout_exceeded();
+
+#endif
+
+#endif
+
+/** @}*/
+

--- a/TESTS/mbed_drivers/watchdog/main.cpp
+++ b/TESTS/mbed_drivers/watchdog/main.cpp
@@ -1,0 +1,221 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !DEVICE_WATCHDOG
+#error [NOT_SUPPORTED] Watchdog not supported for this target
+#endif
+
+#define __STDC_LIMIT_MACROS
+#include <stdint.h>
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "drivers/Watchdog.h"
+#include "Watchdog_tests.h"
+
+/* This is platform specific and depends on the watchdog timer implementation,
+ * e.g. STM32F4 uses 32kHz internal RC oscillator to clock the IWDG, so
+ * when the prescaler divider is set to max value of 256 the resolution
+ * drops to 8 ms.
+ */
+#define WORST_TIMEOUT_RESOLUTION_MS 8UL
+
+#define TIMEOUT_DELTA_MS (WORST_TIMEOUT_RESOLUTION_MS)
+#define WDG_TIMEOUT_MS 500UL
+
+#define MSG_VALUE_DUMMY "0"
+#define MSG_VALUE_LEN 24
+#define MSG_KEY_LEN 24
+
+#define MSG_KEY_DEVICE_READY "ready"
+#define MSG_KEY_START_CASE "start_case"
+#define MSG_KEY_DEVICE_RESET "reset_on_case_teardown"
+
+int CASE_INDEX_START;
+int CASE_INDEX_CURRENT;
+
+using utest::v1::Case;
+using utest::v1::Specification;
+using utest::v1::Harness;
+
+void test_max_timeout_is_valid()
+{
+    Watchdog watchdog;
+    TEST_ASSERT(watchdog.max_timeout() > 1UL);
+}
+
+void test_stop()
+{
+    Watchdog watchdog;
+    if (watchdog.stop() == WATCHDOG_STATUS_NOT_SUPPORTED) {
+        TEST_IGNORE_MESSAGE("Disabling watchdog not supported for this platform");
+        return;
+    }
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.stop());
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(WDG_TIMEOUT_MS));
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.stop());
+    // Make sure that a disabled watchdog does not reset the core.
+    wait_ms(WDG_TIMEOUT_MS + TIMEOUT_DELTA_MS);
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.stop());
+}
+
+void test_restart()
+{
+    Watchdog watchdog;
+    watchdog.start(watchdog.max_timeout());
+    uint64_t timeout = watchdog.max_timeout() - 2ULL * WORST_TIMEOUT_RESOLUTION_MS;
+    watchdog_status_t status = watchdog.start(timeout);
+
+    if (status == WATCHDOG_STATUS_NOT_SUPPORTED) {
+        TEST_IGNORE_MESSAGE("Updating watchdog config not supported for this platform");
+        return;
+    }
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, status);
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, timeout, watchdog.reload_value());
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(watchdog.max_timeout()));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, watchdog.max_timeout(), watchdog.reload_value());
+
+    timeout = watchdog.max_timeout() + 2ULL * WORST_TIMEOUT_RESOLUTION_MS;
+    // Make sure requested timeout does not overflow uint32_t.
+    if (timeout <= UINT32_MAX) {
+        TEST_ASSERT_EQUAL(WATCHDOG_STATUS_INVALID_ARGUMENT, watchdog.start(timeout));
+        TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, watchdog.max_timeout(), watchdog.reload_value());
+    }
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_INVALID_ARGUMENT, watchdog.start(0UL));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, watchdog.max_timeout(), watchdog.reload_value());
+}
+
+utest::v1::status_t case_setup_sync_on_reset(const Case * const source, const size_t index_of_case)
+{
+    CASE_INDEX_CURRENT = index_of_case;
+    return utest::v1::greentea_case_setup_handler(source, index_of_case);
+}
+
+utest::v1::status_t case_teardown_sync_on_reset(const Case * const source, const size_t passed, const size_t failed,
+        const utest::v1::failure_t failure)
+{
+    utest::v1::status_t status = utest::v1::greentea_case_teardown_handler(source, passed, failed, failure);
+    if (failed) {
+        /* Return immediately and skip the device reset, if the test case failed.
+         * Provided that the device won't be restarted by other means (i.e. watchdog timer),
+         * this should allow the test suite to finish in a defined manner
+         * and report failure to host.
+         * In case of watchdog reset during test suite teardown, the loss of serial
+         * connection is possible, so the host-test-runner may return 'TIMEOUT'
+         * instead of 'FAIL'.
+         */
+        return status;
+    }
+    greentea_send_kv(MSG_KEY_DEVICE_RESET, CASE_INDEX_START + CASE_INDEX_CURRENT);
+    utest_printf("The device will now restart.\n");
+    wait_ms(10); // Wait for the serial buffers to flush.
+    NVIC_SystemReset();
+    return status; // Reset is instant so this line won't be reached.
+}
+
+void test_start_zero()
+{
+    Watchdog watchdog;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_INVALID_ARGUMENT, watchdog.start(0UL));
+}
+
+template<uint32_t timeout_ms>
+void test_start()
+{
+    Watchdog watchdog;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(timeout_ms));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, timeout_ms, watchdog.reload_value());
+}
+
+void test_start_max_timeout()
+{
+    Watchdog watchdog;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(watchdog.max_timeout()));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, watchdog.max_timeout(), watchdog.reload_value());
+}
+
+void test_start_max_timeout_exceeded()
+{
+    Watchdog watchdog;
+    uint64_t timeout = watchdog.max_timeout() + 2ULL * WORST_TIMEOUT_RESOLUTION_MS;
+    // Make sure requested timeout does not overflow uint32_t.
+    if (timeout > UINT32_MAX) {
+        TEST_IGNORE_MESSAGE("Requested timeout overflows uint32_t -- ignoring test case.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_INVALID_ARGUMENT, watchdog.start(timeout));
+}
+
+int testsuite_setup_sync_on_reset(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(45, "sync_on_reset");
+    utest::v1::status_t status = utest::v1::greentea_test_setup_handler(number_of_cases);
+    if (status != utest::v1::STATUS_CONTINUE) {
+        return status;
+    }
+
+    char key[MSG_KEY_LEN + 1] = { };
+    char value[MSG_VALUE_LEN + 1] = { };
+
+    greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    greentea_parse_kv(key, value, MSG_KEY_LEN, MSG_VALUE_LEN);
+
+    if (strcmp(key, MSG_KEY_START_CASE) != 0) {
+        utest_printf("Invalid message key.\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    char *tailptr = NULL;
+    CASE_INDEX_START = (int) strtol(value, &tailptr, 10);
+    if (*tailptr != '\0' || CASE_INDEX_START < 0) {
+        utest_printf("Invalid start case index received from host\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    utest_printf("Starting with test case index %i of all %i defined test cases.\n", CASE_INDEX_START, number_of_cases);
+    return CASE_INDEX_START;
+}
+
+Case cases[] = {
+    Case("max_timeout is valid", test_max_timeout_is_valid),
+    Case("Stop", test_stop),
+    Case("Restart multiple times", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_restart, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+
+    // Do not set watchdog timeout shorter than 500 ms as it may cause the
+    // host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
+    // performs reset during test suite teardown.
+    Case("Start, 500 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_start<500UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+    Case("Start, max_timeout", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_start_max_timeout, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+
+    Case("Start, 0 ms", test_start_zero),
+    Case("Start, max_timeout exceeded", test_start_max_timeout_exceeded),
+};
+
+Specification specification((utest::v1::test_setup_handler_t) testsuite_setup_sync_on_reset, cases);
+
+int main()
+{
+    // Harness will start with a test case index provided by host script.
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_drivers/watchdog_reset/Watchdog_reset_tests.h
+++ b/TESTS/mbed_drivers/watchdog_reset/Watchdog_reset_tests.h
@@ -1,0 +1,77 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @addtogroup drivers_watchdog_tests
+ * @{
+ */
+
+#ifndef MBED_DRIVERS_WATCHDOG_RESET_TESTS_H
+#define MBED_DRIVERS_WATCHDOG_RESET_TESTS_H
+
+#if DEVICE_WATCHDOG
+
+/** Test watchdog reset
+ *
+ * Given a device with a watchdog started
+ * When a watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_simple_reset();
+
+/** Test watchdog reset in sleep mode
+ *
+ * Given a device supporting sleep mode, with a watchdog started
+ * When the device is in sleep mode and watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_sleep_reset();
+
+/** Test watchdog reset in deepsleep mode
+ *
+ * Given a device supporting deepsleep mode, with watchdog started
+ * When the device is in deepsleep mode and watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_deepsleep_reset();
+
+/** Test stopped watchdog can be started again and reset the device
+ *
+ * Given a device supporting 'disable_watchdog' feature, with watchdog started
+ * When the watchdog is stopped before timeout expires
+ * Then the device is not restarted
+ * When the watchdog is started again and it's timeout expires
+ * Then the device is restarted
+ */
+void test_restart_reset();
+
+/** Test kicking the watchdog prevents reset
+ *
+ * Given a device with watchdog started
+ * When the watchdog is kicked before timeout expires
+ * Then the device restart is prevented
+ * When the watchdog is *NOT* kicked again before next timeout expires
+ * Then the device is restarted
+ *
+ */
+void test_kick_reset();
+
+#endif
+
+#endif
+
+/** @}*/
+

--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -1,0 +1,285 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !DEVICE_WATCHDOG
+#error [NOT_SUPPORTED] Watchdog not supported for this target
+#endif
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "drivers/Watchdog.h"
+#include "Watchdog_reset_tests.h"
+#include "mbed.h"
+
+#define TIMEOUT_MS 500UL
+#define TIMEOUT_DELTA_MS 50UL
+
+#define MSG_VALUE_DUMMY "0"
+#define CASE_DATA_INVALID 0xffffffffUL
+#define CASE_DATA_PHASE2_OK 0xfffffffeUL
+
+#define MSG_VALUE_LEN 24
+#define MSG_KEY_LEN 24
+
+#define MSG_KEY_DEVICE_READY "ready"
+#define MSG_KEY_START_CASE "start_case"
+#define MSG_KEY_DEVICE_RESET "dev_reset"
+
+using utest::v1::Case;
+using utest::v1::Specification;
+using utest::v1::Harness;
+
+struct testcase_data {
+    int index;
+    int start_index;
+    uint32_t received_data;
+};
+
+void release_sem(Semaphore *sem)
+{
+    sem->release();
+}
+
+testcase_data current_case;
+
+bool send_reset_notification(testcase_data * tcdata, uint32_t delay_ms)
+{
+    char msg_value[12];
+    int str_len = snprintf(msg_value, sizeof msg_value, "%02x,%08lx", tcdata->start_index + tcdata->index, delay_ms);
+    if (str_len != (sizeof msg_value) - 1) {
+        utest_printf("Failed to compose a value string to be sent to host.");
+        return false;
+    }
+    greentea_send_kv(MSG_KEY_DEVICE_RESET, msg_value);
+    return true;
+}
+
+void test_simple_reset()
+{
+    // Phase 2. -- verify the test results.
+    // Verify if this test case passed based on data received from host.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    // Init the watchdog and wait for a device reset.
+    Watchdog watchdog;
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during wait_ms() above;
+
+    watchdog.kick(); // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+#if DEVICE_SLEEP
+void test_sleep_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    Watchdog watchdog;
+    Semaphore sem(0, 1);
+    Timeout timeout;
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    sleep_manager_lock_deep_sleep();
+    timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (TIMEOUT_MS + TIMEOUT_DELTA_MS));
+    if (sleep_manager_can_deep_sleep()) {
+        TEST_ASSERT_MESSAGE(0, "Deepsleep should be disallowed.");
+        return;
+    }
+    while (sem.wait(0) != 1) {
+        sleep(); // Device reset expected.
+    }
+    sleep_manager_unlock_deep_sleep();
+
+    // Watchdog reset should have occurred during sleep() above;
+
+    watchdog.kick(); // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+#if DEVICE_LOWPOWERTIMER
+void test_deepsleep_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    Watchdog watchdog;
+    Semaphore sem(0, 1);
+    LowPowerTimeout lp_timeout;
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    lp_timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (TIMEOUT_MS + TIMEOUT_DELTA_MS));
+    wait_ms(10); // Wait for the serial buffers to flush.
+    if (!sleep_manager_can_deep_sleep()) {
+        TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
+    }
+    while (sem.wait(0) != 1) {
+        sleep(); // Device reset expected.
+    }
+
+    // Watchdog reset should have occurred during that sleep() above;
+
+    watchdog.kick(); // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+#endif
+#endif
+
+void test_restart_reset()
+{
+    Watchdog watchdog;
+    if (watchdog.stop() == WATCHDOG_STATUS_NOT_SUPPORTED) {
+        TEST_IGNORE_MESSAGE("Disabling watchdog not supported for this platform");
+        return;
+    }
+
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    wait_ms(TIMEOUT_MS / 2UL);
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.stop());
+    // Check that stopping the watchdog prevents a device reset.
+    wait_ms(TIMEOUT_MS / 2UL + TIMEOUT_DELTA_MS);
+
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during that wait() above;
+
+    watchdog.kick(); // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+void test_kick_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    Watchdog watchdog;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, watchdog.start(TIMEOUT_MS));
+    for (int i = 3; i; i--) {
+        wait_ms(TIMEOUT_MS / 2UL);
+        watchdog.kick();
+    }
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during that wait() above;
+
+    watchdog.kick(); // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+utest::v1::status_t case_setup(const Case * const source, const size_t index_of_case)
+{
+    current_case.index = index_of_case;
+    return utest::v1::greentea_case_setup_handler(source, index_of_case);
+}
+
+int testsuite_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(90, "watchdog_reset");
+    utest::v1::status_t status = utest::v1::greentea_test_setup_handler(number_of_cases);
+    if (status != utest::v1::STATUS_CONTINUE) {
+        return status;
+    }
+
+    char key[MSG_KEY_LEN + 1] = { };
+    char value[MSG_VALUE_LEN + 1] = { };
+
+    greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    greentea_parse_kv(key, value, MSG_KEY_LEN, MSG_VALUE_LEN);
+
+    if (strcmp(key, MSG_KEY_START_CASE) != 0) {
+        utest_printf("Invalid message key.\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    int num_args = sscanf(value, "%02x,%08lx", &(current_case.start_index), &(current_case.received_data));
+    if (num_args == 0 || num_args == EOF) {
+        utest_printf("Invalid data received from host\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    utest_printf("This test suite is composed of %i test cases. Starting at index %i.\n", number_of_cases,
+            current_case.start_index);
+    return current_case.start_index;
+}
+
+Case cases[] = {
+    Case("Watchdog reset", case_setup, test_simple_reset),
+#if DEVICE_SLEEP
+    Case("Watchdog reset in sleep mode", case_setup, test_sleep_reset),
+#if DEVICE_LOWPOWERTIMER
+    Case("Watchdog reset in deepsleep mode", case_setup, test_deepsleep_reset),
+#endif
+#endif
+    Case("Watchdog started again", case_setup, test_restart_reset),
+    Case("Kicking the watchdog prevents reset", case_setup, test_kick_reset),
+};
+
+Specification specification((utest::v1::test_setup_handler_t) testsuite_setup, cases);
+
+int main()
+{
+    // Harness will start with a test case index provided by host script.
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_hal/watchdog/main.cpp
+++ b/TESTS/mbed_hal/watchdog/main.cpp
@@ -1,0 +1,219 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !DEVICE_WATCHDOG
+#error [NOT_SUPPORTED] Watchdog not supported for this target
+#endif
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "hal/watchdog_api.h"
+#include "watchdog_api_tests.h"
+
+/* This is platform specific and depends on the watchdog timer implementation,
+ * e.g. STM32F4 uses 32kHz internal RC oscillator to clock the IWDG, so
+ * when the prescaler divider is set to max value of 256 the resolution
+ * drops to 8 ms.
+ */
+#define WORST_TIMEOUT_RESOLUTION_MS 8UL
+
+#define TIMEOUT_DELTA_MS (WORST_TIMEOUT_RESOLUTION_MS)
+#define WDG_TIMEOUT_MS 500UL
+
+#define MSG_VALUE_DUMMY "0"
+#define MSG_VALUE_LEN 24
+#define MSG_KEY_LEN 24
+
+#define MSG_KEY_DEVICE_READY "ready"
+#define MSG_KEY_START_CASE "start_case"
+#define MSG_KEY_DEVICE_RESET "reset_on_case_teardown"
+
+int CASE_INDEX_START;
+int CASE_INDEX_CURRENT;
+
+using utest::v1::Case;
+using utest::v1::Specification;
+using utest::v1::Harness;
+
+const watchdog_config_t WDG_CONFIG_DEFAULT = { .timeout_ms = WDG_TIMEOUT_MS };
+
+void test_max_timeout_is_valid()
+{
+    TEST_ASSERT(hal_watchdog_get_platform_features().max_timeout > 1UL);
+}
+
+void test_restart_is_possible()
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (!features.disable_watchdog) {
+        TEST_IGNORE_MESSAGE("Disabling watchdog not supported for this platform");
+        return;
+    }
+    TEST_ASSERT(features.update_config);
+}
+
+void test_stop()
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (!features.disable_watchdog) {
+        TEST_ASSERT_EQUAL(WATCHDOG_STATUS_NOT_SUPPORTED, hal_watchdog_stop());
+        TEST_IGNORE_MESSAGE("Disabling watchdog not supported for this platform");
+        return;
+    }
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_stop());
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&WDG_CONFIG_DEFAULT));
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_stop());
+    // Make sure that a disabled watchdog does not reset the core.
+    wait_ms(WDG_TIMEOUT_MS + TIMEOUT_DELTA_MS);
+
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_stop());
+}
+
+void test_update_config()
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (!features.update_config) {
+        TEST_IGNORE_MESSAGE("Updating watchdog config not supported for this platform");
+        return;
+    }
+
+    watchdog_config_t config = WDG_CONFIG_DEFAULT;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, config.timeout_ms, hal_watchdog_get_reload_value());
+
+    config.timeout_ms = features.max_timeout - 2 * WORST_TIMEOUT_RESOLUTION_MS;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, config.timeout_ms, hal_watchdog_get_reload_value());
+
+    config.timeout_ms = features.max_timeout;
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, config.timeout_ms, hal_watchdog_get_reload_value());
+}
+
+utest::v1::status_t case_setup_sync_on_reset(const Case * const source, const size_t index_of_case)
+{
+    CASE_INDEX_CURRENT = index_of_case;
+    return utest::v1::greentea_case_setup_handler(source, index_of_case);
+}
+
+utest::v1::status_t case_teardown_sync_on_reset(const Case * const source, const size_t passed, const size_t failed,
+        const utest::v1::failure_t failure)
+{
+    utest::v1::status_t status = utest::v1::greentea_case_teardown_handler(source, passed, failed, failure);
+    if (failed) {
+        /* Return immediately and skip the device reset, if the test case failed.
+         * Provided that the device won't be restarted by other means (i.e. watchdog timer),
+         * this should allow the test suite to finish in a defined manner
+         * and report failure to host.
+         * In case of watchdog reset during test suite teardown, the loss of serial
+         * connection is possible, so the host-test-runner may return 'TIMEOUT'
+         * instead of 'FAIL'.
+         */
+        return status;
+    }
+    greentea_send_kv(MSG_KEY_DEVICE_RESET, CASE_INDEX_START + CASE_INDEX_CURRENT);
+    utest_printf("The device will now restart.\n");
+    wait_ms(10); // Wait for the serial buffers to flush.
+    NVIC_SystemReset();
+    return status; // Reset is instant so this line won't be reached.
+}
+
+utest::v1::status_t case_teardown_wdg_stop_or_reset(const Case * const source, const size_t passed, const size_t failed,
+        const utest::v1::failure_t failure)
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (features.disable_watchdog) {
+        hal_watchdog_stop();
+        return utest::v1::greentea_case_teardown_handler(source, passed, failed, failure);
+    }
+
+    return case_teardown_sync_on_reset(source, passed, failed, failure);
+}
+
+template<uint32_t timeout_ms>
+void test_init()
+{
+    watchdog_config_t config = { timeout_ms };
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, timeout_ms, hal_watchdog_get_reload_value());
+}
+
+void test_init_max_timeout()
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    watchdog_config_t config = { .timeout_ms = features.max_timeout };
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    TEST_ASSERT_UINT32_WITHIN(WORST_TIMEOUT_RESOLUTION_MS, features.max_timeout, hal_watchdog_get_reload_value());
+}
+
+int testsuite_setup_sync_on_reset(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(45, "sync_on_reset");
+    utest::v1::status_t status = utest::v1::greentea_test_setup_handler(number_of_cases);
+    if (status != utest::v1::STATUS_CONTINUE) {
+        return status;
+    }
+
+    char key[MSG_KEY_LEN + 1] = { };
+    char value[MSG_VALUE_LEN + 1] = { };
+
+    greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    greentea_parse_kv(key, value, MSG_KEY_LEN, MSG_VALUE_LEN);
+
+    if (strcmp(key, MSG_KEY_START_CASE) != 0) {
+        utest_printf("Invalid message key.\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    char *tailptr = NULL;
+    CASE_INDEX_START = (int) strtol(value, &tailptr, 10);
+    if (*tailptr != '\0' || CASE_INDEX_START < 0) {
+        utest_printf("Invalid start case index received from host\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    utest_printf("Starting with test case index %i of all %i defined test cases.\n", CASE_INDEX_START, number_of_cases);
+    return CASE_INDEX_START;
+}
+
+Case cases[] = {
+    Case("Platform feature max_timeout is valid", test_max_timeout_is_valid),
+    Case("Stopped watchdog can be started again", test_restart_is_possible),
+    Case("Watchdog can be stopped", test_stop),
+
+    Case("Update config with multiple init calls",
+        (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_update_config,
+        (utest::v1::case_teardown_handler_t) case_teardown_wdg_stop_or_reset),
+
+    // Do not set watchdog timeout shorter than 500 ms as it may cause the
+    // host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
+    // performs reset during test suite teardown.
+    Case("Init, 500 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_init<500UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+    Case("Init, max_timeout", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_init_max_timeout, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+};
+
+Specification specification((utest::v1::test_setup_handler_t) testsuite_setup_sync_on_reset, cases);
+
+int main()
+{
+    // Harness will start with a test case index provided by host script.
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_hal/watchdog/watchdog_api_tests.h
+++ b/TESTS/mbed_hal/watchdog/watchdog_api_tests.h
@@ -1,0 +1,101 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @addtogroup hal_watchdog_tests
+ * @{
+ */
+
+#ifndef MBED_HAL_WATCHDOG_API_TESTS_H
+#define MBED_HAL_WATCHDOG_API_TESTS_H
+
+#if DEVICE_WATCHDOG
+
+/** Test max_timeout is valid
+ *
+ * Given a device supporting watchdog HAL API
+ * When @a hal_watchdog_get_platform_features() is called
+ * Then max_timeout member of returned watchdog_features_t struct is greater than 1
+ */
+void test_max_timeout_is_valid();
+
+/** Test stopped watchdog can be started again
+ *
+ * Given a device supporting watchdog HAL API
+ * When the device supports the @a disable_watchdog feature
+ * Then the device also supports @a update_config feature
+ */
+void test_restart_is_possible();
+
+/** Test watchdog can be stopped
+ *
+ * Given a device without a support for the @a disable_watchdog feature
+ * When @a hal_watchdog_stop() is called
+ * Then WATCHDOG_STATUS_NOT_SUPPORTED is returned
+ *
+ * Given a device supporting @a disable_watchdog feature
+ * When watchdog is not running and @a hal_watchdog_stop() is called
+ * Then WATCHDOG_STATUS_OK is returned
+ * When watchdog is running
+ *     and @a hal_watchdog_stop() is called before timeout
+ * Then WATCHDOG_STATUS_OK is returned
+ *     and watchdog does not reset the device
+ * When watchdog has already been stopped and @a hal_watchdog_stop() is called
+ * Then WATCHDOG_STATUS_OK is returned
+ */
+void test_stop();
+
+/** Test update config with multiple init calls
+ *
+ * Given @a max_timeout value returned by @a hal_watchdog_get_platform_features()
+ *     and @a hal_watchdog_init() called multiple times with same @a config
+ * When @a config.timeout_ms is set to WDG_CONFIG_DEFAULT
+ * Then return value of hal_watchdog_init() is @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns WDG_CONFIG_DEFAULT
+ * When @a config.timeout_ms is set to max_timeout-delta
+ * Then return value of hal_watchdog_init() is @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns max_timeout-delta
+ * When @a config.timeout_ms is set to max_timeout
+ * Then return value of hal_watchdog_init() is @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns max_timeout
+ */
+void test_update_config();
+
+/** Test init with a valid config
+ *
+ * Given a device supporting watchdog HAL API
+ * When @a config.timeout_ms is set to value X within platform's timeout range
+ * Then return value of hal_watchdog_init() is @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns X
+ */
+template<uint32_t timeout_ms>
+void test_init();
+
+/** Test init with a max_timeout
+ *
+ * Given @a max_timeout value returned by @a hal_watchdog_get_platform_features()
+ * When @a config.timeout_ms is set to max_timeout
+ * Then return value of hal_watchdog_init() is @a WATCHDOG_STATUS_OK
+ *     and @a hal_watchdog_get_reload_value() returns max_timeout
+ */
+void test_init_max_timeout();
+
+#endif
+
+#endif
+
+/** @}*/
+

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -1,0 +1,286 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !DEVICE_WATCHDOG
+#error [NOT_SUPPORTED] Watchdog not supported for this target
+#endif
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "hal/watchdog_api.h"
+#include "watchdog_reset_tests.h"
+#include "mbed.h"
+
+#define TIMEOUT_MS 500UL
+#define TIMEOUT_DELTA_MS 50UL
+
+#define MSG_VALUE_DUMMY "0"
+#define CASE_DATA_INVALID 0xffffffffUL
+#define CASE_DATA_PHASE2_OK 0xfffffffeUL
+
+#define MSG_VALUE_LEN 24
+#define MSG_KEY_LEN 24
+
+#define MSG_KEY_DEVICE_READY "ready"
+#define MSG_KEY_START_CASE "start_case"
+#define MSG_KEY_DEVICE_RESET "dev_reset"
+
+using utest::v1::Case;
+using utest::v1::Specification;
+using utest::v1::Harness;
+
+struct testcase_data {
+    int index;
+    int start_index;
+    uint32_t received_data;
+};
+
+void release_sem(Semaphore *sem)
+{
+    sem->release();
+}
+
+testcase_data current_case;
+
+bool send_reset_notification(testcase_data * tcdata, uint32_t delay_ms)
+{
+    char msg_value[12];
+    int str_len = snprintf(msg_value, sizeof msg_value, "%02x,%08lx", tcdata->start_index + tcdata->index, delay_ms);
+    if (str_len != (sizeof msg_value) - 1) {
+        utest_printf("Failed to compose a value string to be sent to host.");
+        return false;
+    }
+    greentea_send_kv(MSG_KEY_DEVICE_RESET, msg_value);
+    return true;
+}
+
+void test_simple_reset()
+{
+    // Phase 2. -- verify the test results.
+    // Verify if this test case passed based on data received from host.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    // Init the watchdog and wait for a device reset.
+    watchdog_config_t config = { TIMEOUT_MS };
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during wait_ms() above;
+
+    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+#if DEVICE_SLEEP
+void test_sleep_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    watchdog_config_t config = { TIMEOUT_MS };
+    Semaphore sem(0, 1);
+    Timeout timeout;
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    sleep_manager_lock_deep_sleep();
+    timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (TIMEOUT_MS + TIMEOUT_DELTA_MS));
+    if (sleep_manager_can_deep_sleep()) {
+        TEST_ASSERT_MESSAGE(0, "Deepsleep should be disallowed.");
+        return;
+    }
+    while (sem.wait(0) != 1) {
+        sleep(); // Device reset expected.
+    }
+    sleep_manager_unlock_deep_sleep();
+
+    // Watchdog reset should have occurred during sleep() above;
+
+    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+#if DEVICE_LOWPOWERTIMER
+void test_deepsleep_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    watchdog_config_t config = { TIMEOUT_MS };
+    Semaphore sem(0, 1);
+    LowPowerTimeout lp_timeout;
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    lp_timeout.attach_us(mbed::callback(release_sem, &sem), 1000ULL * (TIMEOUT_MS + TIMEOUT_DELTA_MS));
+    wait_ms(10); // Wait for the serial buffers to flush.
+    if (!sleep_manager_can_deep_sleep()) {
+        TEST_ASSERT_MESSAGE(0, "Deepsleep should be allowed.");
+    }
+    while (sem.wait(0) != 1) {
+        sleep(); // Device reset expected.
+    }
+
+    // Watchdog reset should have occurred during that sleep() above;
+
+    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+#endif
+#endif
+
+void test_restart_reset()
+{
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (!features.disable_watchdog) {
+        TEST_IGNORE_MESSAGE("Disabling watchdog not supported for this platform");
+        return;
+    }
+
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    watchdog_config_t config = { TIMEOUT_MS };
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    wait_ms(TIMEOUT_MS / 2UL);
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_stop());
+    // Check that stopping the watchdog prevents a device reset.
+    wait_ms(TIMEOUT_MS / 2UL + TIMEOUT_DELTA_MS);
+
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during that wait() above;
+
+    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+void test_kick_reset()
+{
+    // Phase 2. -- verify the test results.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_EQUAL(CASE_DATA_PHASE2_OK, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    watchdog_config_t config = { TIMEOUT_MS };
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    for (int i = 3; i; i--) {
+        wait_ms(TIMEOUT_MS / 2UL);
+        hal_watchdog_kick();
+    }
+    if (send_reset_notification(&current_case, TIMEOUT_MS + TIMEOUT_DELTA_MS) == false) {
+        TEST_ASSERT_MESSAGE(0, "Dev-host communication error.");
+        return;
+    }
+    wait_ms(TIMEOUT_MS + TIMEOUT_DELTA_MS); // Device reset expected.
+
+    // Watchdog reset should have occurred during that wait() above;
+
+    hal_watchdog_kick();  // Just to buy some time for testsuite failure handling.
+    TEST_ASSERT_MESSAGE(0, "Watchdog did not reset the device as expected.");
+}
+
+utest::v1::status_t case_setup(const Case * const source, const size_t index_of_case)
+{
+    current_case.index = index_of_case;
+    return utest::v1::greentea_case_setup_handler(source, index_of_case);
+}
+
+int testsuite_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(90, "watchdog_reset");
+    utest::v1::status_t status = utest::v1::greentea_test_setup_handler(number_of_cases);
+    if (status != utest::v1::STATUS_CONTINUE) {
+        return status;
+    }
+
+    char key[MSG_KEY_LEN + 1] = { };
+    char value[MSG_VALUE_LEN + 1] = { };
+
+    greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    greentea_parse_kv(key, value, MSG_KEY_LEN, MSG_VALUE_LEN);
+
+    if (strcmp(key, MSG_KEY_START_CASE) != 0) {
+        utest_printf("Invalid message key.\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    int num_args = sscanf(value, "%02x,%08lx", &(current_case.start_index), &(current_case.received_data));
+    if (num_args == 0 || num_args == EOF) {
+        utest_printf("Invalid data received from host\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    utest_printf("This test suite is composed of %i test cases. Starting at index %i.\n", number_of_cases,
+            current_case.start_index);
+    return current_case.start_index;
+}
+
+Case cases[] = {
+    Case("Watchdog reset", case_setup, test_simple_reset),
+#if DEVICE_SLEEP
+    Case("Watchdog reset in sleep mode", case_setup, test_sleep_reset),
+#if DEVICE_LOWPOWERTIMER
+    Case("Watchdog reset in deepsleep mode", case_setup, test_deepsleep_reset),
+#endif
+#endif
+    Case("Watchdog started again", case_setup, test_restart_reset),
+    Case("Kicking the watchdog prevents reset", case_setup, test_kick_reset),
+};
+
+Specification specification((utest::v1::test_setup_handler_t) testsuite_setup, cases);
+
+int main()
+{
+    // Harness will start with a test case index provided by host script.
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_hal/watchdog_reset/watchdog_reset_tests.h
+++ b/TESTS/mbed_hal/watchdog_reset/watchdog_reset_tests.h
@@ -1,0 +1,77 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @addtogroup hal_watchdog_tests
+ * @{
+ */
+
+#ifndef MBED_HAL_WATCHDOG_RESET_TESTS_H
+#define MBED_HAL_WATCHDOG_RESET_TESTS_H
+
+#if DEVICE_WATCHDOG
+
+/** Test watchdog reset
+ *
+ * Given a device with a watchdog started
+ * When a watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_simple_reset();
+
+/** Test watchdog reset in sleep mode
+ *
+ * Given a device supporting sleep mode, with a watchdog started
+ * When the device is in sleep mode and watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_sleep_reset();
+
+/** Test watchdog reset in deepsleep mode
+ *
+ * Given a device supporting deepsleep mode, with watchdog started
+ * When the device is in deepsleep mode and watchdog timeout expires
+ * Then the device is restarted
+ */
+void test_deepsleep_reset();
+
+/** Test stopped watchdog can be started again and reset the device
+ *
+ * Given a device supporting 'disable_watchdog' feature, with watchdog started
+ * When the watchdog is stopped before timeout expires
+ * Then the device is not restarted
+ * When the watchdog is started again and it's timeout expires
+ * Then the device is restarted
+ */
+void test_restart_reset();
+
+/** Test kicking the watchdog prevents reset
+ *
+ * Given a device with watchdog started
+ * When the watchdog is kicked before timeout expires
+ * Then the device restart is prevented
+ * When the watchdog is *NOT* kicked again before next timeout expires
+ * Then the device is restarted
+ *
+ */
+void test_kick_reset();
+
+#endif
+
+#endif
+
+/** @}*/
+

--- a/TESTS/mbed_hal/watchdog_timing/main.cpp
+++ b/TESTS/mbed_hal/watchdog_timing/main.cpp
@@ -1,0 +1,148 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#if !DEVICE_WATCHDOG
+#error [NOT_SUPPORTED] Watchdog not supported for this target
+#endif
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "hal/watchdog_api.h"
+#include "watchdog_timing_tests.h"
+
+#define MSG_VALUE_DUMMY "0"
+#define CASE_DATA_INVALID 0xffffffffUL
+
+#define MSG_VALUE_LEN 24
+#define MSG_KEY_LEN 24
+
+#define MSG_KEY_DEVICE_READY "ready"
+#define MSG_KEY_START_CASE "start_case"
+#define MSG_KEY_HEARTBEAT "hb"
+
+using utest::v1::Case;
+using utest::v1::Specification;
+using utest::v1::Harness;
+
+struct testcase_data {
+    int index;
+    int start_index;
+    uint32_t received_data;
+};
+
+testcase_data current_case;
+
+template<uint32_t timeout_ms, uint32_t delta_ms>
+void test_timing()
+{
+    // Phase 2. -- verify the test results.
+    // Verify the heartbeat time span sent by host is within given delta.
+    if (current_case.received_data != CASE_DATA_INVALID) {
+        TEST_ASSERT_UINT32_WITHIN(delta_ms, timeout_ms, current_case.received_data);
+        current_case.received_data = CASE_DATA_INVALID;
+        return;
+    }
+
+    // Phase 1. -- run the test code.
+    // Send heartbeat messages to host until the watchdeg resets the device.
+    const ticker_data_t * const us_ticker = get_us_ticker_data();
+    us_timestamp_t current_ts, next_ts, expected_reset_ts, divider, ts_increment;
+    char msg_value[12];
+
+    watchdog_config_t config = { timeout_ms };
+    TEST_ASSERT_EQUAL(WATCHDOG_STATUS_OK, hal_watchdog_init(&config));
+    next_ts = ticker_read_us(us_ticker);
+    expected_reset_ts = next_ts + 1000ULL * timeout_ms;
+
+    divider = 0x2ULL;
+    while (1) {
+        current_ts = ticker_read_us(us_ticker);
+        if (current_ts < next_ts) {
+            continue;
+        }
+
+        int str_len = snprintf(msg_value, sizeof msg_value, "%02x,%08lx", current_case.start_index + current_case.index,
+                (uint32_t) current_ts);
+        if (str_len != (sizeof msg_value) - 1) {
+            utest_printf("Failed to compose a value string to be sent to host.");
+            return;
+        }
+        greentea_send_kv(MSG_KEY_HEARTBEAT, msg_value);
+
+        // The closer to expected reset, the smaller heartbeat time difference.
+        // This should reduce measurement error present for heartbeat with
+        // equal periods.
+        ts_increment = (1000ULL * timeout_ms / divider);
+        next_ts += ts_increment;
+
+        if (current_ts <= expected_reset_ts) {
+            divider <<= 1;
+        } else if (divider > 0x2ULL) {
+            divider >>= 1;
+        }
+    }
+}
+
+utest::v1::status_t case_setup(const Case * const source, const size_t index_of_case)
+{
+    current_case.index = index_of_case;
+    return utest::v1::greentea_case_setup_handler(source, index_of_case);
+}
+
+int testsuite_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(90, "watchdog_reset");
+    utest::v1::status_t status = utest::v1::greentea_test_setup_handler(number_of_cases);
+    if (status != utest::v1::STATUS_CONTINUE) {
+        return status;
+    }
+
+    char key[MSG_KEY_LEN + 1] = { };
+    char value[MSG_VALUE_LEN + 1] = { };
+
+    greentea_send_kv(MSG_KEY_DEVICE_READY, MSG_VALUE_DUMMY);
+    greentea_parse_kv(key, value, MSG_KEY_LEN, MSG_VALUE_LEN);
+
+    if (strcmp(key, MSG_KEY_START_CASE) != 0) {
+        utest_printf("Invalid message key.\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    int num_args = sscanf(value, "%02x,%08lx", &(current_case.start_index), &(current_case.received_data));
+    if (num_args == 0 || num_args == EOF) {
+        utest_printf("Invalid data received from host\n");
+        return utest::v1::STATUS_ABORT;
+    }
+
+    utest_printf("This test suite is composed of %i test cases. Starting at index %i.\n", number_of_cases,
+            current_case.start_index);
+    return current_case.start_index;
+}
+
+Case cases[] = {
+    Case("Timing, 200 ms", case_setup, test_timing<200UL, 55UL>),
+    Case("Timing, 500 ms", case_setup, test_timing<500UL, 65UL>),
+    Case("Timing, 1000 ms", case_setup, test_timing<1000UL, 130UL>),
+    Case("Timing, 3000 ms", case_setup, test_timing<3000UL, 190UL>),
+};
+
+Specification specification((utest::v1::test_setup_handler_t) testsuite_setup, cases);
+
+int main()
+{
+    // Harness will start with a test case index provided by host script.
+    return !Harness::run(specification);
+}

--- a/TESTS/mbed_hal/watchdog_timing/watchdog_timing_tests.h
+++ b/TESTS/mbed_hal/watchdog_timing/watchdog_timing_tests.h
@@ -1,0 +1,47 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * @addtogroup hal_watchdog_tests
+ * @{
+ */
+
+#ifndef MBED_HAL_WATCHDOG_TIMING_TESTS_H
+#define MBED_HAL_WATCHDOG_TIMING_TESTS_H
+
+#if DEVICE_WATCHDOG
+
+/** Test watchdog timing accuracy
+ *
+ * Phase 1.
+ * Given a watchdog timer started with a timeout value of X ms
+ * When given time of X ms elapses
+ * Then the device is restarted by the watchdog
+ *
+ * Phase 2.
+ * Given a device restarted by the watchdog timer
+ * When the device receives time measurement from the host
+ * Then time measured by host equals X ms
+ */
+template<uint32_t timeout_ms, uint32_t delta_ms>
+void test_timing();
+
+#endif
+
+#endif
+
+/** @}*/
+

--- a/targets/TARGET_STM/TARGET_STM32F4/watchdog_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/watchdog_api.c
@@ -24,88 +24,118 @@
 
 #include <stdbool.h>
 
-// Platform specific watchdog definitions
-#define LPO_CLOCK_FREQUENCY 40000
-#define MAX_PRESCALER       256
-#define MAX_TIMEOUT         0xFFFULL
+#define LSI_RC_HZ   32000 // Frequency of the low-speed internal RC oscillator that drives IWDG
+#define MAX_IWDG_PR 0x6 // Max value of Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR)
+#define MAX_IWDG_RL 0xFFFUL // Max value of Watchdog_counter_reload_value bits (RL) of Reload_register (IWDG_RLR).
 
-// Number of decrements in the timeout register per millisecond
-#define TICKS_PER_MS (LPO_CLOCK_FREQUENCY / 1000)
-// Maximum timeout that can be specified in milliseconds
-const uint64_t max_timeout_ms = ((MAX_TIMEOUT / TICKS_PER_MS) * MAX_PRESCALER);
+// Convert Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR) to a prescaler_divider value.
+#define PR2PRESCALER_DIV(PR_BITS) \
+    (4UL << (PR_BITS))
 
-// Maximum supported watchdog timeout for given prescaler value
-#define CALCULATE_MAX_TIMEOUT_MS(scale) \
-   ((MAX_TIMEOUT / TICKS_PER_MS) * scale)
+// Convert Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR)
+// and Watchdog_counter_reload_value bits (RL) of Reload_register (IWDG_RLR)
+// to a timeout value [ms].
+#define PR_RL2UINT64_TIMEOUT_MS(PR_BITS, RL_BITS) \
+	((PR2PRESCALER_DIV(PR_BITS)) * (RL_BITS) * 1000ULL / (LSI_RC_HZ))
 
+// Convert Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR) and a timeout value [ms]
+// to Watchdog_counter_reload_value bits (RL) of Reload_register (IWDG_RLR)
+#define PR_TIMEOUT_MS2RL(PR_BITS, TIMEOUT_MS) \
+	((TIMEOUT_MS) * (LSI_RC_HZ) / (PR2PRESCALER_DIV(PR_BITS)) / 1000UL)
 
-static uint32_t calculate_prescaler_value(const uint32_t timeout_ms)
-{
-    if (timeout_ms > max_timeout_ms) {
-        return 0;
-    }
+#define MAX_TIMEOUT_MS_UINT64 PR_RL2UINT64_TIMEOUT_MS(MAX_IWDG_PR, MAX_IWDG_RL)
+#if (MAX_TIMEOUT_MS_UINT64 > UINT32_MAX)
+#define MAX_TIMEOUT_MS UINT32_MAX
+#else
+#define MAX_TIMEOUT_MS (MAX_TIMEOUT_MS_UINT64 & 0xFFFFFFFFUL)
+#endif
 
-    for (uint32_t scale = 0; scale < 7; ++scale) {
-        const uint32_t prescaler = (4U << scale);
+#define INVALID_IWDG_PR ((MAX_IWDG_PR) + 1) // Arbitrary value used to mark an invalid PR bits value.
 
-        if (timeout_ms < CALCULATE_MAX_TIMEOUT_MS(prescaler)) {
-            return scale;
+// Pick a minimal Prescaler_divider bits (PR) value suitable for given timeout.
+static uint8_t pick_min_iwdg_pr(const uint32_t timeout_ms) {
+    for (uint8_t pr = 0; pr <= MAX_IWDG_PR; pr++) {
+        // Check that max timeout for given pr is greater than
+        // or equal to timeout_ms.
+        if (PR_RL2UINT64_TIMEOUT_MS(pr, MAX_IWDG_RL) >= timeout_ms) {
+            return pr;
         }
     }
-
-    return 0;
+    return INVALID_IWDG_PR;
 }
-
 
 watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
 {
-    const uint32_t prescaler = calculate_prescaler_value(config->timeout_ms);
-
-    if (prescaler == 0) {
+    const uint8_t pr = pick_min_iwdg_pr(config->timeout_ms);
+    if (pr == INVALID_IWDG_PR) {
         return WATCHDOG_STATUS_INVALID_ARGUMENT;
     }
+    const uint32_t rl = PR_TIMEOUT_MS2RL(pr, config->timeout_ms);
 
-    // Enable write access to Prescaler(IWDG_PR) and Reload(IWDG_RLR) registers
-    IWDG->KR  = 0x5555;
+    // Set the Key_value bits (KEY) of Key_register (IWDG_KR) to 0x5555
+    // in order to enable write access to IWDG_PR and IWDG_RLR registers.
+    MODIFY_REG(IWDG->KR, IWDG_KR_KEY_Msk, (IWDG_KR_KEY_Msk & (0x5555U << IWDG_KR_KEY_Pos)));
 
-    // Set the prescaler and timeout values
-    IWDG->RLR = (TICKS_PER_MS * config->timeout_ms) / (4U << prescaler);
-    IWDG->PR  = prescaler;
+    // Wait for the Watchdog_prescaler_value_update bit (PVU) of
+    // Status_register (IWDG_SR) to be reset.
+    while (READ_BIT(IWDG->SR, IWDG_SR_PVU)) {
+    }
+    // Set the Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR).
+    MODIFY_REG(IWDG->PR, IWDG_PR_PR_Msk, (IWDG_PR_PR_Msk & (pr << IWDG_PR_PR_Pos)));
 
-    // Reload the Watchdog Counter.
-    IWDG->KR = 0xAAAA;
-    // Enable the Independent Watchdog.
-    IWDG->KR = 0xCCCC;
+    // Wait for the Watchdog_counter_reload_value_update bit (RVU) of
+    // Status_register (IWDG_SR) to be reset.
+    while (READ_BIT(IWDG->SR, IWDG_SR_RVU)) {
+    }
+    // Set the Watchdog_counter_reload_value bits (RL) of Reload_register (IWDG_RLR).
+    MODIFY_REG(IWDG->RLR, IWDG_RLR_RL_Msk, (IWDG_RLR_RL_Msk & (rl << IWDG_RLR_RL_Pos)));
+
+    // Set the Key_value bits (KEY) of Key_register (IWDG_KR) to 0xAAAA
+    // in order to reload IWDG_RLR register value.
+    MODIFY_REG(IWDG->KR, IWDG_KR_KEY_Msk, (IWDG_KR_KEY_Msk & (0xAAAAU << IWDG_KR_KEY_Pos)));
+
+    // Set the Key_value bits (KEY) of Key_register (IWDG_KR) to 0xCCCC
+    // in order to start the watchdog.
+    MODIFY_REG(IWDG->KR, IWDG_KR_KEY_Msk, (IWDG_KR_KEY_Msk & (0xCCCCU << IWDG_KR_KEY_Pos)));
 
     return WATCHDOG_STATUS_OK;
 }
 
-
 void hal_watchdog_kick(void)
 {
-    IWDG->KR = 0xAAAA;
+    // Set the Key_value bits (KEY) of Key_register (IWDG_KR) to 0xAAAA
+    // in order to reload IWDG_RLR register value.
+    MODIFY_REG(IWDG->KR, IWDG_KR_KEY_Msk, (IWDG_KR_KEY_Msk & (0xAAAAU << IWDG_KR_KEY_Pos)));
 }
-
 
 watchdog_status_t hal_watchdog_stop(void)
 {
     return WATCHDOG_STATUS_NOT_SUPPORTED;
 }
 
-
 uint32_t hal_watchdog_get_reload_value(void)
 {
-    const uint32_t timeout   = (IWDG->RLR & 0xFFF);
-    const uint32_t prescaler = (4U << (IWDG->PR & 0x7));
+    // Wait for the Watchdog_prescaler_value_update bit (PVU) of
+    // Status_register (IWDG_SR) to be reset.
+    while (READ_BIT(IWDG->SR, IWDG_SR_PVU)) {
+    }
+    // Read Prescaler_divider bits (PR) of Prescaler_register (IWDG_PR).
+    const uint8_t pr = (IWDG->PR & IWDG_PR_PR_Msk) >> IWDG_PR_PR_Pos;
 
-    return ((timeout / TICKS_PER_MS) * prescaler);
+    // Wait for the Watchdog_counter_reload_value_update bit (RVU) of
+    // Status_register (IWDG_SR) to be reset.
+    while (READ_BIT(IWDG->SR, IWDG_SR_RVU)) {
+    }
+    // Read Watchdog_counter_reload_value bits (RL) of Reload_register (IWDG_RLR).
+    const uint32_t rl = (IWDG->RLR & IWDG_RLR_RL_Msk) >> IWDG_RLR_RL_Pos;
+
+    return PR_RL2UINT64_TIMEOUT_MS(pr, rl);
 }
-
 
 watchdog_features_t hal_watchdog_get_platform_features(void)
 {
     watchdog_features_t features;
-    features.max_timeout = max_timeout_ms;
+    features.max_timeout = MAX_TIMEOUT_MS;
     features.update_config = true;
     features.disable_watchdog = false;
 


### PR DESCRIPTION
### Description
Add tests for new Watchdog API introduced in #5488:
* `tests-mbed_hal-watchdog`,
* `tests-mbed_hal-watchdog_reset`,
* `tests-mbed_hal-watchdog_timing`,
* `tests-mbed_drivers-watchdog`,
* `tests-mbed_drivers-watchdog_reset`.

CC @bulislaw @0xc0170 @scartmell-arm 