### PR TITLE
Correct `nsapi_dns_query_multiple()`

### DIFF
--- a/features/netsocket/nsapi_dns.cpp
+++ b/features/netsocket/nsapi_dns.cpp
@@ -243,8 +243,9 @@ static nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const
         }
 
         const uint8_t *response = packet;
-        if (dns_scan_response(&response, addr, addr_count) > 0) {
-            result = NSAPI_ERROR_OK;
+        nsapi_size_t cnt;
+        if ((cnt = dns_scan_response(&response, addr, addr_count)) > 0) {
+            result = cnt;
         }
 
         /* The DNS response is final, no need to check other servers */


### PR DESCRIPTION
## Description

All the public overloads of nsapi_dns_query_multiple() are broken. They are documented as returning the number of addresses found on success. However, the return value of dns_scan_response() is not passed down, only its sign is checked and the function always returns NSAPI_ERROR_OK, i.e. zero.

This is especially disastrous for all the overloads that take SocketAddress * as argument; this overload expects the static variant to work as documented, which causes none of the addresses to be copied.

This PR resolves this issue (#5921) 

## Status

**READY**