### PR TITLE
Add support for EFM32GG targets which don't have UART

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralNames.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralNames.h
@@ -51,8 +51,12 @@ typedef enum {
 } PWMName;
 
 typedef enum {
+#ifdef UART0_BASE
     UART_0 = UART0_BASE,
+#endif
+#ifdef UART1_BASE
     UART_1 = UART1_BASE,
+#endif
     USART_0 = USART0_BASE,
     USART_1 = USART1_BASE,
     USART_2 = USART2_BASE,

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
@@ -165,13 +165,17 @@ const PinMap PinMap_SPI_CS[] = {
 
 /************UART**************/
 const PinMap PinMap_UART_TX[] = {
+#ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
     {PE0, UART_0, 1},
+#endif
+#ifdef UART1_BASE
     /* UART1 */
     {PF10, UART_1, 1},
     {PB9, UART_1, 2},
     {PE2, UART_1, 3},
+#endif
     /* USART0 */
     {PE10, USART_0, 0},
     {PE7, USART_0, 1},
@@ -199,13 +203,17 @@ const PinMap PinMap_UART_TX[] = {
 };
 
 const PinMap PinMap_UART_RX[] = {
+#ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},
     {PE1, UART_0, 1},
+#endif
+#ifdef UART1_BASE
     /* UART1 */
     {PF11, UART_1, 1},
     {PB10, UART_1, 2},
     {PE3, UART_1, 3},
+#endif
     /* USART0 */
     {PE11, USART_0, 0},
     {PE6, USART_0, 1},


### PR DESCRIPTION
## Description

Some EFM32GG MCUs do not have `UART0` and `UART1`:
EFM32GG230
EFM32GG232
EFM32GG330
EFM32GG332
EFM32GG840
EFM32GG842
EFM32GG940
EFM32GG942
... while mbed-os in `PeripheralNames.h` and `PeripheralPins.c` assumes that all of them have it. It is kind of understandable, because they are not part of official targets, but it forces people to fork mbed-os for custom boards based on those MCUs.

This PR adds a check for the presence of `UART0` and `UART1` and fixes the last obstacle for me for using mbed-os without forking.

## Status

**READY**

## Migrations

NO