### PR TITLE
STM32F0: fix issue with usarts sharing the same irq vector

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -122,10 +122,14 @@ static void uart3_8_irq(void)
 #endif
 #else // TARGET_STM32F070RB, TARGET_STM32F072RB
 #if defined(USART3_BASE)
-  uart_irq(2);
+  if (USART3->ISR & (UART_FLAG_TXE | UART_FLAG_RXNE | UART_FLAG_ORE)) {
+      uart_irq(2);
+  }
 #endif
 #if defined(USART4_BASE)
-  uart_irq(3);
+  if (USART4->ISR & (UART_FLAG_TXE | UART_FLAG_RXNE | UART_FLAG_ORE)) {
+      uart_irq(3);
+  }
 #endif
 #endif
 }

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -51,34 +51,27 @@ static uart_irq_handler irq_handler;
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static uint32_t uart_irq(int id)
+static void uart_irq(int id)
 {
     UART_HandleTypeDef * huart = &uart_handlers[id];
-    uint32_t status = 0;
-
     if (serial_irq_ids[id] != 0) {
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
-                status = 1;
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
-                status = 1;
+                /* Flag has been cleared when reading the content */
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
                 __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
-                status = 1;
             }
         }
     }
-    
-    return status;
 }
 
 static void uart1_irq(void)
@@ -128,9 +121,12 @@ static void uart3_8_irq(void)
   }
 #endif
 #else // TARGET_STM32F070RB, TARGET_STM32F072RB
-    if (uart_irq(2) == 0) { // Check if it's USART3
-        uart_irq(3); // Otherwise it's USART4
-    }
+#if defined(USART3_BASE)
+  uart_irq(2);
+#endif
+#if defined(USART4_BASE)
+  uart_irq(3);
+#endif
 #endif
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -51,28 +51,34 @@ static uart_irq_handler irq_handler;
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static uint32_t uart_irq(int id)
 {
     UART_HandleTypeDef * huart = &uart_handlers[id];
-    
+    uint32_t status = 0;
+
     if (serial_irq_ids[id] != 0) {
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
                 irq_handler(serial_irq_ids[id], TxIrq);
+                status = 1;
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
                 irq_handler(serial_irq_ids[id], RxIrq);
                 /*  Flag has been cleared when reading the content */
+                status = 1;
             }
         }
         if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
             if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
                 __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+                status = 1;
             }
         }
     }
+    
+    return status;
 }
 
 static void uart1_irq(void)
@@ -90,41 +96,41 @@ static void uart2_irq(void)
 // Used for both USART3_4_IRQn and USART3_8_IRQn
 static void uart3_8_irq(void)
 {
+#if defined(TARGET_STM32F091RC)
 #if defined(USART3_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART3) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART3) != RESET) {
       uart_irq(2);
   }
 #endif
 #if defined(USART4_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART4) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART4) != RESET) {
       uart_irq(3);
   }
 #endif
 #if defined(USART5_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART5) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART5) != RESET) {
       uart_irq(4);
   }
 #endif
 #if defined(USART6_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART6) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART6) != RESET) {
       uart_irq(5);
   }
 #endif
 #if defined(USART7_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART7) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART7) != RESET) {
       uart_irq(6);
   }
 #endif
 #if defined(USART8_BASE)
-  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART8) != RESET)
-  {
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART8) != RESET) {
       uart_irq(7);
   }
+#endif
+#else // TARGET_STM32F070RB, TARGET_STM32F072RB
+    if (uart_irq(2) == 0) { // Check if it's USART3
+        uart_irq(3); // Otherwise it's USART4
+    }
 #endif
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/serial_device.c
@@ -87,47 +87,46 @@ static void uart2_irq(void)
 }
 #endif
 
-#if defined USART3_BASE
-static void uart3_irq(void)
+// Used for both USART3_4_IRQn and USART3_8_IRQn
+static void uart3_8_irq(void)
 {
-    uart_irq(2);
-}
+#if defined(USART3_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART3) != RESET)
+  {
+      uart_irq(2);
+  }
 #endif
