### PR TITLE
NXP LPC4088: Add missing SPI SSEL pin to Pinmap

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -69,6 +69,7 @@ static const PinMap PinMap_SPI_SSEL[] = {
     {P1_28, SPI_0, 5},
     {P2_23, SPI_0, 2},
     {P4_21, SPI_1, 3},
+    {P5_3,  SPI_2, 2},
     {NC   , NC   , 0}
 };
 


### PR DESCRIPTION
The Pin P5_3 (p31) was missing from the NXP LPC4088 SPI PinMap for SSEL.

Adding this Pin allows usage of SPISlave with SSP2 using the SSEL pin.

The pin and its SSP2_SSEL function is both documented in https://os.mbed.com/media/uploads/embeddedartists/lpc4088_qsb_pinning.xlsx as well as in UM10562 LPC408x/407x User manual Rev. 3 — 12 March 2014 chapter 7.4.1.4 Table 90 (https://www.nxp.com/docs/en/user-guide/UM10562.pdf).

Notes:
- Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
- This is just a template, so feel free to use/remove the unnecessary things

## Description

A few sentences describing the overall goals of the pull request's commits.

## Status

**READY/IN DEVELOPMENT/HOLD**

## Migrations

If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES | NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

Notes regarding the deployment of this PR. These should note any required changes in the build environment, tools, compilers and so on.

## Steps to test or reproduce

Outline the steps to test or reproduce the PR here.
