### PR TITLE
Simplify and Improve error/warning parser for gcc_arm

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -26,8 +26,7 @@ class GCC(mbedToolchain):
     LIBRARY_EXT = '.a'
 
     STD_LIB_NAME = "lib%s.a"
-    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
-    INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
+    DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(?P<col>\d+):? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
 
     def __init__(self, target,  notify=None, macros=None,
                  silent=False, extra_verbose=False, build_profile=None,
@@ -128,21 +127,12 @@ class GCC(mbedToolchain):
                     'severity': match.group('severity').lower(),
                     'file': match.group('file'),
                     'line': match.group('line'),
-                    'col': 0,
+                    'col': match.group('col'),
                     'message': match.group('message'),
                     'text': '',
                     'target_name': self.target.name,
                     'toolchain_name': self.name
                 }
-            elif msg is not None:
-                # Determine the warning/error column by calculating the ^ position
-                match = self.INDEX_PATTERN.match(line)
-                if match is not None:
-                    msg['col'] = len(match.group('col'))
-                    self.cc_info(msg)
-                    msg = None
-                else:
-                    msg['text'] += line+"\n"
 
         if msg is not None:
             self.cc_info(msg)


### PR DESCRIPTION
## Description

Simplify parsing of error and warning messages for GCC_ARM.

First, the parsing method is a little bit confusing and hacky and sometimes the column parsing by calculating the ^ position fails and on the output it shows "0" instead of the correct warning/error column. Instead I am parsing the column out of  the gcc_arm output.
Second, the regex for the "INDEX_PATTERN" is not necessary anymore.

## Status

**READY**

## Migrations

NO

## Steps to test or reproduce
`mbed compile -t GCC_ARM --profile release`
note: mcu (TARGET) must/should be configured in ".mbed"

