### PR TITLE
C030 R410M Target Added

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
@@ -82,10 +82,17 @@ typedef enum {
     // Cellular modem (a DCE)
     MDMPWRON  = PE_14,   // Power (active high)
     MDMRST    = PB_5,    // Reset (active low)
+#if defined(TARGET_UBLOX_C030_R410M)
+    MDMTXD    = PA_9,    // Transmit Data
+    MDMRXD    = PA_10,    // Receive Data
+    MDMCTS    = PA_11,    // Clear to Send
+    MDMRTS    = PA_12,    // Request to Send
+#else
     MDMTXD    = PD_5,    // Transmit Data
     MDMRXD    = PD_6,    // Receive Data
     MDMCTS    = PD_3,    // Clear to Send
     MDMRTS    = PD_4,    // Request to Send
+#endif
     MDMDCD    = NC,      // DCD line not connected
     MDMDSR    = NC,      // DSR line not connected
     MDMDTR    = NC,      // DTR line not connected
@@ -149,12 +156,20 @@ typedef enum {
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX
     STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
 #else
+#if defined(TARGET_UBLOX_C030_R410M)
+    STDIO_UART_TX = PD_5,
+#else
     STDIO_UART_TX = PA_9,
+#endif
 #endif
 #ifdef MBED_CONF_TARGET_STDIO_UART_RX
     STDIO_UART_RX = MBED_CONF_TARGET_STDIO_UART_RX,
 #else
+#if defined(TARGET_UBLOX_C030_R410M)
+    STDIO_UART_RX = PD_6,
+#else
     STDIO_UART_RX = PA_10,
+#endif	
 #endif
 
     // ST-Link

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/onboard_modem_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/onboard_modem_api.c
@@ -28,7 +28,12 @@ static void press_power_button(int time_us)
 {
     gpio_t gpio;
 
+#if defined(TARGET_UBLOX_C030_R410M)
+    gpio_init_inout(&gpio, MDMPWRON, PIN_OUTPUT, OpenDrain, 0);
+#else
     gpio_init_out_ex(&gpio, MDMPWRON, 0);
+#endif
+
     wait_us(time_us);
     gpio_write(&gpio, 1);
 }
@@ -51,16 +56,27 @@ void onboard_modem_deinit()
 
 void onboard_modem_power_up()
 {
-    /* keep the power line low for 50 microseconds */
+#if defined(TARGET_UBLOX_C030_R410M)
+	/* keep the power line low for 1 seconds */
+    press_power_button(1000000);
+#else
+	/* keep the power line low for 50 microseconds */
     press_power_button(50);
+#endif
+
     /* give modem a little time to respond */
     wait_ms(100);
 }
 
 void onboard_modem_power_down()
 {
-    /* keep the power line low for 1 second */
+#if defined(TARGET_UBLOX_C030_R410M)
+	/* keep the power line low for 1.5 seconds */
+    press_power_button(1500000);
+#else
+	/* keep the power line low for 1 seconds */
     press_power_button(1000000);
+#endif
 }
 
 #endif //MODEM_ON_BOARD

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/ublox_low_level_api.c
@@ -26,12 +26,18 @@ void ublox_board_init(void) {
     
     // start with modem disabled 
     gpio_init_out_ex(&gpio, MDMRST,    0);
+#if defined(TARGET_UBLOX_C030_R410M)
+    gpio_init_inout(&gpio, MDMPWRON, PIN_OUTPUT, OpenDrain, 1);
+#else
     gpio_init_out_ex(&gpio, MDMPWRON,  0);
+#endif
     gpio_init_out_ex(&gpio, MDMRTS,    0);
     gpio_init_in_ex(&gpio,  MDMCURRENTSENSE, PullNone);
 
-    // start with GNSS disabled
+#if !defined (TARGET_UBLOX_C030_R410M)
+    // start with GNSS disabled, this is ONLY TEMPORARY and that once the HW issue with the GNSSEN pin on the R410M board is resolved then this line will become default for all platforms.
     gpio_init_inout(&gpio,  GNSSEN,  PIN_OUTPUT, PushPullNoPull, 0);
+#endif
 
     // power on SD card
     gpio_init_out_ex(&gpio, SDPWRON,   1);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2122,6 +2122,10 @@
         "inherits": ["UBLOX_C030"],
         "release_versions": ["5"]
     },
+    "UBLOX_C030_R410M": {
+        "inherits": ["UBLOX_C030"],
+        "release_versions": ["5"]
+    },
     "NZ32_SC151": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M3",


### PR DESCRIPTION
## Description

UBLOX_C030_R410M added. The board port is ready in this submission, integration of cellular and GNSS module interfaces will follow. ARM, IAR and GCC toolsets are supported and all mbed platform tests pass.

## Status

**READY**

## Target
UBLOX_C030_R410M





