### PR TITLE
Reserve and Render header in managed BL mode

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -383,13 +383,9 @@ def _fill_header(region_list, current_region):
                    "32be": ">L", "64be": ">Q"}[subtype]
             size = sum(_real_region_size(region_dict[r]) for r in data)
             header.puts(start, struct.pack(fmt, size))
-        start += Config.header_member_size(member)
-    start = current_region.start
-    for member in current_region.filename:
-        _, type, subtype, data = member
-        if type  == "digest":
+        elif type  == "digest":
             if data == "header":
-                ih = header
+                ih = header[:start]
             else:
                 ih = intelhex_offset(region_dict[data].filename, offset=region_dict[data].start)
             if subtype.startswith("CRCITT32"):

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -36,7 +36,7 @@ from jinja2.environment import Environment
 from .arm_pack_manager import Cache
 from .utils import (mkdir, run_cmd, run_cmd_ext, NotSupportedException,
                     ToolException, InvalidReleaseTargetException,
-                    intelhex_offset)
+                    intelhex_offset, integer)
 from .paths import (MBED_CMSIS_PATH, MBED_TARGETS_PATH, MBED_LIBRARIES,
                     MBED_HEADER, MBED_DRIVERS, MBED_PLATFORM, MBED_HAL,
                     MBED_CONFIG_FILE, MBED_LIBRARIES_DRIVERS,
@@ -353,6 +353,7 @@ def _real_region_size(region):
     except AttributeError:
         return region.size
 
+
 def _fill_header(region_list, current_region):
     """Fill an application header region
 
@@ -373,7 +374,7 @@ def _fill_header(region_list, current_region):
                 "8le": ">B", "16le": "<H", "32le": "<L", "64le": "<Q",
                 "8be": "<B", "16be": ">H", "32be": ">L", "64be": ">Q"
             }[subtype]
-            header.puts(start, struct.pack(fmt, int(data, 0)))
+            header.puts(start, struct.pack(fmt, integer(data, 0)))
         elif type == "timestamp":
             fmt = {"32le": "<L", "64le": "<Q",
                    "32be": ">L", "64be": ">Q"}[subtype]

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -573,9 +573,9 @@ class Config(object):
     def header_member_size(member):
         _, _, subtype, _ = member
         try:
-            return int(subtype) // 8
+            return int(subtype[:-2]) // 8
         except:
-            if subtype == "CRCITT32":
+            if subtype.startswith("CRCITT32"):
                 return 32 // 8
             elif subtype == "SHA256":
                 return 256 // 8

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -539,3 +539,11 @@ def intelhex_offset(filename, offset):
         raise ToolException("File %s does not have a known binary file type"
                             % filename)
     return ih
+
+
+def integer(maybe_string, base):
+    """Make an integer of a number or a string"""
+    if isinstance(maybe_string, int):
+        return maybe_string
+    else:
+        return int(maybe_string, base)


### PR DESCRIPTION
# Detailed Design
The header specification is a JSON ordered list of
JSON tuples in the `target.header_format` configu-
ration key. The tuple represents a single element of
the header format as first the name (a valid C identi-
fier), then a type, a subtype and finally a single argu-
ment. For example, the const type defines subtypes
for common sizes of constants, including the 32 sub-
type that indicates the constant will be represented
as 32 bits. The following is a list of all types and
subtypes that we plan to support.

 * `const` A constant value.
   * `8be` A value represented as 8 bits.
   * `16be` A value represented as 16 bits big endian.
   * `32be` A value represented as 32 bits big endian.
   * `64be` A value represented as 64 bits big endian.
   * `8le` A value represented as 8 bits.
   * `16le` A value represented as 16 bits little endian.
   * `32le` A value represented as 32 bits little endian.
   * `64le` A value represented as 64 bits little endian.

 * `timestamp` A time stamp value, in seconds from
    epoch in the timezone GMT/UTC.
    This type’s argument is always null.
    * `64be` A time stamp value truncated to 64 bits big endian.
    * `64le` A time stamp value truncated to 64 bits ilttle endian.

 * `digest` A digest of an image. All digests are
computed in the order they appear. A digest of the header
 digests the header up to its start address.
    * `CRCITT32be` A big endian 32bit checksum of an image.
    * `CRCITT32be` A little endian 32bit checksum of an image.
    * `SHA256` A SHA-2 using a block-size of 256
bits.
    * `SHA512` A SHA-2 using a block-size of 512
bits.

 * `size` The size of a list of images, added together.
    * `32be` A size represented as 32 bits big endian.
    * `64be` A size represented as 64 bits big endain.
    * `32le` A size represented as 32 bits little endian.
    * `64le` A size represented as 64 bits little endain.

The addition of new types and new subtypes must
come in a feature release.

Items in the header are packed starting where
the previous field ended; Items in the header are
packed using the C “packed” struct semantics. The
presence of the target.header format field de-
fines two macros `MBED_HEADER_START`, which expands
to the start address of the firmware header, and
`MBED_HEADER_SIZE`, containing the size in bytes of
the firmware header.The region following the
application header starts at 
`MBED_HEADER_START +
MBED_HEADER_SIZE`
 rounded up to a multiple of 8
bytes.

# Example

I wrote up a `mbed_lib.json` that covers a firmware header I have seen.
The JSON description follows.
```json
{                                                                                                        
    "name": "bootloader_images",                                                                         
    "target_overrides": {                                                                                
        "*": {                                                                                           
            "target.header_format": [                                                                    
                ["magic", "const", "32be", "0x5a51b3d4"],                                                  
                ["version", "const", "32be", "2"],                                                         
                ["firmwareVersion", "timestamp", "64be", null],                                            
                ["firmwareSize", "size", "64be", ["application"]],                                         
                ["firmwareHash", "digest", "SHA256", "application"],                                     
                ["hashpad", "const", "64be", "0"],                                                         
                ["hashpad", "const", "64be", "0"],                                                         
                ["hashpad", "const", "64be", "0"],                                                         
                ["hashpad", "const", "64be", "0"],                                                         
                ["campaign", "const", "64be", "0"],                                                        
                ["campaign", "const", "64be", "0"],                                                        
                ["firmwareSignatureSize", "const", "32be", "0"],                                           
                ["headerCRC", "digest", "CRCITT32be", "header"]                                            
            ]                                                                                            
        },                                                                                               
        "K64F": {                                                                                        
            "target.bootloader_img": "K64F.bin"                                                          
        },                                                                                               
        "NUCLEO_F429ZI": {                                                                               
            "target.bootloader_img": "NUCLEO_F429ZI.bin"                                                 
        },                                                                                               
        "UBLOX_EVK_ODIN_W2": {                                                                           
            "target.bootloader_img": "UBLOX_EVK_ODIN_W2.bin"                                             
        }                                                                                                
    }                                                                                                    
}                                                                                                        
```

This produces a header as follows:
```
$ mbed compile -t gcc_arm -m k64f
[snip]
Using regions in this build:
  Region bootloader size 0x20000, offset 0x0
  Region header size 0x70, offset 0x20000
  Region application size 0xdff90, offset 0x20070
Merging Regions:
  Filling region bootloader with /home/jimmy/src/armmbed/mbed-os-example-bootloader-blinky/bootloader/K64F.bin
  Filling region header with ./BUILD/k64f/gcc_arm/mbed-os-example-bootloader-blinky_header.hex
  Filling region application with ./BUILD/k64f/gcc_arm/mbed-os-example-bootloader-blinky_application.bin
Space used after regions merged: 0x2c000
```
For reference the application compiled to `0xbf90` bytes. which makes application + header `0xc000` bytes.

The header's hex dump is as follows:
```xxd
00020000: 5a51 b3d4 0000 0002 0000 0000 5a74 e345  ZQ..........Zt.E
00020010: 0000 0000 0005 d960 290e 9447 e293 673e  .......`)..G..g>
00020020: 67b2 5e2a e8e5 5443 2a13 0df1 01d6 f0e8  g.^*..TC*.......
00020030: 6ea9 194f 535f 226e 0000 0000 0000 0000  n..OS_"n........
00020040: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00020050: 0000 0000 0000 0000 0000 0000 0000 0000  ................
00020060: 0000 0000 0000 0000 0000 0000 b22c 879e  .............,..
```


# TODO
 * [ ] Testing