### PR TITLE
STM32L0/4 Enable use of LPUART in stop mode

### DIFF
--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -525,6 +525,18 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
         huart->Init.Mode = UART_MODE_TX_RX;
     }
 
+#if defined(LPUART1_BASE)
+    if (huart->Instance == LPUART1) {
+        if (obj_s->baudrate <= 9600) {
+            HAL_UARTEx_EnableClockStopMode(huart);
+            HAL_UARTEx_EnableStopMode(huart);
+        } else {
+            HAL_UARTEx_DisableClockStopMode(huart);
+            HAL_UARTEx_DisableStopMode(huart);
+        }
+    }
+#endif
+
     return HAL_UART_Init(huart);
 }
 


### PR DESCRIPTION
## Description
Working on using the LPUART in stop mode.
Always switching to LSE when available when baudrates are below or equal to 9600.

This is at least still blocked by the `SerialBase::attach()` where `sleep_manager_lock_deep_sleep()` is called.

## Status

**IN DEVELOPMENT**

## Deploy notes

This breaks when compiling on an STM32L4 because the HAL doesn't have the function `HAL_UARTEx_EnableClockStopMode()`. The HAL should have the same function as the STM32L0 has because the peripheral also has the same settings. For example, see chapter 41.4.11 of the ST RM0351 and the UCESM bit in CR3.
