### PR TITLE
RZ_A1H: cmsis nvic include fix

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/cmsis.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/cmsis.h
@@ -8,5 +8,6 @@
 #define MBED_CMSIS_H
 
 #include "MBRZA1H.h"
+#include "cmsis_nvic.h"
 
 #endif


### PR DESCRIPTION
To get cmsis nvic definitions, this header file should be included
in cmsis.h file.

Fixes #5886

@JanneKiiskila @ARMmbed/team-renesas 