### PR TITLE
RTC time conversion test - reduce test execution time.

### DIFF
--- a/TESTS/host_tests/rtc_calc_auto.py
+++ b/TESTS/host_tests/rtc_calc_auto.py
@@ -47,9 +47,14 @@ class RTC_time_calc_test(BaseHostTest):
 
     edge_date = datetime.datetime(2100, 2, 28, 0, 0, 0)
     
-    years = [1970, 1971, 1972, 1973, 1974, 1975, 1976, 1977, 1978, 1979, 1980,
-             2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010,
-             2099, 2100, 2101, 2102, 2103, 2104, 2105, 2106]
+    # Test the following years:
+    # - first - 1970
+    # - example not leap year (not divisible by 4)
+    # - example leap year (divisible by 4 and by 100 and by 400) 
+    # - example leap year (divisible by 4 and not by 100) 
+    # - example not leap year (divisible by 4 and by 100) 
+    # - last fully supported  - 2105
+    years = [1970, 1971, 2000, 2096, 2100, 2105]
     year_id = 0
              
              
@@ -123,6 +128,9 @@ class RTC_time_calc_test(BaseHostTest):
             self.date += datetime.timedelta(days = 1)
             if (self.date.month == 1):
                 self.year_id += 1
+                if (len(self.years) == self.year_id):
+                    # All years were processed, no need to calc next date
+                    return
                 self.date = self.date.replace(year = self.years[self.year_id])
             self.date = self.date.replace(day = 1, minute = 0, second = 0)
             self.first = not self.first
@@ -130,9 +138,3 @@ class RTC_time_calc_test(BaseHostTest):
     def setup(self):
         self.register_callback('timestamp', self._verify_timestamp)
         self.register_callback('leap_year_setup', self._set_leap_year_support)
-
-    def result(self):
-        return self.__result
-
-    def teardown(self):
-        pass

--- a/TESTS/mbed_hal/rtc_time_conv/main.cpp
+++ b/TESTS/mbed_hal/rtc_time_conv/main.cpp
@@ -83,9 +83,7 @@ void test_case_mktime_localtime()
     char _value[128] =
     { };
 
-    size_t years[] = {70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80,
-                      100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110,
-                      199, 200, 201, 202, 203, 204, 205};
+    size_t years[] = {70, 71, 100, 196, 200, 205};
 
     /* Inform host part of the test about tested RTC type. */
     greentea_send_kv("leap_year_setup",  rtc_leap_year_support);


### PR DESCRIPTION
## Description

Reduce number of tested cases as follows:

For each of the following years test example time of the first and last day of each month:
- first - 1970
- example not leap year (not divisible by 4)
- example leap year (divisible by 4 and by 100 and by 400)
- example leap year (divisible by 4 and not by 100)
- example not leap year (divisible by 4 and by 100)
- last fully supported  - 2105

Test execution time on K64F is now ~39 sec.

## Status

**READY**

## Migrations

NO



