### PR TITLE
Correct memap path handling on windows

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -77,7 +77,7 @@ class _Parser(object):
 
 class _GccParser(_Parser):
     RE_OBJECT_FILE = re.compile(r'^(.+\/.+\.o)$')
-    RE_LIBRARY_OBJECT = re.compile(r'^.+\/lib(.+\.a)\((.+\.o)\)$')
+    RE_LIBRARY_OBJECT = re.compile(r'^.+' + os.sep + r'lib((.+\.a)\((.+\.o)\))$')
     RE_STD_SECTION = re.compile(r'^\s+.*0x(\w{8,16})\s+0x(\w+)\s(.+)$')
     RE_FILL_SECTION = re.compile(r'^\s*\*fill\*\s+0x(\w{8,16})\s+0x(\w+).*$')
 
@@ -119,7 +119,7 @@ class _GccParser(_Parser):
 
             # corner case: certain objects are provided by the GCC toolchain
             if 'arm-none-eabi' in line:
-                return os.path.join('[lib]', 'misc', object_name)
+                return os.path.join('[lib]', 'misc', os.path.basename(object_name))
             return object_name
 
         else:

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -136,7 +136,6 @@ class MemapParser(object):
         txt - the path to parse the object and module name from
         """
 
-        line = line.replace('\\', '/')
         test_re_mbed_os_name = re.match(RE_OBJECT_FILE_GCC, line)
 
         if test_re_mbed_os_name:
@@ -145,7 +144,7 @@ class MemapParser(object):
 
             # corner case: certain objects are provided by the GCC toolchain
             if 'arm-none-eabi' in line:
-                return '[lib]/misc/' + object_name
+                return os.path.join('[lib]', 'misc', object_name)
             return object_name
 
         else:
@@ -153,10 +152,10 @@ class MemapParser(object):
             test_re_obj_name = re.match(RE_LIBRARY_OBJECT_GCC, line)
 
             if test_re_obj_name:
-                object_name = test_re_obj_name.group(1) + '/' + \
-                              test_re_obj_name.group(2)
+                object_name = os.path.join(test_re_obj_name.group(1),
+                                           test_re_obj_name.group(2))
 
-                return '[lib]/' + object_name
+                return os.path.join('[lib]', object_name)
 
             else:
                 print "Unknown object name found in GCC map file: %s" % line
@@ -241,8 +240,9 @@ class MemapParser(object):
         else:
             is_obj = re.match(RE_OBJECT_ARMCC, line)
             if is_obj:
-                object_name = os.path.basename(is_obj.group(1)) + '/' + is_obj.group(3)
-                return '[lib]/' + object_name
+                object_name = os.path.join(os.path.basename(is_obj.group(1)),
+                                           is_obj.group(3))
+                return os.path.join('[lib]', object_name)
             else:
                 print "Malformed input found when parsing ARMCC map: %s" % line
                 return '[misc]'
@@ -472,7 +472,7 @@ class MemapParser(object):
                 object_name = self.check_new_object_lib_iar(line)
 
                 if object_name and current_library:
-                    temp = '[lib]' + '/'+ current_library + '/'+ object_name
+                    temp = os.path.join('[lib]', current_library, object_name)
                     self.module_replace(object_name, temp)
 
 
@@ -495,10 +495,10 @@ class MemapParser(object):
         else:
             self.short_modules = dict()
             for module_name, v in self.modules.items():
-                split_name = module_name.split('/')
+                split_name = module_name.split(os.sep)
                 if split_name[0] == '':
                     split_name = split_name[1:]
-                new_name = "/".join(split_name[:depth])
+                new_name = os.path.join(*split_name[:depth])
                 self.short_modules.setdefault(new_name, {})
                 for section_idx, value in v.items():
                     self.short_modules[new_name].setdefault(section_idx, 0)

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -432,15 +432,14 @@ class MemapParser(object):
         for line in lines:
             if line.startswith("*"):
                 break
-            is_cmdline_file = RE_CMDLINE_FILE_IAR.match(line)
-            if is_cmdline_file:
-                full_path = is_cmdline_file.group(1)
-                self.cmd_modules[os.path.basename(full_path)] = full_path
+            for arg in line.split(" "):
+                arg = arg.rstrip(" \n")
+                if (not arg.startswith("-")) and arg.endswith(".o"):
+                    self.cmd_modules[os.path.basename(arg)] = arg
 
         common_prefix = os.path.dirname(os.path.commonprefix(self.cmd_modules.values()))
         self.cmd_modules = {s: os.path.relpath(f, common_prefix)
                             for s, f in self.cmd_modules.items()}
-
 
     def parse_map_file_iar(self, file_desc):
         """ Main logic to decode IAR map files

--- a/tools/test/memap/gcc.map
+++ b/tools/test/memap/gcc.map
@@ -8,6 +8,7 @@ Linker script and memory map
                 0x000000000001b200       0xc0 /common/path/startup/startup.o
                 0x000000000001b200                startup()
                 0x0000000000024020        0x8 /usr/lib/gcc/arm-none-eabi/7.1.0/../../../../arm-none-eabi/lib/armv6-m/libd16M_tlf.a(__main.o)
