### PR TITLE
tests-mbed_drivers-timer - increase tolerance

### DIFF
--- a/TESTS/mbed_drivers/timer/main.cpp
+++ b/TESTS/mbed_drivers/timer/main.cpp
@@ -39,13 +39,13 @@ extern uint32_t SystemCoreClock;
  *   DELTA = TOLERANCE_FACTOR / SystemCoreClock * US_FACTOR
  *
  *   e.g.
- *   For K64F          DELTA = (30000 / 120000000) * 1000000 = 250[us]
- *   For NUCLEO_F070RB DELTA = (30000 /  48000000) * 1000000 = 625[us]
- *   For NRF51_DK      DELTA = (30000 /  16000000) * 1000000 = 1875[us]
+ *   For K64F          DELTA = (40000 / 120000000) * 1000000 = 333[us]
+ *   For NUCLEO_F070RB DELTA = (40000 /  48000000) * 1000000 = 833[us]
+ *   For NRF51_DK      DELTA = (40000 /  16000000) * 1000000 = 2500[us]
  */
 #define US_PER_SEC       1000000
 #define US_PER_MSEC      1000
-#define TOLERANCE_FACTOR 30000.0f
+#define TOLERANCE_FACTOR 40000.0f
 #define US_FACTOR        1000000.0f
 
 static const int delta_sys_clk_us = ((int) (TOLERANCE_FACTOR / (float)SystemCoreClock * US_FACTOR));


### PR DESCRIPTION

## Description

tests-mbed_drivers-timer test occasionally fails on CI (NRF52_DK board).
Proposition is to slightly increase tolerance factor - this should solve the problem.


## Status

**READY**

## Migrations

NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
feature-hal-spec-sleep | [https://github.com/ARMmbed/mbed-os/pull/5509]()
