### PR TITLE
MTB_XX : STDIO configuration

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PeripheralNames.h
@@ -46,10 +46,6 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
-#define STDIO_UART_TX  PB_6
-#define STDIO_UART_RX  PB_7
-#define STDIO_UART     UART_1
-
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PinNames.h
@@ -145,9 +145,26 @@ typedef enum {
     P_39 = PA_13,
     P_40 = PB_7,
 
+    // STDIO for console print
+#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#elif MBED_CONF_TARGET_USB_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_USB_TX,
+#else
+    STDIO_UART_TX = PB_6,
+#endif
+
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#elif MBED_CONF_TARGET_USB_RX
+    STDIO_UART_TX = MBED_CONF_TARGET_USB_RX,
+#else
+    STDIO_UART_RX = PB_7,
+#endif
+
     //DAPLink
-    USBTX       = MBED_CONF_TARGET_USB_TX,
-    USBRX       = MBED_CONF_TARGET_USB_RX,
+    USBTX       = STDIO_UART_TX,
+    USBRX       = STDIO_UART_RX,
     SWDIO      = PA_13,
     SWCLK      = PA_14,
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PeripheralNames.h
@@ -33,10 +33,6 @@ typedef enum {
     UART_6 = (int)USART6_BASE
 } UARTName;
 
-#define STDIO_UART_TX  PD_8
-#define STDIO_UART_RX  PD_9
-#define STDIO_UART     UART_3
-
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
@@ -219,9 +219,25 @@ typedef enum {
     SPI_SCK     = P_6,
     SPI_CS      = P_16,
 
+    // STDIO for console print
+#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#elif MBED_CONF_TARGET_USB_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_USB_TX,
+#else
+    STDIO_UART_TX = PB_6,
+#endif
+
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#elif MBED_CONF_TARGET_USB_RX
+    STDIO_UART_TX = MBED_CONF_TARGET_USB_RX,
+#else
+    STDIO_UART_RX = PB_7,
+#endif
     //DAPLink
-    USBRX      = MBED_CONF_TARGET_USB_RX,
-    USBTX      = MBED_CONF_TARGET_USB_TX,
+    USBRX      = STDIO_UART_RX,
+    USBTX      = STDIO_UART_TX,
     SWDIO      = P_26,
     SWCLK      = P_25,
     NTRST      = P_13,

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1088,19 +1088,14 @@
         "device_name": "STM32F412ZG",
         "bootloader_supported": true,
         "config": {
-            "usb_tx": {
+            "stdio_uart_tx": {
                 "help": "Value PB_6",
                 "value": "PB_6"
             },
-            "usb_rx": {
+            "stdio_uart_rx": {
                 "help": "Value PB_7",
                 "value": "PB_7"
             },
-            "stdio_uart": {
-                "help": "Value: UART_1",
-                "value": "UART_1",
-                "macro_name": "STDIO_UART"
-             },
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSI",
@@ -1891,19 +1886,14 @@
                 "value": 1,
                 "macro_name": "MODEM_ON_BOARD_UART"
             },
-            "usb_tx": {
+            "stdio_uart_tx": {
                 "help": "Value PB_6",
                 "value": "PB_6"
             },
-            "usb_rx": {
+            "stdio_uart_rx": {
                 "help": "Value PB_7",
                 "value": "PB_7"
-            },
-            "stdio_uart": {
-                "help": "Value: UART_1",
-                "value": "UART_1",
-                "macro_name": "STDIO_UART"
-             }
+            }
         },
         "overrides": {
                  "lse_available": 0


### PR DESCRIPTION
## Description

Here is a proposition
 - to align with other STM32
 - and to remove compilation warnings :
[Warning] PeripheralNames.h@38,0: "STDIO_UART" redefined

## Status

**READY**
