### PR TITLE
ARMC5+6: Specify CPU for ARM scatter file preprocessor

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -228,9 +228,10 @@ class Arm(Makefile):
 
     def generate(self):
         if self.resources.linker_script:
+            sct_file = self.resources.linker_script
             new_script = self.toolchain.correct_scatter_shebang(
-                self.resources.linker_script)
-            if new_script is not self.resources.linker_script:
+                sct_file, join(self.resources.file_basepath[sct_file], "BUILD"))
+            if new_script is not sct_file:
                 self.resources.linker_script = new_script
                 self.generated_files.append(new_script)
         return super(Arm, self).generate()

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -217,12 +217,14 @@ class Uvision(Exporter):
             # UVFile tuples defined above
             'project_files': sorted(list(self.format_src(srcs).iteritems()),
                                     key=lambda (group, _): group.lower()),
-            'linker_script':self.toolchain.correct_scatter_shebang(
-                self.resources.linker_script),
             'include_paths': '; '.join(self.resources.inc_dirs).encode('utf-8'),
             'device': DeviceUvision(self.target),
         }
-        self.generated_files.append(ctx['linker_script'])
+        sct_file = self.resources.linker_script
+        ctx['linker_script'] = self.toolchain.correct_scatter_shebang(
+            sct_file, self.resources.file_basepath[sct_file])
+        if ctx['linker_script'] != sct_file:
+            self.generated_files.append(ctx['linker_script'])
         core = ctx['device'].core
         ctx['cputype'] = core.rstrip("FD")
         if core.endswith("FD"):

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -81,6 +81,8 @@ class ARM(mbedToolchain):
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")
 
+        self.SHEBANG += " --cpu=%s" % target.core.lower()
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         for line in open(dep_path).readlines():
@@ -356,6 +358,7 @@ class ARMC6(ARM_STD):
         self.ar = [join(TOOLCHAIN_PATHS["ARMC6"], "armar")]
         self.elf2bin = join(TOOLCHAIN_PATHS["ARMC6"], "fromelf")
 
+        self.SHEBANG += " -mcpu=%s" % target.core.lower()
 
     def parse_dependencies(self, dep_path):
         return mbedToolchain.parse_dependencies(self, dep_path)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -16,8 +16,8 @@ limitations under the License.
 """
 import re
 from copy import copy
-from os.path import join, dirname, splitext, basename, exists
-from os import makedirs, write
+from os.path import join, dirname, splitext, basename, exists, relpath
+from os import makedirs, write, curdir
 from tempfile import mkstemp
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
@@ -184,7 +184,7 @@ class ARM(mbedToolchain):
     def compile_cpp(self, source, object, includes):
         return self.compile(self.cppc, source, object, includes)
 
-    def correct_scatter_shebang(self, scatter_file):
+    def correct_scatter_shebang(self, scatter_file, base_path=curdir):
         """Correct the shebang at the top of a scatter file.
 
         Positional arguments:
@@ -203,7 +203,8 @@ class ARM(mbedToolchain):
                 return scatter_file
             else:
                 new_scatter = join(self.build_dir, ".link_script.sct")
-                self.SHEBANG += " -I %s" % dirname(scatter_file)
+                self.SHEBANG += " -I %s" % relpath(dirname(scatter_file),
+                                                   base_path)
                 if self.need_update(new_scatter, [scatter_file]):
                     with open(new_scatter, "wb") as out:
                         out.write(self.SHEBANG)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -14,12 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
-import glob
 import re
 from copy import copy
 from os.path import join, dirname, splitext, basename, exists
 from os import makedirs, write
-from shutil import copyfile
 from tempfile import mkstemp
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
@@ -201,20 +199,16 @@ class ARM(mbedToolchain):
         with open(scatter_file, "rb") as input:
             lines = input.readlines()
             if (lines[0].startswith(self.SHEBANG) or
-                 not lines[0].startswith("#!")):
+                not lines[0].startswith("#!")):
                 return scatter_file
             else:
                 new_scatter = join(self.build_dir, ".link_script.sct")
+                self.SHEBANG += " -I %s" % dirname(scatter_file)
                 if self.need_update(new_scatter, [scatter_file]):
                     with open(new_scatter, "wb") as out:
                         out.write(self.SHEBANG)
                         out.write("\n")
                         out.write("".join(lines[1:]))
