### PR TITLE
Support for BLOCK2 blockwise messages GET request handling

### DIFF
--- a/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_builder.c
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_builder.c
@@ -63,18 +63,22 @@ sn_coap_hdr_s *sn_coap_build_response(struct coap_s *handle, sn_coap_hdr_s *coap
         return NULL;
     }
 
-    if (coap_packet_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
+    if (msg_code == COAP_MSG_CODE_REQUEST_GET) {
+        // Blockwise message response is new GET
+        coap_res_ptr->msg_type = COAP_MSG_TYPE_CONFIRMABLE;
+        coap_res_ptr->msg_code = (sn_coap_msg_code_e)msg_code;
+        /* msg_id needs to be set by the caller in this case */
+    }
+    else if (coap_packet_ptr->msg_type == COAP_MSG_TYPE_CONFIRMABLE) {
         coap_res_ptr->msg_type = COAP_MSG_TYPE_ACKNOWLEDGEMENT;
         coap_res_ptr->msg_code = (sn_coap_msg_code_e)msg_code;
         coap_res_ptr->msg_id = coap_packet_ptr->msg_id;
     }
-
     else if (coap_packet_ptr->msg_type == COAP_MSG_TYPE_NON_CONFIRMABLE) {
         coap_res_ptr->msg_type = COAP_MSG_TYPE_NON_CONFIRMABLE;
         coap_res_ptr->msg_code = (sn_coap_msg_code_e)msg_code;
         /* msg_id needs to be set by the caller in this case */
     }
-
     else {
         handle->sn_coap_protocol_free( coap_res_ptr );
         return NULL;


### PR DESCRIPTION
* Implements CoAP part of IOTUPD-2326

## Description

Support for sending BLOCK2 GET request. This change is needed to get FW update over CoAP feature to work.

## Status

READY