+                0x0000000000024020        0x8 /usr/lib/gcc/arm-none-eabi/7.1.0/../../../../arm-none-eabi/lib/armv6-m/foo.o
 
 .data           0x0000000020002ef8      0xac8 load address 0x000000000002ca38
                 0x0000000020002ef8                __data_start__ = .

--- a/tools/test/memap/iar.map
+++ b/tools/test/memap/iar.map
@@ -10,12 +10,9 @@
 #    Command line =  
 #        -f
 #        /common/path/.link_files.txt
-#        (-o
-#        --map=/common/path/project.map
-#        /common/path/project.elf
-#        /common/path/main.o
-#        /common/path/startup/startup.o
-#        /common/path/irqs/irqs.o
+#        (-o /common/path/project.elf
+#        --map=/common/path/project.map /common/path/main.o
+#        /common/path/startup/startup.o /common/path/irqs/irqs.o
 #        /common/path/data/data.o
 #
 ###############################################################################

--- a/tools/test/memap/parse_test.py
+++ b/tools/test/memap/parse_test.py
@@ -24,7 +24,7 @@ def test_parse_armcc():
     memap.parse(join(dirname(__file__), "arm.map"), "UARM")
     assert memap.modules == PARSED_ARM_DATA
 
-PARSED_IAR_GCC_DATA = {
+PARSED_IAR_DATA = {
     "startup/startup.o": {".text": 0xc0},
     "[lib]/d16M_tlf.a/__main.o": {".text": 8},
     "irqs/irqs.o": {".text": 0x98},
@@ -35,14 +35,23 @@ PARSED_IAR_GCC_DATA = {
 def test_parse_iar():
     memap = MemapParser()
     memap.parse(join(dirname(__file__), "iar.map"), "IAR")
-    assert memap.modules == PARSED_IAR_GCC_DATA
+    assert memap.modules == PARSED_IAR_DATA
+
+PARSED_GCC_DATA = {
+    "startup/startup.o": {".text": 0xc0},
+    "[lib]/d16M_tlf.a/__main.o": {".text": 8},
+    "[lib]/misc/foo.o": {".text": 8},
+    "irqs/irqs.o": {".text": 0x98},
+    "data/data.o": {".data": 0x18, ".bss": 0x198},
+    "main.o": {".text": 0x36},
+}
 
 def test_parse_gcc():
     memap = MemapParser()
     memap.parse(join(dirname(__file__), "gcc.map"), "GCC_ARM")
-    assert memap.modules == PARSED_IAR_GCC_DATA
+    assert memap.modules == PARSED_GCC_DATA
     memap.parse(join(dirname(__file__), "gcc.map"), "GCC_CR")
-    assert memap.modules == PARSED_IAR_GCC_DATA
+    assert memap.modules == PARSED_GCC_DATA
 
 
 def test_add_empty_module():

--- a/tools/test/memap/parse_test.py
+++ b/tools/test/memap/parse_test.py
@@ -5,7 +5,7 @@ import json
 
 import pytest
 
-from tools.memap import MemapParser
+from tools.memap import MemapParser, _ArmccParser
 from copy import deepcopy
 
 
@@ -19,7 +19,9 @@ PARSED_ARM_DATA = {
 
 def test_parse_armcc():
     memap = MemapParser()
-    memap.parse_map_file_armcc(open(join(dirname(__file__), "arm.map")))
+    memap.parse(join(dirname(__file__), "arm.map"), "ARM")
+    assert memap.modules == PARSED_ARM_DATA
+    memap.parse(join(dirname(__file__), "arm.map"), "UARM")
     assert memap.modules == PARSED_ARM_DATA
 
 PARSED_IAR_GCC_DATA = {
@@ -32,17 +34,19 @@ PARSED_IAR_GCC_DATA = {
 
 def test_parse_iar():
     memap = MemapParser()
-    memap.parse_map_file_iar(open(join(dirname(__file__), "iar.map")))
+    memap.parse(join(dirname(__file__), "iar.map"), "IAR")
     assert memap.modules == PARSED_IAR_GCC_DATA
 
 def test_parse_gcc():
     memap = MemapParser()
-    memap.parse_map_file_gcc(open(join(dirname(__file__), "gcc.map")))
+    memap.parse(join(dirname(__file__), "gcc.map"), "GCC_ARM")
+    assert memap.modules == PARSED_IAR_GCC_DATA
+    memap.parse(join(dirname(__file__), "gcc.map"), "GCC_CR")
     assert memap.modules == PARSED_IAR_GCC_DATA
 
 
 def test_add_empty_module():
-    memap = MemapParser()
+    memap = _ArmccParser()
     old_modules = deepcopy(memap.modules)
     memap.module_add("", 8, ".data")
     assert(old_modules == memap.modules)
@@ -52,7 +56,7 @@ def test_add_empty_module():
     assert(old_modules == memap.modules)
 
 def test_add_full_module():
-    memap = MemapParser()
+    memap = _ArmccParser()
     old_modules = deepcopy(memap.modules)
     memap.module_add("main.o", 8, ".data")
     assert(old_modules != memap.modules)


### PR DESCRIPTION
Includes a parser refactor, as I got a bit irritated by seeing `_gcc`
suffixed method names.

Resolves #5772

# Todo
 - [x] A test for path handling
 - [x] A test for GCC including builtin parsing
 - [x] A test for multi-parameter cmd line parsing with IAR 