### PR TITLE
lpc546xx and ff_lpc546xx: create parent object MCU_LPC546XX

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -743,7 +743,7 @@
     "MCU_LPC546XX": {    
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "IAR", "GCC_ARM"],
-        "extra_labels": ["NXP", "MCUXpresso_MCUS", "LPCXpresso", "LPC"],
+        "extra_labels": ["NXP", "MCUXpresso_MCUS", "LPCXpresso", "LPC", "LPC546XX"],
         "is_disk_virtual": true,
         "macros": ["CPU_LPC54618J512ET180", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
@@ -759,7 +759,6 @@
     },
     "FF_LPC546XX": {
         "inherits": ["MCU_LPC546XX"],
-        "extra_labels_add" : ["LPC546XX"],
         "extra_labels_remove" : ["LPCXpresso"],
         "detect_code": ["8081"]
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -740,24 +740,27 @@
         "release_versions": ["2", "5"],
         "device_name" : "LPC54114J256BD64"
     },
-    "LPC546XX": {
-        "supported_form_factors": ["ARDUINO"],
+    "MCU_LPC546XX": {    
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "IAR", "GCC_ARM"],
         "extra_labels": ["NXP", "MCUXpresso_MCUS", "LPCXpresso", "LPC"],
         "is_disk_virtual": true,
         "macros": ["CPU_LPC54618J512ET180", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
-        "detect_code": ["1056"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name" : "LPC54618J512ET180"
     },
+    "LPC546XX": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_LPC546XX"],
+        "detect_code": ["1056"]
+    },
     "FF_LPC546XX": {
-        "inherits": ["LPC546XX"],
+        "inherits": ["MCU_LPC546XX"],
+        "extra_labels_add" : ["LPC546XX"],
         "extra_labels_remove" : ["LPCXpresso"],
-        "supported_form_factors": [""],
         "detect_code": ["8081"]
     },
     "NUCLEO_F030R8": {


### PR DESCRIPTION
## Abstract
ff_lpc546xx currently inherits from target lpc546xx. This results in error in mbed online compiler:

`Error: Library name 'platform' is not unique (defined in '/extras/mbed_7130f322cb7e/TARGET_LPC546XX/mbed_lib.json' and '/extras/mbed_7130f322cb7e/TARGET_FF_LPC546XX/mbed_lib.json')`

when compiling examples with mbed library (compiling with mbed-os works fine).


## Status: READY

## Priority: High
