### PR TITLE
Ticker requirement and test update

### DIFF
--- a/TESTS/mbed_hal/lp_us_tickers/main.cpp
+++ b/TESTS/mbed_hal/lp_us_tickers/main.cpp
@@ -92,7 +92,7 @@ void wait_cycles(volatile unsigned int cycles)
 }
 
 /* Test that ticker_init can be called multiple times and
- * ticker_init resets the internal count and disables the ticker interrupt.
+ * ticker_init allows the ticker to keep counting and disables the ticker interrupt.
  */
 void ticker_init_test()
 {
@@ -118,7 +118,7 @@ void ticker_init_test()
     }
 
     TEST_ASSERT(intf->read() >= (ticks_start + 2 * TICKER_INT_VAL));
-    TEST_ASSERT(ticks_start > ticks_after_reinit);
+    TEST_ASSERT(ticks_start <= ticks_after_reinit);
     TEST_ASSERT_EQUAL(0, intFlag);
 }
 

--- a/TESTS/mbed_hal/lp_us_tickers/ticker_api_tests.h
+++ b/TESTS/mbed_hal/lp_us_tickers/ticker_api_tests.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * Given ticker is initialised and interrupt is set.
  * When ticker is re-initialised.
- * Then ticker resets the internal count and disables the ticker interrupt.
+ * Then ticker keeps counting and disables the ticker interrupt.
  */
 void ticker_init_test(void);
 

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -61,7 +61,7 @@ extern "C" {
  *
  * # Defined behavior
  * * The function ticker_init is safe to call repeatedly - Verified by test ::ticker_init_test
- * * The function ticker_init resets the internal count and disables the ticker interrupt - Verified by test ::ticker_init_test
+ * * The function ticker_init allows the ticker to keep counting and disables the ticker interrupt - Verified by test ::ticker_init_test
  * * Ticker frequency is non-zero and counter is at least 8 bits - Verified by ::ticker_info_test
  * * The ticker rolls over at (1 << bits) and continues counting starting from 0 - Verified by ::ticker_overflow_test
  * * The ticker counts at the specified frequency +- 10% - Verified by ::ticker_frequency_test


### PR DESCRIPTION
## Description

This PR contains:
- modification of the requirement for the ticker init function (result of the following discussion https://github.com/ARMmbed/mbed-os/pull/5233#pullrequestreview-86677815).
- update of the test case to be consistent with new requirement.
- fix in the us/lp ticker test implementation (The intention was to use ticker_overflow_delta equal to 0 for low power ticker tests and ticker_overflow_delta equal to 50 for high frequency ticker tests. Current implementation is invalid since for devices which provide LOW_POWER_TIMER feature delta is equal to 0 and for devices without this feature delta is equal 50.)

## Status

**READY**

## Migrations

NO

## Related PRs


