### PR TITLE
Remove RTC as a supported peripheral for NCS36510

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3487,7 +3487,7 @@
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
-        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
+        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
         "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {


### PR DESCRIPTION
## Description

Disables RTC for NCS36510 since feature is blocking https://github.com/ARMmbed/mbed-os/pull/5087 from building correctly, and issue will not be resolved soon (https://github.com/ARMmbed/mbed-os/issues/5308).

## Status

**READY**

## Related PRs

Unblocks https://github.com/ARMmbed/mbed-os/pull/5087