### PR TITLE
Correct return value of nsapi_dns_query_multiple

### DIFF
--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -214,7 +214,7 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
     socket.set_timeout(DNS_TIMEOUT);
 
     // create network packet
-    uint8_t *packet = (uint8_t *)malloc(DNS_BUFFER_SIZE);
+    uint8_t * const packet = (uint8_t *)malloc(DNS_BUFFER_SIZE);
     if (!packet) {
         return NSAPI_ERROR_NO_MEMORY;
     }
@@ -243,8 +243,9 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
         }
 
         const uint8_t *response = packet;
-        if (dns_scan_response(&response, addr, addr_count) > 0) {
-            result = NSAPI_ERROR_OK;
+        int count = dns_scan_response(&response, addr, addr_count);
+        if (count > 0) {
+            result = count;
         }
 
         /* The DNS response is final, no need to check other servers */


### PR DESCRIPTION
Documentation states that `nsapi_dns_query_multiple` returns the number of
addresses found on success - it was returning 0.

Overloads using `SocketAddress` are relying on the return value, meaning
those calls didn't work at all.

Fixes #5921.
