### PR TITLE
Commit to fix the Online compiler issue for ARM mbed-os on REALTEK_RT…

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -13,8 +13,8 @@
 LR_IRAM 0x10007000 (0x70000 - 0x7000) {
 
   IMAGE2_TABLE 0x10007000 FIXED {
-    *rtl8195a_init.o(.image2.ram.data*, +FIRST)
-    *rtl8195a_init.o(.image2.validate.rodata*)
+    *rtl8195a_init*.o(.image2.ram.data*, +FIRST)
+    *rtl8195a_init*.o(.image2.validate.rodata*)
   }
 
   ER_IRAM +0 FIXED {
@@ -25,14 +25,14 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
   }
 
   RW_IRAM1 +0 UNINIT FIXED {
-    *rtl8195a_crypto.o(+RW)
+    *rtl8195a_crypto*.o(+RW)
     *libc.a (+RW)
     *(.sdram.data*)
     *lib_peripheral_mbed_arm.ar (+RW)
   }
 
   RW_IRAM2 +0 UNINIT FIXED {
-    *rtl8195a_crypto.o(+ZI, COMMON)
+    *rtl8195a_crypto*.o(+ZI, COMMON)
     *libc.a (+ZI, COMMON)
     *(.bss.thread_stack_main)
     *lib_peripheral_mbed_arm.ar (+ZI, COMMON)
@@ -44,8 +44,8 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
 
 LR_TCM 0x1FFF0000 0x10000 {
     TCM_OVERLAY 0x1FFF0000 0x10000 {
-        *lwip_mem.o(.bss*)
-        *lwip_memp.o(.bss*)
+        *lwip_mem*.o(.bss*)
+        *lwip_memp*.o(.bss*)
         *.o(.tcm.heap*)
     }
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -18,7 +18,7 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
   }
 
   ER_IRAM +0 FIXED {
-    *rtl8195a_crypto.o (+RO)
+    *rtl8195a_crypto*.o (+RO)
     *(i.mbedtls*)
     *libc.a (+RO)
     *rtx_*.o (+RO)


### PR DESCRIPTION


Notes:
Notes:
This pull request fixes the mbed online compile failure for the REALTEK_RTL8195AM device.

## Description
The failure was caused due to a difference in the naming convention of object files generated by the online vs offline compiler.

The .sct file of the ARM compiler was modified to allow for seamless binary generation in both the online as well as offline compilers.

This PR is to fix the issue ARMmbed/mbed-os-example-blinky#102 and #5626

## Status
READY

## Migrations
Once this PR is merged, the online compilation should succeed

## Related PRs
#5719 , The previous PR was closed by me due to some issue with the branch due to which I created a fresh fork, rebased with mbed-os master and submitting this new PR again

Outline the steps to test or reproduce the PR here.

Testing can be done with the following steps.
1. Merge PR with master.
2. Run the online compiler for any example for the REALTEK_RTL8195AM target