### PR TITLE
bd: Add sync function to the block device API

### DIFF
--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -59,6 +59,15 @@ public:
      */
     virtual int deinit() = 0;
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync()
+    {
+        return 0;
+    }
+
     /** Read blocks from a block device
      *
      *  If a failure occurs, it is not possible to determine how many bytes succeeded

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -84,6 +84,18 @@ int ChainingBlockDevice::deinit()
     return 0;
 }
 
+int ChainingBlockDevice::sync()
+{
+    for (size_t i = 0; i < _bd_count; i++) {
+        int err = _bds[i]->sync();
+        if (err) {
+            return err;
+        }
+    }
+
+    return 0;
+}
+
 int ChainingBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
 {
     MBED_ASSERT(is_valid_read(addr, size));

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -85,6 +85,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to write blocks to

--- a/features/filesystem/bd/ExhaustibleBlockDevice.cpp
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.cpp
@@ -53,6 +53,11 @@ int ExhaustibleBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int ExhaustibleBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int ExhaustibleBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 {
     return _bd->read(buffer, addr, size);

--- a/features/filesystem/bd/ExhaustibleBlockDevice.h
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.h
@@ -70,6 +70,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -234,6 +234,11 @@ int MBRBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int MBRBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int MBRBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
 {
     MBED_ASSERT(is_valid_read(addr, size));

--- a/features/filesystem/bd/MBRBlockDevice.h
+++ b/features/filesystem/bd/MBRBlockDevice.h
@@ -139,6 +139,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/bd/ObservingBlockDevice.cpp
+++ b/features/filesystem/bd/ObservingBlockDevice.cpp
@@ -51,6 +51,11 @@ int ObservingBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int ObservingBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int ObservingBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 {
     return _bd->read(buffer, addr, size);

--- a/features/filesystem/bd/ObservingBlockDevice.h
+++ b/features/filesystem/bd/ObservingBlockDevice.h
@@ -56,6 +56,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/bd/ProfilingBlockDevice.cpp
+++ b/features/filesystem/bd/ProfilingBlockDevice.cpp
@@ -35,6 +35,11 @@ int ProfilingBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int ProfilingBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int ProfilingBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
 {
     int err = _bd->read(b, addr, size);

--- a/features/filesystem/bd/ProfilingBlockDevice.h
+++ b/features/filesystem/bd/ProfilingBlockDevice.h
@@ -71,6 +71,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -45,6 +45,11 @@ int ReadOnlyBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int ReadOnlyBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int ReadOnlyBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 {
     return _bd->read(buffer, addr, size);

--- a/features/filesystem/bd/ReadOnlyBlockDevice.h
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.h
@@ -49,6 +49,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -64,6 +64,11 @@ int SlicingBlockDevice::deinit()
     return _bd->deinit();
 }
 
+int SlicingBlockDevice::sync()
+{
+    return _bd->sync();
+}
+
 int SlicingBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
 {
     MBED_ASSERT(is_valid_read(addr, size));

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -77,6 +77,12 @@ public:
      */
     virtual int deinit();
 
+    /** Ensure data on storage is in sync with the driver
+     *
+     *  @return         0 on success or a negative error code on failure
+     */
+    virtual int sync();
+
     /** Read blocks from a block device
      *
      *  @param buffer   Buffer to read blocks into

--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -102,7 +102,8 @@ static int lfs_bd_erase(const struct lfs_config *c, lfs_block_t block)
 
 static int lfs_bd_sync(const struct lfs_config *c)
 {
-    return 0;
+    BlockDevice *bd = (BlockDevice *)c->context;
+    return bd->sync();
 }
 
 


### PR DESCRIPTION
Right now, all block devices must effectively sync data on read/program, or else the power resilience gauruntees of littlefs don't hold true.

This is fine with the current state of the block device, which just write through any buffers provided (since external flash is much cheaper than internal caching and speed is a secondary concern to code footprint). However, in order to provide a decent FTL a syncing mechanic is necessary to ensure storage is up to date with in-flight data.

``` cpp
class BlockDevice {
    /** Ensure data on storage is in sync with the driver
     *
     *  @return         0 on success or a negative error code on failure
     */
    virtual int sync();
}
```

cc @deepikabhavnani 