### PR TITLE
littlefs: Fix block addr overflow

### DIFF
--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -85,19 +85,19 @@ static int lfs_totype(int type)
 static int lfs_bd_read(const struct lfs_config *c, lfs_block_t block,
         lfs_off_t off, void *buffer, lfs_size_t size) {
     BlockDevice *bd = (BlockDevice *)c->context;
-    return bd->read(buffer, block*c->block_size + off, size);
+    return bd->read(buffer, (bd_addr_t)block*c->block_size + off, size);
 }
 
 static int lfs_bd_prog(const struct lfs_config *c, lfs_block_t block,
         lfs_off_t off, const void *buffer, lfs_size_t size) {
     BlockDevice *bd = (BlockDevice *)c->context;
-    return bd->program(buffer, block*c->block_size + off, size);
+    return bd->program(buffer, (bd_addr_t)block*c->block_size + off, size);
 }
 
 static int lfs_bd_erase(const struct lfs_config *c, lfs_block_t block)
 {
     BlockDevice *bd = (BlockDevice *)c->context;
-    return bd->erase(block*c->block_size, c->block_size);
+    return bd->erase((bd_addr_t)block*c->block_size, c->block_size);
 }
 
 static int lfs_bd_sync(const struct lfs_config *c)


### PR DESCRIPTION
deepikabhavnani did the hard work in tracking this issue down.  Block addresses are not cast to the correct type until after multiplying to convert to byte addresses. This results in an overflow when the storage is larger than 4 GB.

same as https://github.com/ARMmbed/mbed-os/pull/5829
related to https://github.com/ARMmbed/mbed-os/issues/5780
cc @deepikabhavnani 
note: intended for patch