### PR TITLE
STM32L4 : add missing ST HAL UART functions

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/stm32l432xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/stm32l432xx.h
@@ -13331,6 +13331,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 #define USART_CR3_TCBGTIE_Pos         (24U)
 #define USART_CR3_TCBGTIE_Msk         (0x1U << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
 #define USART_CR3_TCBGTIE             USART_CR3_TCBGTIE_Msk                    /*!< Transmission Complete Before Guard Time Interrupt Enable */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/stm32l433xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/stm32l433xx.h
@@ -14391,6 +14391,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 #define USART_CR3_TCBGTIE_Pos         (24U)
 #define USART_CR3_TCBGTIE_Msk         (0x1U << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
 #define USART_CR3_TCBGTIE             USART_CR3_TCBGTIE_Msk                    /*!< Transmission Complete Before Guard Time Interrupt Enable */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/stm32l475xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/stm32l475xx.h
@@ -15905,6 +15905,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 
 /******************  Bit definition for USART_BRR register  *******************/
 #define USART_BRR_DIV_FRACTION_Pos    (0U)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/stm32l476xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/stm32l476xx.h
@@ -16056,6 +16056,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 
 /******************  Bit definition for USART_BRR register  *******************/
 #define USART_BRR_DIV_FRACTION_Pos    (0U)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/stm32l486xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/stm32l486xx.h
@@ -16281,6 +16281,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 
 /******************  Bit definition for USART_BRR register  *******************/
 #define USART_BRR_DIV_FRACTION_Pos    (0U)

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/stm32l496xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/stm32l496xx.h
@@ -17276,6 +17276,11 @@ typedef struct
 #define USART_CR3_WUFIE_Pos           (22U)
 #define USART_CR3_WUFIE_Msk           (0x1U << USART_CR3_WUFIE_Pos)            /*!< 0x00400000 */
 #define USART_CR3_WUFIE               USART_CR3_WUFIE_Msk                      /*!< Wake Up Interrupt Enable */
+/* MBED */
+#define USART_CR3_UCESM_Pos           (23U)
+#define USART_CR3_UCESM_Msk           (0x1U << USART_CR3_UCESM_Pos)            /*!< 0x00800000 */
+#define USART_CR3_UCESM               USART_CR3_UCESM_Msk                      /*!< Clock Enable in Stop mode */ 
+/* MBED */
 #define USART_CR3_TCBGTIE_Pos         (24U)
 #define USART_CR3_TCBGTIE_Msk         (0x1U << USART_CR3_TCBGTIE_Pos)          /*!< 0x01000000 */
 #define USART_CR3_TCBGTIE             USART_CR3_TCBGTIE_Msk                    /*!< Transmission Complete Before Guard Time Interrupt Enable */

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_uart_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_uart_ex.c
@@ -472,6 +472,32 @@ HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart)
   return HAL_OK;
 }
 
+/* MBED */
+/**
+  * @brief Enable UART Clock in Stop Mode
+  * The UART keeps the Clock ON during Stop mode
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_EnableClockStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->gState = HAL_UART_STATE_BUSY;
+
+  /* Set the USART UESM bit */
+  huart->Instance->CR3 |= USART_CR3_UCESM;
+
+  huart->gState = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+/* MBED */
+
 /**
   * @brief Disable UART Stop Mode.
   * @param huart UART handle.
@@ -494,6 +520,33 @@ HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart)
   
   return HAL_OK;
 }
+
+
+/* MBED */
+/**
+  * @brief Disable UART Clock in Stop Mode
+  * @param huart: uart handle
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_UARTEx_DisableClockStopMode(UART_HandleTypeDef *huart)
+{
+  /* Process Locked */
+  __HAL_LOCK(huart);
+
+  huart->gState = HAL_UART_STATE_BUSY;
+
+  /* Clear USART UESM bit */
+  huart->Instance->CR3 &= ~(USART_CR3_UCESM);
+
+  huart->gState = HAL_UART_STATE_READY;
+
+  /* Process Unlocked */
+  __HAL_UNLOCK(huart);
+
+  return HAL_OK;
+}
+/* MBED */
+
 
 #if defined(USART_CR2_SLVEN)
 /**

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_uart_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_uart_ex.h
@@ -174,7 +174,7 @@ void HAL_UARTEx_WakeupCallback(UART_HandleTypeDef *huart);
 void HAL_UARTEx_RxFifoFullCallback(UART_HandleTypeDef *huart);
 void HAL_UARTEx_TxFifoEmptyCallback(UART_HandleTypeDef *huart);
 #endif
-  
+
 /**
   * @}
   */
@@ -186,7 +186,13 @@ void HAL_UARTEx_TxFifoEmptyCallback(UART_HandleTypeDef *huart);
 /* Peripheral Control functions  **********************************************/
 HAL_StatusTypeDef HAL_UARTEx_StopModeWakeUpSourceConfig(UART_HandleTypeDef *huart, UART_WakeUpTypeDef WakeUpSelection);
 HAL_StatusTypeDef HAL_UARTEx_EnableStopMode(UART_HandleTypeDef *huart);
+/* MBED */
+HAL_StatusTypeDef HAL_UARTEx_EnableClockStopMode(UART_HandleTypeDef *huart);
+/* MBED */
 HAL_StatusTypeDef HAL_UARTEx_DisableStopMode(UART_HandleTypeDef *huart);
+/* MBED */
+HAL_StatusTypeDef HAL_UARTEx_DisableClockStopMode(UART_HandleTypeDef *huart);
+/* MBED */
 HAL_StatusTypeDef HAL_MultiProcessorEx_AddressLength_Set(UART_HandleTypeDef *huart, uint32_t AddressLength);
 
 #if defined(USART_CR2_SLVEN)


### PR DESCRIPTION
## Description

Issue found by @marcemmers in #5941 

Some functions were missing in L4 CUBE HAL drivers to enable/disable UART Clock in Stop Mode

## Status

**READY**
