### PR TITLE
RTX: fix out of bounds access

### DIFF
--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
@@ -95,7 +95,7 @@ osStatus_t svcRtxKernelInitialize (void) {
 
   // Initialize osRtxInfo, skipping all elements before the kernel struct,
   // (os_id and version), which are set elsewhere
-  memset(&osRtxInfo + sizeof(osRtxInfo.os_id) + sizeof(isRtxInfo.version),
+  memset(&osRtxInfo + sizeof(osRtxInfo.os_id) + sizeof(osRtxInfo.version),
          0,
          sizeof(osRtxInfo) - sizeof(osRtxInfo.os_id) - sizeof(osRtxInfo.version));
 

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_kernel.c
@@ -93,8 +93,11 @@ osStatus_t svcRtxKernelInitialize (void) {
     return osError;
   }
 
-  // Initialize osRtxInfo
-  memset(&osRtxInfo.kernel, 0, sizeof(osRtxInfo) - offsetof(osRtxInfo_t, kernel));
+  // Initialize osRtxInfo, skipping all elements before the kernel struct,
+  // (os_id and version), which are set elsewhere
+  memset(&osRtxInfo + sizeof(osRtxInfo.os_id) + sizeof(isRtxInfo.version),
+         0,
+         sizeof(osRtxInfo) - sizeof(osRtxInfo.os_id) - sizeof(osRtxInfo.version));
 
   if (osRtxConfig.thread_stack_size < (64U + 8U)) {
     EvrRtxKernelError(osRtxErrorInvalidThreadStack);


### PR DESCRIPTION
## Description
Coverity was triggering a Out-of-bounds access (OVERRUN) on the memset that was initializing osRtxInfo. This fix does not change the code behavior, which was not problematic, but reformats the code so that it is easier to understand and makes Coverity accept it. (see JIRA ticket IOTMORF-1650)

## Steps to test or reproduce
Run Coverity on the project. It will produce the Out-of-bounds access (OVERRUN) report.
