### PR TITLE
STM32 CAN: fix wrong ID and MASK filter

### DIFF
--- a/targets/TARGET_STM/can_api.c
+++ b/targets/TARGET_STM/can_api.c
@@ -468,11 +468,11 @@ int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t
             sFilterConfig.FilterIdLow =  0x0;
             sFilterConfig.FilterMaskIdHigh = mask << 5;
             sFilterConfig.FilterMaskIdLow = 0x0; // allows both remote and data frames
-        } else if (format == CANExtended) {
+        } else { // format == CANExtended
             sFilterConfig.FilterIdHigh = id >> 13; // EXTID[28:13]
-            sFilterConfig.FilterIdLow = (0x00FF & (id << 3)) | (1 << 2);  // EXTID[12:0]
+            sFilterConfig.FilterIdLow = (0xFFFF & (id << 3)) | (1 << 2); // EXTID[12:0] + IDE
             sFilterConfig.FilterMaskIdHigh = mask >> 13;
-            sFilterConfig.FilterMaskIdLow = (0x00FF & (mask << 3)) | (1 << 2);
+            sFilterConfig.FilterMaskIdLow = (0xFFFF & (mask << 3)) | (1 << 2);
         }
 
         sFilterConfig.FilterFIFOAssignment = 0;


### PR DESCRIPTION
## Description

This PR fixes a wrong configuration of the STM32 CAN ID and MASK filters resulting that only some IDs and MASKs were working correctly (Thanks @zh0umu).

## Status
**READY**

## Migrations
**NO**

## Related Issues
#5765 
#5351 
