### PR TITLE
ST-DISCO_L475VG_IOT01A: Improve SRAM use for IAR toolchain

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -21,12 +21,11 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
 define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
-/* Stack 1/8 and Heap 1/4 of RAM */
-define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0xa000;
+/* Stack complete SRAM2 and Heap 2/3 of SRAM1 */
+define symbol __size_cstack__ = 0x7e00;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
-define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -34,5 +33,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in SRAM1_region { readwrite, block HEAP };
+place in SRAM2_region { block CSTACK };


### PR DESCRIPTION
## Description
DISCO_L475VG_IOT01A has 128 k of SRAM (32k in SRAM2 + 96k in SRAM1)
At the moment, for IAR toolchain, SRAM2 only contains the nvic vector. 
With this PR:
  Use the entire SRAM2 with NVIC buffer + stack
  Increase HEAP size to 0x10000 in SRAM1
  Increase the available SRAM1 by 0x2000

## Status

**READY**

## Todos

- [x] Tests

## Steps to test or reproduce
I'm working on the wifi driver and I've had memory mapping issues with mbed-tls-client example
