### PR TITLE
Fix internal rtx details in rtos

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
@@ -178,7 +178,7 @@ void test_heap_in_range(void)
  */
 void test_main_stack_in_range(void)
 {
-    os_thread_t *thread = (os_thread_t*) osThreadGetId();
+    mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t*) osThreadGetId();
 
     uint32_t psp = __get_PSP();
     uint8_t *stack_mem = (uint8_t*) thread->stack_mem;

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -161,6 +161,7 @@
  */
 
 #include <stdlib.h>
+#include <string.h>
 
 #include "cmsis.h"
 #include "mbed_rtx.h"

--- a/rtos/TARGET_CORTEX/mbed_rtos_storage.h
+++ b/rtos/TARGET_CORTEX/mbed_rtos_storage.h
@@ -40,17 +40,17 @@ extern "C" {
  implementation specific, header file, therefore limiting scope of possible changes.
  */
 
-#include "rtx_lib.h"
+#include "rtx_os.h"
 #include "mbed_rtx_conf.h"
 
-typedef os_mutex_t mbed_rtos_storage_mutex_t;
-typedef os_semaphore_t mbed_rtos_storage_semaphore_t;
-typedef os_thread_t mbed_rtos_storage_thread_t;
-typedef os_memory_pool_t mbed_rtos_storage_mem_pool_t;
-typedef os_message_queue_t mbed_rtos_storage_msg_queue_t;
-typedef os_event_flags_t mbed_rtos_storage_event_flags_t;
-typedef os_message_t mbed_rtos_storage_message_t;
-typedef os_timer_t mbed_rtos_storage_timer_t;
+typedef osRtxMutex_t mbed_rtos_storage_mutex_t;
+typedef osRtxSemaphore_t mbed_rtos_storage_semaphore_t;
+typedef osRtxThread_t mbed_rtos_storage_thread_t;
+typedef osRtxMemoryPool_t mbed_rtos_storage_mem_pool_t;
+typedef osRtxMessageQueue_t mbed_rtos_storage_msg_queue_t;
+typedef osRtxEventFlags_t mbed_rtos_storage_event_flags_t;
+typedef osRtxMessage_t mbed_rtos_storage_message_t;
+typedef osRtxTimer_t mbed_rtos_storage_timer_t;
 
 #ifdef __cplusplus
 }

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -28,9 +28,6 @@
 #include "mbed_assert.h"
 #include <new>
 #include "rtx_os.h"
-extern "C" {
-#include "rtx_lib.h"
-}
 
 using namespace mbed;
 
@@ -193,7 +190,7 @@ static void default_idle_hook(void)
     uint32_t elapsed_ticks = 0;
 
     core_util_critical_section_enter();
-    uint32_t ticks_to_sleep = svcRtxKernelSuspend();
+    uint32_t ticks_to_sleep = osKernelSuspend();
     if (ticks_to_sleep) {
         os_timer->schedule_tick(ticks_to_sleep);
 

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -264,7 +264,7 @@ uint32_t Thread::free_stack() {
 
 #if defined(MBED_OS_BACKEND_RTX5)
     if (_tid != NULL) {
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         size = (uint32_t)thread->sp - (uint32_t)thread->stack_mem;
     }
 #endif
@@ -279,7 +279,7 @@ uint32_t Thread::used_stack() {
 
 #if defined(MBED_OS_BACKEND_RTX5)
     if (_tid != NULL) {
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         size = ((uint32_t)thread->stack_mem + thread->stack_size) - thread->sp;
     }
 #endif
@@ -294,7 +294,7 @@ uint32_t Thread::max_stack() {
 
     if (_tid != NULL) {
 #if defined(MBED_OS_BACKEND_RTX5)
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         uint32_t high_mark = 0;
         while (((uint32_t *)(thread->stack_mem))[high_mark] == 0xE25A2EA5)
             high_mark++;


### PR DESCRIPTION
When I was using cmsis pack (rtx), I noticed that not all files are in the include paths (@JonatanAntoni confirmed these should not be used, please review). This lead me to do these fixes.

`rtx_lib.h` is internal header file, all what we use it is provided via public functionality

I can squash first three commits as they are related 