### PR TITLE
STM32 NUCLEO F413ZH and L433RC : STDIO configuration

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PeripheralNames.h
@@ -43,10 +43,6 @@ typedef enum {
     UART_10 = (int)UART10_BASE
 } UARTName;
 
-#define STDIO_UART_TX  PD_8
-#define STDIO_UART_RX  PD_9
-#define STDIO_UART     UART_3
-
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
@@ -222,6 +222,18 @@ typedef enum {
     D14         = PB_9,
     D15         = PB_8,
 
+    // STDIO for console print
+#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX = PD_8,
+#endif
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX = PD_9,
+#endif
+
     // Generic signals namings
     LED1        = PB_0,  // Green
     LED2        = PB_7,  // Blue
@@ -231,10 +243,10 @@ typedef enum {
     USER_BUTTON = PC_13,
     // Standardized button names
     BUTTON1 = USER_BUTTON,
-    SERIAL_TX   = PD_8,
-    SERIAL_RX   = PD_9,
-    USBTX       = SERIAL_TX,
-    USBRX       = SERIAL_RX,
+    SERIAL_TX   = STDIO_UART_TX,
+    SERIAL_RX   = STDIO_UART_RX,
+    USBTX       = STDIO_UART_TX,
+    USBRX       = STDIO_UART_RX,
     I2C_SCL     = D15,
     I2C_SDA     = D14,
     SPI_MOSI    = D11,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PeripheralNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PeripheralNames.h
@@ -51,10 +51,6 @@ typedef enum {
     LPUART_1 = (int)LPUART1_BASE
 } UARTName;
 
-#define STDIO_UART_TX  PA_2
-#define STDIO_UART_RX  PA_3
-#define STDIO_UART     UART_2
-
 typedef enum {
     SPI_1 = (int)SPI1_BASE,
     SPI_2 = (int)SPI2_BASE,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
@@ -184,6 +184,18 @@ typedef enum {
   D12         = PB_14,
   D13         = PB_13,
 
+    // STDIO for console print
+#ifdef MBED_CONF_TARGET_STDIO_UART_TX
+    STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
+#else
+    STDIO_UART_TX = PA_2,
+#endif
+#ifdef MBED_CONF_TARGET_STDIO_UART_RX
+    STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
+#else
+    STDIO_UART_RX = PA_3,
+#endif
+
   // Generic signals namings
   LED1        = PA_5,
   LED2        = PA_5,
@@ -191,10 +203,10 @@ typedef enum {
   LED4        = PA_5,
   USER_BUTTON = PC_13,
   BUTTON1 = USER_BUTTON,
-  SERIAL_TX   = PA_2,
-  SERIAL_RX   = PA_3,
-  USBTX       = SERIAL_TX,
-  USBRX       = SERIAL_RX,
+  SERIAL_TX   = STDIO_UART_TX,
+  SERIAL_RX   = STDIO_UART_RX,
+  USBTX       = STDIO_UART_TX,
+  USBRX       = STDIO_UART_RX,
   I2C_SCL     = PB_8,
   I2C_SDA     = PB_7,
   SPI_MOSI    = D11,


### PR DESCRIPTION
## Description

#5795 patches are missing for NUCLEO_F413ZH and NUCLEO_L433RC_P
STDIO_UART_TX and STDIO_UART_RX can be now user defined like all other STM32 targets

Thx

## Status

**READY**
