### PR TITLE
Fix for #5676 make.py generates duplicate file entries in link_files.txt

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -819,7 +819,7 @@ class mbedToolchain:
     def relative_object_path(self, build_path, base_dir, source):
         source_dir, name, _ = split_path(source)
 
-        obj_dir = join(build_path, relpath(source_dir, base_dir))
+        obj_dir = relpath(join(build_path, relpath(source_dir, base_dir)))
         if obj_dir is not self.prev_dir:
             self.prev_dir = obj_dir
             mkdir(obj_dir)


### PR DESCRIPTION
## Description
Fix for #5676. In some cases relative_object_path can result in path's like "path\to\.\some\file.o", which in turn can result in duplicate file names in the linker list (second entry would be in the form of "path\to\some\file.o")

## Status
READY

## Migrations
NO

