### PR TITLE
[WIP] attempt to use lp_ticker as main ticker source when it is possible

### DIFF
--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -21,7 +21,15 @@
 
 namespace mbed {
 
-Timer::Timer() : _running(), _start(), _time(), _ticker_data(get_us_ticker_data()), _lock_deepsleep(true) {
+Timer::Timer() : _running(), _start(), _time(), 
+#if DEVICE_LOWPOWERTIMER
+    _ticker_data(get_lp_ticker_data()),
+    _lock_deepsleep(false)
+#else
+    _ticker_data(get_us_ticker_data()), 
+    _lock_deepsleep(true)
+#endif
+{
     reset();
 }
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1072,7 +1072,12 @@ void operator delete[](void *ptr)
 extern "C" clock_t clock()
 {
     _mutex->lock();
-    clock_t t = ticker_read(get_us_ticker_data());
+#if DEVICE_LOWPOWERTIMER
+    const ticker_data_t *const ticker = get_lp_ticker_data();
+#else
+    const ticker_data_t *const ticker = get_us_ticker_data();
+#endif
+    clock_t t = ticker_read(ticker);
     t /= 1000000 / CLOCKS_PER_SEC; // convert to processor time
     _mutex->unlock();
     return t;

--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -30,7 +30,11 @@ void wait_ms(int ms) {
 }
 
 void wait_us(int us) {
+#if DEVICE_LOWPOWERTIMER
+    const ticker_data_t *const ticker = get_lp_ticker_data();
+#else
     const ticker_data_t *const ticker = get_us_ticker_data();
+#endif
     uint32_t start = ticker_read(ticker);
     while ((ticker_read(ticker) - start) < (uint32_t)us);
 }


### PR DESCRIPTION
## Description

After analyzing the us_ticker api usage, almost no driver is actually using high resolution timer.
The two highest frequencies being by default :
- 10KHz for BLE/Eddystone's urlTicker ;
- 20KHz for nanostack's hal's timer/timeout.

This PR aims at using lp_ticker as the default ticker.

## Status

**IN DEVELOPMENT**

## Migrations

After this PR is merge, *API users* may need to check their ticker usage in case they really need high resolution ticks

YES | NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

## Steps to test or reproduce

