### PR TITLE
Remove tickless assert for tick count

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -194,7 +194,6 @@ static void default_idle_hook(void)
 
     core_util_critical_section_enter();
     uint32_t ticks_to_sleep = svcRtxKernelSuspend();
-    MBED_ASSERT(os_timer->get_tick() == svcRtxKernelGetTickCount());
     if (ticks_to_sleep) {
         os_timer->schedule_tick(ticks_to_sleep);
 


### PR DESCRIPTION
Remove the assert that the tick count of the OS matches the tick count of the tickless timer as this occurs frequently when debugging. This is because the function svcRtxKernelResumeonly increments the OS's tick count until the next wakeup event so if the device was halted by a debugger past the next wakeup event the tick counts will be out of sync.
