### PR TITLE
Add missing EFM32 HAL flash init/deinit function calls

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
@@ -35,6 +35,7 @@
 int32_t flash_init(flash_t *obj)
 {
     (void)obj;
+    MSC_Init();
     return 0;
 }
 
@@ -46,6 +47,7 @@ int32_t flash_init(flash_t *obj)
 int32_t flash_free(flash_t *obj)
 {
     (void)obj;
+    MSC_Deinit();
     return 0;
 }
 


### PR DESCRIPTION
## Description

Add MSC_Init()/MSC_Deinit() to flash_init()/flash_free() in flash_api.c for TARGET_EFM32. This allows using the FLASH IAP without calling the EFM32 HAL MSC_Init()/MSC_Deinit() functions in the application code.
This increases also the portability of the application code.
Furthermore the using of the FLASH IAP is more straight forward, because the writing and erasing functions in flash_api.c do not throw an error when they are not initialized.

## Status

**READY**

## Migrations

NO
