### PR TITLE
Allow overriding of DCDC settings per target

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/TARGET_EFM32PG_STK3401/device_peripherals.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/TARGET_EFM32PG_STK3401/device_peripherals.h
@@ -54,4 +54,9 @@
   cmuOscMode_Crystal,                                                           \
 }
 #endif
+
+/* DCDC settings */
+#if !defined(EMU_DCDCINIT_STK_DEFAULT)
+#define EMU_DCDCINIT_STK_DEFAULT EMU_DCDCINIT_DEFAULT
+#endif
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/TARGET_EFM32PG12_STK3402/device_peripherals.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/TARGET_EFM32PG12_STK3402/device_peripherals.h
@@ -54,4 +54,9 @@
   cmuOscMode_Crystal,                                                           \
 }
 #endif
+
+/* DCDC settings */
+#if !defined(EMU_DCDCINIT_STK_DEFAULT)
+#define EMU_DCDCINIT_STK_DEFAULT EMU_DCDCINIT_DEFAULT
+#endif
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/TARGET_EFR32MG1_BRD4150/device_peripherals.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/TARGET_EFR32MG1_BRD4150/device_peripherals.h
@@ -54,4 +54,9 @@
   cmuOscMode_Crystal,                                                           \
 }
 #endif
+
+/* DCDC settings */
+#if !defined(EMU_DCDCINIT_STK_DEFAULT)
+#define EMU_DCDCINIT_STK_DEFAULT EMU_DCDCINIT_DEFAULT
+#endif
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/TARGET_TB_SENSE_1/device_peripherals.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/TARGET_TB_SENSE_1/device_peripherals.h
@@ -54,4 +54,9 @@
   cmuOscMode_Crystal,                                                           \
 }
 #endif
+
+/* DCDC settings */
+#if !defined(EMU_DCDCINIT_STK_DEFAULT)
+#define EMU_DCDCINIT_STK_DEFAULT EMU_DCDCINIT_DEFAULT
+#endif
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/TARGET_TB_SENSE_12/device_peripherals.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/TARGET_TB_SENSE_12/device_peripherals.h
@@ -54,4 +54,9 @@
   cmuOscMode_Crystal,                                                           \
 }
 #endif
+
+/* DCDC settings */
+#if !defined(EMU_DCDCINIT_STK_DEFAULT)
+#define EMU_DCDCINIT_STK_DEFAULT EMU_DCDCINIT_DEFAULT
+#endif
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
@@ -39,9 +39,13 @@ void mbed_sdk_init()
     CHIP_Init();
 
 #if defined(_SILICON_LABS_32B_SERIES_1)
-    EMU_DCDCInit_TypeDef dcdcInit = EMU_DCDCINIT_DEFAULT;
+#if defined(EMU_NO_DCDC)
+    EMU_DCDCPowerOff();
+#else
+    EMU_DCDCInit_TypeDef dcdcInit = EMU_DCDCINIT_STK_DEFAULT;
     EMU_DCDCInit(&dcdcInit);
-    
+#endif
+
 #if (CORE_CLOCK_SOURCE == HFXO)
     // Only init HFXO if not already done (e.g. by bootloader)
     if (CMU_ClockSelectGet(cmuClock_HF) != cmuSelect_HFXO) {


### PR DESCRIPTION
## Description
Allow custom targets to override the DCDC settings by defining EMU_DCDCINIT_STK_DEFAULT to target-specific initialization values. This feature was requested in #5783 

## Status
**READY**

## Migrations
Custom targets need to define EMU_DCDCINIT_STK_DEFAULT if they need different DCDC initialisation settings versus the defaults in em_emu.h