### PR TITLE
Some enhancements for the USBHost feature and small bug fix

### DIFF
--- a/features/unsupported/USBHost/USBHost/USBDeviceConnected.h
+++ b/features/unsupported/USBHost/USBHost/USBDeviceConnected.h
@@ -106,7 +106,7 @@ public:
     template<typename T>
     inline void onDisconnect(uint8_t intf_nb, T* tptr, void (T::*mptr)(void)) {
         if ((mptr != NULL) && (tptr != NULL)) {
-            intf[intf_nb].detach.attach(tptr, mptr);
+            intf[intf_nb].detach = callback(tptr, mptr);
         }
     }
 
@@ -118,7 +118,7 @@ public:
      */
     inline void onDisconnect(uint8_t intf_nb, void (*fn)(void)) {
         if (fn != NULL) {
-            intf[intf_nb].detach.attach(fn);
+            intf[intf_nb].detach = fn;
         }
     }
 

--- a/features/unsupported/USBHost/USBHost/USBEndpoint.h
+++ b/features/unsupported/USBHost/USBHost/USBEndpoint.h
@@ -89,7 +89,7 @@ public:
     template<typename T>
     inline void attach(T* tptr, void (T::*mptr)(void)) {
         if((mptr != NULL) && (tptr != NULL)) {
-            rx.attach(tptr, mptr);
+            rx = callback(tptr, mptr);
         }
     }
 
@@ -100,7 +100,7 @@ public:
      */
     inline void attach(void (*fptr)(void)) {
         if(fptr != NULL) {
-            rx.attach(fptr);
+            rx = fptr;
         }
     }
 

--- a/features/unsupported/USBHost/USBHost/USBHost.cpp
+++ b/features/unsupported/USBHost/USBHost/USBHost.cpp
@@ -312,7 +312,7 @@ USBHost::USBHost() : usbThread(osPriorityNormal, USB_THREAD_STACK)
     }
 #endif
 
-    usbThread.start(this, &USBHost::usb_process);
+    usbThread.start(callback(this, &USBHost::usb_process));
 }
 
 USBHost::Lock::Lock(USBHost* pHost) : m_pHost(pHost)

--- a/features/unsupported/USBHost/USBHost/USBHost.cpp
+++ b/features/unsupported/USBHost/USBHost/USBHost.cpp
@@ -88,11 +88,14 @@ void USBHost::usb_process()
                         /*  check that hub is connected to root port  */
                         if (usb_msg->hub_parent) {
                             /*  a hub device must be present */
+#if MAX_HUB_NB
+
                             for (k = 0; k < MAX_HUB_NB; k++) {
                                 if ((&hubs[k] == usb_msg->hub_parent) && (hub_in_use[k])) {
                                     hub_unplugged=false;
                                 }
                             }
+#endif
                         } else {
                             hub_unplugged = false;
                         }


### PR DESCRIPTION
Notes:
- Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
- This is just a template, so feel free to use/remove the unnecessary things

## Description

- Rewrite the USBHost module callbacks in the new form.
- Fix a bug related to defining `MAX_HUB_NB` macro, the variable `k` is declared if the macro is not zero [as you can see here](https://github.com/ARMmbed/mbed-os/blob/master/features/unsupported/USBHost/USBHost/USBHost.cpp#L65), and after, used without testing `MAX_HUB_NB` which leads to undefined reference error durring compilation if `MAX_HUB_NB=0`.

## Status

**READY**

## Migrations

If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

NO

## Todos

- [x] Tests
- [ ] Documentation (not needed)

## Steps to test or reproduce

- Define the `MAX_HUB_NB` as zero leads to a compilation *error*.
- Compiling the USBHost leads to compilation *warnings* concerning the `callback`s.
