### PR TITLE
Increase clock tolerance in Flash HAL test

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -28,7 +28,7 @@
 using namespace utest::v1;
 
 #define TEST_CYCLES         1000000
-#define ALLOWED_DRIFT_PPM   1000         //0.1%
+#define ALLOWED_DRIFT_PPM   5000         //0.5%
 
 /*
     return values to be checked are documented at:


### PR DESCRIPTION
## Description

The current 0.1% clock tolerance is too small for certain platforms
which natural variance is larger than this. This commit increases the
tolerance to 0.5% instead.

Sample output from time_cpu_cycles called repeatedly in init,
before running any flash tests:

[1515706585.63][CONN][RXD] diff: 49316
[1515706585.69][CONN][RXD] diff: 49256
[1515706585.75][CONN][RXD] diff: 49286
[1515706585.81][CONN][RXD] diff: 49256
[1515706585.87][CONN][RXD] diff: 49225
[1515706585.94][CONN][RXD] diff: 49286
[1515706585.99][CONN][RXD] diff: 49317
[1515706586.06][CONN][RXD] diff: 49255
[1515706586.12][CONN][RXD] diff: 49286
[1515706586.18][CONN][RXD] diff: 49285
[1515706586.24][CONN][RXD] diff: 49286
[1515706586.31][CONN][RXD] diff: 49347
[1515706586.36][CONN][RXD] diff: 49347
[1515706586.43][CONN][RXD] diff: 49286
[1515706586.49][CONN][RXD] diff: 49286
[1515706586.55][CONN][RXD] diff: 49256
[1515706586.61][CONN][RXD] diff: 49286
[1515706586.68][CONN][RXD] diff: 49346
[1515706586.74][CONN][RXD] diff: 49347
[1515706586.80][CONN][RXD] diff: 49256

Notice the outliers will cause intermittent CI failures.