### PR TITLE
Revert "NUCLEO_F767ZI: Add bootloader support"

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
@@ -30,7 +30,6 @@
 **/
 
 #include "stm32f7xx.h"
-#include "nvic_addr.h"
 #include "mbed_assert.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -93,7 +92,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = RAMDTCM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
 #endif
 
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_MICRO/stm32f767xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_MICRO/stm32f767xi.sct
@@ -1,4 +1,3 @@
-#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -28,18 +27,10 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
-#endif
-
 ; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
-LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
+  ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
@@ -1,4 +1,3 @@
-#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -28,18 +27,10 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x200000
-#endif
-
 ; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
-LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+LR_IROM1 0x08000000 0x200000  {    ; load region size_region
 
-  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
+  ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
@@ -1,16 +1,7 @@
 /* Linker script to configure memory regions. */
-
-#if !defined(MBED_APP_START)
-  #define MBED_APP_START 0x08000000
-#endif
-
-#if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 2048K
-#endif
-
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
+  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
   RAM (rwx)  : ORIGIN = 0x200001F8, LENGTH = 512K - 0x1F8
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
@@ -1,10 +1,7 @@
-if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
-if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
-
 /* [ROM = 2048kb = 0x200000] */
-define symbol __intvec_start__     = MBED_APP_START;
-define symbol __region_ROM_start__ = MBED_APP_START;
-define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
+define symbol __intvec_start__     = 0x08000000;
+define symbol __region_ROM_start__ = 0x08000000;
+define symbol __region_ROM_end__   = 0x081FFFFF;
 
 /* [RAM = 512kb = 0x80000] Vector table dynamic copy: 126 vectors = 504 bytes (0x1F8) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1351,8 +1351,7 @@
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F767ZI",
-        "bootloader_supported": true
+        "device_name": "STM32F767ZI"
     },
     "NUCLEO_L011K4": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
Reverts commit 4d0535a1bff3b069b860f8ccfdbf5b27ca370d83.

Pull request introduced CI bug that causes a serial sync error once greentea tests are started.

## Description

After investigation, it was found that the NUCLEO_F767ZI will not sync with greentea, causing our CI tests to slow down and continuously fail. Reverting prior to when bootloader support was added, and reflashing the device appears to solve the problem.

If this is not the only commit causing the issue, other commits will be reverted in this PR.

## Status

**READY**

## Migrations

For the time being, this will disable bootloader support for NUCLEO_F767ZI.

## Steps to test or reproduce

To reproduce the issue:
- Download mbed-os at 98611c8
- Compile, flash, and test on NUCLEO_F746ZG.
- Power cycle the device.
- Run test again. Sync will fail.

To recover the device:
- Checkout mbed-os prior to https://github.com/ARMmbed/mbed-os/pull/5821
- Compile, flash, and test on NUCLEO_F746ZG.
- Power cycle the device.
- Run test again. Issue goes away.
