### PR TITLE
RTC test: fix __result variable

### DIFF
--- a/TESTS/host_tests/rtc_calc_auto.py
+++ b/TESTS/host_tests/rtc_calc_auto.py
@@ -130,9 +130,3 @@ class RTC_time_calc_test(BaseHostTest):
     def setup(self):
         self.register_callback('timestamp', self._verify_timestamp)
         self.register_callback('leap_year_setup', self._set_leap_year_support)
-
-    def result(self):
-        return self.__result
-
-    def teardown(self):
-        pass


### PR DESCRIPTION
Result was not defined, thus causing attribute error

```
AttributeError: 'RTC_time_calc_test' object has no attribute '_RTC_time_calc_test__result'
```

@mprse @maciejbocianski  please review