### PR TITLE
Netbeans Exporter Bugfix

### DIFF
--- a/tools/export/nb/__init__.py
+++ b/tools/export/nb/__init__.py
@@ -326,15 +326,10 @@ class GNUARMNetbeans(Exporter):
                 # evaluate all matched items (from current and previous list)
                 matched = []
                 # Compare the Element in Previous Dir with the Elements in Current Dir
-                # and add the Differences to the match-List
-                if len(dir_list) <= len(prev_dir_list):
-                    for idx, element in enumerate(dir_list):
-                        if element == prev_dir_list[idx]:
-                            matched.append(element)
-                else:
-                    for idx, element in enumerate(prev_dir_list):
-                        if element == dir_list[idx]:
-                            matched.append(element)
+                # and add the equal Elements to the match-List
+                for elem_prev_dir, elem_cur_dir in zip(prev_dir_list, dir_list):
+                    if elem_prev_dir == elem_cur_dir:
+                        matched.append(elem_cur_dir)
 
                 # calculate difference between matched and length
                 diff = dir_depth - len(matched)

--- a/tools/export/nb/__init__.py
+++ b/tools/export/nb/__init__.py
@@ -325,9 +325,16 @@ class GNUARMNetbeans(Exporter):
             if cur_dir and prev_dir != cur_dir:
                 # evaluate all matched items (from current and previous list)
                 matched = []
-                for element in dir_list:
-                    if element in prev_dir_list:
-                        matched.append(element)
+                # Compare the Element in Previous Dir with the Elements in Current Dir
+                # and add the Differences to the match-List
+                if len(dir_list) <= len(prev_dir_list):
+                    for idx, element in enumerate(dir_list):
+                        if element == prev_dir_list[idx]:
+                            matched.append(element)
+                else:
+                    for idx, element in enumerate(prev_dir_list):
+                        if element == dir_list[idx]:
+                            matched.append(element)
 
                 # calculate difference between matched and length
                 diff = dir_depth - len(matched)


### PR DESCRIPTION
## Description

Fixed a  bug on multiple Sub-Directories with same name.
Was not discovered correctly before.

Problem occured on path with same name like:
storage/filesystem/littlefs/littlefs

## Status

**READY**

## Steps to test or reproduce

mbed export -i netbeans