### PR TITLE
[feature-nrf52] Add GCC linker sections for NRF52 SoftDevice

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -83,6 +83,41 @@ SECTIONS
         KEEP(*(.eh_frame*))
     } > FLASH
 
+    .sdh_soc_observers :
+    {
+        PROVIDE(__start_sdh_soc_observers = .);
+        KEEP(*(SORT(.sdh_soc_observers*)))
+        PROVIDE(__stop_sdh_soc_observers = .);
+    } > FLASH
+
+    .sdh_stack_observers :
+    {
+        PROVIDE(__start_sdh_stack_observers = .);
+        KEEP(*(SORT(.sdh_stack_observers*)))
+        PROVIDE(__stop_sdh_stack_observers = .);
+    } > FLASH
+
+    .sdh_req_observers :
+    {
+        PROVIDE(__start_sdh_req_observers = .);
+        KEEP(*(SORT(.sdh_req_observers*)))
+        PROVIDE(__stop_sdh_req_observers = .);
+    } > FLASH
+
+    .sdh_state_observers :
+    {
+        PROVIDE(__start_sdh_state_observers = .);
+        KEEP(*(SORT(.sdh_state_observers*)))
+        PROVIDE(__stop_sdh_state_observers = .);
+    } > FLASH
+
+    .sdh_ble_observers :
+    {
+        PROVIDE(__start_sdh_ble_observers = .);
+        KEEP(*(SORT(.sdh_ble_observers*)))
+        PROVIDE(__stop_sdh_ble_observers = .);
+    } > FLASH
+
     .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -61,7 +61,6 @@ OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
  */
 ENTRY(Reset_Handler)
 
-
 SECTIONS
 {
     .text :
@@ -89,6 +88,41 @@ SECTIONS
         *(.rodata*)
 
         KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .sdh_soc_observers :
+    {
+        PROVIDE(__start_sdh_soc_observers = .);
+        KEEP(*(SORT(.sdh_soc_observers*)))
+        PROVIDE(__stop_sdh_soc_observers = .);
+    } > FLASH
+
+    .sdh_stack_observers :
+    {
+        PROVIDE(__start_sdh_stack_observers = .);
+        KEEP(*(SORT(.sdh_stack_observers*)))
+        PROVIDE(__stop_sdh_stack_observers = .);
+    } > FLASH
+
+    .sdh_req_observers :
+    {
+        PROVIDE(__start_sdh_req_observers = .);
+        KEEP(*(SORT(.sdh_req_observers*)))
+        PROVIDE(__stop_sdh_req_observers = .);
+    } > FLASH
+
+    .sdh_state_observers :
+    {
+        PROVIDE(__start_sdh_state_observers = .);
+        KEEP(*(SORT(.sdh_state_observers*)))
+        PROVIDE(__stop_sdh_state_observers = .);
+    } > FLASH
+
+    .sdh_ble_observers :
+    {
+        PROVIDE(__start_sdh_ble_observers = .);
+        KEEP(*(SORT(.sdh_ble_observers*)))
+        PROVIDE(__stop_sdh_ble_observers = .);
     } > FLASH
 
     .ARM.extab :


### PR DESCRIPTION
When linking on GCC the SoftDevice expects certain observer sections to be present. 