### PR TITLE
Integrating LoRaWAN protocol in Mbed-OS

### DIFF
--- a/LICENSE-BSD-3-Clause
+++ b/LICENSE-BSD-3-Clause
@@ -1,0 +1,25 @@
+Copyright 2017 Arm Limited and affiliates.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS \"AS IS\"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/features/lorawan/LICENSE
+++ b/features/lorawan/LICENSE
@@ -1,0 +1,25 @@
+--- Revised BSD License ---
+Copyright (c) 2013, SEMTECH S.A.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Semtech corporation nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL SEMTECH S.A. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -177,7 +177,15 @@ int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length,
     }
 }
 
-void LoRaWANInterface::lora_event_callback(mbed::Callback<void(lora_events_t)> event_cb)
-{
-    stk_obj().set_lora_event_cb(event_cb);
-}
+lora_mac_status_t LoRaWANInterface::add_app_callbacks(lorawan_app_callbacks_t *callbacks)
+  {
+
+     if (!callbacks || !callbacks->events) {
+         // Event Callback is mandatory
+         return LORA_MAC_STATUS_PARAMETER_INVALID;
+     }
+
+     stk_obj().set_lora_callbacks(callbacks);
+
+     return LORA_MAC_STATUS_OK;
+  }

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -1,0 +1,177 @@
+/**
+ * @file
+ *
+ * @brief      Implementation of LoRaWANBase
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "lorawan/LoRaWANInterface.h"
+
+inline LoRaWANStack& stk_obj()
+{
+    return LoRaWANStack::get_lorawan_stack();
+}
+
+LoRaWANInterface::LoRaWANInterface(LoRaRadio& radio)
+{
+    // Pass mac_handlers to radio to the radio driver after
+    // binding radio driver to PHY layer
+    radio_events_t *events = stk_obj().bind_radio_driver(radio);
+    radio.lock();
+    radio.init_radio(events);
+    radio.unlock();
+}
+
+LoRaWANInterface::~LoRaWANInterface()
+{
+}
+
+lora_mac_status_t LoRaWANInterface::initialize()
+{
+    return stk_obj().initialize_mac_layer();
+}
+
+lora_mac_status_t LoRaWANInterface::connect()
+{
+    // connection attempt without parameters.
+    // System tries to look for configuration in mbed_lib.json that can be
+    // overridden by mbed_app.json. However, if none of the json files are
+    // available (highly unlikely), we still fallback to some default parameters.
+    // Check lorawan_data_structure for fallback defaults.
+
+    lorawan_connect_t connection_params;
+
+    if (OVER_THE_AIR_ACTIVATION != 0) {
+        static uint8_t dev_eui[] = LORAWAN_DEVICE_EUI;
+        static uint8_t app_eui[] = LORAWAN_APPLICATION_EUI;
+        static uint8_t app_key[] = LORAWAN_APPLICATION_KEY;
+        /**
+         *
+         * OTAA join
+         */
+        connection_params.connect_type = LORAWAN_CONNECTION_OTAA;
+        connection_params.connection_u.otaa.app_eui = app_eui;
+        connection_params.connection_u.otaa.dev_eui = dev_eui;
+        connection_params.connection_u.otaa.app_key = app_key;
+        connection_params.connection_u.otaa.nb_trials = LORAWAN_NB_TRIALS;
+
+        return connect(connection_params);
+    } else {
+        static uint8_t nwk_skey[] = LORAWAN_NWKSKEY;
+        static uint8_t app_skey[] = LORAWAN_APPSKEY;
+        static uint32_t dev_addr = LORAWAN_DEVICE_ADDRESS;
+        static uint32_t nwk_id = (LORAWAN_DEVICE_ADDRESS & LORAWAN_NETWORK_ID_MASK);
+
+        /**
+         *
+         * ABP connection
+         */
+        connection_params.connect_type = LORAWAN_CONNECTION_ABP;
+        connection_params.connection_u.abp.nwk_id = nwk_id;
+        connection_params.connection_u.abp.dev_addr = dev_addr;
+        connection_params.connection_u.abp.nwk_skey = nwk_skey;
+        connection_params.connection_u.abp.app_skey = app_skey;
+
+        return connect(connection_params);
+    }
+}
+
+lora_mac_status_t LoRaWANInterface::connect(const lorawan_connect_t &connect)
+{
+    lora_mac_status_t mac_status;
+
+    if (connect.connect_type == LORAWAN_CONNECTION_OTAA) {
+        mac_status = stk_obj().join_request_by_otaa(connect);
+    } else if (connect.connect_type == LORAWAN_CONNECTION_ABP) {
+        mac_status = stk_obj().activation_by_personalization(connect);
+    } else {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    return mac_status;
+}
+
+lora_mac_status_t LoRaWANInterface::disconnect()
+{
+    stk_obj().shutdown();
+    return LORA_MAC_STATUS_OK;
+}
+
+lora_mac_status_t LoRaWANInterface::set_datarate(uint8_t data_rate)
+{
+    return stk_obj().set_channel_data_rate(data_rate);
+}
+
+lora_mac_status_t LoRaWANInterface::set_confirmed_msg_retries(uint8_t count)
+{
+    return stk_obj().set_confirmed_msg_retry(count);
+}
+
+lora_mac_status_t LoRaWANInterface::enable_adaptive_datarate()
+{
+    return stk_obj().enable_adaptive_datarate(true);
+}
+
+lora_mac_status_t LoRaWANInterface::disable_adaptive_datarate()
+{
+    return stk_obj().enable_adaptive_datarate(false);
+}
+
+lora_mac_status_t LoRaWANInterface::set_channel_plan(const lora_channelplan_t &channel_plan)
+{
+    return stk_obj().add_channels(channel_plan);
+}
+
+lora_mac_status_t LoRaWANInterface::get_channel_plan(lora_channelplan_t &channel_plan)
+{
+    return stk_obj().get_enabled_channels(channel_plan);
+}
+
+lora_mac_status_t LoRaWANInterface::remove_channel(uint8_t id)
+{
+    return stk_obj().remove_a_channel(id);
+}
+
+lora_mac_status_t LoRaWANInterface::remove_channel_plan()
+{
+    return stk_obj().drop_channel_list();
+}
+
+int16_t LoRaWANInterface::send(uint8_t port, const uint8_t* data,
+                               uint16_t length, int flags)
+{
+    if (data) {
+        return stk_obj().handle_tx(port, data, length, flags);
+    } else {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+}
+
+int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length,
+                                  int flags)
+{
+    if (data && length > 0) {
+        return stk_obj().handle_rx(port, data, length, flags);
+    } else {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+}
+
+void LoRaWANInterface::lora_event_callback(mbed::Callback<void(lora_events_t)> event_cb)
+{
+    stk_obj().set_lora_event_cb(event_cb);
+}

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -21,6 +21,8 @@
 
 #include "lorawan/LoRaWANInterface.h"
 
+using namespace events;
+
 inline LoRaWANStack& stk_obj()
 {
     return LoRaWANStack::get_lorawan_stack();
@@ -40,9 +42,13 @@ LoRaWANInterface::~LoRaWANInterface()
 {
 }
 
-lora_mac_status_t LoRaWANInterface::initialize()
+lora_mac_status_t LoRaWANInterface::initialize(EventQueue *queue)
 {
-    return stk_obj().initialize_mac_layer();
+    if(!queue) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    return stk_obj().initialize_mac_layer(queue);
 }
 
 lora_mac_status_t LoRaWANInterface::connect()

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -40,9 +40,11 @@ public:
      *
      * You must call this first to be able to use the LoRa stack.
      *
-     * \return         0 on success, a negative error code on failure.
+     * @param ev_queue A pointer to EventQueue provided by the application.
+     *
+     * @return         0 on success, a negative error code on failure.
      */
-    virtual lora_mac_status_t initialize();
+    virtual lora_mac_status_t initialize(events::EventQueue *ev_queue) ;
 
     /** Connect OTAA or ABP using Mbed-OS config system
      *

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -1,0 +1,339 @@
+/**
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LORAWANINTERFACE_H_
+#define LORAWANINTERFACE_H_
+
+#include "platform/Callback.h"
+#include "netsocket/LoRaWANBase.h"
+#include "lorawan/LoRaWANStack.h"
+#include "netsocket/LoRaRadio.h"
+
+class LoRaWANInterface: public LoRaWANBase {
+
+public:
+
+    /** Constructs a LoRaWANInterface using the LoRaWANStack instance underneath.
+     *
+     * Currently, LoRaWANStack is a singleton and you should only
+     * construct a single instance of LoRaWANInterface.
+     *
+     */
+    LoRaWANInterface(LoRaRadio& radio);
+    virtual ~LoRaWANInterface();
+
+    /** Initialize the LoRa stack.
+     *
+     * You must call this first to be able to use the LoRa stack.
+     *
+     * \return         0 on success, a negative error code on failure.
+     */
+    virtual lora_mac_status_t initialize();
+
+    /** Connect OTAA or ABP using Mbed-OS config system
+     *
+     * Connect by Over The Air Activation or Activation By Personalization.
+     * You need to configure the connection properly via the Mbed OS configuration
+     * system.
+     *
+     * When connecting via OTAA, the return code for success (LORA_MAC_STATUS_CONNECT_IN_PROGRESS) is negative.
+     * However, this is not a real error. It tells you that the connection is in progress and you will
+     * be notified of the completion via an event. By default, after the Join Accept message
+     * is received, base stations may provide the node with a CF-List that replaces
+     * all user-configured channels except the Join/Default channels. A CF-List can
+     * configure a maximum of five channels other than the default channels.
+     *
+     * In case of ABP, the CONNECTED event is posted before the call to `connect()` returns.
+     * To configure more channels, we recommend that you use the `set_channel_plan()` API after the connection.
+     * By default, the PHY layers configure only the mandatory Join channels. The retransmission back-off restrictions
+     * on these channels are severe and you may experience long delays or even failures in the confirmed traffic.
+     * If you add more channels, the aggregated duty cycle becomes much more relaxed as compared to the Join (default) channels only.
+     *
+     * **NOTES ON RECONNECTION:**
+     * Currently, the Mbed OS LoRaWAN implementation does not support non-volatile
+     * memory storage. Therefore, the state and frame counters cannot be restored after
+     * a power cycle. However, if you use the `disconnect()` API to shut down the LoRaWAN
+     * protocol, the state and frame counters are saved. Connecting again would try to
+     * restore the previous session. According to the LoRaWAN 1.0.2 specification, the frame counters are always reset
+     * to zero for OTAA and a new Join request lets the network server know
+     * that the counters need a reset. The same is said about the ABP but there
+     * is no way to convey this information to the network server. For a network
+     * server, an ABP device is always connected. That's why storing the frame counters
+     * is important, at least for ABP. That's why we try to restore frame counters from
+     * session information after a disconnection.
+     *
+     * @return         LORA_MAC_STATUS_OK or LORA_MAC_STATUS_CONNECT_IN_PROGRESS
+     *                 on success, or a negative error code on failure.
+     */
+    virtual lora_mac_status_t connect();
+
+    /** Connect OTAA or ABP with parameters
+     *
+     * All connection parameters are chosen by the user and provided in the
+     * data structure passed down.
+     *
+     * When connecting via OTAA, the return code for success (LORA_MAC_STATUS_CONNECT_IN_PROGRESS) is negative.
+     * However, this is not a real error. It tells you that connection is in progress and you will
+     * be notified of completion via an event. By default, after Join Accept message
+     * is received, base stations may provide the node with a CF-List which replaces
+     * all user-configured channels except the Join/Default channels. A CF-List can
+     * configure a maximum of five channels other than the default channels.
+     *
+     * In case of ABP, the CONNECTED event is posted before the call to `connect()` returns.
+     * To configure more channels, we recommend that you use the `set_channel_plan()` API after the connection.
+     * By default, the PHY layers configure only the mandatory Join
+     * channels. The retransmission back-off restrictions on these channels
+     * are severe and you may experience long delays or even
+     * failures in the confirmed traffic. If you add more channels, the aggregated duty
+     * cycle becomes much more relaxed as compared to the Join (default) channels only.
+     *
+     * **NOTES ON RECONNECTION:**
+     * Currently, the Mbed OS LoRaWAN implementation does not support non-volatile
+     * memory storage. Therefore, the state and frame counters cannot be restored after
+     * a power cycle. However, if you use the `disconnect()` API to shut down the LoRaWAN
+     * protocol, the state and frame counters are saved. Connecting again would try to
+     * restore the previous session. According to the LoRaWAN 1.0.2 specification, the frame counters are always reset
+     * to zero for OTAA and a new Join request lets the network server know
+     * that the counters need a reset. The same is said about the ABP but there
+     * is no way to convey this information to the network server. For a network
+     * server, an ABP device is always connected. That's why storing the frame counters
+     * is important, at least for ABP. That's why we try to restore frame counters from
+     * session information after a disconnection.
+     *
+     * @param connect  Options for an end device connection to the gateway.
+     *
+     * @return        LORA_MAC_STATUS_OK or LORA_MAC_STATUS_CONNECT_IN_PROGRESS,
+     *                a negative error code on failure.
+     */
+    virtual lora_mac_status_t connect(const lorawan_connect_t &connect);
+
+    /** Disconnect the current session.
+     *
+     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     *                 failure.
+     */
+    virtual lora_mac_status_t disconnect();
+
+    /** Sets up a particular data rate
+     *
+     * `set_datarate()` first verifies whether the data rate given is valid or not.
+     * If it is valid, the system sets the given data rate to the channel.
+     *
+     * @param data_rate   The intended data rate, for example DR_0 or DR_1.
+     *                    Please note, that the macro DR_* can mean different
+     *                    things in different regions.
+     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     *                    a negative error code.
+     */
+    virtual lora_mac_status_t set_datarate(uint8_t data_rate);
+
+    /** Enables adaptive data rate (ADR).
+     *
+     * The underlying LoRaPHY and LoRaMac layers handle the data rate automatically
+     * for the user, based upon the radio conditions (network congestion).
+     *
+     * @return          LORA_MAC_STATUS_OK or negative error code otherwise.
+     */
+    virtual lora_mac_status_t enable_adaptive_datarate();
+
+    /** Disables adaptive data rate.
+     *
+     * When adaptive data rate (ADR) is disabled, you can either set a certain
+     * data rate or the MAC layer selects a default value.
+     *
+     * @return          LORA_MAC_STATUS_OK or negative error code otherwise.
+     */
+    virtual lora_mac_status_t disable_adaptive_datarate();
+
+    /** Sets up the retry counter for confirmed messages.
+     *
+     * Valid for confirmed messages only.
+     *
+     * The number of trials to transmit the frame, if the LoRaMAC layer did not
+     * receive an acknowledgment. The MAC performs a data rate adaptation as in
+     * the LoRaWAN Specification V1.0.2, chapter 18.4, table on page 64.
+     *
+     * Note, that if number of retries is set to 1 or 2, MAC will not decrease
+     * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
+     *
+     * @param count     The number of retries for confirmed messages.
+     *
+     * @return          LORA_MAC_STATUS_OK or a negative error code.
+     */
+    virtual lora_mac_status_t set_confirmed_msg_retries(uint8_t count);
+
+    /** Sets the channel plan.
+     *
+     * You can provide a list of channels with appropriate parameters filled
+     * in. However, this list is not absolute. The stack applies a CF-List whenever
+     * available, which means that the network can overwrite your channel
+     * frequency settings right after Join Accept is received. You may try
+     * to set up any channel or channels after that, and if the channel requested
+     * is already active, the request is silently ignored. A negative error
+     * code is returned if there is any problem with parameters.
+     *
+     * There is no reverse mechanism in the 1.0.2 specification for a node to request
+     * a particular channel. Only the network server can initiate such a request.
+     * You need to ensure that the corresponding base station supports the channel or channels being added.
+     *
+     * If your list includes a default channel (a channel where Join Requests
+     * are received) you cannot fully configure the channel parameters.
+     * Either leave the channel settings to default or check your
+     * corresponding PHY layer implementation. For example, LoRaPHYE868.
+     *
+     * @param channel_plan      The channel plan to set.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    virtual lora_mac_status_t set_channel_plan(const lora_channelplan_t &channel_plan);
+
+    /** Gets the channel plans from the LoRa stack.
+     *
+     * Once you have selected a particular PHY layer, a set of channels
+     * is automatically activated. Right after connecting, you can use this API
+     * to see the current plan. Otherwise, this API returns the channel
+     * plan that you have set using `set_channel_plan()`.
+     *
+     * @param  channel_plan     The current channel plan information.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    virtual lora_mac_status_t get_channel_plan(lora_channelplan_t &channel_plan);
+
+    /** Removes an active channel plan.
+     *
+     * You cannot remove default channels (the channels the base stations are listening to).
+     * When a plan is abolished, only the non-default channels are removed.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    virtual lora_mac_status_t remove_channel_plan();
+
+    /** Removes a single channel.
+     *
+     * You cannot remove default channels (the channels the base stations are listening to).
+     *
+     * @param    index          The channel index.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    virtual lora_mac_status_t remove_channel(uint8_t index);
+
+    /** Send message to gateway
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to the data being sent. The ownership of the
+     *                          buffer is not transferred. The data is copied to the
+     *                          internal buffers.
+     *
+     * @param length            The size of data in bytes.
+     *
+     * @param flags             A flag used to determine what type of
+     *                          message is being sent, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          mutually exclusive.
+     *
+     *
+     * @return                  The number of bytes sent, or
+     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          ongoing, or a negative error code on failure.
+     */
+    virtual int16_t send(uint8_t port, const uint8_t* data, uint16_t length,
+                         int flags);
+
+    /** Receives a message from the Network Server.
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to buffer where the received data will be
+     *                          stored.
+     *
+     * @param length            The size of data in bytes
+     *
+     * @param flags             A flag is used to determine what type of
+     *                          message is being sent, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01,
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04,
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          not mutually exclusive, i.e., the user can subscribe to
+     *                          receive both CONFIRMED AND UNCONFIRMED messages at
+     *                          the same time.
+     *
+     * @return                  It could be one of these:
+     *                             i)   0 if there is nothing else to read.
+     *                             ii)  Number of bytes still pending to read.
+     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                                  nothing available to read at the moment.
+     *                             iv)  A negative error code on failure.
+     */
+    virtual int16_t receive(uint8_t port, uint8_t* data, uint16_t length,
+                            int flags);
+
+    /** Callback handler.
+     *
+     * Events that can be posted to user:
+     *
+     * CONNECTED            - When the connection is complete
+     * DISCONNECTED         - When the protocol is shut down in response to disconnect()
+     * TX_DONE              - When a packet is sent
+     * TX_TIMEOUT,          - When stack was unable to send packet in TX window
+     * TX_ERROR,            - A general TX error
+     * TX_CRYPTO_ERROR,     - If MIC fails, or any other crypto relted error
+     * TX_SCHEDULING_ERROR, - When stack is unable to schedule packet
+     * RX_DONE,             - When there is something to receive
+     * RX_TIMEOUT,          - Not yet mapped
+     * RX_ERROR             - A general RX error
+     *
+     * @param event_cb         A callback function for catching events from the stack.
+     */
+    virtual void lora_event_callback(mbed::Callback<void(lora_events_t)> event_cb);
+};
+
+#endif /* LORAWANINTERFACE_H_ */

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -310,7 +310,7 @@ public:
      *
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
-     *                             ii)  Number of bytes still pending to read.
+     *                             ii)  Number of bytes written to user buffer.
      *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -318,24 +318,75 @@ public:
     virtual int16_t receive(uint8_t port, uint8_t* data, uint16_t length,
                             int flags);
 
-    /** Callback handler.
-     *
-     * Events that can be posted to user:
-     *
-     * CONNECTED            - When the connection is complete
-     * DISCONNECTED         - When the protocol is shut down in response to disconnect()
-     * TX_DONE              - When a packet is sent
-     * TX_TIMEOUT,          - When stack was unable to send packet in TX window
-     * TX_ERROR,            - A general TX error
-     * TX_CRYPTO_ERROR,     - If MIC fails, or any other crypto relted error
-     * TX_SCHEDULING_ERROR, - When stack is unable to schedule packet
-     * RX_DONE,             - When there is something to receive
-     * RX_TIMEOUT,          - Not yet mapped
-     * RX_ERROR             - A general RX error
-     *
-     * @param event_cb         A callback function for catching events from the stack.
-     */
-    virtual void lora_event_callback(mbed::Callback<void(lora_events_t)> event_cb);
+    /** Add application callbacks to the stack.
+       *
+       * 'lorawan_app_callbacks' is a structure that holds pointers to the application
+       * provided methods which are needed to be called in response to certain
+       * requests. The structure is default constructed to set all pointers to NULL.
+       * So if the user does not provide the pointer, a response will not be posted.
+       * However, the 'lorawan_events' callback is mandatory to be provided as it
+       * contains essential events.
+       *
+       * Events that can be posted to user via 'lorawan_events' are:
+       *
+       * CONNECTED            - When the connection is complete
+       * DISCONNECTED         - When the protocol is shut down in response to disconnect()
+       * TX_DONE              - When a packet is sent
+       * TX_TIMEOUT,          - When stack was unable to send packet in TX window
+       * TX_ERROR,            - A general TX error
+       * TX_CRYPTO_ERROR,     - If MIC fails, or any other crypto relted error
+       * TX_SCHEDULING_ERROR, - When stack is unable to schedule packet
+       * RX_DONE,             - When there is something to receive
+       * RX_TIMEOUT,          - Not yet mapped
+       * RX_ERROR             - A general RX error
+       *
+       * Other responses to certain standard requests are an item for the future.
+       * For example, a link check request could be sent whenever the device tries
+       * to send a message and if the network server responds with a link check resposne,
+       * the stack notifies the application be calling the appropriate method. For example,
+       * 'link_check_resp' callback could be used to collect a response for a link check
+       * request MAC command and the result is thus transported to the application
+       * via callback function provided.
+       *
+       * As can be seen from declaration, mbed::Callback<void(uint8_t, uint8_t)> *link_check_resp)
+       * carries two parameters. First one is Demodulation Margin and the second one
+       * is number of gateways involved in the path to network server.
+       *
+       * An example of using this API with a latch onto 'lorawan_events' could be:
+       *
+       * LoRaWANInterface lorawan(radio);
+       * lorawan_app_callbacks cbs;
+       * static void my_event_handler();
+       *
+       * int main()
+       * {
+       * lorawan.initialize(&queue);
+       *  cbs.lorawan_events = mbed::callback(my_event_handler);
+       *  lorawan.add_app_callbacks(&cbs);
+       *  lorawan.connect();
+       * }
+       *
+       * static void my_event_handler(lora_events_t events)
+       * {
+       *  switch(events) {
+       *      case CONNECTED:
+       *          //do something
+       *          break;
+       *      case DISCONNECTED:
+       *          //do something
+       *          break;
+       *      case TX_DONE:
+       *          //do something
+       *          break;
+       *      default:
+       *          break;
+       *  }
+       * }
+       *
+       * @param callbacks         A pointer to the structure containing application
+       *                          callbacks.
+       */
+    virtual lora_mac_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks);
 };
 
 #endif /* LORAWANINTERFACE_H_ */

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -332,7 +332,7 @@ lora_mac_status_t LoRaWANStack::send_frame_to_mac()
 {
     lora_mac_mcps_req_t mcps_req;
     lora_mac_status_t status;
-   // LoRaMacTxInfo_t txInfo;
+    lora_mac_mib_request_confirm_t mib_get_params;
 
     GetPhyParams_t phy_params;
     PhyParam_t default_datarate;
@@ -353,7 +353,14 @@ lora_mac_status_t LoRaWANStack::send_frame_to_mac()
         mcps_req.f_buffer = _tx_msg.f_buffer;
         mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
         mcps_req.req.confirmed.nb_trials = _tx_msg.message_u.confirmed.nb_trials;
-        mcps_req.req.confirmed.datarate = default_datarate.Value;
+
+        mib_get_params.type = LORA_MIB_CHANNELS_DATARATE;
+           if(mib_get_request(&mib_get_params) != LORA_MAC_STATUS_OK) {
+               tr_debug("Couldn't get MIB parameters: Using default data rate");
+               mcps_req.req.confirmed.datarate = default_datarate.Value;
+           } else {
+               mcps_req.req.confirmed.datarate = mib_get_params.param.channels_datarate;
+           }
 
     } else if (LORA_MCPS_PROPRIETARY == mcps_req.type) {
         mcps_req.f_buffer = _tx_msg.f_buffer;

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -199,7 +199,7 @@ lora_mac_status_t LoRaWANStack::initialize_mac_layer(EventQueue *queue)
     _compliance_test.app_data_buffer = compliance_test_buffer;
 #endif
 
-    TimerTimeCounterInit( );
+    TimerTimeCounterInit(queue);
     LoRaMacPrimitives.MacMcpsConfirm = callback(this, &LoRaWANStack::mcps_confirm);
     LoRaMacPrimitives.MacMcpsIndication = callback(this, &LoRaWANStack::mcps_indication);
     LoRaMacPrimitives.MacMlmeConfirm = callback(this, &LoRaWANStack::mlme_confirm);

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -991,7 +991,7 @@ int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
         _rx_msg.receive_ready = false;
     }
 
-    return _rx_msg.pending_size;
+    return base_size;
 }
 
 lora_mac_status_t LoRaWANStack::mlme_request_handler(lora_mac_mlme_req_t *mlme_request)

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -1,0 +1,2053 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+Description: LoRaWAN stack layer that controls both MAC and PHY underneath
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <string.h>
+#include <stdlib.h>
+#include "platform/Callback.h"
+#include "lorawan/LoRaWANStack.h"
+#if defined(FEATURE_COMMON_PAL)
+#include "mbed_trace.h"
+#define TRACE_GROUP "LSTK"
+#else
+#define tr_debug(...) (void(0)) //dummies if feature common pal is not added
+#define tr_info(...)  (void(0)) //dummies if feature common pal is not added
+#define tr_error(...) (void(0)) //dummies if feature common pal is not added
+#define tr_warn(...) (void(0)) //dummies if feature common pal is not added
+#endif //defined(FEATURE_COMMON_PAL)
+
+#define INVALID_PORT                0xFF
+#define MAX_CONFIRMED_MSG_RETRIES   255
+
+#ifdef MBED_CONF_LORA_PHY
+ #if MBED_CONF_LORA_PHY      == 0
+  #include "lorawan/lorastack/phy/LoRaPHYEU868.h"
+  static LoRaPHYEU868 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 1
+  #include "lorawan/lorastack/phy/LoRaPHYAS923.h"
+  static LoRaPHYAS923 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 2
+  #include "lorawan/lorastack/phy/LoRaPHYAU915.h"
+ static LoRaPHYAU915 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 3
+  #include "lorawan/lorastack/phy/LoRaPHYCN470.h"
+  static LoRaPHYCN470 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 4
+  #include "lorawan/lorastack/phy/LoRaPHYCN779.h"
+  static LoRaPHYCN779 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 5
+  #include "lorawan/lorastack/phy/LoRaPHYEU433.h"
+  static LoRaPHYEU433 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 6
+  #include "lorawan/lorastack/phy/LoRaPHYIN865.h"
+  static LoRaPHYIN865 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 7
+  #include "lorawan/lorastack/phy/LoRaPHYKR920.h"
+  static LoRaPHYKR920 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 8
+  #include "lorawan/lorastack/phy/LoRaPHYUS915.h"
+  static LoRaPHYUS915 lora_phy;
+ #elif MBED_CONF_LORA_PHY    == 9
+  #include "lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h"
+  static LoRaPHYUS915Hybrid lora_phy;
+ #endif //MBED_CONF_LORA_PHY == VALUE
+#else
+ #error "Must set LoRa PHY layer parameters."
+#endif //MBED_CONF_LORA_PHY
+
+using namespace mbed;
+
+/**
+ * Helper function prototypes
+ */
+static Mcps_t interpret_mcps_confirm_type(const lora_mac_mcps_t& local);
+static Mib_t interpret_mib_req_confirm_type(const lora_mac_mib_t& mib_local);
+static lora_mac_event_info_status_t interpret_event_info_type(const LoRaMacEventInfoStatus_t& remote);
+
+#if MBED_CONF_LORA_PHY      == 0
+#include "lorawan/lorastack/mac/LoRaMacTest.h"
+#endif
+
+/**
+ *
+ * User application data buffer size if compliance test is used
+ */
+#if (MBED_CONF_LORA_PHY == 0 || MBED_CONF_LORA_PHY == 4 || MBED_CONF_LORA_PHY == 6 || MBED_CONF_LORA_PHY == 7)
+#define LORAWAN_COMPLIANCE_TEST_DATA_SIZE                  16
+#elif (MBED_CONF_LORA_PHY == 1 || MBED_CONF_LORA_PHY == 2 || MBED_CONF_LORA_PHY == 8 || MBED_CONF_LORA_PHY == 9)
+#define LORAWAN_COMPLIANCE_TEST_DATA_SIZE                  11
+#else
+#error "Must set LoRa PHY layer parameters."
+#endif
+
+/*****************************************************************************
+ * Private Member Functions                                                  *
+ ****************************************************************************/
+bool LoRaWANStack::is_port_valid(uint8_t port)
+{
+    //Application should not use reserved and illegal port numbers.
+    if (port >= 224 || port == 0) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+lora_mac_status_t LoRaWANStack::set_application_port(uint8_t port)
+{
+    if (is_port_valid(port)) {
+        _app_port = port;
+        return LORA_MAC_STATUS_OK;
+    }
+
+    return LORA_MAC_STATUS_PORT_INVALID;
+}
+
+/*****************************************************************************
+ * Constructor and destructor                                                *
+ ****************************************************************************/
+LoRaWANStack::LoRaWANStack()
+: _device_current_state(DEVICE_STATE_NOT_INITIALIZED), _mac_handlers(NULL),
+  _num_retry(1), _duty_cycle_on(LORAWAN_DUTYCYCLE_ON)
+{
+#ifdef MBED_CONF_LORA_APP_PORT
+    // is_port_valid() is not virtual, so we can call it in constructor
+    if (is_port_valid(MBED_CONF_LORA_APP_PORT)) {
+        _app_port = MBED_CONF_LORA_APP_PORT;
+    } else {
+        tr_error("User defined port in .json is illegal.");
+        _app_port = INVALID_PORT;
+    }
+
+#else
+    // initialize it to INVALID_PORT (255) an illegal port number.
+    // user should set the port
+     _app_port = INVALID_PORT;
+#endif
+
+     memset(&_lw_session, 0, sizeof(_lw_session));
+     memset(&_tx_msg, 0, sizeof(_tx_msg));
+     memset(&_rx_msg, 0, sizeof(_rx_msg));
+}
+
+LoRaWANStack::~LoRaWANStack()
+{
+
+}
+
+/*****************************************************************************
+ * Public member functions                                                   *
+ ****************************************************************************/
+LoRaWANStack& LoRaWANStack::get_lorawan_stack()
+{
+    static LoRaWANStack _lw_stack;
+    return _lw_stack;
+}
+
+radio_events_t *LoRaWANStack::bind_radio_driver(LoRaRadio& radio)
+{
+    // Store pointer to callback routines inside MAC layer (non-IRQ safe)
+    _mac_handlers = GetPhyEventHandlers();
+    //  passes the reference to radio driver down to PHY layer
+    lora_phy.set_radio_instance(radio);
+    return _mac_handlers;
+}
+lora_mac_status_t LoRaWANStack::initialize_mac_layer()
+{
+    if (DEVICE_STATE_NOT_INITIALIZED != _device_current_state)
+    {
+        tr_debug("Initialized already");
+        return LORA_MAC_STATUS_OK;
+    }
+
+    static LoRaMacPrimitives_t LoRaMacPrimitives;
+    static LoRaMacCallback_t LoRaMacCallbacks;
+    static lora_mac_mib_request_confirm_t mib_req;
+    static uint8_t compliance_test_buffer[LORAWAN_TX_MAX_SIZE];
+
+    tr_debug("Initializing MAC layer");
+
+    // Allocate memory for compliance test
+    _compliance_test.app_data_buffer = compliance_test_buffer;
+
+    TimerTimeCounterInit( );
+    LoRaMacPrimitives.MacMcpsConfirm = callback(this, &LoRaWANStack::mcps_confirm);
+    LoRaMacPrimitives.MacMcpsIndication = callback(this, &LoRaWANStack::mcps_indication);
+    LoRaMacPrimitives.MacMlmeConfirm = callback(this, &LoRaWANStack::mlme_confirm);
+    LoRaMacCallbacks.TxNextPacketTimerEvent = callback(this, &LoRaWANStack::on_tx_next_packet_timer_event);
+    LoRaMacInitialization(&LoRaMacPrimitives, &LoRaMacCallbacks, lora_phy);
+
+    mib_req.type = LORA_MIB_ADR;
+    mib_req.param.adr_enable = LORAWAN_ADR_ON;
+    mib_set_request(&mib_req);
+
+    mib_req.type = LORA_MIB_PUBLIC_NETWORK;
+    mib_req.param.enable_public_network = LORAWAN_PUBLIC_NETWORK;
+    mib_set_request(&mib_req);
+
+    // Reset counters to zero. Will change in future with 1.1 support.
+    _lw_session.downlink_counter = 0;
+    _lw_session.uplink_counter = 0;
+
+    // Start loRaWAN state machine.
+    set_device_state(DEVICE_STATE_INIT);
+    return lora_state_machine();
+}
+
+/**
+ *
+ * Prepares the upload message to reserved ports
+ *
+ * \param port              Application port
+ */
+void LoRaWANStack::prepare_special_tx_frame(uint8_t port)
+{
+    if (port == 224) {
+        // Clear any normal message stuff before compliance test.
+        memset(&_tx_msg, 0, sizeof(_tx_msg));
+
+        if (_compliance_test.link_check == true) {
+            _compliance_test.link_check = false;
+            _compliance_test.state = 1;
+            _tx_msg.f_buffer_size = 3;
+            _tx_msg.f_buffer[0] = 5;
+            _tx_msg.f_buffer[1] = _compliance_test.demod_margin;
+            _tx_msg.f_buffer[2] = _compliance_test.nb_gateways;
+        } else {
+            switch (_compliance_test.state) {
+            case 4:
+                _compliance_test.state = 1;
+                _tx_msg.f_buffer_size = _compliance_test.app_data_size;
+
+                _tx_msg.f_buffer[0] = _compliance_test.app_data_buffer[0];
+                for(uint8_t i = 1; i < MIN(_compliance_test.app_data_size, LORAWAN_TX_MAX_SIZE); ++i) {
+                    _tx_msg.f_buffer[i] = _compliance_test.app_data_buffer[i];
+                }
+                break;
+            case 1:
+                _tx_msg.f_buffer_size = 2;
+                _tx_msg.f_buffer[0] = _compliance_test.downlink_counter >> 8;
+                _tx_msg.f_buffer[1] = _compliance_test.downlink_counter;
+                break;
+            }
+        }
+    }
+}
+
+/** Hands over the compliance test frame to MAC layer
+ *
+ * \return          returns the state of the LoRa MAC
+ */
+lora_mac_status_t LoRaWANStack::send_compliance_test_frame_to_mac()
+{
+    lora_mac_mcps_req_t mcps_req;
+
+    GetPhyParams_t phy_params;
+    PhyParam_t default_datarate;
+    phy_params.Attribute = PHY_DEF_TX_DR;
+    default_datarate = lora_phy.get_phy_params(&phy_params);
+
+    prepare_special_tx_frame(_compliance_test.app_port);
+
+    if (!_compliance_test.is_tx_confirmed) {
+        mcps_req.type = LORA_MCPS_UNCONFIRMED;
+        mcps_req.req.unconfirmed.f_port = _compliance_test.app_port;
+        mcps_req.f_buffer = _tx_msg.f_buffer;
+        mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
+        mcps_req.req.unconfirmed.datarate = default_datarate.Value;
+
+        tr_info("Transmit unconfirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
+
+        for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
+            tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);
+        }
+    } else if (_compliance_test.is_tx_confirmed) {
+        mcps_req.type = LORA_MCPS_CONFIRMED;
+        mcps_req.req.confirmed.f_port = _compliance_test.app_port;
+        mcps_req.f_buffer = _tx_msg.f_buffer;
+        mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
+        mcps_req.req.confirmed.nb_trials = _num_retry;
+        mcps_req.req.confirmed.datarate = default_datarate.Value;
+
+        tr_info("Transmit confirmed compliance test frame %d bytes.", mcps_req.f_buffer_size);
+
+        for (uint8_t i = 0; i < mcps_req.f_buffer_size; ++i) {
+            tr_info("Byte %d, data is 0x%x", i+1, ((uint8_t*)mcps_req.f_buffer)[i]);
+        }
+    } else {
+        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+    }
+
+    return mcps_request_handler(&mcps_req);
+}
+
+uint16_t LoRaWANStack::check_possible_tx_size(uint16_t size)
+{
+    LoRaMacTxInfo_t txInfo;
+    if (LoRaMacQueryTxPossible(size, &txInfo) == LORAMAC_STATUS_LENGTH_ERROR) {
+        // Cannot transmit this much. Return how much data can be sent
+        // at the moment
+        return txInfo.MaxPossiblePayload;
+    }
+
+    return txInfo.CurrentPayloadSize;
+}
+
+/** Hands over the frame to MAC layer
+ *
+ * \return          returns the state of the LoRa MAC
+ */
+lora_mac_status_t LoRaWANStack::send_frame_to_mac()
+{
+    lora_mac_mcps_req_t mcps_req;
+    lora_mac_status_t status;
+   // LoRaMacTxInfo_t txInfo;
+
+    GetPhyParams_t phy_params;
+    PhyParam_t default_datarate;
+    phy_params.Attribute = PHY_DEF_TX_DR;
+    default_datarate = lora_phy.get_phy_params(&phy_params);
+
+    mcps_req.type = _tx_msg.type;
+
+    if (LORA_MCPS_UNCONFIRMED == mcps_req.type) {
+        mcps_req.req.unconfirmed.f_port = _tx_msg.message_u.unconfirmed.f_port;
+        mcps_req.f_buffer = _tx_msg.f_buffer;
+
+        mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
+        mcps_req.req.unconfirmed.datarate = default_datarate.Value;
+
+    } else if (LORA_MCPS_CONFIRMED == mcps_req.type) {
+        mcps_req.req.confirmed.f_port = _tx_msg.message_u.confirmed.f_port;
+        mcps_req.f_buffer = _tx_msg.f_buffer;
+        mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
+        mcps_req.req.confirmed.nb_trials = _tx_msg.message_u.confirmed.nb_trials;
+        mcps_req.req.confirmed.datarate = default_datarate.Value;
+
+    } else if (LORA_MCPS_PROPRIETARY == mcps_req.type) {
+        mcps_req.f_buffer = _tx_msg.f_buffer;
+        mcps_req.f_buffer_size = _tx_msg.f_buffer_size;
+        mcps_req.req.proprietary.datarate = default_datarate.Value;
+    } else {
+        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+    }
+
+    status = mcps_request_handler(&mcps_req);
+
+    return status;
+}
+
+/**
+ * Function executed on TxNextPacket Timeout event
+ */
+void LoRaWANStack::on_tx_next_packet_timer_event(void)
+{
+    lora_mac_mib_request_confirm_t mib_req;
+    mib_req.type = LORA_MIB_NETWORK_JOINED;
+
+    if (mib_get_request(&mib_req) != LORA_MAC_STATUS_OK) {
+        // This should never happen
+        MBED_ASSERT("LoRaWAN Stack corrupted.");
+    }
+
+    // If is_network_joined flag is false, it means device haven't
+    // joined the network yet via OTAA
+    if (!mib_req.param.is_network_joined) {
+        set_device_state(DEVICE_STATE_JOINING);
+        lora_state_machine();
+        return;
+    }
+
+    // If compliance test is running, then we jump to send compliance test frame.
+    if (_compliance_test.running == true) {
+        set_device_state(DEVICE_STATE_COMPLIANCE_TEST);
+        lora_state_machine();
+    } else {
+        // Otherwise, either device have joined the network or ABP is in use.
+        // In case of ABP, we already have DevAddr, NwkSkey, AppSkey
+        // so we jump to send state directly
+        set_device_state(DEVICE_STATE_SEND);
+        lora_state_machine();
+    }
+}
+
+lora_mac_status_t LoRaWANStack::set_confirmed_msg_retry(uint8_t count)
+{
+    if (count > MAX_CONFIRMED_MSG_RETRIES) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    _num_retry = count;
+
+    return LORA_MAC_STATUS_OK;
+}
+
+void LoRaWANStack::set_device_state(device_states_t new_state)
+{
+    _device_current_state = new_state;
+}
+
+/** Wrapper function to MCPS-Confirm event function
+ *
+ * \param mcps_confirm      Pointer to the confirm structure,
+ *                          containing confirm attributes.
+ */
+void LoRaWANStack::mcps_confirm(McpsConfirm_t *mcps_confirm)
+{
+    lora_mac_mcps_confirm_t lora_mcps_confirm;
+    lora_mcps_confirm.ack_received = mcps_confirm->AckReceived;
+    lora_mcps_confirm.nb_retries = mcps_confirm->NbRetries;
+    lora_mcps_confirm.datarate = mcps_confirm->Datarate;
+    lora_mcps_confirm.tx_power = mcps_confirm->TxPower;
+    lora_mcps_confirm.uplink_counter = mcps_confirm->UpLinkCounter;
+    lora_mcps_confirm.uplink_frequency = mcps_confirm->UpLinkFrequency;
+
+    // Interprets from Mcps_t to lora_mac_mcps_t
+    mcps_confirm->McpsRequest = interpret_mcps_confirm_type(lora_mcps_confirm.mcps_request);
+    // Interprets from LoRaMacEventInfoStatus_t to lora_mac_event_info_status_t
+    lora_mcps_confirm.status = interpret_event_info_type(mcps_confirm->Status);
+    lora_mcps_confirm.tx_time_on_air = mcps_confirm->TxTimeOnAir;
+
+    mcps_confirm_handler(&lora_mcps_confirm);
+}
+
+/** Wrapper function to MCPS-Indication event function
+ *
+ * \param mcps_indication   Pointer to the indication structure,
+ *                          containing indication attributes.
+ */
+void LoRaWANStack::mcps_indication(McpsIndication_t *mcps_indication)
+{
+    lora_mac_mcps_indication_t lora_mcps_indication;
+
+    lora_mcps_indication.ack_received = mcps_indication->AckReceived;
+    memcpy(lora_mcps_indication.buffer,  mcps_indication->Buffer, mcps_indication->BufferSize);
+    lora_mcps_indication.buffer_size = mcps_indication->BufferSize;
+    lora_mcps_indication.downlink_counter = mcps_indication->DownLinkCounter;
+    lora_mcps_indication.frame_pending = mcps_indication->FramePending;
+    lora_mcps_indication.mcps_indication = (lora_mac_mcps_t)mcps_indication->McpsIndication;
+    lora_mcps_indication.multicast = mcps_indication->Multicast;
+    lora_mcps_indication.port = mcps_indication->Port;
+    lora_mcps_indication.rssi = mcps_indication->Rssi;
+    lora_mcps_indication.rx_data = mcps_indication->RxData;
+    lora_mcps_indication.rx_datarate = mcps_indication->RxDatarate;
+    lora_mcps_indication.rx_slot = mcps_indication->RxSlot;
+    lora_mcps_indication.snr = mcps_indication->Snr;
+    lora_mcps_indication.status = (lora_mac_event_info_status_t)mcps_indication->Status;
+
+    mcps_indication_handler(&lora_mcps_indication);
+}
+
+/** Wrapper function to MLME-Confirm event function
+ *
+ * \param mlme_confirm      Pointer to the confirm structure,
+ *                          containing confirm attributes.
+ */
+void LoRaWANStack::mlme_confirm(MlmeConfirm_t *mlme_confirm)
+{
+    lora_mac_mlme_confirm_t lora_mlme_confirm;
+
+    lora_mlme_confirm.demod_margin = mlme_confirm->DemodMargin;
+    lora_mlme_confirm.mlme_request = (lora_mac_mlme_t)mlme_confirm->MlmeRequest;
+    lora_mlme_confirm.nb_gateways = mlme_confirm->NbGateways;
+    lora_mlme_confirm.nb_retries = mlme_confirm->NbRetries;
+    lora_mlme_confirm.status = (lora_mac_event_info_status_t)mlme_confirm->Status;
+    lora_mlme_confirm.tx_time_on_air = mlme_confirm->TxTimeOnAir;
+
+    mlme_confirm_handler(&lora_mlme_confirm);
+}
+
+void LoRaWANStack::set_lora_event_cb(mbed::Callback<void(lora_events_t)> event_cb)
+{
+    _events = event_cb;
+}
+
+lora_mac_status_t LoRaWANStack::add_channels(const lora_channelplan_t &channel_plan)
+{
+    // If device is not initialized, stop right away
+    if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED) {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    ChannelParams_t mac_layer_ch_params;
+    LoRaMacStatus_t status;
+
+    GetPhyParams_t get_phy;
+    PhyParam_t phy_param;
+    uint8_t max_num_channels;
+
+    // Check first how many channels the selected PHY layer supports
+    get_phy.Attribute = PHY_MAX_NB_CHANNELS;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    max_num_channels = (uint8_t) phy_param.Value;
+
+    // check if user is setting more channels than supported
+    if (channel_plan.nb_channels > max_num_channels) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    for (uint8_t i = 0; i < channel_plan.nb_channels; i++) {
+        mac_layer_ch_params.Band = channel_plan.channels[i].ch_param.band;
+        mac_layer_ch_params.DrRange.Fields.Max = channel_plan.channels[i].ch_param.dr_range.lora_mac_fields_s.max;
+        mac_layer_ch_params.DrRange.Fields.Min = channel_plan.channels[i].ch_param.dr_range.lora_mac_fields_s.min;
+        mac_layer_ch_params.DrRange.Value = channel_plan.channels[i].ch_param.dr_range.value;
+        mac_layer_ch_params.Frequency = channel_plan.channels[i].ch_param.frequency;
+        mac_layer_ch_params.Rx1Frequency =channel_plan.channels[i].ch_param.rx1_frequency;
+
+        status = LoRaMacChannelAdd(channel_plan.channels[i].id, mac_layer_ch_params);
+
+        if (status != LORAMAC_STATUS_OK) {
+            return error_type_converter(status);
+        }
+    }
+
+    return LORA_MAC_STATUS_OK;
+}
+
+lora_mac_status_t LoRaWANStack::drop_channel_list()
+{
+    if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED )
+    {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    lora_mac_status_t status = LORA_MAC_STATUS_OK;
+
+    GetPhyParams_t get_phy;
+    PhyParam_t phy_param;
+    uint8_t max_num_channels;
+    uint16_t *channel_masks;
+    uint16_t *default_channel_masks;
+
+    // Check first how many channels the selected PHY layer supports
+    get_phy.Attribute = PHY_MAX_NB_CHANNELS;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    max_num_channels = (uint8_t) phy_param.Value;
+
+    // Now check the channel mask for enabled channels
+    get_phy.Attribute = PHY_CHANNELS_MASK;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    channel_masks = phy_param.ChannelsMask;
+
+    // Now check the channel mask for default channels
+    get_phy.Attribute = PHY_CHANNELS_DEFAULT_MASK;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    default_channel_masks = phy_param.ChannelsMask;
+
+    for (uint8_t i = 0; i < max_num_channels; i++) {
+        // skip any default channels
+        if ((default_channel_masks[0] & (1U<<i)) != 0) {
+            continue;
+        }
+
+        // skip any channels which are not currently enabled
+        if ((channel_masks[0] & (1U<<i)) == 0) {
+            continue;
+        }
+
+        status = error_type_converter(LoRaMacChannelRemove(i));
+
+        if (status != LORA_MAC_STATUS_OK) {
+            return status;
+        }
+    }
+
+    return status;
+}
+
+lora_mac_status_t LoRaWANStack::remove_a_channel(uint8_t channel_id)
+{
+    if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED )
+    {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    GetPhyParams_t get_phy;
+    PhyParam_t phy_param;
+    uint8_t max_num_channels;
+    uint16_t *channel_masks;
+
+    // Check first how many channels the selected PHY layer supports
+    get_phy.Attribute = PHY_MAX_NB_CHANNELS;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    max_num_channels = (uint8_t) phy_param.Value;
+
+    // According to specification channel IDs start from 0 and last valid
+    // channel ID is N-1 where N=MAX_NUM_CHANNELS.
+    // So any ID which is larger or equal to the Max number of channels is invalid
+    if (channel_id >= max_num_channels) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Now check the Default channel mask
+    get_phy.Attribute = PHY_CHANNELS_DEFAULT_MASK;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    channel_masks = phy_param.ChannelsMask;
+
+    // check if the channel ID give belongs to a default channel
+    // Mostly the default channels are in the first mask if the region
+    // have multiple channel masks for various sub-bands. So we check the first
+    // mask only and return an error code if user sent a default channel id
+    if ((channel_masks[0] & (1U << channel_id)) != 0) {
+        tr_error("Not allowed to remove a Default Channel.");
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    return error_type_converter(LoRaMacChannelRemove(channel_id));
+}
+
+lora_mac_status_t LoRaWANStack::get_enabled_channels(lora_channelplan_t& channel_plan)
+{
+    if (_device_current_state == DEVICE_STATE_JOINING
+            || _device_current_state == DEVICE_STATE_NOT_INITIALIZED
+            || _device_current_state == DEVICE_STATE_INIT)
+    {
+        tr_error("Cannot get channel plan until Joined!");
+        return LORA_MAC_STATUS_BUSY;
+    }
+
+    lora_mac_mib_request_confirm_t mib_params;
+
+    GetPhyParams_t get_phy;
+    PhyParam_t phy_param;
+    uint8_t max_num_channels;
+    uint16_t *channel_masks;
+    uint8_t count = 0;
+
+    // Check first how many channels the selected PHY layer supports
+    get_phy.Attribute = PHY_MAX_NB_CHANNELS;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    max_num_channels = (uint8_t) phy_param.Value;
+
+    // Now check the Default channel mask
+    get_phy.Attribute = PHY_CHANNELS_MASK;
+    phy_param = lora_phy.get_phy_params(&get_phy);
+    channel_masks = phy_param.ChannelsMask;
+
+    // Request Mib to get channels
+    memset(&mib_params, 0, sizeof(mib_params));
+    mib_params.type = LORA_MIB_CHANNELS;
+    mib_get_request(&mib_params);
+
+    for (uint8_t i = 0; i < max_num_channels; i++) {
+        // skip the channels which are not enabled
+        if ((channel_masks[0] & (1U << i)) == 0) {
+            continue;
+        }
+
+        // otherwise add them to the channel_plan struct
+        channel_plan.channels[count].id = i;
+        channel_plan.channels[count].ch_param.frequency = mib_params.param.channel_list[i].frequency;
+        channel_plan.channels[count].ch_param.dr_range.value = mib_params.param.channel_list[i].dr_range.value;
+        channel_plan.channels[count].ch_param.dr_range.lora_mac_fields_s.min = mib_params.param.channel_list[i].dr_range.lora_mac_fields_s.min;
+        channel_plan.channels[count].ch_param.dr_range.lora_mac_fields_s.max = mib_params.param.channel_list[i].dr_range.lora_mac_fields_s.max;
+        channel_plan.channels[count].ch_param.band = mib_params.param.channel_list[i].band;
+        channel_plan.channels[count].ch_param.rx1_frequency = mib_params.param.channel_list[i].rx1_frequency;
+        count++;
+    }
+
+    channel_plan.nb_channels = count;
+
+    return LORA_MAC_STATUS_OK;
+}
+
+lora_mac_status_t LoRaWANStack::enable_adaptive_datarate(bool adr_enabled)
+{
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
+    {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    lora_mac_mib_request_confirm_t adr_mib_params;
+
+    adr_mib_params.type = LORA_MIB_ADR;
+    adr_mib_params.param.adr_enable = adr_enabled;
+
+    return mib_set_request(&adr_mib_params);
+}
+
+lora_mac_status_t LoRaWANStack::set_channel_data_rate(uint8_t data_rate)
+{
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
+    {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    lora_mac_mib_request_confirm_t mib_params;
+    mib_params.type = LORA_MIB_ADR;
+    if (mib_get_request(&mib_params) == true) {
+        tr_error("Cannot set data rate. Please turn off ADR first.");
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    mib_params.type = LORA_MIB_CHANNELS_DATARATE;
+    mib_params.param.channels_datarate = data_rate;
+
+    return mib_set_request(&mib_params);
+}
+
+void LoRaWANStack::commission_device(const lora_dev_commission_t &commission_data)
+{
+    _lw_session.connection.connect_type = commission_data.connection.connect_type;
+    _lw_session.downlink_counter = commission_data.downlink_counter;
+    _lw_session.uplink_counter = commission_data.uplink_counter;
+
+    if (commission_data.connection.connect_type == LORAWAN_CONNECTION_OTAA) {
+        _lw_session.connection.connection_u.otaa.app_eui =
+                commission_data.connection.connection_u.otaa.app_eui;
+        _lw_session.connection.connection_u.otaa.app_key =
+                commission_data.connection.connection_u.otaa.app_key;
+        _lw_session.connection.connection_u.otaa.dev_eui =
+                commission_data.connection.connection_u.otaa.dev_eui;
+        _lw_session.connection.connection_u.otaa.nb_trials =
+                commission_data.connection.connection_u.otaa.nb_trials;
+    } else {
+        _lw_session.connection.connection_u.abp.dev_addr =
+                commission_data.connection.connection_u.abp.dev_addr;
+        _lw_session.connection.connection_u.abp.nwk_skey =
+                commission_data.connection.connection_u.abp.nwk_skey;
+        _lw_session.connection.connection_u.abp.app_skey =
+                commission_data.connection.connection_u.abp.app_skey;
+    }
+}
+
+/**
+ *
+ * Join OTAA
+ */
+lora_mac_status_t LoRaWANStack::join_request_by_otaa(const lorawan_connect_t &params)
+{
+    lora_dev_commission_t commission;
+
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state)
+    {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    tr_debug("Initiating OTAA");
+
+    commission.connection.connect_type = LORAWAN_CONNECTION_OTAA;
+    commission.connection.connection_u.otaa.dev_eui = params.connection_u.otaa.dev_eui;
+    commission.connection.connection_u.otaa.app_eui = params.connection_u.otaa.app_eui;
+    commission.connection.connection_u.otaa.app_key = params.connection_u.otaa.app_key;
+    commission.connection.connection_u.otaa.nb_trials = params.connection_u.otaa.nb_trials;
+
+    // As mentioned in the comment above, in 1.0.2 spec, counters are always set
+    // to zero for new connection. This section is common for both normal and
+    // connection restore at this moment. Will change in future with 1.1 support.
+    commission.downlink_counter = 0;
+    commission.uplink_counter = 0;
+
+    commission_device(commission);
+    set_device_state(DEVICE_STATE_JOINING);
+    return lora_state_machine();
+}
+
+/**
+ *
+ * Connect ABP
+ */
+lora_mac_status_t LoRaWANStack::activation_by_personalization(const lorawan_connect_t &params)
+{
+    lora_mac_status_t status;
+    lora_dev_commission_t commission;
+
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state) {
+        tr_error("Stack not initialized!");
+        return LORA_MAC_STATUS_NOT_INITIALIZED;
+    }
+
+    tr_debug("Initiating ABP");
+
+    commission.connection.connect_type = LORAWAN_CONNECTION_ABP;
+    commission.connection.connection_u.abp.dev_addr = params.connection_u.abp.dev_addr;
+    commission.connection.connection_u.abp.nwk_skey = params.connection_u.abp.nwk_skey;
+    commission.connection.connection_u.abp.app_skey = params.connection_u.abp.app_skey;
+
+    // If current state is SHUTDOWN, device may be trying to re-establish
+    // communication. In case of ABP specification is meddled about frame counters.
+    // It says to reset counters to zero but there is no mechanism to tell the
+    // network server that the device was disconnected or restarted.
+    // At the moment, this implementation does not support a non-volatile
+    // memory storage, so we try a last ditch effort here to restore correct
+    // frame counters. If that doesn't work, user must manually reset frame
+    // counters on their network server.
+    commission.downlink_counter = _lw_session.downlink_counter;
+    commission.uplink_counter = _lw_session.uplink_counter;
+
+    tr_debug("Frame Counters. UpCnt=%lu, DownCnt=%lu",
+             commission.uplink_counter, commission.downlink_counter);
+
+    commission_device(commission);
+
+    set_device_state(DEVICE_STATE_ABP_CONNECTING);
+    status = lora_state_machine();
+
+    return status;
+}
+
+int16_t LoRaWANStack::handle_tx(uint8_t port, const uint8_t* data,
+                                uint16_t length, uint8_t flags)
+{
+    if (!_lw_session.active) {
+        return LORA_MAC_STATUS_NO_ACTIVE_SESSIONS;
+    }
+
+    if (_tx_msg.tx_ongoing) {
+        return LORA_MAC_STATUS_WOULD_BLOCK;
+    }
+
+    if (_compliance_test.running) {
+        return LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+    }
+
+    lora_mac_mib_request_confirm_t mib_req;
+    lora_mac_status_t status;
+    mib_req.type = LORA_MIB_NETWORK_JOINED;
+    status = mib_get_request(&mib_req);
+
+    if (status == LORA_MAC_STATUS_OK) {
+        if (mib_req.param.is_network_joined == false) {
+            return LORA_MAC_STATUS_NO_NETWORK_JOINED;
+        }
+    }
+
+    status = set_application_port(port);
+
+    if (status != LORA_MAC_STATUS_OK) {
+        tr_error("Illegal application port definition.");
+        return status;
+    }
+
+    if (flags == 0
+            || (flags & MSG_FLAG_MASK) == (MSG_CONFIRMED_FLAG|MSG_UNCONFIRMED_FLAG)) {
+        tr_error("CONFIRMED and UNCONFIRMED are mutually exclusive for send()");
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    _tx_msg.port = port;
+
+    uint16_t max_possible_size = check_possible_tx_size(length);
+
+    if (max_possible_size > LORAWAN_TX_MAX_SIZE) {
+        // LORAWAN_APP_DATA_MAX_SIZE should at least be
+        // either equal to or bigger than maximum possible
+        // tx size because our tx message buffer takes its
+        // length from that macro. Force maximum possible tx unit
+        // to be equal to the buffer size user chose.
+        max_possible_size = LORAWAN_TX_MAX_SIZE;
+    }
+
+    if (max_possible_size < length) {
+        tr_info("Cannot transmit %d bytes. Possible TX Size is %d bytes",
+                length, max_possible_size);
+
+        _tx_msg.pending_size = length - max_possible_size;
+        _tx_msg.f_buffer_size = max_possible_size;
+        // copy user buffer upto the max_possible_size
+        memcpy(_tx_msg.f_buffer, data, _tx_msg.f_buffer_size);
+    } else {
+        // Whole message can be sent at one time
+        _tx_msg.f_buffer_size = length;
+        _tx_msg.pending_size = 0;
+        // copy user buffer upto the max_possible_size
+        memcpy(_tx_msg.f_buffer, data, length);
+    }
+
+    // Handles all unconfirmed messages, including proprietary and multicast
+    if ((flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_FLAG
+            || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_MULTICAST
+            || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_PROPRIETARY) {
+
+         _tx_msg.type = LORA_MCPS_UNCONFIRMED;
+         _tx_msg.message_u.unconfirmed.f_port = _app_port;
+    }
+
+    // Handles all confirmed messages, including proprietary and multicast
+    if ((flags & MSG_FLAG_MASK) == MSG_CONFIRMED_FLAG
+            || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_MULTICAST
+            || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_PROPRIETARY) {
+
+        _tx_msg.type = LORA_MCPS_CONFIRMED;
+        _tx_msg.message_u.confirmed.f_port = _app_port;
+        _tx_msg.message_u.confirmed.nb_trials = _num_retry;
+    }
+
+    tr_info("RTS = %u bytes, PEND = %u", _tx_msg.f_buffer_size, _tx_msg.pending_size);
+    set_device_state(DEVICE_STATE_SEND);
+    lora_state_machine();
+
+    // send user the length of data which is scheduled now.
+    // user should take care of the pending data.
+    return _tx_msg.f_buffer_size;
+}
+
+int16_t LoRaWANStack::handle_rx(const uint8_t port, uint8_t* data,
+                                uint16_t length, uint8_t flags)
+{
+    if (!_lw_session.active) {
+        return LORA_MAC_STATUS_NO_ACTIVE_SESSIONS;
+    }
+
+    // No messages to read.
+    if (!_rx_msg.receive_ready) {
+        return LORA_MAC_STATUS_WOULD_BLOCK;
+    }
+
+    if (_compliance_test.running) {
+        return LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+    }
+
+    if (data == NULL) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    uint8_t *base_ptr = _rx_msg.rx_message.mcps_indication.buffer;
+    uint16_t base_size = _rx_msg.rx_message.mcps_indication.buffer_size;
+    bool read_complete = false;
+
+    if (_rx_msg.rx_message.mcps_indication.port != port) {
+        // Nothing yet received for this particular port
+        return LORA_MAC_STATUS_WOULD_BLOCK;
+    }
+
+    // check if message received is a Confirmed message and user subscribed to it or not
+    if (_rx_msg.rx_message.mcps_indication.mcps_indication == LORA_MCPS_CONFIRMED
+            && ((flags & MSG_FLAG_MASK) == MSG_CONFIRMED_FLAG
+                    || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_MULTICAST
+                    || (flags & MSG_FLAG_MASK) == MSG_CONFIRMED_PROPRIETARY)) {
+
+        tr_debug("RX - Confirmed Message, flags=%d", flags);
+    }
+
+    // check if message received is a Unconfirmed message and user subscribed to it or not
+    if (_rx_msg.rx_message.mcps_indication.mcps_indication == LORA_MCPS_UNCONFIRMED
+            && ((flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_FLAG
+                    || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_MULTICAST
+                    || (flags & MSG_FLAG_MASK) == MSG_UNCONFIRMED_PROPRIETARY)) {
+        tr_debug("RX - Unconfirmed Message - flags=%d", flags);
+    }
+
+    // check the length of received message whether we can fit into user
+    // buffer completely or not
+    if (_rx_msg.rx_message.mcps_indication.buffer_size > length &&
+            _rx_msg.prev_read_size == 0) {
+        // we can't fit into user buffer. Invoke counter measures
+        _rx_msg.pending_size = _rx_msg.rx_message.mcps_indication.buffer_size - length;
+        base_size = length;
+        _rx_msg.prev_read_size = base_size;
+        memcpy(data, base_ptr, base_size);
+    } else if (_rx_msg.prev_read_size == 0) {
+        _rx_msg.pending_size = 0;
+        _rx_msg.prev_read_size = 0;
+        memcpy(data, base_ptr, base_size);
+        read_complete = true;
+    }
+
+    // If its the pending read then we should copy only the remaining part of
+    // the buffer. Due to checks above, in case of a pending read, this block
+    // will be the only one to get invoked
+    if (_rx_msg.pending_size > 0 && _rx_msg.prev_read_size > 0) {
+        memcpy(data, base_ptr+_rx_msg.prev_read_size, base_size);
+    }
+
+    // we are done handing over received buffer to user. check if there is
+    // anything pending. If not, memset the buffer to zero and indicate
+    // that no read is in progress
+    if (read_complete) {
+        memset(_rx_msg.rx_message.mcps_indication.buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+        _rx_msg.receive_ready = false;
+    }
+
+    return _rx_msg.pending_size;
+}
+
+lora_mac_status_t LoRaWANStack::mlme_request_handler(lora_mac_mlme_req_t *mlme_request)
+{
+    MlmeReq_t request;
+
+    if (NULL == mlme_request) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    request.Type = (Mlme_t)mlme_request->type;
+
+    switch (mlme_request->type) {
+        case LORA_MLME_JOIN:
+            request.Req.Join.AppEui = mlme_request->req.join.app_eui;
+            request.Req.Join.AppKey = mlme_request->req.join.app_key;
+            request.Req.Join.DevEui = mlme_request->req.join.dev_eui;
+            request.Req.Join.NbTrials = mlme_request->req.join.nb_trials;
+            break;
+        // This is handled in semtech stack. Only type value is needed.
+        case LORA_MLME_LINK_CHECK:
+            break;
+        case LORA_MLME_TXCW:
+            /* no break */
+            /* Fall through */
+        case LORA_MLME_TXCW_1:
+            request.Req.TxCw.Frequency = mlme_request->req.tx_cw.frequency;
+            request.Req.TxCw.Power = mlme_request->req.tx_cw.power;
+            request.Req.TxCw.Timeout = mlme_request->req.tx_cw.timeout;
+            break;
+        default:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return error_type_converter(LoRaMacMlmeRequest(&request));
+}
+
+/** MLME-Confirm event function
+ *
+ * \param mlme_confirm      Pointer to the confirm structure,
+ *                          containing confirm attributes.
+ */
+void LoRaWANStack::mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm)
+{
+    if (NULL == mlme_confirm) {
+        return;
+    }
+
+    switch (mlme_confirm->mlme_request) {
+        case LORA_MLME_JOIN:
+            if (mlme_confirm->status == LORA_EVENT_INFO_STATUS_OK) {
+                // Status is OK, node has joined the network
+                set_device_state(DEVICE_STATE_JOINED);
+                lora_state_machine();
+            } else {
+                // Join attempt failed.
+                set_device_state(DEVICE_STATE_IDLE);
+                lora_state_machine();
+                _events(JOIN_FAILURE);
+            }
+            break;
+        case LORA_MLME_LINK_CHECK:
+            if (mlme_confirm->status == LORA_EVENT_INFO_STATUS_OK) {
+                // Check DemodMargin
+                // Check NbGateways
+                if (_compliance_test.running == true) {
+                    _compliance_test.link_check = true;
+                    _compliance_test.demod_margin = mlme_confirm->demod_margin;
+                    _compliance_test.nb_gateways = mlme_confirm->nb_gateways;
+                }
+            }
+            break;
+        default:
+            return;
+            break;
+    }
+}
+
+lora_mac_status_t LoRaWANStack::mcps_request_handler(lora_mac_mcps_req_t *mcps_request)
+{
+    McpsReq_t request;
+
+    if (NULL == mcps_request) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    request.Type = (Mcps_t)mcps_request->type;
+
+    switch (mcps_request->type) {
+        case LORA_MCPS_UNCONFIRMED:
+            request.Req.Unconfirmed.Datarate = mcps_request->req.unconfirmed.datarate;
+            request.Req.Unconfirmed.fBuffer = mcps_request->f_buffer;
+            request.Req.Unconfirmed.fBufferSize = mcps_request->f_buffer_size;
+            request.Req.Unconfirmed.fPort = mcps_request->req.unconfirmed.f_port;
+            break;
+        case LORA_MCPS_CONFIRMED:
+            request.Req.Confirmed.Datarate = mcps_request->req.confirmed.datarate;
+            request.Req.Confirmed.fBuffer = mcps_request->f_buffer;
+            request.Req.Confirmed.fBufferSize = mcps_request->f_buffer_size;
+            request.Req.Confirmed.fPort = mcps_request->req.confirmed.f_port;
+            request.Req.Confirmed.NbTrials = mcps_request->req.confirmed.nb_trials;
+            break;
+        case LORA_MCPS_PROPRIETARY:
+            request.Req.Proprietary.Datarate = mcps_request->req.proprietary.datarate;
+            request.Req.Proprietary.fBuffer = mcps_request->f_buffer;
+            request.Req.Proprietary.fBufferSize = mcps_request->f_buffer_size;
+            break;
+        default:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return error_type_converter(LoRaMacMcpsRequest(&request));
+}
+
+/** MCPS-Confirm event function
+ *
+ * \param mcps_confirm      Pointer to the confirm structure,
+ *                          containing confirm attributes.
+ */
+void LoRaWANStack::mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm)
+{
+    if (mcps_confirm == NULL) {
+        tr_error("mcps_confirm: struct [in] is null.");
+        return;
+    }
+
+    if (mcps_confirm->status != LORA_EVENT_INFO_STATUS_OK) {
+        // Couldn't schedule packet, ack not recieved in CONFIRMED case
+        // or some other error happened. Discard buffer, unset the tx-ongoing
+        // flag and let the application know
+        _tx_msg.tx_ongoing = false;
+        memset(_tx_msg.f_buffer, 0, LORAWAN_TX_MAX_SIZE);
+        _tx_msg.f_buffer_size = LORAWAN_TX_MAX_SIZE;
+
+        tr_error("mcps_confirm_handler: Error code = %d", mcps_confirm->status);
+
+        // If sending timed out, we have a special event for that
+        if (mcps_confirm->status == LORA_EVENT_INFO_STATUS_TX_TIMEOUT) {
+            _events(TX_TIMEOUT);
+            return;
+        } if (mcps_confirm->status == LORA_EVENT_INFO_STATUS_RX2_TIMEOUT) {
+            tr_debug("Did not receive Ack");
+        }
+
+        // Otherwise send a general TX_ERROR event
+        _events(TX_ERROR);
+        return;
+    }
+
+    // If No errors encountered, let's proceed with the status.
+    // CONFIRMED needs special handling because of acks
+    if (mcps_confirm->mcps_request == LORA_MCPS_CONFIRMED) {
+        // In confirmed case, we need to check if we have received the Ack or not.
+        // This is actually just being paranoid about ack because LoRaMac.cpp doesn't
+        // call this callback until an ack is received.
+        if (mcps_confirm->ack_received) {
+            tr_debug("Ack received.");
+        }
+    }
+
+    // This part is common to both CONFIRMED and UNCONFIRMED.
+    // Tell the application about successful transmission and store
+    // data rate plus frame counter.
+    _lw_session.uplink_counter = mcps_confirm->uplink_counter;
+    _tx_msg.tx_ongoing = false;
+    _events(TX_DONE);
+}
+
+/** MCPS-Indication event function
+ *
+ * \param mcps_indication   Pointer to the indication structure,
+ *                          containing indication attributes.
+ */
+void LoRaWANStack::mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indication)
+{
+    if (mcps_indication == NULL) {
+        tr_error("mcps_indication: struct [in] is null.");
+        return;
+    }
+
+    if (mcps_indication->status != LORA_EVENT_INFO_STATUS_OK) {
+        _events(RX_ERROR);
+        return;
+    }
+
+    switch (mcps_indication->mcps_indication) {
+        case LORA_MCPS_UNCONFIRMED:
+            break;
+        case LORA_MCPS_CONFIRMED:
+            break;
+        case LORA_MCPS_PROPRIETARY:
+            break;
+        case LORA_MCPS_MULTICAST:
+            break;
+        default:
+            break;
+    }
+
+    // Check Multicast
+    // Check Port
+    // Check Datarate
+    // Check FramePending
+    // Check Buffer
+    // Check BufferSize
+    // Check Rssi
+    // Check Snr
+    // Check RxSlot
+
+    _lw_session.downlink_counter++;
+
+    if (_compliance_test.running == true) {
+        _compliance_test.downlink_counter++;
+    }
+
+    if (mcps_indication->rx_data == true) {
+        switch (mcps_indication->port) {
+        case 224:
+            tr_debug("Compliance test command received.");
+            compliance_test_handler(mcps_indication);
+            break;
+        default:
+            if (is_port_valid(mcps_indication->port) == true ||
+                    mcps_indication->mcps_indication == LORA_MCPS_PROPRIETARY) {
+
+                // Valid message arrived.
+                // Save message to buffer with session information.
+                if (_rx_msg.rx_message.mcps_indication.buffer_size > LORAMAC_PHY_MAXPAYLOAD) {
+                    // This may never happen as both radio and MAC are limited
+                    // to the size 255 bytes
+                    tr_debug("Cannot receive more than buffer capacity!");
+                    _events(RX_ERROR);
+                    return;
+                } else {
+                    _rx_msg.type = LORAMAC_RX_MCPS_INDICATION;
+                    _rx_msg.rx_message.mcps_indication.buffer_size = mcps_indication->buffer_size;
+                    _rx_msg.rx_message.mcps_indication.port = mcps_indication->port;
+                    // Copy message for user
+                    memcpy(_rx_msg.rx_message.mcps_indication.buffer,
+                           mcps_indication->buffer, mcps_indication->buffer_size);
+                }
+
+                // Notify application about received frame..
+                tr_debug("Received %d bytes", _rx_msg.rx_message.mcps_indication.buffer_size);
+                _rx_msg.receive_ready = true;
+                _events(RX_DONE);
+            } else {
+                // Invalid port, ports 0, 224 and 225-255 are reserved.
+            }
+            break;
+        }
+    }
+}
+
+/** Compliance testing function
+ *
+ * \param mcps_indication   Pointer to the indication structure,
+ *                          containing indication attributes.
+ */
+void LoRaWANStack::compliance_test_handler(lora_mac_mcps_indication_t *mcps_indication)
+{
+    if (_compliance_test.running == false) {
+        // Check compliance test enable command (i)
+        if ((mcps_indication->buffer_size == 4) &&
+            (mcps_indication->buffer[0] == 0x01) &&
+            (mcps_indication->buffer[1] == 0x01) &&
+            (mcps_indication->buffer[2] == 0x01) &&
+            (mcps_indication->buffer[3] == 0x01)) {
+            _compliance_test.is_tx_confirmed = false;
+            _compliance_test.app_port = 224;
+            _compliance_test.app_data_size = 2;
+            _compliance_test.downlink_counter = 0;
+            _compliance_test.link_check = false;
+            _compliance_test.demod_margin = 0;
+            _compliance_test.nb_gateways = 0;
+            _compliance_test.running = true;
+            _compliance_test.state = 1;
+
+            lora_mac_mib_request_confirm_t mib_req;
+            mib_req.type = LORA_MIB_ADR;
+            mib_req.param.adr_enable = true;
+            mib_set_request(&mib_req);
+
+#if MBED_CONF_LORA_PHY      == 0
+            LoRaMacTestSetDutyCycleOn(false);
+#endif
+            //5000ms
+            LoRaMacSetTxTimer(5000);
+            set_device_state(DEVICE_STATE_COMPLIANCE_TEST);
+            tr_debug("Compliance test activated.");
+        }
+    } else {
+        _compliance_test.state = mcps_indication->buffer[0];
+        switch (_compliance_test.state) {
+        case 0: // Check compliance test disable command (ii)
+            _compliance_test.is_tx_confirmed = true;
+            _compliance_test.app_port = LORAWAN_APP_PORT;
+            _compliance_test.app_data_size = LORAWAN_COMPLIANCE_TEST_DATA_SIZE;
+            _compliance_test.downlink_counter = 0;
+            _compliance_test.running = false;
+
+            lora_mac_mib_request_confirm_t mib_req;
+            mib_req.type = LORA_MIB_ADR;
+            mib_req.param.adr_enable = LORAWAN_ADR_ON;
+            mib_set_request(&mib_req);
+#if MBED_CONF_LORA_PHY      == 0
+            LoRaMacTestSetDutyCycleOn(LORAWAN_DUTYCYCLE_ON);
+#endif
+            // Go to idle state after compliance test mode.
+            tr_debug("Compliance test disabled.");
+            LoRaMacStopTxTimer();
+
+            // Clear any compliance test message stuff before going back to normal operation.
+            memset(&_tx_msg, 0, sizeof(_tx_msg));
+            set_device_state(DEVICE_STATE_IDLE);
+            lora_state_machine();
+            break;
+        case 1: // (iii, iv)
+            _compliance_test.app_data_size = 2;
+            break;
+        case 2: // Enable confirmed messages (v)
+            _compliance_test.is_tx_confirmed = true;
+            _compliance_test.state = 1;
+            break;
+        case 3:  // Disable confirmed messages (vi)
+            _compliance_test.is_tx_confirmed = false;
+            _compliance_test.state = 1;
+            break;
+        case 4: // (vii)
+            _compliance_test.app_data_size = mcps_indication->buffer_size;
+
+            _compliance_test.app_data_buffer[0] = 4;
+            for(uint8_t i = 1; i < MIN(_compliance_test.app_data_size, LORAMAC_PHY_MAXPAYLOAD); ++i) {
+                _compliance_test.app_data_buffer[i] = mcps_indication->buffer[i] + 1;
+            }
+
+            send_compliance_test_frame_to_mac();
+            break;
+        case 5: // (viii)
+            lora_mac_mlme_req_t mlme_req;
+            mlme_req.type = LORA_MLME_LINK_CHECK;
+            mlme_request_handler(&mlme_req);
+            break;
+        case 6: // (ix)
+            lora_mac_mlme_req_t mlme_request;
+            lora_mac_mib_request_confirm_t mib_request;
+
+            // Disable TestMode and revert back to normal operation
+            _compliance_test.is_tx_confirmed = true;
+            _compliance_test.app_port = LORAWAN_APP_PORT;
+            _compliance_test.app_data_size = LORAWAN_COMPLIANCE_TEST_DATA_SIZE;
+            _compliance_test.downlink_counter = 0;
+            _compliance_test.running = false;
+
+            mib_request.type = LORA_MIB_ADR;
+            mib_request.param.adr_enable = LORAWAN_ADR_ON;
+            mib_set_request(&mib_request);
+#if MBED_CONF_LORA_PHY      == 0
+            LoRaMacTestSetDutyCycleOn(LORAWAN_DUTYCYCLE_ON);
+#endif
+            mlme_request.type = LORA_MLME_JOIN;
+            mlme_request.req.join.dev_eui = _lw_session.connection.connection_u.otaa.dev_eui;
+            mlme_request.req.join.app_eui = _lw_session.connection.connection_u.otaa.app_eui;
+            mlme_request.req.join.app_key = _lw_session.connection.connection_u.otaa.app_key;
+            mlme_request.req.join.nb_trials = _lw_session.connection.connection_u.otaa.nb_trials;
+            mlme_request_handler(&mlme_request);
+            break;
+        case 7: // (x)
+            if (mcps_indication->buffer_size == 3) {
+                lora_mac_mlme_req_t mlme_req;
+                mlme_req.type = LORA_MLME_TXCW;
+                mlme_req.req.tx_cw.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
+                mlme_request_handler(&mlme_req);
+            } else if (mcps_indication->buffer_size == 7) {
+                lora_mac_mlme_req_t mlme_req;
+                mlme_req.type = LORA_MLME_TXCW_1;
+                mlme_req.req.tx_cw.timeout = (uint16_t)((mcps_indication->buffer[1] << 8) | mcps_indication->buffer[2]);
+                mlme_req.req.tx_cw.frequency = (uint32_t)((mcps_indication->buffer[3] << 16) | (mcps_indication->buffer[4] << 8)
+                        | mcps_indication->buffer[5]) * 100;
+                mlme_req.req.tx_cw.power = mcps_indication->buffer[6];
+                mlme_request_handler(&mlme_req);
+            }
+            _compliance_test.state = 1;
+            break;
+        }
+    }
+}
+
+lora_mac_status_t LoRaWANStack::mib_set_request(lora_mac_mib_request_confirm_t *mib_set_params)
+{
+    MibRequestConfirm_t stack_mib_set;
+    ChannelParams_t stack_channel_params;
+    MulticastParams_t *stack_multicast_params = NULL;
+    MulticastParams_t *head = NULL;
+    lora_mac_status_t status;
+
+    if (NULL == mib_set_params) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Interpreting from lora_mac_mib_t to Mib_t
+    stack_mib_set.Type = interpret_mib_req_confirm_type(mib_set_params->type);
+
+    switch (mib_set_params->type) {
+        case LORA_MIB_DEVICE_CLASS:
+            stack_mib_set.Param.Class = (DeviceClass_t)mib_set_params->param.lora_class;
+            break;
+
+        case LORA_MIB_NETWORK_JOINED:
+            stack_mib_set.Param.IsNetworkJoined = mib_set_params->param.is_network_joined;
+            break;
+
+        case LORA_MIB_ADR:
+            stack_mib_set.Param.AdrEnable = mib_set_params->param.adr_enable;
+            break;
+
+        case LORA_MIB_NET_ID:
+            stack_mib_set.Param.NetID = mib_set_params->param.net_id;
+            break;
+
+        case LORA_MIB_DEV_ADDR:
+            stack_mib_set.Param.DevAddr = mib_set_params->param.dev_addr;
+            break;
+
+        case LORA_MIB_NWK_SKEY:
+            stack_mib_set.Param.NwkSKey = mib_set_params->param.nwk_skey;
+            break;
+
+        case LORA_MIB_APP_SKEY:
+            stack_mib_set.Param.AppSKey = mib_set_params->param.app_skey;
+            break;
+
+        case LORA_MIB_PUBLIC_NETWORK:
+            stack_mib_set.Param.EnablePublicNetwork = mib_set_params->param.enable_public_network;
+            break;
+
+        case LORA_MIB_REPEATER_SUPPORT:
+            stack_mib_set.Param.EnableRepeaterSupport = mib_set_params->param.enable_repeater_support;
+            break;
+
+        case LORA_MIB_CHANNELS:
+            stack_channel_params.Frequency = mib_set_params->param.channel_list->frequency;
+            stack_channel_params.DrRange.Value = mib_set_params->param.channel_list->dr_range.value;
+            stack_channel_params.DrRange.Fields.Min = mib_set_params->param.channel_list->dr_range.lora_mac_fields_s.min;
+            stack_channel_params.DrRange.Fields.Max = mib_set_params->param.channel_list->dr_range.lora_mac_fields_s.max;
+            stack_channel_params.Band = mib_set_params->param.channel_list->band;
+            stack_channel_params.Rx1Frequency = mib_set_params->param.channel_list->rx1_frequency;
+            stack_mib_set.Param.ChannelList = &stack_channel_params;
+            break;
+
+        case LORA_MIB_RX2_CHANNEL:
+            stack_mib_set.Param.Rx2Channel.Frequency = mib_set_params->param.rx2_channel.frequency;
+            stack_mib_set.Param.Rx2Channel.Datarate = mib_set_params->param.rx2_channel.datarate;
+            break;
+
+        case LORA_MIB_RX2_DEFAULT_CHANNEL:
+            stack_mib_set.Param.Rx2DefaultChannel.Frequency = mib_set_params->param.rx2_default_channel.frequency;
+            stack_mib_set.Param.Rx2DefaultChannel.Datarate = mib_set_params->param.rx2_default_channel.datarate;
+            break;
+
+        case LORA_MIB_CHANNELS_MASK:
+            stack_mib_set.Param.ChannelsMask = mib_set_params->param.channels_mask;
+           break;
+
+        case LORA_MIB_CHANNELS_DEFAULT_MASK:
+            stack_mib_set.Param.ChannelsDefaultMask = mib_set_params->param.channels_default_mask;
+            break;
+
+        case LORA_MIB_CHANNELS_NB_REP:
+            stack_mib_set.Param.ChannelNbRep = mib_set_params->param.channel_nb_rep;
+            break;
+
+        case LORA_MIB_MAX_RX_WINDOW_DURATION:
+            stack_mib_set.Param.MaxRxWindow = mib_set_params->param.max_rx_window;
+            break;
+
+        case LORA_MIB_RECEIVE_DELAY_1:
+            stack_mib_set.Param.ReceiveDelay1 = mib_set_params->param.receive_delay1;
+            break;
+
+        case LORA_MIB_RECEIVE_DELAY_2:
+            stack_mib_set.Param.ReceiveDelay2 = mib_set_params->param.receive_delay2;
+            break;
+
+        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
+            stack_mib_set.Param.JoinAcceptDelay1 = mib_set_params->param.join_accept_delay1;
+            break;
+
+        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
+            stack_mib_set.Param.JoinAcceptDelay2 = mib_set_params->param.join_accept_delay2;
+            break;
+
+        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
+            stack_mib_set.Param.ChannelsDefaultDatarate = mib_set_params->param.channels_default_datarate;
+            break;
+
+        case LORA_MIB_CHANNELS_DATARATE:
+            stack_mib_set.Param.ChannelsDatarate = mib_set_params->param.channels_datarate;
+            break;
+
+        case LORA_MIB_CHANNELS_TX_POWER:
+            stack_mib_set.Param.ChannelsTxPower = mib_set_params->param.channels_tx_power;
+            break;
+
+        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
+            stack_mib_set.Param.ChannelsDefaultTxPower = mib_set_params->param.channels_default_tx_power;
+            break;
+
+        case LORA_MIB_UPLINK_COUNTER:
+            stack_mib_set.Param.UpLinkCounter = mib_set_params->param.uplink_counter;
+            break;
+
+        case LORA_MIB_DOWNLINK_COUNTER:
+            stack_mib_set.Param.DownLinkCounter = mib_set_params->param.downlink_counter;
+            break;
+
+        case LORA_MIB_MULTICAST_CHANNEL:
+            /*
+             * Parse multicast list (C++ linked list)
+             */
+            while (mib_set_params->param.multicast_list != NULL) {
+                if (stack_multicast_params == NULL) {
+                    stack_multicast_params = new MulticastParams_t;
+                    head = stack_multicast_params;
+                } else {
+                    while (stack_multicast_params != NULL) {
+                        stack_multicast_params = stack_multicast_params->Next;
+                    }
+
+                    stack_multicast_params = new MulticastParams_t;
+                }
+
+                stack_multicast_params->Address = mib_set_params->param.multicast_list->address;
+                for (int i = 0; i < 16; i++) {
+                    stack_multicast_params->NwkSKey[i] = mib_set_params->param.multicast_list->nwk_skey[i];
+                    stack_multicast_params->AppSKey[i] = mib_set_params->param.multicast_list->app_skey[i];
+                }
+
+                stack_multicast_params->DownLinkCounter = mib_set_params->param.multicast_list->downlink_counter;
+            }
+
+            stack_mib_set.Param.MulticastList = head;
+            break;
+
+        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
+            stack_mib_set.Param.SystemMaxRxError = mib_set_params->param.system_max_rx_error;
+            break;
+
+        case LORA_MIB_MIN_RX_SYMBOLS:
+            stack_mib_set.Param.MinRxSymbols = mib_set_params->param.min_rx_symbols;
+            break;
+
+        default:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    /*
+     * Set MIB data to LoRa stack
+     */
+    status = error_type_converter(LoRaMacMibSetRequestConfirm(&stack_mib_set));
+    /*
+     * Release memory if reserved by multicast list
+     */
+    if (NULL != head) {
+        while (NULL != head) {
+            delete head;
+            head = NULL;
+            head = stack_mib_set.Param.MulticastList->Next;
+        }
+        stack_mib_set.Param.MulticastList = NULL;
+    }
+
+    return status;
+}
+
+lora_mac_status_t LoRaWANStack::mib_get_request(lora_mac_mib_request_confirm_t *mib_get_params)
+{
+    MibRequestConfirm_t stack_mib_get;
+    MulticastParams_t *origin_multicast_list = NULL;
+    lora_mac_multicast_params_t *new_multicast_list = NULL;
+    lora_mac_status_t mac_status = LORA_MAC_STATUS_OK;
+
+    if(NULL == mib_get_params) {
+        return LORA_MAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Interprets from lora_mac_mib_t to Mib_t
+    stack_mib_get.Type = interpret_mib_req_confirm_type(mib_get_params->type);
+    mac_status = error_type_converter(LoRaMacMibGetRequestConfirm(&stack_mib_get));
+
+    if (LORA_MAC_STATUS_OK != mac_status) {
+        return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+    }
+
+    switch(mib_get_params->type) {
+        case LORA_MIB_DEVICE_CLASS:
+            mib_get_params->param.lora_class = (lora_mac_device_class_t)stack_mib_get.Param.Class;
+            break;
+        case LORA_MIB_NETWORK_JOINED:
+            mib_get_params->param.is_network_joined = stack_mib_get.Param.IsNetworkJoined;
+            break;
+        case LORA_MIB_ADR:
+            mib_get_params->param.adr_enable = stack_mib_get.Param.AdrEnable;
+            break;
+        case LORA_MIB_NET_ID:
+            mib_get_params->param.net_id = stack_mib_get.Param.NetID;
+            break;
+        case LORA_MIB_DEV_ADDR:
+            mib_get_params->param.dev_addr = stack_mib_get.Param.DevAddr;
+            break;
+        case LORA_MIB_NWK_SKEY:
+            mib_get_params->param.nwk_skey = stack_mib_get.Param.NwkSKey;
+            break;
+        case LORA_MIB_APP_SKEY:
+            mib_get_params->param.app_skey = stack_mib_get.Param.AppSKey;
+            break;
+        case LORA_MIB_PUBLIC_NETWORK:
+            mib_get_params->param.enable_public_network = stack_mib_get.Param.EnablePublicNetwork;
+            break;
+        case LORA_MIB_REPEATER_SUPPORT:
+            mib_get_params->param.enable_repeater_support = stack_mib_get.Param.EnableRepeaterSupport;
+            break;
+        case LORA_MIB_CHANNELS:
+            mib_get_params->param.channel_list = (lora_mac_channel_params_t *) stack_mib_get.Param.ChannelList;
+            break;
+        case LORA_MIB_RX2_CHANNEL:
+            mib_get_params->param.rx2_channel.datarate = stack_mib_get.Param.Rx2Channel.Datarate;
+            mib_get_params->param.rx2_channel.frequency = stack_mib_get.Param.Rx2Channel.Frequency;
+            break;
+        case LORA_MIB_RX2_DEFAULT_CHANNEL:
+            mib_get_params->param.rx2_default_channel.datarate = stack_mib_get.Param.Rx2DefaultChannel.Datarate;
+            mib_get_params->param.rx2_default_channel.frequency = stack_mib_get.Param.Rx2DefaultChannel.Frequency;
+            break;
+        case LORA_MIB_CHANNELS_DEFAULT_MASK:
+            mib_get_params->param.channels_default_mask = stack_mib_get.Param.ChannelsDefaultMask;
+            break;
+        case LORA_MIB_CHANNELS_MASK:
+            mib_get_params->param.channels_mask = stack_mib_get.Param.ChannelsMask;
+            break;
+        case LORA_MIB_CHANNELS_NB_REP:
+            mib_get_params->param.channel_nb_rep = stack_mib_get.Param.ChannelNbRep;
+            break;
+        case LORA_MIB_MAX_RX_WINDOW_DURATION:
+            mib_get_params->param.max_rx_window = stack_mib_get.Param.MaxRxWindow;
+            break;
+        case LORA_MIB_RECEIVE_DELAY_1:
+            mib_get_params->param.receive_delay1 = stack_mib_get.Param.ReceiveDelay1;
+            break;
+        case LORA_MIB_RECEIVE_DELAY_2:
+            mib_get_params->param.receive_delay2 = stack_mib_get.Param.ReceiveDelay2;
+            break;
+        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
+            mib_get_params->param.join_accept_delay1 = stack_mib_get.Param.JoinAcceptDelay1;
+            break;
+        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
+            mib_get_params->param.join_accept_delay2 = stack_mib_get.Param.JoinAcceptDelay2;
+            break;
+        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
+            mib_get_params->param.channels_default_datarate = stack_mib_get.Param.ChannelsDefaultDatarate;
+            break;
+        case LORA_MIB_CHANNELS_DATARATE:
+            mib_get_params->param.channels_datarate = stack_mib_get.Param.ChannelsDatarate;
+            break;
+        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
+            mib_get_params->param.channels_default_tx_power = stack_mib_get.Param.ChannelsDefaultTxPower;
+            break;
+        case LORA_MIB_CHANNELS_TX_POWER:
+            mib_get_params->param.channels_tx_power = stack_mib_get.Param.ChannelsTxPower;
+            break;
+        case LORA_MIB_UPLINK_COUNTER:
+            mib_get_params->param.uplink_counter = stack_mib_get.Param.UpLinkCounter;
+            break;
+        case LORA_MIB_DOWNLINK_COUNTER:
+            mib_get_params->param.downlink_counter = stack_mib_get.Param.DownLinkCounter;
+            break;
+        case LORA_MIB_MULTICAST_CHANNEL:
+            /*
+             * Parse multicast list (C++ linked list)
+             */
+            origin_multicast_list = stack_mib_get.Param.MulticastList;
+
+            while (NULL != origin_multicast_list) {
+                if (NULL == new_multicast_list) {
+                    new_multicast_list = new lora_mac_multicast_params_t;
+                    new_multicast_list->next = NULL;
+
+                    mib_get_params->param.multicast_list = new_multicast_list;
+                } else {
+                    while (NULL != new_multicast_list) {
+                        new_multicast_list = new_multicast_list->next;
+                    }
+                    new_multicast_list = new lora_mac_multicast_params_t;
+                    new_multicast_list->next = NULL;
+                }
+
+                new_multicast_list->address = origin_multicast_list->Address;
+                for (int i = 0; i < 16; ++i) {
+                    new_multicast_list->nwk_skey[i] = origin_multicast_list->NwkSKey[i];
+                    new_multicast_list->app_skey[i] = origin_multicast_list->AppSKey[i];
+                }
+                new_multicast_list->downlink_counter = origin_multicast_list->DownLinkCounter;
+
+                origin_multicast_list = origin_multicast_list->Next;
+            }
+            break;
+        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
+            mib_get_params->param.system_max_rx_error = stack_mib_get.Param.SystemMaxRxError;
+            break;
+        case LORA_MIB_MIN_RX_SYMBOLS:
+            mib_get_params->param.min_rx_symbols = stack_mib_get.Param.MinRxSymbols;
+            break;
+        default:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return mac_status;
+}
+
+lora_mac_status_t LoRaWANStack::error_type_converter(LoRaMacStatus_t type)
+{
+    switch (type) {
+        case LORAMAC_STATUS_OK:
+            return LORA_MAC_STATUS_OK;
+            break;
+
+        case LORAMAC_STATUS_BUSY:
+            return LORA_MAC_STATUS_BUSY;
+            break;
+
+        case LORAMAC_STATUS_SERVICE_UNKNOWN:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+
+        case LORAMAC_STATUS_PARAMETER_INVALID:
+            return LORA_MAC_STATUS_PARAMETER_INVALID;
+            break;
+
+        case LORAMAC_STATUS_FREQUENCY_INVALID:
+            return LORA_MAC_STATUS_FREQUENCY_INVALID;
+            break;
+
+        case LORAMAC_STATUS_DATARATE_INVALID:
+            return LORA_MAC_STATUS_DATARATE_INVALID;
+            break;
+
+        case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            return LORA_MAC_STATUS_FREQ_AND_DR_INVALID;
+            break;
+
+        case LORAMAC_STATUS_NO_NETWORK_JOINED:
+            return LORA_MAC_STATUS_NO_NETWORK_JOINED;
+            break;
+
+        case LORAMAC_STATUS_LENGTH_ERROR:
+            return LORA_MAC_STATUS_LENGTH_ERROR;
+            break;
+
+        case LORAMAC_STATUS_DEVICE_OFF:
+            return LORA_MAC_STATUS_DEVICE_OFF;
+            break;
+
+        case LORAMAC_STATUS_CRYPTO_FAIL:
+            return LORA_MAC_STATUS_CRYPTO_FAIL;
+            break;
+
+        default:
+            return LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+}
+
+void LoRaWANStack::shutdown()
+{
+    set_device_state(DEVICE_STATE_SHUTDOWN);
+    lora_state_machine();
+}
+
+lora_mac_status_t LoRaWANStack::lora_state_machine()
+{
+    lora_mac_mib_request_confirm_t mib_req;
+    lora_mac_status_t status = LORA_MAC_STATUS_DEVICE_OFF;
+
+    switch (_device_current_state) {
+        case DEVICE_STATE_SHUTDOWN:
+            /*
+             * Remove channels
+             * Radio will be put to sleep by the APIs underneath
+             */
+            drop_channel_list();
+
+            // Stop sending messages and set joined status to false.
+            LoRaMacStopTxTimer();
+            mib_req.type = LORA_MIB_NETWORK_JOINED;
+            mib_req.param.is_network_joined = false;
+            mib_set_request(&mib_req);
+
+            // reset buffers to original state
+            memset(_tx_msg.f_buffer, 0, LORAWAN_TX_MAX_SIZE);
+            _tx_msg.pending_size = 0;
+            _tx_msg.f_buffer_size = 0;
+            _tx_msg.tx_ongoing = false;
+            memset(_rx_msg.rx_message.mcps_indication.buffer, 0, LORAMAC_PHY_MAXPAYLOAD);
+            _rx_msg.receive_ready = false;
+            _rx_msg.prev_read_size = 0;
+            _rx_msg.rx_message.mcps_indication.buffer_size = 0;
+
+            // disable the session
+            _lw_session.active = false;
+
+            tr_debug("LoRaWAN protocol has been shut down.");
+            _events(DISCONNECTED);
+            status = LORA_MAC_STATUS_DEVICE_OFF;
+            break;
+        case DEVICE_STATE_NOT_INITIALIZED:
+            // Device is disconnected.
+            status = LORA_MAC_STATUS_DEVICE_OFF;
+            break;
+        case DEVICE_STATE_INIT:
+            status = LORA_MAC_STATUS_OK;
+            break;
+        case DEVICE_STATE_JOINING:
+            if (_lw_session.connection.connect_type == LORAWAN_CONNECTION_OTAA) {
+                /*
+                 * OTAA join
+                 */
+                tr_debug("Send Join-request..");
+                lora_mac_mlme_req_t mlme_req;
+                mlme_req.type = LORA_MLME_JOIN;
+
+                mlme_req.req.join.dev_eui = _lw_session.connection.connection_u.otaa.dev_eui;
+                mlme_req.req.join.app_eui = _lw_session.connection.connection_u.otaa.app_eui;
+                mlme_req.req.join.app_key = _lw_session.connection.connection_u.otaa.app_key;
+                mlme_req.req.join.nb_trials = _lw_session.connection.connection_u.otaa.nb_trials;
+
+                // Send join request to server.
+                status = mlme_request_handler(&mlme_req);
+                if (status != LORA_MAC_STATUS_OK) {
+                    return status;
+                }
+                // Otherwise request was successful and OTAA connect is in
+                //progress
+                return LORA_MAC_STATUS_CONNECT_IN_PROGRESS;
+            } else {
+                status = LORA_MAC_STATUS_PARAMETER_INVALID;
+                break;
+            }
+            break;
+        case DEVICE_STATE_JOINED:
+            tr_debug("Join OK!");
+            // Session is now active
+            _lw_session.active = true;
+            // Tell the application that we are connected
+            _events(CONNECTED);
+            break;
+        case DEVICE_STATE_ABP_CONNECTING:
+            /*
+             * ABP connection
+             */
+            mib_req.type = LORA_MIB_NET_ID;
+            mib_req.param.net_id = _lw_session.connection.connection_u.abp.nwk_id;
+            mib_set_request(&mib_req);
+
+            mib_req.type = LORA_MIB_DEV_ADDR;
+            mib_req.param.dev_addr = _lw_session.connection.connection_u.abp.dev_addr;
+            mib_set_request(&mib_req);
+
+            mib_req.type = LORA_MIB_NWK_SKEY;
+            mib_req.param.nwk_skey = _lw_session.connection.connection_u.abp.nwk_skey;
+            mib_set_request(&mib_req);
+
+            mib_req.type = LORA_MIB_APP_SKEY;
+            mib_req.param.app_skey = _lw_session.connection.connection_u.abp.app_skey;
+            mib_set_request(&mib_req);
+
+            mib_req.type = LORA_MIB_NETWORK_JOINED;
+            mib_req.param.is_network_joined = true;
+            mib_set_request(&mib_req);
+            tr_debug("ABP Connection OK!");
+            // tell the application we are okay
+            // if users provide wrong keys, it's their responsibility
+            // there is no way to test ABP authentication success
+            status = LORA_MAC_STATUS_OK;
+            // Session is now active
+            _lw_session.active = true;
+            _events(CONNECTED);
+            break;
+        case DEVICE_STATE_SEND:
+            // If a transmission is ongoing, don't interrupt
+            if (_tx_msg.tx_ongoing) {
+                status = LORA_MAC_STATUS_OK;
+            } else {
+                _tx_msg.tx_ongoing = true;
+                status = send_frame_to_mac();
+
+                switch (status) {
+                    case LORA_MAC_STATUS_OK:
+                        tr_debug("Frame scheduled to TX..");
+                        break;
+                    case LORA_MAC_STATUS_CRYPTO_FAIL:
+                        tr_error("Crypto failed. Clearing TX buffers");
+                        _events(TX_CRYPTO_ERROR);
+                        break;
+                    default:
+                        tr_error("Failure to schedule TX!");
+                        _events(TX_SCHEDULING_ERROR);
+                        break;
+                }
+            }
+            // otherwise all done, put device in idle state
+            set_device_state(DEVICE_STATE_IDLE);
+            break;
+        case DEVICE_STATE_IDLE:
+            //Do nothing
+            status = LORA_MAC_STATUS_IDLE;
+            break;
+        case DEVICE_STATE_COMPLIANCE_TEST:
+            //Device is in compliance test mode
+            tr_debug("Device is in compliance test mode.");
+
+            //5000ms
+            LoRaMacSetTxTimer(5000);
+            if (_compliance_test.running == true) {
+                send_compliance_test_frame_to_mac();
+            }
+            status = LORA_MAC_STATUS_COMPLIANCE_TEST_ON;
+            break;
+        default:
+            status = LORA_MAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return status;
+}
+
+static Mcps_t interpret_mcps_confirm_type(const lora_mac_mcps_t& local)
+{
+    switch (local) {
+        case LORA_MCPS_UNCONFIRMED:
+            return MCPS_UNCONFIRMED;
+        case LORA_MCPS_CONFIRMED:
+            return MCPS_CONFIRMED;
+        case LORA_MCPS_MULTICAST:
+            return MCPS_MULTICAST;
+        case LORA_MCPS_PROPRIETARY:
+            return MCPS_PROPRIETARY;
+        default:
+            MBED_ASSERT("Unknown Mcps_t");
+    }
+
+    // Never reaches here
+    return MCPS_UNCONFIRMED;
+}
+
+static lora_mac_event_info_status_t interpret_event_info_type(const LoRaMacEventInfoStatus_t& remote)
+{
+    switch (remote) {
+        case LORAMAC_EVENT_INFO_STATUS_OK:
+            return LORA_EVENT_INFO_STATUS_OK;
+        case LORAMAC_EVENT_INFO_STATUS_ERROR:
+            return LORA_EVENT_INFO_STATUS_ERROR;
+        case LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT:
+            return LORA_EVENT_INFO_STATUS_TX_TIMEOUT;
+        case LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT:
+            return LORA_EVENT_INFO_STATUS_RX1_TIMEOUT;
+        case LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT:
+            return LORA_EVENT_INFO_STATUS_RX2_TIMEOUT;
+        case LORAMAC_EVENT_INFO_STATUS_RX1_ERROR:
+            return LORA_EVENT_INFO_STATUS_RX1_ERROR;
+        case LORAMAC_EVENT_INFO_STATUS_RX2_ERROR:
+            return LORA_EVENT_INFO_STATUS_RX2_ERROR;
+        case LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL:
+            return LORA_EVENT_INFO_STATUS_JOIN_FAIL;
+        case LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED:
+            return LORA_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
+        case LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR:
+            return LORA_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR;
+        case LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS:
+            return LORA_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS;
+        case LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL:
+            return LORA_EVENT_INFO_STATUS_ADDRESS_FAIL;
+        case LORAMAC_EVENT_INFO_STATUS_MIC_FAIL:
+            return LORA_EVENT_INFO_STATUS_MIC_FAIL;
+        case LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL:
+            return LORA_EVENT_INFO_STATUS_CRYPTO_FAIL;
+        default:
+            MBED_ASSERT("Unknown LoRaMacEventInfoStatus_t");
+    }
+
+    // Never reaches here actually
+    return LORA_EVENT_INFO_STATUS_OK;
+}
+
+static Mib_t interpret_mib_req_confirm_type(const lora_mac_mib_t& local)
+{
+    switch (local) {
+        case LORA_MIB_DEVICE_CLASS:
+            return MIB_DEVICE_CLASS;
+        case LORA_MIB_NETWORK_JOINED:
+            return MIB_NETWORK_JOINED;
+        case LORA_MIB_ADR:
+            return MIB_ADR;
+        case LORA_MIB_NET_ID:
+            return MIB_NET_ID;
+        case LORA_MIB_DEV_ADDR:
+            return MIB_DEV_ADDR;
+        case LORA_MIB_NWK_SKEY:
+            return MIB_NWK_SKEY;
+        case LORA_MIB_APP_SKEY:
+            return MIB_APP_SKEY;
+        case LORA_MIB_PUBLIC_NETWORK:
+            return MIB_PUBLIC_NETWORK;
+        case LORA_MIB_REPEATER_SUPPORT:
+            return MIB_REPEATER_SUPPORT;
+        case LORA_MIB_CHANNELS:
+            return MIB_CHANNELS;
+        case LORA_MIB_RX2_CHANNEL:
+            return MIB_RX2_CHANNEL;
+        case LORA_MIB_RX2_DEFAULT_CHANNEL:
+            return MIB_RX2_DEFAULT_CHANNEL;
+        case LORA_MIB_CHANNELS_MASK:
+            return MIB_CHANNELS_MASK;
+        case LORA_MIB_CHANNELS_DEFAULT_MASK:
+            return MIB_CHANNELS_DEFAULT_MASK;
+        case LORA_MIB_CHANNELS_NB_REP:
+            return MIB_CHANNELS_NB_REP;
+        case LORA_MIB_MAX_RX_WINDOW_DURATION:
+            return MIB_MAX_RX_WINDOW_DURATION;
+        case LORA_MIB_RECEIVE_DELAY_1:
+            return MIB_RECEIVE_DELAY_1;
+        case LORA_MIB_RECEIVE_DELAY_2:
+            return MIB_RECEIVE_DELAY_2;
+        case LORA_MIB_JOIN_ACCEPT_DELAY_1:
+            return MIB_JOIN_ACCEPT_DELAY_1;
+        case LORA_MIB_JOIN_ACCEPT_DELAY_2:
+            return MIB_JOIN_ACCEPT_DELAY_2;
+        case LORA_MIB_CHANNELS_DEFAULT_DATARATE:
+            return MIB_CHANNELS_DEFAULT_DATARATE;
+        case LORA_MIB_CHANNELS_DATARATE:
+            return MIB_CHANNELS_DATARATE;
+        case LORA_MIB_CHANNELS_TX_POWER:
+            return MIB_CHANNELS_TX_POWER;
+        case LORA_MIB_CHANNELS_DEFAULT_TX_POWER:
+            return MIB_CHANNELS_DEFAULT_TX_POWER;
+        case LORA_MIB_UPLINK_COUNTER:
+            return MIB_UPLINK_COUNTER;
+        case LORA_MIB_DOWNLINK_COUNTER:
+            return MIB_DOWNLINK_COUNTER;
+        case LORA_MIB_MULTICAST_CHANNEL:
+            return MIB_MULTICAST_CHANNEL;
+        case LORA_MIB_SYSTEM_MAX_RX_ERROR:
+            return MIB_SYSTEM_MAX_RX_ERROR;
+        case LORA_MIB_MIN_RX_SYMBOLS:
+            return MIB_MIN_RX_SYMBOLS;
+        default:
+            MBED_ASSERT("Cannot Interpret Mib_t");
+    }
+
+    // Never actually reaches here
+    return MIB_DEVICE_CLASS;
+}
+

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -259,7 +259,7 @@ public:
      *
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
-     *                             ii)  Number of bytes still pending to read.
+     *                             ii)  Number of bytes written to user buffer.
      *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -404,7 +404,10 @@ private:
      */
     lora_mac_status_t error_type_converter(LoRaMacStatus_t type);
 
+#if defined(LORAWAN_COMPLIANCE_TEST)
     compliance_test_t _compliance_test;
+#endif
+
     device_states_t _device_current_state;
     lorawan_app_callbacks_t _callbacks;
     radio_events_t *_mac_handlers;

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -65,11 +65,11 @@ public:
      */
     lora_mac_status_t initialize_mac_layer(events::EventQueue *queue);
 
-    /** Sets all callbacks of the LoRaWAN interface.
+    /** Sets all callbacks for the application.
      *
-     * @param *event_cb        An event structure representing all possible callbacks.
+     * \param callbacks        A pointer to the structure carrying callbacks.
      */
-    void set_lora_event_cb(mbed::Callback<void(lora_events_t)> event_cb);
+    void set_lora_callbacks(lorawan_app_callbacks_t *callbacks);
 
     /** Adds channels to use.
      *
@@ -412,7 +412,7 @@ private:
 
     compliance_test_t _compliance_test;
     device_states_t _device_current_state;
-    mbed::Callback<void(lora_events_t)> _events;
+    lorawan_app_callbacks_t _callbacks;
     radio_events_t *_mac_handlers;
     lorawan_session_t _lw_session;
     lora_mac_tx_message_t _tx_msg;

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -27,6 +27,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #define LORAWANSTACK_H_
 
 #include <stdint.h>
+#include "events/EventQueue.h"
 #include "platform/Callback.h"
 #include "platform/NonCopyable.h"
 #include "lorawan/system/LoRaWANTimer.h"
@@ -59,14 +60,14 @@ public:
     radio_events_t *bind_radio_driver(LoRaRadio& radio);
 
     /** End device initialization.
-     *
-     * \return                 0 on success, a negative error code on failure.
+     * @param queue            A pointer to an EventQueue passed from the application.
+     * @return                 LORA_MAC_STATUS_OK on success, a negative error code on failure.
      */
-    lora_mac_status_t initialize_mac_layer();
+    lora_mac_status_t initialize_mac_layer(events::EventQueue *queue);
 
     /** Sets all callbacks of the LoRaWAN interface.
      *
-     * \param *event_cb        An event structure representing all possible callbacks.
+     * @param *event_cb        An event structure representing all possible callbacks.
      */
     void set_lora_event_cb(mbed::Callback<void(lora_events_t)> event_cb);
 
@@ -418,6 +419,7 @@ private:
     lora_mac_rx_message_t _rx_msg;
     uint8_t _app_port;
     uint8_t _num_retry;
+    events::EventQueue *_queue;
     bool _duty_cycle_on;
 };
 

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -307,12 +307,6 @@ private:
     lora_mac_status_t send_frame_to_mac();
 
     /**
-     * Callback function for transmission based on user defined timer.
-     * Used only for testing when duty cycle is off.
-     */
-    void on_tx_next_packet_timer_event(void);
-
-    /**
      * Callback function for MCPS confirm. Mac layer calls this function once
      * an MCPS confirmation is received. This method translates Mac layer data
      * structure into stack layer data structure.

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -1,0 +1,424 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+Description: LoRaWAN stack layer that controls both MAC and PHY underneath
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#ifndef LORAWANSTACK_H_
+#define LORAWANSTACK_H_
+
+#include <stdint.h>
+#include "platform/Callback.h"
+#include "platform/NonCopyable.h"
+#include "lorawan/system/LoRaWANTimer.h"
+#include "lorastack/mac/LoRaMac.h"
+#include "lorawan/system/lorawan_data_structures.h"
+#include "LoRaRadio.h"
+
+/**
+ * A mask for the network ID.
+ */
+#define LORAWAN_NETWORK_ID_MASK                          ( uint32_t )0xFE000000
+
+class LoRaWANStack: private mbed::NonCopyable<LoRaWANStack> {
+public:
+    static LoRaWANStack& get_lorawan_stack();
+
+    /** Binds radio driver to PHY layer.
+     *
+     * MAC layer is totally detached from the PHY layer so the stack layer
+     * needs to play the role of an arbitrator. This API gets a radio driver
+     * object from the application (via LoRaWANInterface), binds it to the PHY
+     * layer and returns MAC layer callback handles which the radio driver will
+     * use in order to report events.
+     *
+     * @param radio            LoRaRadio object, i.e., the radio driver
+     *
+     * @return                 A list of callbacks from MAC layer that needs to
+     *                         be passed to radio driver
+     */
+    radio_events_t *bind_radio_driver(LoRaRadio& radio);
+
+    /** End device initialization.
+     *
+     * \return                 0 on success, a negative error code on failure.
+     */
+    lora_mac_status_t initialize_mac_layer();
+
+    /** Sets all callbacks of the LoRaWAN interface.
+     *
+     * \param *event_cb        An event structure representing all possible callbacks.
+     */
+    void set_lora_event_cb(mbed::Callback<void(lora_events_t)> event_cb);
+
+    /** Adds channels to use.
+     *
+     * You can provide a list of channels with appropriate parameters filled
+     * in. However, this list is not absolute. In some regions, a CF
+     * list gets implemented by default, which means that the network can overwrite your channel
+     * frequency settings right after receiving a Join Accept. You may try
+     * to set up any channel or channels after that and if the channel requested
+     * is already active, the request is silently ignored. A negative error
+     * code is returned if there is any problem with parameters.
+     *
+     * You need to ensure that the base station nearby supports the channel or channels being added.
+     *
+     * If your list includes a default channel (a channel where Join Requests
+     * are received) you cannot fully configure the channel parameters.
+     * Either leave the channel settings to default or check your
+     * corresponding PHY layer implementation. For example, LoRaPHYE868.
+     *
+     * @param  channel_plan     A list of channels or a single channel.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    lora_mac_status_t add_channels(const lora_channelplan_t &channel_plan);
+
+    /** Removes a channel from the list.
+     *
+     * @param channel_id        Index of the channel being removed
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    lora_mac_status_t remove_a_channel(uint8_t channel_id);
+
+    /** Removes a previously set channel plan.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    lora_mac_status_t drop_channel_list();
+
+    /** Gets a list of currently enabled channels .
+     *
+     * @param channel_plan      The channel plan structure to store final result.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    lora_mac_status_t get_enabled_channels(lora_channelplan_t &channel_plan);
+
+    /** Sets up a retry counter for confirmed messages.
+     *
+     * Valid only for confirmed messages. This API sets the number of times the
+     * stack will retry a CONFIRMED message before giving up and reporting an
+     * error.
+     *
+     * @param count             The number of retries for confirmed messages.
+     *
+     * @return                  LORA_MAC_STATUS_OK or a negative error code.
+     */
+    lora_mac_status_t set_confirmed_msg_retry(uint8_t count);
+
+    /** Sets up the data rate.
+     *
+     * `set_datarate()` first verifies whether the data rate given is valid or not.
+     * If it is valid, the system sets the given data rate to the channel.
+     *
+     * @param data_rate   The intended data rate, for example DR_0 or DR_1.
+     *                    Note that the macro DR_* can mean different
+     *                    things in different regions.
+     *
+     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     *                    a negative error code.
+     */
+    lora_mac_status_t set_channel_data_rate(uint8_t data_rate);
+
+    /** Enables ADR.
+     *
+     * @param adr_enabled       0 ADR disabled, 1 ADR enabled.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    lora_mac_status_t enable_adaptive_datarate(bool adr_enabled);
+
+    /** Commissions a LoRa device.
+     *
+     * @param commission_data   A structure representing all the commission
+     *                          information.
+     */
+    void commission_device(const lora_dev_commission_t &commission_data);
+
+    /** End device OTAA join.
+     *
+     * Based on the LoRaWAN standard 1.0.2.
+     * Join the network using the Over The Air Activation (OTAA) procedure.
+     *
+     * @param  params           The `lorawan_connect_t` type structure.
+     *
+     * @return                  LORA_MAC_STATUS_OK or
+     *                          LORA_MAC_STATUS_CONNECT_IN_PROGRESS on success,
+     *                          or a negative error code on failure.
+     */
+    lora_mac_status_t join_request_by_otaa(const lorawan_connect_t &params);
+
+    /** End device ABP join.
+     *
+     * Based on the LoRaWAN standard 1.0.2.
+     * Join the network using the Activation By Personalization (ABP) procedure.
+     *
+     * @param  params           The `lorawan_connect_t` type structure.
+     *
+     * @return                  LORA_MAC_STATUS_OK or
+     *                          LORA_MAC_STATUS_CONNECT_IN_PROGRESS on success,
+     *                          or a negative error code on failure.
+     */
+    lora_mac_status_t activation_by_personalization(const lorawan_connect_t &params);
+
+    /** Send message to gateway
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to the data being sent. The ownership of the
+     *                          buffer is not transferred. The data is copied to the
+     *                          internal buffers.
+     *
+     * @param length            The size of data in bytes.
+     *
+     * @param flags             A flag used to determine what type of
+     *                          message is being sent, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          mutually exclusive.
+     *
+     *
+     * @return                  The number of bytes sent, or
+     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          ongoing, or a negative error code on failure.
+     */
+    int16_t handle_tx(uint8_t port, const uint8_t* data,
+                      uint16_t length, uint8_t flags);
+
+    /** Receives a message from the Network Server.
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to buffer where the received data will be
+     *                          stored.
+     *
+     * @param length            The size of data in bytes
+     *
+     * @param flags             A flag is used to determine what type of
+     *                          message is being received, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01,
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04,
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          not mutually exclusive, i.e., the user can subscribe to
+     *                          receive both CONFIRMED AND UNCONFIRMED messages at
+     *                          the same time.
+     *
+     * @return                  It could be one of these:
+     *                             i)   0 if there is nothing else to read.
+     *                             ii)  Number of bytes still pending to read.
+     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                                  nothing available to read at the moment.
+     *                             iv)  A negative error code on failure.
+     */
+    int16_t handle_rx(const uint8_t port, uint8_t* data,
+                      uint16_t length, uint8_t flags);
+
+    /** Shuts down the LoRaWAN protocol.
+     *
+     * In response to the user call for disconnection, the stack shuts down itself.
+     */
+    void shutdown();
+
+private:
+    LoRaWANStack();
+    ~LoRaWANStack();
+
+    /**
+     * Checks if the user provided port is valid or not
+     */
+    bool is_port_valid(uint8_t port);
+
+    /**
+     * State machine for stack controller layer.
+     * Needs to be wriggled for every state change
+     */
+    lora_mac_status_t lora_state_machine();
+
+    /**
+     * Sets the current state of the device.
+     * Every call to set_device_state() should precede with
+     * a call to lora_state_machine() in order to take the state change
+     * in effect.
+     */
+    void set_device_state(device_states_t new_state);
+
+    /**
+     * This function is used only for compliance testing
+     */
+    void prepare_special_tx_frame(uint8_t port);
+
+    /**
+     * Hands over the packet to Mac layer by posting an MCPS request.
+     */
+    lora_mac_status_t send_frame_to_mac();
+
+    /**
+     * Callback function for transmission based on user defined timer.
+     * Used only for testing when duty cycle is off.
+     */
+    void on_tx_next_packet_timer_event(void);
+
+    /**
+     * Callback function for MCPS confirm. Mac layer calls this function once
+     * an MCPS confirmation is received. This method translates Mac layer data
+     * structure into stack layer data structure.
+     */
+    void mcps_confirm(McpsConfirm_t *mcps_confirm);
+
+    /**
+     * Callback function for MCPS indication. Mac layer calls this function once
+     * an MCPS indication is received. This method translates Mac layer data
+     * structure into stack layer data structure.
+     */
+    void mcps_indication(McpsIndication_t *mcps_indication);
+
+    /**
+     * Callback function for MLME confirm. Mac layer calls this function once
+     * an MLME confirmation is received. This method translates Mac layer data
+     * structure into stack layer data structure.
+     */
+    void mlme_confirm(MlmeConfirm_t *mlme_confirm);
+
+    /**
+     * Handles an MLME request coming from the upper layers and delegates
+     * it to the Mac layer, for example, a Join request goes as an MLME request
+     * to the Mac layer.
+     */
+    lora_mac_status_t mlme_request_handler(lora_mac_mlme_req_t *mlme_request);
+
+    /**
+     * Handles an MLME confirmation coming from the Mac layer and uses it to
+     * update the state for example, a Join Accept triggers an MLME confirmation,
+     * that eventually comes here and we take necessary steps accordingly.
+     */
+    void mlme_confirm_handler(lora_mac_mlme_confirm_t *mlme_confirm);
+
+    /**
+     * Handles an MCPS request while attempting to hand over a packet from
+     * upper layers to Mac layer. For example in response to send_frame_to_mac(),
+     * an MCPS request is generated.
+     */
+    lora_mac_status_t mcps_request_handler(lora_mac_mcps_req_t *mcps_request);
+
+    /**
+     * Handles an MCPS confirmation coming from the Mac layer in response to an
+     * MCPS request. We take appropriate actions in response to the confirmation,
+     * e.g., letting the application know that ack was not received in case of
+     * a CONFIRMED message or scheduling error etc.
+     */
+    void mcps_confirm_handler(lora_mac_mcps_confirm_t *mcps_confirm);
+
+    /**
+     * Handles an MCPS indication coming from the Mac layer, e.g., once we
+     * receive a packet from the Network Server, it is indicated to this handler
+     * and consequently this handler posts an event to the application that
+     * there is something available to read.
+     */
+    void mcps_indication_handler(lora_mac_mcps_indication_t *mcps_indication);
+
+    /**
+     * Sets a MIB request, i.e., update a particular parameter etc.
+     */
+    lora_mac_status_t mib_set_request(lora_mac_mib_request_confirm_t *mib_set_params);
+
+    /**
+     * Requests the MIB to inquire about a particular parameter.
+     */
+    lora_mac_status_t mib_get_request(lora_mac_mib_request_confirm_t *mib_get_params);
+
+    /**
+     * Sets up user application port
+     */
+    lora_mac_status_t set_application_port(uint8_t port);
+
+    /**
+     * Helper function to figure out if the user defined data size is possible
+     * to send or not. The allowed size for transmission depends on the current
+     * data rate set for the channel. If its not possible to send user defined
+     * packet size, this method returns the maximum possible size at the moment,
+     * otherwise the user defined size is returned which means all of user data
+     * can be sent.
+     */
+    uint16_t check_possible_tx_size(uint16_t size);
+
+    /**
+     * Used only for compliance testing
+     */
+    void compliance_test_handler(lora_mac_mcps_indication_t *mcps_indication);
+
+    /**
+     * Used only for compliance testing
+     */
+    lora_mac_status_t send_compliance_test_frame_to_mac();
+
+    /**
+     * converts error codes from Mac layer to controller layer
+     */
+    lora_mac_status_t error_type_converter(LoRaMacStatus_t type);
+
+    compliance_test_t _compliance_test;
+    device_states_t _device_current_state;
+    mbed::Callback<void(lora_events_t)> _events;
+    radio_events_t *_mac_handlers;
+    lorawan_session_t _lw_session;
+    lora_mac_tx_message_t _tx_msg;
+    lora_mac_rx_message_t _rx_msg;
+    uint8_t _app_port;
+    uint8_t _num_retry;
+    bool _duty_cycle_on;
+};
+
+#endif /* LORAWANSTACK_H_ */

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1,0 +1,3606 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+Description: LoRa MAC layer implementation
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#include <stdlib.h>
+#include "events/EventQueue.h"
+#include "rtos/Thread.h"
+#include "LoRaMac.h"
+#include "LoRaMacCrypto.h"
+#include "LoRaMacTest.h"
+#include "netsocket/LoRaRadio.h"
+#include "lorastack/phy/LoRaPHY.h"
+#if defined(FEATURE_COMMON_PAL)
+#include "mbed_trace.h"
+#define TRACE_GROUP "LMAC"
+#else
+#define tr_debug(...) (void(0)) //dummies if feature common pal is not added
+#define tr_info(...)  (void(0)) //dummies if feature common pal is not added
+#define tr_error(...) (void(0)) //dummies if feature common pal is not added
+#endif //defined(FEATURE_COMMON_PAL)
+
+
+/**
+ * LoRa PHY layer object storage
+ */
+static LoRaPHY *lora_phy;
+
+/**
+ * Radio event callback handlers for MAC
+ */
+radio_events_t RadioEvents;
+
+/*!
+ * Maximum PHY layer payload size
+ */
+#define LORAMAC_PHY_MAXPAYLOAD                      255
+
+/*!
+ * Maximum MAC commands buffer size
+ */
+#define LORA_MAC_COMMAND_MAX_LENGTH                 128
+
+/*!
+ * Maximum length of the fOpts field
+ */
+#define LORA_MAC_COMMAND_MAX_FOPTS_LENGTH           15
+
+/*!
+ * LoRaMac duty cycle for the back-off procedure during the first hour.
+ */
+#define BACKOFF_DC_1_HOUR                           100
+
+/*!
+ * LoRaMac duty cycle for the back-off procedure during the next 10 hours.
+ */
+#define BACKOFF_DC_10_HOURS                         1000
+
+/*!
+ * LoRaMac duty cycle for the back-off procedure during the next 24 hours.
+ */
+#define BACKOFF_DC_24_HOURS                         10000
+
+/*!
+ * Device IEEE EUI
+ */
+static uint8_t *LoRaMacDevEui;
+
+/*!
+ * Application IEEE EUI
+ */
+static uint8_t *LoRaMacAppEui;
+
+/*!
+ * AES encryption/decryption cipher application key
+ */
+static uint8_t *LoRaMacAppKey;
+
+/*!
+ * AES encryption/decryption cipher network session key
+ */
+static uint8_t LoRaMacNwkSKey[] =
+{
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+/*!
+ * AES encryption/decryption cipher application session key
+ */
+static uint8_t LoRaMacAppSKey[] =
+{
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+};
+
+/*!
+ * Device nonce is a random value extracted by issuing a sequence of RSSI
+ * measurements
+ */
+static uint16_t LoRaMacDevNonce;
+
+/*!
+ * Network ID ( 3 bytes )
+ */
+static uint32_t LoRaMacNetID;
+
+/*!
+ * Mote Address
+ */
+static uint32_t LoRaMacDevAddr;
+
+/*!
+ * Multicast channels linked list
+ */
+static MulticastParams_t *MulticastChannels = NULL;
+
+/*!
+ * Actual device class
+ */
+static DeviceClass_t LoRaMacDeviceClass;
+
+/*!
+ * Indicates if the node is connected to a private or public network
+ */
+static bool PublicNetwork;
+
+/*!
+ * Indicates if the node supports repeaters
+ */
+static bool RepeaterSupport;
+
+/*!
+ * Buffer containing the data to be sent or received.
+ */
+static uint8_t LoRaMacBuffer[LORAMAC_PHY_MAXPAYLOAD];
+
+/*!
+ * Length of packet in LoRaMacBuffer
+ */
+static uint16_t LoRaMacBufferPktLen = 0;
+
+/*!
+ * Length of the payload in LoRaMacBuffer
+ */
+static uint8_t LoRaMacTxPayloadLen = 0;
+
+/*!
+ * Buffer containing the upper layer data.
+ */
+static uint8_t LoRaMacRxPayload[LORAMAC_PHY_MAXPAYLOAD];
+
+/*!
+ * LoRaMAC frame counter. Each time a packet is sent the counter is incremented.
+ * Only the 16 LSB bits are sent
+ */
+static uint32_t UpLinkCounter = 0;
+
+/*!
+ * LoRaMAC frame counter. Each time a packet is received the counter is incremented.
+ * Only the 16 LSB bits are received
+ */
+static uint32_t DownLinkCounter = 0;
+
+/*!
+ * IsPacketCounterFixed enables the MIC field tests by fixing the
+ * UpLinkCounter value
+ */
+static bool IsUpLinkCounterFixed = false;
+
+/*!
+ * Used for test purposes. Disables the opening of the reception windows.
+ */
+static bool IsRxWindowsEnabled = true;
+
+/*!
+ * Indicates if the MAC layer has already joined a network.
+ */
+static bool IsLoRaMacNetworkJoined = false;
+
+/*!
+ * LoRaMac ADR control status
+ */
+static bool AdrCtrlOn = false;
+
+/*!
+ * Counts the number of missed ADR acknowledgements
+ */
+static uint32_t AdrAckCounter = 0;
+
+/*!
+ * If the node has sent a FRAME_TYPE_DATA_CONFIRMED_UP this variable indicates
+ * if the nodes needs to manage the server acknowledgement.
+ */
+static bool NodeAckRequested = false;
+
+/*!
+ * If the server has sent a FRAME_TYPE_DATA_CONFIRMED_DOWN this variable indicates
+ * if the ACK bit must be set for the next transmission
+ */
+static bool SrvAckRequested = false;
+
+/*!
+ * Indicates if the MAC layer wants to send MAC commands
+ */
+static bool MacCommandsInNextTx = false;
+
+/*!
+ * Contains the current MacCommandsBuffer index
+ */
+static uint8_t MacCommandsBufferIndex = 0;
+
+/*!
+ * Contains the current MacCommandsBuffer index for MAC commands to repeat
+ */
+static uint8_t MacCommandsBufferToRepeatIndex = 0;
+
+/*!
+ * Buffer containing the MAC layer commands
+ */
+static uint8_t MacCommandsBuffer[LORA_MAC_COMMAND_MAX_LENGTH];
+
+/*!
+ * Buffer containing the MAC layer commands which must be repeated
+ */
+static uint8_t MacCommandsBufferToRepeat[LORA_MAC_COMMAND_MAX_LENGTH];
+
+/*!
+ * LoRaMac parameters
+ */
+LoRaMacParams_t LoRaMacParams;
+
+/*!
+ * LoRaMac default parameters
+ */
+LoRaMacParams_t LoRaMacParamsDefaults;
+
+/*!
+ * Uplink messages repetitions counter
+ */
+static uint8_t ChannelsNbRepCounter = 0;
+
+/*!
+ * Maximum duty cycle
+ * \remark Possibility to shutdown the device.
+ */
+static uint8_t MaxDCycle = 0;
+
+/*!
+ * Aggregated duty cycle management
+ */
+static uint16_t AggregatedDCycle;
+static TimerTime_t AggregatedLastTxDoneTime;
+static TimerTime_t AggregatedTimeOff;
+
+/*!
+ * Enables/Disables duty cycle management (Test only)
+ */
+static bool DutyCycleOn;
+
+/*!
+ * Current channel index
+ */
+static uint8_t Channel;
+
+/*!
+ * Current channel index
+ */
+static uint8_t LastTxChannel;
+
+/*!
+ * Set to true, if the last uplink was a join request
+ */
+static bool LastTxIsJoinRequest;
+
+/*!
+ * Stores the time at LoRaMac initialization.
+ *
+ * \remark Used for the BACKOFF_DC computation.
+ */
+static TimerTime_t LoRaMacInitializationTime = 0;
+
+/*!
+ * LoRaMac internal states
+ */
+enum eLoRaMacState
+{
+    LORAMAC_IDLE          = 0x00000000,
+    LORAMAC_TX_RUNNING    = 0x00000001,
+    LORAMAC_RX            = 0x00000002,
+    LORAMAC_ACK_REQ       = 0x00000004,
+    LORAMAC_ACK_RETRY     = 0x00000008,
+    LORAMAC_TX_DELAYED    = 0x00000010,
+    LORAMAC_TX_CONFIG     = 0x00000020,
+    LORAMAC_RX_ABORT      = 0x00000040,
+};
+
+/*!
+ * LoRaMac internal state
+ */
+uint32_t LoRaMacState = LORAMAC_IDLE;
+
+/*!
+ * LoRaMac timer used to check the LoRaMacState (runs every second)
+ */
+static TimerEvent_t MacStateCheckTimer;
+
+/**
+ * Timer to handle the application data transmission duty cycle
+ */
+static TimerEvent_t TxNextPacketTimer;
+
+/*!
+ * LoRaMac upper layer event functions
+ */
+static LoRaMacPrimitives_t *LoRaMacPrimitives;
+
+/*!
+ * LoRaMac upper layer callback functions
+ */
+static LoRaMacCallback_t *LoRaMacCallbacks;
+
+/*!
+ * LoRaMac duty cycle delayed Tx timer
+ */
+static TimerEvent_t TxDelayedTimer;
+
+/*!
+ * LoRaMac reception windows timers
+ */
+static TimerEvent_t RxWindowTimer1;
+static TimerEvent_t RxWindowTimer2;
+
+/*!
+ * LoRaMac reception windows delay
+ * \remark normal frame: RxWindowXDelay = ReceiveDelayX - RADIO_WAKEUP_TIME
+ *         join frame  : RxWindowXDelay = JoinAcceptDelayX - RADIO_WAKEUP_TIME
+ */
+static uint32_t RxWindow1Delay;
+static uint32_t RxWindow2Delay;
+
+/*!
+ * LoRaMac Rx windows configuration
+ */
+static RxConfigParams_t RxWindow1Config;
+static RxConfigParams_t RxWindow2Config;
+
+/*!
+ * Acknowledge timeout timer. Used for packet retransmissions.
+ */
+static TimerEvent_t AckTimeoutTimer;
+
+/*!
+ * Number of trials to get a frame acknowledged
+ */
+static uint8_t AckTimeoutRetries = 1;
+
+/*!
+ * Number of trials to get a frame acknowledged
+ */
+static uint8_t AckTimeoutRetriesCounter = 1;
+
+/*!
+ * Indicates if the AckTimeout timer has expired or not
+ */
+static bool AckTimeoutRetry = false;
+
+/*!
+ * Last transmission time on air
+ */
+TimerTime_t TxTimeOnAir = 0;
+
+/*!
+ * Number of trials for the Join Request
+ */
+static uint8_t JoinRequestTrials;
+
+/*!
+ * Maximum number of trials for the Join Request
+ */
+static uint8_t MaxJoinRequestTrials;
+
+/*!
+ * Structure to hold an MCPS indication data.
+ */
+static McpsIndication_t McpsIndication;
+
+/*!
+ * Structure to hold MCPS confirm data.
+ */
+static McpsConfirm_t McpsConfirm;
+
+/*!
+ * Structure to hold MLME confirm data.
+ */
+static MlmeConfirm_t MlmeConfirm;
+
+/*!
+ * Holds the current rx window slot
+ */
+static uint8_t RxSlot = 0;
+
+/*!
+ * LoRaMac tx/rx operation state
+ */
+LoRaMacFlags_t LoRaMacFlags;
+
+/*!
+ * \brief Function to be executed on Radio Tx Done event
+ */
+static void OnRadioTxDone( void );
+
+/*!
+ * \brief This function prepares the MAC to abort the execution of function
+ *        OnRadioRxDone in case of a reception error.
+ */
+static void PrepareRxDoneAbort( void );
+
+/*!
+ * \brief Function to be executed on Radio Rx Done event
+ */
+static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr );
+
+/*!
+ * \brief Function executed on Radio Tx Timeout event
+ */
+static void OnRadioTxTimeout( void );
+
+/*!
+ * \brief Function executed on Radio Rx error event
+ */
+static void OnRadioRxError( void );
+
+/*!
+ * \brief Function executed on Radio Rx Timeout event
+ */
+static void OnRadioRxTimeout( void );
+
+/*!
+ * \brief Function executed on Resend Frame timer event.
+ */
+static void OnMacStateCheckTimerEvent( void );
+
+/*!
+ * \brief Function executed on duty cycle delayed Tx  timer event
+ */
+static void OnTxDelayedTimerEvent( void );
+
+/**
+ * \brief Function to be executed when next Tx is possible
+ */
+static void OnNextTx( void );
+
+/*!
+ * \brief Function executed on first Rx window timer event
+ */
+static void OnRxWindow1TimerEvent( void );
+
+/*!
+ * \brief Function executed on second Rx window timer event
+ */
+static void OnRxWindow2TimerEvent( void );
+
+/*!
+ * \brief Function executed on AckTimeout timer event
+ */
+static void OnAckTimeoutTimerEvent( void );
+
+/*!
+ * \brief Initializes and opens the reception window
+ *
+ * \param [IN] rxContinuous Set to true, if the RX is in continuous mode
+ * \param [IN] maxRxWindow Maximum RX window timeout
+ */
+static void RxWindowSetup( bool rxContinuous, uint32_t maxRxWindow );
+
+/*!
+ * \brief Adds a new MAC command to be sent.
+ *
+ * \Remark MAC layer internal function
+ *
+ * \param [in] cmd MAC command to be added
+ *                 [MOTE_MAC_LINK_CHECK_REQ,
+ *                  MOTE_MAC_LINK_ADR_ANS,
+ *                  MOTE_MAC_DUTY_CYCLE_ANS,
+ *                  MOTE_MAC_RX2_PARAM_SET_ANS,
+ *                  MOTE_MAC_DEV_STATUS_ANS
+ *                  MOTE_MAC_NEW_CHANNEL_ANS]
+ * \param [in] p1  1st parameter ( optional depends on the command )
+ * \param [in] p2  2nd parameter ( optional depends on the command )
+ *
+ * \retval status  Function status [0: OK, 1: Unknown command, 2: Buffer full]
+ */
+static LoRaMacStatus_t AddMacCommand( uint8_t cmd, uint8_t p1, uint8_t p2 );
+
+/*!
+ * \brief Parses the MAC commands which must be repeated.
+ *
+ * \Remark MAC layer internal function
+ *
+ * \param [IN] cmdBufIn  Buffer which stores the MAC commands to send
+ * \param [IN] length  Length of the input buffer to parse
+ * \param [OUT] cmdBufOut  Buffer which stores the MAC commands which must be
+ *                         repeated.
+ *
+ * \retval Size of the MAC commands to repeat.
+ */
+static uint8_t ParseMacCommandsToRepeat( uint8_t* cmdBufIn, uint8_t length, uint8_t* cmdBufOut );
+
+/*!
+ * \brief Validates if the payload fits into the frame, taking the datarate
+ *        into account.
+ *
+ * \details Refer to chapter 4.3.2 of the LoRaWAN specification, v1.0
+ *
+ * \param lenN Length of the application payload. The length depends on the
+ *             datarate and is region specific
+ *
+ * \param datarate Current datarate
+ *
+ * \param fOptsLen Length of the fOpts field
+ *
+ * \retval [false: payload does not fit into the frame, true: payload fits into
+ *          the frame]
+ */
+static bool ValidatePayloadLength( uint8_t lenN, int8_t datarate, uint8_t fOptsLen );
+
+/*!
+ * \brief Decodes MAC commands in the fOpts field and in the payload
+ */
+static void ProcessMacCommands( uint8_t *payload, uint8_t macIndex, uint8_t commandsSize, uint8_t snr );
+
+/*!
+ * \brief LoRaMAC layer generic send frame
+ *
+ * \param [IN] macHdr      MAC header field
+ * \param [IN] fPort       MAC payload port
+ * \param [IN] fBuffer     MAC data buffer to be sent
+ * \param [IN] fBufferSize MAC data buffer size
+ * \retval status          Status of the operation.
+ */
+LoRaMacStatus_t Send( LoRaMacHeader_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
+
+/*!
+ * \brief LoRaMAC layer frame buffer initialization
+ *
+ * \param [IN] macHdr      MAC header field
+ * \param [IN] fCtrl       MAC frame control field
+ * \param [IN] fOpts       MAC commands buffer
+ * \param [IN] fPort       MAC payload port
+ * \param [IN] fBuffer     MAC data buffer to be sent
+ * \param [IN] fBufferSize MAC data buffer size
+ * \retval status          Status of the operation.
+ */
+LoRaMacStatus_t PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize );
+
+/*
+ * \brief Schedules the frame according to the duty cycle
+ *
+ * \retval Status of the operation
+ */
+static LoRaMacStatus_t ScheduleTx( void );
+
+/*
+ * \brief Calculates the back-off time for the band of a channel.
+ *
+ * \param [IN] channel     The last Tx channel index
+ */
+static void CalculateBackOff( uint8_t channel );
+
+/*!
+ * \brief LoRaMAC layer prepared frame buffer transmission with channel specification
+ *
+ * \remark PrepareFrame must be called at least once before calling this
+ *         function.
+ *
+ * \param [IN] channel     Channel to transmit on
+ * \retval status          Status of the operation.
+ */
+LoRaMacStatus_t SendFrameOnChannel( uint8_t channel );
+
+/*!
+ * \brief Sets the radio in continuous transmission mode
+ *
+ * \remark Uses the radio parameters set on the previous transmission.
+ *
+ * \param [IN] timeout     Time in seconds while the radio is kept in continuous wave mode
+ * \retval status          Status of the operation.
+ */
+LoRaMacStatus_t SetTxContinuousWave( uint16_t timeout );
+
+/*!
+ * \brief Sets the radio in continuous transmission mode
+ *
+ * \remark Uses the radio parameters set on the previous transmission.
+ *
+ * \param [IN] timeout     Time in seconds while the radio is kept in continuous wave mode
+ * \param [IN] frequency   RF frequency to be set.
+ * \param [IN] power       RF output power to be set.
+ * \retval status          Status of the operation.
+ */
+LoRaMacStatus_t SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power );
+
+/*!
+ * \brief Resets MAC specific parameters to default
+ */
+static void ResetMacParameters( void );
+
+
+/**
+ * Prototypes for ISR handlers
+ */
+static void handle_cad_done(bool cad);
+static void handle_tx_done(void);
+static void handle_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
+                              int8_t snr);
+static void handle_rx_error(void);
+static void handle_rx_timeout(void);
+static void handle_tx_timeout(void);
+static void handle_fhss_change_channel(uint8_t cur_channel);
+static void handle_rx1_timer_event(void);
+static void handle_rx2_timer_event(void);
+static void handle_ack_timeout(void);
+static void handle_delayed_tx_timer_event(void);
+static void handle_mac_state_check_timer_event(void);
+static void handle_next_tx_timer_event(void);
+
+/***************************************************************************
+ * LoRaMACTask class - Handles deferred callbacks                          *
+ *                     and timers from Interrupt context                   *
+ **************************************************************************/
+/**
+ * An internal class to facilitate MAC related tasks.
+ * Idea is to mould Semtech code as less as possible so
+ * as to make future integration smoother.
+ *
+ * This class is present only if RTOS is being used.
+ */
+#ifdef MBED_CONF_RTOS_PRESENT
+
+class LoRaMACTask {
+
+public:
+    LoRaMACTask();
+    events::EventQueue queue;
+
+private:
+    rtos::Thread t;
+};
+
+LoRaMACTask::LoRaMACTask()
+    : queue(16 * EVENTS_EVENT_SIZE),
+      t(osPriorityNormal, 2048)
+{
+    t.start(callback(&queue, &events::EventQueue::dispatch_forever));
+}
+
+static LoRaMACTask mac_task;
+
+#endif //MBED_CONF_RTOS_PRESENT
+
+/***************************************************************************
+ * ISRs - Handlers                                                         *
+ **************************************************************************/
+static void handle_tx_done(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRadioTxDone);
+#else
+    OnRadioTxDone();
+#endif
+}
+
+static void handle_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
+                              int8_t snr)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRadioRxDone, payload, size, rssi, snr);
+#else
+    OnRadioRxDone(payload, size, rssi, snr);
+#endif
+}
+
+static void handle_rx_error(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRadioRxError);
+#else
+    OnRadioRxError();
+#endif
+}
+
+static void handle_rx_timeout(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRadioRxTimeout);
+#else
+    OnRadioRxTimeout();
+#endif
+}
+
+static void handle_tx_timeout(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRadioTxTimeout);
+#else
+    OnRadioTxTimeout();
+#endif
+}
+
+static void handle_cad_done(bool cad)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    //mac_task.queue.call(OnRadioCadDone, cad);
+#else
+    //TODO Doesn't exist yet
+    //OnRadioCadDOne(cad);
+#endif
+}
+
+static void handle_fhss_change_channel(uint8_t cur_channel)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    //mac_task.queue.call(OnRadioFHSSChangeChannel, cur_channel);
+#else
+    // TODO Not implemented yet
+    //OnRadioFHSSChangeChannel(cur_channel);
+#endif
+}
+static void handle_mac_state_check_timer_event(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnMacStateCheckTimerEvent);
+#else
+    OnMacStateCheckTimerEvent();
+#endif
+}
+
+static void handle_next_tx_timer_event(void)
+{
+    // Validate if the MAC is in a correct state
+    if ((LoRaMacState & LORAMAC_TX_RUNNING) == LORAMAC_TX_RUNNING) {
+        return;
+    }
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnNextTx);
+#else
+    OnNextTx();
+#endif
+}
+
+static void handle_delayed_tx_timer_event(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnTxDelayedTimerEvent);
+#else
+    OnTxDelayedTimerEvent();
+#endif
+}
+
+static void handle_ack_timeout()
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnAckTimeoutTimerEvent);
+#else
+    OnAckTimeoutTimerEvent();
+#endif
+}
+
+static void handle_rx1_timer_event(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRxWindow1TimerEvent);
+#else
+    OnRxWindow1TimerEvent();
+#endif
+}
+
+static void handle_rx2_timer_event(void)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    mac_task.queue.call(OnRxWindow2TimerEvent);
+#else
+    OnRxWindow2TimerEvent();
+#endif
+}
+
+/***************************************************************************
+ * Radio event callbacks - delegated to Radio driver                       *
+ **************************************************************************/
+static void OnRadioTxDone( void )
+{
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    SetBandTxDoneParams_t txDone;
+    TimerTime_t curTime = TimerGetCurrentTime( );
+
+    if( LoRaMacDeviceClass != CLASS_C )
+    {
+        lora_phy->put_radio_to_sleep();
+    }
+    else
+    {
+        handle_rx2_timer_event();
+    }
+
+    // Setup timers
+    if( IsRxWindowsEnabled == true )
+    {
+        TimerSetValue( &RxWindowTimer1, RxWindow1Delay );
+        TimerStart( &RxWindowTimer1 );
+        if( LoRaMacDeviceClass != CLASS_C )
+        {
+            TimerSetValue( &RxWindowTimer2, RxWindow2Delay );
+            TimerStart( &RxWindowTimer2 );
+        }
+        if( ( LoRaMacDeviceClass == CLASS_C ) || ( NodeAckRequested == true ) )
+        {
+            getPhy.Attribute = PHY_ACK_TIMEOUT;
+            phyParam = lora_phy->get_phy_params(&getPhy);
+            TimerSetValue( &AckTimeoutTimer, RxWindow2Delay + phyParam.Value );
+            TimerStart( &AckTimeoutTimer );
+        }
+    }
+    else
+    {
+        McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+        MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+
+        if( LoRaMacFlags.Value == 0 )
+        {
+            LoRaMacFlags.Bits.McpsReq = 1;
+        }
+        LoRaMacFlags.Bits.MacDone = 1;
+    }
+
+    // Verify if the last uplink was a join request
+    if( ( LoRaMacFlags.Bits.MlmeReq == 1 ) && ( MlmeConfirm.MlmeRequest == MLME_JOIN ) )
+    {
+        LastTxIsJoinRequest = true;
+    }
+    else
+    {
+        LastTxIsJoinRequest = false;
+    }
+
+    // Store last Tx channel
+    LastTxChannel = Channel;
+    // Update last tx done time for the current channel
+    txDone.Channel = Channel;
+    txDone.Joined = IsLoRaMacNetworkJoined;
+    txDone.LastTxDoneTime = curTime;
+    lora_phy->set_band_tx_done(&txDone);
+    // Update Aggregated last tx done time
+    AggregatedLastTxDoneTime = curTime;
+
+    if( NodeAckRequested == false )
+    {
+        McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+        ChannelsNbRepCounter++;
+    }
+}
+
+static void PrepareRxDoneAbort( void )
+{
+    LoRaMacState |= LORAMAC_RX_ABORT;
+
+    if( NodeAckRequested )
+    {
+        handle_ack_timeout();
+    }
+
+    LoRaMacFlags.Bits.McpsInd = 1;
+    LoRaMacFlags.Bits.MacDone = 1;
+
+    // Trig OnMacCheckTimerEvent call as soon as possible
+    TimerSetValue( &MacStateCheckTimer, 1 );
+    TimerStart( &MacStateCheckTimer );
+}
+
+static void OnRadioRxDone( uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr )
+{
+    LoRaMacHeader_t macHdr;
+    LoRaMacFrameCtrl_t fCtrl;
+    ApplyCFListParams_t applyCFList;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    bool skipIndication = false;
+
+    uint8_t pktHeaderLen = 0;
+    uint32_t address = 0;
+    uint8_t appPayloadStartIndex = 0;
+    uint8_t port = 0xFF;
+    uint8_t frameLen = 0;
+    uint32_t mic = 0;
+    uint32_t micRx = 0;
+
+    uint16_t sequenceCounter = 0;
+    uint16_t sequenceCounterPrev = 0;
+    uint16_t sequenceCounterDiff = 0;
+    uint32_t downLinkCounter = 0;
+
+    MulticastParams_t *curMulticastParams = NULL;
+    uint8_t *nwkSKey = LoRaMacNwkSKey;
+    uint8_t *appSKey = LoRaMacAppSKey;
+
+    uint8_t multicast = 0;
+
+    bool isMicOk = false;
+
+    McpsConfirm.AckReceived = false;
+    McpsIndication.Rssi = rssi;
+    McpsIndication.Snr = snr;
+    McpsIndication.RxSlot = RxSlot;
+    McpsIndication.Port = 0;
+    McpsIndication.Multicast = 0;
+    McpsIndication.FramePending = 0;
+    McpsIndication.Buffer = NULL;
+    McpsIndication.BufferSize = 0;
+    McpsIndication.RxData = false;
+    McpsIndication.AckReceived = false;
+    McpsIndication.DownLinkCounter = 0;
+    McpsIndication.McpsIndication = MCPS_UNCONFIRMED;
+
+    lora_phy->put_radio_to_sleep();
+
+    TimerStop( &RxWindowTimer2 );
+
+    macHdr.Value = payload[pktHeaderLen++];
+
+    switch( macHdr.Bits.MType )
+    {
+        case FRAME_TYPE_JOIN_ACCEPT:
+            if( IsLoRaMacNetworkJoined == true )
+            {
+                McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+                PrepareRxDoneAbort( );
+                return;
+            }
+
+            if (0 != LoRaMacJoinDecrypt( payload + 1, size - 1, LoRaMacAppKey, LoRaMacRxPayload + 1 )) {
+                McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                return;
+            }
+
+            LoRaMacRxPayload[0] = macHdr.Value;
+
+            if (0 != LoRaMacJoinComputeMic( LoRaMacRxPayload, size - LORAMAC_MFR_LEN, LoRaMacAppKey, &mic )) {
+                McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                return;
+            }
+
+            micRx |= ( uint32_t )LoRaMacRxPayload[size - LORAMAC_MFR_LEN];
+            micRx |= ( ( uint32_t )LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 1] << 8 );
+            micRx |= ( ( uint32_t )LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 2] << 16 );
+            micRx |= ( ( uint32_t )LoRaMacRxPayload[size - LORAMAC_MFR_LEN + 3] << 24 );
+
+            if( micRx == mic )
+            {
+                if (0 != LoRaMacJoinComputeSKeys( LoRaMacAppKey, LoRaMacRxPayload + 1, LoRaMacDevNonce, LoRaMacNwkSKey, LoRaMacAppSKey )) {
+                    McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                    return;
+                }
+
+                LoRaMacNetID = ( uint32_t )LoRaMacRxPayload[4];
+                LoRaMacNetID |= ( ( uint32_t )LoRaMacRxPayload[5] << 8 );
+                LoRaMacNetID |= ( ( uint32_t )LoRaMacRxPayload[6] << 16 );
+
+                LoRaMacDevAddr = ( uint32_t )LoRaMacRxPayload[7];
+                LoRaMacDevAddr |= ( ( uint32_t )LoRaMacRxPayload[8] << 8 );
+                LoRaMacDevAddr |= ( ( uint32_t )LoRaMacRxPayload[9] << 16 );
+                LoRaMacDevAddr |= ( ( uint32_t )LoRaMacRxPayload[10] << 24 );
+
+                // DLSettings
+                LoRaMacParams.Rx1DrOffset = ( LoRaMacRxPayload[11] >> 4 ) & 0x07;
+                LoRaMacParams.Rx2Channel.Datarate = LoRaMacRxPayload[11] & 0x0F;
+
+                // RxDelay
+                LoRaMacParams.ReceiveDelay1 = ( LoRaMacRxPayload[12] & 0x0F );
+                if( LoRaMacParams.ReceiveDelay1 == 0 )
+                {
+                    LoRaMacParams.ReceiveDelay1 = 1;
+                }
+                LoRaMacParams.ReceiveDelay1 *= 1000;
+                LoRaMacParams.ReceiveDelay2 = LoRaMacParams.ReceiveDelay1 + 1000;
+
+                // Apply CF list
+                applyCFList.Payload = &LoRaMacRxPayload[13];
+                // Size of the regular payload is 12. Plus 1 byte MHDR and 4 bytes MIC
+                applyCFList.Size = size - 17;
+
+                lora_phy->apply_cf_list(&applyCFList);
+
+                MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+                IsLoRaMacNetworkJoined = true;
+                LoRaMacParams.ChannelsDatarate = LoRaMacParamsDefaults.ChannelsDatarate;
+            }
+            else
+            {
+                MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL;
+            }
+            break;
+        case FRAME_TYPE_DATA_CONFIRMED_DOWN:
+        case FRAME_TYPE_DATA_UNCONFIRMED_DOWN:
+            {
+                // Check if the received payload size is valid
+                getPhy.UplinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+                getPhy.Datarate = McpsIndication.RxDatarate;
+                getPhy.Attribute = PHY_MAX_PAYLOAD;
+
+                // Get the maximum payload length
+                if( RepeaterSupport == true )
+                {
+                    getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
+                }
+                phyParam = lora_phy->get_phy_params(&getPhy);
+                if( MAX( 0, ( int16_t )( ( int16_t )size - ( int16_t )LORA_MAC_FRMPAYLOAD_OVERHEAD ) ) > phyParam.Value )
+                {
+                    McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+                    PrepareRxDoneAbort( );
+                    return;
+                }
+
+                address = payload[pktHeaderLen++];
+                address |= ( (uint32_t)payload[pktHeaderLen++] << 8 );
+                address |= ( (uint32_t)payload[pktHeaderLen++] << 16 );
+                address |= ( (uint32_t)payload[pktHeaderLen++] << 24 );
+
+                if( address != LoRaMacDevAddr )
+                {
+                    curMulticastParams = MulticastChannels;
+                    while( curMulticastParams != NULL )
+                    {
+                        if( address == curMulticastParams->Address )
+                        {
+                            multicast = 1;
+                            nwkSKey = curMulticastParams->NwkSKey;
+                            appSKey = curMulticastParams->AppSKey;
+                            downLinkCounter = curMulticastParams->DownLinkCounter;
+                            break;
+                        }
+                        curMulticastParams = curMulticastParams->Next;
+                    }
+                    if( multicast == 0 )
+                    {
+                        // We are not the destination of this frame.
+                        McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL;
+                        PrepareRxDoneAbort( );
+                        return;
+                    }
+                }
+                else
+                {
+                    multicast = 0;
+                    nwkSKey = LoRaMacNwkSKey;
+                    appSKey = LoRaMacAppSKey;
+                    downLinkCounter = DownLinkCounter;
+                }
+
+                fCtrl.Value = payload[pktHeaderLen++];
+
+                sequenceCounter = ( uint16_t )payload[pktHeaderLen++];
+                sequenceCounter |= ( uint16_t )payload[pktHeaderLen++] << 8;
+
+                appPayloadStartIndex = 8 + fCtrl.Bits.FOptsLen;
+
+                micRx |= ( uint32_t )payload[size - LORAMAC_MFR_LEN];
+                micRx |= ( ( uint32_t )payload[size - LORAMAC_MFR_LEN + 1] << 8 );
+                micRx |= ( ( uint32_t )payload[size - LORAMAC_MFR_LEN + 2] << 16 );
+                micRx |= ( ( uint32_t )payload[size - LORAMAC_MFR_LEN + 3] << 24 );
+
+                sequenceCounterPrev = ( uint16_t )downLinkCounter;
+                sequenceCounterDiff = ( sequenceCounter - sequenceCounterPrev );
+
+                if( sequenceCounterDiff < ( 1 << 15 ) )
+                {
+                    downLinkCounter += sequenceCounterDiff;
+                    LoRaMacComputeMic( payload, size - LORAMAC_MFR_LEN, nwkSKey, address, DOWN_LINK, downLinkCounter, &mic );
+                    if( micRx == mic )
+                    {
+                        isMicOk = true;
+                    }
+                }
+                else
+                {
+                    // check for sequence roll-over
+                    uint32_t  downLinkCounterTmp = downLinkCounter + 0x10000 + ( int16_t )sequenceCounterDiff;
+                    LoRaMacComputeMic( payload, size - LORAMAC_MFR_LEN, nwkSKey, address, DOWN_LINK, downLinkCounterTmp, &mic );
+                    if( micRx == mic )
+                    {
+                        isMicOk = true;
+                        downLinkCounter = downLinkCounterTmp;
+                    }
+                }
+
+                // Check for a the maximum allowed counter difference
+                getPhy.Attribute = PHY_MAX_FCNT_GAP;
+                phyParam = lora_phy->get_phy_params( &getPhy );
+                if( sequenceCounterDiff >= phyParam.Value )
+                {
+                    McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS;
+                    McpsIndication.DownLinkCounter = downLinkCounter;
+                    PrepareRxDoneAbort( );
+                    return;
+                }
+
+                if( isMicOk == true )
+                {
+                    McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+                    McpsIndication.Multicast = multicast;
+                    McpsIndication.FramePending = fCtrl.Bits.FPending;
+                    McpsIndication.Buffer = NULL;
+                    McpsIndication.BufferSize = 0;
+                    McpsIndication.DownLinkCounter = downLinkCounter;
+
+                    McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+
+                    AdrAckCounter = 0;
+                    MacCommandsBufferToRepeatIndex = 0;
+
+                    // Update 32 bits downlink counter
+                    if( multicast == 1 )
+                    {
+                        McpsIndication.McpsIndication = MCPS_MULTICAST;
+
+                        if( ( curMulticastParams->DownLinkCounter == downLinkCounter ) &&
+                            ( curMulticastParams->DownLinkCounter != 0 ) )
+                        {
+                            McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
+                            McpsIndication.DownLinkCounter = downLinkCounter;
+                            PrepareRxDoneAbort( );
+                            return;
+                        }
+                        curMulticastParams->DownLinkCounter = downLinkCounter;
+                    }
+                    else
+                    {
+                        if( macHdr.Bits.MType == FRAME_TYPE_DATA_CONFIRMED_DOWN )
+                        {
+                            SrvAckRequested = true;
+                            McpsIndication.McpsIndication = MCPS_CONFIRMED;
+
+                            if( ( DownLinkCounter == downLinkCounter ) &&
+                                ( DownLinkCounter != 0 ) )
+                            {
+                                // Duplicated confirmed downlink. Skip indication.
+                                // In this case, the MAC layer shall accept the MAC commands
+                                // which are included in the downlink retransmission.
+                                // It should not provide the same frame to the application
+                                // layer again.
+                                skipIndication = true;
+                            }
+                        }
+                        else
+                        {
+                            SrvAckRequested = false;
+                            McpsIndication.McpsIndication = MCPS_UNCONFIRMED;
+
+                            if( ( DownLinkCounter == downLinkCounter ) &&
+                                ( DownLinkCounter != 0 ) )
+                            {
+                                McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED;
+                                McpsIndication.DownLinkCounter = downLinkCounter;
+                                PrepareRxDoneAbort( );
+                                return;
+                            }
+                        }
+                        DownLinkCounter = downLinkCounter;
+                    }
+
+                    // This must be done before parsing the payload and the MAC commands.
+                    // We need to reset the MacCommandsBufferIndex here, since we need
+                    // to take retransmissions and repetitions into account. Error cases
+                    // will be handled in function OnMacStateCheckTimerEvent.
+                    if( McpsConfirm.McpsRequest == MCPS_CONFIRMED )
+                    {
+                        if( fCtrl.Bits.Ack == 1 )
+                        {// Reset MacCommandsBufferIndex when we have received an ACK.
+                            MacCommandsBufferIndex = 0;
+                        }
+                    }
+                    else
+                    {// Reset the variable if we have received any valid frame.
+                        MacCommandsBufferIndex = 0;
+                    }
+
+                    // Process payload and MAC commands
+                    if( ( ( size - 4 ) - appPayloadStartIndex ) > 0 )
+                    {
+                        port = payload[appPayloadStartIndex++];
+                        frameLen = ( size - 4 ) - appPayloadStartIndex;
+
+                        McpsIndication.Port = port;
+
+                        if( port == 0 )
+                        {
+                            // Only allow frames which do not have fOpts
+                            if( fCtrl.Bits.FOptsLen == 0 )
+                            {
+                                if (0 != LoRaMacPayloadDecrypt( payload + appPayloadStartIndex,
+                                                                frameLen,
+                                                                nwkSKey,
+                                                                address,
+                                                                DOWN_LINK,
+                                                                downLinkCounter,
+                                                                LoRaMacRxPayload )) {
+                                    McpsIndication.Status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                                }
+
+                                // Decode frame payload MAC commands
+                                ProcessMacCommands( LoRaMacRxPayload, 0, frameLen, snr );
+                            }
+                            else
+                            {
+                                skipIndication = true;
+                            }
+                        }
+                        else
+                        {
+                            if( fCtrl.Bits.FOptsLen > 0 )
+                            {
+                                // Decode Options field MAC commands. Omit the fPort.
+                                ProcessMacCommands( payload, 8, appPayloadStartIndex - 1, snr );
+                            }
+
+                            if (0 != LoRaMacPayloadDecrypt( payload + appPayloadStartIndex,
+                                                            frameLen,
+                                                            appSKey,
+                                                            address,
+                                                            DOWN_LINK,
+                                                            downLinkCounter,
+                                                            LoRaMacRxPayload )) {
+                                McpsIndication.Status =  LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL;
+                            }
+
+                            if( skipIndication == false )
+                            {
+                                McpsIndication.Buffer = LoRaMacRxPayload;
+                                McpsIndication.BufferSize = frameLen;
+                                McpsIndication.RxData = true;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if( fCtrl.Bits.FOptsLen > 0 )
+                        {
+                            // Decode Options field MAC commands
+                            ProcessMacCommands( payload, 8, appPayloadStartIndex, snr );
+                        }
+                    }
+
+                    if( skipIndication == false )
+                    {
+                        // Check if the frame is an acknowledgement
+                        if( fCtrl.Bits.Ack == 1 )
+                        {
+                            McpsConfirm.AckReceived = true;
+                            McpsIndication.AckReceived = true;
+
+                            // Stop the AckTimeout timer as no more retransmissions
+                            // are needed.
+                            TimerStop( &AckTimeoutTimer );
+                        }
+                        else
+                        {
+                            McpsConfirm.AckReceived = false;
+
+                            if( AckTimeoutRetriesCounter > AckTimeoutRetries )
+                            {
+                                // Stop the AckTimeout timer as no more retransmissions
+                                // are needed.
+                                TimerStop( &AckTimeoutTimer );
+                            }
+                        }
+                    }
+                    // Provide always an indication, skip the callback to the user application,
+                    // in case of a confirmed downlink retransmission.
+                    LoRaMacFlags.Bits.McpsInd = 1;
+                    LoRaMacFlags.Bits.McpsIndSkip = skipIndication;
+                }
+                else
+                {
+                    McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_MIC_FAIL;
+
+                    PrepareRxDoneAbort( );
+                    return;
+                }
+            }
+            break;
+        case FRAME_TYPE_PROPRIETARY:
+            {
+                memcpy( LoRaMacRxPayload, &payload[pktHeaderLen], size );
+
+                McpsIndication.McpsIndication = MCPS_PROPRIETARY;
+                McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+                McpsIndication.Buffer = LoRaMacRxPayload;
+                McpsIndication.BufferSize = size - pktHeaderLen;
+
+                LoRaMacFlags.Bits.McpsInd = 1;
+                break;
+            }
+        default:
+            McpsIndication.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+            PrepareRxDoneAbort( );
+            break;
+    }
+    LoRaMacFlags.Bits.MacDone = 1;
+
+    // Trig OnMacCheckTimerEvent call as soon as possible
+    TimerSetValue( &MacStateCheckTimer, 1 );
+    TimerStart( &MacStateCheckTimer );
+}
+
+static void OnRadioTxTimeout( void )
+{
+    if( LoRaMacDeviceClass != CLASS_C )
+    {
+        lora_phy->put_radio_to_sleep();
+    }
+    else
+    {
+        handle_rx2_timer_event();
+    }
+
+    McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
+    MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
+    LoRaMacFlags.Bits.MacDone = 1;
+}
+
+static void OnRadioRxError( void )
+{
+    if( LoRaMacDeviceClass != CLASS_C )
+    {
+        lora_phy->put_radio_to_sleep();
+    }
+    else
+    {
+        handle_rx2_timer_event();
+    }
+
+    if( RxSlot == 0 )
+    {
+        if( NodeAckRequested == true )
+        {
+            McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
+        }
+        MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX1_ERROR;
+
+        if( TimerGetElapsedTime( AggregatedLastTxDoneTime ) >= RxWindow2Delay )
+        {
+            LoRaMacFlags.Bits.MacDone = 1;
+        }
+    }
+    else
+    {
+        if( NodeAckRequested == true )
+        {
+            McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
+        }
+        MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_ERROR;
+        LoRaMacFlags.Bits.MacDone = 1;
+    }
+}
+
+static void OnRadioRxTimeout( void )
+{
+    if( LoRaMacDeviceClass != CLASS_C )
+    {
+        lora_phy->put_radio_to_sleep();
+    }
+    else
+    {
+        handle_rx2_timer_event();
+    }
+
+    if( RxSlot == 0 )
+    {
+        if( NodeAckRequested == true )
+        {
+            McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
+        }
+        MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT;
+
+        if( TimerGetElapsedTime( AggregatedLastTxDoneTime ) >= RxWindow2Delay )
+        {
+            LoRaMacFlags.Bits.MacDone = 1;
+        }
+    }
+    else
+    {
+        if( NodeAckRequested == true )
+        {
+            McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+        }
+        MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT;
+
+        if( LoRaMacDeviceClass != CLASS_C )
+        {
+            LoRaMacFlags.Bits.MacDone = 1;
+        }
+    }
+}
+
+/***************************************************************************
+ * Timer event callbacks - deliberated locally                             *
+ **************************************************************************/
+static void OnMacStateCheckTimerEvent( void )
+{
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    bool txTimeout = false;
+
+    TimerStop( &MacStateCheckTimer );
+
+    if( LoRaMacFlags.Bits.MacDone == 1 )
+    {
+        if( ( LoRaMacState & LORAMAC_RX_ABORT ) == LORAMAC_RX_ABORT )
+        {
+            LoRaMacState &= ~LORAMAC_RX_ABORT;
+            LoRaMacState &= ~LORAMAC_TX_RUNNING;
+        }
+
+        if( ( LoRaMacFlags.Bits.MlmeReq == 1 ) || ( ( LoRaMacFlags.Bits.McpsReq == 1 ) ) )
+        {
+            if( ( McpsConfirm.Status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) ||
+                ( MlmeConfirm.Status == LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT ) )
+            {
+                // Stop transmit cycle due to tx timeout.
+                LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                MacCommandsBufferIndex = 0;
+                McpsConfirm.NbRetries = AckTimeoutRetriesCounter;
+                McpsConfirm.AckReceived = false;
+                McpsConfirm.TxTimeOnAir = 0;
+                txTimeout = true;
+            }
+        }
+
+        if( ( NodeAckRequested == false ) && ( txTimeout == false ) )
+        {
+            if( ( LoRaMacFlags.Bits.MlmeReq == 1 ) || ( ( LoRaMacFlags.Bits.McpsReq == 1 ) ) )
+            {
+                if( ( LoRaMacFlags.Bits.MlmeReq == 1 ) && ( MlmeConfirm.MlmeRequest == MLME_JOIN ) )
+                {// Procedure for the join request
+                    MlmeConfirm.NbRetries = JoinRequestTrials;
+
+                    if( MlmeConfirm.Status == LORAMAC_EVENT_INFO_STATUS_OK )
+                    {// Node joined successfully
+                        UpLinkCounter = 0;
+                        ChannelsNbRepCounter = 0;
+                        LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                    }
+                    else
+                    {
+                        if( JoinRequestTrials >= MaxJoinRequestTrials )
+                        {
+                            LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                        }
+                        else
+                        {
+                            LoRaMacFlags.Bits.MacDone = 0;
+                            // Sends the same frame again
+                            handle_delayed_tx_timer_event();
+                        }
+                    }
+                }
+                else
+                {// Procedure for all other frames
+                    if( ( ChannelsNbRepCounter >= LoRaMacParams.ChannelsNbRep ) || ( LoRaMacFlags.Bits.McpsInd == 1 ) )
+                    {
+                        if( LoRaMacFlags.Bits.McpsInd == 0 )
+                        {   // Maximum repetitions without downlink. Reset MacCommandsBufferIndex. Increase ADR Ack counter.
+                            // Only process the case when the MAC did not receive a downlink.
+                            MacCommandsBufferIndex = 0;
+                            AdrAckCounter++;
+                        }
+
+                        ChannelsNbRepCounter = 0;
+
+                        if( IsUpLinkCounterFixed == false )
+                        {
+                            UpLinkCounter++;
+                        }
+
+                        LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                    }
+                    else
+                    {
+                        LoRaMacFlags.Bits.MacDone = 0;
+                        // Sends the same frame again
+                        handle_delayed_tx_timer_event();
+                    }
+                }
+            }
+        }
+
+        if( LoRaMacFlags.Bits.McpsInd == 1 )
+        {// Procedure if we received a frame
+            if( ( McpsConfirm.AckReceived == true ) || ( AckTimeoutRetriesCounter > AckTimeoutRetries ) )
+            {
+                AckTimeoutRetry = false;
+                NodeAckRequested = false;
+                if( IsUpLinkCounterFixed == false )
+                {
+                    UpLinkCounter++;
+                }
+                McpsConfirm.NbRetries = AckTimeoutRetriesCounter;
+
+                LoRaMacState &= ~LORAMAC_TX_RUNNING;
+            }
+        }
+
+        if( ( AckTimeoutRetry == true ) && ( ( LoRaMacState & LORAMAC_TX_DELAYED ) == 0 ) )
+        {// Retransmissions procedure for confirmed uplinks
+            AckTimeoutRetry = false;
+            if( ( AckTimeoutRetriesCounter < AckTimeoutRetries ) && ( AckTimeoutRetriesCounter <= MAX_ACK_RETRIES ) )
+            {
+                AckTimeoutRetriesCounter++;
+
+                if( ( AckTimeoutRetriesCounter % 2 ) == 1 )
+                {
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+                    getPhy.Datarate = LoRaMacParams.ChannelsDatarate;
+                    phyParam = lora_phy->get_phy_params( &getPhy );
+                    LoRaMacParams.ChannelsDatarate = phyParam.Value;
+                }
+                // Try to send the frame again
+                if( ScheduleTx( ) == LORAMAC_STATUS_OK )
+                {
+                    LoRaMacFlags.Bits.MacDone = 0;
+                }
+                else
+                {
+                    // The DR is not applicable for the payload size
+                    McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR;
+
+                    MacCommandsBufferIndex = 0;
+                    LoRaMacState &= ~LORAMAC_TX_RUNNING;
+                    NodeAckRequested = false;
+                    McpsConfirm.AckReceived = false;
+                    McpsConfirm.NbRetries = AckTimeoutRetriesCounter;
+                    McpsConfirm.Datarate = LoRaMacParams.ChannelsDatarate;
+                    if( IsUpLinkCounterFixed == false )
+                    {
+                        UpLinkCounter++;
+                    }
+                }
+            }
+            else
+            {
+                lora_phy->load_defaults(INIT_TYPE_RESTORE);
+
+                LoRaMacState &= ~LORAMAC_TX_RUNNING;
+
+                MacCommandsBufferIndex = 0;
+                NodeAckRequested = false;
+                McpsConfirm.AckReceived = false;
+                McpsConfirm.NbRetries = AckTimeoutRetriesCounter;
+                if( IsUpLinkCounterFixed == false )
+                {
+                    UpLinkCounter++;
+                }
+            }
+        }
+    }
+    // Handle reception for Class B and Class C
+    if( ( LoRaMacState & LORAMAC_RX ) == LORAMAC_RX )
+    {
+        LoRaMacState &= ~LORAMAC_RX;
+    }
+    if( LoRaMacState == LORAMAC_IDLE )
+    {
+        if( LoRaMacFlags.Bits.McpsReq == 1 )
+        {
+            LoRaMacPrimitives->MacMcpsConfirm( &McpsConfirm );
+            LoRaMacFlags.Bits.McpsReq = 0;
+        }
+
+        if( LoRaMacFlags.Bits.MlmeReq == 1 )
+        {
+            LoRaMacPrimitives->MacMlmeConfirm( &MlmeConfirm );
+            LoRaMacFlags.Bits.MlmeReq = 0;
+        }
+
+        // Procedure done. Reset variables.
+        LoRaMacFlags.Bits.MacDone = 0;
+    }
+    else
+    {
+        // Operation not finished restart timer
+        TimerSetValue( &MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
+        TimerStart( &MacStateCheckTimer );
+    }
+
+    if( LoRaMacFlags.Bits.McpsInd == 1 )
+    {
+        if( LoRaMacDeviceClass == CLASS_C )
+        {// Activate RX2 window for Class C
+            handle_rx2_timer_event();
+        }
+        if( LoRaMacFlags.Bits.McpsIndSkip == 0 )
+        {
+            LoRaMacPrimitives->MacMcpsIndication( &McpsIndication );
+        }
+        LoRaMacFlags.Bits.McpsIndSkip = 0;
+        LoRaMacFlags.Bits.McpsInd = 0;
+    }
+}
+
+static void OnNextTx( void )
+{
+    TimerStop( &TxNextPacketTimer );
+    LoRaMacCallbacks->TxNextPacketTimerEvent( );
+}
+
+LoRaMacStatus_t LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
+{
+    TimerSetValue(&TxNextPacketTimer, TxDutyCycleTime);
+    TimerStart(&TxNextPacketTimer);
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacStopTxTimer( )
+{
+    TimerStop(&TxNextPacketTimer);
+
+    return LORAMAC_STATUS_OK;
+}
+
+static void OnTxDelayedTimerEvent( void )
+{
+    LoRaMacHeader_t macHdr;
+    LoRaMacFrameCtrl_t fCtrl;
+    AlternateDrParams_t altDr;
+
+    TimerStop( &TxDelayedTimer );
+    LoRaMacState &= ~LORAMAC_TX_DELAYED;
+
+    if( ( LoRaMacFlags.Bits.MlmeReq == 1 ) && ( MlmeConfirm.MlmeRequest == MLME_JOIN ) )
+    {
+        ResetMacParameters( );
+
+        altDr.NbTrials = JoinRequestTrials + 1;
+        LoRaMacParams.ChannelsDatarate = lora_phy->get_alternate_DR(&altDr);
+
+        macHdr.Value = 0;
+        macHdr.Bits.MType = FRAME_TYPE_JOIN_REQ;
+
+        fCtrl.Value = 0;
+        fCtrl.Bits.Adr = AdrCtrlOn;
+
+        /* In case of join request retransmissions, the stack must prepare
+         * the frame again, because the network server keeps track of the random
+         * LoRaMacDevNonce values to prevent reply attacks. */
+        PrepareFrame( &macHdr, &fCtrl, 0, NULL, 0 );
+    }
+
+    ScheduleTx( );
+}
+
+static void OnRxWindow1TimerEvent( void )
+{
+    TimerStop( &RxWindowTimer1 );
+    RxSlot = 0;
+
+    RxWindow1Config.Channel = Channel;
+    RxWindow1Config.DrOffset = LoRaMacParams.Rx1DrOffset;
+    RxWindow1Config.DownlinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+    RxWindow1Config.RepeaterSupport = RepeaterSupport;
+    RxWindow1Config.RxContinuous = false;
+    RxWindow1Config.Window = RxSlot;
+
+    if( LoRaMacDeviceClass == CLASS_C )
+    {
+        lora_phy->put_radio_to_standby();
+    }
+
+    lora_phy->rx_config(&RxWindow1Config, ( int8_t* )&McpsIndication.RxDatarate);
+    RxWindowSetup( RxWindow1Config.RxContinuous, LoRaMacParams.MaxRxWindow );
+}
+
+static void OnRxWindow2TimerEvent( void )
+{
+    TimerStop( &RxWindowTimer2 );
+
+    RxWindow2Config.Channel = Channel;
+    RxWindow2Config.Frequency = LoRaMacParams.Rx2Channel.Frequency;
+    RxWindow2Config.DownlinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+    RxWindow2Config.RepeaterSupport = RepeaterSupport;
+    RxWindow2Config.Window = 1;
+
+    if( LoRaMacDeviceClass != CLASS_C )
+    {
+        RxWindow2Config.RxContinuous = false;
+    }
+    else
+    {
+        RxWindow2Config.RxContinuous = true;
+    }
+
+    if(lora_phy->rx_config(&RxWindow2Config, ( int8_t* )&McpsIndication.RxDatarate) == true )
+    {
+        RxWindowSetup( RxWindow2Config.RxContinuous, LoRaMacParams.MaxRxWindow );
+        RxSlot = RxWindow2Config.Window;
+    }
+}
+
+static void OnAckTimeoutTimerEvent( void )
+{
+    TimerStop( &AckTimeoutTimer );
+
+    if( NodeAckRequested == true )
+    {
+        AckTimeoutRetry = true;
+        LoRaMacState &= ~LORAMAC_ACK_REQ;
+    }
+    if( LoRaMacDeviceClass == CLASS_C )
+    {
+        LoRaMacFlags.Bits.MacDone = 1;
+    }
+}
+
+static void RxWindowSetup( bool rxContinuous, uint32_t maxRxWindow )
+{
+    lora_phy->setup_rx_window(rxContinuous, maxRxWindow);
+}
+
+static bool ValidatePayloadLength( uint8_t lenN, int8_t datarate, uint8_t fOptsLen )
+{
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    uint16_t maxN = 0;
+    uint16_t payloadSize = 0;
+
+    // Setup PHY request
+    getPhy.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+    getPhy.Datarate = datarate;
+    getPhy.Attribute = PHY_MAX_PAYLOAD;
+
+    // Get the maximum payload length
+    if( RepeaterSupport == true )
+    {
+        getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
+    }
+    phyParam = lora_phy->get_phy_params(&getPhy);
+    maxN = phyParam.Value;
+
+    // Calculate the resulting payload size
+    payloadSize = ( lenN + fOptsLen );
+
+    // Validation of the application payload size
+    if( ( payloadSize <= maxN ) && ( payloadSize <= LORAMAC_PHY_MAXPAYLOAD ) )
+    {
+        return true;
+    }
+    return false;
+}
+
+static LoRaMacStatus_t AddMacCommand( uint8_t cmd, uint8_t p1, uint8_t p2 )
+{
+    LoRaMacStatus_t status = LORAMAC_STATUS_BUSY;
+    // The maximum buffer length must take MAC commands to re-send into account.
+    uint8_t bufLen = LORA_MAC_COMMAND_MAX_LENGTH - MacCommandsBufferToRepeatIndex;
+
+    switch( cmd )
+    {
+        case MOTE_MAC_LINK_CHECK_REQ:
+            if( MacCommandsBufferIndex < bufLen )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // No payload for this command
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_LINK_ADR_ANS:
+            if( MacCommandsBufferIndex < ( bufLen - 1 ) )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // Margin
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_DUTY_CYCLE_ANS:
+            if( MacCommandsBufferIndex < bufLen )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // No payload for this answer
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_RX_PARAM_SETUP_ANS:
+            if( MacCommandsBufferIndex < ( bufLen - 1 ) )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // Status: Datarate ACK, Channel ACK
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_DEV_STATUS_ANS:
+            if( MacCommandsBufferIndex < ( bufLen - 2 ) )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // 1st byte Battery
+                // 2nd byte Margin
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p2;
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_NEW_CHANNEL_ANS:
+            if( MacCommandsBufferIndex < ( bufLen - 1 ) )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // Status: Datarate range OK, Channel frequency OK
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_RX_TIMING_SETUP_ANS:
+            if( MacCommandsBufferIndex < bufLen )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // No payload for this answer
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_TX_PARAM_SETUP_ANS:
+            if( MacCommandsBufferIndex < bufLen )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // No payload for this answer
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        case MOTE_MAC_DL_CHANNEL_ANS:
+            if( MacCommandsBufferIndex < bufLen )
+            {
+                MacCommandsBuffer[MacCommandsBufferIndex++] = cmd;
+                // Status: Uplink frequency exists, Channel frequency OK
+                MacCommandsBuffer[MacCommandsBufferIndex++] = p1;
+                status = LORAMAC_STATUS_OK;
+            }
+            break;
+        default:
+            return LORAMAC_STATUS_SERVICE_UNKNOWN;
+    }
+    if( status == LORAMAC_STATUS_OK )
+    {
+        MacCommandsInNextTx = true;
+    }
+    return status;
+}
+
+static uint8_t ParseMacCommandsToRepeat( uint8_t* cmdBufIn, uint8_t length, uint8_t* cmdBufOut )
+{
+    uint8_t i = 0;
+    uint8_t cmdCount = 0;
+
+    if( ( cmdBufIn == NULL ) || ( cmdBufOut == NULL ) )
+    {
+        return 0;
+    }
+
+    for( i = 0; i < length; i++ )
+    {
+        switch( cmdBufIn[i] )
+        {
+            // STICKY
+            case MOTE_MAC_DL_CHANNEL_ANS:
+            case MOTE_MAC_RX_PARAM_SETUP_ANS:
+            { // 1 byte payload
+                cmdBufOut[cmdCount++] = cmdBufIn[i++];
+                cmdBufOut[cmdCount++] = cmdBufIn[i];
+                break;
+            }
+            case MOTE_MAC_RX_TIMING_SETUP_ANS:
+            { // 0 byte payload
+                cmdBufOut[cmdCount++] = cmdBufIn[i];
+                break;
+            }
+            // NON-STICKY
+            case MOTE_MAC_DEV_STATUS_ANS:
+            { // 2 bytes payload
+                i += 2;
+                break;
+            }
+            case MOTE_MAC_LINK_ADR_ANS:
+            case MOTE_MAC_NEW_CHANNEL_ANS:
+            { // 1 byte payload
+                i++;
+                break;
+            }
+            case MOTE_MAC_TX_PARAM_SETUP_ANS:
+            case MOTE_MAC_DUTY_CYCLE_ANS:
+            case MOTE_MAC_LINK_CHECK_REQ:
+            { // 0 byte payload
+                break;
+            }
+            default:
+                break;
+        }
+    }
+
+    return cmdCount;
+}
+
+static void ProcessMacCommands( uint8_t *payload, uint8_t macIndex, uint8_t commandsSize, uint8_t snr )
+{
+    uint8_t status = 0;
+
+    while( macIndex < commandsSize )
+    {
+        // Decode Frame MAC commands
+        switch( payload[macIndex++] )
+        {
+            case SRV_MAC_LINK_CHECK_ANS:
+                MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_OK;
+                MlmeConfirm.DemodMargin = payload[macIndex++];
+                MlmeConfirm.NbGateways = payload[macIndex++];
+                break;
+            case SRV_MAC_LINK_ADR_REQ:
+                {
+                    LinkAdrReqParams_t linkAdrReq;
+                    int8_t linkAdrDatarate = DR_0;
+                    int8_t linkAdrTxPower = TX_POWER_0;
+                    uint8_t linkAdrNbRep = 0;
+                    uint8_t linkAdrNbBytesParsed = 0;
+
+                    // Fill parameter structure
+                    linkAdrReq.Payload = &payload[macIndex - 1];
+                    linkAdrReq.PayloadSize = commandsSize - ( macIndex - 1 );
+                    linkAdrReq.AdrEnabled = AdrCtrlOn;
+                    linkAdrReq.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+                    linkAdrReq.CurrentDatarate = LoRaMacParams.ChannelsDatarate;
+                    linkAdrReq.CurrentTxPower = LoRaMacParams.ChannelsTxPower;
+                    linkAdrReq.CurrentNbRep = LoRaMacParams.ChannelsNbRep;
+
+                    // Process the ADR requests
+                    status = lora_phy->link_ADR_request(&linkAdrReq, &linkAdrDatarate,
+                                               &linkAdrTxPower, &linkAdrNbRep,
+                                               &linkAdrNbBytesParsed);
+
+                    if( ( status & 0x07 ) == 0x07 )
+                    {
+                        LoRaMacParams.ChannelsDatarate = linkAdrDatarate;
+                        LoRaMacParams.ChannelsTxPower = linkAdrTxPower;
+                        LoRaMacParams.ChannelsNbRep = linkAdrNbRep;
+                    }
+
+                    // Add the answers to the buffer
+                    for( uint8_t i = 0; i < ( linkAdrNbBytesParsed / 5 ); i++ )
+                    {
+                        AddMacCommand( MOTE_MAC_LINK_ADR_ANS, status, 0 );
+                    }
+                    // Update MAC index
+                    macIndex += linkAdrNbBytesParsed - 1;
+                }
+                break;
+            case SRV_MAC_DUTY_CYCLE_REQ:
+                MaxDCycle = payload[macIndex++];
+                AggregatedDCycle = 1 << MaxDCycle;
+                AddMacCommand( MOTE_MAC_DUTY_CYCLE_ANS, 0, 0 );
+                break;
+            case SRV_MAC_RX_PARAM_SETUP_REQ:
+                {
+                    RxParamSetupReqParams_t rxParamSetupReq;
+                    status = 0x07;
+
+                    rxParamSetupReq.DrOffset = ( payload[macIndex] >> 4 ) & 0x07;
+                    rxParamSetupReq.Datarate = payload[macIndex] & 0x0F;
+                    macIndex++;
+
+                    rxParamSetupReq.Frequency =  ( uint32_t )payload[macIndex++];
+                    rxParamSetupReq.Frequency |= ( uint32_t )payload[macIndex++] << 8;
+                    rxParamSetupReq.Frequency |= ( uint32_t )payload[macIndex++] << 16;
+                    rxParamSetupReq.Frequency *= 100;
+
+                    // Perform request on region
+                    status = lora_phy->setup_rx_params(&rxParamSetupReq);
+
+                    if( ( status & 0x07 ) == 0x07 )
+                    {
+                        LoRaMacParams.Rx2Channel.Datarate = rxParamSetupReq.Datarate;
+                        LoRaMacParams.Rx2Channel.Frequency = rxParamSetupReq.Frequency;
+                        LoRaMacParams.Rx1DrOffset = rxParamSetupReq.DrOffset;
+                    }
+                    AddMacCommand( MOTE_MAC_RX_PARAM_SETUP_ANS, status, 0 );
+                }
+                break;
+            case SRV_MAC_DEV_STATUS_REQ:
+                {
+                    uint8_t batteryLevel = BAT_LEVEL_NO_MEASURE;
+                    if( ( LoRaMacCallbacks != NULL ) && ( LoRaMacCallbacks->GetBatteryLevel != NULL ) )
+                    {
+                        batteryLevel = LoRaMacCallbacks->GetBatteryLevel( );
+                    }
+                    AddMacCommand( MOTE_MAC_DEV_STATUS_ANS, batteryLevel, snr );
+                    break;
+                }
+            case SRV_MAC_NEW_CHANNEL_REQ:
+                {
+                    NewChannelReqParams_t newChannelReq;
+                    ChannelParams_t chParam;
+                    status = 0x03;
+
+                    newChannelReq.ChannelId = payload[macIndex++];
+                    newChannelReq.NewChannel = &chParam;
+
+                    chParam.Frequency = ( uint32_t )payload[macIndex++];
+                    chParam.Frequency |= ( uint32_t )payload[macIndex++] << 8;
+                    chParam.Frequency |= ( uint32_t )payload[macIndex++] << 16;
+                    chParam.Frequency *= 100;
+                    chParam.Rx1Frequency = 0;
+                    chParam.DrRange.Value = payload[macIndex++];
+
+                    status = lora_phy->request_new_channel(&newChannelReq);
+
+                    AddMacCommand( MOTE_MAC_NEW_CHANNEL_ANS, status, 0 );
+                }
+                break;
+            case SRV_MAC_RX_TIMING_SETUP_REQ:
+                {
+                    uint8_t delay = payload[macIndex++] & 0x0F;
+
+                    if( delay == 0 )
+                    {
+                        delay++;
+                    }
+                    LoRaMacParams.ReceiveDelay1 = delay * 1000;
+                    LoRaMacParams.ReceiveDelay2 = LoRaMacParams.ReceiveDelay1 + 1000;
+                    AddMacCommand( MOTE_MAC_RX_TIMING_SETUP_ANS, 0, 0 );
+                }
+                break;
+            case SRV_MAC_TX_PARAM_SETUP_REQ:
+                {
+                    TxParamSetupReqParams_t txParamSetupReq;
+                    uint8_t eirpDwellTime = payload[macIndex++];
+
+                    txParamSetupReq.UplinkDwellTime = 0;
+                    txParamSetupReq.DownlinkDwellTime = 0;
+
+                    if( ( eirpDwellTime & 0x20 ) == 0x20 )
+                    {
+                        txParamSetupReq.DownlinkDwellTime = 1;
+                    }
+                    if( ( eirpDwellTime & 0x10 ) == 0x10 )
+                    {
+                        txParamSetupReq.UplinkDwellTime = 1;
+                    }
+                    txParamSetupReq.MaxEirp = eirpDwellTime & 0x0F;
+
+                    // Check the status for correctness
+                    if( lora_phy->setup_tx_params(&txParamSetupReq ) != -1 )
+                    {
+                        // Accept command
+                        LoRaMacParams.UplinkDwellTime = txParamSetupReq.UplinkDwellTime;
+                        LoRaMacParams.DownlinkDwellTime = txParamSetupReq.DownlinkDwellTime;
+                        LoRaMacParams.MaxEirp = LoRaMacMaxEirpTable[txParamSetupReq.MaxEirp];
+                        // Add command response
+                        AddMacCommand( MOTE_MAC_TX_PARAM_SETUP_ANS, 0, 0 );
+                    }
+                }
+                break;
+            case SRV_MAC_DL_CHANNEL_REQ:
+                {
+                    DlChannelReqParams_t dlChannelReq;
+                    status = 0x03;
+
+                    dlChannelReq.ChannelId = payload[macIndex++];
+                    dlChannelReq.Rx1Frequency = ( uint32_t )payload[macIndex++];
+                    dlChannelReq.Rx1Frequency |= ( uint32_t )payload[macIndex++] << 8;
+                    dlChannelReq.Rx1Frequency |= ( uint32_t )payload[macIndex++] << 16;
+                    dlChannelReq.Rx1Frequency *= 100;
+
+                    status = lora_phy->dl_channel_request(&dlChannelReq);
+
+                    AddMacCommand( MOTE_MAC_DL_CHANNEL_ANS, status, 0 );
+                }
+                break;
+            default:
+                // Unknown command. ABORT MAC commands processing
+                return;
+        }
+    }
+}
+
+// This is not actual transmission. It just schedules a message in response
+// to MCPS request
+LoRaMacStatus_t Send( LoRaMacHeader_t *macHdr, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
+{
+    LoRaMacFrameCtrl_t fCtrl;
+    LoRaMacStatus_t status = LORAMAC_STATUS_PARAMETER_INVALID;
+
+    fCtrl.Value = 0;
+    fCtrl.Bits.FOptsLen      = 0;
+    fCtrl.Bits.FPending      = 0;
+    fCtrl.Bits.Ack           = false;
+    fCtrl.Bits.AdrAckReq     = false;
+    fCtrl.Bits.Adr           = AdrCtrlOn;
+
+    // Prepare the frame
+    status = PrepareFrame( macHdr, &fCtrl, fPort, fBuffer, fBufferSize );
+
+    // Validate status
+    if( status != LORAMAC_STATUS_OK )
+    {
+        return status;
+    }
+
+    // Reset confirm parameters
+    McpsConfirm.NbRetries = 0;
+    McpsConfirm.AckReceived = false;
+    McpsConfirm.UpLinkCounter = UpLinkCounter;
+
+    status = ScheduleTx( );
+
+    return status;
+}
+
+static LoRaMacStatus_t ScheduleTx( void )
+{
+    TimerTime_t dutyCycleTimeOff = 0;
+    NextChanParams_t nextChan;
+
+    // Check if the device is off
+    if( MaxDCycle == 255 )
+    {
+        return LORAMAC_STATUS_DEVICE_OFF;
+    }
+    if( MaxDCycle == 0 )
+    {
+        AggregatedTimeOff = 0;
+    }
+
+    // Update Backoff
+    CalculateBackOff( LastTxChannel );
+
+    nextChan.AggrTimeOff = AggregatedTimeOff;
+    nextChan.Datarate = LoRaMacParams.ChannelsDatarate;
+    DutyCycleOn = LORAWAN_DUTYCYCLE_ON;
+    nextChan.DutyCycleEnabled = DutyCycleOn;
+    nextChan.Joined = IsLoRaMacNetworkJoined;
+    nextChan.LastAggrTx = AggregatedLastTxDoneTime;
+
+    // Select channel
+    while( lora_phy->set_next_channel(&nextChan, &Channel, &dutyCycleTimeOff, &AggregatedTimeOff ) == false )
+    {
+        // Set the default datarate
+        LoRaMacParams.ChannelsDatarate = LoRaMacParamsDefaults.ChannelsDatarate;
+        // Update datarate in the function parameters
+        nextChan.Datarate = LoRaMacParams.ChannelsDatarate;
+    }
+
+    tr_debug("Next Channel Idx=%d, DR=%d", Channel, nextChan.Datarate);
+
+    // Compute Rx1 windows parameters
+    uint8_t dr_offset = lora_phy->apply_DR_offset(LoRaMacParams.DownlinkDwellTime,
+                                                 LoRaMacParams.ChannelsDatarate,
+                                                 LoRaMacParams.Rx1DrOffset);
+
+    lora_phy->compute_rx_win_params(dr_offset, LoRaMacParams.MinRxSymbols,
+                                     LoRaMacParams.SystemMaxRxError,
+                                     &RxWindow1Config );
+    // Compute Rx2 windows parameters
+    lora_phy->compute_rx_win_params(LoRaMacParams.Rx2Channel.Datarate,
+                                    LoRaMacParams.MinRxSymbols,
+                                    LoRaMacParams.SystemMaxRxError,
+                                    &RxWindow2Config );
+
+    if( IsLoRaMacNetworkJoined == false )
+    {
+        RxWindow1Delay = LoRaMacParams.JoinAcceptDelay1 + RxWindow1Config.WindowOffset;
+        RxWindow2Delay = LoRaMacParams.JoinAcceptDelay2 + RxWindow2Config.WindowOffset;
+    }
+    else
+    {
+        if( ValidatePayloadLength( LoRaMacTxPayloadLen, LoRaMacParams.ChannelsDatarate, MacCommandsBufferIndex ) == false )
+        {
+            return LORAMAC_STATUS_LENGTH_ERROR;
+        }
+        RxWindow1Delay = LoRaMacParams.ReceiveDelay1 + RxWindow1Config.WindowOffset;
+        RxWindow2Delay = LoRaMacParams.ReceiveDelay2 + RxWindow2Config.WindowOffset;
+    }
+
+    // Schedule transmission of frame
+    if( dutyCycleTimeOff == 0 )
+    {
+        // Try to send now
+        return SendFrameOnChannel( Channel );
+    }
+    else
+    {
+        // Send later - prepare timer
+        LoRaMacState |= LORAMAC_TX_DELAYED;
+        tr_debug("Next Transmission in %lu ms", dutyCycleTimeOff);
+        TimerSetValue( &TxDelayedTimer, dutyCycleTimeOff );
+        TimerStart( &TxDelayedTimer );
+
+        return LORAMAC_STATUS_OK;
+    }
+}
+
+static void CalculateBackOff( uint8_t channel )
+{
+    CalcBackOffParams_t calcBackOff;
+
+    calcBackOff.Joined = IsLoRaMacNetworkJoined;
+    DutyCycleOn = LORAWAN_DUTYCYCLE_ON;
+    calcBackOff.DutyCycleEnabled = DutyCycleOn;
+    calcBackOff.Channel = channel;
+    calcBackOff.ElapsedTime = TimerGetElapsedTime( LoRaMacInitializationTime );
+    calcBackOff.TxTimeOnAir = TxTimeOnAir;
+    calcBackOff.LastTxIsJoinRequest = LastTxIsJoinRequest;
+
+    // Update regional back-off
+    lora_phy->calculate_backoff(&calcBackOff);
+
+    // Update aggregated time-off
+    AggregatedTimeOff = AggregatedTimeOff + ( TxTimeOnAir * AggregatedDCycle - TxTimeOnAir );
+}
+
+static void ResetMacParameters( void )
+{
+    IsLoRaMacNetworkJoined = false;
+
+    // Counters
+    UpLinkCounter = 0;
+    DownLinkCounter = 0;
+    AdrAckCounter = 0;
+
+    ChannelsNbRepCounter = 0;
+
+    AckTimeoutRetries = 1;
+    AckTimeoutRetriesCounter = 1;
+    AckTimeoutRetry = false;
+
+    MaxDCycle = 0;
+    AggregatedDCycle = 1;
+
+    MacCommandsBufferIndex = 0;
+    MacCommandsBufferToRepeatIndex = 0;
+
+    IsRxWindowsEnabled = true;
+
+    LoRaMacParams.ChannelsTxPower = LoRaMacParamsDefaults.ChannelsTxPower;
+    LoRaMacParams.ChannelsDatarate = LoRaMacParamsDefaults.ChannelsDatarate;
+    LoRaMacParams.Rx1DrOffset = LoRaMacParamsDefaults.Rx1DrOffset;
+    LoRaMacParams.Rx2Channel = LoRaMacParamsDefaults.Rx2Channel;
+    LoRaMacParams.UplinkDwellTime = LoRaMacParamsDefaults.UplinkDwellTime;
+    LoRaMacParams.DownlinkDwellTime = LoRaMacParamsDefaults.DownlinkDwellTime;
+    LoRaMacParams.MaxEirp = LoRaMacParamsDefaults.MaxEirp;
+    LoRaMacParams.AntennaGain = LoRaMacParamsDefaults.AntennaGain;
+
+    NodeAckRequested = false;
+    SrvAckRequested = false;
+    MacCommandsInNextTx = false;
+
+    // Reset Multicast downlink counters
+    MulticastParams_t *cur = MulticastChannels;
+    while( cur != NULL )
+    {
+        cur->DownLinkCounter = 0;
+        cur = cur->Next;
+    }
+
+    // Initialize channel index.
+    Channel = 0;
+    LastTxChannel = Channel;
+}
+
+void memcpy_convert_endianess( uint8_t *dst, const uint8_t *src, uint16_t size )
+{
+    dst = dst + ( size - 1 );
+    while( size-- )
+    {
+        *dst-- = *src++;
+    }
+}
+
+LoRaMacStatus_t PrepareFrame( LoRaMacHeader_t *macHdr, LoRaMacFrameCtrl_t *fCtrl, uint8_t fPort, void *fBuffer, uint16_t fBufferSize )
+{
+    AdrNextParams_t adrNext;
+    uint16_t i;
+    uint8_t pktHeaderLen = 0;
+    uint32_t mic = 0;
+    const void* payload = fBuffer;
+    uint8_t framePort = fPort;
+    LoRaMacStatus_t status = LORAMAC_STATUS_OK;
+
+    LoRaMacBufferPktLen = 0;
+
+    NodeAckRequested = false;
+
+    if( fBuffer == NULL )
+    {
+        fBufferSize = 0;
+    }
+
+    LoRaMacTxPayloadLen = fBufferSize;
+
+    LoRaMacBuffer[pktHeaderLen++] = macHdr->Value;
+
+    switch( macHdr->Bits.MType )
+    {
+        case FRAME_TYPE_JOIN_REQ:
+            LoRaMacBufferPktLen = pktHeaderLen;
+
+            memcpy_convert_endianess( LoRaMacBuffer + LoRaMacBufferPktLen, LoRaMacAppEui, 8 );
+            LoRaMacBufferPktLen += 8;
+            memcpy_convert_endianess( LoRaMacBuffer + LoRaMacBufferPktLen, LoRaMacDevEui, 8 );
+            LoRaMacBufferPktLen += 8;
+
+            LoRaMacDevNonce = lora_phy->get_radio_rng();
+
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = LoRaMacDevNonce & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = ( LoRaMacDevNonce >> 8 ) & 0xFF;
+
+            if (0 != LoRaMacJoinComputeMic( LoRaMacBuffer, LoRaMacBufferPktLen & 0xFF, LoRaMacAppKey, &mic )) {
+                return LORAMAC_STATUS_CRYPTO_FAIL;
+            }
+
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = mic & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = ( mic >> 8 ) & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = ( mic >> 16 ) & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen++] = ( mic >> 24 ) & 0xFF;
+
+            break;
+        case FRAME_TYPE_DATA_CONFIRMED_UP:
+            NodeAckRequested = true;
+            //Intentional fallthrough
+        case FRAME_TYPE_DATA_UNCONFIRMED_UP:
+            if( IsLoRaMacNetworkJoined == false )
+            {
+                return LORAMAC_STATUS_NO_NETWORK_JOINED; // No network has been joined yet
+            }
+
+            // Adr next request
+            adrNext.UpdateChanMask = true;
+            adrNext.AdrEnabled = fCtrl->Bits.Adr;
+            adrNext.AdrAckCounter = AdrAckCounter;
+            adrNext.Datarate = LoRaMacParams.ChannelsDatarate;
+            adrNext.TxPower = LoRaMacParams.ChannelsTxPower;
+            adrNext.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+
+            fCtrl->Bits.AdrAckReq = lora_phy->get_next_ADR(&adrNext,
+                                                          &LoRaMacParams.ChannelsDatarate,
+                                                          &LoRaMacParams.ChannelsTxPower,
+                                                          &AdrAckCounter);
+
+            if( SrvAckRequested == true )
+            {
+                SrvAckRequested = false;
+                fCtrl->Bits.Ack = 1;
+            }
+
+            LoRaMacBuffer[pktHeaderLen++] = ( LoRaMacDevAddr ) & 0xFF;
+            LoRaMacBuffer[pktHeaderLen++] = ( LoRaMacDevAddr >> 8 ) & 0xFF;
+            LoRaMacBuffer[pktHeaderLen++] = ( LoRaMacDevAddr >> 16 ) & 0xFF;
+            LoRaMacBuffer[pktHeaderLen++] = ( LoRaMacDevAddr >> 24 ) & 0xFF;
+
+            LoRaMacBuffer[pktHeaderLen++] = fCtrl->Value;
+
+            LoRaMacBuffer[pktHeaderLen++] = UpLinkCounter & 0xFF;
+            LoRaMacBuffer[pktHeaderLen++] = ( UpLinkCounter >> 8 ) & 0xFF;
+
+            // Copy the MAC commands which must be re-send into the MAC command buffer
+            memcpy( &MacCommandsBuffer[MacCommandsBufferIndex], MacCommandsBufferToRepeat, MacCommandsBufferToRepeatIndex );
+            MacCommandsBufferIndex += MacCommandsBufferToRepeatIndex;
+
+            if( ( payload != NULL ) && ( LoRaMacTxPayloadLen > 0 ) )
+            {
+                if( MacCommandsInNextTx == true )
+                {
+                    if( MacCommandsBufferIndex <= LORA_MAC_COMMAND_MAX_FOPTS_LENGTH )
+                    {
+                        fCtrl->Bits.FOptsLen += MacCommandsBufferIndex;
+
+                        // Update FCtrl field with new value of OptionsLength
+                        LoRaMacBuffer[0x05] = fCtrl->Value;
+                        for( i = 0; i < MacCommandsBufferIndex; i++ )
+                        {
+                            LoRaMacBuffer[pktHeaderLen++] = MacCommandsBuffer[i];
+                        }
+                    }
+                    else
+                    {
+                        LoRaMacTxPayloadLen = MacCommandsBufferIndex;
+                        payload = MacCommandsBuffer;
+                        framePort = 0;
+                    }
+                }
+            }
+            else
+            {
+                if( ( MacCommandsBufferIndex > 0 ) && ( MacCommandsInNextTx == true ) )
+                {
+                    LoRaMacTxPayloadLen = MacCommandsBufferIndex;
+                    payload = MacCommandsBuffer;
+                    framePort = 0;
+                }
+            }
+            MacCommandsInNextTx = false;
+            // Store MAC commands which must be re-send in case the device does not receive a downlink anymore
+            MacCommandsBufferToRepeatIndex = ParseMacCommandsToRepeat( MacCommandsBuffer, MacCommandsBufferIndex, MacCommandsBufferToRepeat );
+            if( MacCommandsBufferToRepeatIndex > 0 )
+            {
+                MacCommandsInNextTx = true;
+            }
+
+            if( ( payload != NULL ) && ( LoRaMacTxPayloadLen > 0 ) )
+            {
+                LoRaMacBuffer[pktHeaderLen++] = framePort;
+
+                if( framePort == 0 )
+                {
+                    // Reset buffer index as the mac commands are being sent on port 0
+                    MacCommandsBufferIndex = 0;
+                    if (0 != LoRaMacPayloadEncrypt( (uint8_t* ) payload, LoRaMacTxPayloadLen, LoRaMacNwkSKey, LoRaMacDevAddr, UP_LINK, UpLinkCounter, &LoRaMacBuffer[pktHeaderLen] )) {
+                        status = LORAMAC_STATUS_CRYPTO_FAIL;
+                    }
+
+                }
+                else
+                {
+                    if (0 != LoRaMacPayloadEncrypt( (uint8_t* ) payload, LoRaMacTxPayloadLen, LoRaMacAppSKey, LoRaMacDevAddr, UP_LINK, UpLinkCounter, &LoRaMacBuffer[pktHeaderLen] )) {
+                        status = LORAMAC_STATUS_CRYPTO_FAIL;
+                    }
+                }
+            }
+            LoRaMacBufferPktLen = pktHeaderLen + LoRaMacTxPayloadLen;
+
+            if (0 != LoRaMacComputeMic( LoRaMacBuffer, LoRaMacBufferPktLen, LoRaMacNwkSKey, LoRaMacDevAddr, UP_LINK, UpLinkCounter, &mic )) {
+                status = LORAMAC_STATUS_CRYPTO_FAIL;
+            }
+
+            LoRaMacBuffer[LoRaMacBufferPktLen + 0] = mic & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen + 1] = ( mic >> 8 ) & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen + 2] = ( mic >> 16 ) & 0xFF;
+            LoRaMacBuffer[LoRaMacBufferPktLen + 3] = ( mic >> 24 ) & 0xFF;
+
+            LoRaMacBufferPktLen += LORAMAC_MFR_LEN;
+
+            break;
+        case FRAME_TYPE_PROPRIETARY:
+            if( ( fBuffer != NULL ) && ( LoRaMacTxPayloadLen > 0 ) )
+            {
+                memcpy( LoRaMacBuffer + pktHeaderLen, ( uint8_t* ) fBuffer, LoRaMacTxPayloadLen );
+                LoRaMacBufferPktLen = pktHeaderLen + LoRaMacTxPayloadLen;
+            }
+            break;
+        default:
+            status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+    }
+
+    return status;
+}
+
+LoRaMacStatus_t SendFrameOnChannel( uint8_t channel )
+{
+    TxConfigParams_t txConfig;
+    int8_t txPower = 0;
+
+    txConfig.Channel = channel;
+    txConfig.Datarate = LoRaMacParams.ChannelsDatarate;
+    txConfig.TxPower = LoRaMacParams.ChannelsTxPower;
+    txConfig.MaxEirp = LoRaMacParams.MaxEirp;
+    txConfig.AntennaGain = LoRaMacParams.AntennaGain;
+    txConfig.PktLen = LoRaMacBufferPktLen;
+
+    lora_phy->tx_config(&txConfig, &txPower, &TxTimeOnAir);
+
+    MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+    McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+    McpsConfirm.Datarate = LoRaMacParams.ChannelsDatarate;
+    McpsConfirm.TxPower = txPower;
+
+    // Store the time on air
+    McpsConfirm.TxTimeOnAir = TxTimeOnAir;
+    MlmeConfirm.TxTimeOnAir = TxTimeOnAir;
+
+    // Starts the MAC layer status check timer
+    TimerSetValue( &MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
+    TimerStart( &MacStateCheckTimer );
+
+    if( IsLoRaMacNetworkJoined == false )
+    {
+        JoinRequestTrials++;
+    }
+
+    // Send now
+    lora_phy->handle_send(LoRaMacBuffer, LoRaMacBufferPktLen);
+
+    LoRaMacState |= LORAMAC_TX_RUNNING;
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t SetTxContinuousWave( uint16_t timeout )
+{
+    ContinuousWaveParams_t continuousWave;
+
+    continuousWave.Channel = Channel;
+    continuousWave.Datarate = LoRaMacParams.ChannelsDatarate;
+    continuousWave.TxPower = LoRaMacParams.ChannelsTxPower;
+    continuousWave.MaxEirp = LoRaMacParams.MaxEirp;
+    continuousWave.AntennaGain = LoRaMacParams.AntennaGain;
+    continuousWave.Timeout = timeout;
+
+    lora_phy->set_tx_cont_mode(&continuousWave);
+
+    // Starts the MAC layer status check timer
+    TimerSetValue( &MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
+    TimerStart( &MacStateCheckTimer );
+
+    LoRaMacState |= LORAMAC_TX_RUNNING;
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t SetTxContinuousWave1( uint16_t timeout, uint32_t frequency, uint8_t power )
+{
+    lora_phy->setup_tx_cont_wave_mode(frequency, power, timeout);
+
+    // Starts the MAC layer status check timer
+    TimerSetValue( &MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT );
+    TimerStart( &MacStateCheckTimer );
+
+    LoRaMacState |= LORAMAC_TX_RUNNING;
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t *primitives, LoRaMacCallback_t *callbacks, LoRaPHY& phy)
+{
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    if(!primitives || !callbacks)
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    lora_phy = &phy;
+
+    LoRaMacPrimitives = primitives;
+    LoRaMacCallbacks = callbacks;
+
+    LoRaMacFlags.Value = 0;
+
+    LoRaMacDeviceClass = CLASS_A;
+    LoRaMacState = LORAMAC_IDLE;
+
+    JoinRequestTrials = 0;
+    MaxJoinRequestTrials = 1;
+    RepeaterSupport = false;
+
+    // Reset duty cycle times
+    AggregatedLastTxDoneTime = 0;
+    AggregatedTimeOff = 0;
+
+    // Reset to defaults
+    getPhy.Attribute = PHY_DUTY_CYCLE;
+    phyParam = lora_phy->get_phy_params(&getPhy);
+    // load default at this moment. Later can be changed using json
+    DutyCycleOn = ( bool ) phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_TX_POWER;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.ChannelsTxPower = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_TX_DR;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.ChannelsDatarate = phyParam.Value;
+
+    getPhy.Attribute = PHY_MAX_RX_WINDOW;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.MaxRxWindow = phyParam.Value;
+
+    getPhy.Attribute = PHY_RECEIVE_DELAY1;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.ReceiveDelay1 = phyParam.Value;
+
+    getPhy.Attribute = PHY_RECEIVE_DELAY2;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.ReceiveDelay2 = phyParam.Value;
+
+    getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY1;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.JoinAcceptDelay1 = phyParam.Value;
+
+    getPhy.Attribute = PHY_JOIN_ACCEPT_DELAY2;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.JoinAcceptDelay2 = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_DR1_OFFSET;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.Rx1DrOffset = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_RX2_FREQUENCY;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.Rx2Channel.Frequency = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_RX2_DR;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.Rx2Channel.Datarate = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_UPLINK_DWELL_TIME;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.UplinkDwellTime = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_DOWNLINK_DWELL_TIME;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.DownlinkDwellTime = phyParam.Value;
+
+    getPhy.Attribute = PHY_DEF_MAX_EIRP;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.MaxEirp = phyParam.fValue;
+
+    getPhy.Attribute = PHY_DEF_ANTENNA_GAIN;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    LoRaMacParamsDefaults.AntennaGain = phyParam.fValue;
+
+    lora_phy->load_defaults(INIT_TYPE_INIT);
+
+    // Init parameters which are not set in function ResetMacParameters
+    LoRaMacParamsDefaults.ChannelsNbRep = 1;
+    LoRaMacParamsDefaults.SystemMaxRxError = 10;
+    LoRaMacParamsDefaults.MinRxSymbols = 6;
+
+    LoRaMacParams.SystemMaxRxError = LoRaMacParamsDefaults.SystemMaxRxError;
+    LoRaMacParams.MinRxSymbols = LoRaMacParamsDefaults.MinRxSymbols;
+    LoRaMacParams.MaxRxWindow = LoRaMacParamsDefaults.MaxRxWindow;
+    LoRaMacParams.ReceiveDelay1 = LoRaMacParamsDefaults.ReceiveDelay1;
+    LoRaMacParams.ReceiveDelay2 = LoRaMacParamsDefaults.ReceiveDelay2;
+    LoRaMacParams.JoinAcceptDelay1 = LoRaMacParamsDefaults.JoinAcceptDelay1;
+    LoRaMacParams.JoinAcceptDelay2 = LoRaMacParamsDefaults.JoinAcceptDelay2;
+    LoRaMacParams.ChannelsNbRep = LoRaMacParamsDefaults.ChannelsNbRep;
+
+    ResetMacParameters( );
+
+    // Random seed initialization
+    srand(lora_phy->get_radio_rng());
+
+    PublicNetwork = LORAWAN_PUBLIC_NETWORK;
+    lora_phy->setup_public_network_mode(PublicNetwork);
+    lora_phy->put_radio_to_sleep();
+
+    // Initialize timers
+    TimerInit(&MacStateCheckTimer, handle_mac_state_check_timer_event);
+    TimerSetValue(&MacStateCheckTimer, MAC_STATE_CHECK_TIMEOUT);
+
+    TimerInit(&TxDelayedTimer, handle_delayed_tx_timer_event);
+    TimerInit(&RxWindowTimer1, handle_rx1_timer_event);
+    TimerInit(&RxWindowTimer2, handle_rx2_timer_event);
+    TimerInit(&AckTimeoutTimer, handle_ack_timeout);
+    TimerInit(&TxNextPacketTimer, handle_next_tx_timer_event);
+
+    // Store the current initialization time
+    LoRaMacInitializationTime = TimerGetCurrentTime();
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacQueryTxPossible( uint8_t size, LoRaMacTxInfo_t* txInfo )
+{
+    AdrNextParams_t adrNext;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    int8_t datarate = LoRaMacParamsDefaults.ChannelsDatarate;
+    int8_t txPower = LoRaMacParamsDefaults.ChannelsTxPower;
+    uint8_t fOptLen = MacCommandsBufferIndex + MacCommandsBufferToRepeatIndex;
+
+    if( txInfo == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Setup ADR request
+    adrNext.UpdateChanMask = false;
+    adrNext.AdrEnabled = AdrCtrlOn;
+    adrNext.AdrAckCounter = AdrAckCounter;
+    adrNext.Datarate = LoRaMacParams.ChannelsDatarate;
+    adrNext.TxPower = LoRaMacParams.ChannelsTxPower;
+    adrNext.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+
+    // We call the function for information purposes only. We don't want to
+    // apply the datarate, the tx power and the ADR ack counter.
+    lora_phy->get_next_ADR(&adrNext, &datarate, &txPower, &AdrAckCounter);
+
+    // Setup PHY request
+    getPhy.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+    getPhy.Datarate = datarate;
+    getPhy.Attribute = PHY_MAX_PAYLOAD;
+
+    // Change request in case repeater is supported
+    if( RepeaterSupport == true )
+    {
+        getPhy.Attribute = PHY_MAX_PAYLOAD_REPEATER;
+    }
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    txInfo->CurrentPayloadSize = phyParam.Value;
+
+    // Verify if the fOpts fit into the maximum payload
+    if( txInfo->CurrentPayloadSize >= fOptLen )
+    {
+        txInfo->MaxPossiblePayload = txInfo->CurrentPayloadSize - fOptLen;
+    }
+    else
+    {
+        txInfo->MaxPossiblePayload = txInfo->CurrentPayloadSize;
+        // The fOpts don't fit into the maximum payload. Omit the MAC commands to
+        // ensure that another uplink is possible.
+        fOptLen = 0;
+        MacCommandsBufferIndex = 0;
+        MacCommandsBufferToRepeatIndex = 0;
+    }
+
+    // Verify if the fOpts and the payload fit into the maximum payload
+    if( ValidatePayloadLength( size, datarate, fOptLen ) == false )
+    {
+        return LORAMAC_STATUS_LENGTH_ERROR;
+    }
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t *mibGet )
+{
+    LoRaMacStatus_t status = LORAMAC_STATUS_OK;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    if( mibGet == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    switch( mibGet->Type )
+    {
+        case MIB_DEVICE_CLASS:
+        {
+            mibGet->Param.Class = LoRaMacDeviceClass;
+            break;
+        }
+        case MIB_NETWORK_JOINED:
+        {
+            mibGet->Param.IsNetworkJoined = IsLoRaMacNetworkJoined;
+            break;
+        }
+        case MIB_ADR:
+        {
+            mibGet->Param.AdrEnable = AdrCtrlOn;
+            break;
+        }
+        case MIB_NET_ID:
+        {
+            mibGet->Param.NetID = LoRaMacNetID;
+            break;
+        }
+        case MIB_DEV_ADDR:
+        {
+            mibGet->Param.DevAddr = LoRaMacDevAddr;
+            break;
+        }
+        case MIB_NWK_SKEY:
+        {
+            mibGet->Param.NwkSKey = LoRaMacNwkSKey;
+            break;
+        }
+        case MIB_APP_SKEY:
+        {
+            mibGet->Param.AppSKey = LoRaMacAppSKey;
+            break;
+        }
+        case MIB_PUBLIC_NETWORK:
+        {
+            mibGet->Param.EnablePublicNetwork = PublicNetwork;
+            break;
+        }
+        case MIB_REPEATER_SUPPORT:
+        {
+            mibGet->Param.EnableRepeaterSupport = RepeaterSupport;
+            break;
+        }
+        case MIB_CHANNELS:
+        {
+            getPhy.Attribute = PHY_CHANNELS;
+            phyParam = lora_phy->get_phy_params( &getPhy );
+
+            mibGet->Param.ChannelList = phyParam.Channels;
+            break;
+        }
+        case MIB_RX2_CHANNEL:
+        {
+            mibGet->Param.Rx2Channel = LoRaMacParams.Rx2Channel;
+            break;
+        }
+        case MIB_RX2_DEFAULT_CHANNEL:
+        {
+            mibGet->Param.Rx2Channel = LoRaMacParamsDefaults.Rx2Channel;
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_MASK:
+        {
+            getPhy.Attribute = PHY_CHANNELS_DEFAULT_MASK;
+            phyParam = lora_phy->get_phy_params( &getPhy );
+
+            mibGet->Param.ChannelsDefaultMask = phyParam.ChannelsMask;
+            break;
+        }
+        case MIB_CHANNELS_MASK:
+        {
+            getPhy.Attribute = PHY_CHANNELS_MASK;
+            phyParam = lora_phy->get_phy_params( &getPhy );
+
+            mibGet->Param.ChannelsMask = phyParam.ChannelsMask;
+            break;
+        }
+        case MIB_CHANNELS_NB_REP:
+        {
+            mibGet->Param.ChannelNbRep = LoRaMacParams.ChannelsNbRep;
+            break;
+        }
+        case MIB_MAX_RX_WINDOW_DURATION:
+        {
+            mibGet->Param.MaxRxWindow = LoRaMacParams.MaxRxWindow;
+            break;
+        }
+        case MIB_RECEIVE_DELAY_1:
+        {
+            mibGet->Param.ReceiveDelay1 = LoRaMacParams.ReceiveDelay1;
+            break;
+        }
+        case MIB_RECEIVE_DELAY_2:
+        {
+            mibGet->Param.ReceiveDelay2 = LoRaMacParams.ReceiveDelay2;
+            break;
+        }
+        case MIB_JOIN_ACCEPT_DELAY_1:
+        {
+            mibGet->Param.JoinAcceptDelay1 = LoRaMacParams.JoinAcceptDelay1;
+            break;
+        }
+        case MIB_JOIN_ACCEPT_DELAY_2:
+        {
+            mibGet->Param.JoinAcceptDelay2 = LoRaMacParams.JoinAcceptDelay2;
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_DATARATE:
+        {
+            mibGet->Param.ChannelsDefaultDatarate = LoRaMacParamsDefaults.ChannelsDatarate;
+            break;
+        }
+        case MIB_CHANNELS_DATARATE:
+        {
+            mibGet->Param.ChannelsDatarate = LoRaMacParams.ChannelsDatarate;
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_TX_POWER:
+        {
+            mibGet->Param.ChannelsDefaultTxPower = LoRaMacParamsDefaults.ChannelsTxPower;
+            break;
+        }
+        case MIB_CHANNELS_TX_POWER:
+        {
+            mibGet->Param.ChannelsTxPower = LoRaMacParams.ChannelsTxPower;
+            break;
+        }
+        case MIB_UPLINK_COUNTER:
+        {
+            mibGet->Param.UpLinkCounter = UpLinkCounter;
+            break;
+        }
+        case MIB_DOWNLINK_COUNTER:
+        {
+            mibGet->Param.DownLinkCounter = DownLinkCounter;
+            break;
+        }
+        case MIB_MULTICAST_CHANNEL:
+        {
+            mibGet->Param.MulticastList = MulticastChannels;
+            break;
+        }
+        case MIB_SYSTEM_MAX_RX_ERROR:
+        {
+            mibGet->Param.SystemMaxRxError = LoRaMacParams.SystemMaxRxError;
+            break;
+        }
+        case MIB_MIN_RX_SYMBOLS:
+        {
+            mibGet->Param.MinRxSymbols = LoRaMacParams.MinRxSymbols;
+            break;
+        }
+        case MIB_ANTENNA_GAIN:
+        {
+            mibGet->Param.AntennaGain = LoRaMacParams.AntennaGain;
+            break;
+        }
+        default:
+            status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return status;
+}
+
+LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t *mibSet )
+{
+    LoRaMacStatus_t status = LORAMAC_STATUS_OK;
+    ChanMaskSetParams_t chanMaskSet;
+    VerifyParams_t verify;
+
+    if( mibSet == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    switch( mibSet->Type )
+    {
+        case MIB_DEVICE_CLASS:
+        {
+            LoRaMacDeviceClass = mibSet->Param.Class;
+            switch( LoRaMacDeviceClass )
+            {
+                case CLASS_A:
+                {
+                    // Set the radio into sleep to setup a defined state
+                    lora_phy->put_radio_to_sleep();
+                    break;
+                }
+                case CLASS_B:
+                {
+                    break;
+                }
+                case CLASS_C:
+                {
+                    // Set the NodeAckRequested indicator to default
+                    NodeAckRequested = false;
+                    handle_rx2_timer_event();
+                    break;
+                }
+            }
+            break;
+        }
+        case MIB_NETWORK_JOINED:
+        {
+            IsLoRaMacNetworkJoined = mibSet->Param.IsNetworkJoined;
+            break;
+        }
+        case MIB_ADR:
+        {
+            AdrCtrlOn = mibSet->Param.AdrEnable;
+            break;
+        }
+        case MIB_NET_ID:
+        {
+            LoRaMacNetID = mibSet->Param.NetID;
+            break;
+        }
+        case MIB_DEV_ADDR:
+        {
+            LoRaMacDevAddr = mibSet->Param.DevAddr;
+            break;
+        }
+        case MIB_NWK_SKEY:
+        {
+            if( mibSet->Param.NwkSKey != NULL )
+            {
+                memcpy( LoRaMacNwkSKey, mibSet->Param.NwkSKey,
+                               sizeof( LoRaMacNwkSKey ) );
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_APP_SKEY:
+        {
+            if( mibSet->Param.AppSKey != NULL )
+            {
+                memcpy( LoRaMacAppSKey, mibSet->Param.AppSKey,
+                               sizeof( LoRaMacAppSKey ) );
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_PUBLIC_NETWORK:
+        {
+            PublicNetwork = mibSet->Param.EnablePublicNetwork;
+            lora_phy->setup_public_network_mode(PublicNetwork);
+            break;
+        }
+        case MIB_REPEATER_SUPPORT:
+        {
+             RepeaterSupport = mibSet->Param.EnableRepeaterSupport;
+            break;
+        }
+        case MIB_RX2_CHANNEL:
+        {
+            verify.DatarateParams.Datarate = mibSet->Param.Rx2Channel.Datarate;
+            verify.DatarateParams.DownlinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+
+            if( lora_phy->verify(&verify, PHY_RX_DR) == true )
+            {
+                LoRaMacParams.Rx2Channel = mibSet->Param.Rx2Channel;
+
+                if( ( LoRaMacDeviceClass == CLASS_C ) && ( IsLoRaMacNetworkJoined == true ) )
+                {
+                    // Compute Rx2 windows parameters
+                    lora_phy->compute_rx_win_params(LoRaMacParams.Rx2Channel.Datarate,
+                                                   LoRaMacParams.MinRxSymbols,
+                                                   LoRaMacParams.SystemMaxRxError,
+                                                   &RxWindow2Config);
+
+                    RxWindow2Config.Channel = Channel;
+                    RxWindow2Config.Frequency = LoRaMacParams.Rx2Channel.Frequency;
+                    RxWindow2Config.DownlinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+                    RxWindow2Config.RepeaterSupport = RepeaterSupport;
+                    RxWindow2Config.Window = 1;
+                    RxWindow2Config.RxContinuous = true;
+
+                    if(lora_phy->rx_config(&RxWindow2Config, ( int8_t* )&McpsIndication.RxDatarate) == true )
+                    {
+                        RxWindowSetup( RxWindow2Config.RxContinuous, LoRaMacParams.MaxRxWindow );
+                        RxSlot = RxWindow2Config.Window;
+                    }
+                    else
+                    {
+                        status = LORAMAC_STATUS_PARAMETER_INVALID;
+                    }
+                }
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_RX2_DEFAULT_CHANNEL:
+        {
+            verify.DatarateParams.Datarate = mibSet->Param.Rx2Channel.Datarate;
+            verify.DatarateParams.DownlinkDwellTime = LoRaMacParams.DownlinkDwellTime;
+
+            if( lora_phy->verify(&verify, PHY_RX_DR) == true )
+            {
+                LoRaMacParamsDefaults.Rx2Channel = mibSet->Param.Rx2DefaultChannel;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_MASK:
+        {
+            chanMaskSet.ChannelsMaskIn = mibSet->Param.ChannelsMask;
+            chanMaskSet.ChannelsMaskType = CHANNELS_DEFAULT_MASK;
+
+            if(lora_phy->set_channel_mask(&chanMaskSet) == false )
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_MASK:
+        {
+            chanMaskSet.ChannelsMaskIn = mibSet->Param.ChannelsMask;
+            chanMaskSet.ChannelsMaskType = CHANNELS_MASK;
+
+            if(lora_phy->set_channel_mask(&chanMaskSet) == false )
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_NB_REP:
+        {
+            if( ( mibSet->Param.ChannelNbRep >= 1 ) &&
+                ( mibSet->Param.ChannelNbRep <= 15 ) )
+            {
+                LoRaMacParams.ChannelsNbRep = mibSet->Param.ChannelNbRep;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_MAX_RX_WINDOW_DURATION:
+        {
+            LoRaMacParams.MaxRxWindow = mibSet->Param.MaxRxWindow;
+            break;
+        }
+        case MIB_RECEIVE_DELAY_1:
+        {
+            LoRaMacParams.ReceiveDelay1 = mibSet->Param.ReceiveDelay1;
+            break;
+        }
+        case MIB_RECEIVE_DELAY_2:
+        {
+            LoRaMacParams.ReceiveDelay2 = mibSet->Param.ReceiveDelay2;
+            break;
+        }
+        case MIB_JOIN_ACCEPT_DELAY_1:
+        {
+            LoRaMacParams.JoinAcceptDelay1 = mibSet->Param.JoinAcceptDelay1;
+            break;
+        }
+        case MIB_JOIN_ACCEPT_DELAY_2:
+        {
+            LoRaMacParams.JoinAcceptDelay2 = mibSet->Param.JoinAcceptDelay2;
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_DATARATE:
+        {
+            verify.DatarateParams.Datarate = mibSet->Param.ChannelsDefaultDatarate;
+
+            if(lora_phy->verify(&verify, PHY_DEF_TX_DR) == true)
+            {
+                LoRaMacParamsDefaults.ChannelsDatarate = verify.DatarateParams.Datarate;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_DATARATE:
+        {
+            verify.DatarateParams.Datarate = mibSet->Param.ChannelsDatarate;
+
+            if(lora_phy->verify(&verify, PHY_TX_DR) == true)
+            {
+                LoRaMacParams.ChannelsDatarate = verify.DatarateParams.Datarate;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_DEFAULT_TX_POWER:
+        {
+            verify.TxPower = mibSet->Param.ChannelsDefaultTxPower;
+
+            if(lora_phy->verify(&verify, PHY_DEF_TX_POWER) == true)
+            {
+                LoRaMacParamsDefaults.ChannelsTxPower = verify.TxPower;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_CHANNELS_TX_POWER:
+        {
+            verify.TxPower = mibSet->Param.ChannelsTxPower;
+
+            if(lora_phy->verify(&verify, PHY_TX_POWER) == true)
+            {
+                LoRaMacParams.ChannelsTxPower = verify.TxPower;
+            }
+            else
+            {
+                status = LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+            break;
+        }
+        case MIB_UPLINK_COUNTER:
+        {
+            UpLinkCounter = mibSet->Param.UpLinkCounter;
+            break;
+        }
+        case MIB_DOWNLINK_COUNTER:
+        {
+            DownLinkCounter = mibSet->Param.DownLinkCounter;
+            break;
+        }
+        case MIB_SYSTEM_MAX_RX_ERROR:
+        {
+            LoRaMacParams.SystemMaxRxError = LoRaMacParamsDefaults.SystemMaxRxError = mibSet->Param.SystemMaxRxError;
+            break;
+        }
+        case MIB_MIN_RX_SYMBOLS:
+        {
+            LoRaMacParams.MinRxSymbols = LoRaMacParamsDefaults.MinRxSymbols = mibSet->Param.MinRxSymbols;
+            break;
+        }
+        case MIB_ANTENNA_GAIN:
+        {
+            LoRaMacParams.AntennaGain = mibSet->Param.AntennaGain;
+            break;
+        }
+        default:
+            status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+            break;
+    }
+
+    return status;
+}
+
+LoRaMacStatus_t LoRaMacChannelAdd( uint8_t id, ChannelParams_t params )
+{
+    ChannelAddParams_t channelAdd;
+
+    // Validate if the MAC is in a correct state
+    if( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    {
+        if( ( LoRaMacState & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
+        {
+            return LORAMAC_STATUS_BUSY;
+        }
+    }
+
+    channelAdd.NewChannel = &params;
+    channelAdd.ChannelId = id;
+
+    return lora_phy->add_channel(&channelAdd);
+}
+
+LoRaMacStatus_t LoRaMacChannelRemove( uint8_t id )
+{
+    ChannelRemoveParams_t channelRemove;
+
+    if( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    {
+        if( ( LoRaMacState & LORAMAC_TX_CONFIG ) != LORAMAC_TX_CONFIG )
+        {
+            return LORAMAC_STATUS_BUSY;
+        }
+    }
+
+    channelRemove.ChannelId = id;
+
+    if(lora_phy->remove_channel(&channelRemove) == false)
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    lora_phy->put_radio_to_sleep();
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacMulticastChannelLink( MulticastParams_t *channelParam )
+{
+    if( channelParam == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+    if( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    {
+        return LORAMAC_STATUS_BUSY;
+    }
+
+    // Reset downlink counter
+    channelParam->DownLinkCounter = 0;
+
+    if( MulticastChannels == NULL )
+    {
+        // New node is the fist element
+        MulticastChannels = channelParam;
+    }
+    else
+    {
+        MulticastParams_t *cur = MulticastChannels;
+
+        // Search the last node in the list
+        while( cur->Next != NULL )
+        {
+            cur = cur->Next;
+        }
+        // This function always finds the last node
+        cur->Next = channelParam;
+    }
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacMulticastChannelUnlink( MulticastParams_t *channelParam )
+{
+    if( channelParam == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+    if( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    {
+        return LORAMAC_STATUS_BUSY;
+    }
+
+    if( MulticastChannels != NULL )
+    {
+        if( MulticastChannels == channelParam )
+        {
+          // First element
+          MulticastChannels = channelParam->Next;
+        }
+        else
+        {
+            MulticastParams_t *cur = MulticastChannels;
+
+            // Search the node in the list
+            while( cur->Next && cur->Next != channelParam )
+            {
+                cur = cur->Next;
+            }
+            // If we found the node, remove it
+            if( cur->Next )
+            {
+                cur->Next = channelParam->Next;
+            }
+        }
+        channelParam->Next = NULL;
+    }
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMacMlmeRequest( MlmeReq_t *mlmeRequest )
+{
+    LoRaMacStatus_t status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+    LoRaMacHeader_t macHdr;
+    AlternateDrParams_t altDr;
+    VerifyParams_t verify;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    if( mlmeRequest == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+    if( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING )
+    {
+        return LORAMAC_STATUS_BUSY;
+    }
+
+    memset( ( uint8_t* ) &MlmeConfirm, 0, sizeof( MlmeConfirm ) );
+
+    MlmeConfirm.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+
+    switch( mlmeRequest->Type )
+    {
+        case MLME_JOIN:
+        {
+            if( ( LoRaMacState & LORAMAC_TX_DELAYED ) == LORAMAC_TX_DELAYED )
+            {
+                return LORAMAC_STATUS_BUSY;
+            }
+
+            if( ( mlmeRequest->Req.Join.DevEui == NULL ) ||
+                ( mlmeRequest->Req.Join.AppEui == NULL ) ||
+                ( mlmeRequest->Req.Join.AppKey == NULL ) ||
+                ( mlmeRequest->Req.Join.NbTrials == 0 ) )
+            {
+                return LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+
+            // Verify the parameter NbTrials for the join procedure
+            verify.NbJoinTrials = mlmeRequest->Req.Join.NbTrials;
+
+            if(lora_phy->verify(&verify, PHY_NB_JOIN_TRIALS) == false)
+            {
+                // Value not supported, get default
+                getPhy.Attribute = PHY_DEF_NB_JOIN_TRIALS;
+                phyParam = lora_phy->get_phy_params( &getPhy );
+                mlmeRequest->Req.Join.NbTrials = ( uint8_t ) phyParam.Value;
+            }
+
+            LoRaMacFlags.Bits.MlmeReq = 1;
+            MlmeConfirm.MlmeRequest = mlmeRequest->Type;
+
+            LoRaMacDevEui = mlmeRequest->Req.Join.DevEui;
+            LoRaMacAppEui = mlmeRequest->Req.Join.AppEui;
+            LoRaMacAppKey = mlmeRequest->Req.Join.AppKey;
+            MaxJoinRequestTrials = mlmeRequest->Req.Join.NbTrials;
+
+            // Reset variable JoinRequestTrials
+            JoinRequestTrials = 0;
+
+            // Setup header information
+            macHdr.Value = 0;
+            macHdr.Bits.MType  = FRAME_TYPE_JOIN_REQ;
+
+            ResetMacParameters( );
+
+            altDr.NbTrials = JoinRequestTrials + 1;
+
+            LoRaMacParams.ChannelsDatarate = lora_phy->get_alternate_DR(&altDr);
+
+            status = Send( &macHdr, 0, NULL, 0 );
+            break;
+        }
+        case MLME_LINK_CHECK:
+        {
+            LoRaMacFlags.Bits.MlmeReq = 1;
+            // LoRaMac will send this command piggy-pack
+            MlmeConfirm.MlmeRequest = mlmeRequest->Type;
+
+            status = AddMacCommand( MOTE_MAC_LINK_CHECK_REQ, 0, 0 );
+            break;
+        }
+        case MLME_TXCW:
+        {
+            MlmeConfirm.MlmeRequest = mlmeRequest->Type;
+            LoRaMacFlags.Bits.MlmeReq = 1;
+            status = SetTxContinuousWave( mlmeRequest->Req.TxCw.Timeout );
+            break;
+        }
+        case MLME_TXCW_1:
+        {
+            MlmeConfirm.MlmeRequest = mlmeRequest->Type;
+            LoRaMacFlags.Bits.MlmeReq = 1;
+            status = SetTxContinuousWave1( mlmeRequest->Req.TxCw.Timeout, mlmeRequest->Req.TxCw.Frequency, mlmeRequest->Req.TxCw.Power );
+            break;
+        }
+        default:
+            break;
+    }
+
+    if( status != LORAMAC_STATUS_OK )
+    {
+        NodeAckRequested = false;
+        LoRaMacFlags.Bits.MlmeReq = 0;
+    }
+
+    return status;
+}
+
+LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest )
+{
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    LoRaMacStatus_t status = LORAMAC_STATUS_SERVICE_UNKNOWN;
+    LoRaMacHeader_t macHdr;
+    VerifyParams_t verify;
+    uint8_t fPort = 0;
+    void *fBuffer;
+    uint16_t fBufferSize;
+    int8_t datarate;
+    bool readyToSend = false;
+
+    if( mcpsRequest == NULL )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+    if( ( ( LoRaMacState & LORAMAC_TX_RUNNING ) == LORAMAC_TX_RUNNING ) ||
+        ( ( LoRaMacState & LORAMAC_TX_DELAYED ) == LORAMAC_TX_DELAYED ) )
+    {
+        return LORAMAC_STATUS_BUSY;
+    }
+
+    macHdr.Value = 0;
+    memset ( ( uint8_t* ) &McpsConfirm, 0, sizeof( McpsConfirm ) );
+    McpsConfirm.Status = LORAMAC_EVENT_INFO_STATUS_ERROR;
+
+    // AckTimeoutRetriesCounter must be reset every time a new request (unconfirmed or confirmed) is performed.
+    AckTimeoutRetriesCounter = 1;
+
+    switch( mcpsRequest->Type )
+    {
+        case MCPS_UNCONFIRMED:
+        {
+            readyToSend = true;
+            AckTimeoutRetries = 1;
+
+            macHdr.Bits.MType = FRAME_TYPE_DATA_UNCONFIRMED_UP;
+            fPort = mcpsRequest->Req.Unconfirmed.fPort;
+            fBuffer = mcpsRequest->Req.Unconfirmed.fBuffer;
+            fBufferSize = mcpsRequest->Req.Unconfirmed.fBufferSize;
+            datarate = mcpsRequest->Req.Unconfirmed.Datarate;
+            break;
+        }
+        case MCPS_CONFIRMED:
+        {
+            readyToSend = true;
+            AckTimeoutRetries = mcpsRequest->Req.Confirmed.NbTrials;
+
+            macHdr.Bits.MType = FRAME_TYPE_DATA_CONFIRMED_UP;
+            fPort = mcpsRequest->Req.Confirmed.fPort;
+            fBuffer = mcpsRequest->Req.Confirmed.fBuffer;
+            fBufferSize = mcpsRequest->Req.Confirmed.fBufferSize;
+            datarate = mcpsRequest->Req.Confirmed.Datarate;
+            break;
+        }
+        case MCPS_PROPRIETARY:
+        {
+            readyToSend = true;
+            AckTimeoutRetries = 1;
+
+            macHdr.Bits.MType = FRAME_TYPE_PROPRIETARY;
+            fBuffer = mcpsRequest->Req.Proprietary.fBuffer;
+            fBufferSize = mcpsRequest->Req.Proprietary.fBufferSize;
+            datarate = mcpsRequest->Req.Proprietary.Datarate;
+            break;
+        }
+        default:
+            break;
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+    phyParam = lora_phy->get_phy_params( &getPhy );
+    // Apply the minimum possible datarate.
+    // Some regions have limitations for the minimum datarate.
+    datarate = MAX( datarate, phyParam.Value );
+
+    if( readyToSend == true )
+    {
+        if( AdrCtrlOn == false )
+        {
+            verify.DatarateParams.Datarate = datarate;
+            verify.DatarateParams.UplinkDwellTime = LoRaMacParams.UplinkDwellTime;
+
+            if(lora_phy->verify(&verify, PHY_TX_DR) == true)
+            {
+                LoRaMacParams.ChannelsDatarate = verify.DatarateParams.Datarate;
+            }
+            else
+            {
+                return LORAMAC_STATUS_PARAMETER_INVALID;
+            }
+        }
+
+        status = Send( &macHdr, fPort, fBuffer, fBufferSize );
+        if( status == LORAMAC_STATUS_OK )
+        {
+            McpsConfirm.McpsRequest = mcpsRequest->Type;
+            LoRaMacFlags.Bits.McpsReq = 1;
+        }
+        else
+        {
+            NodeAckRequested = false;
+        }
+    }
+
+    return status;
+}
+
+radio_events_t *GetPhyEventHandlers()
+{
+    RadioEvents.tx_done = handle_tx_done;
+    RadioEvents.rx_done = handle_rx_done;
+    RadioEvents.rx_error = handle_rx_error;
+    RadioEvents.tx_timeout = handle_tx_timeout;
+    RadioEvents.rx_timeout = handle_rx_timeout;
+
+    return &RadioEvents;
+}
+
+/***************************************************************************
+* TODO: Something related to Testing ? Need to figure out what is it       *
+ **************************************************************************/
+void LoRaMacTestRxWindowsOn( bool enable )
+{
+    IsRxWindowsEnabled = enable;
+}
+
+void LoRaMacTestSetMic( uint16_t txPacketCounter )
+{
+    UpLinkCounter = txPacketCounter;
+    IsUpLinkCounterFixed = true;
+}
+
+void LoRaMacTestSetDutyCycleOn( bool enable )
+{
+    VerifyParams_t verify;
+
+    verify.DutyCycle = enable;
+
+    if(lora_phy->verify(&verify, PHY_DUTY_CYCLE) == true)
+    {
+        DutyCycleOn = enable;
+    }
+}
+
+void LoRaMacTestSetChannel( uint8_t channel )
+{
+    Channel = channel;
+}

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -2136,6 +2136,7 @@ static LoRaMacStatus_t ScheduleTx( void )
         // Send later - prepare timer
         LoRaMacState |= LORAMAC_TX_DELAYED;
         tr_debug("Next Transmission in %lu ms", dutyCycleTimeOff);
+
         TimerSetValue( &TxDelayedTimer, dutyCycleTimeOff );
         TimerStart( &TxDelayedTimer );
 

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -23,7 +23,6 @@ SPDX-License-Identifier: BSD-3-Clause
 */
 #include <stdlib.h>
 #include "events/EventQueue.h"
-#include "rtos/Thread.h"
 #include "LoRaMac.h"
 #include "LoRaMacCrypto.h"
 #include "LoRaMacTest.h"
@@ -1524,21 +1523,6 @@ static void OnMacStateCheckTimerEvent( void )
         LoRaMacFlags.Bits.McpsIndSkip = 0;
         LoRaMacFlags.Bits.McpsInd = 0;
     }
-}
-
-LoRaMacStatus_t LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
-{
-    TimerSetValue(&TxNextPacketTimer, TxDutyCycleTime);
-    TimerStart(&TxNextPacketTimer);
-
-    return LORAMAC_STATUS_OK;
-}
-
-LoRaMacStatus_t LoRaMacStopTxTimer( )
-{
-    TimerStop(&TxNextPacketTimer);
-
-    return LORAMAC_STATUS_OK;
 }
 
 static void OnTxDelayedTimerEvent( void )
@@ -3474,9 +3458,27 @@ radio_events_t *GetPhyEventHandlers()
     return &RadioEvents;
 }
 
+#if defined(LORAWAN_COMPLIANCE_TEST)
 /***************************************************************************
-* TODO: Something related to Testing ? Need to figure out what is it       *
+ * Compliance testing                                                      *
  **************************************************************************/
+
+LoRaMacStatus_t LoRaMac::LoRaMacSetTxTimer( uint32_t TxDutyCycleTime )
+{
+    TimerSetValue(&TxNextPacketTimer, TxDutyCycleTime);
+    TimerStart(&TxNextPacketTimer);
+
+    return LORAMAC_STATUS_OK;
+}
+
+LoRaMacStatus_t LoRaMac::LoRaMacStopTxTimer( )
+
+{
+    TimerStop(&TxNextPacketTimer);
+
+    return LORAMAC_STATUS_OK;
+}
+
 void LoRaMacTestRxWindowsOn( bool enable )
 {
     IsRxWindowsEnabled = enable;
@@ -3504,3 +3506,4 @@ void LoRaMacTestSetChannel( uint8_t channel )
 {
     Channel = channel;
 }
+#endif

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -331,6 +331,7 @@ LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest );
  */
 radio_events_t *GetPhyEventHandlers();
 
+
 /**
  * \brief   LoRaMAC set tx timer.
  *

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -331,7 +331,7 @@ LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest );
  */
 radio_events_t *GetPhyEventHandlers();
 
-
+#if defined(LORAWAN_COMPLIANCE_TEST)
 /**
  * \brief   LoRaMAC set tx timer.
  *
@@ -355,5 +355,6 @@ LoRaMacStatus_t LoRaMacSetTxTimer( uint32_t NextTxTime );
  *          \ref LORAMAC_STATUS_PARAMETER_INVALID
  */
 LoRaMacStatus_t LoRaMacStopTxTimer( );
+#endif
 
 #endif // __LORAMAC_H__

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -86,14 +86,19 @@ static const uint8_t LoRaMacMaxEirpTable[] = { 8, 10, 12, 13, 14, 16, 18, 20, 21
  * \param   callbacks [in] - A pointer to the structure defining the LoRaMAC
  *                        callback functions. Refer to \ref LoRaMacCallback_t.
  *
- * \param   phy [in]- A reference to the selected PHY layer.
+ * \param   phy [in]- A pointer to the selected PHY layer.
+ *
+ * \param   queue [in]- A pointer to the application provided EventQueue.
  *
  * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
  *          \ref LORAMAC_STATUS_OK
  *          \ref LORAMAC_STATUS_PARAMETER_INVALID
  *          \ref LORAMAC_STATUS_REGION_NOT_SUPPORTED.
  */
-LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t *primitives, LoRaMacCallback_t *callbacks, LoRaPHY& phy);
+LoRaMacStatus_t LoRaMacInitialization(LoRaMacPrimitives_t *primitives,
+                                      LoRaMacCallback_t *callbacks,
+                                      LoRaPHY *phy,
+                                      events::EventQueue *queue);
 
 /*!
  * \brief   Queries the LoRaMAC whether it is possible to send the next frame with

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -1,0 +1,353 @@
+/**
+ * \file      LoRaMac.h
+ *
+ * \brief     LoRa MAC layer implementation
+ *
+ * \copyright Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * \code
+ *                ______                              _
+ *               / _____)             _              | |
+ *              ( (____  _____ ____ _| |_ _____  ____| |__
+ *               \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *               _____) ) ____| | | || |_| ____( (___| | | |
+ *              (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *              (C)2013 Semtech
+ *
+ *               ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ *              / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ *              \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ *              |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ *              embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ * \author    Miguel Luis ( Semtech )
+ *
+ * \author    Gregory Cristian ( Semtech )
+ *
+ * \author    Daniel Jaeckle ( STACKFORCE )
+ *
+ * \defgroup  LORAMAC LoRa MAC layer implementation
+ *            This module specifies the API implementation of the LoRaMAC layer.
+ *            This is a placeholder for a detailed description of the LoRaMac
+ *            layer and the supported features.
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+#ifndef __LORAMAC_H__
+#define __LORAMAC_H__
+
+#include "lorawan/system/LoRaWANTimer.h"
+#include "netsocket/LoRaRadio.h"
+#include "lorastack/phy/LoRaPHY.h"
+#include "lorawan/system/lorawan_data_structures.h"
+
+/*!
+ * Check the MAC layer state every MAC_STATE_CHECK_TIMEOUT in ms.
+ */
+#define MAC_STATE_CHECK_TIMEOUT                     1000
+
+/*!
+ * The maximum number of times the MAC layer tries to get an acknowledge.
+ */
+#define MAX_ACK_RETRIES                             8
+
+/*!
+ * The frame direction definition for uplink communications.
+ */
+#define UP_LINK                                     0
+
+/*!
+ * The frame direction definition for downlink communications.
+ */
+#define DOWN_LINK                                   1
+
+
+/*!
+ * LoRaMAC max EIRP (dBm) table.
+ */
+static const uint8_t LoRaMacMaxEirpTable[] = { 8, 10, 12, 13, 14, 16, 18, 20, 21, 24, 26, 27, 29, 30, 33, 36 };
+
+
+/*!
+ * \brief   LoRaMAC layer initialization
+ *
+ * \details In addition to the initialization of the LoRaMAC layer, this
+ *          function initializes the callback primitives of the MCPS and
+ *          MLME services. Every data field of \ref LoRaMacPrimitives_t must be
+ *          set to a valid callback function.
+ *
+ * \param   primitives [in] - A pointer to the structure defining the LoRaMAC
+ *                            event functions. Refer to \ref LoRaMacPrimitives_t.
+ *
+ * \param   callbacks [in] - A pointer to the structure defining the LoRaMAC
+ *                        callback functions. Refer to \ref LoRaMacCallback_t.
+ *
+ * \param   phy [in]- A reference to the selected PHY layer.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ *          \ref LORAMAC_STATUS_REGION_NOT_SUPPORTED.
+ */
+LoRaMacStatus_t LoRaMacInitialization( LoRaMacPrimitives_t *primitives, LoRaMacCallback_t *callbacks, LoRaPHY& phy);
+
+/*!
+ * \brief   Queries the LoRaMAC whether it is possible to send the next frame with
+ *          a given payload size. The LoRaMAC takes the scheduled MAC commands into
+ *          account and reports when the frame can be sent.
+ *
+ * \param   size [in]- The size of the applicable payload to be sent next.
+ * \param   txInfo  [out] - The structure \ref LoRaMacTxInfo_t contains
+ *                         information on the actual maximum payload possible
+ *                         (according to the configured datarate or the next
+ *                         datarate according to ADR), and the maximum frame
+ *                         size, taking the scheduled MAC commands into account.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. When the parameters are
+ *          not valid, the function returns \ref LORAMAC_STATUS_PARAMETER_INVALID.
+ *          In case of a length error caused by the applicable payload in combination
+ *          with the MAC commands, the function returns \ref LORAMAC_STATUS_LENGTH_ERROR.
+ *          Please note that if the size of the MAC commands in the queue do
+ *          not fit into the payload size on the related datarate, the LoRaMAC will
+ *          omit the MAC commands.
+ *          If the query is valid, and the LoRaMAC is able to send the frame,
+ *          the function returns \ref LORAMAC_STATUS_OK.
+ */
+LoRaMacStatus_t LoRaMacQueryTxPossible( uint8_t size, LoRaMacTxInfo_t* txInfo );
+
+/*!
+ * \brief   LoRaMAC channel add service.
+ *
+ * \details Adds a new channel to the channel list and activates the ID in
+ *          the channel mask. Please note that this functionality is not available
+ *          in all regions. Information on the allowed ranges is available at the LoRaWAN Regional Parameters V1.0.2rB.
+ *
+ * \param   id [in] - The ID of the channel.
+ *
+ * \param   params [in] - The channel parameters to set.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacChannelAdd( uint8_t id, ChannelParams_t params );
+
+/*!
+ * \brief   LoRaMAC channel remove service.
+ *
+ * \details Deactivates the ID in the channel mask.
+ *
+ * \param   id - Id of the channel.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacChannelRemove( uint8_t id );
+
+/*!
+ * \brief   LoRaMAC multicast channel link service.
+ *
+ * \details Links a multicast channel into the linked list.
+ *
+ * \param   [in] channelParam - The multicast channel parameters to link.
+ *
+ * \retval  `LoRaMacStatus_t` The  status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacMulticastChannelLink( MulticastParams_t *channelParam );
+
+/*!
+ * \brief   LoRaMAC multicast channel unlink service.
+ *
+ * \details Unlinks a multicast channel from the linked list.
+ *
+ * \param   [in] channelParam - The multicast channel parameters to unlink.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacMulticastChannelUnlink( MulticastParams_t *channelParam );
+
+/*!
+ * \brief   LoRaMAC MIB-GET.
+ *
+ * \details The MAC information base service to get the attributes of the LoRaMac layer.
+ *
+ *          The following code-snippet shows how to use the API to get the
+ *          parameter `AdrEnable`, defined by the enumeration type
+ *          \ref MIB_ADR.
+ * \code
+ * MibRequestConfirm_t mibReq;
+ * mibReq.Type = MIB_ADR;
+ *
+ * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAMAC_STATUS_OK )
+ * {
+ *   // LoRaMAC updated the parameter mibParam.AdrEnable
+ * }
+ * \endcode
+ *
+ * \param   [in] mibGet - The MIB-GET request to perform. Refer to \ref MibRequestConfirm_t.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacMibGetRequestConfirm( MibRequestConfirm_t *mibGet );
+
+/*!
+ * \brief   LoRaMAC MIB-SET.
+ *
+ * \details The MAC information base service to set the attributes of the LoRaMac layer.
+ *
+ *          The following code-snippet shows how to use the API to set the
+ *          parameter `AdrEnable`, defined by the enumeration type
+ *          \ref MIB_ADR.
+ *
+ * \code
+ * MibRequestConfirm_t mibReq;
+ * mibReq.Type = MIB_ADR;
+ * mibReq.Param.AdrEnable = true;
+ *
+ * if( LoRaMacMibGetRequestConfirm( &mibReq ) == LORAMAC_STATUS_OK )
+ * {
+ *   // LoRaMAC updated the parameter
+ * }
+ * \endcode
+ *
+ * \param   [in] mibSet - The MIB-SET request to perform. Refer to \ref MibRequestConfirm_t.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacMibSetRequestConfirm( MibRequestConfirm_t *mibSet );
+
+/*!
+ * \brief   LoRaMAC MLME request
+ *
+ * \details The MAC layer management entity handles the management services. The
+ *          following code-snippet shows how to use the API to perform a
+ *          network join request.
+ *
+ * \code
+ * static uint8_t DevEui[] =
+ * {
+ *   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+ * };
+ * static uint8_t AppEui[] =
+ * {
+ *   0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+ * };
+ * static uint8_t AppKey[] =
+ * {
+ *   0x2B, 0x7E, 0x15, 0x16, 0x28, 0xAE, 0xD2, 0xA6,
+ *   0xAB, 0xF7, 0x15, 0x88, 0x09, 0xCF, 0x4F, 0x3C
+ * };
+ *
+ * MlmeReq_t mlmeReq;
+ * mlmeReq.Type = MLME_JOIN;
+ * mlmeReq.Req.Join.DevEui = DevEui;
+ * mlmeReq.Req.Join.AppEui = AppEui;
+ * mlmeReq.Req.Join.AppKey = AppKey;
+ *
+ * if( LoRaMacMlmeRequest( &mlmeReq ) == LORAMAC_STATUS_OK )
+ * {
+ *   // Service started successfully. Waiting for the Mlme-Confirm event
+ * }
+ * \endcode
+ *
+ * \param   [in] mlmeRequest - The MLME request to perform. Refer to \ref MlmeReq_t.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ *          \ref LORAMAC_STATUS_NO_NETWORK_JOINED
+ *          \ref LORAMAC_STATUS_LENGTH_ERROR
+ *          \ref LORAMAC_STATUS_DEVICE_OFF
+ */
+LoRaMacStatus_t LoRaMacMlmeRequest( MlmeReq_t *mlmeRequest );
+
+/*!
+ * \brief   LoRaMAC MCPS request
+ *
+ * \details The MAC Common Part Sublayer handles the data services. The following
+ *          code-snippet shows how to use the API to send an unconfirmed
+ *          LoRaMAC frame.
+ *
+ * \code
+ * uint8_t myBuffer[] = { 1, 2, 3 };
+ *
+ * McpsReq_t mcpsReq;
+ * mcpsReq.Type = MCPS_UNCONFIRMED;
+ * mcpsReq.Req.Unconfirmed.fPort = 1;
+ * mcpsReq.Req.Unconfirmed.fBuffer = myBuffer;
+ * mcpsReq.Req.Unconfirmed.fBufferSize = sizeof( myBuffer );
+ *
+ * if( LoRaMacMcpsRequest( &mcpsReq ) == LORAMAC_STATUS_OK )
+ * {
+ *   // Service started successfully. Waiting for the MCPS-Confirm event
+ * }
+ * \endcode
+ *
+ * \param   [in] mcpsRequest - The MCPS request to perform. Refer to \ref McpsReq_t.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_BUSY
+ *          \ref LORAMAC_STATUS_SERVICE_UNKNOWN
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ *          \ref LORAMAC_STATUS_NO_NETWORK_JOINED
+ *          \ref LORAMAC_STATUS_LENGTH_ERROR
+ *          \ref LORAMAC_STATUS_DEVICE_OFF
+ */
+LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest );
+
+/**
+ * \brief LoRaMAC layer provides its callback functions for
+ *        PHY layer
+ *
+ * \return Pointer to callback functions for radio events
+ */
+radio_events_t *GetPhyEventHandlers();
+
+/**
+ * \brief   LoRaMAC set tx timer.
+ *
+ * \details Sets up a timer for next transmission (application specific timers).
+ *
+ * \param   [in] NextTxTime - Periodic time for next uplink.
+
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacSetTxTimer( uint32_t NextTxTime );
+
+/**
+ * \brief   LoRaMAC stop tx timer.
+ *
+ * \details Stops the next tx timer.
+ *
+ * \retval  `LoRaMacStatus_t` The status of the operation. The possible values are:
+ *          \ref LORAMAC_STATUS_OK
+ *          \ref LORAMAC_STATUS_PARAMETER_INVALID
+ */
+LoRaMacStatus_t LoRaMacStopTxTimer( );
+
+#endif // __LORAMAC_H__

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
@@ -1,0 +1,347 @@
+/**
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *    (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * Description: LoRa MAC crypto implementation
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jäckle ( STACKFORCE )
+ *
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <stdlib.h>
+#include <stdint.h>
+#include "lorastack/mac/LoRaMacCrypto.h"
+#include "lorawan/system/lorawan_data_structures.h"
+
+#include "mbedtls/aes.h"
+#include "mbedtls/cmac.h"
+
+#if defined(MBEDTLS_CMAC_C) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
+
+/**
+ * CMAC/AES Message Integrity Code (MIC) Block B0 size
+ */
+#define LORAMAC_MIC_BLOCK_B0_SIZE                   16
+
+/**
+ * MIC field computation initial data
+ */
+static uint8_t MicBlockB0[] = { 0x49, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                              };
+
+/**
+ * Contains the computed MIC field.
+ *
+ * \remark Only the 4 first bytes are used
+ */
+static uint8_t Mic[16];
+
+/**
+ * Encryption aBlock and sBlock
+ */
+static uint8_t aBlock[] = { 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                          };
+static uint8_t sBlock[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+                          };
+
+/**
+ * AES computation context variable
+ */
+static mbedtls_aes_context AesContext;
+
+/**
+ * CMAC computation context variable
+ */
+static mbedtls_cipher_context_t AesCmacCtx[1];
+
+#define AES_CMAC_KEY_LENGTH     16
+
+/**
+ * \brief Computes the LoRaMAC frame MIC field
+ *
+ * \param [in]  buffer          Data buffer
+ * \param [in]  size            Data buffer size
+ * \param [in]  key             AES key to be used
+ * \param [in]  address         Frame address
+ * \param [in]  dir             Frame direction [0: uplink, 1: downlink]
+ * \param [in]  sequenceCounter Frame sequence counter
+ * \param [out] mic Computed MIC field
+ */
+int LoRaMacComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint32_t *mic )
+{
+
+    int ret = 0;
+
+    MicBlockB0[5] = dir;
+
+    MicBlockB0[6] = ( address ) & 0xFF;
+    MicBlockB0[7] = ( address >> 8 ) & 0xFF;
+    MicBlockB0[8] = ( address >> 16 ) & 0xFF;
+    MicBlockB0[9] = ( address >> 24 ) & 0xFF;
+
+    MicBlockB0[10] = ( sequenceCounter ) & 0xFF;
+    MicBlockB0[11] = ( sequenceCounter >> 8 ) & 0xFF;
+    MicBlockB0[12] = ( sequenceCounter >> 16 ) & 0xFF;
+    MicBlockB0[13] = ( sequenceCounter >> 24 ) & 0xFF;
+
+    MicBlockB0[15] = size & 0xFF;
+
+    mbedtls_cipher_init(AesCmacCtx);
+    const mbedtls_cipher_info_t* cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
+    if (NULL != cipher_info) {
+        ret = mbedtls_cipher_setup(AesCmacCtx, cipher_info);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_starts(AesCmacCtx, key, AES_CMAC_KEY_LENGTH*8);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_update(AesCmacCtx, MicBlockB0, LORAMAC_MIC_BLOCK_B0_SIZE);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_update(AesCmacCtx, buffer, size & 0xFF);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_finish(AesCmacCtx, Mic);
+        if (0 != ret)
+            goto exit;
+
+        *mic = ( uint32_t )( ( uint32_t )Mic[3] << 24 | ( uint32_t )Mic[2] << 16 | ( uint32_t )Mic[1] << 8 | ( uint32_t )Mic[0] );
+    } else {
+        ret = MBEDTLS_ERR_CIPHER_ALLOC_FAILED;
+    }
+
+exit:
+    mbedtls_cipher_free( AesCmacCtx );
+    return ret;
+}
+
+int LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint8_t *encBuffer )
+{
+    uint16_t i;
+    uint8_t bufferIndex = 0;
+    uint16_t ctr = 1;
+    int ret = 0;
+
+    mbedtls_aes_init(&AesContext);
+    ret = mbedtls_aes_setkey_enc(&AesContext, key, 16*8);
+    if (0 != ret)
+        goto exit;
+
+    aBlock[5] = dir;
+
+    aBlock[6] = ( address ) & 0xFF;
+    aBlock[7] = ( address >> 8 ) & 0xFF;
+    aBlock[8] = ( address >> 16 ) & 0xFF;
+    aBlock[9] = ( address >> 24 ) & 0xFF;
+
+    aBlock[10] = ( sequenceCounter ) & 0xFF;
+    aBlock[11] = ( sequenceCounter >> 8 ) & 0xFF;
+    aBlock[12] = ( sequenceCounter >> 16 ) & 0xFF;
+    aBlock[13] = ( sequenceCounter >> 24 ) & 0xFF;
+
+    while( size >= 16 )
+    {
+        aBlock[15] = ( ( ctr ) & 0xFF );
+        ctr++;
+        ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, aBlock, sBlock);
+        if (0 != ret)
+            goto exit;
+
+        for( i = 0; i < 16; i++ )
+        {
+            encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+        }
+        size -= 16;
+        bufferIndex += 16;
+    }
+
+    if( size > 0 )
+    {
+        aBlock[15] = ( ( ctr ) & 0xFF );
+        ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, aBlock, sBlock);
+        if (0 != ret)
+            goto exit;
+
+        for( i = 0; i < size; i++ )
+        {
+            encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+        }
+    }
+
+exit:
+    mbedtls_aes_free(&AesContext);
+    return ret;
+}
+
+int LoRaMacPayloadDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint8_t *decBuffer )
+{
+    return LoRaMacPayloadEncrypt( buffer, size, key, address, dir, sequenceCounter, decBuffer );
+}
+
+int LoRaMacJoinComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t *mic )
+{
+    int ret = 0;
+
+    mbedtls_cipher_init(AesCmacCtx);
+    const mbedtls_cipher_info_t* cipher_info = mbedtls_cipher_info_from_type(MBEDTLS_CIPHER_AES_128_ECB);
+    if (NULL != cipher_info) {
+        ret = mbedtls_cipher_setup(AesCmacCtx, cipher_info);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_starts(AesCmacCtx, key, AES_CMAC_KEY_LENGTH*8);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_update(AesCmacCtx, buffer, size & 0xFF);
+        if (0 != ret)
+            goto exit;
+
+        ret = mbedtls_cipher_cmac_finish(AesCmacCtx, Mic);
+        if (0 != ret)
+            goto exit;
+
+        *mic = ( uint32_t )( ( uint32_t )Mic[3] << 24 | ( uint32_t )Mic[2] << 16 | ( uint32_t )Mic[1] << 8 | ( uint32_t )Mic[0] );
+    } else {
+        ret = MBEDTLS_ERR_CIPHER_ALLOC_FAILED;
+    }
+
+exit:
+    mbedtls_cipher_free(AesCmacCtx);
+    return ret;
+}
+
+int LoRaMacJoinDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint8_t *decBuffer )
+{
+    int ret = 0;
+
+    mbedtls_aes_init(&AesContext);
+
+    ret = mbedtls_aes_setkey_enc(&AesContext, key, 16*8);
+    if (0 != ret)
+        goto exit;
+
+    ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, buffer, decBuffer);
+    if (0 != ret)
+        goto exit;
+
+    // Check if optional CFList is included
+    if( size >= 16 )
+    {
+        ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, buffer + 16, decBuffer + 16);
+    }
+
+exit:
+    mbedtls_aes_free(&AesContext);
+    return ret;
+}
+
+int LoRaMacJoinComputeSKeys( const uint8_t *key, const uint8_t *appNonce, uint16_t devNonce, uint8_t *nwkSKey, uint8_t *appSKey )
+{
+    uint8_t nonce[16];
+    uint8_t *pDevNonce = ( uint8_t * )&devNonce;
+    int ret = 0;
+
+    mbedtls_aes_init(&AesContext);
+
+    ret = mbedtls_aes_setkey_enc(&AesContext, key, 16*8);
+    if (0 != ret)
+        goto exit;
+
+    memset( nonce, 0, sizeof( nonce ) );
+    nonce[0] = 0x01;
+    memcpy( nonce + 1, appNonce, 6 );
+    memcpy( nonce + 7, pDevNonce, 2 );
+    ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, nonce, nwkSKey);
+    if (0 != ret)
+        goto exit;
+
+    memset( nonce, 0, sizeof( nonce ) );
+    nonce[0] = 0x02;
+    memcpy( nonce + 1, appNonce, 6 );
+    memcpy( nonce + 7, pDevNonce, 2 );
+    ret = mbedtls_aes_crypt_ecb(&AesContext, MBEDTLS_AES_ENCRYPT, nonce, appSKey);
+
+exit:
+    mbedtls_aes_free(&AesContext);
+    return ret;
+}
+#else
+
+// If mbedTLS is not configured properly, these dummies will ensure that
+// user knows what is wrong and in addition to that these ensure that
+// Mbed-OS compiles properly under normal conditions where LoRaWAN in conjunction
+// with mbedTLS is not being used.
+int LoRaMacComputeMic( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
+                       uint8_t dir, uint32_t, uint32_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+
+int LoRaMacPayloadEncrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
+                           uint8_t , uint32_t , uint8_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+
+int LoRaMacPayloadDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint32_t,
+                           uint8_t , uint32_t , uint8_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+int LoRaMacJoinComputeMic( const uint8_t *, uint16_t , const uint8_t *, uint32_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+
+int LoRaMacJoinDecrypt( const uint8_t *, uint16_t , const uint8_t *, uint8_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+
+int LoRaMacJoinComputeSKeys( const uint8_t *, const uint8_t *, uint16_t , uint8_t *, uint8_t * )
+{
+    MBED_ASSERT("[LoRaCrypto] Must enable AES, CMAC & CIPHER from mbedTLS");
+
+    // Never actually reaches here
+    return LORA_MAC_STATUS_CRYPTO_FAIL;
+}
+
+#endif

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.h
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.h
@@ -1,0 +1,112 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+Description: LoRa MAC Crypto implementation
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#ifndef MBED_LORAWAN_MAC_LORAMAC_CRYPTO_H__
+#define MBED_LORAWAN_MAC_LORAMAC_CRYPTO_H__
+
+/**
+ * Computes the LoRaMAC frame MIC field
+ *
+ * \param [in]  buffer          - Data buffer
+ * \param [in]  size            - Data buffer size
+ * \param [in]  key             - AES key to be used
+ * \param [in]  address         - Frame address
+ * \param [in]  dir             - Frame direction [0: uplink, 1: downlink]
+ * \param [in]  sequenceCounter - Frame sequence counter
+ * \param [out] mic             - Computed MIC field
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ */
+int LoRaMacComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint32_t *mic );
+
+/**
+ * Computes the LoRaMAC payload encryption
+ *
+ * \param [in]  buffer          - Data buffer
+ * \param [in]  size            - Data buffer size
+ * \param [in]  key             - AES key to be used
+ * \param [in]  address         - Frame address
+ * \param [in]  dir             - Frame direction [0: uplink, 1: downlink]
+ * \param [in]  sequenceCounter - Frame sequence counter
+ * \param [out] encBuffer       - Encrypted buffer
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ */
+int LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint8_t *encBuffer );
+
+/**
+ * Computes the LoRaMAC payload decryption
+ *
+ * \param [in]  buffer          - Data buffer
+ * \param [in]  size            - Data buffer size
+ * \param [in]  key             - AES key to be used
+ * \param [in]  address         - Frame address
+ * \param [in]  dir             - Frame direction [0: uplink, 1: downlink]
+ * \param [in]  sequenceCounter - Frame sequence counter
+ * \param [out] decBuffer       - Decrypted buffer
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ */
+int LoRaMacPayloadDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t address, uint8_t dir, uint32_t sequenceCounter, uint8_t *decBuffer );
+
+/**
+ * Computes the LoRaMAC Join Request frame MIC field
+ *
+ * \param [in]  buffer          - Data buffer
+ * \param [in]  size            - Data buffer size
+ * \param [in]  key             - AES key to be used
+ * \param [out] mic             - Computed MIC field
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ *
+ */
+int LoRaMacJoinComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint32_t *mic );
+
+/**
+ * Computes the LoRaMAC join frame decryption
+ *
+ * \param [in]  buffer          - Data buffer
+ * \param [in]  size            - Data buffer size
+ * \param [in]  key             - AES key to be used
+ * \param [out] decBuffer       - Decrypted buffer
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ */
+int LoRaMacJoinDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint8_t *decBuffer );
+
+/**
+ * Computes the LoRaMAC join frame decryption
+ *
+ * \param [in]  key             - AES key to be used
+ * \param [in]  appNonce        - Application nonce
+ * \param [in]  devNonce        - Device nonce
+ * \param [out] nwkSKey         - Network session key
+ * \param [out] appSKey         - Application session key
+ *
+ * \return                        0 if successful, or a cipher specific error code
+ */
+int LoRaMacJoinComputeSKeys( const uint8_t *key, const uint8_t *appNonce, uint16_t devNonce, uint8_t *nwkSKey, uint8_t *appSKey );
+
+#endif // MBED_LORAWAN_MAC_LORAMAC_CRYPTO_H__

--- a/features/lorawan/lorastack/mac/LoRaMacTest.h
+++ b/features/lorawan/lorastack/mac/LoRaMacTest.h
@@ -1,0 +1,68 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+Description: LoRa MAC layer test function implementation
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+#ifndef __LORAMACTEST_H__
+#define __LORAMACTEST_H__
+
+/**
+ * \brief   Enabled or disables the reception windows
+ *
+ * \details This is a test function. It shall be used for testing purposes only.
+ *          Changing this attribute may lead to a non-conformance LoRaMac operation.
+ *
+ * \param   [in] enable - Enabled or disables the reception windows
+ */
+void LoRaMacTestRxWindowsOn( bool enable );
+
+/**
+ * \brief   Enables the MIC field test
+ *
+ * \details This is a test function. It shall be used for testing purposes only.
+ *          Changing this attribute may lead to a non-conformance LoRaMac operation.
+ *
+ * \param   [in] txPacketCounter - Fixed Tx packet counter value
+ */
+void LoRaMacTestSetMic( uint16_t txPacketCounter );
+
+/**
+ * \brief   Enabled or disables the duty cycle
+ *
+ * \details This is a test function. It shall be used for testing purposes only.
+ *          Changing this attribute may lead to a non-conformance LoRaMac operation.
+ *
+ * \param   [in] enable - Enabled or disables the duty cycle
+ */
+void LoRaMacTestSetDutyCycleOn( bool enable );
+
+/**
+ * \brief   Sets the channel index
+ *
+ * \details This is a test function. It shall be used for testing purposes only.
+ *          Changing this attribute may lead to a non-conformance LoRaMac operation.
+ *
+ * \param   [in] channel - Channel index
+ */
+void LoRaMacTestSetChannel( uint8_t channel );
+
+#endif // __LORAMACTEST_H__

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -1,0 +1,437 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+ ___ _____ _   ___ _  _____ ___  ___  ___ ___
+/ __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+\__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+|___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+embedded.connectivity.solutions===============
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+#include <math.h>
+#include "lorawan/lorastack/phy/LoRaPHY.h"
+#include "lorawan/system/LoRaWANTimer.h"
+
+#define BACKOFF_DC_1_HOUR       100
+#define BACKOFF_DC_10_HOURS     1000
+#define BACKOFF_DC_24_HOURS     10000
+
+static uint8_t CountChannels( uint16_t mask, uint8_t nbBits )
+{
+    uint8_t nbActiveBits = 0;
+
+    for( uint8_t j = 0; j < nbBits; j++ )
+    {
+        if( ( mask & ( 1 << j ) ) == ( 1 << j ) )
+        {
+            nbActiveBits++;
+        }
+    }
+    return nbActiveBits;
+}
+
+LoRaPHY::LoRaPHY()
+{
+}
+
+LoRaPHY::~LoRaPHY()
+{
+    _radio = NULL;
+}
+
+void LoRaPHY::set_radio_instance(LoRaRadio& radio)
+{
+    _radio = &radio;
+}
+
+void LoRaPHY::put_radio_to_sleep() {
+    _radio->lock();
+    _radio->sleep();
+    _radio->unlock();
+}
+
+void LoRaPHY::put_radio_to_standby() {
+    _radio->lock();
+    _radio->standby();
+    _radio->unlock();
+}
+
+void LoRaPHY::setup_tx_cont_wave_mode(uint16_t timeout, uint32_t frequency,
+                                      uint8_t power)
+{
+    _radio->lock();
+    _radio->set_tx_continuous_wave(frequency, power, timeout);
+    _radio->unlock();
+}
+
+void LoRaPHY::setup_public_network_mode(bool set)
+{
+    _radio->lock();
+    _radio->set_public_network(set);
+    _radio->unlock();
+}
+
+void LoRaPHY::setup_rx_window(bool rx_continuous, uint32_t max_rx_window)
+{
+    _radio->lock();
+
+    if (!rx_continuous) {
+        _radio->receive(max_rx_window);
+        _radio->unlock();
+        return;
+    }
+
+    _radio->receive(0); // Continuous mode
+
+    _radio->unlock();
+}
+
+// For DevNonce for example
+uint32_t LoRaPHY::get_radio_rng()
+{
+    uint32_t rand;
+
+    _radio->lock();
+    rand =_radio->random();
+    _radio->unlock();
+
+    return rand;
+}
+
+void LoRaPHY::handle_send(uint8_t *buf, uint8_t size)
+{
+    _radio->lock();
+    _radio->send(buf, size);
+    _radio->unlock();
+}
+
+int32_t LoRaPHY::get_random(int32_t min, int32_t max)
+{
+    return (int32_t) rand() % (max - min + 1) + min;
+}
+
+uint16_t LoRaPHY::get_join_DC( TimerTime_t elapsedTime )
+{
+    uint16_t dutyCycle = 0;
+
+    if( elapsedTime < 3600000 )
+    {
+        dutyCycle = BACKOFF_DC_1_HOUR;
+    }
+    else if( elapsedTime < ( 3600000 + 36000000 ) )
+    {
+        dutyCycle = BACKOFF_DC_10_HOURS;
+    }
+    else
+    {
+        dutyCycle = BACKOFF_DC_24_HOURS;
+    }
+    return dutyCycle;
+}
+
+bool LoRaPHY::verify_channel_DR( uint8_t nbChannels, uint16_t* channelsMask, int8_t dr, int8_t minDr, int8_t maxDr, ChannelParams_t* channels )
+{
+    if( val_in_range( dr, minDr, maxDr ) == 0 )
+    {
+        return false;
+    }
+
+    for( uint8_t i = 0, k = 0; i < nbChannels; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( ( channelsMask[k] & ( 1 << j ) ) != 0 ) )
+            {// Check datarate validity for enabled channels
+                if( val_in_range( dr, ( channels[i + j].DrRange.Fields.Min & 0x0F ),
+                                                  ( channels[i + j].DrRange.Fields.Max & 0x0F ) ) == 1 )
+                {
+                    // At least 1 channel has been found we can return OK.
+                    return true;
+                }
+            }
+        }
+    }
+    return false;
+}
+
+uint8_t LoRaPHY::val_in_range( int8_t value, int8_t min, int8_t max )
+{
+    if( ( value >= min ) && ( value <= max ) )
+    {
+        return 1;
+    }
+    return 0;
+}
+
+bool LoRaPHY::disable_channel( uint16_t* channelsMask, uint8_t id, uint8_t maxChannels )
+{
+    uint8_t index = id / 16;
+
+    if( ( index > ( maxChannels / 16 ) ) || ( id >= maxChannels ) )
+    {
+        return false;
+    }
+
+    // Deactivate channel
+    channelsMask[index] &= ~( 1 << ( id % 16 ) );
+
+    return true;
+}
+
+uint8_t LoRaPHY::num_active_channels( uint16_t* channelsMask, uint8_t startIdx, uint8_t stopIdx )
+{
+    uint8_t nbChannels = 0;
+
+    if( channelsMask == NULL )
+    {
+        return 0;
+    }
+
+    for( uint8_t i = startIdx; i < stopIdx; i++ )
+    {
+        nbChannels += CountChannels( channelsMask[i], 16 );
+    }
+
+    return nbChannels;
+}
+
+void LoRaPHY::copy_channel_mask( uint16_t* channelsMaskDest, uint16_t* channelsMaskSrc, uint8_t len )
+{
+    if( ( channelsMaskDest != NULL ) && ( channelsMaskSrc != NULL ) )
+    {
+        for( uint8_t i = 0; i < len; i++ )
+        {
+            channelsMaskDest[i] = channelsMaskSrc[i];
+        }
+    }
+}
+
+void LoRaPHY::set_last_tx_done( bool joined, Band_t* band, TimerTime_t lastTxDone )
+{
+    if( joined == true )
+    {
+        band->LastTxDoneTime = lastTxDone;
+    }
+    else
+    {
+        band->LastTxDoneTime = lastTxDone;
+        band->LastJoinTxDoneTime = lastTxDone;
+    }
+}
+
+TimerTime_t LoRaPHY::update_band_timeoff( bool joined, bool dutyCycle, Band_t* bands, uint8_t nbBands )
+{
+    TimerTime_t nextTxDelay = ( TimerTime_t )( -1 );
+
+    // Update bands Time OFF
+    for( uint8_t i = 0; i < nbBands; i++ )
+    {
+        if( joined == false )
+        {
+            uint32_t txDoneTime =  MAX( TimerGetElapsedTime( bands[i].LastJoinTxDoneTime ),
+                                        ( dutyCycle == true ) ? TimerGetElapsedTime( bands[i].LastTxDoneTime ) : 0 );
+
+            if( bands[i].TimeOff <= txDoneTime )
+            {
+                bands[i].TimeOff = 0;
+            }
+            if( bands[i].TimeOff != 0 )
+            {
+                nextTxDelay = MIN( bands[i].TimeOff - txDoneTime, nextTxDelay );
+            }
+        }
+        else
+        {
+            if( dutyCycle == true )
+            {
+                if( bands[i].TimeOff <= TimerGetElapsedTime( bands[i].LastTxDoneTime ) )
+                {
+                    bands[i].TimeOff = 0;
+                }
+                if( bands[i].TimeOff != 0 )
+                {
+                    nextTxDelay = MIN( bands[i].TimeOff - TimerGetElapsedTime( bands[i].LastTxDoneTime ),
+                                       nextTxDelay );
+                }
+            }
+            else
+            {
+                nextTxDelay = 0;
+                bands[i].TimeOff = 0;
+            }
+        }
+    }
+    return nextTxDelay;
+}
+
+uint8_t LoRaPHY::parse_link_ADR_req( uint8_t* payload, RegionCommonLinkAdrParams_t* linkAdrParams )
+{
+    uint8_t retIndex = 0;
+
+    if( payload[0] == SRV_MAC_LINK_ADR_REQ )
+    {
+        // Parse datarate and tx power
+        linkAdrParams->Datarate = payload[1];
+        linkAdrParams->TxPower = linkAdrParams->Datarate & 0x0F;
+        linkAdrParams->Datarate = ( linkAdrParams->Datarate >> 4 ) & 0x0F;
+        // Parse ChMask
+        linkAdrParams->ChMask = ( uint16_t )payload[2];
+        linkAdrParams->ChMask |= ( uint16_t )payload[3] << 8;
+        // Parse ChMaskCtrl and nbRep
+        linkAdrParams->NbRep = payload[4];
+        linkAdrParams->ChMaskCtrl = ( linkAdrParams->NbRep >> 4 ) & 0x07;
+        linkAdrParams->NbRep &= 0x0F;
+
+        // LinkAdrReq has 4 bytes length + 1 byte CMD
+        retIndex = 5;
+    }
+    return retIndex;
+}
+
+uint8_t LoRaPHY::verify_link_ADR_req( RegionCommonLinkAdrReqVerifyParams_t* verifyParams, int8_t* dr, int8_t* txPow, uint8_t* nbRep )
+{
+    uint8_t status = verifyParams->Status;
+    int8_t datarate = verifyParams->Datarate;
+    int8_t txPower = verifyParams->TxPower;
+    int8_t nbRepetitions = verifyParams->NbRep;
+
+    // Handle the case when ADR is off.
+    if( verifyParams->AdrEnabled == false )
+    {
+        // When ADR is off, we are allowed to change the channels mask and the NbRep,
+        // if the datarate and the TX power of the LinkAdrReq are set to 0x0F.
+        if( ( verifyParams->Datarate != 0x0F ) || ( verifyParams->TxPower != 0x0F ) )
+        {
+            status = 0;
+            nbRepetitions = verifyParams->CurrentNbRep;
+        }
+        // Get the current datarate and tx power
+        datarate = verifyParams->CurrentDatarate;
+        txPower = verifyParams->CurrentTxPower;
+    }
+
+    if( status != 0 )
+    {
+        // Verify datarate. The variable phyParam. Value contains the minimum allowed datarate.
+        if( verify_channel_DR( verifyParams->NbChannels, verifyParams->ChannelsMask, datarate,
+                                      verifyParams->MinDatarate, verifyParams->MaxDatarate, verifyParams->Channels  ) == false )
+        {
+            status &= 0xFD; // Datarate KO
+        }
+
+        // Verify tx power
+        if( val_in_range( txPower, verifyParams->MaxTxPower, verifyParams->MinTxPower ) == 0 )
+        {
+            // Verify if the maximum TX power is exceeded
+            if( verifyParams->MaxTxPower > txPower )
+            { // Apply maximum TX power. Accept TX power.
+                txPower = verifyParams->MaxTxPower;
+            }
+            else
+            {
+                status &= 0xFB; // TxPower KO
+            }
+        }
+    }
+
+    // If the status is ok, verify the NbRep
+    if( status == 0x07 )
+    {
+        if( nbRepetitions == 0 )
+        { // Keep the current one
+            nbRepetitions = verifyParams->CurrentNbRep;
+        }
+    }
+
+    // Apply changes
+    *dr = datarate;
+    *txPow = txPower;
+    *nbRep = nbRepetitions;
+
+    return status;
+}
+
+double LoRaPHY::compute_symb_timeout_lora( uint8_t phyDr, uint32_t bandwidth )
+{
+    return ( ( double )( 1 << phyDr ) / ( double )bandwidth ) * 1000;
+}
+
+double LoRaPHY::compute_symb_timeout_fsk( uint8_t phyDr )
+{
+    return ( 8.0 / ( double )phyDr ); // 1 symbol equals 1 byte
+}
+
+void LoRaPHY::get_rx_window_params( double tSymbol, uint8_t minRxSymbols, uint32_t rxError, uint32_t wakeUpTime, uint32_t* windowTimeout, int32_t* windowOffset )
+{
+    *windowTimeout = MAX( ( uint32_t )ceil( ( ( 2 * minRxSymbols - 8 ) * tSymbol + 2 * rxError ) / tSymbol ), minRxSymbols ); // Computed number of symbols
+    *windowOffset = ( int32_t )ceil( ( 4.0 * tSymbol ) - ( ( *windowTimeout * tSymbol ) / 2.0 ) - wakeUpTime );
+}
+
+int8_t LoRaPHY::compute_tx_power( int8_t txPowerIndex, float maxEirp, float antennaGain )
+{
+    int8_t phyTxPower = 0;
+
+    phyTxPower = ( int8_t )floor( ( maxEirp - ( txPowerIndex * 2U ) ) - antennaGain );
+
+    return phyTxPower;
+}
+
+void LoRaPHY::get_DC_backoff( RegionCommonCalcBackOffParams_t* calcBackOffParams )
+{
+    uint8_t bandIdx = calcBackOffParams->Channels[calcBackOffParams->Channel].Band;
+    uint16_t dutyCycle = calcBackOffParams->Bands[bandIdx].DCycle;
+    uint16_t joinDutyCycle = 0;
+
+    // Reset time-off to initial value.
+    calcBackOffParams->Bands[bandIdx].TimeOff = 0;
+
+    if( calcBackOffParams->Joined == false )
+    {
+        // Get the join duty cycle
+        joinDutyCycle = get_join_DC( calcBackOffParams->ElapsedTime );
+        // Apply the most restricting duty cycle
+        dutyCycle = MAX( dutyCycle, joinDutyCycle );
+        // Reset the timeoff if the last frame was not a join request and when the duty cycle is not enabled
+        if( ( calcBackOffParams->DutyCycleEnabled == false ) && ( calcBackOffParams->LastTxIsJoinRequest == false ) )
+        {
+            // This is the case when the duty cycle is off and the last uplink frame was not a join.
+            // This could happen in case of a rejoin, e.g. in compliance test mode.
+            // In this special case we have to set the time off to 0, since the join duty cycle shall only
+            // be applied after the first join request.
+            calcBackOffParams->Bands[bandIdx].TimeOff = 0;
+        }
+        else
+        {
+            // Apply band time-off.
+            calcBackOffParams->Bands[bandIdx].TimeOff = calcBackOffParams->TxTimeOnAir * dutyCycle - calcBackOffParams->TxTimeOnAir;
+        }
+    }
+    else
+    {
+        if( calcBackOffParams->DutyCycleEnabled == true )
+        {
+            calcBackOffParams->Bands[bandIdx].TimeOff = calcBackOffParams->TxTimeOnAir * dutyCycle - calcBackOffParams->TxTimeOnAir;
+        }
+        else
+        {
+            calcBackOffParams->Bands[bandIdx].TimeOff = 0;
+        }
+    }
+}

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -1,0 +1,677 @@
+/**
+ *  @file LoRaPHY.h
+ *
+ *  @brief An abstract class providing radio object to children and
+ *         provide base for implementing LoRa PHY layer
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ * Description: LoRa PHY layer
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_BASE_
+#define MBED_OS_LORAPHY_BASE_
+
+#include "lorawan/system/LoRaWANTimer.h"
+#include "lorawan/lorastack/phy/lora_phy_ds.h"
+#include "netsocket/LoRaRadio.h"
+
+class LoRaPHY {
+
+public:
+    LoRaPHY();
+    virtual ~LoRaPHY();
+
+    void set_radio_instance(LoRaRadio& radio);
+
+    void put_radio_to_sleep(void);
+
+    void put_radio_to_standby(void);
+
+    void setup_rx_window(bool is_rx_continuous, uint32_t max_rx_window);
+
+    void setup_tx_cont_wave_mode(uint16_t timeout, uint32_t frequency,
+                                          uint8_t power);
+
+    void handle_send(uint8_t *buf, uint8_t size);
+
+    void setup_public_network_mode(bool set);
+
+    uint32_t get_radio_rng();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval A structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy ) = 0;
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone ) = 0;
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type ) = 0;
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute for which the verification is needed.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute ) = 0;
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList ) = 0;
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet ) = 0;
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter ) = 0;
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate ) = 0;
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol.
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     *
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams) = 0;
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir ) = 0;
+
+    /*!
+     * \brief The function processes a Link ADR Request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed ) = 0;
+
+    /*!
+     * \brief The function processes a RX Parameter Setup Request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq ) = 0;
+
+    /*!
+     * \brief The function processes a New Channel Request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq ) = 0;
+
+    /*!
+     * \brief The function processes a TX ParamSetup Request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq ) = 0;
+
+    /*!
+     * \brief The function processes a DlChannel Request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq ) = 0;
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr ) = 0;
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff ) = 0;
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams Parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff ) = 0;
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd ) = 0;
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove ) = 0;
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave ) = 0;
+
+    /*!
+     * \brief Computes new datarate according to the given offset
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset ) = 0;
+
+protected:
+    LoRaRadio *_radio;
+
+    typedef struct sRegionCommonLinkAdrParams
+    {
+        /*!
+         * The number of repetitions.
+         */
+        uint8_t NbRep;
+        /*!
+         * Datarate.
+         */
+        int8_t Datarate;
+        /*!
+         * TX power.
+         */
+        int8_t TxPower;
+        /*!
+         * Channels mask control field.
+         */
+        uint8_t ChMaskCtrl;
+        /*!
+         * Channels mask field.
+         */
+        uint16_t ChMask;
+    }RegionCommonLinkAdrParams_t;
+
+    typedef struct sRegionCommonLinkAdrReqVerifyParams
+    {
+        /*!
+         * The current status of the AdrLinkRequest.
+         */
+        uint8_t Status;
+        /*!
+         * Set to true, if ADR is enabled.
+         */
+        bool AdrEnabled;
+        /*!
+         * The datarate the AdrLinkRequest wants to set.
+         */
+        int8_t Datarate;
+        /*!
+         * The TX power the AdrLinkRequest wants to set.
+         */
+        int8_t TxPower;
+        /*!
+         * The number of repetitions the AdrLinkRequest wants to set.
+         */
+        uint8_t NbRep;
+        /*!
+         * The current datarate the node is using.
+         */
+        int8_t CurrentDatarate;
+        /*!
+         * The current TX power the node is using.
+         */
+        int8_t CurrentTxPower;
+        /*!
+         * The current number of repetitions the node is using.
+         */
+        int8_t CurrentNbRep;
+        /*!
+         * The number of channels.
+         */
+        uint8_t NbChannels;
+        /*!
+         * A pointer to the first element of the channels mask.
+         */
+        uint16_t* ChannelsMask;
+        /*!
+         * The minimum possible datarate.
+         */
+        int8_t MinDatarate;
+        /*!
+         * The maximum possible datarate.
+         */
+        int8_t MaxDatarate;
+        /*!
+         * A pointer to the channels.
+         */
+        ChannelParams_t* Channels;
+        /*!
+         * The minimum possible TX power.
+         */
+        int8_t MinTxPower;
+        /*!
+         * The maximum possible TX power.
+         */
+        int8_t MaxTxPower;
+    }RegionCommonLinkAdrReqVerifyParams_t;
+
+    typedef struct sRegionCommonCalcBackOffParams
+    {
+        /*!
+         * A pointer to region specific channels.
+         */
+        ChannelParams_t* Channels;
+        /*!
+         * A pointer to region specific bands.
+         */
+        Band_t* Bands;
+        /*!
+         * Set to true, if the last uplink was a join request.
+         */
+        bool LastTxIsJoinRequest;
+        /*!
+         * Set to true, if the node is joined.
+         */
+        bool Joined;
+        /*!
+         * Set to true, if the duty cycle is enabled.
+         */
+        bool DutyCycleEnabled;
+        /*!
+         * The current channel.
+         */
+        uint8_t Channel;
+        /*!
+         * The elapsed time since initialization.
+         */
+        TimerTime_t ElapsedTime;
+        /*!
+         * The time on air of the last TX frame.
+         */
+        TimerTime_t TxTimeOnAir;
+    }RegionCommonCalcBackOffParams_t;
+
+    /*!
+     * \brief Calculates the join duty cycle.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] elapsedTime The time elapsed since starting the device.
+     *
+     * \retval Duty cycle restriction.
+     */
+    uint16_t get_join_DC( TimerTime_t elapsedTime );
+
+    /*!
+     * \brief Verifies, if a value is in a given range.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] value The value to verify, if it is in range.
+     *
+     * \param [in] min The minimum possible value.
+     *
+     * \param [in] max The maximum possible value.
+     *
+     * \retval 1 if the value is in range, otherwise 0.
+     */
+    uint8_t val_in_range( int8_t value, int8_t min, int8_t max );
+
+    /*!
+     * \brief Verifies, if a datarate is available on an active channel.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] nbChannels The number of channels.
+     *
+     * \param [in] channelsMask The channels mask of the region.
+     *
+     * \param [in] dr The datarate to verify.
+     *
+     * \param [in] minDr The minimum datarate.
+     *
+     * \param [in] maxDr The maximum datarate.
+     *
+     * \param [in] channels The channels of the region.
+     *
+     * \retval True if the datarate is supported, false if not.
+     */
+    bool verify_channel_DR( uint8_t nbChannels, uint16_t* channelsMask, int8_t dr,
+                                int8_t minDr, int8_t maxDr, ChannelParams_t* channels );
+
+    /*!
+     * \brief Disables a channel in a given channels mask.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] channelsMask The channels mask of the region.
+     *
+     * \param [in] id The ID of the channels mask to disable.
+     *
+     * \param [in] maxChannels The maximum number of channels.
+     *
+     * \retval True if the channel could be disabled, false if not.
+     */
+    bool disable_channel( uint16_t* channelsMask, uint8_t id, uint8_t maxChannels );
+
+    /*!
+     * \brief Counts the number of active channels in a given channels mask.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] channelsMask The channels mask of the region.
+     *
+     * \param [in] startIdx The start index.
+     *
+     * \param [in] stopIdx The stop index (the channels of this index will not be counted).
+     *
+     * \retval The number of active channels.
+     */
+    uint8_t num_active_channels( uint16_t* channelsMask, uint8_t startIdx, uint8_t stopIdx );
+
+    /*!
+     * \brief Copy a channels mask.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] channelsMaskDest The destination channels mask.
+     *
+     * \param [in] channelsMaskSrc The source channels mask.
+     *
+     * \param [in] len The index length to copy.
+     */
+    void copy_channel_mask( uint16_t* channelsMaskDest, uint16_t* channelsMaskSrc, uint8_t len );
+
+    /*!
+     * \brief Sets the last TX done property.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] joined Set to true, if the node has joined the network
+     *
+     * \param [in] band The band to be updated.
+     *
+     * \param [in] lastTxDone The time of the last TX done.
+     */
+    void set_last_tx_done( bool joined, Band_t* band, TimerTime_t lastTxDone );
+
+    /*!
+     * \brief Updates the time-offs of the bands.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] joined Set to true, if the node has joined the network
+     *
+     * \param [in] dutyCycle Set to true, if the duty cycle is enabled.
+     *
+     * \param [in] bands A pointer to the bands.
+     *
+     * \param [in] nbBands The number of bands available.
+     *
+     * \retval The time which must be waited to perform the next uplink.
+     */
+    TimerTime_t update_band_timeoff( bool joined, bool dutyCycle, Band_t* bands, uint8_t nbBands );
+
+    /*!
+     * \brief Parses the parameter of an LinkAdrRequest.
+     *        This is a generic function and valid for all regions.
+     *
+     * \param [in] payload A pointer to the payload containing the MAC commands. The payload
+     *                     must contain the CMD identifier, followed by the parameters.
+     *
+     * \param [out] parseLinkAdr The function fills the structure with the ADR parameters.
+     *
+     * \retval The length of the ADR request, if a request was found. Otherwise, the
+     *         function returns 0.
+     */
+    uint8_t parse_link_ADR_req( uint8_t* payload, RegionCommonLinkAdrParams_t* parseLinkAdr );
+
+    /*!
+     * \brief Verifies and updates the datarate, the TX power and the number of repetitions
+     *        of a LinkAdrRequest. This also depends on the ADR configuration.
+     *
+     * \param [in] verifyParams A pointer to a structure containing the input parameters.
+     *
+     * \param [out] dr The updated datarate.
+     *
+     * \param [out] txPow The updated TX power.
+     *
+     * \param [out] nbRep The updated number of repetitions.
+     *
+     * \retval The status according to the LinkAdrRequest definition.
+     */
+    uint8_t verify_link_ADR_req( RegionCommonLinkAdrReqVerifyParams_t* verifyParams, int8_t* dr, int8_t* txPow, uint8_t* nbRep );
+
+    /*!
+     * \brief Computes the symbol time for LoRa modulation.
+     *
+     * \param [in] phyDr The physical datarate to use.
+     *
+     * \param [in] bandwidth The bandwidth to use.
+     *
+     * \retval The symbol time.
+     */
+    double compute_symb_timeout_lora( uint8_t phyDr, uint32_t bandwidth );
+
+    /*!
+     * \brief Computes the symbol time for FSK modulation.
+     *
+     * \param [in] phyDr The physical datarate to use.
+     *
+     * \retval The symbol time.
+     */
+    double compute_symb_timeout_fsk( uint8_t phyDr );
+
+    /*!
+     * \brief Computes the RX window timeout and the RX window offset.
+     *
+     * \param [in] tSymbol The symbol timeout.
+     *
+     * \param [in] minRxSymbols The minimum required number of symbols to detect an RX frame.
+     *
+     * \param [in] rxError The system maximum timing error of the receiver in milliseconds
+     *                     The receiver will turn on in a [-rxError : +rxError] ms interval around RxOffset.
+     *
+     * \param [in] wakeUpTime The wakeup time of the system.
+     *
+     * \param [out] windowTimeout The RX window timeout.
+     *
+     * \param [out] windowOffset The RX window time offset to be applied to the RX delay.
+     */
+    void get_rx_window_params( double tSymbol, uint8_t minRxSymbols, uint32_t rxError, uint32_t wakeUpTime, uint32_t* windowTimeout, int32_t* windowOffset );
+
+    /*!
+     * \brief Computes the txPower, based on the max EIRP and the antenna gain.
+     *
+     * \param [in] txPowerIndex The TX power index.
+     *
+     * \param [in] maxEirp The maximum EIRP.
+     *
+     * \param [in] antennaGain The antenna gain.
+     *
+     * \retval The physical TX power.
+     */
+    int8_t compute_tx_power( int8_t txPowerIndex, float maxEirp, float antennaGain );
+
+    /*!
+     * \brief Provides a random number in the range provided.
+     *
+     * \param [in] min lower boundary
+     * \param [in] max upper boundary
+     */
+    int32_t get_random(int32_t min, int32_t max);
+
+    /*!
+     * \brief Calculates the duty cycle for the current band.
+     *
+     * \param [in] calcBackOffParams A pointer to the input parameters.
+     */
+    void get_DC_backoff( RegionCommonCalcBackOffParams_t* calcBackOffParams );
+};
+
+#endif /* MBED_OS_LORAPHY_BASE_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -1,0 +1,1338 @@
+/**
+ *  @file LoRaPHYAS923.cpp
+ *
+ *  @brief Implements LoRaPHY for Asia-Pacific 923 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYAS923.h"
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Number of default channels
+ */
+#define AS923_NUMB_DEFAULT_CHANNELS                 2
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define AS923_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define AS923_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define AS923_TX_MAX_DATARATE                       DR_7
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define AS923_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define AS923_RX_MAX_DATARATE                       DR_7
+
+/*!
+ * Default datarate used by the node
+ */
+#define AS923_DEFAULT_DATARATE                      DR_2
+
+/*!
+ * The minimum datarate which is used when the
+ * dwell time is limited.
+ */
+#define AS923_DWELL_LIMIT_DATARATE                  DR_2
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define AS923_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define AS923_MAX_RX1_DR_OFFSET                     7
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define AS923_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define AS923_MIN_TX_POWER                          TX_POWER_7
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define AS923_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define AS923_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default uplink dwell time configuration
+ */
+#define AS923_DEFAULT_UPLINK_DWELL_TIME             1
+
+/*!
+ * Default downlink dwell time configuration
+ */
+#define AS923_DEFAULT_DOWNLINK_DWELL_TIME           1
+
+/*!
+ * Default Max EIRP
+ */
+#define AS923_DEFAULT_MAX_EIRP                      16.0f
+
+/*!
+ * Default antenna gain
+ */
+#define AS923_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define AS923_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define AS923_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define AS923_DUTY_CYCLE_ENABLED                    0
+
+/*!
+ * Maximum RX window duration
+ */
+#define AS923_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define AS923_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define AS923_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define AS923_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define AS923_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define AS923_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define AS923_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define AS923_ACK_TIMEOUT_RND                       1000
+
+#if ( AS923_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define AS923_RX_WND_2_FREQ                         923200000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define AS923_RX_WND_2_DR                           DR_2
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define AS923_BAND0                                 { 100, AS923_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define AS923_LC1                                   { 923200000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define AS923_LC2                                   { 923400000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define AS923_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) )
+
+/*!
+ * RSSI threshold for a free channel [dBm]
+ */
+#define AS923_RSSI_FREE_TH                          -85
+
+/*!
+ * Specifies the time the node performs a carrier sense
+ */
+#define AS923_CARRIER_SENSE_TIME                    6
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesAS923[]  = { 12, 11, 10,  9,  8,  7, 7, 50 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsAS923[] = { 125000, 125000, 125000, 125000, 125000, 125000, 250000, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ * The table is valid for the dwell time configuration of 0 for uplinks and downlinks.
+ */
+static const uint8_t MaxPayloadOfDatarateDwell0AS923[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ * The table is valid for the dwell time configuration of 0 for uplinks and downlinks. The table provides
+ * repeater support.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterDwell0AS923[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with and without repeater.
+ * The table proides repeater support. The table is only valid for uplinks.
+ */
+static const uint8_t MaxPayloadOfDatarateDwell1UpAS923[] = { 0, 0, 11, 53, 125, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with and without repeater.
+ * The table proides repeater support. The table is only valid for downlinks.
+ */
+static const uint8_t MaxPayloadOfDatarateDwell1DownAS923[] = { 0, 0, 11, 53, 126, 242, 242, 242 };
+
+/*!
+ * Effective datarate offsets for receive window 1.
+ */
+static const int8_t EffectiveRx1DrOffsetAS923[] = { 0, 1, 2, 3, 4, 5, -1, -2 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsAS923[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq )
+{
+    // Not checking the radio drivers here as all radio drivers
+    // always return true. Just check for Asia-Pacific band here
+    if( ( freq < 915000000 ) || ( freq > 928000000 ) )
+    {
+        return false;
+    }
+    return true;
+}
+
+uint8_t LoRaPHYAS923::CountNbOfEnabledChannels(bool joined, uint8_t datarate,
+                                               uint16_t* channelsMask,
+                                               ChannelParams_t* channels, Band_t* bands,
+                                               uint8_t* enabledChannels, uint8_t* delayTx)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < AS923_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( AS923_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYAS923::LoRaPHYAS923()
+{
+    const Band_t band0 = AS923_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYAS923::~LoRaPHYAS923()
+{
+}
+
+PhyParam_t LoRaPHYAS923::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            if( getPhy->DownlinkDwellTime == 0 )
+            {
+                phyParam.Value = AS923_RX_MIN_DATARATE;
+            }
+            else
+            {
+                phyParam.Value = AS923_DWELL_LIMIT_DATARATE;
+            }
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            if( getPhy->UplinkDwellTime == 0 )
+            {
+                phyParam.Value = AS923_TX_MIN_DATARATE;
+            }
+            else
+            {
+                phyParam.Value = AS923_DWELL_LIMIT_DATARATE;
+            }
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = AS923_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            if( getPhy->UplinkDwellTime == 0 )
+            {
+                phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, AS923_TX_MIN_DATARATE );
+            }
+            else
+            {
+                phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, AS923_DWELL_LIMIT_DATARATE );
+            }
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = AS923_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            if( getPhy->UplinkDwellTime == 0 )
+            {
+                phyParam.Value = MaxPayloadOfDatarateDwell0AS923[getPhy->Datarate];
+            }
+            else
+            {
+                phyParam.Value = MaxPayloadOfDatarateDwell1UpAS923[getPhy->Datarate];
+            }
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            if( getPhy->UplinkDwellTime == 0 )
+            {
+                phyParam.Value = MaxPayloadOfDatarateRepeaterDwell0AS923[getPhy->Datarate];
+            }
+            else
+            {
+                phyParam.Value = MaxPayloadOfDatarateDwell1UpAS923[getPhy->Datarate];
+            }
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = AS923_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = AS923_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = AS923_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = AS923_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = AS923_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = AS923_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = AS923_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( AS923_ACKTIMEOUT + get_random( -AS923_ACK_TIMEOUT_RND, AS923_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = AS923_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = AS923_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = AS923_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = AS923_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        {
+            phyParam.Value = AS923_DEFAULT_UPLINK_DWELL_TIME;
+            break;
+        }
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = AS923_DEFAULT_DOWNLINK_DWELL_TIME;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = AS923_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = AS923_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 1;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYAS923::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYAS923::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = AS923_LC1;
+            const ChannelParams_t channel2 = AS923_LC2;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYAS923::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            if( verify->DatarateParams.UplinkDwellTime == 0 )
+            {
+                return val_in_range( verify->DatarateParams.Datarate, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE );
+            }
+            else
+            {
+                return val_in_range( verify->DatarateParams.Datarate, AS923_DWELL_LIMIT_DATARATE, AS923_TX_MAX_DATARATE );
+            }
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            if( verify->DatarateParams.DownlinkDwellTime == 0 )
+            {
+                return val_in_range( verify->DatarateParams.Datarate, AS923_RX_MIN_DATARATE, AS923_RX_MAX_DATARATE );
+            }
+            else
+            {
+                return val_in_range( verify->DatarateParams.Datarate, AS923_DWELL_LIMIT_DATARATE, AS923_RX_MAX_DATARATE );
+            }
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, AS923_MAX_TX_POWER, AS923_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return AS923_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            return true;
+        }
+        default:
+            return false;
+    }
+}
+
+void LoRaPHYAS923::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = AS923_NUMB_DEFAULT_CHANNELS; chanIdx < AS923_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( AS923_NUMB_CHANNELS_CF_LIST + AS923_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel(&channelAdd);
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel(&channelRemove);
+        }
+    }
+}
+
+bool LoRaPHYAS923::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYAS923::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t minTxDatarate = 0;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+    phyParam = get_phy_params(&getPhy);
+    minTxDatarate = phyParam.Value;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    // Apply the minimum possible datarate.
+    datarate = MAX( datarate, minTxDatarate );
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == minTxDatarate )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= AS923_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = AS923_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( AS923_ADR_ACK_LIMIT + AS923_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % AS923_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params(&getPhy);
+                    datarate = phyParam.Value;
+
+                    if( datarate == minTxDatarate )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYAS923::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, AS923_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    if( rxConfigParams->Datarate == DR_7 )
+    { // FSK
+        tSymbol = compute_symb_timeout_fsk( DataratesAS923[rxConfigParams->Datarate] );
+    }
+    else
+    { // LoRa
+        tSymbol = compute_symb_timeout_lora( DataratesAS923[rxConfigParams->Datarate], BandwidthsAS923[rxConfigParams->Datarate] );
+    }
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYAS923::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    radio_modems_t modem;
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesAS923[dr];
+
+    _radio->set_channel(frequency);
+
+    // Radio configuration
+    if( dr == DR_7 )
+    {
+        modem = MODEM_FSK;
+        _radio->set_rx_config(modem, 50000, phyDr * 1000, 0, 83333, 5,
+                              rxConfig->WindowTimeout, false, 0, true, 0,
+                              0, false, rxConfig->RxContinuous);
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_rx_config(modem, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                              rxConfig->WindowTimeout, false, 0, false, 0, 0,
+                              true, rxConfig->RxContinuous);
+    }
+
+    // Check for repeater support
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterDwell0AS923[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateDwell0AS923[dr];
+    }
+
+    _radio->set_max_payload_length(modem, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD);
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYAS923::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    radio_modems_t modem;
+    int8_t phyDr = DataratesAS923[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+
+    if( txConfig->Datarate == DR_7 )
+    { // High Speed FSK channel
+        modem = MODEM_FSK;
+        _radio->set_tx_config(modem, phyTxPower, 25000, bandwidth, phyDr * 1000,
+                              0, 5, false, true, 0, 0, false, 3000 );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_tx_config(modem, phyTxPower, 0, bandwidth, phyDr, 1, 8,
+                              false, true, 0, 0, false, 3000);
+    }
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length(modem, txConfig->PktLen);
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air(modem, txConfig->PktLen);
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYAS923::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < AS923_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params(&getPhy);
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = AS923_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = AS923_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = AS923_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = AS923_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYAS923::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if(_radio->check_rf_frequency(rxParamSetupReq->Frequency) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, AS923_RX_MIN_DATARATE, AS923_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, AS923_MIN_RX1_DR_OFFSET, AS923_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYAS923::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if( remove_channel(&channelRemove) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch( add_channel (&channelAdd ))
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYAS923::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    // Accept the request
+    return 0;
+}
+
+uint8_t LoRaPHYAS923::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq( dlChannelReq->Rx1Frequency ) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYAS923::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    // Only AS923_DWELL_LIMIT_DATARATE is supported
+    return AS923_DWELL_LIMIT_DATARATE;
+}
+
+void LoRaPHYAS923::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYAS923::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t channelNext = 0;
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[AS923_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, AS923_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        for( uint8_t  i = 0, j = get_random( 0, nbEnabledChannels - 1 ); i < AS923_MAX_NB_CHANNELS; i++ )
+        {
+            channelNext = enabledChannels[j];
+            j = ( j + 1 ) % nbEnabledChannels;
+
+            // Perform carrier sense for AS923_CARRIER_SENSE_TIME
+            // If the channel is free, we can stop the LBT mechanism
+            if( _radio->perform_carrier_sense(MODEM_LORA,
+                                              Channels[channelNext].Frequency,
+                                              AS923_RSSI_FREE_TH,
+                                              AS923_CARRIER_SENSE_TIME ) == true)
+            {
+                // Free channel found
+                *channel = channelNext;
+                *time = 0;
+                return true;
+            }
+        }
+        return false;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYAS923::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= AS923_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, AS923_TX_MIN_DATARATE, AS923_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < AS923_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, AS923_TX_MAX_DATARATE ) == 0 )
+        {
+            drInvalid = true;
+        }
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYAS923::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < AS923_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, AS923_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYAS923::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave(frequency, phyTxPower, continuousWave->Timeout);
+}
+
+uint8_t LoRaPHYAS923::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr,
+                                      int8_t drOffset)
+{
+    // Initialize minDr for a downlink dwell time configuration of 0
+    int8_t minDr = DR_0;
+
+    // Update the minDR for a downlink dwell time configuration of 1
+    if( downlinkDwellTime == 1 )
+    {
+        minDr = AS923_DWELL_LIMIT_DATARATE;
+    }
+
+    // Apply offset formula
+    return MIN( DR_5, MAX( minDr, dr - EffectiveRx1DrOffsetAS923[drOffset] ) );
+}
+
+

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.h
@@ -1,0 +1,363 @@
+/**
+ *  @file LoRaPHYAS923.h
+ *
+ *  @brief Implements LoRaPHY for Asia-Pacific 923 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_AS923_H_
+#define MBED_OS_LORAPHY_AS923_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define AS923_MAX_NB_CHANNELS                       16
+
+/*!
+ * Maximum number of bands
+ */
+#define AS923_MAX_NB_BANDS                          1
+
+#define AS923_CHANNELS_MASK_SIZE                    1
+
+
+class LoRaPHYAS923 : public LoRaPHY {
+
+public:
+
+    LoRaPHYAS923();
+    virtual ~LoRaPHYAS923();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval A structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to be verified.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the
+     *        CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing.
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum required number of symbols to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams The updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR Request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels(bool joined, uint8_t datarate,
+                                     uint16_t* channelsMask,
+                                     ChannelParams_t* channels, Band_t* bands,
+                                     uint8_t* enabledChannels, uint8_t* delayTx);
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[AS923_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[AS923_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[AS923_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[AS923_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_AS923_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -1,0 +1,984 @@
+/**
+ *  @file LoRaPHYAU915.cpp
+ *
+ *  @brief Implements LoRaPHY for Australian 915 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYAU915.h"
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define AU915_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define AU915_TX_MAX_DATARATE                       DR_6
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define AU915_RX_MIN_DATARATE                       DR_8
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define AU915_RX_MAX_DATARATE                       DR_13
+
+/*!
+ * Default datarate used by the node
+ */
+#define AU915_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define AU915_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define AU915_MAX_RX1_DR_OFFSET                     6
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define AU915_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define AU915_MIN_TX_POWER                          TX_POWER_10
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define AU915_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define AU915_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define AU915_DEFAULT_MAX_EIRP                      30.0f
+
+/*!
+ * Default antenna gain
+ */
+#define AU915_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define AU915_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define AU915_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define AU915_DUTY_CYCLE_ENABLED                    0
+
+/*!
+ * Maximum RX window duration
+ */
+#define AU915_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define AU915_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define AU915_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define AU915_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define AU915_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define AU915_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define AU915_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define AU915_ACK_TIMEOUT_RND                       1000
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define AU915_RX_WND_2_FREQ                         923300000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define AU915_RX_WND_2_DR                           DR_8
+
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define AU915_BAND0                                 { 1, AU915_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * Defines the first channel for RX window 1 for US band
+ */
+#define AU915_FIRST_RX1_CHANNEL                     ( (uint32_t) 923300000 )
+
+/*!
+ * Defines the last channel for RX window 1 for US band
+ */
+#define AU915_LAST_RX1_CHANNEL                      ( (uint32_t) 927500000 )
+
+/*!
+ * Defines the step width of the channels for RX window 1
+ */
+#define AU915_STEPWIDTH_RX1_CHANNEL                 ( (uint32_t) 600000 )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesAU915[] = { 12, 11, 10, 9, 8, 7, 8, 0, 12, 11, 10,
+    9, 8, 7, 0, 0 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsAU915[] = { 125000, 125000, 125000, 125000,
+    125000, 125000, 500000, 0, 500000, 500000, 500000, 500000, 500000, 500000,
+    0, 0 };
+
+/*!
+ * Up/Down link data rates offset definition
+ */
+static const int8_t DatarateOffsetsAU915[7][6] = { { DR_8, DR_8, DR_8, DR_8,
+    DR_8, DR_8 }, // DR_0
+    { DR_9, DR_8, DR_8, DR_8, DR_8, DR_8 }, // DR_1
+    { DR_10, DR_9, DR_8, DR_8, DR_8, DR_8 }, // DR_2
+    { DR_11, DR_10, DR_9, DR_8, DR_8, DR_8 }, // DR_3
+    { DR_12, DR_11, DR_10, DR_9, DR_8, DR_8 }, // DR_4
+    { DR_13, DR_12, DR_11, DR_10, DR_9, DR_8 }, // DR_5
+    { DR_13, DR_13, DR_12, DR_11, DR_10, DR_9 }, // DR_6
+        };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateAU915[] = { 51, 51, 51, 115, 242, 242,
+    242, 0, 53, 129, 242, 242, 242, 242, 0, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterAU915[] = { 51, 51, 51, 115,
+    222, 222, 222, 0, 33, 109, 222, 222, 222, 222, 0, 0 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr(int8_t dr, int8_t minDr)
+{
+    uint8_t nextLowerDr = 0;
+
+    if (dr == minDr) {
+        nextLowerDr = minDr;
+    } else {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth(uint32_t drIndex)
+{
+    switch (BandwidthsAU915[drIndex]) {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower(int8_t txPower, int8_t maxBandTxPower,
+                           int8_t datarate, uint16_t* channelsMask)
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult = MAX(txPower, maxBandTxPower);
+
+    return txPowerResult;
+}
+
+uint8_t LoRaPHYAU915::CountNbOfEnabledChannels(uint8_t datarate,
+                                               uint16_t* channelsMask,
+                                               ChannelParams_t* channels,
+                                               Band_t* bands, uint8_t* enabledChannels,
+                                               uint8_t* delayTx)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for (uint8_t i = 0, k = 0; i < AU915_MAX_NB_CHANNELS; i += 16, k++) {
+        for (uint8_t j = 0; j < 16; j++) {
+            if ((channelsMask[k] & (1 << j)) != 0) {
+                if (channels[i + j].Frequency == 0) { // Check if the channel is enabled
+                    continue;
+                }
+                if (val_in_range(datarate, channels[i + j].DrRange.Fields.Min,
+                                 channels[i + j].DrRange.Fields.Max) == 0) { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if (bands[channels[i + j].Band].TimeOff > 0) { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYAU915::LoRaPHYAU915()
+{
+    const Band_t band0 = AU915_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYAU915::~LoRaPHYAU915()
+{
+}
+
+PhyParam_t LoRaPHYAU915::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch (getPhy->Attribute) {
+        case PHY_MIN_RX_DR: {
+            phyParam.Value = AU915_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR: {
+            phyParam.Value = AU915_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR: {
+            phyParam.Value = AU915_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR: {
+            phyParam.Value = GetNextLowerTxDr(getPhy->Datarate,
+                                              AU915_TX_MIN_DATARATE);
+            break;
+        }
+        case PHY_DEF_TX_POWER: {
+            phyParam.Value = AU915_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD: {
+            phyParam.Value = MaxPayloadOfDatarateAU915[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER: {
+            phyParam.Value =
+                    MaxPayloadOfDatarateRepeaterAU915[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE: {
+            phyParam.Value = AU915_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW: {
+            phyParam.Value = AU915_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1: {
+            phyParam.Value = AU915_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2: {
+            phyParam.Value = AU915_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1: {
+            phyParam.Value = AU915_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2: {
+            phyParam.Value = AU915_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP: {
+            phyParam.Value = AU915_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT: {
+            phyParam.Value =
+                    ( AU915_ACKTIMEOUT
+                            + get_random(-AU915_ACK_TIMEOUT_RND,
+                                         AU915_ACK_TIMEOUT_RND));
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET: {
+            phyParam.Value = AU915_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY: {
+            phyParam.Value = AU915_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR: {
+            phyParam.Value = AU915_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK: {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK: {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS: {
+            phyParam.Value = AU915_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS: {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME: {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP: {
+            phyParam.fValue = AU915_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN: {
+            phyParam.fValue = AU915_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS: {
+            phyParam.Value = 2;
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYAU915::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done(txDone->Joined, &Bands[Channels[txDone->Channel].Band],
+                     txDone->LastTxDoneTime);
+}
+
+void LoRaPHYAU915::load_defaults(InitType_t type)
+{
+    switch (type) {
+        case INIT_TYPE_INIT: {
+            // Channels
+            // 125 kHz channels
+            for (uint8_t i = 0; i < AU915_MAX_NB_CHANNELS - 8; i++) {
+                Channels[i].Frequency = 915200000 + i * 200000;
+                Channels[i].DrRange.Value = ( DR_5 << 4) | DR_0;
+                Channels[i].Band = 0;
+            }
+            // 500 kHz channels
+            for (uint8_t i = AU915_MAX_NB_CHANNELS - 8;
+                    i < AU915_MAX_NB_CHANNELS; i++) {
+                Channels[i].Frequency = 915900000
+                        + (i - ( AU915_MAX_NB_CHANNELS - 8)) * 1600000;
+                Channels[i].DrRange.Value = ( DR_6 << 4) | DR_6;
+                Channels[i].Band = 0;
+            }
+
+            // Initialize channels default mask
+            ChannelsDefaultMask[0] = 0xFFFF;
+            ChannelsDefaultMask[1] = 0xFFFF;
+            ChannelsDefaultMask[2] = 0xFFFF;
+            ChannelsDefaultMask[3] = 0xFFFF;
+            ChannelsDefaultMask[4] = 0x00FF;
+            ChannelsDefaultMask[5] = 0x0000;
+
+            // Copy channels default mask
+            copy_channel_mask(ChannelsMask, ChannelsDefaultMask, 6);
+
+            // Copy into channels mask remaining
+            copy_channel_mask(ChannelsMaskRemaining, ChannelsMask, 6);
+            break;
+        }
+        case INIT_TYPE_RESTORE: {
+            // Copy channels default mask
+            copy_channel_mask(ChannelsMask, ChannelsDefaultMask, 6);
+
+            for (uint8_t i = 0; i < 6; i++) { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+            break;
+        }
+        default: {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYAU915::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch (phyAttribute) {
+        case PHY_TX_DR:
+        case PHY_DEF_TX_DR: {
+            return val_in_range(verify->DatarateParams.Datarate,
+                                AU915_TX_MIN_DATARATE, AU915_TX_MAX_DATARATE);
+        }
+        case PHY_RX_DR: {
+            return val_in_range(verify->DatarateParams.Datarate,
+                                AU915_RX_MIN_DATARATE, AU915_RX_MAX_DATARATE);
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER: {
+            // Remark: switched min and max!
+            return val_in_range(verify->TxPower, AU915_MAX_TX_POWER,
+                                AU915_MIN_TX_POWER);
+        }
+        case PHY_DUTY_CYCLE: {
+            return AU915_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS: {
+            if (verify->NbJoinTrials < 2) {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYAU915::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    return;
+}
+
+bool LoRaPHYAU915::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    uint8_t nbChannels = num_active_channels(chanMaskSet->ChannelsMaskIn, 0, 4);
+
+    // Check the number of active channels
+    // According to ACMA regulation, we require at least 20 125KHz channels, if
+    // the node shall utilize 125KHz channels.
+    if ((nbChannels < 20) && (nbChannels > 0)) {
+        return false;
+    }
+
+    switch (chanMaskSet->ChannelsMaskType) {
+        case CHANNELS_MASK: {
+            copy_channel_mask(ChannelsMask, chanMaskSet->ChannelsMaskIn, 6);
+
+            for (uint8_t i = 0; i < 6; i++) { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK: {
+            copy_channel_mask(ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn,
+                              6);
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYAU915::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if (adrNext->AdrEnabled == true) {
+        if (datarate == AU915_TX_MIN_DATARATE) {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        } else {
+            if (adrNext->AdrAckCounter >= AU915_ADR_ACK_LIMIT) {
+                adrAckReq = true;
+                txPower = AU915_MAX_TX_POWER;
+            } else {
+                adrAckReq = false;
+            }
+            if (adrNext->AdrAckCounter
+                    >= ( AU915_ADR_ACK_LIMIT + AU915_ADR_ACK_DELAY)) {
+                if ((adrNext->AdrAckCounter % AU915_ADR_ACK_DELAY) == 1) {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params(&getPhy);
+                    datarate = phyParam.Value;
+
+                    if (datarate == AU915_TX_MIN_DATARATE) {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if (adrNext->UpdateChanMask == true) {
+                            // Re-enable default channels
+                            ChannelsMask[0] = 0xFFFF;
+                            ChannelsMask[1] = 0xFFFF;
+                            ChannelsMask[2] = 0xFFFF;
+                            ChannelsMask[3] = 0xFFFF;
+                            ChannelsMask[4] = 0x00FF;
+                            ChannelsMask[5] = 0x0000;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYAU915::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN(datarate, AU915_RX_MAX_DATARATE);
+    rxConfigParams->Bandwidth = GetBandwidth(rxConfigParams->Datarate);
+
+    tSymbol = compute_symb_timeout_lora(
+            DataratesAU915[rxConfigParams->Datarate],
+            BandwidthsAU915[rxConfigParams->Datarate]);
+
+    get_rx_window_params(tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME,
+                         &rxConfigParams->WindowTimeout,
+                         &rxConfigParams->WindowOffset);
+}
+
+bool LoRaPHYAU915::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if (_radio->get_status() != RF_IDLE) {
+        return false;
+    }
+
+    if (rxConfig->Window == 0) {
+        // Apply window 1 frequency
+        frequency = AU915_FIRST_RX1_CHANNEL
+                + (rxConfig->Channel % 8) * AU915_STEPWIDTH_RX1_CHANNEL;
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesAU915[dr];
+
+    _radio->set_channel(frequency);
+
+    // Radio configuration
+    _radio->set_rx_config(MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                          rxConfig->WindowTimeout, false, 0, false, 0, 0, true,
+                          rxConfig->RxContinuous);
+
+    if (rxConfig->RepeaterSupport == true) {
+        maxPayload = MaxPayloadOfDatarateRepeaterAU915[dr];
+    } else {
+        maxPayload = MaxPayloadOfDatarateAU915[dr];
+    }
+    _radio->set_max_payload_length(MODEM_LORA,
+                                   maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD);
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYAU915::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    int8_t phyDr = DataratesAU915[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower(
+            txConfig->TxPower,
+            Bands[Channels[txConfig->Channel].Band].TxMaxPower,
+            txConfig->Datarate, ChannelsMask);
+    uint32_t bandwidth = GetBandwidth(txConfig->Datarate);
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power(txPowerLimited, txConfig->MaxEirp,
+                                  txConfig->AntennaGain);
+
+    // Setup the radio frequency
+    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+
+    _radio->set_tx_config(MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8,
+                          false, true, 0, 0, false, 3000);
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length(MODEM_LORA, txConfig->PktLen);
+
+    *txTimeOnAir = _radio->time_on_air(MODEM_LORA, txConfig->PktLen);
+    *txPower = txPowerLimited;
+
+    return true;
+}
+
+uint8_t LoRaPHYAU915::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut,
+                                       uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t channelsMask[6] = { 0, 0, 0, 0, 0, 0 };
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    // Initialize local copy of channels mask
+    copy_channel_mask(channelsMask, ChannelsMask, 6);
+
+    while (bytesProcessed < linkAdrReq->PayloadSize) {
+        nextIndex = parse_link_ADR_req(&(linkAdrReq->Payload[bytesProcessed]),
+                                       &linkAdrParams);
+
+        if (nextIndex == 0)
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        if (linkAdrParams.ChMaskCtrl == 6) {
+            // Enable all 125 kHz channels
+            channelsMask[0] = 0xFFFF;
+            channelsMask[1] = 0xFFFF;
+            channelsMask[2] = 0xFFFF;
+            channelsMask[3] = 0xFFFF;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        } else if (linkAdrParams.ChMaskCtrl == 7) {
+            // Disable all 125 kHz channels
+            channelsMask[0] = 0x0000;
+            channelsMask[1] = 0x0000;
+            channelsMask[2] = 0x0000;
+            channelsMask[3] = 0x0000;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        } else if (linkAdrParams.ChMaskCtrl == 5) {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        } else {
+            channelsMask[linkAdrParams.ChMaskCtrl] = linkAdrParams.ChMask;
+        }
+    }
+
+    // FCC 15.247 paragraph F mandates to hop on at least 2 125 kHz channels
+    if ((linkAdrParams.Datarate < DR_6)
+            && (num_active_channels(channelsMask, 0, 4) < 2)) {
+        status &= 0xFE; // Channel mask KO
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params(&getPhy);
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = AU915_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = channelsMask;
+    linkAdrVerifyParams.MinDatarate = (int8_t) phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = AU915_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = AU915_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = AU915_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req(&linkAdrVerifyParams, &linkAdrParams.Datarate,
+                                 &linkAdrParams.TxPower, &linkAdrParams.NbRep);
+
+    // Update channelsMask if everything is correct
+    if (status == 0x07) {
+        // Copy Mask
+        copy_channel_mask(ChannelsMask, channelsMask, 6);
+
+        ChannelsMaskRemaining[0] &= ChannelsMask[0];
+        ChannelsMaskRemaining[1] &= ChannelsMask[1];
+        ChannelsMaskRemaining[2] &= ChannelsMask[2];
+        ChannelsMaskRemaining[3] &= ChannelsMask[3];
+        ChannelsMaskRemaining[4] = ChannelsMask[4];
+        ChannelsMaskRemaining[5] = ChannelsMask[5];
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYAU915::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+    uint32_t freq = rxParamSetupReq->Frequency;
+
+    // Verify radio frequency
+    if ((_radio->check_rf_frequency(freq) == false)
+            || (freq < AU915_FIRST_RX1_CHANNEL)
+            || (freq > AU915_LAST_RX1_CHANNEL)
+            || (((freq - (uint32_t) AU915_FIRST_RX1_CHANNEL)
+                    % (uint32_t) AU915_STEPWIDTH_RX1_CHANNEL) != 0)) {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if (val_in_range(rxParamSetupReq->Datarate, AU915_RX_MIN_DATARATE,
+                     AU915_RX_MAX_DATARATE) == 0) {
+        status &= 0xFD; // Datarate KO
+    }
+    if ((rxParamSetupReq->Datarate == DR_7)
+            || (rxParamSetupReq->Datarate > DR_13)) {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if (val_in_range(rxParamSetupReq->DrOffset, AU915_MIN_RX1_DR_OFFSET,
+                     AU915_MAX_RX1_DR_OFFSET) == 0) {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYAU915::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    // Datarate and frequency KO
+    return 0;
+}
+
+int8_t LoRaPHYAU915::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYAU915::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    return 0;
+}
+
+int8_t LoRaPHYAU915::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    // Re-enable 500 kHz default channels
+    ChannelsMask[4] = 0x00FF;
+
+    if ((alternateDr->NbTrials & 0x01) == 0x01) {
+        datarate = DR_6;
+    } else {
+        datarate = DR_0;
+    }
+    return datarate;
+}
+
+void LoRaPHYAU915::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff(&calcBackOffParams);
+}
+
+bool LoRaPHYAU915::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[AU915_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    // Count 125kHz channels
+    if (num_active_channels(ChannelsMaskRemaining, 0, 4) == 0) { // Reactivate default channels
+        copy_channel_mask(ChannelsMaskRemaining, ChannelsMask, 4);
+    }
+    // Check other channels
+    if (nextChanParams->Datarate >= DR_6) {
+        if ((ChannelsMaskRemaining[4] & 0x00FF) == 0) {
+            ChannelsMaskRemaining[4] = ChannelsMask[4];
+        }
+    }
+
+    if (nextChanParams->AggrTimeOff
+            <= TimerGetElapsedTime(nextChanParams->LastAggrTx)) {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff(nextChanParams->Joined,
+                                          nextChanParams->DutyCycleEnabled,
+                                          Bands, AU915_MAX_NB_BANDS);
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels(nextChanParams->Datarate,
+                                                     ChannelsMaskRemaining,
+                                                     Channels, Bands,
+                                                     enabledChannels, &delayTx);
+    } else {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff
+                - TimerGetElapsedTime(nextChanParams->LastAggrTx);
+    }
+
+    if (nbEnabledChannels > 0) {
+        // We found a valid channel
+        *channel = enabledChannels[get_random(0, nbEnabledChannels - 1)];
+        // Disable the channel in the mask
+        disable_channel(ChannelsMaskRemaining, *channel,
+                        AU915_MAX_NB_CHANNELS - 8);
+
+        *time = 0;
+        return true;
+    } else {
+        if (delayTx > 0) {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYAU915::add_channel(ChannelAddParams_t* channelAdd)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+bool LoRaPHYAU915::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+void LoRaPHYAU915::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower(
+            continuousWave->TxPower,
+            Bands[Channels[continuousWave->Channel].Band].TxMaxPower,
+            continuousWave->Datarate, ChannelsMask);
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power(txPowerLimited, continuousWave->MaxEirp,
+                                  continuousWave->AntennaGain);
+
+    _radio->set_tx_continuous_wave(frequency, phyTxPower,
+                                   continuousWave->Timeout);
+}
+
+uint8_t LoRaPHYAU915::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr,
+                                      int8_t drOffset)
+{
+    int8_t datarate = DatarateOffsetsAU915[dr][drOffset];
+
+    if (datarate < 0) {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.h
@@ -1,0 +1,373 @@
+/**
+ *  @file LoRaPHYAU915.h
+ *
+ *  @brief Implements LoRaPHY for Australian 915 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_AU915_H_
+
+#define MBED_OS_LORAPHY_AU915_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+// Definitions
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define AU915_MAX_NB_CHANNELS                       72
+
+/*!
+ * LoRaMac maximum number of bands
+ */
+#define AU915_MAX_NB_BANDS                          1
+
+#define AU915_CHANNELS_MASK_SIZE                    6
+
+
+class LoRaPHYAU915 : public LoRaPHY{
+
+public:
+
+    LoRaPHYAU915();
+    virtual ~LoRaPHYAU915();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval A structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to be verified.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the
+     *        CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the Rx window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams The updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR Request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty
+     *              cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels(uint8_t datarate,
+                                     uint16_t* channelsMask,
+                                     ChannelParams_t* channels,
+                                     Band_t* bands, uint8_t* enabledChannels,
+                                     uint8_t* delayTx);
+
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[AU915_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[AU915_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[AU915_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels remaining
+     */
+    uint16_t ChannelsMaskRemaining[AU915_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[AU915_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_AU915_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -1,0 +1,979 @@
+/**
+ *  @file LoRaPHYCN470.cpp
+ *
+ *  @brief Implements LoRaPHY for Chinese 470 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYCN470.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define CN470_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define CN470_TX_MAX_DATARATE                       DR_5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define CN470_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define CN470_RX_MAX_DATARATE                       DR_5
+
+/*!
+ * Default datarate used by the node
+ */
+#define CN470_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define CN470_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define CN470_MAX_RX1_DR_OFFSET                     3
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define CN470_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define CN470_MIN_TX_POWER                        TX_POWER_7
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define CN470_MAX_TX_POWER                        TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define CN470_DEFAULT_TX_POWER                    TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define CN470_DEFAULT_MAX_EIRP                      19.15f
+
+/*!
+ * Default antenna gain
+ */
+#define CN470_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define CN470_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define CN470_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define CN470_DUTY_CYCLE_ENABLED                    0
+
+/*!
+ * Maximum RX window duration
+ */
+#define CN470_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define CN470_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define CN470_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define CN470_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define CN470_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define CN470_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define CN470_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define CN470_ACK_TIMEOUT_RND                       1000
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define CN470_RX_WND_2_FREQ                         505300000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define CN470_RX_WND_2_DR                           DR_0
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define CN470_BAND0                                 { 1, CN470_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * Defines the first channel for RX window 1 for CN470 band
+ */
+#define CN470_FIRST_RX1_CHANNEL                     ( (uint32_t) 500300000 )
+
+/*!
+ * Defines the last channel for RX window 1 for CN470 band
+ */
+#define CN470_LAST_RX1_CHANNEL                      ( (uint32_t) 509700000 )
+
+/*!
+ * Defines the step width of the channels for RX window 1
+ */
+#define CN470_STEPWIDTH_RX1_CHANNEL                 ( (uint32_t) 200000 )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesCN470[]  = { 12, 11, 10,  9,  8,  7 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsCN470[] = { 125000, 125000, 125000, 125000, 125000, 125000 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateCN470[] = { 51, 51, 51, 115, 222, 222 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterCN470[] = { 51, 51, 51, 115, 222, 222 };
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsCN470[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+uint8_t LoRaPHYCN470::CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < CN470_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYCN470::LoRaPHYCN470()
+{
+    const Band_t band0 = CN470_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYCN470::~LoRaPHYCN470()
+{
+}
+
+PhyParam_t LoRaPHYCN470::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = CN470_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = CN470_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = CN470_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, CN470_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = CN470_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateCN470[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterCN470[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = CN470_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = CN470_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = CN470_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = CN470_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = CN470_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = CN470_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = CN470_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( CN470_ACKTIMEOUT + get_random( -CN470_ACK_TIMEOUT_RND, CN470_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = CN470_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = CN470_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = CN470_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = CN470_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = CN470_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = CN470_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYCN470::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYCN470::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            // 125 kHz channels
+            for( uint8_t i = 0; i < CN470_MAX_NB_CHANNELS; i++ )
+            {
+                Channels[i].Frequency = 470300000 + i * 200000;
+                Channels[i].DrRange.Value = ( DR_5 << 4 ) | DR_0;
+                Channels[i].Band = 0;
+            }
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = 0xFFFF;
+            ChannelsDefaultMask[1] = 0xFFFF;
+            ChannelsDefaultMask[2] = 0xFFFF;
+            ChannelsDefaultMask[3] = 0xFFFF;
+            ChannelsDefaultMask[4] = 0xFFFF;
+            ChannelsDefaultMask[5] = 0xFFFF;
+
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 6 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 6 );
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYCN470::verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, CN470_TX_MIN_DATARATE, CN470_TX_MAX_DATARATE );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, CN470_RX_MIN_DATARATE, CN470_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, CN470_MAX_TX_POWER, CN470_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return CN470_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYCN470::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    return;
+}
+
+bool LoRaPHYCN470::set_channel_mask( ChanMaskSetParams_t* chanMaskSet )
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 6 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 6 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYCN470::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == CN470_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= CN470_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = CN470_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( CN470_ADR_ACK_LIMIT + CN470_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % CN470_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params(&getPhy);
+                    datarate = phyParam.Value;
+
+                    if( datarate == CN470_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] = 0xFFFF;
+                            ChannelsMask[1] = 0xFFFF;
+                            ChannelsMask[2] = 0xFFFF;
+                            ChannelsMask[3] = 0xFFFF;
+                            ChannelsMask[4] = 0xFFFF;
+                            ChannelsMask[5] = 0xFFFF;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYCN470::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, CN470_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    tSymbol = compute_symb_timeout_lora( DataratesCN470[rxConfigParams->Datarate], BandwidthsCN470[rxConfigParams->Datarate] );
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYCN470::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if(_radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = CN470_FIRST_RX1_CHANNEL + ( rxConfig->Channel % 48 ) * CN470_STEPWIDTH_RX1_CHANNEL;
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesCN470[dr];
+
+    _radio->set_channel(frequency);
+
+    // Radio configuration
+    _radio->set_rx_config(MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                          rxConfig->WindowTimeout, false, 0, false, 0, 0, true,
+                          rxConfig->RxContinuous);
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterCN470[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateCN470[dr];
+    }
+    _radio->set_max_payload_length(MODEM_LORA, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD);
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYCN470::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    int8_t phyDr = DataratesCN470[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+
+   _radio->set_tx_config(MODEM_LORA, phyTxPower, 0, 0, phyDr, 1, 8, false, true,
+                         0, 0, false, 3000);
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length(MODEM_LORA, txConfig->PktLen);
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air(MODEM_LORA, txConfig->PktLen);
+    *txPower = txPowerLimited;
+
+    return true;
+}
+
+uint8_t LoRaPHYCN470::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t channelsMask[6] = { 0, 0, 0, 0, 0, 0 };
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    // Initialize local copy of channels mask
+    copy_channel_mask( channelsMask, ChannelsMask, 6 );
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        if( linkAdrParams.ChMaskCtrl == 6 )
+        {
+            // Enable all 125 kHz channels
+            channelsMask[0] = 0xFFFF;
+            channelsMask[1] = 0xFFFF;
+            channelsMask[2] = 0xFFFF;
+            channelsMask[3] = 0xFFFF;
+            channelsMask[4] = 0xFFFF;
+            channelsMask[5] = 0xFFFF;
+        }
+        else if( linkAdrParams.ChMaskCtrl == 7 )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < 16; i++ )
+            {
+                if( ( ( linkAdrParams.ChMask & ( 1 << i ) ) != 0 ) &&
+                    ( Channels[linkAdrParams.ChMaskCtrl * 16 + i].Frequency == 0 ) )
+                {// Trying to enable an undefined channel
+                    status &= 0xFE; // Channel mask KO
+                }
+            }
+            channelsMask[linkAdrParams.ChMaskCtrl] = linkAdrParams.ChMask;
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params(&getPhy);
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = CN470_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = channelsMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = CN470_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = CN470_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = CN470_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Copy Mask
+        copy_channel_mask( ChannelsMask, channelsMask, 6 );
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYCN470::setup_rx_params( RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+    uint32_t freq = rxParamSetupReq->Frequency;
+
+    // Verify radio frequency
+    if( (_radio->check_rf_frequency(freq) == false ) ||
+        ( freq < CN470_FIRST_RX1_CHANNEL ) ||
+        ( freq > CN470_LAST_RX1_CHANNEL ) ||
+        ( ( ( freq - ( uint32_t ) CN470_FIRST_RX1_CHANNEL ) % ( uint32_t ) CN470_STEPWIDTH_RX1_CHANNEL ) != 0 ) )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, CN470_RX_MIN_DATARATE, CN470_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, CN470_MIN_RX1_DR_OFFSET, CN470_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYCN470::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    // Datarate and frequency KO
+    return 0;
+}
+
+int8_t LoRaPHYCN470::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYCN470::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    return 0;
+}
+
+int8_t LoRaPHYCN470::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYCN470::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYCN470::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[CN470_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    // Count 125kHz channels
+    if( num_active_channels( ChannelsMask, 0, 6 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] = 0xFFFF;
+        ChannelsMask[1] = 0xFFFF;
+        ChannelsMask[2] = 0xFFFF;
+        ChannelsMask[3] = 0xFFFF;
+        ChannelsMask[4] = 0xFFFF;
+        ChannelsMask[5] = 0xFFFF;
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, CN470_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYCN470::add_channel(ChannelAddParams_t* channelAdd)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+bool LoRaPHYCN470::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+void LoRaPHYCN470::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave(frequency, phyTxPower, continuousWave->Timeout);
+}
+
+uint8_t LoRaPHYCN470::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr,
+                                      int8_t drOffset)
+{
+    int8_t datarate = dr - drOffset;
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}
+
+
+

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.h
@@ -1,0 +1,365 @@
+/**
+ *  @file LoRaPHYCN470.h
+ *
+ *  @brief Implements LoRaPHY for Chinese 470 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_CN470_H_
+#define MBED_OS_LORAPHY_CN470_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+// Definitions
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define CN470_MAX_NB_CHANNELS                        96
+
+/*!
+ * LoRaMac maximum number of bands
+ */
+#define CN470_MAX_NB_BANDS                           1
+
+
+#define CN470_CHANNELS_MASK_SIZE                     6
+
+
+class LoRaPHYCN470 : public LoRaPHY {
+
+public:
+
+    LoRaPHYCN470();
+    virtual ~LoRaPHYCN470();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval A structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to be verified.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the
+     *        CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams The updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty
+     *              cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+    bool RegionCN470ChanMaskSet( ChanMaskSetParams_t* chanMaskSet );
+
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[CN470_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[CN470_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[CN470_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[CN470_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_CN470_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
@@ -1,0 +1,1239 @@
+/**
+ *  @file LoRaPHYCN779.cpp
+ *
+ *  @brief Implements LoRaPHY for Chinese 779 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYCN779.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Number of default channels
+ */
+#define CN779_NUMB_DEFAULT_CHANNELS                 3
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define CN779_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define CN779_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define CN779_TX_MAX_DATARATE                       DR_7
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define CN779_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define CN779_RX_MAX_DATARATE                       DR_7
+
+/*!
+ * Default datarate used by the node
+ */
+#define CN779_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define CN779_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define CN779_MAX_RX1_DR_OFFSET                     5
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define CN779_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define CN779_MIN_TX_POWER                          TX_POWER_5
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define CN779_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define CN779_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define CN779_DEFAULT_MAX_EIRP                      12.15f
+
+/*!
+ * Default antenna gain
+ */
+#define CN779_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define CN779_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define CN779_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define CN779_DUTY_CYCLE_ENABLED                    1
+
+/*!
+ * Maximum RX window duration
+ */
+#define CN779_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define CN779_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define CN779_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define CN779_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define CN779_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define CN779_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define CN779_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define CN779_ACK_TIMEOUT_RND                       1000
+
+/*!
+ * Verification of default datarate
+ */
+#if ( CN779_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define CN779_RX_WND_2_FREQ                         786000000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define CN779_RX_WND_2_DR                           DR_0
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define CN779_BAND0                                 { 100, CN779_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define CN779_LC1                                   { 779500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define CN779_LC2                                   { 779700000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 3
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define CN779_LC3                                   { 779900000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define CN779_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) | LC( 3 ) )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesCN779[]  = { 12, 11, 10,  9,  8,  7,  7, 50 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsCN779[] = { 125000, 125000, 125000, 125000, 125000, 125000, 250000, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateCN779[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterCN779[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsCN779[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq, LoRaRadio *radio)
+{
+    // Check radio driver support
+    if(radio->check_rf_frequency(freq) == false)
+    {
+        return false;
+    }
+
+    if( ( freq < 779500000 ) || ( freq > 786500000 ) )
+    {
+        return false;
+    }
+    return true;
+}
+
+uint8_t LoRaPHYCN779::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < CN779_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( CN779_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYCN779::LoRaPHYCN779()
+{
+    const Band_t band0 = CN779_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYCN779::~LoRaPHYCN779()
+{
+}
+
+PhyParam_t LoRaPHYCN779::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = CN779_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = CN779_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = CN779_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, CN779_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = CN779_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateCN779[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterCN779[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = CN779_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = CN779_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = CN779_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = CN779_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = CN779_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = CN779_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = CN779_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = (CN779_ACKTIMEOUT + get_random(-CN779_ACK_TIMEOUT_RND, CN779_ACK_TIMEOUT_RND));
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = CN779_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = CN779_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = CN779_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = CN779_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = CN779_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = CN779_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYCN779::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYCN779::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = CN779_LC1;
+            const ChannelParams_t channel2 = CN779_LC2;
+            const ChannelParams_t channel3 = CN779_LC3;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+            Channels[2] = channel3;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 ) + LC( 3 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYCN779::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, CN779_TX_MIN_DATARATE, CN779_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, CN779_RX_MIN_DATARATE, CN779_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, CN779_MAX_TX_POWER, CN779_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return CN779_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYCN779::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = CN779_NUMB_DEFAULT_CHANNELS; chanIdx < CN779_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( CN779_NUMB_CHANNELS_CF_LIST + CN779_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel(&channelAdd);
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel(&channelRemove);
+        }
+    }
+}
+
+bool LoRaPHYCN779::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYCN779::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == CN779_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= CN779_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = CN779_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( CN779_ADR_ACK_LIMIT + CN779_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % CN779_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params(&getPhy);
+                    datarate = phyParam.Value;
+
+                    if( datarate == CN779_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYCN779::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, CN779_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    if( rxConfigParams->Datarate == DR_7 )
+    { // FSK
+        tSymbol = compute_symb_timeout_fsk( DataratesCN779[rxConfigParams->Datarate] );
+    }
+    else
+    { // LoRa
+        tSymbol = compute_symb_timeout_lora( DataratesCN779[rxConfigParams->Datarate], BandwidthsCN779[rxConfigParams->Datarate] );
+    }
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYCN779::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    radio_modems_t modem;
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if(_radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesCN779[dr];
+
+    _radio->set_channel(frequency);
+
+    // Radio configuration
+    if( dr == DR_7 )
+    {
+        modem = MODEM_FSK;
+       _radio->set_rx_config(modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->WindowTimeout, false, 0, true, 0, 0, false, rxConfig->RxContinuous);
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_rx_config(modem, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous);
+    }
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterCN779[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateCN779[dr];
+    }
+    _radio->set_max_payload_length(modem, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD);
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYCN779::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    radio_modems_t modem;
+    int8_t phyDr = DataratesCN779[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel(Channels[txConfig->Channel].Frequency);
+
+    if( txConfig->Datarate == DR_7 )
+    { // High Speed FSK channel
+        modem = MODEM_FSK;
+       _radio->set_tx_config(modem, phyTxPower, 25000, bandwidth, phyDr * 1000, 0, 5, false, true, 0, 0, false, 3000);
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_tx_config(modem, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000);
+    }
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length(modem, txConfig->PktLen);
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air(modem, txConfig->PktLen);
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYCN779::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < CN779_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params(&getPhy);
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = CN779_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = CN779_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = CN779_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = CN779_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYCN779::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if(_radio->check_rf_frequency(rxParamSetupReq->Frequency) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, CN779_RX_MIN_DATARATE, CN779_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, CN779_MIN_RX1_DR_OFFSET, CN779_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYCN779::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if(remove_channel(&channelRemove) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch (add_channel(&channelAdd))
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYCN779::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYCN779::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq(dlChannelReq->Rx1Frequency, _radio) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYCN779::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYCN779::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYCN779::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[CN779_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, CN779_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYCN779::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= CN779_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, CN779_TX_MIN_DATARATE, CN779_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, CN779_TX_MIN_DATARATE, CN779_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < CN779_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, CN779_TX_MAX_DATARATE ) == 0 )
+        {
+            drInvalid = true;
+        }
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq(channelAdd->NewChannel->Frequency, _radio) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYCN779::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < CN779_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, CN779_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYCN779::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave(frequency, phyTxPower, continuousWave->Timeout);
+}
+
+uint8_t LoRaPHYCN779::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset)
+{
+    int8_t datarate = dr - drOffset;
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.h
@@ -1,0 +1,354 @@
+/**
+ *  @file LoRaPHYCN779.h
+ *
+ *  @brief Implements LoRaPHY for Chinese 779 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_CN779_H_
+#define MBED_OS_LORAPHY_CN779_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+#define CN779_MAX_NB_CHANNELS                       16
+
+#define CN779_MAX_NB_BANDS                           1
+
+#define CN779_CHANNELS_MASK_SIZE                     1
+
+
+class LoRaPHYCN779 : public LoRaPHY {
+
+public:
+
+    LoRaPHYCN779();
+    virtual ~LoRaPHYCN779();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum required number of symbols to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty
+     *              cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[CN779_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[CN779_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[CN779_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[CN779_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_CN779_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
@@ -1,0 +1,1244 @@
+/**
+ *  @file LoRaPHYEU433.cpp
+ *
+ *  @brief Implements LoRaPHY for European 433 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYEU433.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+/*!
+ * Number of default channels
+ */
+#define EU433_NUMB_DEFAULT_CHANNELS                 3
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define EU433_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define EU433_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define EU433_TX_MAX_DATARATE                       DR_7
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define EU433_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define EU433_RX_MAX_DATARATE                       DR_7
+
+/*!
+ * Default datarate used by the node
+ */
+#define EU433_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define EU433_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define EU433_MAX_RX1_DR_OFFSET                     5
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define EU433_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define EU433_MIN_TX_POWER                          TX_POWER_5
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define EU433_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define EU433_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define EU433_DEFAULT_MAX_EIRP                      12.15f
+
+/*!
+ * Default antenna gain
+ */
+#define EU433_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define EU433_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define EU433_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define EU433_DUTY_CYCLE_ENABLED                    1
+
+/*!
+ * Maximum RX window duration
+ */
+#define EU433_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define EU433_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define EU433_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define EU433_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define EU433_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define EU433_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define EU433_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define EU433_ACK_TIMEOUT_RND                       1000
+
+/*!
+ * Verification of default datarate
+ */
+#if ( EU433_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define EU433_RX_WND_2_FREQ                         434665000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define EU433_RX_WND_2_DR                           DR_0
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU433_BAND0                                 { 100, EU433_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU433_LC1                                   { 433175000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU433_LC2                                   { 433375000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 3
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU433_LC3                                   { 433575000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define EU433_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) | LC( 3 ) )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesEU433[] = { 12, 11, 10,  9,  8,  7,  7, 50 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsEU433[] = { 125000, 125000, 125000, 125000, 125000, 125000, 250000, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateEU433[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterEU433[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsEU433[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq, LoRaRadio *radio )
+{
+    // Check radio driver support
+    if(radio->check_rf_frequency(freq) == false )
+    {
+        return false;
+    }
+
+    if( ( freq < 433175000 ) || ( freq > 434665000 ) )
+    {
+        return false;
+    }
+    return true;
+}
+
+uint8_t LoRaPHYEU433::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < EU433_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( EU433_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYEU433::LoRaPHYEU433()
+{
+    const Band_t band0 = EU433_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYEU433::~LoRaPHYEU433()
+{
+}
+
+PhyParam_t LoRaPHYEU433::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = EU433_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = EU433_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = EU433_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, EU433_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = EU433_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateEU433[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterEU433[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = EU433_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = EU433_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = EU433_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = EU433_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = EU433_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = EU433_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = EU433_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( EU433_ACKTIMEOUT + get_random( -EU433_ACK_TIMEOUT_RND, EU433_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = EU433_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = EU433_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = EU433_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = EU433_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = EU433_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = EU433_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYEU433::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYEU433::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = EU433_LC1;
+            const ChannelParams_t channel2 = EU433_LC2;
+            const ChannelParams_t channel3 = EU433_LC3;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+            Channels[2] = channel3;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 ) + LC( 3 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYEU433::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, EU433_RX_MIN_DATARATE, EU433_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, EU433_MAX_TX_POWER, EU433_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return EU433_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYEU433::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = EU433_NUMB_DEFAULT_CHANNELS; chanIdx < EU433_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( EU433_NUMB_CHANNELS_CF_LIST + EU433_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel( &channelAdd );
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel( &channelRemove );
+        }
+    }
+}
+
+bool LoRaPHYEU433::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYEU433::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == EU433_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= EU433_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = EU433_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( EU433_ADR_ACK_LIMIT + EU433_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % EU433_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == EU433_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYEU433::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, EU433_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    if( rxConfigParams->Datarate == DR_7 )
+    { // FSK
+        tSymbol = compute_symb_timeout_fsk( DataratesEU433[rxConfigParams->Datarate] );
+    }
+    else
+    { // LoRa
+        tSymbol = compute_symb_timeout_lora( DataratesEU433[rxConfigParams->Datarate], BandwidthsEU433[rxConfigParams->Datarate] );
+    }
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYEU433::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    radio_modems_t modem;
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesEU433[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    if( dr == DR_7 )
+    {
+        modem = MODEM_FSK;
+        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5,
+                               rxConfig->WindowTimeout, false, 0, true, 0, 0,
+                               false, rxConfig->RxContinuous );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                               rxConfig->WindowTimeout, false, 0, false, 0, 0,
+                               true, rxConfig->RxContinuous );
+    }
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterEU433[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateEU433[dr];
+    }
+    _radio->set_max_payload_length( modem, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYEU433::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    radio_modems_t modem;
+    int8_t phyDr = DataratesEU433[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    if( txConfig->Datarate == DR_7 )
+    { // High Speed FSK channel
+        modem = MODEM_FSK;
+        _radio->set_tx_config( modem, phyTxPower, 25000, bandwidth, phyDr * 1000, 0, 5, false, true, 0, 0, false, 3000 );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_tx_config( modem, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
+    }
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( modem, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air( modem, txConfig->PktLen );
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYEU433::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < EU433_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+        // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = EU433_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = EU433_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = EU433_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = EU433_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYEU433::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if( _radio->check_rf_frequency( rxParamSetupReq->Frequency ) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, EU433_RX_MIN_DATARATE, EU433_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, EU433_MIN_RX1_DR_OFFSET, EU433_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYEU433::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if( remove_channel( &channelRemove ) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch( add_channel( &channelAdd ) )
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYEU433::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYEU433::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq( dlChannelReq->Rx1Frequency, _radio ) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYEU433::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYEU433::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYEU433::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[EU433_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, EU433_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYEU433::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= EU433_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, EU433_TX_MIN_DATARATE, EU433_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < EU433_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU433_TX_MAX_DATARATE ) == 0 )
+        {
+            drInvalid = true;
+        }
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, _radio ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYEU433::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < EU433_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, EU433_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYEU433::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYEU433::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset)
+{
+    int8_t datarate = dr - drOffset;
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.h
@@ -1,0 +1,361 @@
+/**
+ *  @file LoRaPHYEU433.h
+ *
+ *  @brief Implements LoRaPHY for European 433 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_EU433_H_
+#define MBED_OS_LORAPHY_EU433_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define EU433_MAX_NB_CHANNELS                       16
+
+/*!
+ * LoRaMac maximum number of bands
+ */
+#define EU433_MAX_NB_BANDS                          1
+
+#define EU433_CHANNELS_MASK_SIZE                    1
+
+
+class LoRaPHYEU433 : public LoRaPHY {
+
+public:
+
+    LoRaPHYEU433();
+    virtual ~LoRaPHYEU433();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty
+     *              cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval Function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[EU433_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[EU433_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[EU433_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[EU433_CHANNELS_MASK_SIZE];
+};
+
+
+#endif /* MBED_OS_LORAPHY_EU433_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
@@ -1,0 +1,1296 @@
+/**
+ *  @file LoRaPHYEU868.cpp
+ *
+ *  @brief Implements LoRaPHY for European 868 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYEU868.h"
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+/*!
+ * Number of default channels
+ */
+#define EU868_NUMB_DEFAULT_CHANNELS                 3
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define EU868_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define EU868_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define EU868_TX_MAX_DATARATE                       DR_7
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define EU868_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define EU868_RX_MAX_DATARATE                       DR_7
+
+/*!
+ * Default datarate used by the node
+ */
+#define EU868_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define EU868_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define EU868_MAX_RX1_DR_OFFSET                     5
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define EU868_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define EU868_MIN_TX_POWER                          TX_POWER_7
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define EU868_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define EU868_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define EU868_DEFAULT_MAX_EIRP                      16.0f
+
+/*!
+ * Default antenna gain
+ */
+#define EU868_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define EU868_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define EU868_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define EU868_DUTY_CYCLE_ENABLED                    1
+
+/*!
+ * Maximum RX window duration
+ */
+#define EU868_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define EU868_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define EU868_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define EU868_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define EU868_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define EU868_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define EU868_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define EU868_ACK_TIMEOUT_RND                       1000
+
+#if ( EU868_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define EU868_RX_WND_2_FREQ                         869525000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define EU868_RX_WND_2_DR                           DR_0
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND0                                 { 100 , EU868_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * Band 1 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND1                                 { 100 , EU868_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * Band 2 definition
+ * Band = { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND2                                 { 1000, EU868_MAX_TX_POWER, 0,  0 } //  0.1 %
+
+/*!
+ * Band 2 definition
+ * Band = { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND3                                 { 10  , EU868_MAX_TX_POWER, 0,  0 } // 10.0 %
+
+/*!
+ * Band 2 definition
+ * Band = { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define EU868_BAND4                                 { 100 , EU868_MAX_TX_POWER, 0,  0 } //  1.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU868_LC1                                   { 868100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 }
+
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU868_LC2                                   { 868300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 }
+
+/*!
+ * LoRaMac default channel 3
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define EU868_LC3                                   { 868500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 1 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define EU868_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) | LC( 3 ) )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesEU868[]  = { 12, 11, 10,  9,  8,  7,  7, 50 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsEU868[] = { 125000, 125000, 125000, 125000, 125000, 125000, 250000, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateEU868[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterEU868[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsEU868[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq, uint8_t *band, LoRaRadio *radio )
+{
+    // Check radio driver support
+    if( radio->check_rf_frequency( freq ) == false )
+    {
+        return false;
+    }
+
+    // Check frequency bands
+    if( ( freq >= 863000000 ) && ( freq < 865000000 ) )
+    {
+        *band = 2;
+    }
+    else if( ( freq >= 865000000 ) && ( freq <= 868000000 ) )
+    {
+        *band = 0;
+    }
+    else if( ( freq > 868000000 ) && ( freq <= 868600000 ) )
+    {
+        *band = 1;
+    }
+    else if( ( freq >= 868700000 ) && ( freq <= 869200000 ) )
+    {
+        *band = 2;
+    }
+    else if( ( freq >= 869400000 ) && ( freq <= 869650000 ) )
+    {
+        *band = 3;
+    }
+    else if( ( freq >= 869700000 ) && ( freq <= 870000000 ) )
+    {
+        *band = 4;
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+uint8_t LoRaPHYEU868::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < EU868_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( EU868_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYEU868::LoRaPHYEU868()
+{
+    const Band_t band0 = EU868_BAND0;
+    const Band_t band1 = EU868_BAND1;
+    const Band_t band2 = EU868_BAND2;
+    const Band_t band3 = EU868_BAND3;
+    const Band_t band4 = EU868_BAND4;
+
+    Bands[0] = band0;
+    Bands[1] = band1;
+    Bands[2] = band2;
+    Bands[3] = band3;
+    Bands[4] = band4;
+}
+
+LoRaPHYEU868::~LoRaPHYEU868()
+{
+}
+
+PhyParam_t LoRaPHYEU868::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = EU868_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = EU868_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = EU868_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, EU868_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = EU868_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateEU868[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterEU868[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = EU868_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = EU868_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = EU868_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = EU868_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = EU868_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = EU868_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = EU868_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( EU868_ACKTIMEOUT + get_random( -EU868_ACK_TIMEOUT_RND, EU868_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = EU868_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = EU868_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = EU868_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = EU868_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = EU868_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = EU868_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYEU868::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYEU868::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = EU868_LC1;
+            const ChannelParams_t channel2 = EU868_LC2;
+            const ChannelParams_t channel3 = EU868_LC3;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+            Channels[2] = channel3;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 ) + LC( 3 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYEU868::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, EU868_RX_MIN_DATARATE, EU868_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, EU868_MAX_TX_POWER, EU868_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return EU868_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYEU868::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = EU868_NUMB_DEFAULT_CHANNELS; chanIdx < EU868_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( EU868_NUMB_CHANNELS_CF_LIST + EU868_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel( &channelAdd );
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel( &channelRemove );
+        }
+    }
+}
+
+bool LoRaPHYEU868::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYEU868::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == EU868_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= EU868_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = EU868_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( EU868_ADR_ACK_LIMIT + EU868_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % EU868_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == EU868_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYEU868::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, EU868_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    if( rxConfigParams->Datarate == DR_7 )
+    { // FSK
+        tSymbol = compute_symb_timeout_fsk( DataratesEU868[rxConfigParams->Datarate] );
+    }
+    else
+    { // LoRa
+        tSymbol = compute_symb_timeout_lora( DataratesEU868[rxConfigParams->Datarate], BandwidthsEU868[rxConfigParams->Datarate] );
+    }
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYEU868::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    radio_modems_t modem;
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesEU868[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    if( dr == DR_7 )
+    {
+        modem = MODEM_FSK;
+        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->WindowTimeout, false, 0, true, 0, 0, false, rxConfig->RxContinuous );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+    }
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterEU868[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateEU868[dr];
+    }
+
+    _radio->set_max_payload_length( modem, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYEU868::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    radio_modems_t modem;
+    int8_t phyDr = DataratesEU868[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    if( txConfig->Datarate == DR_7 )
+    { // High Speed FSK channel
+        modem = MODEM_FSK;
+        _radio->set_tx_config( modem, phyTxPower, 25000, bandwidth, phyDr * 1000, 0, 5, false, true, 0, 0, false, 3000 );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_tx_config( modem, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
+    }
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( modem, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air( modem, txConfig->PktLen );
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYEU868::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < EU868_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = EU868_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = EU868_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = EU868_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = EU868_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYEU868::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if( _radio->check_rf_frequency( rxParamSetupReq->Frequency ) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, EU868_RX_MIN_DATARATE, EU868_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, EU868_MIN_RX1_DR_OFFSET, EU868_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYEU868::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if( remove_channel( &channelRemove ) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch( add_channel( &channelAdd ) )
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYEU868::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYEU868::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+    uint8_t band = 0;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq( dlChannelReq->Rx1Frequency, &band, _radio ) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYEU868::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYEU868::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYEU868::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[EU868_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, EU868_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYEU868::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= EU868_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, EU868_TX_MIN_DATARATE, EU868_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < EU868_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, EU868_TX_MAX_DATARATE ) == 0 )
+        {
+            drInvalid = true;
+        }
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, &band, _radio ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYEU868::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < EU868_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, EU868_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYEU868::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYEU868::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset)
+{
+    int8_t datarate = dr - drOffset;
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.h
@@ -1,0 +1,358 @@
+/**
+ *  @file LoRaPHYEU868.h
+ *
+ *  @brief Implements LoRaPHY for European 868 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_EU868_H_
+#define MBED_OS_LORAPHY_EU868_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define EU868_MAX_NB_CHANNELS                       16
+
+/*!
+ * Maximum number of bands
+ */
+#define EU868_MAX_NB_BANDS                          5
+
+#define EU868_CHANNELS_MASK_SIZE                    1
+
+
+class LoRaPHYEU868 : public LoRaPHY {
+
+public:
+    LoRaPHYEU868();
+    virtual ~LoRaPHYEU868();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[EU868_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[EU868_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[EU868_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[EU868_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_EU868_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
@@ -1,0 +1,1243 @@
+/**
+ *  @file LoRaPHYIN865.cpp
+ *
+ *  @brief Implements LoRaPHY for Indian 865 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYIN865.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Number of default channels
+ */
+#define IN865_NUMB_DEFAULT_CHANNELS                 3
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define IN865_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define IN865_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define IN865_TX_MAX_DATARATE                       DR_7
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define IN865_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define IN865_RX_MAX_DATARATE                       DR_7
+
+/*!
+ * Default datarate used by the node
+ */
+#define IN865_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define IN865_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define IN865_MAX_RX1_DR_OFFSET                     7
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define IN865_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define IN865_MIN_TX_POWER                          TX_POWER_10
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define IN865_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define IN865_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP
+ */
+#define IN865_DEFAULT_MAX_EIRP                      30.0f
+
+/*!
+ * Default antenna gain
+ */
+#define IN865_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define IN865_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define IN865_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define IN865_DUTY_CYCLE_ENABLED                    1
+
+/*!
+ * Maximum RX window duration
+ */
+#define IN865_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define IN865_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define IN865_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define IN865_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define IN865_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define IN865_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define IN865_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define IN865_ACK_TIMEOUT_RND                       1000
+
+#if ( IN865_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define IN865_RX_WND_2_FREQ                         866550000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define IN865_RX_WND_2_DR                           DR_2
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define IN865_BAND0                                 { 1 , IN865_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define IN865_LC1                                   { 865062500, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define IN865_LC2                                   { 865402500, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 3
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define IN865_LC3                                   { 865985000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define IN865_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) | LC( 3 ) )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesIN865[]  = { 12, 11, 10,  9,  8,  7,  7, 50 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsIN865[] = { 125000, 125000, 125000, 125000, 125000, 125000, 250000, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateIN865[] = { 51, 51, 51, 115, 242, 242, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterIN865[] = { 51, 51, 51, 115, 222, 222, 222, 222 };
+
+/*!
+ * Effective datarate offsets for receive window 1.
+ */
+static const int8_t EffectiveRx1DrOffsetIN865[] = { 0, 1, 2, 3, 4, 5, -1, -2 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else if( dr == DR_7 )
+    {
+        nextLowerDr = DR_5;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsIN865[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq, uint8_t *band, LoRaRadio *radio )
+{
+    // Check radio driver support
+    if( radio->check_rf_frequency( freq ) == false )
+    {
+        return false;
+    }
+
+    if( ( freq < 865000000 ) || ( freq > 867000000 ) )
+    {
+        return false;
+    }
+    return true;
+}
+
+uint8_t LoRaPHYIN865::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < IN865_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( IN865_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYIN865::LoRaPHYIN865()
+{
+    const Band_t band0 = IN865_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYIN865::~LoRaPHYIN865()
+{
+}
+
+PhyParam_t LoRaPHYIN865::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = IN865_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = IN865_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = IN865_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, IN865_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = IN865_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateIN865[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterIN865[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = IN865_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = IN865_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = IN865_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = IN865_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = IN865_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = IN865_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = IN865_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( IN865_ACKTIMEOUT + get_random( -IN865_ACK_TIMEOUT_RND, IN865_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = IN865_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = IN865_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = IN865_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = IN865_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            phyParam.fValue = IN865_DEFAULT_MAX_EIRP;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = IN865_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYIN865::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYIN865::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = IN865_LC1;
+            const ChannelParams_t channel2 = IN865_LC2;
+            const ChannelParams_t channel3 = IN865_LC3;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+            Channels[2] = channel3;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 ) + LC( 3 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYIN865::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, IN865_RX_MIN_DATARATE, IN865_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, IN865_MAX_TX_POWER, IN865_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return IN865_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYIN865::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = IN865_NUMB_DEFAULT_CHANNELS; chanIdx < IN865_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( IN865_NUMB_CHANNELS_CF_LIST + IN865_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel( &channelAdd );
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel( &channelRemove );
+        }
+    }
+}
+
+bool LoRaPHYIN865::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYIN865::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == IN865_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= IN865_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = IN865_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( IN865_ADR_ACK_LIMIT + IN865_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % IN865_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == IN865_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYIN865::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, IN865_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    if( rxConfigParams->Datarate == DR_7 )
+    { // FSK
+        tSymbol = compute_symb_timeout_fsk( DataratesIN865[rxConfigParams->Datarate] );
+    }
+    else
+    { // LoRa
+        tSymbol = compute_symb_timeout_lora( DataratesIN865[rxConfigParams->Datarate], BandwidthsIN865[rxConfigParams->Datarate] );
+    }
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYIN865::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    radio_modems_t modem;
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesIN865[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    if( dr == DR_7 )
+    {
+        modem = MODEM_FSK;
+        _radio->set_rx_config( modem, 50000, phyDr * 1000, 0, 83333, 5, rxConfig->WindowTimeout, false, 0, true, 0, 0, false, rxConfig->RxContinuous );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_rx_config( modem, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+    }
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterIN865[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateIN865[dr];
+    }
+    _radio->set_max_payload_length( modem, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYIN865::tx_config(TxConfigParams_t* txConfig, int8_t* txPower, TimerTime_t* txTimeOnAir)
+{
+    radio_modems_t modem;
+    int8_t phyDr = DataratesIN865[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, txConfig->MaxEirp, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    if( txConfig->Datarate == DR_7 )
+    { // High Speed FSK channel
+        modem = MODEM_FSK;
+        _radio->set_tx_config( modem, phyTxPower, 25000, bandwidth, phyDr * 1000, 0, 5, false, true, 0, 0, false, 3000 );
+    }
+    else
+    {
+        modem = MODEM_LORA;
+        _radio->set_tx_config( modem, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
+    }
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( modem, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air( modem, txConfig->PktLen );
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYIN865::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < IN865_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = IN865_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = IN865_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = IN865_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = IN865_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYIN865::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if( _radio->check_rf_frequency( rxParamSetupReq->Frequency ) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, IN865_RX_MIN_DATARATE, IN865_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, IN865_MIN_RX1_DR_OFFSET, IN865_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYIN865::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if( remove_channel( &channelRemove ) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch( add_channel( &channelAdd ) )
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYIN865::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYIN865::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+    uint8_t band = 0;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq( dlChannelReq->Rx1Frequency, &band, _radio ) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYIN865::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYIN865::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYIN865::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[IN865_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, IN865_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYIN865::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= IN865_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, IN865_TX_MIN_DATARATE, IN865_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < IN865_NUMB_DEFAULT_CHANNELS )
+    {
+        // Validate the datarate range for min: must be DR_0
+        if( channelAdd->NewChannel->DrRange.Fields.Min > DR_0 )
+        {
+            drInvalid = true;
+        }
+        // Validate the datarate range for max: must be DR_5 <= Max <= TX_MAX_DATARATE
+        if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, DR_5, IN865_TX_MAX_DATARATE ) == 0 )
+        {
+            drInvalid = true;
+        }
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, &band, _radio ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYIN865::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < IN865_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, IN865_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYIN865::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, continuousWave->MaxEirp, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYIN865::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr,
+                                      int8_t drOffset)
+{
+    // Apply offset formula
+    return MIN( DR_5, MAX( DR_0, dr - EffectiveRx1DrOffsetIN865[drOffset] ) );
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.h
@@ -1,0 +1,361 @@
+/**
+ *  @file LoRaPHYIN865.h
+ *
+ *  @brief Implements LoRaPHY for Indian 865 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_IN865_H_
+#define MBED_OS_LORAPHY_IN865_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define IN865_MAX_NB_CHANNELS                       16
+
+/*!
+ * Maximum number of bands
+ */
+#define IN865_MAX_NB_BANDS                          1
+
+
+#define IN865_CHANNELS_MASK_SIZE                    1
+
+
+class LoRaPHYIN865 : public LoRaPHY {
+
+public:
+
+    LoRaPHYIN865();
+    virtual ~LoRaPHYIN865();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details, please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pPointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[IN865_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[IN865_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[IN865_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[IN865_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_IN865_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -1,0 +1,1258 @@
+/**
+ *  @file LoRaPHYKR920.cpp
+ *
+ *  @brief Implements LoRaPHY for Korean 920 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYKR920.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Number of default channels
+ */
+#define KR920_NUMB_DEFAULT_CHANNELS                 3
+
+/*!
+ * Number of channels to apply for the CF list
+ */
+#define KR920_NUMB_CHANNELS_CF_LIST                 5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define KR920_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define KR920_TX_MAX_DATARATE                       DR_5
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define KR920_RX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define KR920_RX_MAX_DATARATE                       DR_5
+
+/*!
+ * Default datarate used by the node
+ */
+#define KR920_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define KR920_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define KR920_MAX_RX1_DR_OFFSET                     5
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define KR920_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define KR920_MIN_TX_POWER                          TX_POWER_7
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define KR920_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define KR920_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max EIRP for frequency 920.9 MHz - 921.9 MHz
+ */
+#define KR920_DEFAULT_MAX_EIRP_LOW                  10.0f
+
+/*!
+ * Default Max EIRP for frequency 922.1 MHz - 923.3 MHz
+ */
+#define KR920_DEFAULT_MAX_EIRP_HIGH                 14.0f
+
+/*!
+ * Default antenna gain
+ */
+#define KR920_DEFAULT_ANTENNA_GAIN                  2.15f
+
+/*!
+ * ADR Ack limit
+ */
+#define KR920_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define KR920_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define KR920_DUTY_CYCLE_ENABLED                    0
+
+/*!
+ * Maximum RX window duration
+ */
+#define KR920_MAX_RX_WINDOW                         4000
+
+/*!
+ * Receive delay 1
+ */
+#define KR920_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define KR920_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define KR920_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define KR920_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define KR920_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define KR920_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define KR920_ACK_TIMEOUT_RND                       1000
+
+#if ( KR920_DEFAULT_DATARATE > DR_5 )
+#error "A default DR higher than DR_5 may lead to connectivity loss."
+#endif
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define KR920_RX_WND_2_FREQ                         921900000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define KR920_RX_WND_2_DR                           DR_0
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define KR920_BAND0                                 { 1 , KR920_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * LoRaMac default channel 1
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define KR920_LC1                                   { 922100000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 2
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define KR920_LC2                                   { 922300000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac default channel 3
+ * Channel = { Frequency [Hz], RX1 Frequency [Hz], { ( ( DrMax << 4 ) | DrMin ) }, Band }
+ */
+#define KR920_LC3                                   { 922500000, 0, { ( ( DR_5 << 4 ) | DR_0 ) }, 0 }
+
+/*!
+ * LoRaMac channels which are allowed for the join procedure
+ */
+#define KR920_JOIN_CHANNELS                         ( uint16_t )( LC( 1 ) | LC( 2 ) | LC( 3 ) )
+
+/*!
+ * RSSI threshold for a free channel [dBm]
+ */
+#define KR920_RSSI_FREE_TH                          -65
+
+/*!
+ * Specifies the time the node performs a carrier sense
+ */
+#define KR920_CARRIER_SENSE_TIME                    6
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesKR920[]  = { 12, 11, 10,  9,  8,  7 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsKR920[] = { 125000, 125000, 125000, 125000, 125000, 125000 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with and without a repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateKR920[] = { 51, 51, 51, 115, 242, 242 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterKR920[] = { 51, 51, 51, 115, 222, 222 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static int8_t GetMaxEIRP( uint32_t freq )
+{
+    if( freq >= 922100000 )
+    {// Limit to 14dBm
+        return KR920_DEFAULT_MAX_EIRP_HIGH;
+    }
+    // Limit to 10dBm
+    return KR920_DEFAULT_MAX_EIRP_LOW;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsKR920[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    return txPowerResult;
+}
+
+static bool VerifyTxFreq( uint32_t freq, LoRaRadio *radio )
+{
+    uint32_t tmpFreq = freq;
+
+    // Check radio driver support
+    if( radio->check_rf_frequency( tmpFreq ) == false )
+    {
+        return false;
+    }
+
+    // Verify if the frequency is valid. The frequency must be in a specified
+    // range and can be set to specific values.
+    if( ( tmpFreq >= 920900000 ) && ( tmpFreq <=923300000 ) )
+    {
+        // Range ok, check for specific value
+        tmpFreq -= 920900000;
+        if( ( tmpFreq % 200000 ) == 0 )
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+uint8_t LoRaPHYKR920::CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < KR920_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( joined == false )
+                {
+                    if( ( KR920_JOIN_CHANNELS & ( 1 << j ) ) == 0 )
+                    {
+                        continue;
+                    }
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYKR920::LoRaPHYKR920()
+{
+    const Band_t band0 = KR920_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYKR920::~LoRaPHYKR920()
+{
+}
+
+PhyParam_t LoRaPHYKR920::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = KR920_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = KR920_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = KR920_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, KR920_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = KR920_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateKR920[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterKR920[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = KR920_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = KR920_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = KR920_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = KR920_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = KR920_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = KR920_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = KR920_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( KR920_ACKTIMEOUT + get_random( -KR920_ACK_TIMEOUT_RND, KR920_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = KR920_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = KR920_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = KR920_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = KR920_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        {
+            // We set the higher maximum EIRP as default value.
+            // The reason for this is, that the frequency may
+            // change during a channel selection for the next uplink.
+            // The value has to be recalculated in the TX configuration.
+            phyParam.fValue = KR920_DEFAULT_MAX_EIRP_HIGH;
+            break;
+        }
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = KR920_DEFAULT_ANTENNA_GAIN;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 48;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYKR920::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYKR920::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            const ChannelParams_t channel1 = KR920_LC1;
+            const ChannelParams_t channel2 = KR920_LC2;
+            const ChannelParams_t channel3 = KR920_LC3;
+            Channels[0] = channel1;
+            Channels[1] = channel2;
+            Channels[2] = channel3;
+
+            // Initialize the channels default mask
+            ChannelsDefaultMask[0] = LC( 1 ) + LC( 2 ) + LC( 3 );
+            // Update the channels mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 1 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Restore channels default mask
+            ChannelsMask[0] |= ChannelsDefaultMask[0];
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYKR920::verify( VerifyParams_t* verify, PhyAttribute_t phyAttribute )
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, KR920_TX_MIN_DATARATE, KR920_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, KR920_RX_MIN_DATARATE, KR920_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, KR920_MAX_TX_POWER, KR920_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return KR920_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 48 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYKR920::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    ChannelParams_t newChannel;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    // Setup default datarate range
+    newChannel.DrRange.Value = ( DR_5 << 4 ) | DR_0;
+
+    // Size of the optional CF list
+    if( applyCFList->Size != 16 )
+    {
+        return;
+    }
+
+    // Last byte is RFU, don't take it into account
+    for( uint8_t i = 0, chanIdx = KR920_NUMB_DEFAULT_CHANNELS; chanIdx < KR920_MAX_NB_CHANNELS; i+=3, chanIdx++ )
+    {
+        if( chanIdx < ( KR920_NUMB_CHANNELS_CF_LIST + KR920_NUMB_DEFAULT_CHANNELS ) )
+        {
+            // Channel frequency
+            newChannel.Frequency = (uint32_t) applyCFList->Payload[i];
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 1] << 8 );
+            newChannel.Frequency |= ( (uint32_t) applyCFList->Payload[i + 2] << 16 );
+            newChannel.Frequency *= 100;
+
+            // Initialize alternative frequency to 0
+            newChannel.Rx1Frequency = 0;
+        }
+        else
+        {
+            newChannel.Frequency = 0;
+            newChannel.DrRange.Value = 0;
+            newChannel.Rx1Frequency = 0;
+        }
+
+        if( newChannel.Frequency != 0 )
+        {
+            channelAdd.NewChannel = &newChannel;
+            channelAdd.ChannelId = chanIdx;
+
+            // Try to add all channels
+            add_channel( &channelAdd );
+        }
+        else
+        {
+            channelRemove.ChannelId = chanIdx;
+
+            remove_channel( &channelRemove );
+        }
+    }
+}
+
+bool LoRaPHYKR920::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 1 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYKR920::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == KR920_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= KR920_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = KR920_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( KR920_ADR_ACK_LIMIT + KR920_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % KR920_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == KR920_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYKR920::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, KR920_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    tSymbol = compute_symb_timeout_lora( DataratesKR920[rxConfigParams->Datarate], BandwidthsKR920[rxConfigParams->Datarate] );
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYKR920::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = Channels[rxConfig->Channel].Frequency;
+        // Apply the alternative RX 1 window frequency, if it is available
+        if( Channels[rxConfig->Channel].Rx1Frequency != 0 )
+        {
+            frequency = Channels[rxConfig->Channel].Rx1Frequency;
+        }
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesKR920[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    _radio->set_rx_config( MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                           rxConfig->WindowTimeout, false, 0, false, 0, 0, true,
+                           rxConfig->RxContinuous );
+    maxPayload = MaxPayloadOfDatarateKR920[dr];
+    _radio->set_max_payload_length( MODEM_LORA, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYKR920::tx_config(TxConfigParams_t* txConfig, int8_t* txPower, TimerTime_t* txTimeOnAir)
+{
+    int8_t phyDr = DataratesKR920[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    float maxEIRP = GetMaxEIRP( Channels[txConfig->Channel].Frequency );
+    int8_t phyTxPower = 0;
+
+    // Take the minimum between the maxEIRP and txConfig->MaxEirp.
+    // The value of txConfig->MaxEirp could have changed during runtime, e.g. due to a MAC command.
+    maxEIRP = MIN( txConfig->MaxEirp, maxEIRP );
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, maxEIRP, txConfig->AntennaGain );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    _radio->set_tx_config( MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( MODEM_LORA, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir =_radio->time_on_air( MODEM_LORA, txConfig->PktLen );
+
+    *txPower = txPowerLimited;
+    return true;
+}
+
+uint8_t LoRaPHYKR920::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t chMask = 0;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        // Get ADR request parameters
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        // Setup temporary channels mask
+        chMask = linkAdrParams.ChMask;
+
+        // Verify channels mask
+        if( ( linkAdrParams.ChMaskCtrl == 0 ) && ( chMask == 0 ) )
+        {
+            status &= 0xFE; // Channel mask KO
+        }
+        else if( ( ( linkAdrParams.ChMaskCtrl >= 1 ) && ( linkAdrParams.ChMaskCtrl <= 5 )) ||
+                ( linkAdrParams.ChMaskCtrl >= 7 ) )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            for( uint8_t i = 0; i < KR920_MAX_NB_CHANNELS; i++ )
+            {
+                if( linkAdrParams.ChMaskCtrl == 6 )
+                {
+                    if( Channels[i].Frequency != 0 )
+                    {
+                        chMask |= 1 << i;
+                    }
+                }
+                else
+                {
+                    if( ( ( chMask & ( 1 << i ) ) != 0 ) &&
+                        ( Channels[i].Frequency == 0 ) )
+                    {// Trying to enable an undefined channel
+                        status &= 0xFE; // Channel mask KO
+                    }
+                }
+            }
+        }
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = KR920_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = &chMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = KR920_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = KR920_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = KR920_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Set the channels mask to a default value
+        memset( ChannelsMask, 0, sizeof( ChannelsMask ) );
+        // Update the channels mask
+        ChannelsMask[0] = chMask;
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYKR920::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+
+    // Verify radio frequency
+    if(_radio->check_rf_frequency( rxParamSetupReq->Frequency ) == false )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, KR920_RX_MIN_DATARATE, KR920_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, KR920_MIN_RX1_DR_OFFSET, KR920_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYKR920::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    uint8_t status = 0x03;
+    ChannelAddParams_t channelAdd;
+    ChannelRemoveParams_t channelRemove;
+
+    if( newChannelReq->NewChannel->Frequency == 0 )
+    {
+        channelRemove.ChannelId = newChannelReq->ChannelId;
+
+        // Remove
+        if( remove_channel( &channelRemove ) == false )
+        {
+            status &= 0xFC;
+        }
+    }
+    else
+    {
+        channelAdd.NewChannel = newChannelReq->NewChannel;
+        channelAdd.ChannelId = newChannelReq->ChannelId;
+
+        switch( add_channel( &channelAdd ) )
+        {
+            case LORAMAC_STATUS_OK:
+            {
+                break;
+            }
+            case LORAMAC_STATUS_FREQUENCY_INVALID:
+            {
+                status &= 0xFE;
+                break;
+            }
+            case LORAMAC_STATUS_DATARATE_INVALID:
+            {
+                status &= 0xFD;
+                break;
+            }
+            case LORAMAC_STATUS_FREQ_AND_DR_INVALID:
+            {
+                status &= 0xFC;
+                break;
+            }
+            default:
+            {
+                status &= 0xFC;
+                break;
+            }
+        }
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYKR920::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYKR920::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    uint8_t status = 0x03;
+
+    // Verify if the frequency is supported
+    if( VerifyTxFreq( dlChannelReq->Rx1Frequency, _radio ) == false )
+    {
+        status &= 0xFE;
+    }
+
+    // Verify if an uplink frequency exists
+    if( Channels[dlChannelReq->ChannelId].Frequency == 0 )
+    {
+        status &= 0xFD;
+    }
+
+    // Apply Rx1 frequency, if the status is OK
+    if( status == 0x03 )
+    {
+        Channels[dlChannelReq->ChannelId].Rx1Frequency = dlChannelReq->Rx1Frequency;
+    }
+
+    return status;
+}
+
+int8_t LoRaPHYKR920::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    if( ( alternateDr->NbTrials % 48 ) == 0 )
+    {
+        datarate = DR_0;
+    }
+    else if( ( alternateDr->NbTrials % 32 ) == 0 )
+    {
+        datarate = DR_1;
+    }
+    else if( ( alternateDr->NbTrials % 24 ) == 0 )
+    {
+        datarate = DR_2;
+    }
+    else if( ( alternateDr->NbTrials % 16 ) == 0 )
+    {
+        datarate = DR_3;
+    }
+    else if( ( alternateDr->NbTrials % 8 ) == 0 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_5;
+    }
+    return datarate;
+}
+
+void LoRaPHYKR920::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYKR920::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t channelNext = 0;
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[KR920_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    if( num_active_channels( ChannelsMask, 0, 1 ) == 0 )
+    { // Reactivate default channels
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, KR920_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Joined, nextChanParams->Datarate,
+                                                      ChannelsMask, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        for( uint8_t  i = 0, j = get_random( 0, nbEnabledChannels - 1 ); i < KR920_MAX_NB_CHANNELS; i++ )
+        {
+            channelNext = enabledChannels[j];
+            j = ( j + 1 ) % nbEnabledChannels;
+
+            // Perform carrier sense for KR920_CARRIER_SENSE_TIME
+            // If the channel is free, we can stop the LBT mechanism
+            if( _radio->perform_carrier_sense( MODEM_LORA,
+                                               Channels[channelNext].Frequency,
+                                               KR920_RSSI_FREE_TH,
+                                               KR920_CARRIER_SENSE_TIME ) == true )
+            {
+                // Free channel found
+                *channel = channelNext;
+                *time = 0;
+                return true;
+            }
+        }
+        return false;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel, restore defaults
+        ChannelsMask[0] |= LC( 1 ) + LC( 2 ) + LC( 3 );
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYKR920::add_channel(ChannelAddParams_t* channelAdd)
+{
+    uint8_t band = 0;
+    bool drInvalid = false;
+    bool freqInvalid = false;
+    uint8_t id = channelAdd->ChannelId;
+
+    if( id >= KR920_MAX_NB_CHANNELS )
+    {
+        return LORAMAC_STATUS_PARAMETER_INVALID;
+    }
+
+    // Validate the datarate range
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Min, KR920_TX_MIN_DATARATE, KR920_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( val_in_range( channelAdd->NewChannel->DrRange.Fields.Max, KR920_TX_MIN_DATARATE, KR920_TX_MAX_DATARATE ) == 0 )
+    {
+        drInvalid = true;
+    }
+    if( channelAdd->NewChannel->DrRange.Fields.Min > channelAdd->NewChannel->DrRange.Fields.Max )
+    {
+        drInvalid = true;
+    }
+
+    // Default channels don't accept all values
+    if( id < KR920_NUMB_DEFAULT_CHANNELS )
+    {
+        // All datarates are supported
+        // We are not allowed to change the frequency
+        if( channelAdd->NewChannel->Frequency != Channels[id].Frequency )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check frequency
+    if( freqInvalid == false )
+    {
+        if( VerifyTxFreq( channelAdd->NewChannel->Frequency, _radio ) == false )
+        {
+            freqInvalid = true;
+        }
+    }
+
+    // Check status
+    if( ( drInvalid == true ) && ( freqInvalid == true ) )
+    {
+        return LORAMAC_STATUS_FREQ_AND_DR_INVALID;
+    }
+    if( drInvalid == true )
+    {
+        return LORAMAC_STATUS_DATARATE_INVALID;
+    }
+    if( freqInvalid == true )
+    {
+        return LORAMAC_STATUS_FREQUENCY_INVALID;
+    }
+
+    memcpy( &(Channels[id]), channelAdd->NewChannel, sizeof( Channels[id] ) );
+    Channels[id].Band = band;
+    ChannelsMask[0] |= ( 1 << id );
+    return LORAMAC_STATUS_OK;
+}
+
+bool LoRaPHYKR920::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    uint8_t id = channelRemove->ChannelId;
+
+    if( id < KR920_NUMB_DEFAULT_CHANNELS )
+    {
+        return false;
+    }
+
+    // Remove the channel from the list of channels
+    const ChannelParams_t empty_channel = { 0, 0, { 0 }, 0 };
+    Channels[id] = empty_channel;
+
+    return disable_channel( ChannelsMask, id, KR920_MAX_NB_CHANNELS );
+}
+
+void LoRaPHYKR920::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    float maxEIRP = GetMaxEIRP( Channels[continuousWave->Channel].Frequency );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Take the minimum between the maxEIRP and continuousWave->MaxEirp.
+    // The value of continuousWave->MaxEirp could have changed during runtime, e.g. due to a MAC command.
+    maxEIRP = MIN( continuousWave->MaxEirp, maxEIRP );
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, maxEIRP, continuousWave->AntennaGain );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYKR920::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset)
+{
+    int8_t datarate = dr - drOffset;
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.h
@@ -1,0 +1,359 @@
+/**
+ *  @file LoRaPHYKR920.h
+ *
+ *  @brief Implements LoRaPHY for Korean 920 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_KR920_H_
+#define MBED_OS_LORAPHY_KR920_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define KR920_MAX_NB_CHANNELS                       16
+
+/*!
+ * Maximum number of bands
+ */
+#define KR920_MAX_NB_BANDS                          1
+
+#define KR920_CHANNELS_MASK_SIZE                    1
+
+
+class LoRaPHYKR920 : public LoRaPHY {
+
+public:
+
+    LoRaPHYKR920();
+    virtual ~LoRaPHYKR920();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details, please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+    uint8_t CountNbOfEnabledChannels( bool joined, uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[KR920_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[KR920_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[KR920_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[KR920_CHANNELS_MASK_SIZE];
+};
+
+#endif // MBED_OS_LORAPHY_KR920_H_
+

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -1,0 +1,1037 @@
+/**
+ *  @file LoRaPHUS915.cpp
+ *
+ *  @brief Implements LoRaPHY for US 915 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYUS915.h"
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define US915_TX_MIN_DATARATE                       DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define US915_TX_MAX_DATARATE                       DR_4
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define US915_RX_MIN_DATARATE                       DR_8
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define US915_RX_MAX_DATARATE                       DR_13
+
+/*!
+ * Default datarate used by the node
+ */
+#define US915_DEFAULT_DATARATE                      DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define US915_MIN_RX1_DR_OFFSET                     0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define US915_MAX_RX1_DR_OFFSET                     3
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define US915_DEFAULT_RX1_DR_OFFSET                 0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define US915_MIN_TX_POWER                          TX_POWER_10
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define US915_MAX_TX_POWER                          TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define US915_DEFAULT_TX_POWER                      TX_POWER_0
+
+/*!
+ * Default Max ERP
+ */
+#define US915_DEFAULT_MAX_ERP                      30.0f
+
+/*!
+ * ADR Ack limit
+ */
+#define US915_ADR_ACK_LIMIT                         64
+
+/*!
+ * ADR Ack delay
+ */
+#define US915_ADR_ACK_DELAY                         32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define US915_DUTY_CYCLE_ENABLED                    0
+
+/*!
+ * Maximum RX window duration
+ */
+#define US915_MAX_RX_WINDOW                         3000
+
+/*!
+ * Receive delay 1
+ */
+#define US915_RECEIVE_DELAY1                        1000
+
+/*!
+ * Receive delay 2
+ */
+#define US915_RECEIVE_DELAY2                        2000
+
+/*!
+ * Join accept delay 1
+ */
+#define US915_JOIN_ACCEPT_DELAY1                    5000
+
+/*!
+ * Join accept delay 2
+ */
+#define US915_JOIN_ACCEPT_DELAY2                    6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define US915_MAX_FCNT_GAP                          16384
+
+/*!
+ * Ack timeout
+ */
+#define US915_ACKTIMEOUT                            2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define US915_ACK_TIMEOUT_RND                       1000
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define US915_RX_WND_2_FREQ                         923300000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define US915_RX_WND_2_DR                           DR_8
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define US915_BAND0                                 { 1, US915_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * Defines the first channel for RX window 1 for US band
+ */
+#define US915_FIRST_RX1_CHANNEL                     ( (uint32_t) 923300000 )
+
+/*!
+ * Defines the last channel for RX window 1 for US band
+ */
+#define US915_LAST_RX1_CHANNEL                      ( (uint32_t) 927500000 )
+
+/*!
+ * Defines the step width of the channels for RX window 1
+ */
+#define US915_STEPWIDTH_RX1_CHANNEL                 ( (uint32_t) 600000 )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesUS915[]  = { 10, 9, 8,  7,  8,  0,  0, 0, 12, 11, 10, 9, 8, 7, 0, 0 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsUS915[] = { 125000, 125000, 125000, 125000, 500000, 0, 0, 0, 500000, 500000, 500000, 500000, 500000, 500000, 0, 0 };
+
+/*!
+ * Up/Down link data rates offset definition
+ */
+static const int8_t DatarateOffsetsUS915[5][4] =
+{
+    { DR_10, DR_9 , DR_8 , DR_8  }, // DR_0
+    { DR_11, DR_10, DR_9 , DR_8  }, // DR_1
+    { DR_12, DR_11, DR_10, DR_9  }, // DR_2
+    { DR_13, DR_12, DR_11, DR_10 }, // DR_3
+    { DR_13, DR_13, DR_12, DR_11 }, // DR_4
+};
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateUS915[] = { 11, 53, 125, 242, 242, 0, 0, 0, 53, 129, 242, 242, 242, 242, 0, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterUS915[] = { 11, 53, 125, 242, 242, 0, 0, 0, 33, 109, 222, 222, 222, 222, 0, 0 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsUS915[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+int8_t LoRaPHYUS915::LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    if( datarate == DR_4 )
+    {// Limit tx power to max 26dBm
+        txPowerResult = MAX( txPower, TX_POWER_2 );
+    }
+    else
+    {
+        if( num_active_channels( channelsMask, 0, 4 ) < 50 )
+        {// Limit tx power to max 21dBm
+            txPowerResult = MAX( txPower, TX_POWER_5 );
+        }
+    }
+    return txPowerResult;
+}
+
+uint8_t LoRaPHYUS915::CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < US915_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYUS915::LoRaPHYUS915()
+{
+    const Band_t band0 = US915_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYUS915::~LoRaPHYUS915()
+{
+}
+
+PhyParam_t LoRaPHYUS915::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = US915_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = US915_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = US915_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, US915_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = US915_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateUS915[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterUS915[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = US915_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = US915_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = US915_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = US915_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = US915_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = US915_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = US915_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( US915_ACKTIMEOUT + get_random( -US915_ACK_TIMEOUT_RND, US915_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = US915_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = US915_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = US915_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = US915_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = 0;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 2;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYUS915::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYUS915::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            // 125 kHz channels
+            for( uint8_t i = 0; i < US915_MAX_NB_CHANNELS - 8; i++ )
+            {
+                Channels[i].Frequency = 902300000 + i * 200000;
+                Channels[i].DrRange.Value = ( DR_3 << 4 ) | DR_0;
+                Channels[i].Band = 0;
+            }
+            // 500 kHz channels
+            for( uint8_t i = US915_MAX_NB_CHANNELS - 8; i < US915_MAX_NB_CHANNELS; i++ )
+            {
+                Channels[i].Frequency = 903000000 + ( i - ( US915_MAX_NB_CHANNELS - 8 ) ) * 1600000;
+                Channels[i].DrRange.Value = ( DR_4 << 4 ) | DR_4;
+                Channels[i].Band = 0;
+            }
+
+            // ChannelsMask
+            ChannelsDefaultMask[0] = 0xFFFF;
+            ChannelsDefaultMask[1] = 0xFFFF;
+            ChannelsDefaultMask[2] = 0xFFFF;
+            ChannelsDefaultMask[3] = 0xFFFF;
+            ChannelsDefaultMask[4] = 0x00FF;
+            ChannelsDefaultMask[5] = 0x0000;
+
+            // Copy channels default mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 6 );
+
+            // Copy into channels mask remaining
+            copy_channel_mask( ChannelsMaskRemaining, ChannelsMask, 6 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            // Copy channels default mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 6 );
+
+            for( uint8_t i = 0; i < 6; i++ )
+            { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYUS915::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, US915_TX_MIN_DATARATE, US915_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, US915_RX_MIN_DATARATE, US915_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, US915_MAX_TX_POWER, US915_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return US915_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 2 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYUS915::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    return;
+}
+
+bool LoRaPHYUS915::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    uint8_t nbChannels = num_active_channels( chanMaskSet->ChannelsMaskIn, 0, 4 );
+
+    // Check the number of active channels
+    if( ( nbChannels < 2 ) &&
+        ( nbChannels > 0 ) )
+    {
+        return false;
+    }
+
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 6 );
+
+            for( uint8_t i = 0; i < 6; i++ )
+            { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 6 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYUS915::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == US915_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= US915_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = US915_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( US915_ADR_ACK_LIMIT + US915_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % US915_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == US915_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ChannelsMask[0] = 0xFFFF;
+                            ChannelsMask[1] = 0xFFFF;
+                            ChannelsMask[2] = 0xFFFF;
+                            ChannelsMask[3] = 0xFFFF;
+                            ChannelsMask[4] = 0x00FF;
+                            ChannelsMask[5] = 0x0000;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYUS915::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                         uint32_t rxError,
+                                         RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, US915_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    tSymbol = compute_symb_timeout_lora( DataratesUS915[rxConfigParams->Datarate], BandwidthsUS915[rxConfigParams->Datarate] );
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYUS915::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if(_radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = US915_FIRST_RX1_CHANNEL + ( rxConfig->Channel % 8 ) * US915_STEPWIDTH_RX1_CHANNEL;
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesUS915[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    _radio->set_rx_config( MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8,
+                           rxConfig->WindowTimeout, false, 0, false, 0, 0, true,
+                           rxConfig->RxContinuous );
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterUS915[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateUS915[dr];
+    }
+    _radio->set_max_payload_length( MODEM_LORA, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYUS915::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                             TimerTime_t* txTimeOnAir)
+{
+    int8_t phyDr = DataratesUS915[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, US915_DEFAULT_MAX_ERP, 0 );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    _radio->set_tx_config( MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8,
+                           false, true, 0, 0, false, 3000 );
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( MODEM_LORA, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air( MODEM_LORA, txConfig->PktLen );
+    *txPower = txPowerLimited;
+
+    return true;
+}
+
+uint8_t LoRaPHYUS915::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                       int8_t* drOut, int8_t* txPowOut,
+                                       uint8_t* nbRepOut, uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t channelsMask[6] = { 0, 0, 0, 0, 0, 0 };
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    // Initialize local copy of channels mask
+    copy_channel_mask( channelsMask, ChannelsMask, 6 );
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        if( linkAdrParams.ChMaskCtrl == 6 )
+        {
+            // Enable all 125 kHz channels
+            channelsMask[0] = 0xFFFF;
+            channelsMask[1] = 0xFFFF;
+            channelsMask[2] = 0xFFFF;
+            channelsMask[3] = 0xFFFF;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        }
+        else if( linkAdrParams.ChMaskCtrl == 7 )
+        {
+            // Disable all 125 kHz channels
+            channelsMask[0] = 0x0000;
+            channelsMask[1] = 0x0000;
+            channelsMask[2] = 0x0000;
+            channelsMask[3] = 0x0000;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        }
+        else if( linkAdrParams.ChMaskCtrl == 5 )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            channelsMask[linkAdrParams.ChMaskCtrl] = linkAdrParams.ChMask;
+        }
+    }
+
+    // FCC 15.247 paragraph F mandates to hop on at least 2 125 kHz channels
+    if( ( linkAdrParams.Datarate < DR_4 ) && ( num_active_channels( channelsMask, 0, 4 ) < 2 ) )
+    {
+        status &= 0xFE; // Channel mask KO
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = US915_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = channelsMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = US915_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = US915_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = US915_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Copy Mask
+        copy_channel_mask( ChannelsMask, channelsMask, 6 );
+
+        ChannelsMaskRemaining[0] &= ChannelsMask[0];
+        ChannelsMaskRemaining[1] &= ChannelsMask[1];
+        ChannelsMaskRemaining[2] &= ChannelsMask[2];
+        ChannelsMaskRemaining[3] &= ChannelsMask[3];
+        ChannelsMaskRemaining[4] = ChannelsMask[4];
+        ChannelsMaskRemaining[5] = ChannelsMask[5];
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYUS915::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+    uint32_t freq = rxParamSetupReq->Frequency;
+
+    // Verify radio frequency
+    if( ( _radio->check_rf_frequency( freq ) == false ) ||
+        ( freq < US915_FIRST_RX1_CHANNEL ) ||
+        ( freq > US915_LAST_RX1_CHANNEL ) ||
+        ( ( ( freq - ( uint32_t ) US915_FIRST_RX1_CHANNEL ) % ( uint32_t ) US915_STEPWIDTH_RX1_CHANNEL ) != 0 ) )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, US915_RX_MIN_DATARATE, US915_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+    if( ( val_in_range( rxParamSetupReq->Datarate, DR_5, DR_7 ) == 1 ) ||
+        ( rxParamSetupReq->Datarate > DR_13 ) )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, US915_MIN_RX1_DR_OFFSET, US915_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYUS915::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    // Datarate and frequency KO
+    return 0;
+}
+
+int8_t LoRaPHYUS915::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYUS915::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    return 0;
+}
+
+int8_t LoRaPHYUS915::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    // Re-enable 500 kHz default channels
+    ChannelsMask[4] = 0x00FF;
+
+    if( ( alternateDr->NbTrials & 0x01 ) == 0x01 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}
+
+void LoRaPHYUS915::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYUS915::set_next_channel(NextChanParams_t* nextChanParams,
+                                    uint8_t* channel, TimerTime_t* time,
+                                    TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[US915_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    // Count 125kHz channels
+    if( num_active_channels( ChannelsMaskRemaining, 0, 4 ) == 0 )
+    { // Reactivate default channels
+        copy_channel_mask( ChannelsMaskRemaining, ChannelsMask, 4  );
+    }
+    // Check other channels
+    if( nextChanParams->Datarate >= DR_4 )
+    {
+        if( ( ChannelsMaskRemaining[4] & 0x00FF ) == 0 )
+        {
+            ChannelsMaskRemaining[4] = ChannelsMask[4];
+        }
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, US915_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Datarate,
+                                                      ChannelsMaskRemaining, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+        // Disable the channel in the mask
+        disable_channel( ChannelsMaskRemaining, *channel, US915_MAX_NB_CHANNELS - 8 );
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYUS915::add_channel(ChannelAddParams_t* channelAdd)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+bool LoRaPHYUS915::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+void LoRaPHYUS915::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, US915_DEFAULT_MAX_ERP, 0 );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYUS915::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr,
+                                      int8_t drOffset)
+{
+    int8_t datarate = DatarateOffsetsUS915[dr][drOffset];
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.h
@@ -1,0 +1,365 @@
+/**
+ *  @file LoRaPHYUS915.h
+ *
+ *  @brief Implements LoRaPHY for US 915 MHz band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHYUS_915_H_
+#define MBED_OS_LORAPHYUS_915_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define US915_MAX_NB_CHANNELS                       72
+
+/*!
+ * LoRaMac maximum number of bands
+ */
+#define US915_MAX_NB_BANDS                          1
+
+#define US915_CHANNELS_MASK_SIZE                    6
+
+
+class LoRaPHYUS915 : public LoRaPHY {
+
+public:
+
+    LoRaPHYUS915();
+    virtual ~LoRaPHYUS915();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details, please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask );
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[US915_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[US915_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[US915_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels remaining
+     */
+    uint16_t ChannelsMaskRemaining[US915_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[US915_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_US915_H_ */

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -1,0 +1,1127 @@
+/**
+ *  @file LoRaPHYUS915Hybrid.cpp
+ *
+ *  @brief Implements LoRaPHY for US 915 MHz Hybrid band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#include "LoRaPHYUS915Hybrid.h"
+
+#include "lora_phy_ds.h"
+#include "LoRaRadio.h"
+
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define US915_HYBRID_TX_MIN_DATARATE                DR_0
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define US915_HYBRID_TX_MAX_DATARATE                DR_4
+
+/*!
+ * Minimal datarate that can be used by the node
+ */
+#define US915_HYBRID_RX_MIN_DATARATE                DR_8
+
+/*!
+ * Maximal datarate that can be used by the node
+ */
+#define US915_HYBRID_RX_MAX_DATARATE                DR_13
+
+/*!
+ * Default datarate used by the node
+ */
+#define US915_HYBRID_DEFAULT_DATARATE               DR_0
+
+/*!
+ * Minimal Rx1 receive datarate offset
+ */
+#define US915_HYBRID_MIN_RX1_DR_OFFSET              0
+
+/*!
+ * Maximal Rx1 receive datarate offset
+ */
+#define US915_HYBRID_MAX_RX1_DR_OFFSET              3
+
+/*!
+ * Default Rx1 receive datarate offset
+ */
+#define US915_HYBRID_DEFAULT_RX1_DR_OFFSET          0
+
+/*!
+ * Minimal Tx output power that can be used by the node
+ */
+#define US915_HYBRID_MIN_TX_POWER                   TX_POWER_10
+
+/*!
+ * Maximal Tx output power that can be used by the node
+ */
+#define US915_HYBRID_MAX_TX_POWER                   TX_POWER_0
+
+/*!
+ * Default Tx output power used by the node
+ */
+#define US915_HYBRID_DEFAULT_TX_POWER               TX_POWER_0
+
+/*!
+ * Default Max ERP
+ */
+#define US915_HYBRID_DEFAULT_MAX_ERP                30.0f
+
+/*!
+ * ADR Ack limit
+ */
+#define US915_HYBRID_ADR_ACK_LIMIT                  64
+
+/*!
+ * ADR Ack delay
+ */
+#define US915_HYBRID_ADR_ACK_DELAY                  32
+
+/*!
+ * Enabled or disabled the duty cycle
+ */
+#define US915_HYBRID_DUTY_CYCLE_ENABLED             0
+
+/*!
+ * Maximum RX window duration
+ */
+#define US915_HYBRID_MAX_RX_WINDOW                  3000
+
+/*!
+ * Receive delay 1
+ */
+#define US915_HYBRID_RECEIVE_DELAY1                 1000
+
+/*!
+ * Receive delay 2
+ */
+#define US915_HYBRID_RECEIVE_DELAY2                 2000
+
+/*!
+ * Join accept delay 1
+ */
+#define US915_HYBRID_JOIN_ACCEPT_DELAY1             5000
+
+/*!
+ * Join accept delay 2
+ */
+#define US915_HYBRID_JOIN_ACCEPT_DELAY2             6000
+
+/*!
+ * Maximum frame counter gap
+ */
+#define US915_HYBRID_MAX_FCNT_GAP                   16384
+
+/*!
+ * Ack timeout
+ */
+#define US915_HYBRID_ACKTIMEOUT                     2000
+
+/*!
+ * Random ack timeout limits
+ */
+#define US915_HYBRID_ACK_TIMEOUT_RND                1000
+
+/*!
+ * Second reception window channel frequency definition.
+ */
+#define US915_HYBRID_RX_WND_2_FREQ                  923300000
+
+/*!
+ * Second reception window channel datarate definition.
+ */
+#define US915_HYBRID_RX_WND_2_DR                    DR_8
+
+/*!
+ * Band 0 definition
+ * { DutyCycle, TxMaxPower, LastTxDoneTime, TimeOff }
+ */
+#define US915_HYBRID_BAND0                          { 1, US915_HYBRID_MAX_TX_POWER, 0,  0 } //  100.0 %
+
+/*!
+ * Defines the first channel for RX window 1 for US band
+ */
+#define US915_HYBRID_FIRST_RX1_CHANNEL              ( (uint32_t) 923300000 )
+
+/*!
+ * Defines the last channel for RX window 1 for US band
+ */
+#define US915_HYBRID_LAST_RX1_CHANNEL               ( (uint32_t) 927500000 )
+
+/*!
+ * Defines the step width of the channels for RX window 1
+ */
+#define US915_HYBRID_STEPWIDTH_RX1_CHANNEL          ( (uint32_t) 600000 )
+
+/*!
+ * Data rates table definition
+ */
+static const uint8_t DataratesUS915_HYBRID[]  = { 10, 9, 8,  7,  8,  0,  0, 0, 12, 11, 10, 9, 8, 7, 0, 0 };
+
+/*!
+ * Bandwidths table definition in Hz
+ */
+static const uint32_t BandwidthsUS915_HYBRID[] = { 125000, 125000, 125000, 125000, 500000, 0, 0, 0, 500000, 500000, 500000, 500000, 500000, 500000, 0, 0 };
+
+/*!
+ * Up/Down link data rates offset definition
+ */
+static const int8_t DatarateOffsetsUS915_HYBRID[5][4] =
+{
+    { DR_10, DR_9 , DR_8 , DR_8  }, // DR_0
+    { DR_11, DR_10, DR_9 , DR_8  }, // DR_1
+    { DR_12, DR_11, DR_10, DR_9  }, // DR_2
+    { DR_13, DR_12, DR_11, DR_10 }, // DR_3
+    { DR_13, DR_13, DR_12, DR_11 }, // DR_4
+};
+
+/*!
+ * Maximum payload with respect to the datarate index. Cannot operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateUS915_HYBRID[] = { 11, 53, 125, 242, 242, 0, 0, 0, 53, 129, 242, 242, 242, 242, 0, 0 };
+
+/*!
+ * Maximum payload with respect to the datarate index. Can operate with repeater.
+ */
+static const uint8_t MaxPayloadOfDatarateRepeaterUS915_HYBRID[] = { 11, 53, 125, 242, 242, 0, 0, 0, 33, 109, 222, 222, 222, 222, 0, 0 };
+
+
+// Static functions
+static int8_t GetNextLowerTxDr( int8_t dr, int8_t minDr )
+{
+    uint8_t nextLowerDr = 0;
+
+    if( dr == minDr )
+    {
+        nextLowerDr = minDr;
+    }
+    else
+    {
+        nextLowerDr = dr - 1;
+    }
+    return nextLowerDr;
+}
+
+static uint32_t GetBandwidth( uint32_t drIndex )
+{
+    switch( BandwidthsUS915_HYBRID[drIndex] )
+    {
+        default:
+        case 125000:
+            return 0;
+        case 250000:
+            return 1;
+        case 500000:
+            return 2;
+    }
+}
+
+static void ReenableChannels( uint16_t mask, uint16_t* channelsMask )
+{
+    uint16_t blockMask = mask;
+
+    for( uint8_t i = 0, j = 0; i < 4; i++, j += 2 )
+    {
+        channelsMask[i] = 0;
+        if( ( blockMask & ( 1 << j ) ) != 0 )
+        {
+            channelsMask[i] |= 0x00FF;
+        }
+        if( ( blockMask & ( 1 << ( j + 1 ) ) ) != 0 )
+        {
+            channelsMask[i] |= 0xFF00;
+        }
+    }
+    channelsMask[4] = blockMask;
+    channelsMask[5] = 0x0000;
+}
+
+static uint8_t CountBits( uint16_t mask, uint8_t nbBits )
+{
+    uint8_t nbActiveBits = 0;
+
+    for( uint8_t j = 0; j < nbBits; j++ )
+    {
+        if( ( mask & ( 1 << j ) ) == ( 1 << j ) )
+        {
+            nbActiveBits++;
+        }
+    }
+    return nbActiveBits;
+}
+
+int8_t LoRaPHYUS915Hybrid::LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask )
+{
+    int8_t txPowerResult = txPower;
+
+    // Limit tx power to the band max
+    txPowerResult =  MAX( txPower, maxBandTxPower );
+
+    if( datarate == DR_4 )
+    {// Limit tx power to max 26dBm
+        txPowerResult = MAX( txPower, TX_POWER_2 );
+    }
+    else
+    {
+        if( num_active_channels( channelsMask, 0, 4 ) < 50 )
+        {// Limit tx power to max 21dBm
+            txPowerResult = MAX( txPower, TX_POWER_5 );
+        }
+    }
+    return txPowerResult;
+}
+
+static bool ValidateChannelsMask( uint16_t* channelsMask )
+{
+    bool chanMaskState = false;
+    uint16_t block1 = 0;
+    uint16_t block2 = 0;
+    uint8_t index = 0;
+    uint16_t channelsMaskCpy[6];
+
+    // Copy channels mask to not change the input
+    for( uint8_t i = 0; i < 4; i++ )
+    {
+        channelsMaskCpy[i] = channelsMask[i];
+    }
+
+    for( uint8_t i = 0; i < 4; i++ )
+    {
+        block1 = channelsMaskCpy[i] & 0x00FF;
+        block2 = channelsMaskCpy[i] & 0xFF00;
+
+        if( CountBits( block1, 16 ) > 5 )
+        {
+            channelsMaskCpy[i] &= block1;
+            channelsMaskCpy[4] = 1 << ( i * 2 );
+            chanMaskState = true;
+            index = i;
+            break;
+        }
+        else if( CountBits( block2, 16 ) > 5 )
+        {
+            channelsMaskCpy[i] &= block2;
+            channelsMaskCpy[4] = 1 << ( i * 2 + 1 );
+            chanMaskState = true;
+            index = i;
+            break;
+        }
+    }
+
+    // Do only change the channel mask, if we have found a valid block.
+    if( chanMaskState == true )
+    {
+        // Copy channels mask back again
+        for( uint8_t i = 0; i < 4; i++ )
+        {
+            channelsMask[i] = channelsMaskCpy[i];
+
+            if( i != index )
+            {
+                channelsMask[i] = 0;
+            }
+        }
+        channelsMask[4] = channelsMaskCpy[4];
+    }
+    return chanMaskState;
+}
+
+uint8_t LoRaPHYUS915Hybrid::CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx )
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTransmission = 0;
+
+    for( uint8_t i = 0, k = 0; i < US915_HYBRID_MAX_NB_CHANNELS; i += 16, k++ )
+    {
+        for( uint8_t j = 0; j < 16; j++ )
+        {
+            if( ( channelsMask[k] & ( 1 << j ) ) != 0 )
+            {
+                if( channels[i + j].Frequency == 0 )
+                { // Check if the channel is enabled
+                    continue;
+                }
+                if( val_in_range( datarate, channels[i + j].DrRange.Fields.Min,
+                                              channels[i + j].DrRange.Fields.Max ) == 0 )
+                { // Check if the current channel selection supports the given datarate
+                    continue;
+                }
+                if( bands[channels[i + j].Band].TimeOff > 0 )
+                { // Check if the band is available for transmission
+                    delayTransmission++;
+                    continue;
+                }
+                enabledChannels[nbEnabledChannels++] = i + j;
+            }
+        }
+    }
+
+    *delayTx = delayTransmission;
+    return nbEnabledChannels;
+}
+
+LoRaPHYUS915Hybrid::LoRaPHYUS915Hybrid()
+{
+    const Band_t band0 = US915_HYBRID_BAND0;
+    Bands[0] = band0;
+}
+
+LoRaPHYUS915Hybrid::~LoRaPHYUS915Hybrid()
+{
+}
+
+PhyParam_t LoRaPHYUS915Hybrid::get_phy_params(GetPhyParams_t* getPhy)
+{
+    PhyParam_t phyParam = { 0 };
+
+    switch( getPhy->Attribute )
+    {
+        case PHY_MIN_RX_DR:
+        {
+            phyParam.Value = US915_HYBRID_RX_MIN_DATARATE;
+            break;
+        }
+        case PHY_MIN_TX_DR:
+        {
+            phyParam.Value = US915_HYBRID_TX_MIN_DATARATE;
+            break;
+        }
+        case PHY_DEF_TX_DR:
+        {
+            phyParam.Value = US915_HYBRID_DEFAULT_DATARATE;
+            break;
+        }
+        case PHY_NEXT_LOWER_TX_DR:
+        {
+            phyParam.Value = GetNextLowerTxDr( getPhy->Datarate, US915_HYBRID_TX_MIN_DATARATE );
+            break;
+        }
+        case PHY_DEF_TX_POWER:
+        {
+            phyParam.Value = US915_HYBRID_DEFAULT_TX_POWER;
+            break;
+        }
+        case PHY_MAX_PAYLOAD:
+        {
+            phyParam.Value = MaxPayloadOfDatarateUS915_HYBRID[getPhy->Datarate];
+            break;
+        }
+        case PHY_MAX_PAYLOAD_REPEATER:
+        {
+            phyParam.Value = MaxPayloadOfDatarateRepeaterUS915_HYBRID[getPhy->Datarate];
+            break;
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            phyParam.Value = US915_HYBRID_DUTY_CYCLE_ENABLED;
+            break;
+        }
+        case PHY_MAX_RX_WINDOW:
+        {
+            phyParam.Value = US915_HYBRID_MAX_RX_WINDOW;
+            break;
+        }
+        case PHY_RECEIVE_DELAY1:
+        {
+            phyParam.Value = US915_HYBRID_RECEIVE_DELAY1;
+            break;
+        }
+        case PHY_RECEIVE_DELAY2:
+        {
+            phyParam.Value = US915_HYBRID_RECEIVE_DELAY2;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY1:
+        {
+            phyParam.Value = US915_HYBRID_JOIN_ACCEPT_DELAY1;
+            break;
+        }
+        case PHY_JOIN_ACCEPT_DELAY2:
+        {
+            phyParam.Value = US915_HYBRID_JOIN_ACCEPT_DELAY2;
+            break;
+        }
+        case PHY_MAX_FCNT_GAP:
+        {
+            phyParam.Value = US915_HYBRID_MAX_FCNT_GAP;
+            break;
+        }
+        case PHY_ACK_TIMEOUT:
+        {
+            phyParam.Value = ( US915_HYBRID_ACKTIMEOUT + get_random( -US915_HYBRID_ACK_TIMEOUT_RND, US915_HYBRID_ACK_TIMEOUT_RND ) );
+            break;
+        }
+        case PHY_DEF_DR1_OFFSET:
+        {
+            phyParam.Value = US915_HYBRID_DEFAULT_RX1_DR_OFFSET;
+            break;
+        }
+        case PHY_DEF_RX2_FREQUENCY:
+        {
+            phyParam.Value = US915_HYBRID_RX_WND_2_FREQ;
+            break;
+        }
+        case PHY_DEF_RX2_DR:
+        {
+            phyParam.Value = US915_HYBRID_RX_WND_2_DR;
+            break;
+        }
+        case PHY_CHANNELS_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsMask;
+            break;
+        }
+        case PHY_CHANNELS_DEFAULT_MASK:
+        {
+            phyParam.ChannelsMask = ChannelsDefaultMask;
+            break;
+        }
+        case PHY_MAX_NB_CHANNELS:
+        {
+            phyParam.Value = US915_HYBRID_MAX_NB_CHANNELS;
+            break;
+        }
+        case PHY_CHANNELS:
+        {
+            phyParam.Channels = Channels;
+            break;
+        }
+        case PHY_DEF_UPLINK_DWELL_TIME:
+        case PHY_DEF_DOWNLINK_DWELL_TIME:
+        {
+            phyParam.Value = 0;
+            break;
+        }
+        case PHY_DEF_MAX_EIRP:
+        case PHY_DEF_ANTENNA_GAIN:
+        {
+            phyParam.fValue = 0;
+            break;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        case PHY_DEF_NB_JOIN_TRIALS:
+        {
+            phyParam.Value = 2;
+            break;
+        }
+        default:
+        {
+            break;
+        }
+    }
+
+    return phyParam;
+}
+
+void LoRaPHYUS915Hybrid::set_band_tx_done(SetBandTxDoneParams_t* txDone)
+{
+    set_last_tx_done( txDone->Joined, &Bands[Channels[txDone->Channel].Band], txDone->LastTxDoneTime );
+}
+
+void LoRaPHYUS915Hybrid::load_defaults(InitType_t type)
+{
+    switch( type )
+    {
+        case INIT_TYPE_INIT:
+        {
+            // Channels
+            // 125 kHz channels
+            for( uint8_t i = 0; i < US915_HYBRID_MAX_NB_CHANNELS - 8; i++ )
+            {
+                Channels[i].Frequency = 902300000 + i * 200000;
+                Channels[i].DrRange.Value = ( DR_3 << 4 ) | DR_0;
+                Channels[i].Band = 0;
+            }
+            // 500 kHz channels
+            for( uint8_t i = US915_HYBRID_MAX_NB_CHANNELS - 8; i < US915_HYBRID_MAX_NB_CHANNELS; i++ )
+            {
+                Channels[i].Frequency = 903000000 + ( i - ( US915_HYBRID_MAX_NB_CHANNELS - 8 ) ) * 1600000;
+                Channels[i].DrRange.Value = ( DR_4 << 4 ) | DR_4;
+                Channels[i].Band = 0;
+            }
+
+            // ChannelsMask
+            ChannelsDefaultMask[0] = 0x00FF;
+            ChannelsDefaultMask[1] = 0x0000;
+            ChannelsDefaultMask[2] = 0x0000;
+            ChannelsDefaultMask[3] = 0x0000;
+            ChannelsDefaultMask[4] = 0x0001;
+            ChannelsDefaultMask[5] = 0x0000;
+
+            // Copy channels default mask
+            copy_channel_mask( ChannelsMask, ChannelsDefaultMask, 6 );
+
+            // Copy into channels mask remaining
+            copy_channel_mask( ChannelsMaskRemaining, ChannelsMask, 6 );
+            break;
+        }
+        case INIT_TYPE_RESTORE:
+        {
+            ReenableChannels( ChannelsDefaultMask[4], ChannelsMask );
+
+            for( uint8_t i = 0; i < 6; i++ )
+            { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+        }
+        default:
+        {
+            break;
+        }
+    }
+}
+
+bool LoRaPHYUS915Hybrid::verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute)
+{
+    switch( phyAttribute )
+    {
+        case PHY_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, US915_HYBRID_TX_MIN_DATARATE, US915_HYBRID_TX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, DR_0, DR_5 );
+        }
+        case PHY_RX_DR:
+        {
+            return val_in_range( verify->DatarateParams.Datarate, US915_HYBRID_RX_MIN_DATARATE, US915_HYBRID_RX_MAX_DATARATE );
+        }
+        case PHY_DEF_TX_POWER:
+        case PHY_TX_POWER:
+        {
+            // Remark: switched min and max!
+            return val_in_range( verify->TxPower, US915_HYBRID_MAX_TX_POWER, US915_HYBRID_MIN_TX_POWER );
+        }
+        case PHY_DUTY_CYCLE:
+        {
+            return US915_HYBRID_DUTY_CYCLE_ENABLED;
+        }
+        case PHY_NB_JOIN_TRIALS:
+        {
+            if( verify->NbJoinTrials < 2 )
+            {
+                return false;
+            }
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+void LoRaPHYUS915Hybrid::apply_cf_list(ApplyCFListParams_t* applyCFList)
+{
+    return;
+}
+
+bool LoRaPHYUS915Hybrid::set_channel_mask(ChanMaskSetParams_t* chanMaskSet)
+{
+    uint8_t nbChannels = num_active_channels( chanMaskSet->ChannelsMaskIn, 0, 4 );
+
+    // Check the number of active channels
+    if( ( nbChannels < 2 ) &&
+        ( nbChannels > 0 ) )
+    {
+        return false;
+    }
+
+    // Validate the channels mask
+    if( ValidateChannelsMask( chanMaskSet->ChannelsMaskIn ) == false  )
+    {
+        return false;
+    }
+
+    switch( chanMaskSet->ChannelsMaskType )
+    {
+        case CHANNELS_MASK:
+        {
+            copy_channel_mask( ChannelsMask, chanMaskSet->ChannelsMaskIn, 6 );
+
+            for( uint8_t i = 0; i < 6; i++ )
+            { // Copy-And the channels mask
+                ChannelsMaskRemaining[i] &= ChannelsMask[i];
+            }
+            break;
+        }
+        case CHANNELS_DEFAULT_MASK:
+        {
+            copy_channel_mask( ChannelsDefaultMask, chanMaskSet->ChannelsMaskIn, 6 );
+            break;
+        }
+        default:
+            return false;
+    }
+    return true;
+}
+
+bool LoRaPHYUS915Hybrid::get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                                      int8_t* txPowOut, uint32_t* adrAckCounter)
+{
+    bool adrAckReq = false;
+    int8_t datarate = adrNext->Datarate;
+    int8_t txPower = adrNext->TxPower;
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+
+    // Report back the adr ack counter
+    *adrAckCounter = adrNext->AdrAckCounter;
+
+    if( adrNext->AdrEnabled == true )
+    {
+        if( datarate == US915_HYBRID_TX_MIN_DATARATE )
+        {
+            *adrAckCounter = 0;
+            adrAckReq = false;
+        }
+        else
+        {
+            if( adrNext->AdrAckCounter >= US915_HYBRID_ADR_ACK_LIMIT )
+            {
+                adrAckReq = true;
+                txPower = US915_HYBRID_MAX_TX_POWER;
+            }
+            else
+            {
+                adrAckReq = false;
+            }
+            if( adrNext->AdrAckCounter >= ( US915_HYBRID_ADR_ACK_LIMIT + US915_HYBRID_ADR_ACK_DELAY ) )
+            {
+                if( ( adrNext->AdrAckCounter % US915_HYBRID_ADR_ACK_DELAY ) == 1 )
+                {
+                    // Decrease the datarate
+                    getPhy.Attribute = PHY_NEXT_LOWER_TX_DR;
+                    getPhy.Datarate = datarate;
+                    getPhy.UplinkDwellTime = adrNext->UplinkDwellTime;
+                    phyParam = get_phy_params( &getPhy );
+                    datarate = phyParam.Value;
+
+                    if( datarate == US915_HYBRID_TX_MIN_DATARATE )
+                    {
+                        // We must set adrAckReq to false as soon as we reach the lowest datarate
+                        adrAckReq = false;
+                        if( adrNext->UpdateChanMask == true )
+                        {
+                            // Re-enable default channels
+                            ReenableChannels( ChannelsMask[4], ChannelsMask );
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    *drOut = datarate;
+    *txPowOut = txPower;
+    return adrAckReq;
+}
+
+void LoRaPHYUS915Hybrid::compute_rx_win_params(int8_t datarate, uint8_t minRxSymbols,
+                                               uint32_t rxError, RxConfigParams_t *rxConfigParams)
+{
+    double tSymbol = 0.0;
+
+    // Get the datarate, perform a boundary check
+    rxConfigParams->Datarate = MIN( datarate, US915_HYBRID_RX_MAX_DATARATE );
+    rxConfigParams->Bandwidth = GetBandwidth( rxConfigParams->Datarate );
+
+    tSymbol = compute_symb_timeout_lora( DataratesUS915_HYBRID[rxConfigParams->Datarate], BandwidthsUS915_HYBRID[rxConfigParams->Datarate] );
+
+    get_rx_window_params( tSymbol, minRxSymbols, rxError, RADIO_WAKEUP_TIME, &rxConfigParams->WindowTimeout, &rxConfigParams->WindowOffset );
+}
+
+bool LoRaPHYUS915Hybrid::rx_config(RxConfigParams_t* rxConfig, int8_t* datarate)
+{
+    int8_t dr = rxConfig->Datarate;
+    uint8_t maxPayload = 0;
+    int8_t phyDr = 0;
+    uint32_t frequency = rxConfig->Frequency;
+
+    if( _radio->get_status() != RF_IDLE )
+    {
+        return false;
+    }
+
+    if( rxConfig->Window == 0 )
+    {
+        // Apply window 1 frequency
+        frequency = US915_HYBRID_FIRST_RX1_CHANNEL + ( rxConfig->Channel % 8 ) * US915_HYBRID_STEPWIDTH_RX1_CHANNEL;
+    }
+
+    // Read the physical datarate from the datarates table
+    phyDr = DataratesUS915_HYBRID[dr];
+
+    _radio->set_channel( frequency );
+
+    // Radio configuration
+    _radio->set_rx_config( MODEM_LORA, rxConfig->Bandwidth, phyDr, 1, 0, 8, rxConfig->WindowTimeout, false, 0, false, 0, 0, true, rxConfig->RxContinuous );
+
+    if( rxConfig->RepeaterSupport == true )
+    {
+        maxPayload = MaxPayloadOfDatarateRepeaterUS915_HYBRID[dr];
+    }
+    else
+    {
+        maxPayload = MaxPayloadOfDatarateUS915_HYBRID[dr];
+    }
+    _radio->set_max_payload_length( MODEM_LORA, maxPayload + LORA_MAC_FRMPAYLOAD_OVERHEAD );
+
+    *datarate = (uint8_t) dr;
+    return true;
+}
+
+bool LoRaPHYUS915Hybrid::tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                   TimerTime_t* txTimeOnAir)
+{
+    int8_t phyDr = DataratesUS915_HYBRID[txConfig->Datarate];
+    int8_t txPowerLimited = LimitTxPower( txConfig->TxPower, Bands[Channels[txConfig->Channel].Band].TxMaxPower, txConfig->Datarate, ChannelsMask );
+    uint32_t bandwidth = GetBandwidth( txConfig->Datarate );
+    int8_t phyTxPower = 0;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, US915_HYBRID_DEFAULT_MAX_ERP, 0 );
+
+    // Setup the radio frequency
+    _radio->set_channel( Channels[txConfig->Channel].Frequency );
+
+    _radio->set_tx_config( MODEM_LORA, phyTxPower, 0, bandwidth, phyDr, 1, 8, false, true, 0, 0, false, 3000 );
+
+    // Setup maximum payload lenght of the radio driver
+    _radio->set_max_payload_length( MODEM_LORA, txConfig->PktLen );
+    // Get the time-on-air of the next tx frame
+    *txTimeOnAir = _radio->time_on_air( MODEM_LORA, txConfig->PktLen );
+    *txPower = txPowerLimited;
+
+    return true;
+}
+
+uint8_t LoRaPHYUS915Hybrid::link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                             int8_t* drOut, int8_t* txPowOut,
+                                             uint8_t* nbRepOut,
+                                             uint8_t* nbBytesParsed)
+{
+    uint8_t status = 0x07;
+    RegionCommonLinkAdrParams_t linkAdrParams;
+    uint8_t nextIndex = 0;
+    uint8_t bytesProcessed = 0;
+    uint16_t channelsMask[6] = { 0, 0, 0, 0, 0, 0 };
+    GetPhyParams_t getPhy;
+    PhyParam_t phyParam;
+    RegionCommonLinkAdrReqVerifyParams_t linkAdrVerifyParams;
+
+    // Initialize local copy of channels mask
+    copy_channel_mask( channelsMask, ChannelsMask, 6 );
+
+    while( bytesProcessed < linkAdrReq->PayloadSize )
+    {
+        nextIndex = parse_link_ADR_req( &( linkAdrReq->Payload[bytesProcessed] ), &linkAdrParams );
+
+        if( nextIndex == 0 )
+            break; // break loop, since no more request has been found
+
+        // Update bytes processed
+        bytesProcessed += nextIndex;
+
+        // Revert status, as we only check the last ADR request for the channel mask KO
+        status = 0x07;
+
+        if( linkAdrParams.ChMaskCtrl == 6 )
+        {
+            // Enable all 125 kHz channels
+            channelsMask[0] = 0xFFFF;
+            channelsMask[1] = 0xFFFF;
+            channelsMask[2] = 0xFFFF;
+            channelsMask[3] = 0xFFFF;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        }
+        else if( linkAdrParams.ChMaskCtrl == 7 )
+        {
+            // Disable all 125 kHz channels
+            channelsMask[0] = 0x0000;
+            channelsMask[1] = 0x0000;
+            channelsMask[2] = 0x0000;
+            channelsMask[3] = 0x0000;
+            // Apply chMask to channels 64 to 71
+            channelsMask[4] = linkAdrParams.ChMask;
+        }
+        else if( linkAdrParams.ChMaskCtrl == 5 )
+        {
+            // RFU
+            status &= 0xFE; // Channel mask KO
+        }
+        else
+        {
+            channelsMask[linkAdrParams.ChMaskCtrl] = linkAdrParams.ChMask;
+        }
+    }
+
+    // FCC 15.247 paragraph F mandates to hop on at least 2 125 kHz channels
+    if( ( linkAdrParams.Datarate < DR_4 ) && ( num_active_channels( channelsMask, 0, 4 ) < 2 ) )
+    {
+        status &= 0xFE; // Channel mask KO
+    }
+
+    if( ValidateChannelsMask( channelsMask ) == false )
+    {
+        status &= 0xFE; // Channel mask KO
+    }
+
+    // Get the minimum possible datarate
+    getPhy.Attribute = PHY_MIN_TX_DR;
+    getPhy.UplinkDwellTime = linkAdrReq->UplinkDwellTime;
+    phyParam = get_phy_params( &getPhy );
+
+    linkAdrVerifyParams.Status = status;
+    linkAdrVerifyParams.AdrEnabled = linkAdrReq->AdrEnabled;
+    linkAdrVerifyParams.Datarate = linkAdrParams.Datarate;
+    linkAdrVerifyParams.TxPower = linkAdrParams.TxPower;
+    linkAdrVerifyParams.NbRep = linkAdrParams.NbRep;
+    linkAdrVerifyParams.CurrentDatarate = linkAdrReq->CurrentDatarate;
+    linkAdrVerifyParams.CurrentTxPower = linkAdrReq->CurrentTxPower;
+    linkAdrVerifyParams.CurrentNbRep = linkAdrReq->CurrentNbRep;
+    linkAdrVerifyParams.NbChannels = US915_HYBRID_MAX_NB_CHANNELS;
+    linkAdrVerifyParams.ChannelsMask = channelsMask;
+    linkAdrVerifyParams.MinDatarate = ( int8_t )phyParam.Value;
+    linkAdrVerifyParams.MaxDatarate = US915_HYBRID_TX_MAX_DATARATE;
+    linkAdrVerifyParams.Channels = Channels;
+    linkAdrVerifyParams.MinTxPower = US915_HYBRID_MIN_TX_POWER;
+    linkAdrVerifyParams.MaxTxPower = US915_HYBRID_MAX_TX_POWER;
+
+    // Verify the parameters and update, if necessary
+    status = verify_link_ADR_req( &linkAdrVerifyParams, &linkAdrParams.Datarate, &linkAdrParams.TxPower, &linkAdrParams.NbRep );
+
+    // Update channelsMask if everything is correct
+    if( status == 0x07 )
+    {
+        // Copy Mask
+        copy_channel_mask( ChannelsMask, channelsMask, 6 );
+
+        ChannelsMaskRemaining[0] &= ChannelsMask[0];
+        ChannelsMaskRemaining[1] &= ChannelsMask[1];
+        ChannelsMaskRemaining[2] &= ChannelsMask[2];
+        ChannelsMaskRemaining[3] &= ChannelsMask[3];
+        ChannelsMaskRemaining[4] = ChannelsMask[4];
+        ChannelsMaskRemaining[5] = ChannelsMask[5];
+    }
+
+    // Update status variables
+    *drOut = linkAdrParams.Datarate;
+    *txPowOut = linkAdrParams.TxPower;
+    *nbRepOut = linkAdrParams.NbRep;
+    *nbBytesParsed = bytesProcessed;
+
+    return status;
+}
+
+uint8_t LoRaPHYUS915Hybrid::setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq)
+{
+    uint8_t status = 0x07;
+    uint32_t freq = rxParamSetupReq->Frequency;
+
+    // Verify radio frequency
+    if( ( _radio->check_rf_frequency( freq ) == false ) ||
+        ( freq < US915_HYBRID_FIRST_RX1_CHANNEL ) ||
+        ( freq > US915_HYBRID_LAST_RX1_CHANNEL ) ||
+        ( ( ( freq - ( uint32_t ) US915_HYBRID_FIRST_RX1_CHANNEL ) % ( uint32_t ) US915_HYBRID_STEPWIDTH_RX1_CHANNEL ) != 0 ) )
+    {
+        status &= 0xFE; // Channel frequency KO
+    }
+
+    // Verify datarate
+    if( val_in_range( rxParamSetupReq->Datarate, US915_HYBRID_RX_MIN_DATARATE, US915_HYBRID_RX_MAX_DATARATE ) == 0 )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+    if( ( val_in_range( rxParamSetupReq->Datarate, DR_5, DR_7 ) == 1 ) ||
+        ( rxParamSetupReq->Datarate > DR_13 ) )
+    {
+        status &= 0xFD; // Datarate KO
+    }
+
+    // Verify datarate offset
+    if( val_in_range( rxParamSetupReq->DrOffset, US915_HYBRID_MIN_RX1_DR_OFFSET, US915_HYBRID_MAX_RX1_DR_OFFSET ) == 0 )
+    {
+        status &= 0xFB; // Rx1DrOffset range KO
+    }
+
+    return status;
+}
+
+uint8_t LoRaPHYUS915Hybrid::request_new_channel(NewChannelReqParams_t* newChannelReq)
+{
+    // Datarate and frequency KO
+    return 0;
+}
+
+int8_t LoRaPHYUS915Hybrid::setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq)
+{
+    return -1;
+}
+
+uint8_t LoRaPHYUS915Hybrid::dl_channel_request(DlChannelReqParams_t* dlChannelReq)
+{
+    return 0;
+}
+
+int8_t LoRaPHYUS915Hybrid::get_alternate_DR(AlternateDrParams_t* alternateDr)
+{
+    int8_t datarate = 0;
+
+    // Re-enable 500 kHz default channels
+    ReenableChannels( ChannelsMask[4], ChannelsMask );
+
+    if( ( alternateDr->NbTrials & 0x01 ) == 0x01 )
+    {
+        datarate = DR_4;
+    }
+    else
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}
+
+void LoRaPHYUS915Hybrid::calculate_backoff(CalcBackOffParams_t* calcBackOff)
+{
+    RegionCommonCalcBackOffParams_t calcBackOffParams;
+
+    calcBackOffParams.Channels = Channels;
+    calcBackOffParams.Bands = Bands;
+    calcBackOffParams.LastTxIsJoinRequest = calcBackOff->LastTxIsJoinRequest;
+    calcBackOffParams.Joined = calcBackOff->Joined;
+    calcBackOffParams.DutyCycleEnabled = calcBackOff->DutyCycleEnabled;
+    calcBackOffParams.Channel = calcBackOff->Channel;
+    calcBackOffParams.ElapsedTime = calcBackOff->ElapsedTime;
+    calcBackOffParams.TxTimeOnAir = calcBackOff->TxTimeOnAir;
+
+    get_DC_backoff( &calcBackOffParams );
+}
+
+bool LoRaPHYUS915Hybrid::set_next_channel(NextChanParams_t* nextChanParams,
+                                          uint8_t* channel, TimerTime_t* time,
+                                          TimerTime_t* aggregatedTimeOff)
+{
+    uint8_t nbEnabledChannels = 0;
+    uint8_t delayTx = 0;
+    uint8_t enabledChannels[US915_HYBRID_MAX_NB_CHANNELS] = { 0 };
+    TimerTime_t nextTxDelay = 0;
+
+    // Count 125kHz channels
+    if( num_active_channels( ChannelsMaskRemaining, 0, 4 ) == 0 )
+    { // Reactivate default channels
+        copy_channel_mask( ChannelsMaskRemaining, ChannelsMask, 4  );
+    }
+    // Check other channels
+    if( nextChanParams->Datarate >= DR_4 )
+    {
+        if( ( ChannelsMaskRemaining[4] & 0x00FF ) == 0 )
+        {
+            ChannelsMaskRemaining[4] = ChannelsMask[4];
+        }
+    }
+
+    if( nextChanParams->AggrTimeOff <= TimerGetElapsedTime( nextChanParams->LastAggrTx ) )
+    {
+        // Reset Aggregated time off
+        *aggregatedTimeOff = 0;
+
+        // Update bands Time OFF
+        nextTxDelay = update_band_timeoff( nextChanParams->Joined, nextChanParams->DutyCycleEnabled, Bands, US915_HYBRID_MAX_NB_BANDS );
+
+        // Search how many channels are enabled
+        nbEnabledChannels = CountNbOfEnabledChannels( nextChanParams->Datarate,
+                                                      ChannelsMaskRemaining, Channels,
+                                                      Bands, enabledChannels, &delayTx );
+    }
+    else
+    {
+        delayTx++;
+        nextTxDelay = nextChanParams->AggrTimeOff - TimerGetElapsedTime( nextChanParams->LastAggrTx );
+    }
+
+    if( nbEnabledChannels > 0 )
+    {
+        // We found a valid channel
+        *channel = enabledChannels[get_random( 0, nbEnabledChannels - 1 )];
+        // Disable the channel in the mask
+        disable_channel( ChannelsMaskRemaining, *channel, US915_HYBRID_MAX_NB_CHANNELS - 8 );
+
+        *time = 0;
+        return true;
+    }
+    else
+    {
+        if( delayTx > 0 )
+        {
+            // Delay transmission due to AggregatedTimeOff or to a band time off
+            *time = nextTxDelay;
+            return true;
+        }
+        // Datarate not supported by any channel
+        *time = 0;
+        return false;
+    }
+}
+
+LoRaMacStatus_t LoRaPHYUS915Hybrid::add_channel(ChannelAddParams_t* channelAdd)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+bool LoRaPHYUS915Hybrid::remove_channel(ChannelRemoveParams_t* channelRemove)
+{
+    return LORAMAC_STATUS_PARAMETER_INVALID;
+}
+
+void LoRaPHYUS915Hybrid::set_tx_cont_mode(ContinuousWaveParams_t* continuousWave)
+{
+    int8_t txPowerLimited = LimitTxPower( continuousWave->TxPower, Bands[Channels[continuousWave->Channel].Band].TxMaxPower, continuousWave->Datarate, ChannelsMask );
+    int8_t phyTxPower = 0;
+    uint32_t frequency = Channels[continuousWave->Channel].Frequency;
+
+    // Calculate physical TX power
+    phyTxPower = compute_tx_power( txPowerLimited, US915_HYBRID_DEFAULT_MAX_ERP, 0 );
+
+    _radio->set_tx_continuous_wave( frequency, phyTxPower, continuousWave->Timeout );
+}
+
+uint8_t LoRaPHYUS915Hybrid::apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset)
+{
+    int8_t datarate = DatarateOffsetsUS915_HYBRID[dr][drOffset];
+
+    if( datarate < 0 )
+    {
+        datarate = DR_0;
+    }
+    return datarate;
+}

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
@@ -1,0 +1,366 @@
+/**
+ *  @file LoRaPHYUS915Hybrid.h
+ *
+ *  @brief Implements LoRaPHY for US 915 MHz Hybrid band
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORAPHY_US915HYBRID_H_
+#define MBED_OS_LORAPHY_US915_HYBRID_H_
+
+#include "LoRaPHY.h"
+#include "netsocket/LoRaRadio.h"
+
+
+/*!
+ * LoRaMac maximum number of channels
+ */
+#define US915_HYBRID_MAX_NB_CHANNELS                72
+
+/*!
+ * LoRaMac maximum number of bands
+ */
+#define US915_HYBRID_MAX_NB_BANDS                   1
+
+#define US915_HYBRID_CHANNELS_MASK_SIZE             6
+
+
+class LoRaPHYUS915Hybrid : public LoRaPHY {
+
+public:
+
+    LoRaPHYUS915Hybrid();
+    virtual ~LoRaPHYUS915Hybrid();
+
+    /*!
+     * \brief The function gets a value of a specific PHY attribute.
+     *
+     * \param [in] getPhy A pointer to the function parameters.
+     *
+     * \retval The structure containing the PHY parameter.
+     */
+    virtual PhyParam_t get_phy_params(GetPhyParams_t* getPhy );
+
+    /*!
+     * \brief Updates the last TX done parameters of the current channel.
+     *
+     * \param [in] txDone A pointer to the function parameters.
+     */
+    virtual void set_band_tx_done(SetBandTxDoneParams_t* txDone );
+
+    /*!
+     * \brief Initializes the channels masks and the channels.
+     *
+     * \param [in] type Sets the initialization type.
+     */
+    virtual void load_defaults(InitType_t type );
+
+    /*!
+     * \brief Verifies a parameter.
+     *
+     * \param [in] verify A pointer to the function parameters.
+     *
+     * \param [in] phyAttribute The attribute to verify.
+     *
+     * \retval True, if the parameter is valid.
+     */
+   virtual bool verify(VerifyParams_t* verify, PhyAttribute_t phyAttribute );
+
+    /*!
+     * \brief The function parses the input buffer and sets up the channels of the CF list.
+     *
+     * \param [in] applyCFList A pointer to the function parameters.
+     */
+   virtual void apply_cf_list(ApplyCFListParams_t* applyCFList );
+
+    /*!
+     * \brief Sets a channels mask.
+     *
+     * \param [in] chanMaskSet A pointer to the function parameters.
+     *
+     * \retval True, if the channels mask could be set.
+     */
+    virtual bool set_channel_mask(ChanMaskSetParams_t* chanMaskSet );
+
+    /*!
+     * \brief Calculates the next datarate to set, when ADR is on or off.
+     *
+     * \param [in] adrNext A pointer to the function parameters.
+     *
+     * \param [out] drOut The calculated datarate for the next TX.
+     *
+     * \param [out] txPowOut The TX power for the next TX.
+     *
+     * \param [out] adrAckCounter The calculated ADR acknowledgement counter.
+     *
+     * \retval True, if an ADR request should be performed.
+     */
+    virtual bool get_next_ADR(AdrNextParams_t* adrNext, int8_t* drOut,
+                               int8_t* txPowOut, uint32_t* adrAckCounter );
+
+    /*!
+     * \brief Configuration of the RX windows.
+     *
+     * \param [in] rxConfig A pointer to the function parameters.
+     *
+     * \param [out] datarate The datarate index set.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool rx_config(RxConfigParams_t* rxConfig, int8_t* datarate );
+
+    /*
+     * RX window precise timing
+     *
+     * For more details, please consult the following document, chapter 3.1.2.
+     * http://www.semtech.com/images/datasheet/SX1272_settings_for_LoRaWAN_v2.0.pdf
+     * or
+     * http://www.semtech.com/images/datasheet/SX1276_settings_for_LoRaWAN_v2.0.pdf
+     *
+     *                 Downlink start: T = Tx + 1s (+/- 20 us)
+     *                            |
+     *             TRxEarly       |        TRxLate
+     *                |           |           |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |       Latest Rx window        |
+     *                |           |           +---+---+---+---+---+---+---+---+
+     *                |           |           |
+     *                +---+---+---+---+---+---+---+---+
+     *                |       Earliest Rx window      |
+     *                +---+---+---+---+---+---+---+---+
+     *                            |
+     *                            +---+---+---+---+---+---+---+---+
+     *Downlink preamble 8 symbols |   |   |   |   |   |   |   |   |
+     *                            +---+---+---+---+---+---+---+---+
+     *
+     *                     Worst case Rx window timings
+     *
+     * TRxLate  = DEFAULT_MIN_RX_SYMBOLS * tSymbol - RADIO_WAKEUP_TIME
+     * TRxEarly = 8 - DEFAULT_MIN_RX_SYMBOLS * tSymbol - RxWindowTimeout - RADIO_WAKEUP_TIME
+     *
+     * TRxLate - TRxEarly = 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     *
+     * RxOffset = ( TRxLate + TRxEarly ) / 2
+     *
+     * RxWindowTimeout = ( 2 * DEFAULT_MIN_RX_SYMBOLS - 8 ) * tSymbol + 2 * DEFAULT_SYSTEM_MAX_RX_ERROR
+     * RxOffset = 4 * tSymbol - RxWindowTimeout / 2 - RADIO_WAKE_UP_TIME
+     *
+     * The minimum value of RxWindowTimeout must be 5 symbols which implies that the system always tolerates at least an error of 1.5 * tSymbol
+     */
+    /*!
+     * Computes the RX window timeout and offset.
+     *
+     * \param [in] datarate     The RX window datarate index to be used.
+     *
+     * \param [in] minRxSymbols The minimum number of symbols required to detect an RX frame.
+     *
+     * \param [in] rxError      The system maximum timing error of the receiver in milliseconds.
+     *                          The receiver will turn on in a [-rxError : +rxError] ms
+     *                          interval around RxOffset.
+     *
+     * \param [out] rxConfigParams Returns the updated WindowTimeout and WindowOffset fields.
+     */
+    virtual void compute_rx_win_params(int8_t datarate,
+                                                 uint8_t minRxSymbols,
+                                                 uint32_t rxError,
+                                                 RxConfigParams_t *rxConfigParams);
+
+    /*!
+     * \brief TX configuration.
+     *
+     * \param [in] txConfig A pointer to the function parameters.
+     *
+     * \param [out] txPower The TX power index set.
+     *
+     * \param [out] txTimeOnAir The time-on-air of the frame.
+     *
+     * \retval True, if the configuration was applied successfully.
+     */
+    virtual bool tx_config(TxConfigParams_t* txConfig, int8_t* txPower,
+                                TimerTime_t* txTimeOnAir );
+
+    /*!
+     * \brief The function processes a Link ADR request.
+     *
+     * \param [in] linkAdrReq A pointer to the function parameters.
+     *
+     * \param [out] drOut The datarate applied.
+     *
+     * \param [out] txPowOut The TX power applied.
+     *
+     * \param [out] nbRepOut The number of repetitions to apply.
+     *
+     * \param [out] nbBytesParsed The number of bytes parsed.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t link_ADR_request(LinkAdrReqParams_t* linkAdrReq,
+                                     int8_t* drOut, int8_t* txPowOut,
+                                     uint8_t* nbRepOut,
+                                     uint8_t* nbBytesParsed );
+
+    /*!
+     * \brief The function processes a RX parameter setup request.
+     *
+     * \param [in] rxParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t setup_rx_params(RxParamSetupReqParams_t* rxParamSetupReq );
+
+    /*!
+     * \brief The function processes a new channel request.
+     *
+     * \param [in] newChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t request_new_channel(NewChannelReqParams_t* newChannelReq );
+
+    /*!
+     * \brief The function processes a TX ParamSetup request.
+     *
+     * \param [in] txParamSetupReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     *         Returns -1, if the functionality is not implemented. In this case, the end node
+     *         shall ignore the command.
+     */
+    virtual int8_t setup_tx_params(TxParamSetupReqParams_t* txParamSetupReq );
+
+    /*!
+     * \brief The function processes a DlChannel request.
+     *
+     * \param [in] dlChannelReq A pointer to the function parameters.
+     *
+     * \retval The status of the operation, according to the LoRaMAC specification.
+     */
+    virtual uint8_t dl_channel_request(DlChannelReqParams_t* dlChannelReq );
+
+    /*!
+     * \brief Alternates the datarate of the channel for the join request.
+     *
+     * \param [in] alternateDr A pointer to the function parameters.
+     *
+     * \retval The datarate to apply.
+     */
+    virtual int8_t get_alternate_DR(AlternateDrParams_t* alternateDr );
+
+    /*!
+     * \brief Calculates the back-off time.
+     *
+     * \param [in] calcBackOff A pointer to the function parameters.
+     */
+    virtual void calculate_backoff(CalcBackOffParams_t* calcBackOff );
+
+    /*!
+     * \brief Searches and sets the next random available channel.
+     *
+     * \param [in]  nextChanParams The parameters for the next channel.
+     *
+     * \param [out] channel The next channel to use for TX.
+     *
+     * \param [out] time The time to wait for the next transmission according to the duty cycle.
+     *
+     * \param [out] aggregatedTimeOff Updates the aggregated time off.
+     *
+     * \retval The function status [1: OK, 0: Unable to find a channel on the current datarate].
+     */
+    virtual bool set_next_channel(NextChanParams_t* nextChanParams,
+                                   uint8_t* channel, TimerTime_t* time,
+                                   TimerTime_t* aggregatedTimeOff );
+
+    /*!
+     * \brief Adds a channel.
+     *
+     * \param [in] channelAdd A pointer to the function parameters.
+     *
+     * \retval The status of the operation.
+     */
+    virtual LoRaMacStatus_t add_channel(ChannelAddParams_t* channelAdd );
+
+    /*!
+     * \brief Removes a channel.
+     *
+     * \param [in] channelRemove A pointer to the function parameters.
+     *
+     * \retval True, if the channel was removed successfully.
+     */
+    virtual bool remove_channel(ChannelRemoveParams_t* channelRemove );
+
+    /*!
+     * \brief Sets the radio into continuous wave mode.
+     *
+     * \param [in] continuousWave A pointer to the function parameters.
+     */
+    virtual void set_tx_cont_mode(ContinuousWaveParams_t* continuousWave );
+
+    /*!
+     * \brief Computes a new datarate according to the given offset.
+     *
+     * \param [in] downlinkDwellTime The downlink dwell time configuration. 0: No limit, 1: 400ms
+     *
+     * \param [in] dr The current datarate.
+     *
+     * \param [in] drOffset The offset to be applied.
+     *
+     * \retval newDr The computed datarate.
+     */
+    virtual uint8_t apply_DR_offset(uint8_t downlinkDwellTime, int8_t dr, int8_t drOffset );
+
+private:
+    int8_t LimitTxPower( int8_t txPower, int8_t maxBandTxPower, int8_t datarate, uint16_t* channelsMask );
+    uint8_t CountNbOfEnabledChannels( uint8_t datarate, uint16_t* channelsMask, ChannelParams_t* channels, Band_t* bands, uint8_t* enabledChannels, uint8_t* delayTx );
+
+    // Global attributes
+    /*!
+     * LoRaMAC channels
+     */
+    ChannelParams_t Channels[US915_HYBRID_MAX_NB_CHANNELS];
+
+    /*!
+     * LoRaMac bands
+     */
+    Band_t Bands[US915_HYBRID_MAX_NB_BANDS];
+
+    /*!
+     * LoRaMac channels mask
+     */
+    uint16_t ChannelsMask[US915_HYBRID_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels remaining
+     */
+    uint16_t ChannelsMaskRemaining[US915_HYBRID_CHANNELS_MASK_SIZE];
+
+    /*!
+     * LoRaMac channels default mask
+     */
+    uint16_t ChannelsDefaultMask[US915_HYBRID_CHANNELS_MASK_SIZE];
+};
+
+#endif /* MBED_OS_LORAPHY_US915HYBRID_H_ */

--- a/features/lorawan/lorastack/phy/lora_phy_ds.h
+++ b/features/lorawan/lorastack/phy/lora_phy_ds.h
@@ -1,0 +1,1177 @@
+/**
+ *  @file lora_phy_ds.h
+ *
+ *  @brief Data structures relating to PHY layer
+ *
+ *  \code
+ *   ______                              _
+ *  / _____)             _              | |
+ * ( (____  _____ ____ _| |_ _____  ____| |__
+ *  \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ *  _____) ) ____| | | || |_| ____( (___| | | |
+ * (______/|_____)_|_|_| \__)_____)\____)_| |_|
+ *   (C)2013 Semtech
+ *  ___ _____ _   ___ _  _____ ___  ___  ___ ___
+ * / __|_   _/_\ / __| |/ / __/ _ \| _ \/ __| __|
+ * \__ \ | |/ _ \ (__| ' <| _| (_) |   / (__| _|
+ * |___/ |_/_/ \_\___|_|\_\_| \___/|_|_\\___|___|
+ * embedded.connectivity.solutions===============
+ *
+ * \endcode
+ *
+ * License: Revised BSD License, see LICENSE.TXT file include in the project
+ *
+ * Maintainer: Miguel Luis ( Semtech ), Gregory Cristian ( Semtech ) and Daniel Jaeckle ( STACKFORCE )
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ */
+
+#ifndef MBED_OS_LORA_PHY_DATASTRUCTURES_
+#define MBED_OS_LORA_PHY_DATASTRUCTURES_
+
+#include "lorawan/system/lorawan_data_structures.h"
+
+/*!
+ * \brief Returns the minimum value between a and b.
+ *
+ * \param [in] a The first value.
+ * \param [in] b The second value.
+ * \retval minValue The minimum value.
+ */
+#ifndef MIN
+#define MIN( a, b ) ( ( ( a ) < ( b ) ) ? ( a ) : ( b ) )
+#endif
+
+/*!
+ * \brief Returns the maximum value between a and b
+ *
+ * \param [in] a The first value.
+ * \param [in] b The second value.
+ * \retval maxValue The maximum value.
+ */
+#ifndef MAX
+#define MAX( a, b ) ( ( ( a ) > ( b ) ) ? ( a ) : ( b ) )
+#endif
+
+/**
+ * LoRaMac maximum number of channels.
+ */
+#define LORA_MAX_NB_CHANNELS                        16
+
+/*!
+ * Macro to compute bit of a channel index.
+ */
+#define LC( channelIndex )                          ( uint16_t )( 1 << ( channelIndex - 1 ) )
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF12 - BW125
+ * AU915        | SF10 - BW125
+ * CN470        | SF12 - BW125
+ * CN779        | SF12 - BW125
+ * EU433        | SF12 - BW125
+ * EU868        | SF12 - BW125
+ * IN865        | SF12 - BW125
+ * KR920        | SF12 - BW125
+ * US915        | SF10 - BW125
+ * US915_HYBRID | SF10 - BW125
+ */
+#define DR_0                                        0
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF11 - BW125
+ * AU915        | SF9  - BW125
+ * CN470        | SF11 - BW125
+ * CN779        | SF11 - BW125
+ * EU433        | SF11 - BW125
+ * EU868        | SF11 - BW125
+ * IN865        | SF11 - BW125
+ * KR920        | SF11 - BW125
+ * US915        | SF9  - BW125
+ * US915_HYBRID | SF9  - BW125
+ */
+#define DR_1                                        1
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF10 - BW125
+ * AU915        | SF8  - BW125
+ * CN470        | SF10 - BW125
+ * CN779        | SF10 - BW125
+ * EU433        | SF10 - BW125
+ * EU868        | SF10 - BW125
+ * IN865        | SF10 - BW125
+ * KR920        | SF10 - BW125
+ * US915        | SF8  - BW125
+ * US915_HYBRID | SF8  - BW125
+ */
+#define DR_2                                        2
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF9  - BW125
+ * AU915        | SF7  - BW125
+ * CN470        | SF9  - BW125
+ * CN779        | SF9  - BW125
+ * EU433        | SF9  - BW125
+ * EU868        | SF9  - BW125
+ * IN865        | SF9  - BW125
+ * KR920        | SF9  - BW125
+ * US915        | SF7  - BW125
+ * US915_HYBRID | SF7  - BW125
+ */
+#define DR_3                                        3
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF8  - BW125
+ * AU915        | SF8  - BW500
+ * CN470        | SF8  - BW125
+ * CN779        | SF8  - BW125
+ * EU433        | SF8  - BW125
+ * EU868        | SF8  - BW125
+ * IN865        | SF8  - BW125
+ * KR920        | SF8  - BW125
+ * US915        | SF8  - BW500
+ * US915_HYBRID | SF8  - BW500
+ */
+#define DR_4                                        4
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF7  - BW125
+ * AU915        | RFU
+ * CN470        | SF7  - BW125
+ * CN779        | SF7  - BW125
+ * EU433        | SF7  - BW125
+ * EU868        | SF7  - BW125
+ * IN865        | SF7  - BW125
+ * KR920        | SF7  - BW125
+ * US915        | RFU
+ * US915_HYBRID | RFU
+ */
+#define DR_5                                        5
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | SF7  - BW250
+ * AU915        | RFU
+ * CN470        | SF12 - BW125
+ * CN779        | SF7  - BW250
+ * EU433        | SF7  - BW250
+ * EU868        | SF7  - BW250
+ * IN865        | SF7  - BW250
+ * KR920        | RFU
+ * US915        | RFU
+ * US915_HYBRID | RFU
+ */
+#define DR_6                                        6
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | FSK
+ * AU915        | RFU
+ * CN470        | SF12 - BW125
+ * CN779        | FSK
+ * EU433        | FSK
+ * EU868        | FSK
+ * IN865        | FSK
+ * KR920        | RFU
+ * US915        | RFU
+ * US915_HYBRID | RFU
+ */
+#define DR_7                                        7
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF12 - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF12 - BW500
+ * US915_HYBRID | SF12 - BW500
+ */
+#define DR_8                                        8
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF11 - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF11 - BW500
+ * US915_HYBRID | SF11 - BW500
+ */
+#define DR_9                                        9
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF10 - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF10 - BW500
+ * US915_HYBRID | SF10 - BW500
+ */
+#define DR_10                                       10
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF9  - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF9  - BW500
+ * US915_HYBRID | SF9  - BW500
+ */
+#define DR_11                                       11
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF8  - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF8  - BW500
+ * US915_HYBRID | SF8  - BW500
+ */
+#define DR_12                                       12
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | SF7  - BW500
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | SF7  - BW500
+ * US915_HYBRID | SF7  - BW500
+ */
+#define DR_13                                       13
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | RFU
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | RFU
+ * US915_HYBRID | RFU
+ */
+#define DR_14                                       14
+
+/*!
+ * Region       | SF
+ * ------------ | :-----:
+ * AS923        | RFU
+ * AU915        | RFU
+ * CN470        | RFU
+ * CN779        | RFU
+ * EU433        | RFU
+ * EU868        | RFU
+ * IN865        | RFU
+ * KR920        | RFU
+ * US915        | RFU
+ * US915_HYBRID | RFU
+ */
+#define DR_15                                       15
+
+
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP
+ * AU915        | Max EIRP
+ * CN470        | Max EIRP
+ * CN779        | Max EIRP
+ * EU433        | Max EIRP
+ * EU868        | Max EIRP
+ * IN865        | Max EIRP
+ * KR920        | Max EIRP
+ * US915        | Max ERP
+ * US915_HYBRID | Max ERP
+ */
+#define TX_POWER_0                                  0
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 2
+ * AU915        | Max EIRP - 2
+ * CN470        | Max EIRP - 2
+ * CN779        | Max EIRP - 2
+ * EU433        | Max EIRP - 2
+ * EU868        | Max EIRP - 2
+ * IN865        | Max EIRP - 2
+ * KR920        | Max EIRP - 2
+ * US915        | Max ERP - 2
+ * US915_HYBRID | Max ERP - 2
+ */
+#define TX_POWER_1                                  1
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 4
+ * AU915        | Max EIRP - 4
+ * CN470        | Max EIRP - 4
+ * CN779        | Max EIRP - 4
+ * EU433        | Max EIRP - 4
+ * EU868        | Max EIRP - 4
+ * IN865        | Max EIRP - 4
+ * KR920        | Max EIRP - 4
+ * US915        | Max ERP - 4
+ * US915_HYBRID | Max ERP - 4
+ */
+#define TX_POWER_2                                  2
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 6
+ * AU915        | Max EIRP - 6
+ * CN470        | Max EIRP - 6
+ * CN779        | Max EIRP - 6
+ * EU433        | Max EIRP - 6
+ * EU868        | Max EIRP - 6
+ * IN865        | Max EIRP - 6
+ * KR920        | Max EIRP - 6
+ * US915        | Max ERP - 6
+ * US915_HYBRID | Max ERP - 6
+ */
+#define TX_POWER_3                                  3
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 8
+ * AU915        | Max EIRP - 8
+ * CN470        | Max EIRP - 8
+ * CN779        | Max EIRP - 8
+ * EU433        | Max EIRP - 8
+ * EU868        | Max EIRP - 8
+ * IN865        | Max EIRP - 8
+ * KR920        | Max EIRP - 8
+ * US915        | Max ERP - 8
+ * US915_HYBRID | Max ERP - 8
+ */
+#define TX_POWER_4                                  4
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 10
+ * AU915        | Max EIRP - 10
+ * CN470        | Max EIRP - 10
+ * CN779        | Max EIRP - 10
+ * EU433        | Max EIRP - 10
+ * EU868        | Max EIRP - 10
+ * IN865        | Max EIRP - 10
+ * KR920        | Max EIRP - 10
+ * US915        | Max ERP - 10
+ * US915_HYBRID | Max ERP - 10
+ */
+#define TX_POWER_5                                  5
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 12
+ * AU915        | Max EIRP - 12
+ * CN470        | Max EIRP - 12
+ * CN779        | -
+ * EU433        | -
+ * EU868        | Max EIRP - 12
+ * IN865        | Max EIRP - 12
+ * KR920        | Max EIRP - 12
+ * US915        | Max ERP - 12
+ * US915_HYBRID | Max ERP - 12
+ */
+#define TX_POWER_6                                  6
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | Max EIRP - 14
+ * AU915        | Max EIRP - 14
+ * CN470        | Max EIRP - 14
+ * CN779        | -
+ * EU433        | -
+ * EU868        | Max EIRP - 14
+ * IN865        | Max EIRP - 14
+ * KR920        | Max EIRP - 14
+ * US915        | Max ERP - 14
+ * US915_HYBRID | Max ERP - 14
+ */
+#define TX_POWER_7                                  7
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | -
+ * AU915        | Max EIRP - 16
+ * CN470        | -
+ * CN779        | -
+ * EU433        | -
+ * EU868        | -
+ * IN865        | Max EIRP - 16
+ * KR920        | -
+ * US915        | Max ERP - 16
+ * US915_HYBRID | Max ERP -16
+ */
+#define TX_POWER_8                                  8
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | -
+ * AU915        | Max EIRP - 18
+ * CN470        | -
+ * CN779        | -
+ * EU433        | -
+ * EU868        | -
+ * IN865        | Max EIRP - 18
+ * KR920        | -
+ * US915        | Max ERP - 16
+ * US915_HYBRID | Max ERP - 16
+ */
+#define TX_POWER_9                                  9
+
+/*!
+ * Region       | dBM
+ * ------------ | :-----:
+ * AS923        | -
+ * AU915        | Max EIRP - 20
+ * CN470        | -
+ * CN779        | -
+ * EU433        | -
+ * EU868        | -
+ * IN865        | Max EIRP - 20
+ * KR920        | -
+ * US915        | Max ERP - 10
+ * US915_HYBRID | Max ERP - 10
+ */
+#define TX_POWER_10                                 10
+
+/*!
+ * RFU
+ */
+#define TX_POWER_11                                 11
+
+/*!
+ * RFU
+ */
+#define TX_POWER_12                                 12
+
+/*!
+ * RFU
+ */
+#define TX_POWER_13                                 13
+
+/*!
+ * RFU
+ */
+#define TX_POWER_14                                 14
+
+/*!
+ * RFU
+ */
+#define TX_POWER_15                                 15
+
+/*!
+ * Enumeration of PHY attributes.
+ */
+typedef enum ePhyAttribute
+{
+    /*!
+     * The minimum RX datarate.
+     */
+    PHY_MIN_RX_DR,
+    /*!
+     * The minimum TX datarate.
+     */
+    PHY_MIN_TX_DR,
+    /*!
+     * The maximum RX datarate.
+     */
+    PHY_MAX_RX_DR,
+    /*!
+     * The maximum TX datarate.
+     */
+    PHY_MAX_TX_DR,
+    /*!
+     * The TX datarate.
+     */
+    PHY_TX_DR,
+    /*!
+     * The default TX datarate.
+     */
+    PHY_DEF_TX_DR,
+    /*!
+     * The RX datarate.
+     */
+    PHY_RX_DR,
+    /*!
+     * The TX power.
+     */
+    PHY_TX_POWER,
+    /*!
+     * The default TX power.
+     */
+    PHY_DEF_TX_POWER,
+    /*!
+     * Maximum payload possible.
+     */
+    PHY_MAX_PAYLOAD,
+    /*!
+     * Maximum payload possible when the repeater support is enabled.
+     */
+    PHY_MAX_PAYLOAD_REPEATER,
+    /*!
+     * The duty cycle.
+     */
+    PHY_DUTY_CYCLE,
+    /*!
+     * The maximum receive window duration.
+     */
+    PHY_MAX_RX_WINDOW,
+    /*!
+     * The receive delay for window 1.
+     */
+    PHY_RECEIVE_DELAY1,
+    /*!
+     * The receive delay for window 2.
+     */
+    PHY_RECEIVE_DELAY2,
+    /*!
+     * The join accept delay for window 1.
+     */
+    PHY_JOIN_ACCEPT_DELAY1,
+    /*!
+     * The join accept delay for window 2.
+     */
+    PHY_JOIN_ACCEPT_DELAY2,
+    /*!
+     * The maximum frame counter gap.
+     */
+    PHY_MAX_FCNT_GAP,
+    /*!
+     * The acknowledgement time out.
+     */
+    PHY_ACK_TIMEOUT,
+    /*!
+     * The default datarate offset for window 1.
+     */
+    PHY_DEF_DR1_OFFSET,
+    /*!
+     * The default receive window 2 frequency.
+     */
+    PHY_DEF_RX2_FREQUENCY,
+    /*!
+     * The default receive window 2 datarate.
+     */
+    PHY_DEF_RX2_DR,
+    /*!
+     * The channels mask.
+     */
+    PHY_CHANNELS_MASK,
+    /*!
+     * The channels default mask.
+     */
+    PHY_CHANNELS_DEFAULT_MASK,
+    /*!
+     * The maximum number of supported channels.
+     */
+    PHY_MAX_NB_CHANNELS,
+    /*!
+     * The channels.
+     */
+    PHY_CHANNELS,
+    /*!
+     * The default value of the uplink dwell time.
+     */
+    PHY_DEF_UPLINK_DWELL_TIME,
+    /*!
+     * The default value of the downlink dwell time.
+     */
+    PHY_DEF_DOWNLINK_DWELL_TIME,
+    /*!
+     * The default value of the MaxEIRP.
+     */
+    PHY_DEF_MAX_EIRP,
+    /*!
+     * The default value of the antenna gain.
+     */
+    PHY_DEF_ANTENNA_GAIN,
+    /*!
+     * The value for the number of join trials.
+     */
+    PHY_NB_JOIN_TRIALS,
+    /*!
+     * The default value for the number of join trials.
+     */
+    PHY_DEF_NB_JOIN_TRIALS,
+    /*!
+     * The next lower datarate.
+     */
+    PHY_NEXT_LOWER_TX_DR
+}PhyAttribute_t;
+
+/*!
+ * Enumeration of initialization types.
+ */
+typedef enum eInitType
+{
+    /*!
+     * Performs an initialization and overwrites all existing data.
+     */
+    INIT_TYPE_INIT,
+    /*!
+     * Restores default channels only.
+     */
+    INIT_TYPE_RESTORE
+}InitType_t;
+
+/*!
+ * Selects a given or a default channel mask.
+ */
+typedef enum eChannelsMask
+{
+    /*!
+     * The channels mask.
+     */
+    CHANNELS_MASK,
+    /*!
+     * The channels default mask.
+     */
+    CHANNELS_DEFAULT_MASK
+}ChannelsMask_t;
+
+/*!
+ * The union for the structure uGetPhyParams.
+ */
+typedef union uPhyParam
+{
+    /*!
+     * A parameter value.
+     */
+    uint32_t Value;
+    /*!
+     * A floating point value.
+     */
+    float fValue;
+    /*!
+     * A pointer to the channels mask.
+     */
+    uint16_t* ChannelsMask;
+    /*!
+     * A pointer to the channels.
+     */
+    ChannelParams_t* Channels;
+}PhyParam_t;
+
+/*!
+ * The parameter structure for the function RegionGetPhyParam.
+ */
+typedef struct sGetPhyParams
+{
+    /*!
+     * Set up the parameter to get.
+     */
+    PhyAttribute_t Attribute;
+    /*!
+     * Datarate.
+     * The parameter is needed for the following queries:
+     * PHY_MAX_PAYLOAD, PHY_MAX_PAYLOAD_REPEATER, PHY_NEXT_LOWER_TX_DR.
+     */
+    int8_t Datarate;
+    /*!
+     * Uplink dwell time.
+     * The parameter is needed for the following queries:
+     * PHY_MIN_TX_DR, PHY_MAX_PAYLOAD, PHY_MAX_PAYLOAD_REPEATER, PHY_NEXT_LOWER_TX_DR.
+     */
+    uint8_t UplinkDwellTime;
+    /*!
+     * Downlink dwell time.
+     * The parameter is needed for the following queries:
+     * PHY_MIN_RX_DR, PHY_MAX_PAYLOAD, PHY_MAX_PAYLOAD_REPEATER.
+     */
+    uint8_t DownlinkDwellTime;
+}GetPhyParams_t;
+
+/*!
+ * The parameter structure for the function RegionSetBandTxDone.
+ */
+typedef struct sSetBandTxDoneParams
+{
+    /*!
+     * The channel to update.
+     */
+    uint8_t Channel;
+    /*!
+     * Joined set to true, if the node has joined the network.
+     */
+    bool Joined;
+    /*!
+     * The last TX done time.
+     */
+    TimerTime_t LastTxDoneTime;
+}SetBandTxDoneParams_t;
+
+/*!
+ * The parameter structure for the function RegionVerify.
+ */
+typedef union uVerifyParams
+{
+    /*!
+     * The TX power to verify.
+     */
+    int8_t TxPower;
+    /*!
+     * Set to true, if the duty cycle is enabled, otherwise false.
+     */
+    bool DutyCycle;
+    /*!
+     * The number of join trials.
+     */
+    uint8_t NbJoinTrials;
+    /*!
+     * The datarate to verify.
+     */
+    struct sDatarateParams
+    {
+        /*!
+        * The datarate to verify.
+        */
+        int8_t Datarate;
+        /*!
+        * The downlink dwell time.
+        */
+        uint8_t DownlinkDwellTime;
+        /*!
+        * The uplink dwell time.
+        */
+        uint8_t UplinkDwellTime;
+    }DatarateParams;
+}VerifyParams_t;
+
+/*!
+ * The parameter structure for the function RegionApplyCFList.
+ */
+typedef struct sApplyCFListParams
+{
+    /*!
+     * The payload containing the CF list.
+     */
+    uint8_t* Payload;
+    /*!
+     * The size of the payload.
+     */
+    uint8_t Size;
+}ApplyCFListParams_t;
+
+/*!
+ * The parameter structure for the function RegionChanMaskSet.
+ */
+typedef struct sChanMaskSetParams
+{
+    /*!
+     * A pointer to the channels mask which should be set.
+     */
+    uint16_t* ChannelsMaskIn;
+    /*!
+     * A pointer to the channels mask which should be set.
+     */
+    ChannelsMask_t ChannelsMaskType;
+}ChanMaskSetParams_t;
+
+/*!
+ * The parameter structure for the function RegionAdrNext.
+ */
+typedef struct sAdrNextParams
+{
+    /*!
+     * Set to true, if the function should update the channels mask.
+     */
+    bool UpdateChanMask;
+    /*!
+     * Set to true, if ADR is enabled.
+     */
+    bool AdrEnabled;
+    /*!
+     * The ADR ack counter.
+     */
+    uint32_t AdrAckCounter;
+    /*!
+     * The datarate used currently.
+     */
+    int8_t Datarate;
+    /*!
+     * The TX power used currently.
+     */
+    int8_t TxPower;
+    /*!
+     * UplinkDwellTime
+     */
+    uint8_t UplinkDwellTime;
+}AdrNextParams_t;
+
+/*!
+ * The parameter structure for the function RegionRxConfig.
+ */
+typedef struct sRxConfigParams
+{
+    /*!
+     * The RX channel.
+     */
+    uint8_t Channel;
+    /*!
+     * The RX datarate.
+     */
+    int8_t Datarate;
+    /*!
+     * The RX bandwidth.
+     */
+    uint8_t Bandwidth;
+    /*!
+     * The RX datarate offset.
+     */
+    int8_t DrOffset;
+    /*!
+     * The RX frequency.
+     */
+    uint32_t Frequency;
+    /*!
+     * The RX window timeout
+     */
+     uint32_t WindowTimeout;
+    /*!
+     * The RX window offset
+     */
+    int32_t WindowOffset;
+    /*!
+     * The downlink dwell time.
+     */
+    uint8_t DownlinkDwellTime;
+    /*!
+     * Set to true, if a repeater is supported.
+     */
+    bool RepeaterSupport;
+    /*!
+     * Set to true, if RX should be continuous.
+     */
+    bool RxContinuous;
+    /*!
+     * Sets the RX window. 0: RX window 1, 1: RX window 2.
+     */
+    bool Window;
+}RxConfigParams_t;
+
+/*!
+ * The parameter structure for the function RegionTxConfig.
+ */
+typedef struct sTxConfigParams
+{
+    /*!
+     * The TX channel.
+     */
+    uint8_t Channel;
+    /*!
+     * The TX datarate.
+     */
+    int8_t Datarate;
+    /*!
+     * The TX power.
+     */
+    int8_t TxPower;
+    /*!
+     * The Max EIRP, if applicable.
+     */
+    float MaxEirp;
+    /*!
+     * The antenna gain, if applicable.
+     */
+    float AntennaGain;
+    /*!
+     * The frame length to set up.
+     */
+    uint16_t PktLen;
+}TxConfigParams_t;
+
+/*!
+ * The parameter structure for the function RegionLinkAdrReq.
+ */
+typedef struct sLinkAdrReqParams
+{
+    /*!
+     * A pointer to the payload containing the MAC commands.
+     */
+    uint8_t* Payload;
+    /*!
+     * The size of the payload.
+     */
+    uint8_t PayloadSize;
+    /*!
+     * The uplink dwell time.
+     */
+    uint8_t UplinkDwellTime;
+    /*!
+     * Set to true, if ADR is enabled.
+     */
+    bool AdrEnabled;
+    /*!
+     * The current datarate.
+     */
+    int8_t CurrentDatarate;
+    /*!
+     * The current TX power.
+     */
+    int8_t CurrentTxPower;
+    /*!
+     * The current number of repetitions.
+     */
+    uint8_t CurrentNbRep;
+}LinkAdrReqParams_t;
+
+/*!
+ * The parameter structure for the function RegionRxParamSetupReq.
+ */
+typedef struct sRxParamSetupReqParams
+{
+    /*!
+     * The datarate to set up.
+     */
+    int8_t Datarate;
+    /*!
+     * The datarate offset.
+     */
+    int8_t DrOffset;
+    /*!
+     * The frequency to set up.
+     */
+    uint32_t Frequency;
+}RxParamSetupReqParams_t;
+
+/*!
+ * The parameter structure for the function RegionNewChannelReq.
+ */
+typedef struct sNewChannelReqParams
+{
+    /*!
+     * A pointer to the new channels.
+     */
+    ChannelParams_t* NewChannel;
+    /*!
+     * The channel ID.
+     */
+    int8_t ChannelId;
+}NewChannelReqParams_t;
+
+/*!
+ * The parameter structure for the function RegionTxParamSetupReq.
+ */
+typedef struct sTxParamSetupReqParams
+{
+    /*!
+     * The uplink dwell time.
+     */
+    uint8_t UplinkDwellTime;
+    /*!
+     * The downlink dwell time.
+     */
+    uint8_t DownlinkDwellTime;
+    /*!
+     * The max EIRP.
+     */
+    uint8_t MaxEirp;
+}TxParamSetupReqParams_t;
+
+/*!
+ * The parameter structure for the function RegionDlChannelReq.
+ */
+typedef struct sDlChannelReqParams
+{
+    /*!
+     * The channel ID to add the frequency.
+     */
+    uint8_t ChannelId;
+    /*!
+     * The alternative frequency for the Rx1 window.
+     */
+    uint32_t Rx1Frequency;
+}DlChannelReqParams_t;
+
+/*!
+ * The parameter structure for the function RegionAlternateDr.
+ */
+typedef struct sAlternateDrParams
+{
+    /*!
+     * The number of trials.
+     */
+    uint16_t NbTrials;
+}AlternateDrParams_t;
+
+/*!
+ * The parameter structure for the function RegionCalcBackOff.
+ */
+typedef struct sCalcBackOffParams
+{
+    /*!
+     * Set to true, if the node has already joined a network, otherwise false.
+     */
+    bool Joined;
+    /*!
+     * Joined set to true, if the last uplink was a join request.
+     */
+    bool LastTxIsJoinRequest;
+    /*!
+     * Set to true, if the duty cycle is enabled, otherwise false.
+     */
+    bool DutyCycleEnabled;
+    /*!
+     * The current channel index.
+     */
+    uint8_t Channel;
+    /*!
+     * Elapsed time since the start of the node.
+     */
+    TimerTime_t ElapsedTime;
+    /*!
+     * Time-on-air of the last transmission.
+     */
+    TimerTime_t TxTimeOnAir;
+}CalcBackOffParams_t;
+
+/*!
+ * The parameter structure for the function RegionNextChannel.
+ */
+typedef struct sNextChanParams
+{
+    /*!
+     * The aggregated time-off time.
+     */
+    TimerTime_t AggrTimeOff;
+    /*!
+     * The time of the last aggregated TX.
+     */
+    TimerTime_t LastAggrTx;
+    /*!
+     * The current datarate.
+     */
+    int8_t Datarate;
+    /*!
+     * Set to true, if the node has already joined a network, otherwise false.
+     */
+    bool Joined;
+    /*!
+     * Set to true, if the duty cycle is enabled, otherwise false.
+     */
+    bool DutyCycleEnabled;
+}NextChanParams_t;
+
+/*!
+ * The parameter structure for the function RegionChannelsAdd.
+ */
+typedef struct sChannelAddParams
+{
+    /*!
+     * A pointer to the new channel to add.
+     */
+    ChannelParams_t* NewChannel;
+    /*!
+     * The channel ID to add.
+     */
+    uint8_t ChannelId;
+}ChannelAddParams_t;
+
+/*!
+ * The parameter structure for the function RegionChannelsRemove.
+ */
+typedef struct sChannelRemoveParams
+{
+    /*!
+     * The channel ID to remove.
+     */
+    uint8_t ChannelId;
+}ChannelRemoveParams_t;
+
+/*!
+ * The parameter structure for the function RegionContinuousWave.
+ */
+typedef struct sContinuousWaveParams
+{
+    /*!
+     * The current channel index.
+     */
+    uint8_t Channel;
+    /*!
+     * The datarate. Used to limit the TX power.
+     */
+    int8_t Datarate;
+    /*!
+     * The TX power to set up.
+     */
+    int8_t TxPower;
+    /*!
+     * The max EIRP, if applicable.
+     */
+    float MaxEirp;
+    /*!
+     * The antenna gain, if applicable.
+     */
+    float AntennaGain;
+    /*!
+     * Specifies the time the radio will stay in CW mode.
+     */
+    uint16_t Timeout;
+}ContinuousWaveParams_t;
+
+
+#endif /* MBED_OS_LORA_PHY_DATASTRUCTURES_ */

--- a/features/lorawan/mbed_lib.json
+++ b/features/lorawan/mbed_lib.json
@@ -71,8 +71,8 @@
         	"value": true
         },
         "lbt-on": {
-        	"help": "Enables/disables LBT. NOTE: Disable only for testing. Mandatory in many regions/sub-bands.",
-        	"value": true
+        	"help": "Enables/disables LBT. NOTE: [This feature is not yet integrated].",
+        	"value": false
         }
     }
 }

--- a/features/lorawan/mbed_lib.json
+++ b/features/lorawan/mbed_lib.json
@@ -1,0 +1,78 @@
+{
+    "name": "lora",
+    "config": {
+        "phy": {
+            "help": ["Select LoRa PHY layer. See README.md for more information. Default: 0 = LORA_PHY_EU868",
+            "                                                                             1 = LORA_PHY_AS923",
+            "                                                                             2 = LORA_PHY_AU915",
+            "                                                                             3 = LORA_PHY_CN470",
+            "                                                                             4 = LORA_PHY_CN779",
+            "                                                                             5 = LORA_PHY_EU433",
+            "                                                                             6 = LORA_PHY_IN865",
+            "                                                                             7 = LORA_PHY_KR920",
+            "                                                                             8 = LORA_PHY_US915",
+            "                                                                             9 = LORA_PHY_US915_HYBRID"],
+            "value": "0"
+        },
+        "over-the-air-activation": {
+            "help": "When set to 1 the application uses the Over-the-Air activation procedure, default: true",
+            "value": true
+        },
+        "nb-trials": {
+            "help": "Indicates how many times join can be tried, default: 8",
+            "value": 8
+        },
+        "device-eui": {
+            "help": "Mote device IEEE EUI",
+            "value": "{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
+        },
+        "application-eui": {
+            "help": "Application IEEE EUI",
+            "value": "{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
+        },
+        "application-key": {
+            "help": "AES encryption/decryption cipher application key",
+            "value": "{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
+        },
+        "network-id": {
+            "help": "Current network ID",
+            "value": 0
+        },
+        "device-address": {
+            "help": "Device address on the network",
+            "value": "0x00000000"
+        },
+        "nwkskey": {
+            "help": "AES encryption/decryption cipher network session key",
+            "value": "{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
+        },
+        "appskey": {
+            "help": "AES encryption/decryption cipher application session key",
+            "value": "{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}"
+        },
+        "app-port": {
+            "help": "LoRaWAN application port, default: 15",
+            "value": 15
+        },
+        "tx-max-size": {
+            "help": "User application data buffer maximum size, default: 64, MAX: 255",
+            "value": 64
+        },
+        "adr-on": {
+            "help": "LoRaWAN Adaptive Data Rate, default: 1",
+            "value": 1
+        },
+        "public-network": {
+            "help": "LoRaWAN will connect to a public network or private network, true = public network",
+            "value": true
+        },
+        "duty-cycle-on": {
+        	"help": "Enables/disables duty cycling. NOTE: Disable only for testing. Mandatory in many regions.",
+        	"value": true
+        },
+        "lbt-on": {
+        	"help": "Enables/disables LBT. NOTE: Disable only for testing. Mandatory in many regions/sub-bands.",
+        	"value": true
+        }
+    }
+}

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -46,12 +46,12 @@ void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
 
 void TimerStart( TimerEvent_t *obj )
 {
-    obj->Timer.attach_us( mbed::callback( obj->Callback ), obj->value * 1000 );
+    obj->Timer.get()->attach_us( mbed::callback( obj->Callback ), obj->value * 1000 );
 }
 
 void TimerStop( TimerEvent_t *obj )
 {
-    obj->Timer.detach( );
+    obj->Timer.get()->detach( );
 }
 
 void TimerSetValue( TimerEvent_t *obj, uint32_t value )

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -1,0 +1,84 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+
+Description: Timer objects and scheduling management
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis and Gregory Cristian
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#include "lorawan/system/LoRaWANTimer.h"
+
+static mbed::Timer TimeCounter;
+static mbed::Ticker LoadTimeCounter;
+
+volatile uint32_t CurrentTime = 0;
+
+void TimerResetTimeCounter( void )
+{
+    CurrentTime = CurrentTime + TimeCounter.read_us( ) / 1000;
+    TimeCounter.reset( );
+    TimeCounter.start( );
+}
+
+void TimerTimeCounterInit( void )
+{
+    TimeCounter.start( );
+    LoadTimeCounter.attach( mbed::callback( &TimerResetTimeCounter ), 10 );
+}
+
+TimerTime_t TimerGetCurrentTime( void )
+{
+    CurrentTime += TimeCounter.read_us( ) / 1000;
+    TimeCounter.reset( );
+    TimeCounter.start( );
+    return ( ( TimerTime_t )CurrentTime );
+}
+
+TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime )
+{
+    CurrentTime += TimeCounter.read_us( ) / 1000;
+    TimeCounter.reset( );
+    TimeCounter.start( );
+    return ( TimerTime_t )( CurrentTime - savedTime );
+}
+
+TimerTime_t TimerGetFutureTime( TimerTime_t eventInFuture )
+{
+    CurrentTime += TimeCounter.read_us( ) / 1000;
+    TimeCounter.reset( );
+    TimeCounter.start( );
+    return ( TimerTime_t )( CurrentTime + eventInFuture );
+}
+
+void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )
+{
+    obj->value = 0;
+    obj->Callback = callback;
+}
+
+void TimerStart( TimerEvent_t *obj )
+{
+    obj->Timer.attach_us( mbed::callback( obj->Callback ), obj->value * 1000 );
+}
+
+void TimerStop( TimerEvent_t *obj )
+{
+    obj->Timer.detach( );
+}
+
+void TimerSetValue( TimerEvent_t *obj, uint32_t value )
+{
+    obj->value = value;
+}

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -20,46 +20,22 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #include "lorawan/system/LoRaWANTimer.h"
 
-static mbed::Timer TimeCounter;
-static mbed::Ticker LoadTimeCounter;
+static events::EventQueue *_queue = NULL;
 
-volatile uint32_t CurrentTime = 0;
-
-void TimerResetTimeCounter( void )
+void TimerTimeCounterInit(events::EventQueue *queue)
 {
-    CurrentTime = CurrentTime + TimeCounter.read_us( ) / 1000;
-    TimeCounter.reset( );
-    TimeCounter.start( );
-}
-
-void TimerTimeCounterInit( void )
-{
-    TimeCounter.start( );
-    LoadTimeCounter.attach( mbed::callback( &TimerResetTimeCounter ), 10 );
+    _queue = queue;
 }
 
 TimerTime_t TimerGetCurrentTime( void )
 {
-    CurrentTime += TimeCounter.read_us( ) / 1000;
-    TimeCounter.reset( );
-    TimeCounter.start( );
-    return ( ( TimerTime_t )CurrentTime );
+    const uint32_t current_time = _queue->tick();
+    return (TimerTime_t)current_time;
 }
 
 TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime )
 {
-    CurrentTime += TimeCounter.read_us( ) / 1000;
-    TimeCounter.reset( );
-    TimeCounter.start( );
-    return ( TimerTime_t )( CurrentTime - savedTime );
-}
-
-TimerTime_t TimerGetFutureTime( TimerTime_t eventInFuture )
-{
-    CurrentTime += TimeCounter.read_us( ) / 1000;
-    TimeCounter.reset( );
-    TimeCounter.start( );
-    return ( TimerTime_t )( CurrentTime + eventInFuture );
+    return TimerGetCurrentTime() - savedTime;
 }
 
 void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) )

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -1,0 +1,107 @@
+/**
+ / _____)             _              | |
+( (____  _____ ____ _| |_ _____  ____| |__
+ \____ \| ___ |    (_   _) ___ |/ ___)  _ \
+ _____) ) ____| | | || |_| ____( (___| | | |
+(______/|_____)_|_|_| \__)_____)\____)_| |_|
+    (C)2013 Semtech
+
+Description: Timer objects and scheduling management
+
+License: Revised BSD License, see LICENSE.TXT file include in the project
+
+Maintainer: Miguel Luis and Gregory Cristian
+
+
+Copyright (c) 2017, Arm Limited and affiliates.
+
+SPDX-License-Identifier: BSD-3-Clause
+*/
+
+#ifndef MBED_LORAWAN_SYS_TIMER_H__
+#define MBED_LORAWAN_SYS_TIMER_H__
+#include "drivers/Timer.h"
+#include "drivers/Ticker.h"
+#include "lorawan/system/lorawan_data_structures.h"
+
+/*!
+ * \brief Timer object description
+ */
+typedef struct TimerEvent_s
+{
+    uint32_t value;
+    void ( *Callback )( void );
+    mbed::Ticker Timer;
+}TimerEvent_t;
+
+/*!
+ * \brief Initializes the timer used to get the current time.
+ *
+ * \remark The current time corresponds to the time since system startup.
+ */
+void TimerTimeCounterInit( void );
+
+/*!
+ * \brief Initializes the timer object.
+ *
+ * \remark The TimerSetValue function must be called before starting the timer.
+ *         This function initializes the timestamp and reloads the value at 0.
+ *
+ * \param [in] obj          The structure containing the timer object parameters.
+ * \param [in] callback     The function callback called at the end of the timeout.
+ */
+void TimerInit( TimerEvent_t *obj, void ( *callback )( void ) );
+
+/*!
+ * \brief Starts and adds the timer object to the list of timer events.
+ *
+ * \param [in] obj The structure containing the timer object parameters.
+ */
+void TimerStart( TimerEvent_t *obj );
+
+/*!
+ * \brief Stops and removes the timer object from the list of timer events.
+ *
+ * \param [in] obj The structure containing the timer object parameters.
+ */
+void TimerStop( TimerEvent_t *obj );
+
+/*!
+ * \brief Resets the timer object.
+ *
+ * \param [in] obj The structure containing the timer object parameters.
+ */
+void TimerReset( TimerEvent_t *obj );
+
+/*!
+ * \brief Set a new timeout value.
+ *
+ * \param [in] obj   The structure containing the timer object parameters.
+ * \param [in] value The new timeout value.
+ */
+void TimerSetValue( TimerEvent_t *obj, uint32_t value );
+
+/*!
+ * \brief Read the current time.
+ *
+ * \retval time The current time.
+ */
+TimerTime_t TimerGetCurrentTime( void );
+
+/*!
+ * \brief Return the time elapsed since a fixed moment in time.
+ *
+ * \param [in] savedTime    The fixed moment in time.
+ * \retval time             The elapsed time.
+ */
+TimerTime_t TimerGetElapsedTime( TimerTime_t savedTime );
+
+/*!
+ * \brief Return the time elapsed since a fixed moment in time.
+ *
+ * \param [in] eventInFuture    The fixed moment in the future.
+ * \retval time             The difference between now and a future event.
+ */
+TimerTime_t TimerGetFutureTime( TimerTime_t eventInFuture );
+
+#endif // MBED_LORAWAN_SYS_TIMER_H__

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -20,10 +20,12 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #ifndef MBED_LORAWAN_SYS_TIMER_H__
 #define MBED_LORAWAN_SYS_TIMER_H__
+
 #include "drivers/Timer.h"
 #include "drivers/Ticker.h"
 #include "lorawan/system/lorawan_data_structures.h"
 #include "events/EventQueue.h"
+#include "platform/SingletonPtr.h"
 
 /*!
  * \brief Timer object description
@@ -32,7 +34,7 @@ typedef struct TimerEvent_s
 {
     uint32_t value;
     void ( *Callback )( void );
-    mbed::Ticker Timer;
+    SingletonPtr<mbed::Ticker> Timer;
 }TimerEvent_t;
 
 /*!

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -23,6 +23,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "drivers/Timer.h"
 #include "drivers/Ticker.h"
 #include "lorawan/system/lorawan_data_structures.h"
+#include "events/EventQueue.h"
 
 /*!
  * \brief Timer object description
@@ -33,13 +34,6 @@ typedef struct TimerEvent_s
     void ( *Callback )( void );
     mbed::Ticker Timer;
 }TimerEvent_t;
-
-/*!
- * \brief Initializes the timer used to get the current time.
- *
- * \remark The current time corresponds to the time since system startup.
- */
-void TimerTimeCounterInit( void );
 
 /*!
  * \brief Initializes the timer object.
@@ -80,6 +74,15 @@ void TimerReset( TimerEvent_t *obj );
  * \param [in] value The new timeout value.
  */
 void TimerSetValue( TimerEvent_t *obj, uint32_t value );
+
+/*!
+ * \brief Initializes the timer used to get the current time.
+ *
+ * \remark The current time corresponds to the time since system startup.
+ *
+ * \param [in] queue  Handle to EventQueue object
+ */
+void TimerTimeCounterInit(events::EventQueue *queue);
 
 /*!
  * \brief Read the current time.

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1635,7 +1635,6 @@ typedef struct sLoRaMacCallback
      */
     uint8_t ( *GetBatteryLevel )( void );
 
-    mbed::Callback<void()> TxNextPacketTimerEvent;
 }LoRaMacCallback_t;
 
 /**

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1,0 +1,2910 @@
+/**
+ * @file lorawan_data_structures.h
+ *
+ * @brief Contains common data structures used by Mbed-OS
+ *        LoRaWAN mplementation.
+ *
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LORAWAN_SYSTEM_LORAWAN_DATA_STRUCTURES_H_
+#define LORAWAN_SYSTEM_LORAWAN_DATA_STRUCTURES_H_
+
+#include <inttypes.h>
+#include "platform/Callback.h"
+
+/*!
+ * \brief Timer time variable definition
+ */
+#ifndef TimerTime_t
+typedef uint32_t TimerTime_t;
+#endif
+
+// Radio wake-up time from sleep - unit ms.
+#define RADIO_WAKEUP_TIME                           1
+
+/**
+ * Option Flags for send(), receive() APIs
+ */
+#define MSG_UNCONFIRMED_FLAG                  0x01
+#define MSG_CONFIRMED_FLAG                    0x02
+#define MSG_MULTICAST_FLAG                    0x04
+#define MSG_PROPRIETARY_FLAG                  0x08
+
+/**
+ * Bit mask for message flags
+ */
+
+#define MSG_FLAG_MASK                         0x0F
+
+/**
+ * Mask for unconfirmed multicast message
+ */
+#define MSG_UNCONFIRMED_MULTICAST              0x05
+
+/**
+ * Mask for confirmed multicast message
+ */
+#define MSG_CONFIRMED_MULTICAST                0x06
+
+/**
+ * Mask for unconfirmed message proprietary message
+ */
+#define MSG_UNCONFIRMED_PROPRIETARY            0x09
+
+/**
+ * Mask for confirmed proprietary message
+ */
+#define MSG_CONFIRMED_PROPRIETARY              0x0A
+
+/*!
+ * Sets the length of the LoRaMAC footer field.
+ * Mainly indicates the MIC field length.
+ */
+#define LORAMAC_MFR_LEN                             4
+
+/*!
+ * The FRMPayload overhead to be used when setting the `Radio.SetMaxPayloadLength`
+ * in the `RxWindowSetup` function.
+ * The maximum PHYPayload = MaxPayloadOfDatarate/MaxPayloadOfDatarateRepeater + LORA_MAC_FRMPAYLOAD_OVERHEAD
+ */
+#define LORA_MAC_FRMPAYLOAD_OVERHEAD                13 // MHDR(1) + FHDR(7) + Port(1) + MIC(4)
+
+/**
+ * LoRaMac maximum number of channels
+ */
+#define LORA_MAX_NB_CHANNELS                        16
+
+/*!
+ * LoRaWAN device classes definition.
+ *
+ * LoRaWAN Specification V1.0.2, chapter 2.1.
+ */
+typedef enum eDeviceClass
+{
+    /*!
+     * LoRaWAN device class A.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 3.
+     */
+    CLASS_A,
+    /*!
+     * LoRaWAN device class B.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 8.
+     */
+    CLASS_B,
+    /*!
+     * LoRaWAN device class C.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 17.
+     */
+    CLASS_C,
+}DeviceClass_t;
+
+/*!
+ * LoRaMAC channel parameters definition.
+ */
+typedef union uDrRange
+{
+    /*!
+     * Byte-access to the bits.
+     */
+    int8_t Value;
+    /*!
+     * The structure to store the minimum and the maximum datarate.
+     */
+    struct sFields
+    {
+         /*!
+         * The minimum data rate.
+         *
+         * LoRaWAN Regional Parameters V1.0.2rB.
+         *
+         * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+         */
+        int8_t Min : 4;
+        /*!
+         * The maximum data rate.
+         *
+         * LoRaWAN Regional Parameters V1.0.2rB.
+         *
+         * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+         */
+        int8_t Max : 4;
+    }Fields;
+}DrRange_t;
+
+/*!
+ * LoRaMAC channel definition.
+ */
+typedef struct sChannelParams
+{
+    /*!
+     * The frequency in Hz.
+     */
+    uint32_t Frequency;
+    /*!
+     * The alternative frequency for RX window 1.
+     */
+    uint32_t Rx1Frequency;
+    /*!
+     * The data rate definition.
+     */
+    DrRange_t DrRange;
+    /*!
+     * The band index.
+     */
+    uint8_t Band;
+}ChannelParams_t;
+
+/*!
+ * LoRaMAC band parameters definition.
+ */
+typedef struct sBand
+{
+    /*!
+     * The duty cycle.
+     */
+    uint16_t DCycle;
+    /*!
+     * The maximum TX power.
+     */
+    int8_t TxMaxPower;
+    /*!
+     * The timestamp of the last JoinReq TX frame.
+     */
+    TimerTime_t LastJoinTxDoneTime;
+    /*!
+     * The timestamp of the last TX frame.
+     */
+    TimerTime_t LastTxDoneTime;
+    /*!
+     * The device off time.
+     */
+    TimerTime_t TimeOff;
+}Band_t;
+
+
+/*!
+ * LoRaMAC receive window 2 channel parameters.
+ */
+typedef struct sRx2ChannelParams
+{
+    /*!
+     * The frequency in Hz.
+     */
+    uint32_t Frequency;
+    /*!
+     * The data rate.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+     */
+    uint8_t  Datarate;
+}Rx2ChannelParams_t;
+
+/*!
+ * The global MAC layer parameters.
+ */
+typedef struct sLoRaMacParams
+{
+    /*!
+     * The TX power in channels.
+     */
+    int8_t ChannelsTxPower;
+    /*!
+     * The data rate in channels.
+     */
+    int8_t ChannelsDatarate;
+    /*!
+     * The system overall timing error in milliseconds.
+     * [-SystemMaxRxError : +SystemMaxRxError]
+     * Default: +/-10 ms
+     */
+    uint32_t SystemMaxRxError;
+    /*!
+     * The minimum number of symbols required to detect an RX frame.
+     * Default: 6 symbols
+     */
+    uint8_t MinRxSymbols;
+    /*!
+     * LoRaMac maximum time a reception window stays open.
+     */
+    uint32_t MaxRxWindow;
+    /*!
+     * Receive delay 1.
+     */
+    uint32_t ReceiveDelay1;
+    /*!
+     * Receive delay 2.
+     */
+    uint32_t ReceiveDelay2;
+    /*!
+     * Join accept delay 1.
+     */
+    uint32_t JoinAcceptDelay1;
+    /*!
+     * Join accept delay 1.
+     */
+    uint32_t JoinAcceptDelay2;
+    /*!
+     * The number of uplink messages repetitions [1:15] (unconfirmed messages only).
+     */
+    uint8_t ChannelsNbRep;
+    /*!
+     * The datarate offset between uplink and downlink on first window.
+     */
+    uint8_t Rx1DrOffset;
+    /*!
+     * LoRaMAC 2nd reception window settings.
+     */
+    Rx2ChannelParams_t Rx2Channel;
+    /*!
+     * The uplink dwell time configuration. 0: No limit, 1: 400ms
+     */
+    uint8_t UplinkDwellTime;
+    /*!
+     * The downlink dwell time configuration. 0: No limit, 1: 400ms
+     */
+    uint8_t DownlinkDwellTime;
+    /*!
+     * The maximum possible EIRP.
+     */
+    float MaxEirp;
+    /*!
+     * The antenna gain of the node.
+     */
+    float AntennaGain;
+}LoRaMacParams_t;
+
+/*!
+ * LoRaMAC multicast channel parameter.
+ */
+typedef struct sMulticastParams
+{
+    /*!
+     * Address.
+     */
+    uint32_t Address;
+    /*!
+     * Network session key.
+     */
+    uint8_t NwkSKey[16];
+    /*!
+     * Application session key.
+     */
+    uint8_t AppSKey[16];
+    /*!
+     * Downlink counter.
+     */
+    uint32_t DownLinkCounter;
+    /*!
+     * A reference pointer to the next multicast channel parameters in the list.
+     */
+    struct sMulticastParams *Next;
+}MulticastParams_t;
+
+/*!
+ * LoRaMAC frame types.
+ *
+ * LoRaWAN Specification V1.0.2, chapter 4.2.1, table 1.
+ */
+typedef enum eLoRaMacFrameType
+{
+    /*!
+     * LoRaMAC join request frame.
+     */
+    FRAME_TYPE_JOIN_REQ              = 0x00,
+    /*!
+     * LoRaMAC join accept frame.
+     */
+    FRAME_TYPE_JOIN_ACCEPT           = 0x01,
+    /*!
+     * LoRaMAC unconfirmed uplink frame.
+     */
+    FRAME_TYPE_DATA_UNCONFIRMED_UP   = 0x02,
+    /*!
+     * LoRaMAC unconfirmed downlink frame.
+     */
+    FRAME_TYPE_DATA_UNCONFIRMED_DOWN = 0x03,
+    /*!
+     * LoRaMAC confirmed uplink frame.
+     */
+    FRAME_TYPE_DATA_CONFIRMED_UP     = 0x04,
+    /*!
+     * LoRaMAC confirmed downlink frame.
+     */
+    FRAME_TYPE_DATA_CONFIRMED_DOWN   = 0x05,
+    /*!
+     * LoRaMAC RFU frame.
+     */
+    FRAME_TYPE_RFU                   = 0x06,
+    /*!
+     * LoRaMAC proprietary frame.
+     */
+    FRAME_TYPE_PROPRIETARY           = 0x07,
+}LoRaMacFrameType_t;
+
+/*!
+ * LoRaMAC mote MAC commands.
+ *
+ * LoRaWAN Specification V1.0.2, chapter 5, table 4.
+ */
+typedef enum eLoRaMacMoteCmd
+{
+    /*!
+     * LinkCheckReq
+     */
+    MOTE_MAC_LINK_CHECK_REQ          = 0x02,
+    /*!
+     * LinkADRAns
+     */
+    MOTE_MAC_LINK_ADR_ANS            = 0x03,
+    /*!
+     * DutyCycleAns
+     */
+    MOTE_MAC_DUTY_CYCLE_ANS          = 0x04,
+    /*!
+     * RXParamSetupAns
+     */
+    MOTE_MAC_RX_PARAM_SETUP_ANS      = 0x05,
+    /*!
+     * DevStatusAns
+     */
+    MOTE_MAC_DEV_STATUS_ANS          = 0x06,
+    /*!
+     * NewChannelAns
+     */
+    MOTE_MAC_NEW_CHANNEL_ANS         = 0x07,
+    /*!
+     * RXTimingSetupAns
+     */
+    MOTE_MAC_RX_TIMING_SETUP_ANS     = 0x08,
+    /*!
+     * TXParamSetupAns
+     */
+    MOTE_MAC_TX_PARAM_SETUP_ANS      = 0x09,
+    /*!
+     * DlChannelAns
+     */
+    MOTE_MAC_DL_CHANNEL_ANS          = 0x0A
+}LoRaMacMoteCmd_t;
+
+/*!
+ * LoRaMAC server MAC commands.
+ *
+ * LoRaWAN Specification V1.0.2 chapter 5, table 4.
+ */
+typedef enum eLoRaMacSrvCmd
+{
+    /*!
+     * LinkCheckAns
+     */
+    SRV_MAC_LINK_CHECK_ANS           = 0x02,
+    /*!
+     * LinkADRReq
+     */
+    SRV_MAC_LINK_ADR_REQ             = 0x03,
+    /*!
+     * DutyCycleReq
+     */
+    SRV_MAC_DUTY_CYCLE_REQ           = 0x04,
+    /*!
+     * RXParamSetupReq
+     */
+    SRV_MAC_RX_PARAM_SETUP_REQ       = 0x05,
+    /*!
+     * DevStatusReq
+     */
+    SRV_MAC_DEV_STATUS_REQ           = 0x06,
+    /*!
+     * NewChannelReq
+     */
+    SRV_MAC_NEW_CHANNEL_REQ          = 0x07,
+    /*!
+     * RXTimingSetupReq
+     */
+    SRV_MAC_RX_TIMING_SETUP_REQ      = 0x08,
+    /*!
+     * NewChannelReq
+     */
+    SRV_MAC_TX_PARAM_SETUP_REQ       = 0x09,
+    /*!
+     * DlChannelReq
+     */
+    SRV_MAC_DL_CHANNEL_REQ           = 0x0A,
+}LoRaMacSrvCmd_t;
+
+/*!
+ * LoRaMAC battery level indicator.
+ */
+typedef enum eLoRaMacBatteryLevel
+{
+    /*!
+     * An external power source.
+     */
+    BAT_LEVEL_EXT_SRC                = 0x00,
+    /*!
+     * Battery level empty.
+     */
+    BAT_LEVEL_EMPTY                  = 0x01,
+    /*!
+     * Battery level full.
+     */
+    BAT_LEVEL_FULL                   = 0xFE,
+    /*!
+     * Battery level - no measurement available.
+     */
+    BAT_LEVEL_NO_MEASURE             = 0xFF,
+}LoRaMacBatteryLevel_t;
+
+/*!
+ * LoRaMAC header field definition (MHDR field).
+ *
+ * LoRaWAN Specification V1.0.2, chapter 4.2.
+ */
+typedef union uLoRaMacHeader
+{
+    /*!
+     * Byte-access to the bits.
+     */
+    uint8_t Value;
+    /*!
+     * The structure containing single access to header bits.
+     */
+    struct sHdrBits
+    {
+        /*!
+         * Major version.
+         */
+        uint8_t Major           : 2;
+        /*!
+         * RFU
+         */
+        uint8_t RFU             : 3;
+        /*!
+         * Message type
+         */
+        uint8_t MType           : 3;
+    }Bits;
+}LoRaMacHeader_t;
+
+/*!
+ * LoRaMAC frame control field definition (FCtrl).
+ *
+ * LoRaWAN Specification V1.0.2, chapter 4.3.1.
+ */
+typedef union uLoRaMacFrameCtrl
+{
+    /*!
+     * Byte-access to the bits.
+     */
+    uint8_t Value;
+    /*!
+     * The structure containing single access to bits.
+     */
+    struct sCtrlBits
+    {
+        /*!
+         * Frame options length.
+         */
+        uint8_t FOptsLen        : 4;
+        /*!
+         * Frame pending bit.
+         */
+        uint8_t FPending        : 1;
+        /*!
+         * Message acknowledge bit.
+         */
+        uint8_t Ack             : 1;
+        /*!
+         * ADR acknowledgment request bit.
+         */
+        uint8_t AdrAckReq       : 1;
+        /*!
+         * ADR control in the frame header.
+         */
+        uint8_t Adr             : 1;
+    }Bits;
+}LoRaMacFrameCtrl_t;
+
+/*!
+ * The enumeration containing the status of the operation of a MAC service.
+ */
+typedef enum eLoRaMacEventInfoStatus
+{
+    /*!
+     * Service performed successfully.
+     */
+    LORAMAC_EVENT_INFO_STATUS_OK = 0,
+    /*!
+     * An error occurred during the execution of the service.
+     */
+    LORAMAC_EVENT_INFO_STATUS_ERROR,
+    /*!
+     * A TX timeout occurred.
+     */
+    LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT,
+    /*!
+     * An RX timeout occurred on receive window 1.
+     */
+    LORAMAC_EVENT_INFO_STATUS_RX1_TIMEOUT,
+    /*!
+     * An RX timeout occurred on receive window 2.
+     */
+    LORAMAC_EVENT_INFO_STATUS_RX2_TIMEOUT,
+    /*!
+     * An RX error occurred on receive window 1.
+     */
+    LORAMAC_EVENT_INFO_STATUS_RX1_ERROR,
+    /*!
+     * An RX error occurred on receive window 2.
+     */
+    LORAMAC_EVENT_INFO_STATUS_RX2_ERROR,
+    /*!
+     * An error occurred in the join procedure.
+     */
+    LORAMAC_EVENT_INFO_STATUS_JOIN_FAIL,
+    /*!
+     * A frame with an invalid downlink counter was received. The
+     * downlink counter of the frame was equal to the local copy
+     * of the downlink counter of the node.
+     */
+    LORAMAC_EVENT_INFO_STATUS_DOWNLINK_REPEATED,
+    /*!
+     * The MAC could not retransmit a frame since the MAC decreased the datarate. The
+     * payload size is not applicable for the datarate.
+     */
+    LORAMAC_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR,
+    /*!
+     * The node has lost MAX_FCNT_GAP or more frames.
+     */
+    LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS,
+    /*!
+     * An address error occurred.
+     */
+    LORAMAC_EVENT_INFO_STATUS_ADDRESS_FAIL,
+    /*!
+     * Message integrity check failure.
+     */
+    LORAMAC_EVENT_INFO_STATUS_MIC_FAIL,
+    /*!
+     * Crypto methods failure
+     */
+    LORAMAC_EVENT_INFO_STATUS_CRYPTO_FAIL,
+}LoRaMacEventInfoStatus_t;
+
+/*!
+ * LoRaMac TX/RX operation state.
+ */
+typedef union eLoRaMacFlags_t
+{
+    /*!
+     * Byte-access to the bits.
+     */
+    uint8_t Value;
+    /*!
+     * The structure containing single access to bits.
+     */
+    struct sMacFlagBits
+    {
+        /*!
+         * MCPS-Req pending
+         */
+        uint8_t McpsReq         : 1;
+        /*!
+         * MCPS-Ind pending
+         */
+        uint8_t McpsInd         : 1;
+        /*!
+         * MCPS-Ind pending. Skip indication to the application layer.
+         */
+        uint8_t McpsIndSkip     : 1;
+        /*!
+         * MLME-Req pending
+         */
+        uint8_t MlmeReq         : 1;
+        /*!
+         * MAC cycle done
+         */
+        uint8_t MacDone         : 1;
+    }Bits;
+}LoRaMacFlags_t;
+
+/*!
+ *
+ * \brief   LoRaMAC data services
+ *
+ * \details The following table list the primitives supported by a
+ *          specific MAC data service:
+ *
+ * Name                  | Request | Indication | Response | Confirm
+ * --------------------- | :-----: | :--------: | :------: | :-----:
+ * \ref MCPS_UNCONFIRMED | YES     | YES        | NO       | YES
+ * \ref MCPS_CONFIRMED   | YES     | YES        | NO       | YES
+ * \ref MCPS_MULTICAST   | NO      | YES        | NO       | NO
+ * \ref MCPS_PROPRIETARY | YES     | YES        | NO       | YES
+ *
+ * The following table provides links to the function implementations of the
+ * related MCPS primitives:
+ *
+ * Primitive        | Function
+ * ---------------- | :---------------------:
+ * MCPS-Request     | \ref LoRaMacMlmeRequest
+ * MCPS-Confirm     | MacMcpsConfirm in \ref LoRaMacPrimitives_t
+ * MCPS-Indication  | MacMcpsIndication in \ref LoRaMacPrimitives_t
+ */
+typedef enum eMcps
+{
+    /*!
+     * Unconfirmed LoRaMAC frame.
+     */
+    MCPS_UNCONFIRMED,
+    /*!
+     * Confirmed LoRaMAC frame.
+     */
+    MCPS_CONFIRMED,
+    /*!
+     * Multicast LoRaMAC frame.
+     */
+    MCPS_MULTICAST,
+    /*!
+     * Proprietary frame.
+     */
+    MCPS_PROPRIETARY,
+}Mcps_t;
+
+/*!
+ * LoRaMAC MCPS-Request for an unconfirmed frame.
+ */
+typedef struct sMcpsReqUnconfirmed
+{
+    /*!
+     * Frame port field. Must be set if the payload is not empty. Use the
+     * application-specific frame port values: [1...223].
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.2.
+     */
+    uint8_t fPort;
+    /*!
+     * A pointer to the buffer of the frame payload.
+     */
+    void *fBuffer;
+    /*!
+     * The size of the frame payload.
+     */
+    uint16_t fBufferSize;
+    /*!
+     * Uplink datarate, if ADR is off.
+     */
+    int8_t Datarate;
+}McpsReqUnconfirmed_t;
+
+/*!
+ * LoRaMAC MCPS-Request for a confirmed frame.
+ */
+typedef struct sMcpsReqConfirmed
+{
+    /*!
+     * Frame port field. Must be set if the payload is not empty. Use the
+     * application-specific frame port values: [1...223].
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.2.
+     */
+    uint8_t fPort;
+    /*!
+     * A pointer to the buffer of the frame payload.
+     */
+    void *fBuffer;
+    /*!
+     * The size of the frame payload.
+     */
+    uint16_t fBufferSize;
+    /*!
+     * Uplink datarate, if ADR is off.
+     */
+    int8_t Datarate;
+    /*!
+     * The number of trials to transmit the frame, if the LoRaMAC layer did not
+     * receive an acknowledgment. The MAC performs a datarate adaptation
+     * according to the LoRaWAN Specification V1.0.2, chapter 18.4, as in
+     * the following table:
+     *
+     * Transmission nb | Data Rate
+     * ----------------|-----------
+     * 1 (first)       | DR
+     * 2               | DR
+     * 3               | max(DR-1,0)
+     * 4               | max(DR-1,0)
+     * 5               | max(DR-2,0)
+     * 6               | max(DR-2,0)
+     * 7               | max(DR-3,0)
+     * 8               | max(DR-3,0)
+     *
+     * Note that if NbTrials is set to 1 or 2, the MAC will not decrease
+     * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
+     */
+    uint8_t NbTrials;
+}McpsReqConfirmed_t;
+
+/*!
+ * LoRaMAC MCPS-Request for a proprietary frame.
+ */
+typedef struct sMcpsReqProprietary
+{
+    /*!
+     * A pointer to the buffer of the frame payload.
+     */
+    void *fBuffer;
+    /*!
+     * The size of the frame payload.
+     */
+    uint16_t fBufferSize;
+    /*!
+     * Uplink datarate, if ADR is off.
+     */
+    int8_t Datarate;
+}McpsReqProprietary_t;
+
+/*!
+ * LoRaMAC MCPS-Request structure.
+ */
+typedef struct sMcpsReq
+{
+    /*!
+     * MCPS-Request type.
+     */
+    Mcps_t Type;
+
+    /*!
+     * MCPS-Request parameters.
+     */
+    union uMcpsParam
+    {
+        /*!
+         * MCPS-Request parameters for an unconfirmed frame.
+         */
+        McpsReqUnconfirmed_t Unconfirmed;
+        /*!
+         * MCPS-Request parameters for a confirmed frame.
+         */
+        McpsReqConfirmed_t Confirmed;
+        /*!
+         * MCPS-Request parameters for a proprietary frame.
+         */
+        McpsReqProprietary_t Proprietary;
+    }Req;
+}McpsReq_t;
+
+/*!
+ * LoRaMAC MCPS-Confirm.
+ */
+typedef struct sMcpsConfirm
+{
+    /*!
+     * Holds the previously performed MCPS-Request.
+     */
+    Mcps_t McpsRequest;
+    /*!
+     * The status of the operation.
+     */
+    LoRaMacEventInfoStatus_t Status;
+    /*!
+     * The uplink datarate.
+     */
+    uint8_t Datarate;
+    /*!
+     * The transmission power.
+     */
+    int8_t TxPower;
+    /*!
+     * Set if an acknowledgement was received.
+     */
+    bool AckReceived;
+    /*!
+     * Provides the number of retransmissions.
+     */
+    uint8_t NbRetries;
+    /*!
+     * The transmission time on air of the frame.
+     */
+    TimerTime_t TxTimeOnAir;
+    /*!
+     * The uplink counter value related to the frame.
+     */
+    uint32_t UpLinkCounter;
+    /*!
+     * The uplink frequency related to the frame.
+     */
+    uint32_t UpLinkFrequency;
+}McpsConfirm_t;
+
+/*!
+ * LoRaMAC MCPS-Indication primitive.
+ */
+typedef struct sMcpsIndication
+{
+    /*!
+     * MCPS-Indication type.
+     */
+    Mcps_t McpsIndication;
+    /*!
+     * The status of the operation.
+     */
+    LoRaMacEventInfoStatus_t Status;
+    /*!
+     * Multicast.
+     */
+    uint8_t Multicast;
+    /*!
+     * The application port.
+     */
+    uint8_t Port;
+    /*!
+     * The downlink datarate.
+     */
+    uint8_t RxDatarate;
+    /*!
+     * Frame pending status.
+     */
+    uint8_t FramePending;
+    /*!
+     * A pointer to the received data stream.
+     */
+    uint8_t *Buffer;
+    /*!
+     * The size of the received data stream.
+     */
+    uint8_t BufferSize;
+    /*!
+     * Indicates, if data is available.
+     */
+    bool RxData;
+    /*!
+     * The RSSI of the received packet.
+     */
+    int16_t Rssi;
+    /*!
+     * The SNR of the received packet.
+     */
+    uint8_t Snr;
+    /*!
+     * The receive window.
+     *
+     * [0: Rx window 1, 1: Rx window 2]
+     */
+    uint8_t RxSlot;
+    /*!
+     * Set if an acknowledgement was received.
+     */
+    bool AckReceived;
+    /*!
+     * The downlink counter value for the received frame.
+     */
+    uint32_t DownLinkCounter;
+}McpsIndication_t;
+
+/*!
+ * \brief LoRaMAC management services.
+ *
+ * \details The following table list the primitives supported by a
+ *          specific MAC management service:
+ *
+ * Name                  | Request | Indication | Response | Confirm
+ * --------------------- | :-----: | :--------: | :------: | :-----:
+ * \ref MLME_JOIN        | YES     | NO         | NO       | YES
+ * \ref MLME_LINK_CHECK  | YES     | NO         | NO       | YES
+ * \ref MLME_TXCW        | YES     | NO         | NO       | YES
+ *
+ * The following table provides links to the function implementations of the
+ * related MLME primitives.
+ *
+ * Primitive        | Function
+ * ---------------- | :---------------------:
+ * MLME-Request     | \ref LoRaMacMlmeRequest
+ * MLME-Confirm     | MacMlmeConfirm in \ref LoRaMacPrimitives_t
+ */
+typedef enum eMlme
+{
+    /*!
+     * Initiates the Over-the-Air activation.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.2.
+     */
+    MLME_JOIN,
+    /*!
+     * LinkCheckReq - Connectivity validation.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 5, table 4.
+     */
+    MLME_LINK_CHECK,
+    /*!
+     * Sets TX continuous wave mode.
+     *
+     * LoRaWAN end-device certification.
+     */
+    MLME_TXCW,
+    /*!
+     * Sets TX continuous wave mode (new LoRa-Alliance CC definition).
+     *
+     * LoRaWAN end-device certification.
+     */
+    MLME_TXCW_1,
+}Mlme_t;
+
+/*!
+ * LoRaMAC MLME-Request for the join service.
+ */
+typedef struct sMlmeReqJoin
+{
+    /*!
+     * A globally unique end-device identifier.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.2.1.
+     */
+    uint8_t *DevEui;
+    /*!
+     * An application identifier.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.2
+     */
+    uint8_t *AppEui;
+    /*!
+     * AES-128 application key.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.2.2.
+     */
+    uint8_t *AppKey;
+    /*!
+     * The number of trials for the join request.
+     */
+    uint8_t NbTrials;
+}MlmeReqJoin_t;
+
+/*!
+ * LoRaMAC MLME-Request for TX continuous wave mode.
+ */
+typedef struct sMlmeReqTxCw
+{
+    /*!
+     * The time while the radio is kept in continuous wave mode, in seconds.
+     */
+    uint16_t Timeout;
+    /*!
+     * The RF frequency to set (only used with the new way).
+     */
+    uint32_t Frequency;
+    /*!
+     * The RF output power to set (only used with the new way).
+     */
+    uint8_t Power;
+}MlmeReqTxCw_t;
+
+/*!
+ * LoRaMAC MLME-Request structure.
+ */
+typedef struct sMlmeReq
+{
+    /*!
+     * MLME-Request type.
+     */
+    Mlme_t Type;
+
+    /*!
+     * MLME-Request parameters.
+     */
+    union uMlmeParam
+    {
+        /*!
+         * MLME-Request parameters for a join request.
+         */
+        MlmeReqJoin_t Join;
+        /*!
+         * MLME-Request parameters for TX continuous mode request.
+         */
+        MlmeReqTxCw_t TxCw;
+    }Req;
+}MlmeReq_t;
+
+/*!
+ * LoRaMAC MLME-Confirm primitive.
+ */
+typedef struct sMlmeConfirm
+{
+    /*!
+     * The previously performed MLME-Request.
+     */
+    Mlme_t MlmeRequest;
+    /*!
+     * The status of the operation.
+     */
+    LoRaMacEventInfoStatus_t Status;
+    /*!
+     * The transmission time on air of the frame.
+     */
+    TimerTime_t TxTimeOnAir;
+    /*!
+     * The demodulation margin. Contains the link margin [dB] of the last LinkCheckReq
+     * successfully received.
+     */
+    uint8_t DemodMargin;
+    /*!
+     * The number of gateways which received the last LinkCheckReq.
+     */
+    uint8_t NbGateways;
+    /*!
+     * The number of retransmissions.
+     */
+    uint8_t NbRetries;
+}MlmeConfirm_t;
+
+/*!
+ * LoRa MAC Information Base (MIB).
+ *
+ * The following table lists the MIB parameters and the related attributes:
+ *
+ * Attribute                         | Get | Set
+ * --------------------------------- | :-: | :-:
+ * \ref MIB_DEVICE_CLASS             | YES | YES
+ * \ref MIB_NETWORK_JOINED           | YES | YES
+ * \ref MIB_ADR                      | YES | YES
+ * \ref MIB_NET_ID                   | YES | YES
+ * \ref MIB_DEV_ADDR                 | YES | YES
+ * \ref MIB_NWK_SKEY                 | YES | YES
+ * \ref MIB_APP_SKEY                 | YES | YES
+ * \ref MIB_PUBLIC_NETWORK           | YES | YES
+ * \ref MIB_REPEATER_SUPPORT         | YES | YES
+ * \ref MIB_CHANNELS                 | YES | NO
+ * \ref MIB_RX2_CHANNEL              | YES | YES
+ * \ref MIB_CHANNELS_MASK            | YES | YES
+ * \ref MIB_CHANNELS_DEFAULT_MASK    | YES | YES
+ * \ref MIB_CHANNELS_NB_REP          | YES | YES
+ * \ref MIB_MAX_RX_WINDOW_DURATION   | YES | YES
+ * \ref MIB_RECEIVE_DELAY_1          | YES | YES
+ * \ref MIB_RECEIVE_DELAY_2          | YES | YES
+ * \ref MIB_JOIN_ACCEPT_DELAY_1      | YES | YES
+ * \ref MIB_JOIN_ACCEPT_DELAY_2      | YES | YES
+ * \ref MIB_CHANNELS_DATARATE        | YES | YES
+ * \ref MIB_CHANNELS_DEFAULT_DATARATE| YES | YES
+ * \ref MIB_CHANNELS_TX_POWER        | YES | YES
+ * \ref MIB_CHANNELS_DEFAULT_TX_POWER| YES | YES
+ * \ref MIB_UPLINK_COUNTER           | YES | YES
+ * \ref MIB_DOWNLINK_COUNTER         | YES | YES
+ * \ref MIB_MULTICAST_CHANNEL        | YES | NO
+ * \ref MIB_SYSTEM_MAX_RX_ERROR      | YES | YES
+ * \ref MIB_MIN_RX_SYMBOLS           | YES | YES
+ * \ref MIB_ANTENNA_GAIN             | YES | YES
+ *
+ * The following table provides links to the function implementations of the
+ * related MIB primitives:
+ *
+ * Primitive        | Function
+ * ---------------- | :---------------------:
+ * MIB-Set          | \ref LoRaMacMibSetRequestConfirm
+ * MIB-Get          | \ref LoRaMacMibGetRequestConfirm
+ */
+typedef enum eMib
+{
+    /*!
+     * LoRaWAN device class.
+     *
+     * LoRaWAN Specification V1.0.2.
+     */
+    MIB_DEVICE_CLASS,
+    /*!
+     * LoRaWAN Network joined attribute.
+     *
+     * LoRaWAN Specification V1.0.2.
+     */
+    MIB_NETWORK_JOINED,
+    /*!
+     * Adaptive data rate.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.1.1.
+     *
+     * [true: ADR enabled, false: ADR disabled].
+     */
+    MIB_ADR,
+    /*!
+     * Network identifier.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.1.
+     */
+    MIB_NET_ID,
+    /*!
+     * End-device address.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.1.
+     */
+    MIB_DEV_ADDR,
+    /*!
+     * Network session key.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.3.
+     */
+    MIB_NWK_SKEY,
+    /*!
+     * Application session key.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.4.
+     */
+    MIB_APP_SKEY,
+    /*!
+     * Set the network type to public or private.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * [true: public network, false: private network]
+     */
+    MIB_PUBLIC_NETWORK,
+    /*!
+     * Support the operation with repeaters.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * [true: repeater support enabled, false: repeater support disabled]
+     */
+    MIB_REPEATER_SUPPORT,
+    /*!
+     * Communication channels. A GET request will return a
+     * pointer that references the first entry of the channel list. The
+     * list is of size LORA_MAX_NB_CHANNELS.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_CHANNELS,
+    /*!
+     * Set receive window 2 channel.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 3.3.1.
+     */
+    MIB_RX2_CHANNEL,
+    /*!
+     * Set receive window 2 channel.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 3.3.2.
+     */
+    MIB_RX2_DEFAULT_CHANNEL,
+    /*!
+     * LoRaWAN channels mask.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_CHANNELS_MASK,
+    /*!
+     * LoRaWAN default channels mask.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_CHANNELS_DEFAULT_MASK,
+    /*!
+     * Set the number of repetitions on a channel.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 5.2.
+     */
+    MIB_CHANNELS_NB_REP,
+    /*!
+     * The maximum receive window duration in [ms].
+     *
+     * LoRaWAN Specification V1.0.2, chapter 3.3.3.
+     */
+    MIB_MAX_RX_WINDOW_DURATION,
+    /*!
+     * The receive delay 1 in [ms].
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_RECEIVE_DELAY_1,
+    /*!
+     * The receive delay 2 in [ms].
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_RECEIVE_DELAY_2,
+    /*!
+     * The join accept delay 1 in [ms].
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_JOIN_ACCEPT_DELAY_1,
+    /*!
+     * The join accept delay 2 in [ms].
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     */
+    MIB_JOIN_ACCEPT_DELAY_2,
+    /*!
+     * The default data rate of a channel.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+     */
+    MIB_CHANNELS_DEFAULT_DATARATE,
+    /*!
+     * The data rate of a channel.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * The allowed ranges are region-specific. Please refer to \ref DR_0 to \ref DR_15 for details.
+     */
+    MIB_CHANNELS_DATARATE,
+    /*!
+     * The transmission power of a channel.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * The allowed ranges are region-specific. Please refer to \ref TX_POWER_0 to \ref TX_POWER_15 for details.
+     */
+    MIB_CHANNELS_TX_POWER,
+    /*!
+     * The transmission power of a channel.
+     *
+     * LoRaWAN Regional Parameters V1.0.2rB.
+     *
+     * The allowed ranges are region-specific. Please refer to \ref TX_POWER_0 to \ref TX_POWER_15 for details.
+     */
+    MIB_CHANNELS_DEFAULT_TX_POWER,
+    /*!
+     * LoRaWAN uplink counter.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.1.5.
+     */
+    MIB_UPLINK_COUNTER,
+    /*!
+     * LoRaWAN downlink counter.
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.1.5.
+     */
+    MIB_DOWNLINK_COUNTER,
+    /*!
+     * Multicast channels. A GET request will return a pointer to the first
+     * entry of the multicast channel linked list. If the pointer is equal to
+     * NULL, the list is empty.
+     */
+    MIB_MULTICAST_CHANNEL,
+    /*!
+     * System overall timing error in milliseconds.
+     * [-SystemMaxRxError : +SystemMaxRxError]
+     * Default: +/-10 ms
+     */
+    MIB_SYSTEM_MAX_RX_ERROR,
+    /*!
+     * The minimum  number of symbols required to detect an RX frame.
+     * Default: 6 symbols
+     */
+    MIB_MIN_RX_SYMBOLS,
+    /*!
+     * The antenna gain of the node. The default value is region-specific.
+     * The antenna gain is used to calculate the TX power of the node.
+     * The formula is:
+     * radioTxPower = ( int8_t )floor( maxEirp - antennaGain )
+     */
+    MIB_ANTENNA_GAIN
+}Mib_t;
+
+/*!
+ * LoRaMAC MIB parameters.
+ */
+typedef union uMibParam
+{
+    /*!
+     * LoRaWAN device class.
+     *
+     * Related MIB type: \ref MIB_DEVICE_CLASS
+     */
+    DeviceClass_t Class;
+    /*!
+     * LoRaWAN network joined attribute
+     *
+     * Related MIB type: \ref MIB_NETWORK_JOINED
+     */
+    bool IsNetworkJoined;
+    /*!
+     * Activation state of ADR
+     *
+     * Related MIB type: \ref MIB_ADR
+     */
+    bool AdrEnable;
+    /*!
+     * Network identifier
+     *
+     * Related MIB type: \ref MIB_NET_ID
+     */
+    uint32_t NetID;
+    /*!
+     * End-device address
+     *
+     * Related MIB type: \ref MIB_DEV_ADDR
+     */
+    uint32_t DevAddr;
+    /*!
+     * Network session key
+     *
+     * Related MIB type: \ref MIB_NWK_SKEY
+     */
+    uint8_t *NwkSKey;
+    /*!
+     * Application session key
+     *
+     * Related MIB type: \ref MIB_APP_SKEY
+     */
+    uint8_t *AppSKey;
+    /*!
+     * Enable or disable a public network
+     *
+     * Related MIB type: \ref MIB_PUBLIC_NETWORK
+     */
+    bool EnablePublicNetwork;
+    /*!
+     * Enable or disable repeater support
+     *
+     * Related MIB type: \ref MIB_REPEATER_SUPPORT
+     */
+    bool EnableRepeaterSupport;
+    /*!
+     * LoRaWAN channel
+     *
+     * Related MIB type: \ref MIB_CHANNELS
+     */
+    ChannelParams_t* ChannelList;
+     /*!
+     * Channel for the receive window 2
+     *
+     * Related MIB type: \ref MIB_RX2_CHANNEL
+     */
+    Rx2ChannelParams_t Rx2Channel;
+     /*!
+     * Channel for the receive window 2
+     *
+     * Related MIB type: \ref MIB_RX2_DEFAULT_CHANNEL
+     */
+    Rx2ChannelParams_t Rx2DefaultChannel;
+    /*!
+     * Channel mask
+     *
+     * Related MIB type: \ref MIB_CHANNELS_MASK
+     */
+    uint16_t* ChannelsMask;
+    /*!
+     * Default channel mask
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_MASK
+     */
+    uint16_t* ChannelsDefaultMask;
+    /*!
+     * Number of frame repetitions
+     *
+     * Related MIB type: \ref MIB_CHANNELS_NB_REP
+     */
+    uint8_t ChannelNbRep;
+    /*!
+     * Maximum receive window duration
+     *
+     * Related MIB type: \ref MIB_MAX_RX_WINDOW_DURATION
+     */
+    uint32_t MaxRxWindow;
+    /*!
+     * Receive delay 1
+     *
+     * Related MIB type: \ref MIB_RECEIVE_DELAY_1
+     */
+    uint32_t ReceiveDelay1;
+    /*!
+     * Receive delay 2
+     *
+     * Related MIB type: \ref MIB_RECEIVE_DELAY_2
+     */
+    uint32_t ReceiveDelay2;
+    /*!
+     * Join accept delay 1
+     *
+     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_1
+     */
+    uint32_t JoinAcceptDelay1;
+    /*!
+     * Join accept delay 2
+     *
+     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_2
+     */
+    uint32_t JoinAcceptDelay2;
+    /*!
+     * Channels data rate
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_DATARATE
+     */
+    int8_t ChannelsDefaultDatarate;
+    /*!
+     * Channels data rate
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DATARATE
+     */
+    int8_t ChannelsDatarate;
+    /*!
+     * Channels TX power
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_TX_POWER
+     */
+    int8_t ChannelsDefaultTxPower;
+    /*!
+     * Channels TX power
+     *
+     * Related MIB type: \ref MIB_CHANNELS_TX_POWER
+     */
+    int8_t ChannelsTxPower;
+    /*!
+     * LoRaWAN uplink counter
+     *
+     * Related MIB type: \ref MIB_UPLINK_COUNTER
+     */
+    uint32_t UpLinkCounter;
+    /*!
+     * LoRaWAN downlink counter
+     *
+     * Related MIB type: \ref MIB_DOWNLINK_COUNTER
+     */
+    uint32_t DownLinkCounter;
+    /*!
+     * Multicast channel
+     *
+     * Related MIB type: \ref MIB_MULTICAST_CHANNEL
+     */
+    MulticastParams_t* MulticastList;
+    /*!
+     * System overall timing error in milliseconds
+     *
+     * Related MIB type: \ref MIB_SYSTEM_MAX_RX_ERROR
+     */
+    uint32_t SystemMaxRxError;
+    /*!
+     * Minimum required number of symbols to detect an RX frame
+     *
+     * Related MIB type: \ref MIB_MIN_RX_SYMBOLS
+     */
+    uint8_t MinRxSymbols;
+    /*!
+     * Antenna gain
+     *
+     * Related MIB type: \ref MIB_ANTENNA_GAIN
+     */
+    float AntennaGain;
+}MibParam_t;
+
+/*!
+ * LoRaMAC MIB-RequestConfirm structure
+ */
+typedef struct eMibRequestConfirm
+{
+    /*!
+     * MIB-Request type
+     */
+    Mib_t Type;
+
+    /*!
+     * MLME-RequestConfirm parameters
+     */
+    MibParam_t Param;
+}MibRequestConfirm_t;
+
+/*!
+ * LoRaMAC TX information
+ */
+typedef struct sLoRaMacTxInfo
+{
+    /*!
+     * Defines the size of the applicable payload that can be processed.
+     */
+    uint8_t MaxPossiblePayload;
+    /*!
+     * The current payload size, dependent on the current datarate.
+     */
+    uint8_t CurrentPayloadSize;
+}LoRaMacTxInfo_t;
+
+/*!
+ * LoRaMAC status.
+ */
+typedef enum eLoRaMacStatus
+{
+    /*!
+     * Service started successfully.
+     */
+    LORAMAC_STATUS_OK,
+    /*!
+     * Service not started - LoRaMAC is busy.
+     */
+    LORAMAC_STATUS_BUSY,
+    /*!
+     * Service unknown.
+     */
+    LORAMAC_STATUS_SERVICE_UNKNOWN,
+    /*!
+     * Service not started - invalid parameter.
+     */
+    LORAMAC_STATUS_PARAMETER_INVALID,
+    /*!
+     * Service not started - invalid frequency.
+     */
+    LORAMAC_STATUS_FREQUENCY_INVALID,
+    /*!
+     * Service not started - invalid datarate.
+     */
+    LORAMAC_STATUS_DATARATE_INVALID,
+    /*!
+     * Service not started - invalid frequency and datarate.
+     */
+    LORAMAC_STATUS_FREQ_AND_DR_INVALID,
+    /*!
+     * Service not started - the device is not in a LoRaWAN.
+     */
+    LORAMAC_STATUS_NO_NETWORK_JOINED,
+    /*!
+     * Service not started - payload length error.
+     */
+    LORAMAC_STATUS_LENGTH_ERROR,
+    /*!
+     * Service not started - the device is switched off.
+     */
+    LORAMAC_STATUS_DEVICE_OFF,
+    /*!
+     * Service not started - the specified region is not supported
+     * or not activated with preprocessor definitions.
+     */
+    LORAMAC_STATUS_REGION_NOT_SUPPORTED,
+    /*!
+     * Crypto methods failure.
+     */
+    LORAMAC_STATUS_CRYPTO_FAIL,
+}LoRaMacStatus_t;
+
+/*!
+ * LoRaMAC events structure.
+ * Used to notify upper layers of MAC events.
+ */
+typedef struct sLoRaMacPrimitives
+{
+    /*!
+     * \brief   MCPS-Confirm primitive.
+     *
+     * \param   [OUT] MCPS-Confirm parameters.
+     */
+    mbed::Callback<void(McpsConfirm_t*)> MacMcpsConfirm;
+
+    /*!
+     * \brief   MCPS-Indication primitive.
+     *
+     * \param   [OUT] MCPS-Indication parameters.
+     */
+    mbed::Callback<void(McpsIndication_t*)> MacMcpsIndication;
+
+    /*!
+     * \brief   MLME-Confirm primitive.
+     *
+     * \param   [OUT] MLME-Confirm parameters.
+     */
+    mbed::Callback<void(MlmeConfirm_t*)> MacMlmeConfirm;
+}LoRaMacPrimitives_t;
+
+/*!
+ * LoRaMAC callback structure.
+ */
+typedef struct sLoRaMacCallback
+{
+    /*!
+     * \brief   Measures the battery level.
+     *
+     * \retval  The battery level [0: node is connected to an external
+     *          power source, 1..254: battery level, where 1 is the minimum
+     *          and 254 is the maximum value, 255: the node was not able
+     *          to measure the battery level].
+     */
+    uint8_t ( *GetBatteryLevel )( void );
+
+    mbed::Callback<void()> TxNextPacketTimerEvent;
+}LoRaMacCallback_t;
+
+/**
+ * The maximum size of receiver buffer.
+ */
+#ifdef MBED_CONF_LORA_RX_MESSAGE_BUFFER_MAX_SIZE
+#define LORAWAN_RX_MESSAGE_BUFFER_MAX_SIZE            MBED_CONF_LORA_RX_MESSAGE_BUFFER_MAX_SIZE
+#else
+#define LORAWAN_RX_MESSAGE_BUFFER_MAX_SIZE            5
+#endif
+
+/**
+ * The maximum size of transmission buffer.
+ */
+#ifdef MBED_CONF_LORA_TX_MESSAGE_BUFFER_MAX_SIZE
+#define LORAWAN_TX_MESSAGE_BUFFER_MAX_SIZE            MBED_CONF_LORA_TX_MESSAGE_BUFFER_MAX_SIZE
+#else
+#define LORAWAN_TX_MESSAGE_BUFFER_MAX_SIZE            5
+#endif
+
+/**
+ * The AES encryption/decryption cipher application session key.
+ */
+#ifdef MBED_CONF_LORA_APPSKEY
+#define LORAWAN_APPSKEY                               MBED_CONF_LORA_APPSKEY
+#else
+#define LORAWAN_APPSKEY          {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+#endif
+
+/**
+ * The AES encryption/decryption cipher network session key.
+ */
+#ifdef MBED_CONF_LORA_NWKSKEY
+#define LORAWAN_NWKSKEY                               MBED_CONF_LORA_NWKSKEY
+#else
+#define LORAWAN_NWKSKEY          {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+#endif
+
+/**
+ * The device address on the network (big endian).
+ */
+#ifdef MBED_CONF_LORA_DEVICE_ADDRESS
+#define LORAWAN_DEVICE_ADDRESS                        MBED_CONF_LORA_DEVICE_ADDRESS
+#else
+#define LORAWAN_DEVICE_ADDRESS                        0
+#endif
+
+/**
+ * The current network ID.
+ */
+#ifdef MBED_CONF_LORA_NETWORK_ID
+#define LORAWAN_NETWORK_ID                            MBED_CONF_LORA_NETWORK_ID
+#else
+#define LORAWAN_NETWORK_ID                            0
+#endif
+
+/**
+ * The AES encryption/decryption cipher application key.
+ */
+#ifdef MBED_CONF_LORA_APPLICATION_KEY
+#define LORAWAN_APPLICATION_KEY                       MBED_CONF_LORA_APPLICATION_KEY
+#else
+#define LORAWAN_APPLICATION_KEY  {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+#endif
+
+/**
+ * The application IEEE EUI.
+ */
+
+#ifdef MBED_CONF_LORA_APPLICATION_EUI
+#define LORAWAN_APPLICATION_EUI                       MBED_CONF_LORA_APPLICATION_EUI
+#else
+#define LORAWAN_APPLICATION_EUI                       {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+#endif
+
+/**
+ * The mote device IEEE EUI.
+ */
+#ifdef MBED_CONF_LORA_DEVICE_EUI
+#define LORAWAN_DEVICE_EUI                            MBED_CONF_LORA_DEVICE_EUI
+#else
+#define LORAWAN_DEVICE_EUI                            {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
+#endif
+
+/**
+ * Indicates how many times join can be tried.
+ */
+#ifdef MBED_CONF_LORA_NB_TRIALS
+#define LORAWAN_NB_TRIALS                             MBED_CONF_LORA_NB_TRIALS
+#else
+#define LORAWAN_NB_TRIALS                             8
+#endif
+
+/**
+ * When set to true, the application uses the Over-the-Air activation procedure.
+ */
+#if defined(MBED_CONF_LORA_OVER_THE_AIR_ACTIVATION) == 1
+#define OVER_THE_AIR_ACTIVATION                       MBED_CONF_LORA_OVER_THE_AIR_ACTIVATION
+#else
+#define OVER_THE_AIR_ACTIVATION                       false
+#endif
+
+/**
+ * LoRaWAN connects to a public network or private network, true = public network.
+ */
+#if defined(MBED_CONF_LORA_PUBLIC_NETWORK) == 1
+#define LORAWAN_PUBLIC_NETWORK                        MBED_CONF_LORA_PUBLIC_NETWORK
+#else
+#define LORAWAN_PUBLIC_NETWORK                        false
+#endif
+
+/**
+ * Maximum PHY layer payload size for reception.
+ * This is not user configurable. Its hard coded in LoRaMac.cpp
+ * and we don't want to change that file too much
+ */
+#define LORAMAC_PHY_MAXPAYLOAD                        255
+
+/**
+ *
+ * Default user application maximum data size for trasnmission
+ */
+// reject if user tries to set more than MTU
+#if defined MBED_CONF_LORA_TX_MAX_SIZE  && MBED_CONF_LORA_TX_MAX_SIZE > 255
+#warning "Cannot set TX Max size more than MTU=255"
+#define LORAWAN_TX_MAX_SIZE   255
+#elif defined MBED_CONF_LORA_TX_MAX_SIZE  && MBED_CONF_LORA_TX_MAX_SIZE < 255
+#define LORAWAN_TX_MAX_SIZE                      MBED_CONF_LORA_TX_MAX_SIZE
+#else
+#define LORAWAN_TX_MAX_SIZE                      64
+#endif
+
+/**
+ *
+ * Defines the application data transmission timer cycle, value in [ms]
+ * Used only when automatic duty cycling is off
+ */
+#ifdef MBED_CONF_APP_TX_TIMER
+#define TX_TIMER                              MBED_CONF_APP_TX_TIMER
+#else
+#define TX_TIMER                              5000
+#endif
+
+/**
+ *
+ * Defines a random delay for application data transmission cycle, value in [ms]
+ * Used only when automatic duty cycling is off
+ */
+#ifdef MBED_CONF_APP_TX_TIMER_RND
+#define TX_TIMER_RND                          MBED_CONF_APP_TX_TIMER_RND
+#else
+#define TX_TIMER_RND                          1000
+#endif
+
+/**
+ *
+ * LoRaWAN Adaptive Data Rate
+ *
+ * \remark Please note that when ADR is enabled, the end-device should be static.
+ */
+#if defined(MBED_CONF_LORA_ADR_ON) == 1
+#define LORAWAN_ADR_ON                                MBED_CONF_LORA_ADR_ON
+#else
+#define LORAWAN_ADR_ON                                false
+#endif
+
+/**
+ *
+ * The default application port.
+ */
+#ifdef MBED_CONF_LORA_APP_PORT
+#define LORAWAN_APP_PORT                              MBED_CONF_LORA_APP_PORT
+#else
+#define LORAWAN_APP_PORT                              0x15
+#endif
+
+/**
+ * Default duty cycling setting
+ */
+#if defined(MBED_CONF_LORA_DUTY_CYCLE_ON) == 1
+#define LORAWAN_DUTYCYCLE_ON        MBED_CONF_LORA_DUTY_CYCLE_ON
+#else
+#define LORAWAN_DUTYCYCLE_ON    false
+#endif
+
+/**
+ * Listen-before-talk setting
+ */
+#if defined(MBED_CONF_LORA_LBT_ON) == 1
+#define LORAWAN_LBT_ON        MBED_CONF_LORA_LBT_ON
+#else
+#define LORAWAN_LBT_ON    false
+#endif
+
+/** End-device states.
+ *
+ */
+typedef enum device_states {
+    DEVICE_STATE_NOT_INITIALIZED,
+    DEVICE_STATE_INIT,
+    DEVICE_STATE_JOINING,
+    DEVICE_STATE_ABP_CONNECTING,
+    DEVICE_STATE_JOINED,
+    DEVICE_STATE_SEND,
+    DEVICE_STATE_IDLE,
+    DEVICE_STATE_COMPLIANCE_TEST,
+    DEVICE_STATE_SHUTDOWN
+} device_states_t;
+
+/** Enum of LoRaWAN connection type.
+ *
+ * The LoRaWAN connection type specifies how an end-device connects to the gateway.
+ */
+typedef enum lorawan_connect_type {
+    LORAWAN_CONNECTION_OTAA = 0,    /**< Over The Air Activation */
+    LORAWAN_CONNECTION_ABP          /**< Activation By Personalization */
+} lorawan_connect_type_t;
+
+/** The lorawan_connect_otaa structure.
+ *
+ * A structure representing the LoRaWAN Over The Air Activation
+ * parameters.
+ */
+typedef struct lorawan_connect_otaa {
+    /** End-device identifier
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.2.1
+     */
+    uint8_t *dev_eui;
+    /** Application identifier
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.2
+     */
+    uint8_t *app_eui;
+    /** AES-128 application key
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.2.2
+     */
+    uint8_t *app_key;
+    /** Join request trials
+     *
+     * Number of trials for the join request.
+     */
+    uint8_t nb_trials;
+} lorawan_connect_otaa_t;
+
+/** The lorawan_connect_abp structure.
+ *
+ * A structure representing the LoRaWAN Activation By Personalization
+ * parameters.
+ */
+typedef struct lorawan_connect_abp {
+    /** Network identifier
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.1
+     */
+    uint32_t nwk_id;
+    /** End-device address
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.1
+     */
+    uint32_t dev_addr;
+    /** Network session key
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.3
+     */
+    uint8_t *nwk_skey;
+    /** Application session key
+     *
+     * LoRaWAN Specification V1.0.2, chapter 6.1.4
+     */
+    uint8_t *app_skey;
+} lorawan_connect_abp_t;
+
+/** LoRaMAC data services
+ *
+ */
+typedef enum lora_mac_mcps {
+    LORA_MCPS_UNCONFIRMED = 0,  /**< Unconfirmed LoRaMAC frame */
+    LORA_MCPS_CONFIRMED,        /**< Confirmed LoRaMAC frame */
+    LORA_MCPS_MULTICAST,        /**< Multicast LoRaMAC frame */
+    LORA_MCPS_PROPRIETARY,      /**< Proprietary frame */
+} lora_mac_mcps_t;
+
+/** LoRaMAC management services
+ *
+ */
+typedef enum lora_mac_mlme {
+    LORA_MLME_JOIN,         /**< Initiates the Over-the-Air activation */
+    LORA_MLME_LINK_CHECK,   /**< LinkCheckReq - Connectivity validation */
+    LORA_MLME_TXCW,         /**< Sets Tx continuous wave mode */
+    LORA_MLME_TXCW_1,       /**< Sets Tx continuous wave mode (new LoRa-Alliance CC definition) */
+} lora_mac_mlme_t;
+
+/** Unconfirmed message.
+ *
+ * A message for an unconfirmed frame.
+ */
+typedef struct lora_mac_unconfirmed {
+    /** Frame port field.
+     *
+     * Must be set if the payload is not empty. Use the
+     * application-specific frame port values: [1...223]
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.2
+     */
+    uint8_t f_port;
+    /** Uplink datarate
+     *
+     * Used if ADR is off
+     */
+    int8_t datarate;
+} lora_mac_unconfirmed_t;
+
+/** Confirmed message.
+ *
+ * A message for a confirmed frame.
+ */
+typedef struct lora_mac_confirmed {
+    /** Frame port field.
+     *
+     * Must be set if the payload is not empty. Use the
+     * application-specific frame port values: [1...223]
+     *
+     * LoRaWAN Specification V1.0.2, chapter 4.3.2
+     */
+    uint8_t f_port;
+    /** Uplink datarate.
+     *
+     * Used if ADR is off.
+     */
+    int8_t datarate;
+    /** Number of trials.
+     *
+     * The number of trials to transmit the frame, if the LoRaMAC layer did not
+     * receive an acknowledgment. The MAC performs a datarate adaptation
+     * according to the LoRaWAN Specification V1.0.2, chapter 18.4, as in
+     * the following table:
+     *
+     * Transmission nb | Data Rate
+     * ----------------|-----------
+     * 1 (first)       | DR
+     * 2               | DR
+     * 3               | max(DR-1,0)
+     * 4               | max(DR-1,0)
+     * 5               | max(DR-2,0)
+     * 6               | max(DR-2,0)
+     * 7               | max(DR-3,0)
+     * 8               | max(DR-3,0)
+     *
+     * Note that if NbTrials is set to 1 or 2, the MAC does not decrease
+     * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
+     */
+    uint8_t nb_trials;
+} lora_mac_confirmed_t;
+
+/** A proprietary message.
+ *
+ * A message for a proprietary frame.
+ */
+typedef struct lora_mac_proprietary {
+    /** Uplink datarate.
+     *
+     *  Used if ADR is off.
+     */
+    int8_t datarate;
+} lora_mac_proprietary_t;
+
+/** LoRaMAC message structure.
+ *
+ */
+typedef struct lora_mac_tx_message {
+
+    /**
+     * TX Ongoing flag
+     */
+    bool tx_ongoing;
+
+    /**
+     * Application Port Number
+     */
+    uint8_t port;
+
+    /**
+     * Message type
+     */
+    lora_mac_mcps_t type;
+    /** Message parameters.
+     *
+     */
+    union message {
+        /** An unconfirmed frame.
+         *
+         * The message parameters for an unconfirmed frame.
+         */
+        lora_mac_unconfirmed_t unconfirmed;
+        /** A confirmed frame.
+         *
+         * The message parameters for a confirmed frame.
+         */
+        lora_mac_confirmed_t confirmed;
+        /** A proprietary frame.
+         *
+         * The message parameters for a proprietary frame.
+         */
+        lora_mac_proprietary_t proprietary;
+    } message_u;
+
+    /** Payload data
+     *
+     * Base pointer to the buffer
+     */
+    uint8_t f_buffer[LORAWAN_TX_MAX_SIZE];
+
+    /** Payload size.
+     *
+     * The size of the frame payload.
+     */
+    uint16_t f_buffer_size;
+
+    /**
+     * Pending data size
+     */
+    uint16_t pending_size;
+
+} lora_mac_tx_message_t;
+
+/** LoRaMAC status.
+ *
+ */
+typedef enum lora_mac_status {
+    LORA_MAC_STATUS_OK = 0,                         /**< Service started successfully */
+    LORA_MAC_STATUS_BUSY = -1000,                   /**< Service not started - LoRaMAC is busy */
+    LORA_MAC_STATUS_WOULD_BLOCK = -1001,            /**< LoRaMAC cannot send at the moment or have nothing to read */
+    LORA_MAC_STATUS_SERVICE_UNKNOWN = -1002,        /**< Service unknown */
+    LORA_MAC_STATUS_PARAMETER_INVALID = -1003,      /**< Service not started - invalid parameter */
+    LORA_MAC_STATUS_FREQUENCY_INVALID = -1004,      /**< Service not started - invalid frequency */
+    LORA_MAC_STATUS_DATARATE_INVALID = -1005,       /**< Service not started - invalid datarate */
+    LORA_MAC_STATUS_FREQ_AND_DR_INVALID = -1006,    /**< Service not started - invalid frequency and datarate */
+    LORA_MAC_STATUS_NO_NETWORK_JOINED = -1009,      /**< Service not started - the device is not in a LoRaWAN */
+    LORA_MAC_STATUS_LENGTH_ERROR = -1010,           /**< Service not started - payload lenght error */
+    LORA_MAC_STATUS_DEVICE_OFF = -1011,             /**< Service not started - the device is switched off */
+    LORA_MAC_STATUS_NOT_INITIALIZED = -1012,        /**< Service not started - stack not initialized */
+    LORA_MAC_STATUS_UNSUPPORTED = -1013,            /**< Service not supported */
+    LORA_MAC_STATUS_CRYPTO_FAIL = -1014,            /**< Service not started - crypto failure */
+    LORA_MAC_STATUS_PORT_INVALID = -1015,           /**< Invalid port */
+    LORA_MAC_STATUS_CONNECT_IN_PROGRESS = -1016,    /**< Services started - Connection in progress */
+    LORA_MAC_STATUS_NO_ACTIVE_SESSIONS = -1017,            /**< Services not started - No active session */
+    LORA_MAC_STATUS_IDLE = -1018,                   /**< Services started - Idle at the moment */
+    LORA_MAC_STATUS_COMPLIANCE_TEST_ON = -1019         /**< Compliance test - is on-going */
+} lora_mac_status_t;
+
+/**
+ *
+ * Enumeration containing the status of the operation of a MAC service
+ */
+typedef enum lora_mac_event_info_status {
+    LORA_EVENT_INFO_STATUS_OK = 0,                           /**< Service performed successfully */
+    LORA_EVENT_INFO_STATUS_ERROR,                            /**< An error occurred during the execution of the service */
+    LORA_EVENT_INFO_STATUS_TX_TIMEOUT,                       /**< A TX timeout occurred */
+    LORA_EVENT_INFO_STATUS_RX1_TIMEOUT,                      /**< An RX timeout occurred on receive window 1 */
+    LORA_EVENT_INFO_STATUS_RX2_TIMEOUT,                      /**< An RX timeout occurred on receive window 2 */
+    LORA_EVENT_INFO_STATUS_RX1_ERROR,                        /**< An RX error occurred on receive window 1 */
+    LORA_EVENT_INFO_STATUS_RX2_ERROR,                        /**< An RX error occurred on receive window 2 */
+    LORA_EVENT_INFO_STATUS_JOIN_FAIL,                        /**< An error occurred in the join procedure */
+    LORA_EVENT_INFO_STATUS_DOWNLINK_REPEATED,                /**< A frame with an invalid downlink counter */
+    LORA_EVENT_INFO_STATUS_TX_DR_PAYLOAD_SIZE_ERROR,         /**< Payload size is not applicable for the datarate */
+    LORA_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOSS,    /**< The node has lost MAX_FCNT_GAP or more frames. */
+    LORA_EVENT_INFO_STATUS_ADDRESS_FAIL,                     /**< An address error occurred */
+    LORA_EVENT_INFO_STATUS_MIC_FAIL,                         /**< Message integrity check failure */
+    LORA_EVENT_INFO_STATUS_CRYPTO_FAIL                       /**< Crypto error*/
+} lora_mac_event_info_status_t;
+
+/**
+ * LoRaMAC MLME-Request for TX continuous wave mode.
+ */
+typedef struct mlme_req_tx_cw {
+    /**
+     * The time while the radio is kept in continuous wave mode, in seconds.
+     */
+    uint16_t timeout;
+    /**
+     * RF frequency to set (only used with the new way).
+     */
+    uint32_t frequency;
+    /**
+     * RF output power to set (only used with the new way).
+     */
+    uint8_t power;
+} mlme_req_tx_cw_t;
+
+/**
+ * LoRaMAC MLME-Request structure
+ */
+typedef struct lora_mac_mlme_req {
+    /**
+     * MLME-Request type
+     */
+    lora_mac_mlme_t type;
+
+    /**
+     * MLME-Request parameters
+     */
+    union mlme_param {
+        /**
+         * MLME-Request parameters for a join request
+         */
+        lorawan_connect_otaa_t join;
+        /**
+         * MLME-Request parameters for TX continuous mode request
+         */
+        mlme_req_tx_cw_t tx_cw;
+    } req;
+} lora_mac_mlme_req_t;
+
+/**
+ * LoRaMAC MCPS-Request structure
+ */
+typedef struct lora_mac_mcps_req {
+    /**
+     * MCPS-Request type
+     */
+    lora_mac_mcps_t type;
+
+    /**
+     * MCPS-Request parameters
+     */
+    union mcps_param
+    {
+        /**
+         * MCPS-Request parameters for an unconfirmed frame.
+         */
+        lora_mac_unconfirmed_t unconfirmed;
+        /**
+         * MCPS-Request parameters for a confirmed frame.
+         */
+        lora_mac_confirmed_t confirmed;
+        /**
+         * MCPS-Request parameters for a proprietary frame.
+         */
+        lora_mac_proprietary_t proprietary;
+    } req;
+    /** Payload data
+     *
+     * A pointer to the buffer of the frame payload.
+     */
+    void *f_buffer;
+    /** Payload size
+     *
+     * The size of the frame payload.
+     */
+    uint16_t f_buffer_size;
+} lora_mac_mcps_req_t;
+
+/** LoRaMAC MLME-Confirm
+ *
+ */
+typedef struct lora_mac_mlme_confirm {
+    /** The previous MLME-Request.
+     *
+     * The previously performed MLME-Request.
+     */
+    lora_mac_mlme_t mlme_request;
+    /** The status of the operation.
+     *
+     * The current status of the MAC service operation.
+     */
+    lora_mac_event_info_status_t status;
+    /** Time on air.
+     *
+     * The transmission time on air of the frame.
+     */
+    TimerTime_t tx_time_on_air;
+    /** Demodulation margin.
+     *
+     * The link margin [dB] of the last LinkCheckReq successfully received.
+     */
+    uint8_t demod_margin;
+    /** The number of gateways.
+     *
+     * The number of gateways that received the last LinkCheckReq.
+     */
+    uint8_t nb_gateways;
+    /** The retransmission counter.
+     *
+     * The number of retransmissions.
+     */
+    uint8_t nb_retries;
+} lora_mac_mlme_confirm_t;
+
+/** LoRaMAC MCPS-Confirm
+ *
+ */
+typedef struct lora_mac_mcps_confirm {
+    /** MCPS-request
+     *
+     * Holds the previously performed MCPS-Request.
+     */
+    lora_mac_mcps_t mcps_request;
+    /** The status of the operation.
+     *
+     * The current status of MAC service operation.
+     */
+    lora_mac_event_info_status_t status;
+    /** Uplink datarate
+     *
+     */
+    uint8_t datarate;
+    /** Transmission power
+     *
+     */
+    int8_t tx_power;
+    /** ACK-received
+     *
+     * Set if an acknowledgement was received.
+     */
+    bool ack_received;
+    /** Retransmission counter
+     *
+     * Provides the number of retransmissions.
+     */
+    uint8_t nb_retries;
+    /** Time on air
+     *
+     * The transmission time on air of the frame.
+     */
+    TimerTime_t tx_time_on_air;
+    /** Uplink counter
+     *
+     * The uplink counter value related to the frame.
+     */
+    uint32_t uplink_counter;
+    /** Uplink frequency
+     *
+     * The uplink frequency related to the frame.
+     */
+    uint32_t uplink_frequency;
+} lora_mac_mcps_confirm_t;
+
+/** LoRaMAC MCPS-Indication
+ *
+ */
+typedef struct lora_mac_mcps_indication {
+    /** MCPS-Indication type
+     *
+     */
+    lora_mac_mcps_t mcps_indication;
+    /** The status of the operation
+     *
+     * The current status of MAC service operation.
+     */
+    lora_mac_event_info_status_t status;
+    /** Multicast
+     *
+     * This is a multicast message.
+     */
+    uint8_t multicast;
+    /** Application port
+     *
+     */
+    uint8_t port;
+    /** Downlink datarate
+     *
+     */
+    uint8_t rx_datarate;
+    /** Frame pending
+     *
+     * The frame is pending.
+     */
+    uint8_t frame_pending;
+    /** Payload data
+     *
+     * A pointer to the received data stream.
+     */
+    uint8_t buffer[LORAMAC_PHY_MAXPAYLOAD];
+    /** Payload size
+     *
+     * The size of the received data stream.
+     */
+    uint16_t buffer_size;
+    /** RX-data indication
+     *
+     * Indicates, if data is available.
+     */
+    bool rx_data;
+    /** Packet RSSI
+     *
+     * The RSSI of the received packet.
+     */
+    int16_t rssi;
+    /** Packet SNR
+     *
+     * The SNR of the received packet.
+     */
+    uint8_t snr;
+    /** Receive window
+     *
+     * [0: Rx window 1, 1: Rx window 2]
+     */
+    uint8_t rx_slot;
+    /** ACK-received
+     *
+     * Set if an acknowledgement was received.
+     */
+    bool ack_received;
+    /** Downlink counter
+     *
+     * The downlink counter value for the received frame.
+     */
+    uint32_t downlink_counter;
+} lora_mac_mcps_indication_t;
+
+/** lora_mac_rx_message_type_t
+ *
+ * An enum representing a structure for RX messages.
+ */
+typedef enum lora_mac_rx_message_type {
+    LORAMAC_RX_MLME_CONFIRM = 0,    /**< lora_mac_mlme_confirm_t */
+    LORAMAC_RX_MCPS_CONFIRM,        /**< lora_mac_mcps_confirm_t */
+    LORAMAC_RX_MCPS_INDICATION      /**< lora_mac_mcps_indication_t */
+} lora_mac_rx_message_type_t;
+
+/** lora_mac_rx_message_by_type_t union
+ *
+ * A union representing a structure for RX messages.
+ */
+typedef union lora_mac_rx_message_by_type_t {
+    lora_mac_mlme_confirm_t mlme_confirm;
+    lora_mac_mcps_confirm_t mcps_confirm;
+    lora_mac_mcps_indication_t mcps_indication;
+} lora_mac_rx_message_by_type_t;
+
+/** lora_mac_rx_message_t
+ *
+ * A structure representing a structure for an RX message.
+ */
+typedef struct lora_mac_rx_message {
+    bool receive_ready;
+    lora_mac_rx_message_type_t type;
+    lora_mac_rx_message_by_type_t rx_message;
+    uint16_t pending_size;
+    uint16_t prev_read_size;
+} lora_mac_rx_message_t;
+
+/** lora_mac_dr_range_t union
+ *
+ * A union representing a structure for the minimum and maximum data rate.
+ */
+typedef union lora_mac_dr_range {
+    /** Byte-access
+     *
+     * Byte-access to the bits.
+     */
+    int8_t value;
+    /** lora_mac_fields_s
+     *
+     * A structure to store the minimum and maximum data rate.
+     */
+    struct lora_mac_fields {
+        /** Minimum data rate
+         *
+         * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
+         *
+         * US915 - [DR_0, DR_1, DR_2, DR_3, DR_4]
+         */
+        int8_t min :4;
+        /** Maximum data rate
+         *
+         * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
+         *
+         * US915 - [DR_0, DR_1, DR_2, DR_3, DR_4]
+         */
+        int8_t max :4;
+    } lora_mac_fields_s;
+} lora_mac_dr_range_t;
+
+/** LoRaWAN device class definition
+ *
+ */
+typedef enum lora_mac_device_class {
+    LORA_CLASS_A, /**< LoRaWAN device class A */
+    LORA_CLASS_B, /**< LoRaWAN device class B */
+    LORA_CLASS_C, /**< LoRaWAN device class C */
+} lora_mac_device_class_t;
+
+/** LoRaMAC channel definition
+ *
+ */
+typedef struct lora_mac_channel_params {
+    /** Frequency in Hz
+     *
+     */
+    uint32_t frequency;
+    /** Alternative frequency for RX window 1
+     *
+     */
+    uint32_t rx1_frequency;
+    /** Data rate definition
+     *
+     */
+    lora_mac_dr_range_t dr_range;
+    /** Band index
+     *
+     */
+    uint8_t band;
+} lora_mac_channel_params_t;
+
+/**
+ * Structure to hold A list of LoRa Channels
+ */
+typedef struct lora_channels_s {
+    uint8_t id;
+    lora_mac_channel_params_t ch_param;
+} lora_channels_t;
+
+/** LoRaMAC receive window 2 channel parameters
+ *
+ */
+typedef struct lora_mac_rx2_channel_params {
+    /** Frequency in Hz
+     *
+     */
+    uint32_t frequency;
+    /** Data rate
+     *
+     * EU868 - [DR_0, DR_1, DR_2, DR_3, DR_4, DR_5, DR_6, DR_7]
+     *
+     * US915 - [DR_8, DR_9, DR_10, DR_11, DR_12, DR_13]
+     */
+    uint8_t datarate;
+} lora_mac_rx2_channel_params_t;
+
+/** LoRaMAC multicast channel parameter
+ *
+ */
+typedef struct lora_mac_multicast_params {
+    /** Address
+     *
+     */
+    uint32_t address;
+    /** Network session key
+     *
+     */
+    uint8_t nwk_skey[16];
+    /** Application session key
+     *
+     */
+    uint8_t app_skey[16];
+    /** Downlink counter
+     *
+     */
+    uint32_t downlink_counter;
+    /** Next multicast
+     *
+     * A reference pointer to the next multicast channel parameters in the list
+     */
+    struct lora_mac_multicast_params *next;
+} lora_mac_multicast_params_t;
+
+/** Enum lora_mac_mib_t
+ *
+ */
+typedef enum lora_mac_mib {
+    LORA_MIB_DEVICE_CLASS,              /**< LoRaWAN device class */
+    LORA_MIB_NETWORK_JOINED,            /**< LoRaWAN network joined attribute */
+    LORA_MIB_ADR,                       /**< Adaptive data rate */
+    LORA_MIB_NET_ID,                    /**< Network identifier */
+    LORA_MIB_DEV_ADDR,                  /**< End-device address */
+    LORA_MIB_NWK_SKEY,                  /**< Network session key */
+    LORA_MIB_APP_SKEY,                  /**< Application session key */
+    LORA_MIB_PUBLIC_NETWORK,            /**< Set the network type to public or private */
+    LORA_MIB_REPEATER_SUPPORT,          /**< Support the operation with repeaters */
+    LORA_MIB_CHANNELS,                  /**< Communication channels */
+    LORA_MIB_RX2_CHANNEL,               /**< Set receive window 2 channel */
+    LORA_MIB_RX2_DEFAULT_CHANNEL,       /**< Set receive window 2 channel */
+    LORA_MIB_CHANNELS_MASK,             /**< LoRaWAN channels mask */
+    LORA_MIB_CHANNELS_DEFAULT_MASK,     /**< LoRaWAN default channels mask */
+    LORA_MIB_CHANNELS_NB_REP,           /**< Set the number of repetitions on a channel */
+    LORA_MIB_MAX_RX_WINDOW_DURATION,    /**< Maximum receive window duration in [ms] */
+    LORA_MIB_RECEIVE_DELAY_1,           /**< Receive delay 1 in [ms] */
+    LORA_MIB_RECEIVE_DELAY_2,           /**< Receive delay 2 in [ms] */
+    LORA_MIB_JOIN_ACCEPT_DELAY_1,       /**< Join accept delay 1 in [ms] */
+    LORA_MIB_JOIN_ACCEPT_DELAY_2,       /**< Join accept delay 2 in [ms] */
+    LORA_MIB_CHANNELS_DEFAULT_DATARATE, /**< Default data rate of a channel */
+    LORA_MIB_CHANNELS_DATARATE,         /**< Data rate of a channel */
+    LORA_MIB_CHANNELS_TX_POWER,         /**< Transmission power of a channel */
+    LORA_MIB_CHANNELS_DEFAULT_TX_POWER, /**< Transmission power of a channel */
+    LORA_MIB_UPLINK_COUNTER,            /**< LoRaWAN uplink counter */
+    LORA_MIB_DOWNLINK_COUNTER,          /**< LoRaWAN downlink counter */
+    LORA_MIB_MULTICAST_CHANNEL,         /**< Multicast channels */
+    LORA_MIB_SYSTEM_MAX_RX_ERROR,       /**< System overall timing error in milliseconds. */
+    LORA_MIB_MIN_RX_SYMBOLS,            /**< Minimum number of symbols required to detect an RX frame */
+} lora_mac_mib_t;
+
+/** lorawan_connect_t structure
+ *
+ * A structure representing the parameters for different connections.
+ */
+typedef struct lorawan_connect {
+    /*!
+     * Select the connection type, either LORAWAN_CONNECTION_OTAA
+     * or LORAWAN_CONNECTION_ABP.
+     */
+    uint8_t connect_type;
+
+    union {
+        /*!
+         * Join the network using OTA
+         */
+        lorawan_connect_otaa_t otaa;
+        /*!
+         * Authentication by personalization
+         */
+        lorawan_connect_abp_t abp;
+    } connection_u;
+
+} lorawan_connect_t;
+
+/** LoRaWAN session
+ *
+ * A structure for keeping session details.
+ */
+typedef struct lorawan_session {
+    /**
+     * True if the session is active
+     */
+    bool active;
+
+    lorawan_connect_t connection;
+    /**
+     * LoRaWAN uplink counter
+     *
+     * Related MIB type: LORA_MIB_UPLINK_COUNTER
+     */
+    uint32_t uplink_counter;
+    /**
+     * LoRaWAN downlink counter
+     *
+     * Related MIB type: LORA_MIB_DOWNLINK_COUNTER
+     */
+    uint32_t downlink_counter;
+} lorawan_session_t;
+
+/** Commissioning data
+ *
+ * A structure for data in commission.
+ */
+typedef struct lora_dev_commission {
+    /** Connection information
+     *
+     * Saves information for etc. keys
+     */
+    lorawan_connect_t connection;
+    /**
+     * LoRaWAN Up-link counter
+     *
+     * Related MIB type: LORA_MIB_UPLINK_COUNTER
+     */
+    uint32_t uplink_counter;
+    /**
+     * LoRaWAN Down-link counter
+     *
+     * Related MIB type: LORA_MIB_DOWNLINK_COUNTER
+     */
+    uint32_t downlink_counter;
+} lora_dev_commission_t;
+
+/** LoRaMAC MIB parameters
+ *
+ */
+typedef union lora_mac_mib_param {
+    /** LoRaWAN device class
+     *
+     * Related MIB type: \ref MIB_DEVICE_CLASS
+     */
+    lora_mac_device_class_t lora_class;
+    /** LoRaWAN network joined attribute
+     *
+     * Related MIB type: \ref MIB_NETWORK_JOINED
+     */
+    bool is_network_joined;
+    /** Activation state of ADR
+     *
+     * Related MIB type: \ref MIB_ADR
+     */
+    bool adr_enable;
+    /** Network identifier
+     *
+     * Related MIB type: \ref MIB_NET_ID
+     */
+    uint32_t net_id;
+    /** End-device address
+     *
+     * Related MIB type: \ref MIB_DEV_ADDR
+     */
+    uint32_t dev_addr;
+    /** Network session key
+     *
+     * Related MIB type: \ref MIB_NWK_SKEY
+     */
+    uint8_t *nwk_skey;
+    /** Application session key
+     *
+     * Related MIB type: \ref MIB_APP_SKEY
+     */
+    uint8_t *app_skey;
+    /** Enable public network
+     *
+     * Enable or disable a public network
+     * Related MIB type: \ref MIB_PUBLIC_NETWORK
+     */
+    bool enable_public_network;
+    /** Enable repeater support
+     *
+     * Enable or disable repeater support
+     * Related MIB type: \ref MIB_REPEATER_SUPPORT
+     */
+    bool enable_repeater_support;
+    /** LoRaWAN Channel
+     *
+     * Related MIB type: \ref MIB_CHANNELS
+     */
+    lora_mac_channel_params_t *channel_list;
+    /** Channel rx 2
+     *
+     * Channel for the receive window 2
+     * Related MIB type: \ref MIB_RX2_CHANNEL
+     */
+    lora_mac_rx2_channel_params_t rx2_channel;
+    /** Default channel rx 2
+     *
+     * Channel for the receive window 2
+     * Related MIB type: \ref MIB_RX2_DEFAULT_CHANNEL
+     */
+    lora_mac_rx2_channel_params_t rx2_default_channel;
+    /** Channel mask
+     *
+     * Related MIB type: \ref MIB_CHANNELS_MASK
+     */
+    uint16_t *channels_mask;
+    /** Default channel mask
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_MASK
+     */
+    uint16_t *channels_default_mask;
+    /** Frame repetition number
+     *
+     * Number of frame repetitions
+     * Related MIB type: \ref MIB_CHANNELS_NB_REP
+     */
+    uint8_t channel_nb_rep;
+    /** Maximum receive window duration
+     *
+     * Related MIB type: \ref MIB_MAX_RX_WINDOW_DURATION
+     */
+    uint32_t max_rx_window;
+    /** Receive delay 1
+     *
+     * Related MIB type: \ref MIB_RECEIVE_DELAY_1
+     */
+    uint32_t receive_delay1;
+    /** Receive delay 2
+     *
+     * Related MIB type: \ref MIB_RECEIVE_DELAY_2
+     */
+    uint32_t receive_delay2;
+    /** Join accept delay 1
+     *
+     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_1
+     */
+    uint32_t join_accept_delay1;
+    /** Join accept delay 2
+     *
+     * Related MIB type: \ref MIB_JOIN_ACCEPT_DELAY_2
+     */
+    uint32_t join_accept_delay2;
+    /** Channels default data rate
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_DATARATE
+     */
+    int8_t channels_default_datarate;
+    /** Channels data rate
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DATARATE
+     */
+    int8_t channels_datarate;
+    /** Channels default TX power
+     *
+     * Related MIB type: \ref MIB_CHANNELS_DEFAULT_TX_POWER
+     */
+    int8_t channels_default_tx_power;
+    /** Channels TX power
+     *
+     * Related MIB type: \ref MIB_CHANNELS_TX_POWER
+     */
+    int8_t channels_tx_power;
+    /** LoRaWAN uplink counter
+     *
+     * Related MIB type: \ref MIB_UPLINK_COUNTER
+     */
+    uint32_t uplink_counter;
+    /** LoRaWAN downlink counter
+     *
+     * Related MIB type: \ref MIB_DOWNLINK_COUNTER
+     */
+    uint32_t downlink_counter;
+    /** Multicast channel
+     *
+     * Related MIB type: \ref MIB_MULTICAST_CHANNEL
+     */
+    lora_mac_multicast_params_t *multicast_list;
+    /** Maximum RX error timing
+     *
+     * System overall timing error in milliseconds.
+     * Related MIB type: \ref MIB_SYSTEM_MAX_RX_ERROR
+     */
+    uint32_t system_max_rx_error;
+    /** Minimum RX symbols
+     *
+     * Minimum required number of symbols to detect an RX frame
+     * Related MIB type: \ref MIB_MIN_RX_SYMBOLS
+     */
+    uint8_t min_rx_symbols;
+} lora_mac_mib_param_t;
+
+/** LoRaMAC MIB-RequestConfirm structure
+ *
+ */
+typedef struct lora_mac_mib_request_confirm {
+    /** MIB-Request type
+     *
+     */
+    lora_mac_mib_t type;
+    /** MIB-RequestConfirm parameters
+     *
+     */
+    lora_mac_mib_param_t param;
+} lora_mac_mib_request_confirm_t;
+
+/**  LoRaWAN compliance tests support data
+ *
+ */
+typedef struct compliance_test {
+    /** Is test running
+     *
+     */
+    bool running;
+    /** State of test
+     *
+     */
+    uint8_t state;
+    /** Is TX confirmed
+     *
+     */
+    bool is_tx_confirmed;
+    /** Port used by the application
+     *
+     */
+    uint8_t app_port;
+    /** Maximum size of data used by application
+     *
+     */
+    uint8_t app_data_size;
+    /** Data provided by application
+     *
+     */
+    uint8_t *app_data_buffer;
+    /** Downlink counter
+     *
+     */
+    uint16_t downlink_counter;
+    /** Is link check required
+     *
+     */
+    bool link_check;
+    /** Demodulation margin
+     *
+     */
+    uint8_t demod_margin;
+    /** Number of gateways
+     *
+     */
+    uint8_t nb_gateways;
+} compliance_test_t;
+
+/** Structure containing the uplink status
+ *
+ */
+typedef struct loramac_uplink_status {
+    /** Is acked
+     *
+     */
+    uint8_t acked;
+    /** Uplink data rate
+     *
+     */
+    int8_t datarate;
+    /** Uplink counter
+     *
+     */
+    uint16_t uplink_counter;
+    /** Port is used by application
+     *
+     */
+    uint8_t port;
+    /** Payload
+     *
+     */
+    uint8_t *buffer;
+    /** Payload size
+     *
+     */
+    uint8_t buffer_size;
+} loramac_uplink_status_t;
+
+/** A structure containing the downlink status
+ *
+ */
+typedef struct loramac_downlink_status {
+    /** RSSI of downlink
+     *
+     */
+    int16_t rssi;
+    /** SNR of downlink
+     *
+     */
+    int8_t snr;
+    /** Downlink counter
+     *
+     */
+    uint16_t downlink_counter;
+    /** Is RX data received
+     *
+     */
+    bool rx_data;
+    /** Port used by application
+     *
+     */
+    uint8_t port;
+    /** Payload
+     *
+     */
+    uint8_t *buffer;
+    /** Payload size
+     *
+     */
+    uint8_t buffer_size;
+} loramac_downlink_status_t;
+
+/** LoRaWAN callback functions
+ *
+ */
+typedef enum lora_events {
+    CONNECTED=0,
+    DISCONNECTED,
+    TX_DONE,
+    TX_TIMEOUT,
+    TX_ERROR,
+    TX_CRYPTO_ERROR,
+    TX_SCHEDULING_ERROR,
+    RX_DONE,
+    RX_TIMEOUT,
+    RX_ERROR,
+    JOIN_FAILURE,
+} lora_events_t;
+
+typedef struct lora_channelplan {
+    uint8_t nb_channels;    // number of channels
+    lora_channels_t *channels;
+} lora_channelplan_t;
+
+#endif /* LORAWAN_SYSTEM_LORAWAN_DATA_STRUCTURES_H_ */

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1639,24 +1639,6 @@ typedef struct sLoRaMacCallback
 }LoRaMacCallback_t;
 
 /**
- * The maximum size of receiver buffer.
- */
-#ifdef MBED_CONF_LORA_RX_MESSAGE_BUFFER_MAX_SIZE
-#define LORAWAN_RX_MESSAGE_BUFFER_MAX_SIZE            MBED_CONF_LORA_RX_MESSAGE_BUFFER_MAX_SIZE
-#else
-#define LORAWAN_RX_MESSAGE_BUFFER_MAX_SIZE            5
-#endif
-
-/**
- * The maximum size of transmission buffer.
- */
-#ifdef MBED_CONF_LORA_TX_MESSAGE_BUFFER_MAX_SIZE
-#define LORAWAN_TX_MESSAGE_BUFFER_MAX_SIZE            MBED_CONF_LORA_TX_MESSAGE_BUFFER_MAX_SIZE
-#else
-#define LORAWAN_TX_MESSAGE_BUFFER_MAX_SIZE            5
-#endif
-
-/**
  * The AES encryption/decryption cipher application session key.
  */
 #ifdef MBED_CONF_LORA_APPSKEY

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -2884,6 +2884,18 @@ typedef enum lora_events {
     JOIN_FAILURE,
 } lora_events_t;
 
+typedef struct  {
+     // Mandatory. Event Callback must be provided
+     mbed::Callback<void(lora_events_t)> events;
+
+     // Rest are optional
+     // If the user do not assign these callbacks, these callbacks would return
+     // null if checked with bool operator
+     // link_check_resp callback and other such callbacks will be maped in
+     // future releases of Mbed-OS
+     mbed::Callback<void(uint8_t, uint8_t)> link_check_resp;
+ }lorawan_app_callbacks_t;
+
 typedef struct lora_channelplan {
     uint8_t nb_channels;    // number of channels
     lora_channels_t *channels;

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1822,7 +1822,9 @@ typedef enum device_states {
     DEVICE_STATE_JOINED,
     DEVICE_STATE_SEND,
     DEVICE_STATE_IDLE,
+#if defined(LORAWAN_COMPLIANCE_TEST)
     DEVICE_STATE_COMPLIANCE_TEST,
+#endif
     DEVICE_STATE_SHUTDOWN
 } device_states_t;
 
@@ -2066,7 +2068,9 @@ typedef enum lora_mac_status {
     LORA_MAC_STATUS_CONNECT_IN_PROGRESS = -1016,    /**< Services started - Connection in progress */
     LORA_MAC_STATUS_NO_ACTIVE_SESSIONS = -1017,            /**< Services not started - No active session */
     LORA_MAC_STATUS_IDLE = -1018,                   /**< Services started - Idle at the moment */
-    LORA_MAC_STATUS_COMPLIANCE_TEST_ON = -1019         /**< Compliance test - is on-going */
+#if defined(LORAWAN_COMPLIANCE_TEST)
+    LORA_MAC_STATUS_COMPLIANCE_TEST_ON = -1019,         /**< Compliance test - is on-going */
+#endif
 } lora_mac_status_t;
 
 /**
@@ -2756,6 +2760,7 @@ typedef struct lora_mac_mib_request_confirm {
     lora_mac_mib_param_t param;
 } lora_mac_mib_request_confirm_t;
 
+#if defined(LORAWAN_COMPLIANCE_TEST)
 /**  LoRaWAN compliance tests support data
  *
  */
@@ -2801,6 +2806,7 @@ typedef struct compliance_test {
      */
     uint8_t nb_gateways;
 } compliance_test_t;
+#endif
 
 /** Structure containing the uplink status
  *

--- a/features/netsocket/LoRaRadio.h
+++ b/features/netsocket/LoRaRadio.h
@@ -18,6 +18,20 @@
 #ifndef LORARADIO_H_
 #define LORARADIO_H_
 
+/**
+ * Structure to hold RF controls for LoRa Radio.
+ * SX1276 have an extra control for the crystal (used in DOSCO-L072CZ)
+ */
+typedef struct {
+    PinName rf_switch_ctl1;
+    PinName rf_switch_ctl2;
+    PinName txctl;
+    PinName rxctl;
+    PinName ant_switch;
+    PinName pwr_amp_ctl;
+    PinName tcxo;
+} rf_ctrls;
+
 /** Radio driver internal state.
  * State machine states definition.
  */

--- a/features/netsocket/LoRaRadio.h
+++ b/features/netsocket/LoRaRadio.h
@@ -1,0 +1,399 @@
+/**
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef LORARADIO_H_
+#define LORARADIO_H_
+
+/** Radio driver internal state.
+ * State machine states definition.
+ */
+typedef enum radio_state {
+    RF_IDLE = 0,
+    RF_RX_RUNNING,
+    RF_TX_RUNNING,
+    RF_CAD,
+} radio_state_t;
+
+/** Type of the modem.
+ *  [LORA/FSK]
+ */
+typedef enum modem_type {
+    MODEM_FSK = 0,
+    MODEM_LORA
+} radio_modems_t;
+
+/** Radio FSK modem parameters.
+ *
+ */
+typedef struct radio_fsk_settings {
+    int8_t   power;
+    uint32_t f_dev;
+    uint32_t bandwidth;
+    uint32_t bandwidth_afc;
+    uint32_t datarate;
+    uint16_t preamble_len;
+    bool     fix_len;
+    uint8_t  payload_len;
+    bool     crc_on;
+    bool     iq_inverted;
+    bool     rx_continuous;
+    uint32_t tx_timeout;
+    uint32_t rx_single_timeout;
+} radio_fsk_settings_t;
+
+/** Radio FSK packet handler state.
+ *
+ */
+typedef struct radio_fsk_packet_handler {
+    uint8_t  preamble_detected;
+    uint8_t  sync_word_detected;
+    int8_t   rssi_value;
+    int32_t  afc_value;
+    uint8_t  rx_gain;
+    uint16_t size;
+    uint16_t nb_bytes;
+    uint8_t  fifo_thresh;
+    uint8_t  chunk_size;
+} radio_fsk_packet_handler_t;
+
+/** Radio LoRa modem parameters.
+ *
+ */
+typedef struct radio_lora_settings {
+    int8_t   power;
+    uint32_t bandwidth;
+    uint32_t datarate;
+    bool     low_datarate_optimize;
+    uint8_t  coderate;
+    uint16_t preamble_len;
+    bool     fix_len;
+    uint8_t  payload_len;
+    bool     crc_on;
+    bool     freq_hop_on;
+    uint8_t  hop_period;
+    bool     iq_inverted;
+    bool     rx_continuous;
+    uint32_t tx_timeout;
+    bool     public_network;
+} radio_lora_settings_t;
+
+/** Radio LoRa packet handler state.
+ *
+ */
+typedef struct radio_lora_packet_handler {
+    int8_t  snr_value;
+    int8_t  rssi_value;
+    uint8_t size;
+} radio_lora_packet_handler_t;
+
+/** Radio settings.
+ *
+ */
+typedef struct radio_settings {
+    uint8_t                     state;
+    uint8_t                     modem;
+    uint32_t                    channel;
+    radio_fsk_settings_t        fsk;
+    radio_fsk_packet_handler_t  fsk_packet_handler;
+    radio_lora_settings_t       lora;
+    radio_lora_packet_handler_t lora_packet_handler;
+} radio_settings_t;
+
+/** Radio driver callback functions.
+ *
+ */
+typedef struct radio_events {
+    /*  Tx Done callback prototype.
+     *
+     */
+    void (*tx_done) (void);
+
+    /*  Tx Timeout callback prototype.
+     *
+     */
+    void (*tx_timeout) (void);
+
+    /*  Rx Done callback prototype.
+     *
+     *  @param payload Received buffer pointer.
+     *  @param size    Received buffer size.
+     *  @param rssi    RSSI value computed while receiving the frame [dBm].
+     *  @param snr     Raw SNR value given by the radio hardware.
+     *                     FSK : N/A (set to 0)
+     *                     LoRa: SNR value in dB
+     */
+    void (*rx_done) (uint8_t *payload, uint16_t size, int16_t rssi, int8_t snr);
+
+    /*  Rx Timeout callback prototype.
+     *
+     */
+    void (*rx_timeout) (void);
+
+    /*  Rx Error callback prototype.
+     *
+     */
+    void (*rx_error) (void);
+
+    /*  FHSS Change Channel callback prototype.
+     *
+     *  @param current_channel   The index number of the current channel.
+     */
+    void (*fhss_change_channel) (uint8_t current_channel);
+
+    /*  CAD Done callback prototype.
+     *
+     *  @param channel_activity_detected    Channel activity detected during the CAD.
+     */
+    void (*cad_done) (bool channel_activity_detected);
+} radio_events_t;
+
+/**
+ *    Interface for the radios, contains the main functions that a radio needs, and five callback functions.
+ */
+class LoRaRadio
+{
+
+public:
+
+    /**
+     * Registers radio events with the Mbed LoRaWAN stack and undergoes the initialization steps if any.
+     *
+     *  @param events The structure containing the driver callback functions.
+     */
+    virtual void init_radio(radio_events_t *events) = 0;
+
+    /**
+     * Resets the radio module.
+     */
+    virtual void radio_reset() = 0;
+
+    /**
+     *  Put the RF module in the sleep mode.
+     */
+    virtual void sleep(void) = 0;
+
+    /**
+     *  Sets the radio in the standby mode.
+     */
+    virtual void standby(void) = 0;
+
+    /**
+     *  Sets the reception parameters.
+     *
+     *  @param modem         The radio modem to be used [0: FSK, 1: LoRa].
+     *  @param bandwidth     Sets the bandwidth.
+     *                          FSK : >= 2600 and <= 250000 Hz
+     *                          LoRa: [0: 125 kHz, 1: 250 kHz,
+     *                                 2: 500 kHz, 3: Reserved]
+     *  @param datarate      Sets the datarate.
+     *                          FSK : 600..300000 bits/s
+     *                          LoRa: [6: 64, 7: 128, 8: 256, 9: 512,
+     *                                10: 1024, 11: 2048, 12: 4096  chips]
+     *  @param coderate      Sets the coding rate (LoRa only).
+     *                          FSK : N/A ( set to 0 )
+     *                          LoRa: [1: 4/5, 2: 4/6, 3: 4/7, 4: 4/8]
+     *  @param bandwidth_afc Sets the AFC bandwidth (FSK only).
+     *                          FSK : >= 2600 and <= 250000 Hz
+     *                          LoRa: N/A (set to 0)
+     *  @param preamble_len  Sets the preamble length (LoRa only).
+     *                          FSK : N/A (set to 0)
+     *                          LoRa: Length in symbols (the hardware adds four more symbols).
+     *  @param symb_timeout  Sets the RxSingle timeout value.
+     *                          FSK : Timeout number of bytes
+     *                          LoRa: Timeout in symbols
+     *  @param fix_len        Fixed length packets [0: variable, 1: fixed].
+     *  @param payload_len   Sets the payload length when fixed length is used.
+     *  @param crc_on        Enables/disables the CRC [0: OFF, 1: ON].
+     *  @param freq_hop_on   Enables/disables the intra-packet frequency hopping [0: OFF, 1: ON] (LoRa only).
+     *  @param hop_period    The number of symbols bewteen each hop (LoRa only).
+     *  @param iq_inverted   Inverts the IQ signals (LoRa only).
+     *                          FSK : N/A (set to 0)
+     *                          LoRa: [0: not inverted, 1: inverted]
+     *  @param rx_continuous Sets the reception in continuous mode.
+     *                          [false: single mode, true: continuous mode]
+     */
+    virtual void set_rx_config (radio_modems_t modem, uint32_t bandwidth,
+                               uint32_t datarate, uint8_t coderate,
+                               uint32_t bandwidth_afc, uint16_t preamble_len,
+                               uint16_t symb_timeout, bool fix_len,
+                               uint8_t payload_len,
+                               bool crc_on, bool freq_hop_on, uint8_t hop_period,
+                               bool iq_inverted, bool rx_continuous) = 0;
+
+    /**
+     *  Sets the transmission parameters.
+     *
+     *  @param modem         The radio modem to be used [0: FSK, 1: LoRa].
+     *  @param power         Sets the output power [dBm].
+     *  @param fdev          Sets the frequency deviation (FSK only).
+     *                          FSK : [Hz]
+     *                          LoRa: 0
+     *  @param bandwidth     Sets the bandwidth (LoRa only).
+     *                          FSK : 0
+     *                          LoRa: [0: 125 kHz, 1: 250 kHz,
+     *                                 2: 500 kHz, 3: Reserved]
+     *  @param datarate      Sets the datarate.
+     *                          FSK : 600..300000 bits/s
+     *                          LoRa: [6: 64, 7: 128, 8: 256, 9: 512,
+     *                                10: 1024, 11: 2048, 12: 4096  chips]
+     *  @param coderate      Sets the coding rate (LoRa only).
+     *                          FSK : N/A ( set to 0 )
+     *                          LoRa: [1: 4/5, 2: 4/6, 3: 4/7, 4: 4/8]
+     *  @param preamble_len  Sets the preamble length.
+     *  @param fix_len       Fixed length packets [0: variable, 1: fixed].
+     *  @param crc_on        Enables/disables the CRC [0: OFF, 1: ON].
+     *  @param freq_hop_on   Enables/disables the intra-packet frequency hopping [0: OFF, 1: ON] (LoRa only).
+     *  @param hop_period    The number of symbols between each hop (LoRa only).
+     *  @param iq_inverted   Inverts IQ signals (LoRa only)
+     *                          FSK : N/A (set to 0).
+     *                          LoRa: [0: not inverted, 1: inverted]
+     *  @param timeout       The transmission timeout [us].
+     */
+    virtual void set_tx_config(radio_modems_t modem, int8_t power, uint32_t fdev,
+                              uint32_t bandwidth, uint32_t datarate,
+                              uint8_t coderate, uint16_t preamble_len,
+                              bool fix_len, bool crc_on, bool freq_hop_on,
+                              uint8_t hop_period, bool iq_inverted, uint32_t timeout) = 0;
+
+    /**
+     *  Sends the buffer of size
+     *
+     *  Prepares the packet to be sent and sets the radio in transmission.
+     *
+     *  @param buffer        A pointer to the buffer.
+     *  @param size          The buffer size.
+     */
+    virtual void send(uint8_t *buffer, uint8_t size) = 0;
+
+    /**
+     *  Sets the radio in reception mode for a given time.
+     *
+     *  If the timeout is set to 0, it essentially puts the receiver in continuous mode and it should
+     *  be treated as if in continuous mode. However, an appropriate way to set the receiver in continuous mode is
+     *  to use the `set_rx_config()` API.
+     *
+     *  @param timeout       Reception timeout [ms].
+     *
+     */
+    virtual void receive(uint32_t timeout) = 0;
+
+    /**
+     *  Sets the carrier frequency
+     *
+     *  @param freq          Channel RF frequency.
+     */
+    virtual void set_channel(uint32_t freq) = 0;
+
+    /**
+     *  Generates a 32 bit random value based on the RSSI readings.
+     *
+     *  \remark This function sets the radio in LoRa modem mode and disables all interrupts.
+     *          After calling this function, either `Radio.SetRxConfig` or
+     *         `Radio.SetTxConfig` functions must be called.
+     *
+     *  @return             A 32 bit random value.
+     */
+    virtual uint32_t random(void) = 0;
+
+    /**
+     *  Gets the radio status.
+     *
+     *  @return              The current radio status.
+     */
+    virtual uint8_t get_status(void) = 0;
+
+    /**
+     *  Sets the maximum payload length.
+     *
+     *  @param modem         The radio modem to be used [0: FSK, 1: LoRa].
+     *  @param max           The maximum payload length in bytes.
+     */
+    virtual void set_max_payload_length(radio_modems_t modem, uint8_t max) = 0;
+
+    /**
+     *  Sets the network to public or private.
+     *
+     *  Updates the sync byte. Applies to LoRa modem only.
+     *
+     *  @param enable        If true, it enables a public network.
+     */
+    virtual void set_public_network(bool enable) = 0;
+
+    /**
+     *  Computes the packet time on air for the given payload.
+     *
+     *  \remark This can only be called once `SetRxConfig` or `SetTxConfig` have been called.
+     *
+     *  @param modem         The radio modem to be used [0: FSK, 1: LoRa].
+     *  @param pkt_len       The packet payload length.
+     *  @return              The computed `airTime` for the given packet payload length.
+     */
+    virtual uint32_t time_on_air(radio_modems_t modem, uint8_t pkt_len) = 0;
+
+    /**
+     * Performs carrier sensing.
+     *
+     * Checks for a certain time if the RSSI is above a given threshold.
+     * This threshold determines whether or not there is a transmission going on
+     * in the channel already.
+     *
+     * @param modem                     The type of the radio modem.
+     * @param freq                      The carrier frequency.
+     * @param rssi_threshold            The threshold value of RSSI.
+     * @param max_carrier_sense_time    The time set for sensing the channel (ms).
+     *
+     * @return                          True if there is no active transmission
+     *                                  in the channel, otherwise false.
+     */
+    virtual bool perform_carrier_sense(radio_modems_t modem,
+                                       uint32_t freq,
+                                       int16_t rssi_threshold,
+                                       uint32_t max_carrier_sense_time) = 0;
+
+    /**
+     *  Sets the radio in CAD mode.
+     *
+     */
+    virtual void start_cad(void) = 0;
+
+    /**
+     *  Checks whether the given RF is in range.
+     *
+     *  @param frequency       The frequency to be checked.
+     */
+    virtual bool check_rf_frequency(uint32_t frequency) = 0;
+
+    /** Sets the radio in continuous wave transmission mode.
+     *
+     *  @param freq          The RF frequency of the channel.
+     *  @param power         The output power [dBm].
+     *  @param time          The transmission mode timeout [s].
+     */
+    virtual void set_tx_continuous_wave(uint32_t freq, int8_t power, uint16_t time) = 0;
+
+    /**
+     * Acquires exclusive access to this radio.
+     */
+    virtual void lock(void) = 0;
+
+    /**
+     * Releases the exclusive access to this radio.
+     */
+    virtual void unlock(void) = 0;
+};
+
+#endif // LORARADIO_H_

--- a/features/netsocket/LoRaWANBase.h
+++ b/features/netsocket/LoRaWANBase.h
@@ -222,7 +222,7 @@ public:
      *
      * @return                  It could be one of these:
      *                             i)   0 if there is nothing else to read.
-     *                             ii)  Number of bytes still pending to read.
+     *                             ii)  Number of bytes written to user buffer.
      *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
      *                                  nothing available to read at the moment.
      *                             iv)  A negative error code on failure.

--- a/features/netsocket/LoRaWANBase.h
+++ b/features/netsocket/LoRaWANBase.h
@@ -1,0 +1,250 @@
+/**
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#ifndef LORAWAN_BASE_H_
+#define LORAWAN_BASE_H_
+
+#include "lorawan/system/lorawan_data_structures.h"
+
+class LoRaWANBase {
+
+public:
+    /** Initialize the LoRa stack.
+     *
+     * You must call this before using the LoRa stack.
+     *
+     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     *                 failure.
+     */
+    virtual lora_mac_status_t initialize() = 0;
+
+    /** Connect OTAA or ABP by setup.
+     *
+     * Connect by Over The Air Activation or Activation By Personalization.
+     * The connection type is selected at the setup.
+     *
+     * @return         LORA_MAC_STATUS_OK on success, a negative error code on
+     *                 failure.
+     */
+    virtual lora_mac_status_t connect() = 0;
+
+    /** Connect OTAA or ABP by parameters
+     *
+     * Connect by Over The Air Activation or Activation By Personalization.
+     * The connection type is selected using the parameters.
+     * You need to define the parameters in the main application.
+     *
+     * @param connect       Options how end-device will connect to gateway
+     * @return              LORA_MAC_STATUS_OK on success, negative error code
+     *                      on failure
+     */
+    virtual lora_mac_status_t connect(const lorawan_connect_t &connect) = 0;
+
+    /** Disconnects the current session.
+     *
+     * @return         LORA_MAC_STATUS_OK on success, a negative error code on failure.
+     */
+    virtual lora_mac_status_t disconnect() = 0;
+
+    /** Sets up a particular data rate of choice
+     *
+     * @param data_rate   Intended data rate e.g., DR_0, DR_1 etc.
+     *                    Caution is advised as the macro DR_* can mean different
+     *                    things while being in a different region.
+     * @return            LORA_MAC_STATUS_OK if everything goes well, otherwise
+     *                    a negative error code.
+     */
+    virtual lora_mac_status_t set_datarate(uint8_t data_rate) = 0;
+
+    /** Enables adaptive data rate (ADR)
+     *
+     * Underlying LoRaPHY and LoRaMac layers handle the data rate automatically
+     * for the user based upon radio conditions (network congestion).
+     *
+     * @return             LORA_MAC_STATUS_OK on success, negative error code
+     *                     on failure.
+     */
+    virtual lora_mac_status_t enable_adaptive_datarate() = 0;
+
+    /** Disables adaptive data rate
+     *
+     * When adaptive data rate (ADR) is disabled, user can either set a certain
+     * data rate or the Mac layer will choose a default value.
+     *
+     * @return             LORA_MAC_STATUS_OK on success, negative error code
+     *                     on failure.
+     */
+    virtual lora_mac_status_t disable_adaptive_datarate() = 0;
+
+    /** Sets up retry counter for confirmed messages
+     *
+     * Valid only for confirmed messages.
+     *
+     * Number of trials to transmit the frame, if the LoRaMAC layer did not
+     * receive an acknowledgment. The MAC performs a data-rate adaptation,
+     * according to the LoRaWAN Specification V1.0.2, chapter 18.4, according
+     * to the table on page 64.
+     *
+     * Note, that if the number of trials is set to 1 or 2, the MAC will not decrease
+     * the datarate, in case the LoRaMAC layer did not receive an acknowledgment.
+     *
+     * @param count     number of retries for confirmed messages
+     *
+     * @return          LORA_MAC_STATUS_OK or a negative error code
+     */
+    virtual lora_mac_status_t set_confirmed_msg_retries(uint8_t count) = 0;
+
+    /** Sets channel plan
+     *
+     * @param channel_plan  The defined channel plans to be set.
+     * @return              0 on success, a negative error code on failure.
+     */
+    virtual lora_mac_status_t set_channel_plan(const lora_channelplan_t &channel_plan) = 0;
+
+    /** Gets the current channel plan.
+     *
+     * @param  channel_plan     The current channel information.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, a negative error
+     *                          code on failure.
+     */
+    virtual lora_mac_status_t get_channel_plan(lora_channelplan_t &channel_plan) = 0;
+
+    /** Removes currently active channel plan
+     *
+     * Default channels (channels where Base Stations are listening) are not
+     * allowed to be removed. So when a plan is abolished, only non-default
+     * channels are removed.
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, negative error
+     *                          code on failure
+     */
+    virtual lora_mac_status_t remove_channel_plan() = 0;
+
+    /** Removes a given single channel
+     *
+     * Default channels (channels where Base Stations are listening) are not
+     * allowed to be removed.
+     *
+     * @param    index          The channel index
+     *
+     * @return                  LORA_MAC_STATUS_OK on success, negative error
+     *                          code on failure
+     */
+    virtual lora_mac_status_t remove_channel(uint8_t index) = 0;
+
+    /** Send message to gateway
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to the data being sent. The ownership of the
+     *                          buffer is not transferred. The data is copied to the
+     *                          internal buffers.
+     *
+     * @param length            The size of data in bytes.
+     *
+     * @param flags             A flag used to determine what type of
+     *                          message is being sent, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          mutually exclusive.
+     *
+     *
+     * @return                  The number of bytes sent, or
+     *                          LORA_MAC_STATUS_WOULD_BLOCK if another TX is
+     *                          ongoing, or a negative error code on failure.
+     */
+    virtual int16_t send(uint8_t port, const uint8_t* data,
+                         uint16_t length, int flags) = 0;
+
+    /** Receives a message from the Network Server.
+     *
+     * @param port              The application port number. Port numbers 0 and 224
+     *                          are reserved, whereas port numbers from 1 to 223
+     *                          (0x01 to 0xDF) are valid port numbers.
+     *                          Anything out of this range is illegal.
+     *
+     * @param data              A pointer to buffer where the received data will be
+     *                          stored.
+     *
+     * @param length            The size of data in bytes.
+     *
+     * @param flags             A flag is used to determine what type of
+     *                          message is being sent, for example:
+     *
+     *                          MSG_UNCONFIRMED_FLAG = 0x01,
+     *                          MSG_CONFIRMED_FLAG = 0x02
+     *                          MSG_MULTICAST_FLAG = 0x04,
+     *                          MSG_PROPRIETARY_FLAG = 0x08
+     *
+     *                          MSG_MULTICAST_FLAG and MSG_PROPRIETARY_FLAG can be
+     *                          used in conjunction with MSG_UNCONFIRMED_FLAG and
+     *                          MSG_CONFIRMED_FLAG depending on the intended use.
+     *
+     *                          MSG_PROPRIETARY_FLAG|MSG_CONFIRMED_FLAG mask will set
+     *                          a confirmed message flag for a proprietary message.
+     *
+     *                          MSG_CONFIRMED_FLAG and MSG_UNCONFIRMED_FLAG are
+     *                          not mutually exclusive, i.e., the user can subscribe to
+     *                          receive both CONFIRMED AND UNCONFIRMED messages at
+     *                          the same time.
+     *
+     * @return                  It could be one of these:
+     *                             i)   0 if there is nothing else to read.
+     *                             ii)  Number of bytes still pending to read.
+     *                             iii) LORA_MAC_STATUS_WOULD_BLOCK if there is
+     *                                  nothing available to read at the moment.
+     *                             iv)  A negative error code on failure.
+     */
+    virtual int16_t receive(uint8_t port, uint8_t* data, uint16_t length,
+                            int flags) = 0;
+
+    /** Callback handler.
+     *
+     * Events that can be posted to user:
+     *
+     * CONNECTED            - When the connection is complete
+     * DISCONNECTED         - When the protocol is shut down in response to disconnect()
+     * TX_DONE              - When a packet is sent
+     * TX_TIMEOUT,          - When stack was unable to send packet in TX window
+     * TX_ERROR,            - A general TX error
+     * TX_CRYPTO_ERROR,     - If MIC fails, or any other crypto relted error
+     * TX_SCHEDULING_ERROR, - When stack is unable to schedule packet
+     * RX_DONE,             - When there is something to receive
+     * RX_TIMEOUT,          - Not yet mapped
+     * RX_ERROR             - A general RX error
+     *
+     * @param cb         A pointer to the callback function.
+     */
+    virtual void lora_event_callback(mbed::Callback<void(lora_events_t)> cb) = 0;
+};
+
+#endif /* LORAWAN_BASE_H_ */

--- a/features/netsocket/LoRaWANBase.h
+++ b/features/netsocket/LoRaWANBase.h
@@ -20,6 +20,7 @@
 #define LORAWAN_BASE_H_
 
 #include "lorawan/system/lorawan_data_structures.h"
+#include "events/EventQueue.h"
 
 class LoRaWANBase {
 
@@ -28,10 +29,12 @@ public:
      *
      * You must call this before using the LoRa stack.
      *
+     * @param queue A pointer to EventQueue provided by the application.
+     *
      * @return         LORA_MAC_STATUS_OK on success, a negative error code on
      *                 failure.
      */
-    virtual lora_mac_status_t initialize() = 0;
+    virtual lora_mac_status_t initialize(events::EventQueue *queue) = 0;
 
     /** Connect OTAA or ABP by setup.
      *

--- a/features/netsocket/LoRaWANBase.h
+++ b/features/netsocket/LoRaWANBase.h
@@ -230,9 +230,16 @@ public:
     virtual int16_t receive(uint8_t port, uint8_t* data, uint16_t length,
                             int flags) = 0;
 
-    /** Callback handler.
+    /** Add application callbacks to the stack.
      *
-     * Events that can be posted to user:
+     * 'lorawan_app_callbacks_t' is a structure that holds pointers to the application
+     * provided methods which are needed to be called in response to certain
+     * requests. The structure is default constructed to set all pointers to NULL.
+     * So if the user does not provide the pointer, a response will not be posted.
+     * However, the 'lorawan_events' callback is mandatory to be provided as it
+     * contains essential events.
+     *
+     * Events that can be posted to user via 'lorawan_events' are:
      *
      * CONNECTED            - When the connection is complete
      * DISCONNECTED         - When the protocol is shut down in response to disconnect()
@@ -245,9 +252,53 @@ public:
      * RX_TIMEOUT,          - Not yet mapped
      * RX_ERROR             - A general RX error
      *
-     * @param cb         A pointer to the callback function.
+     * Other responses to certain standard requests are an item for the future.
+     * For example, a link check request could be sent whenever the device tries
+     * to send a message and if the network server responds with a link check resposne,
+     * the stack notifies the application be calling the appropriate method. For example,
+     * 'link_check_resp' callback could be used to collect a response for a link check
+     * request MAC command and the result is thus transported to the application
+     * via callback function provided.
+     *
+     * As can be seen from declaration, mbed::Callback<void(uint8_t, uint8_t)> *link_check_resp)
+     * carries two parameters. First one is Demodulation Margin and the second one
+     * is number of gateways involved in the path to network server.
+     *
+     * An example of using this API with a latch onto 'lorawan_events' could be:
+     *
+     * LoRaWANInterface lorawan(radio);
+     * lorawan_app_callbacks_t cbs;
+     * static void my_event_handler();
+     *
+     * int main()
+     * {
+     * lorawan.initialize();
+     *  cbs.lorawan_events = mbed::callback(my_event_handler);
+     *  lorawan.add_app_callbacks(&cbs);
+     *  lorawan.connect();
+     * }
+     *
+     * static void my_event_handler(lora_events_t events)
+     * {
+     *  switch(events) {
+     *      case CONNECTED:
+     *          //do something
+     *          break;
+     *      case DISCONNECTED:
+     *          //do something
+     *          break;
+     *      case TX_DONE:
+     *          //do something
+     *          break;
+     *      default:
+     *          break;
+     *  }
+     * }
+     *
+     * @param callbacks         A pointer to the structure containing application
+     *                          callbacks.
      */
-    virtual void lora_event_callback(mbed::Callback<void(lora_events_t)> cb) = 0;
+    virtual lora_mac_status_t add_app_callbacks(lorawan_app_callbacks_t *callbacks) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */


### PR DESCRIPTION
Please check the last three commits. 

Picking up from #5656  , 

 - LoRaWANStack class is singleton. It should return a reference not a pointer.
 - Having Callbacks as pointers is not a sane idea. Callbacks can be checked if they are not assigned,  
   thanks to template magic, so that would suffice for @sg- comments.  

We have taken three commits from our development branch which were destined for Mbed-OS 5.8 as they were not stress tested when #5656 was opened. However, now we have confidence in them and that's why they are made part of this PR.

@0xc0170 @sg- @SenRamakri