### PR TITLE
Fix issue with MBED_11 test (mbed2)

### DIFF
--- a/features/unsupported/tests/mbed/ticker/main.cpp
+++ b/features/unsupported/tests/mbed/ticker/main.cpp
@@ -1,11 +1,7 @@
 #include "mbed.h"
 #include "test_env.h"
 
-void print_char(char c = '*')
-{
-    printf("%c", c);
-    fflush(stdout);
-}
+RawSerial pc(USBTX, USBRX);
 
 Ticker flipper_1;
 DigitalOut led1(LED1);
@@ -17,7 +13,7 @@ void flip_1() {
     } else {
         led1 = 1; led1_state = 1;
     }
-    print_char();
+    pc.putc('*');
 }
 
 Ticker flipper_2;


### PR DESCRIPTION
## Description

- The MBED_11 test was failed/unstabled on our test bench since mbed revision 153 / mbed-os-5.6.2
- It was due to the use of printf inside ticker callback. Replacing it with `RawSerial `solved the issue
- More discussion in PR #5842 (closed)

## Status
**READY**

## Migrations
NO
