### PR TITLE
relax max frequency requirement on lp_ticker.

### DIFF
--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -34,7 +34,7 @@ extern "C" {
  * Low level interface to the low power ticker of a target
  *
  * # Defined behavior
- * * Has a reported frequency between 8KHz and 64KHz - verified by ::lp_ticker_info_test
+ * * Has a reported frequency of at least 8KHz - verified by ::lp_ticker_info_test
  * * Has a counter that is at least 12 bits wide - verified by ::lp_ticker_info_test
  * * Continues operating in deep sleep mode - verified by ::lp_ticker_deepsleep_test
  * * All behavior defined by the @ref hal_ticker_shared "ticker specification"


### PR DESCRIPTION
## Description

Some silicon may be able to provider a lp_ticker from an rtc or an lptimer with a frequency higher than 64kHz.
#5749 introduces usage of the `LPTIM` which can accept as input an external clock up to 15MHz.

This PR aims at removing this requirement limiting tickers' resolutions.

## Status

READY

## Migrations

NO

## Related PRs

This may affect #5233 as it implements tests for tickers.

## Todos

- [x] Tests
- [x] Documentation
