### PR TITLE
littlefs: Set specific hash for littlefs-fuse testing in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -127,6 +127,7 @@ matrix:
       before_script:
         # Setup and patch littlefs-fuse
         - git clone https://github.com/geky/littlefs-fuse littlefs_fuse
+        - git -C littlefs_fuse checkout 3f1ed6e37799e49e3710830dc6abb926d5503cf2
         - echo '*' > littlefs_fuse/.mbedignore
         - rm -rf littlefs_fuse/littlefs/*
         - cp -r $(git ls-tree --name-only HEAD $LITTLEFS/littlefs/) littlefs_fuse/littlefs


### PR DESCRIPTION
The self-hosted littlefs-fuse testing in Mbed OS is currently dependent on the master of littlefs-fuse, which is a moving target. Locking this to a specific hash will remove this problem. Other options could be to commit the littlefs-fuse wrapper into mbed-os specifically for testing, or remove fuse testing.

see https://github.com/ARMmbed/mbed-os/pull/5903#issuecomment-359792709
cc @theotherjimmy, @0xc0170 

Note: I don't think device testing is needed