### PR TITLE
Let libraries, targets configure bootloader

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -284,26 +284,20 @@ def get_mbed_official_release(version):
 
     return mbed_official_release
 
-def add_regions_to_profile(profile, config, toolchain_class):
+def add_regions_to_toolchain(toolchain):
     """Add regions to the build profile, if there are any.
 
     Positional Arguments:
-    profile - the profile to update
-    config - the configuration object that owns the region
-    toolchain_class - the class of the toolchain being used
+    toolchain - the toolchain to add the region defines to
     """
-    if not profile:
-        return
-    regions = list(config.regions)
+    regions = list(toolchain.config.regions)
     for region in regions:
         for define in [(region.name.upper() + "_ADDR", region.start),
                        (region.name.upper() + "_SIZE", region.size)]:
-            profile["common"].append("-D%s=0x%x" %  define)
-    active_region = [r for r in regions if r.active][0]
-    for define in [("MBED_APP_START", active_region.start),
-                   ("MBED_APP_SIZE", active_region.size)]:
-        profile["ld"].append(toolchain_class.make_ld_define(*define))
-
+            toolchain.cc.append("-D%s=0x%x" %  define)
+            toolchain.cppc.append("-D%s=0x%x" %  define)
+            if region.active:
+                toolchain.ld.append(toolchain.make_ld_define(*define))
     print("Using regions in this build:")
     for region in regions:
         print("  Region %s size 0x%x, offset 0x%x"
@@ -351,9 +345,6 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     for contents in build_profile or []:
         for key in profile:
             profile[key].extend(contents[toolchain_name][key])
-
-    if config.has_regions:
-        add_regions_to_profile(profile, config, cur_tc)
 
     toolchain = cur_tc(target, notify, macros, silent, build_dir=build_dir,
                        extra_verbose=extra_verbose, build_profile=profile)
@@ -438,6 +429,9 @@ def scan_resources(src_paths, toolchain, dependencies_paths=None,
 
     # Set the toolchain's configuration data
     toolchain.set_config_data(toolchain.config.get_config_data())
+
+    if toolchain.config.has_regions:
+        add_regions_to_toolchain(toolchain)
 
     if  (hasattr(toolchain.target, "release_versions") and
             "5" not in toolchain.target.release_versions and

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -284,25 +284,6 @@ def get_mbed_official_release(version):
 
     return mbed_official_release
 
-def add_regions_to_toolchain(toolchain):
-    """Add regions to the build profile, if there are any.
-
-    Positional Arguments:
-    toolchain - the toolchain to add the region defines to
-    """
-    regions = list(toolchain.config.regions)
-    for region in regions:
-        for define in [(region.name.upper() + "_ADDR", region.start),
-                       (region.name.upper() + "_SIZE", region.size)]:
-            toolchain.cc.append("-D%s=0x%x" %  define)
-            toolchain.cppc.append("-D%s=0x%x" %  define)
-            if region.active:
-                toolchain.ld.append(toolchain.make_ld_define(*define))
-    print("Using regions in this build:")
-    for region in regions:
-        print("  Region %s size 0x%x, offset 0x%x"
-              % (region.name, region.size, region.start))
-
 
 def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
@@ -429,9 +410,6 @@ def scan_resources(src_paths, toolchain, dependencies_paths=None,
 
     # Set the toolchain's configuration data
     toolchain.set_config_data(toolchain.config.get_config_data())
-
-    if toolchain.config.has_regions:
-        add_regions_to_toolchain(toolchain)
 
     if  (hasattr(toolchain.target, "release_versions") and
             "5" not in toolchain.target.release_versions and

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -685,17 +685,19 @@ class Config(object):
 
                 # Consider the others as overrides
                 for name, val in overrides.items():
+                    if (name.startswith("target.") and
+                        (unit_kind is "application" or
+                         name in self.__unused_overrides)):
+                        _, attribute = name.split(".")
+                        setattr(self.target, attribute, val)
+                        continue
+
                     # Get the full name of the parameter
                     full_name = ConfigParameter.get_full_name(name, unit_name,
                                                               unit_kind, label)
                     if full_name in params:
                         params[full_name].set_value(val, unit_name, unit_kind,
                                                     label)
-                    elif (name.startswith("target.") and
-                          unit_kind is "application" or
-                          name in self.__unused_overrides):
-                        _, attribute = name.split(".")
-                        setattr(self.target, attribute, val)
                     else:
                         self.config_errors.append(
                             ConfigException(

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -210,6 +210,8 @@ class GNUARMEclipse(Exporter):
 
             # Hack to fill in build_dir
             toolchain.build_dir = self.toolchain.build_dir
+            toolchain.config = self.toolchain.config
+            toolchain.set_config_data(self.toolchain.config.get_config_data())
 
             flags = self.toolchain_flags(toolchain)
 

--- a/tools/test/config/bootloader_missing/bootloaders/mbed_lib.json
+++ b/tools/test/config/bootloader_missing/bootloaders/mbed_lib.json
@@ -1,6 +1,7 @@
 {
+    "name": "bl",
     "target_overrides": {
-        "K64F": {
+        "LPC1768": {
             "target.bootloader_img": "does_not_exists.bin",
             "target.restrict_size": "0xFFFFF"
         }

--- a/tools/test/config/bootloader_missing/test_data.json
+++ b/tools/test/config/bootloader_missing/test_data.json
@@ -1,5 +1,8 @@
 {
     "K64F": {
         "exception_msg": "not found"
+    },
+    "LPC1768": {
+        "exception_msg": "not found"
     }
 }

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1231,9 +1231,31 @@ class mbedToolchain:
 
         return None
 
+    def add_regions(self):
+        """Add regions to the build profile, if there are any.
+        """
+        print("Using regions in this build:")
+        for region in self.config.regions:
+            for define in [(region.name.upper() + "_ADDR", region.start),
+                           (region.name.upper() + "_SIZE", region.size)]:
+                define_string = "-D%s=0x%x" %  define
+                self.cc.append(define_string)
+                self.cppc.append(define_string)
+                self.flags["common"].append(define_string)
+            if region.active:
+                for define in [("MBED_APP_START", region.start),
+                               ("MBED_APP_SIZE", region.size)]:
+                    define_string = self.make_ld_define(*define)
+                    self.ld.append(define_string)
+                    self.flags["ld"].append(define_string)
+            print("  Region %s size 0x%x, offset 0x%x"
+                    % (region.name, region.size, region.start))
+
     # Set the configuration data
     def set_config_data(self, config_data):
         self.config_data = config_data
+        if self.config.has_regions:
+            self.add_regions()
 
     # Creates the configuration header if needed:
     # - if there is no configuration data, "mbed_config.h" is not create (or deleted if it exists).


### PR DESCRIPTION
# Abstract

This PR lets libraries and targets configure boot loader parameters like any other parameter. This allows a release of a boot loader as an mbed library, with an `mbed_lib.json` that contains links to the boot loader binaries.

# Usage
The following patch, to `mbed-os-example-bootloader-blinky`, shows how this allows a standalone `bootloader` directory to contain all information required to merge a boot loader.
```diff
diff --git a/bootloader/mbed_lib.json b/bootloader/mbed_lib.json
new file mode 100644
index 0000000..eea6b25
--- /dev/null
+++ b/bootloader/mbed_lib.json
@@ -0,0 +1,24 @@
+{
+    "name": "bootloader_images",
+    "target_overrides": {
+        "K64F": {
+            "target.bootloader_img": "K64F.bin"
+        },
+        "NUCLEO_F429ZI": {
+            "target.bootloader_img": "NUCLEO_F429ZI.bin"
+        },
+        "UBLOX_EVK_ODIN_W2": {
+            "target.bootloader_img": "UBLOX_EVK_ODIN_W2.bin"
+        }
+    }
+}
diff --git a/mbed_app.json b/mbed_app.json
deleted file mode 100644
index 12ced95..0000000
--- a/mbed_app.json
+++ /dev/null
@@ -1,13 +0,0 @@
-{
-    "target_overrides": {
-        "K64F": {
-            "target.bootloader_img": "bootloader/K64F.bin"
-        },
-        "NUCLEO_F429ZI": {
-            "target.bootloader_img": "bootloader/NUCLEO_F429ZI.bin"
-        },
-        "UBLOX_EVK_ODIN_W2": {
-            "target.bootloader_img": "bootloader/UBLOX_EVK_ODIN_W2.bin"
-        }
-    }
-}
```

# TODO
 * [x] Config Tests