### PR TITLE
Renesas: fix cmsis lib build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -188,3 +188,5 @@ matrix:
       env: NAME=mbed2-ATMEL
     - <<: *mbed-2
       env: NAME=mbed2-NUVOTON
+    - <<: *mbed-2
+      env: NAME=mbed2-RENESAS

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -22,6 +22,8 @@
  * limitations under the License.
  */
 
+#ifdef MBED_CONF_RTOS_PRESENT
+
 #include "os_tick.h"
 #include "irq_ctrl.h"
 
@@ -185,3 +187,6 @@ uint32_t OS_Tick_GetCount (void) {
 uint32_t OS_Tick_GetOverflow (void) {
   return (IRQ_GetPending(OSTM_IRQn));
 }
+
+#endif
+

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/device/VKRZA1H.h
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/device/VKRZA1H.h
@@ -626,9 +626,9 @@ typedef enum IRQn
 #define __NVIC_PRIO_BITS          5         /*!< Number of Bits used for Priority Levels          */
 #define __Vendor_SysTickConfig    0         /*!< Set to 1 if different SysTick Config is used     */
 
-#include <core_ca9.h>
+#include "core_ca.h"
 #include "system_VKRZA1H.h"
-
+#include "iodefine.h"
 
 /******************************************************************************/
 /*                Device Specific Peripheral Section                          */

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/serial_api.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/serial_api.c
@@ -23,6 +23,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "gpio_api.h"
+#include "mbed_critical.h"
 
 #include "scif_iodefine.h"
 #include "cpg_iodefine.h"
@@ -570,21 +571,14 @@ static void serial_flow_irq_set(serial_t *obj, uint32_t enable) {
 int serial_getc(serial_t *obj) {
     uint16_t err_read;
     int data;
-    int was_masked;
 
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
     if (obj->uart->SCFSR & 0x93) {
         err_read = obj->uart->SCFSR;
         obj->uart->SCFSR = (err_read & ~0x93);
     }
     obj->uart->SCSCR |= 0x0040;     // Set RIE
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
 
     if (obj->uart->SCLSR & 0x0001) {
         obj->uart->SCLSR = 0u;      // ORER clear
@@ -593,16 +587,12 @@ int serial_getc(serial_t *obj) {
     while (!serial_readable(obj));
     data = obj->uart->SCFRDR & 0xff;
 
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
+
     err_read = obj->uart->SCFSR;
     obj->uart->SCFSR = (err_read & 0xfffD);     // Clear RDF
-    if (!was_masked) {
-        __enable_irq();
-    }
+
+    core_util_critical_section_exit();
 
     if (err_read & 0x80) {
         data = -1;  //err
@@ -612,29 +602,16 @@ int serial_getc(serial_t *obj) {
 
 void serial_putc(serial_t *obj, int c) {
     uint16_t dummy_read;
-    int was_masked;
 
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
     obj->uart->SCSCR |= 0x0080;     // Set TIE
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
     while (!serial_writable(obj));
     obj->uart->SCFTDR = c;
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
     dummy_read = obj->uart->SCFSR;
     obj->uart->SCFSR = (dummy_read & 0xff9f);  // Clear TEND/TDFE
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
     uart_data[obj->index].count++;
 }
 
@@ -647,20 +624,11 @@ int serial_writable(serial_t *obj) {
 }
 
 void serial_clear(serial_t *obj) {
-    int was_masked;
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
-
+    core_util_critical_section_enter();
     obj->uart->SCFCR |=  0x06;          // TFRST = 1, RFRST = 1
     obj->uart->SCFCR &= ~0x06;          // TFRST = 0, RFRST = 0
     obj->uart->SCFSR &= ~0x0093u;       // ER, BRK, RDF, DR = 0
-
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
 }
 
 void serial_pinout_tx(PinName tx) {
@@ -668,62 +636,34 @@ void serial_pinout_tx(PinName tx) {
 }
 
 void serial_break_set(serial_t *obj) {
-    int was_masked;
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
     // TxD Output(L)
     obj->uart->SCSPTR &= ~0x0001u;  // SPB2DT = 0
     obj->uart->SCSCR &= ~0x0020u;   // TE = 0 (Output disable)
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
 }
 
 void serial_break_clear(serial_t *obj) {
-    int was_masked;
-#if defined ( __ICCARM__ )
-    was_masked = __disable_irq_iar();
-#else
-    was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
     obj->uart->SCSCR |= 0x0020u; // TE = 1 (Output enable)
     obj->uart->SCSPTR |= 0x0001u; // SPB2DT = 1
-    if (!was_masked) {
-        __enable_irq();
-    }
+    core_util_critical_section_exit();
 }
 
 void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow) {
     // determine the UART to use
-    int was_masked;
-
     serial_flow_irq_set(obj, 0);
 
     if (type == FlowControlRTSCTS) {
-#if defined ( __ICCARM__ )
-        was_masked = __disable_irq_iar();
-#else
-        was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+        core_util_critical_section_enter();
         obj->uart->SCFCR = 0x0008u;   // CTS/RTS enable
-        if (!was_masked) {
-            __enable_irq();
-        }
+        core_util_critical_section_exit();
         pinmap_pinout(rxflow, PinMap_UART_RTS);
         pinmap_pinout(txflow, PinMap_UART_CTS);
     } else {
-#if defined ( __ICCARM__ )
-        was_masked = __disable_irq_iar();
-#else
-        was_masked = __disable_irq();
-#endif /* __ICCARM__ */
+        core_util_critical_section_enter();
         obj->uart->SCFCR = 0x0000u; // CTS/RTS diable
-        if (!was_masked) {
-            __enable_irq();
-        }
+        core_util_critical_section_exit();
     }
 }
 

--- a/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/us_ticker.c
+++ b/targets/TARGET_RENESAS/TARGET_VK_RZ_A1H/us_ticker.c
@@ -20,6 +20,7 @@
 
 #include "RZ_A1_Init.h"
 #include "VKRZA1H.h"
+#include "mbed_critical.h"
 
 #define US_TICKER_TIMER_IRQn (OSTMI1TINT_IRQn)
 #define CPG_STBCR5_BIT_MSTP50   (0x01u) /* OSTM1 */
@@ -83,22 +84,14 @@ static uint64_t ticker_read_counter64(void) {
 uint32_t us_ticker_read() {
     uint64_t cnt_val64;
     uint64_t us_val64;
-    int check_irq_masked;
 
-#if defined ( __ICCARM__)
-    check_irq_masked = __disable_irq_iar();
-#else
-    check_irq_masked = __disable_irq();
-#endif /* __ICCARM__ */
+    core_util_critical_section_enter();
 
     cnt_val64        = ticker_read_counter64();
     us_val64         = (cnt_val64 / count_clock);
     ticker_us_last64 = us_val64;
 
-    if (!check_irq_masked) {
-        __enable_irq();
-    }
-
+    core_util_critical_section_exit();
     /* clock to us */
     return (uint32_t)us_val64;
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2411,7 +2411,7 @@
         "device_has": ["ANALOGIN", "CAN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
         "default_lib": "std",
-        "release_versions": ["2"]
+        "release_versions": []
     },
     "MAXWSNENV": {
         "inherits": ["Target"],

--- a/tools/build_travis.py
+++ b/tools/build_travis.py
@@ -168,6 +168,14 @@ build_list = [
             { "target": "NUMAKER_PFM_M453",     "toolchains": "GCC_ARM",    "libs": ["dsp", "usb"] },
             { "target": "NUMAKER_PFM_M487",     "toolchains": "GCC_ARM",    "libs": ["dsp", "usb"] },
         )
+    },
+
+
+    {
+        "RENESAS":
+        (
+            { "target": "RZ_A1H", "toolchains": "GCC_ARM" },
+        )
     }
 ]
 
@@ -325,6 +333,17 @@ linking_list = [
                        "usb"  : ["USB_1", "USB_2" ,"USB_3"],
                        }
              }
+        )
+    },
+    {
+        "RENESAS": 
+        (
+            {
+             "target": "RZ_A1H",
+             "toolchains": "GCC_ARM",
+             "tests": {""     : ["MBED_2", "MBED_10", "MBED_11", "MBED_16"],
+                      }
+            },
         )
     }
 ]


### PR DESCRIPTION
device header file not needed in cmsis implementation, thus removed - causing problems to build cmsis lib in mbed 2

another fix is for renesas target code that implements os tick, should only be available if rtos is present

Tested locally with GCC ARM

@ARMmbed/team-renesas please verify this patch