### PR TITLE
Remove wait in MBED_11 test (mbed 2)

### DIFF
--- a/features/unsupported/tests/mbed/ticker/main.cpp
+++ b/features/unsupported/tests/mbed/ticker/main.cpp
@@ -43,7 +43,5 @@ int main() {
     flipper_1.attach(&flip_1, 1.0); // the address of the function to be attached (flip) and the interval (1 second)
     flipper_2.attach(&flip_2, 2.0); // the address of the function to be attached (flip) and the interval (2 seconds)
 
-    while (true) {
-        wait(1.0);
-    }
+    while (1);
 }


### PR DESCRIPTION
## Description
Remove the wait loop present in the main function for the **MBED_11** test for mbed 2
- This test was failed/unstabled on our test bench since mbed revision 153 / mbed-os-5.6.2
- Removing this wait loop makes the MBED_11 test to be PASS again.
- The MBED_34 and MBED_23 OS2 tests don't have this wait loop.

## Status
**READY**

## Migrations
NO

ST_INTERNAL_REF 39289
