### PR TITLE
ESP8266 Test Config and fixes for tests tcp_echo/tcp_hello_world

### DIFF
--- a/TESTS/netsocket/tcp_echo/main.cpp
+++ b/TESTS/netsocket/tcp_echo/main.cpp
@@ -28,13 +28,13 @@
 
 using namespace utest::v1;
 
-#ifndef MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE
-#define MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE 256
+#ifndef MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE
+#define MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE 256
 #endif
 
 namespace {
-    char tx_buffer[MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
-    char rx_buffer[MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
+    char tx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
+    char rx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
 }
 
 void prep_buffer(char *tx_buffer, size_t tx_size) {
@@ -44,7 +44,7 @@ void prep_buffer(char *tx_buffer, size_t tx_size) {
 }
 
 void test_tcp_echo() {
-
+    int n = 0;
     NetworkInterface* net = MBED_CONF_APP_OBJECT_CONSTRUCTION;
     int err =  MBED_CONF_APP_CONNECT_STATEMENT;
 
@@ -86,7 +86,12 @@ void test_tcp_echo() {
 
         prep_buffer(tx_buffer, sizeof(tx_buffer));
 #if defined(MBED_CONF_APP_TCP_ECHO_PREFIX)
-        sock.recv(rx_buffer, sizeof(MBED_CONF_APP_TCP_ECHO_PREFIX));
+        n = sock.recv(rx_buffer, sizeof(MBED_CONF_APP_TCP_ECHO_PREFIX));
+        if (n >= 0) {
+            printf("recv-ed prefix: %d bytes - %.*s  \n", n, n, rx_buffer);
+        } else {
+            printf("Network error in receiving prefix: %d\n", n);
+        }
 #endif /* MBED_CONF_APP_TCP_ECHO_PREFIX */
         const int ret = sock.send(tx_buffer, sizeof(tx_buffer));
         if (ret >= 0) {
@@ -95,7 +100,7 @@ void test_tcp_echo() {
             printf("Network error %d\n", ret);
         }
 
-        int n = sock.recv(rx_buffer, sizeof(rx_buffer));
+        n = sock.recv(rx_buffer, sizeof(rx_buffer));
         if (n >= 0) {
             printf("recv %d bytes - %.*s  \n", n, n, rx_buffer);
         } else {

--- a/TESTS/netsocket/tcp_hello_world/main.cpp
+++ b/TESTS/netsocket/tcp_hello_world/main.cpp
@@ -76,9 +76,15 @@ void test_tcp_hello_world() {
         sock.send(buffer, strlen(buffer));
 
         // Server will respond with HTTP GET's success code
-        const int ret = sock.recv(buffer, sizeof(buffer) - 1);
-        buffer[ret] = '\0';
+        int ret = 0;
+        int bytes_recvd = 0;
 
+        do {
+            ret += bytes_recvd;
+            bytes_recvd = sock.recv(buffer+ret, sizeof(buffer) - 1 - ret);
+        }while(bytes_recvd > 0);
+        buffer[ret] = '\0';
+        
         // Find 200 OK HTTP status in reply
         bool found_200_ok = find_substring(buffer, buffer + ret, HTTP_OK_STR, HTTP_OK_STR + strlen(HTTP_OK_STR));
         // Find "Hello World!" string in reply

--- a/tools/test_configs/ESP8266Interface.json
+++ b/tools/test_configs/ESP8266Interface.json
@@ -1,0 +1,37 @@
+{
+    "config": {
+        "header-file": {
+            "help" : "String for including your driver header file",
+            "value" : "\"ESP8266Interface.h\""
+        },
+        "object-construction" : {
+            "value" : "new ESP8266Interface( D1, D0, false )"
+        },
+        "connect-statement" : {
+            "help" : "Must use 'net' variable name, replace WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY, WIFI_CHANNEL with your WiFi settings",
+            "value" : "((ESP8266Interface *)net)->connect(WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY, WIFI_CHANNEL)"
+        },
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"195.34.89.241\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        },
+        "tcp-echo-prefix" : {
+            "help" : "Some servers send a prefix before echoed message",
+            "value" : "\"u-blox AG TCP/UDP test service\\n\""
+        },
+        "tcp-client-echo-buffer-size" : {
+            "help" : "Number of bytes to be send to echo server",
+            "value" : "200"
+        },
+        "ESP8266-TX": {
+            "value":"D1"
+        },
+        "ESP8266-RX": {
+            "value":"D0"
+        }
+    }
+}

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -4,5 +4,6 @@
     "HEAPBLOCKDEVICE_AND_ETHERNET": "HeapBlockDeviceAndEthernetInterface.json",
     "ODIN_WIFI" : "OdinInterface.json",
     "ODIN_ETHERNET" : "Odin_EthernetInterface.json",
-    "REALTEK_WIFI" : "RealtekInterface.json"
+    "REALTEK_WIFI" : "RealtekInterface.json",	
+    "ESP8266_WIFI" : "ESP8266Interface.json"
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -9,7 +9,7 @@
     },
     "K64F": {
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",
-        "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET"]
+        "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET", "ESP8266_WIFI", "ETHERNET"]
     },
     "NUCLEO_F429ZI": {
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",


### PR DESCRIPTION
This PR contains following changes:

New ESP8266 Test config and a config for selecting the buffer size used in tcp_echo test. 
tcp_hello_world test has also been fixed to receive all the data from socket until there in no more data to be read.