-
-#if defined USART4_BASE
-static void uart4_irq(void)
-{
-    uart_irq(3);
-}
+#if defined(USART4_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART4) != RESET)
+  {
+      uart_irq(3);
+  }
 #endif
-
-#if defined USART5_BASE
-static void uart5_irq(void)
-{
-    uart_irq(4);
-}
+#if defined(USART5_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART5) != RESET)
+  {
+      uart_irq(4);
+  }
 #endif
-
-#if defined USART6_BASE
-static void uart6_irq(void)
-{
-    uart_irq(5);
-}
+#if defined(USART6_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART6) != RESET)
+  {
+      uart_irq(5);
+  }
 #endif
-
-#if defined USART7_BASE
-static void uart7_irq(void)
-{
-    uart_irq(6);
-}
+#if defined(USART7_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART7) != RESET)
+  {
+      uart_irq(6);
+  }
 #endif
-
-#if defined USART8_BASE
-static void uart8_irq(void)
-{
-    uart_irq(7);
-}
+#if defined(USART8_BASE)
+  if (__HAL_GET_PENDING_IT(HAL_ITLINE_USART8) != RESET)
+  {
+      uart_irq(7);
+  }
 #endif
+}
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
@@ -156,53 +155,55 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     }
 #endif
 
-#if defined (TARGET_STM32F091RC)
-    if (obj_s->uart == UART_3) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart3_irq;
-    }
-
-    if (obj_s->uart == UART_4) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart4_irq;
-    }
-
-    if (obj_s->uart == UART_5) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart5_irq;
-    }
-
-    if (obj_s->uart == UART_6) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart6_irq;
-    }
-
-    if (obj_s->uart == UART_7) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart7_irq;
-    }
-
-    if (obj_s->uart == UART_8) {
-        irq_n = USART3_8_IRQn;
-        vector = (uint32_t)&uart8_irq;
-    }
-
-#elif defined (TARGET_STM32F030R8) || defined (TARGET_STM32F051R8)
-
-#else
 #if defined(USART3_BASE)
     if (obj_s->uart == UART_3) {
+#if defined(TARGET_STM32F091RC)
+        irq_n = USART3_8_IRQn;
+#else
         irq_n = USART3_4_IRQn;
-        vector = (uint32_t)&uart3_irq;
+#endif
+        vector = (uint32_t)&uart3_8_irq;
     }
 #endif
 
 #if defined(USART4_BASE)
     if (obj_s->uart == UART_4) {
+#if defined(TARGET_STM32F091RC)
+        irq_n = USART3_8_IRQn;
+#else
         irq_n = USART3_4_IRQn;
-        vector = (uint32_t)&uart4_irq;
+#endif
+        vector = (uint32_t)&uart3_8_irq;
     }
 #endif
+
+// Below usart are available only on TARGET_STM32F091RC
+#if defined(USART5_BASE)
+    if (obj_s->uart == UART_5) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart3_8_irq;
+    }
+#endif
+
+#if defined(USART6_BASE)
+    if (obj_s->uart == UART_6) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart3_8_irq;
+    }
+#endif
+
+#if defined(USART7_BASE)
+    if (obj_s->uart == UART_7) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart3_8_irq;
+    }
+#endif
+
+#if defined(USART8_BASE)
+    if (obj_s->uart == UART_8) {
+        irq_n = USART3_8_IRQn;
+        vector = (uint32_t)&uart3_8_irq;
+    }
 #endif
 
     if (enable) {


### PR DESCRIPTION
## Description

Issue flagged here: https://os.mbed.com/forum/mbed/topic/28545/ 

On some F0 devices, multiple USART are sharing the same IRQ vector and this case was not managed.

Tested on NUCLEO_F091RC and NUCLEO_F070RB boards using two usarts (USART3 and USART4).

## Status
**READY**

## Migrations
NO

