### PR TITLE
Nuvoton: Add gpio_is_connected

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/gpio_api.c
@@ -37,6 +37,11 @@ uint32_t gpio_set(PinName pin)
     return (uint32_t)(1 << pin_index);    // Return the pin mask
 }
 
+int gpio_is_connected(const gpio_t *obj)
+{
+    return (obj->pin != (PinName) NC);
+}
+
 void gpio_init(gpio_t *obj, PinName pin)
 {
     obj->pin = pin;

--- a/targets/TARGET_NUVOTON/TARGET_M480/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/gpio_api.c
@@ -37,6 +37,11 @@ uint32_t gpio_set(PinName pin)
     return (uint32_t)(1 << pin_index);    // Return the pin mask
 }
 
+int gpio_is_connected(const gpio_t *obj)
+{
+    return (obj->pin != (PinName) NC);
+}
+
 void gpio_init(gpio_t *obj, PinName pin)
 {
     obj->pin = pin;

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_api.c
@@ -34,6 +34,11 @@ uint32_t gpio_set(PinName pin)
     return (uint32_t)(1 << pin_index);    // Return the pin mask
 }
 
+int gpio_is_connected(const gpio_t *obj)
+{
+    return (obj->pin != (PinName) NC);
+}
+
 void gpio_init(gpio_t *obj, PinName pin)
 {
     obj->pin = pin;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_api.c
@@ -37,6 +37,11 @@ uint32_t gpio_set(PinName pin)
     return (uint32_t)(1 << pin_index);    // Return the pin mask
 }
 
+int gpio_is_connected(const gpio_t *obj)
+{
+    return (obj->pin != (PinName) NC);
+}
+
 void gpio_init(gpio_t *obj, PinName pin)
 {
     obj->pin = pin;


### PR DESCRIPTION
## Description

This PR adds missing `gpio_is_connected` for all Nuvoton targets.