### PR TITLE
STM32LX : HAL_RCC_OscConfig update in PLL configuration

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/device/stm32l0xx_hal_rcc.c
@@ -709,7 +709,19 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     }
     else
     {
-      return HAL_ERROR;
+      /* MBED patch - ST internal ticket 42806 */
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLSRC) != RCC_OscInitStruct->PLL.PLLSource) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLDIV) != RCC_OscInitStruct->PLL.PLLDIV) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLMUL) != RCC_OscInitStruct->PLL.PLLMUL) {
+        return HAL_ERROR;
+      }
+      /* MBED patch - ST internal ticket 42806 */
     }
   }
   return HAL_OK;

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.c
@@ -713,10 +713,21 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     }
     else
     {
-      return HAL_ERROR;
+      /* MBED patch - ST internal ticket 42806 */
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLSRC) != RCC_OscInitStruct->PLL.PLLSource) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLDIV) != RCC_OscInitStruct->PLL.PLLDIV) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_CFGR_PLLMUL) != RCC_OscInitStruct->PLL.PLLMUL) {
+        return HAL_ERROR;
+      }
+      /* MBED patch - ST internal ticket 42806 */
     }
   }
-  
   return HAL_OK;
 }
 

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_rcc.c
@@ -877,7 +877,31 @@ HAL_StatusTypeDef HAL_RCC_OscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct)
     }
     else
     {
-      return HAL_ERROR;
+      /* MBED patch - ST internal ticket 42806 */
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLSRC) != RCC_OscInitStruct->PLL.PLLSource) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLM) != RCC_OscInitStruct->PLL.PLLM) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLN) != RCC_OscInitStruct->PLL.PLLN) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLP) != RCC_OscInitStruct->PLL.PLLP) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLQ) != RCC_OscInitStruct->PLL.PLLQ) {
+        return HAL_ERROR;
+      }
+
+      if (READ_BIT(RCC->CFGR, RCC_PLLCFGR_PLLR) != RCC_OscInitStruct->PLL.PLLR) {
+        return HAL_ERROR;
+      }
+      /* MBED patch - ST internal ticket 42806 */
     }
   }
   return HAL_OK;


### PR DESCRIPTION
## Description

This should fix #5830 
When wake up is too early after deep sleep,
it seems that some register didn't have time to be reset.

## Status

**READY**
