### PR TITLE
CriticalSectionLock: fixing missing include

### DIFF
--- a/platform/CriticalSectionLock.h
+++ b/platform/CriticalSectionLock.h
@@ -19,6 +19,7 @@
 #define MBED_CRITICALSECTIONLOCK_H
 
 #include "platform/mbed_critical.h"
+#include "platform/mbed_toolchain.h"
 
 namespace mbed {
 


### PR DESCRIPTION
## Description

Macro MBED_DEPRECATED_SINCE is defined in platform/mbed_toolchain.h which was not included.
If someone used member functions lock or unlock (which are prefixed with MBED_DEPRECATED_SINCE since some time), there would be a compile error instead of a warning.
Including mbed_toolchain.h fixes that.


## Status

**READY**

## Steps to test or reproduce

Use CriticalSectionLock.lock() in a cpp file where CriticalSectionLock.h is included before mbed.h - compile error will occur.

