### PR TITLE
RTX idle: sleep without locked deep sleep fix

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -198,9 +198,7 @@ static void default_idle_hook(void)
     if (ticks_to_sleep) {
         os_timer->schedule_tick(ticks_to_sleep);
 
-        sleep_manager_lock_deep_sleep();
         sleep();
-        sleep_manager_unlock_deep_sleep();
 
         os_timer->cancel_tick();
         // calculate how long we slept


### PR DESCRIPTION
I could not find a reason from the logs why this locking was present if tickless is enabled. 

Please review