### PR TITLE
STM32 LPT optimisation

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -292,15 +292,8 @@ void lp_ticker_init(void)
 
 uint32_t lp_ticker_read(void)
 {
-    uint32_t usecs = 0;
-    time_t time = 0;
-
-    do {
-        time = rtc_read();
-        usecs = rtc_read_subseconds();
-    } while (time != rtc_read());
-
-    return (time * 1000000) + usecs;
+    uint32_t usecs = rtc_read_us();
+    return usecs;
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -51,11 +51,11 @@ extern "C" {
 #define RTC_CLOCK LSI_VALUE
 #endif
 
-/** Read the subsecond register.
+/** Read RTC time with subsecond precision.
  *
- * @return The remaining time as microseconds (0-999999)
+ * @return Time is microsecond
  */
-uint32_t rtc_read_subseconds(void);
+uint32_t rtc_read_us(void);
 
 /** Program a wake up timer event in delta microseconds.
  *


### PR DESCRIPTION
## Description

For each low power timer/ticker start, lp_ticker_read function is called 3 or 4 times.
lp_ticker_read duration was around 58us.
It is now reduced to 9us.

Hope it will solve #5790 

## Status

**READY**
