### PR TITLE
littlefs: Fix positive seek bounds checking

### DIFF
--- a/features/filesystem/littlefs/littlefs/lfs.c
+++ b/features/filesystem/littlefs/littlefs/lfs.c
@@ -1635,13 +1635,13 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     if (whence == LFS_SEEK_SET) {
         file->pos = off;
     } else if (whence == LFS_SEEK_CUR) {
-        if ((lfs_off_t)-off > file->pos) {
+        if (off < 0 && (lfs_off_t)-off > file->pos) {
             return LFS_ERR_INVAL;
         }
 
         file->pos = file->pos + off;
     } else if (whence == LFS_SEEK_END) {
-        if ((lfs_off_t)-off > file->size) {
+        if (off < 0 && (lfs_off_t)-off > file->size) {
             return LFS_ERR_INVAL;
         }
 

--- a/features/filesystem/littlefs/littlefs/tests/test_seek.sh
+++ b/features/filesystem/littlefs/littlefs/tests/test_seek.sh
@@ -133,6 +133,14 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
+    lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
+    lfs_file_read(&lfs, &file[0], buffer, size) => size;
+    memcmp(buffer, "kittycatcat", size) => 0;
+
+    lfs_file_seek(&lfs, &file[0], size, LFS_SEEK_CUR) => 3*size;
+    lfs_file_read(&lfs, &file[0], buffer, size) => size;
+    memcmp(buffer, "kittycatcat", size) => 0;
+
     lfs_file_seek(&lfs, &file[0], pos, LFS_SEEK_SET) => pos;
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
@@ -171,6 +179,14 @@ tests/test.py << TEST
     memcmp(buffer, "kittycatcat", size) => 0;
 
     lfs_file_rewind(&lfs, &file[0]) => 0;
+    lfs_file_read(&lfs, &file[0], buffer, size) => size;
+    memcmp(buffer, "kittycatcat", size) => 0;
+
+    lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
+    lfs_file_read(&lfs, &file[0], buffer, size) => size;
+    memcmp(buffer, "kittycatcat", size) => 0;
+
+    lfs_file_seek(&lfs, &file[0], size, LFS_SEEK_CUR) => 3*size;
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 


### PR DESCRIPTION
This bug was a result of an annoying corner case around intermingling signed and unsigned offsets. The boundary check that prevents seeking a file to a position before the file was preventing valid seeks with
positive offsets.

This corner case is a bit more complicated than it looks because the offset is signed, while the size of the file is unsigned. Simply casting both to signed or unsigned offsets won't handle large files.

from https://github.com/geky/littlefs/issues/4
note: intended for patch
  