-
-                # Copy headers into the build dir as well
-                headers = glob.glob(join(dirname(scatter_file), '*.h'))
-                for header in headers:
-                    copyfile(header, join(self.build_dir, basename(header)))
 
                 return new_scatter
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -81,7 +81,7 @@ class ARM(mbedToolchain):
         self.ar = join(ARM_BIN, "armar")
         self.elf2bin = join(ARM_BIN, "fromelf")
 
-        self.SHEBANG += " --cpu=%s" % target.core.lower()
+        self.SHEBANG += " --cpu=%s" % cpu
 
     def parse_dependencies(self, dep_path):
         dependencies = []
@@ -312,15 +312,19 @@ class ARMC6(ARM_STD):
         if target.core.lower().endswith("fd"):
             self.flags['common'].append("-mcpu=%s" % target.core.lower()[:-2])
             self.flags['ld'].append("--cpu=%s" % target.core.lower()[:-2])
+            self.SHEBANG += " -mcpu=%s" % target.core.lower()[:-2]
         elif target.core.lower().endswith("f"):
             self.flags['common'].append("-mcpu=%s" % target.core.lower()[:-1])
             self.flags['ld'].append("--cpu=%s" % target.core.lower()[:-1])
+            self.SHEBANG += " -mcpu=%s" % target.core.lower()[:-1]
         elif target.core.lower().endswith("ns"):
             self.flags['common'].append("-mcpu=%s" % target.core.lower()[:-3])
             self.flags['ld'].append("--cpu=%s" % target.core.lower()[:-3])
+            self.SHEBANG += " -mcpu=%s" % target.core.lower()[:-3]
         else:
             self.flags['common'].append("-mcpu=%s" % target.core.lower())
             self.flags['ld'].append("--cpu=%s" % target.core.lower())
+            self.SHEBANG += " -mcpu=%s" % target.core.lower()
 
         if target.core == "Cortex-M4F":
             self.flags['common'].append("-mfpu=fpv4-sp-d16")
@@ -357,8 +361,6 @@ class ARMC6(ARM_STD):
         self.ld = [join(TOOLCHAIN_PATHS["ARMC6"], "armlink")] + self.flags['ld']
         self.ar = [join(TOOLCHAIN_PATHS["ARMC6"], "armar")]
         self.elf2bin = join(TOOLCHAIN_PATHS["ARMC6"], "fromelf")
-
-        self.SHEBANG += " -mcpu=%s" % target.core.lower()
 
     def parse_dependencies(self, dep_path):
         return mbedToolchain.parse_dependencies(self, dep_path)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -14,10 +14,12 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 """
+import glob
 import re
 from copy import copy
 from os.path import join, dirname, splitext, basename, exists
 from os import makedirs, write
+from shutil import copyfile
 from tempfile import mkstemp
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
@@ -198,7 +200,7 @@ class ARM(mbedToolchain):
         """
         with open(scatter_file, "rb") as input:
             lines = input.readlines()
-            if  (lines[0].startswith(self.SHEBANG) or
+            if (lines[0].startswith(self.SHEBANG) or
                  not lines[0].startswith("#!")):
                 return scatter_file
             else:
@@ -208,6 +210,12 @@ class ARM(mbedToolchain):
                         out.write(self.SHEBANG)
                         out.write("\n")
                         out.write("".join(lines[1:]))
+
+                # Copy headers into the build dir as well
+                headers = glob.glob(join(dirname(scatter_file), '*.h'))
+                for header in headers:
+                    copyfile(header, join(self.build_dir, basename(header)))
+
                 return new_scatter
 
     @hook_tool


### PR DESCRIPTION
Fixes #5796

## Description

Fix for targets which include the c preprocessor in the ARM and ARMC6 scatter file.

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce
1. Pull the mbed-os-example-blinky app
2. Import the latest mbed-os (>= mbed-os-5.5.4)
3. Compile with either the ARM or ARMC6 compiler and target the MultiTech xDot
(e.g. mbed compile -t ARMC6 -m xdot_l151cc)
4. Verify the app builds