### PR TITLE
STM32: Fix usart irq index

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/serial_device.c
@@ -39,48 +39,60 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(UARTName uart_name);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(UARTName uart_name)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
+    int8_t id = get_uart_index(uart_name);
+
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
+                    irq_handler(serial_irq_ids[id], TxIrq);
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /* Flag has been cleared when reading the content */
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_ERR) != RESET) {
+                    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(UART_1);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(UART_2);
 }
+#endif
 
+#if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(UART_3);
 }
+#endif
 
 void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
@@ -97,20 +109,26 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
+#if defined(USART1_BASE)
     if (obj_s->uart == UART_1) {
         irq_n = USART1_IRQn;
         vector = (uint32_t)&uart1_irq;
     }
+#endif
 
+#if defined(USART2_BASE)
     if (obj_s->uart == UART_2) {
         irq_n = USART2_IRQn;
         vector = (uint32_t)&uart2_irq;
     }
+#endif
 
+#if defined(USART3_BASE)
     if (obj_s->uart == UART_3) {
         irq_n = USART3_IRQn;
         vector = (uint32_t)&uart3_irq;
     }
+#endif
 
     if (enable) {
         if (irq == RxIrq) {
@@ -261,31 +279,33 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
-        case 0:
+    switch (uart_name) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
-
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
-
-        case 2:
+#endif
+#if defined(USART3_BASE)
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
-
+#endif
         default:
             irq_n = (IRQn_Type)0;
     }
-    
+
     return irq_n;
 }
 
@@ -330,7 +350,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -380,7 +400,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);
@@ -471,8 +491,8 @@ int serial_irq_handler_asynch(serial_t *obj)
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_PARITY_ERROR & obj_s->events);
         }
-}
-
+    }
+    
     if (__HAL_UART_GET_FLAG(huart, UART_FLAG_FE) != RESET) {
         if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
             return_event |= (SERIAL_EVENT_RX_FRAMING_ERROR & obj_s->events);
@@ -535,7 +555,7 @@ void serial_tx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    
+
     // reset states
     huart->TxXferCount = 0;
     // update handle state

--- a/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/serial_device.c
@@ -39,83 +39,93 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(UARTName uart_name);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(UARTName uart_name)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
+    int8_t id = get_uart_index(uart_name);
+
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
+                    irq_handler(serial_irq_ids[id], TxIrq);
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /* Flag has been cleared when reading the content */
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
+                    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(UART_1);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(UART_2);
 }
+#endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(UART_3);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(3);
+    uart_irq(UART_4);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(4);
+    uart_irq(UART_5);
 }
 #endif
 
 #if defined(USART6_BASE)
 static void uart6_irq(void)
 {
-    uart_irq(5);
+    uart_irq(UART_6);
 }
 #endif
 
 #if defined(UART7_BASE)
 static void uart7_irq(void)
 {
-    uart_irq(6);
+    uart_irq(UART_7);
 }
 #endif
 
 #if defined(UART8_BASE)
 static void uart8_irq(void)
 {
-    uart_irq(7);
+    uart_irq(UART8);
 }
 #endif
 
@@ -134,48 +144,51 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
-    switch (obj_s->index) {
-        case 0:
+    switch (obj_s->uart) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             vector = (uint32_t)&uart1_irq;
             break;
-
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             vector = (uint32_t)&uart2_irq;
             break;
+#endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             vector = (uint32_t)&uart3_irq;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             vector = (uint32_t)&uart4_irq;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             vector = (uint32_t)&uart5_irq;
             break;
 #endif
 #if defined(USART6_BASE)
-        case 5:
+        case UART_6:
             irq_n = USART6_IRQn;
             vector = (uint32_t)&uart6_irq;
             break;
 #endif
 #if defined(UART7_BASE)
-        case 6:
+        case UART_7:
             irq_n = UART7_IRQn;
             vector = (uint32_t)&uart7_irq;
             break;
 #endif
 #if defined(UART8_BASE)
-        case 7:
+        case UART_8:
             irq_n = UART8_IRQn;
             vector = (uint32_t)&uart8_irq;
             break;
@@ -188,8 +201,8 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         } else { // TxIrq
             __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
-            NVIC_SetVector(irq_n, vector);
-            NVIC_EnableIRQ(irq_n);
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
 
     } else { // disable
         int all_disabled = 0;
@@ -323,55 +336,54 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
+    switch (uart_name) {
 #if defined(USART1_BASE)
-        case 0:
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
 #endif
 #if defined(USART2_BASE)
-        case 1:
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
 #endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             break;
 #endif
 #if defined(USART6_BASE)
-        case 5:
+        case UART_6:
             irq_n = USART6_IRQn;
             break;
 #endif
 #if defined(UART7_BASE)
-        case 6:
+        case UART_7:
             irq_n = UART7_IRQn;
             break;
 #endif
 #if defined(UART8_BASE)
-        case 7:
+        case UART_8:
             irq_n = UART8_IRQn;
             break;
-#endif      
+#endif
         default:
             irq_n = (IRQn_Type)0;
     }
@@ -421,7 +433,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -471,7 +483,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);
@@ -626,7 +638,7 @@ void serial_tx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_FLAG_TC);
-    
+
     // reset states
     huart->TxXferCount = 0;
     // update handle state

--- a/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/serial_device.c
@@ -43,62 +43,72 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(UARTName uart_name);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(UARTName uart_name)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
-            irq_handler(serial_irq_ids[id], TxIrq);
-        }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+    int8_t id = get_uart_index(uart_name);
+
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
+                irq_handler(serial_irq_ids[id], TxIrq);
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
-                __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+            }
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /*  Flag has been cleared when reading the content */
+                }
+            }
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
+                    __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_OREF);
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(UART_1);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(UART_2);
 }
+#endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(UART_3);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(3);
+    uart_irq(UART_4);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(4);
+    uart_irq(UART_5);
 }
 #endif
 
@@ -117,15 +127,19 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
+#if defined(USART1_BASE)
     if (obj_s->uart == UART_1) {
         irq_n = USART1_IRQn;
         vector = (uint32_t)&uart1_irq;
     }
+#endif
 
+#if defined(USART2_BASE)
     if (obj_s->uart == UART_2) {
         irq_n = USART2_IRQn;
         vector = (uint32_t)&uart2_irq;
     }
+#endif
 
 #if defined(USART3_BASE)
     if (obj_s->uart == UART_3) {
@@ -297,42 +311,43 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
-        case 0:
+    switch (uart_name) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
-
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
-
+#endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             break;
 #endif
         default:
             irq_n = (IRQn_Type)0;
     }
-    
+
     return irq_n;
 }
 
@@ -378,7 +393,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -428,7 +443,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);
@@ -586,7 +601,7 @@ void serial_tx_abort_asynch(serial_t *obj)
     
     // clear flags
     __HAL_UART_CLEAR_FLAG(huart, UART_CLEAR_TCF);
-    
+
     // reset states
     huart->TxXferCount = 0;
     // update handle state

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -168,59 +168,63 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
-    switch (obj_s->index) {
-        case 0:
+    switch (obj_s->uart) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             vector = (uint32_t)&uart1_irq;
             break;
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             vector = (uint32_t)&uart2_irq;
             break;
+#endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             vector = (uint32_t)&uart3_irq;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             vector = (uint32_t)&uart4_irq;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             vector = (uint32_t)&uart5_irq;
             break;
 #endif
 #if defined(USART6_BASE)
-        case 5:
+        case UART_6:
             irq_n = USART6_IRQn;
             vector = (uint32_t)&uart6_irq;
             break;
 #endif
 #if defined(UART7_BASE)
-        case 6:
+        case UART_7:
             irq_n = UART7_IRQn;
             vector = (uint32_t)&uart7_irq;
             break;
 #endif
 #if defined(UART8_BASE)
-        case 7:
+        case UART_8:
             irq_n = UART8_IRQn;
             vector = (uint32_t)&uart8_irq;
             break;
 #endif
 #if defined(UART9_BASE)
-        case 8:
+        case UART_9:
             irq_n = UART9_IRQn;
             vector = (uint32_t)&uart9_irq;
             break;
 #endif
 #if defined(UART10_BASE)
-        case 9:
+        case UART_10:
             irq_n = UART10_IRQn;
             vector = (uint32_t)&uart10_irq;
             break;
@@ -233,8 +237,8 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         } else { // TxIrq
             __HAL_UART_ENABLE_IT(huart, UART_IT_TXE);
         }
-            NVIC_SetVector(irq_n, vector);
-            NVIC_EnableIRQ(irq_n);
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
 
     } else { // disable
         int all_disabled = 0;
@@ -253,7 +257,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         }
 
         if (all_disabled) {
-          NVIC_DisableIRQ(irq_n);
+            NVIC_DisableIRQ(irq_n);
         }
     }
 }
@@ -284,7 +288,7 @@ void serial_clear(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     huart->TxXferCount = 0;
     huart->RxXferCount = 0;
 }
@@ -293,7 +297,7 @@ void serial_break_set(serial_t *obj)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
     UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    
+
     HAL_LIN_SendBreak(huart);
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -56,9 +56,10 @@ int8_t get_uart_index(int uart_base);
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int uart_base)
+static void uart_irq(UARTName uart_name)
 {
-    int8_t id = get_uart_index(uart_base);
+    int8_t id = get_uart_index(uart_name);
+
     if (id >= 0) {
         UART_HandleTypeDef * huart = &uart_handlers[id];
         if (serial_irq_ids[id] != 0) {
@@ -85,70 +86,70 @@ static void uart_irq(int uart_base)
 #if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(USART1_BASE);
+    uart_irq(UART_1);
 }
 #endif
 
 #if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(USART2_BASE);
+    uart_irq(UART_2);
 }
 #endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(USART3_BASE);
+    uart_irq(UART_3);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(UART4_BASE);
+    uart_irq(UART_4);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(UART5_BASE);
+    uart_irq(UART_5);
 }
 #endif
 
 #if defined(USART6_BASE)
 static void uart6_irq(void)
 {
-    uart_irq(USART6_BASE);
+    uart_irq(UART_6);
 }
 #endif
 
 #if defined(UART7_BASE)
 static void uart7_irq(void)
 {
-    uart_irq(UART7_BASE);
+    uart_irq(UART_7);
 }
 #endif
 
 #if defined(UART8_BASE)
 static void uart8_irq(void)
 {
-    uart_irq(UART8_BASE);
+    uart_irq(UART_8);
 }
 #endif
 
 #if defined(UART9_BASE)
 static void uart9_irq(void)
 {
-    uart_irq(UART9_BASE);
+    uart_irq(UART_9);
 }
 #endif
 
 #if defined(UART10_BASE)
 static void uart10_irq(void)
 {
-    uart_irq(UART10_BASE);
+    uart_irq(UART_10);
 }
 #endif
 

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -49,97 +49,106 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(int uart_base);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(int uart_base)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
+    int8_t id = get_uart_index(uart_base);
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_TXE) != RESET) {
+                    irq_handler(serial_irq_ids[id], TxIrq);
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /* Flag has been cleared when reading the content */
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
-                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT_SOURCE(huart, USART_IT_ERR) != RESET) {
+                    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->DR; // Clear ORE flag
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(USART1_BASE);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(USART2_BASE);
 }
+#endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(USART3_BASE);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(3);
+    uart_irq(UART4_BASE);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(4);
+    uart_irq(UART5_BASE);
 }
 #endif
 
 #if defined(USART6_BASE)
 static void uart6_irq(void)
 {
-    uart_irq(5);
+    uart_irq(USART6_BASE);
 }
 #endif
 
 #if defined(UART7_BASE)
 static void uart7_irq(void)
 {
-    uart_irq(6);
+    uart_irq(UART7_BASE);
 }
 #endif
 
 #if defined(UART8_BASE)
 static void uart8_irq(void)
 {
-    uart_irq(7);
+    uart_irq(UART8_BASE);
 }
 #endif
 
 #if defined(UART9_BASE)
 static void uart9_irq(void)
 {
-    uart_irq(8);
+    uart_irq(UART9_BASE);
 }
 #endif
 
 #if defined(UART10_BASE)
 static void uart10_irq(void)
 {
-    uart_irq(9);
+    uart_irq(UART10_BASE);
 }
 #endif
 
@@ -163,7 +172,6 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             irq_n = USART1_IRQn;
             vector = (uint32_t)&uart1_irq;
             break;
-
         case 1:
             irq_n = USART2_IRQn;
             vector = (uint32_t)&uart2_irq;

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -50,7 +50,7 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 static uart_irq_handler irq_handler;
 
 // Defined in serial_api.c
-inline int8_t get_uart_index(int uart_base);
+int8_t get_uart_index(int uart_base);
 
 /******************************************************************************
  * INTERRUPTS HANDLING
@@ -367,69 +367,68 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
+    switch (uart_name) {
 #if defined(USART1_BASE)
-        case 0:
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
 #endif
 #if defined(USART2_BASE)
-        case 1:
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
 #endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             break;
 #endif
-#if defined(USART5_BASE)
-        case 4:
+#if defined(UART5_BASE)
+        case UART_5:
             irq_n = UART5_IRQn;
             break;
 #endif
 #if defined(USART6_BASE)
-        case 5:
+        case UART_6:
             irq_n = USART6_IRQn;
             break;
 #endif
 #if defined(UART7_BASE)
-        case 6:
+        case UART_7:
             irq_n = UART7_IRQn;
             break;
 #endif
 #if defined(UART8_BASE)
-        case 7:
+        case UART_8:
             irq_n = UART8_IRQn;
             break;
 #endif
 #if defined(UART9_BASE)
-        case 8:
+        case UART_9:
             irq_n = UART9_IRQn;
             break;
 #endif
 #if defined(UART10_BASE)
-        case 9:
+        case UART_10:
             irq_n = UART10_IRQn;
             break;
 #endif
         default:
             irq_n = (IRQn_Type)0;
     }
-    
+
     return irq_n;
 }
 
@@ -474,7 +473,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -524,7 +523,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);

--- a/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/serial_device.c
@@ -50,7 +50,7 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 static uart_irq_handler irq_handler;
 
 // Defined in serial_api.c
-int8_t get_uart_index(int uart_base);
+inline int8_t get_uart_index(UARTName uart_name);
 
 /******************************************************************************
  * INTERRUPTS HANDLING

--- a/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/serial_device.c
@@ -38,81 +38,93 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(UARTName uart_name);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(UARTName uart_name)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
+    int8_t id = get_uart_index(uart_name);
+
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
+                    irq_handler(serial_irq_ids[id], TxIrq);
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /* Flag has been cleared when reading the content */
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
-                __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
+                    __HAL_UART_CLEAR_IT(huart, UART_CLEAR_OREF);
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(UART_1);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(UART_2);
 }
+#endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(UART_3);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(3);
+    uart_irq(UART_4);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(4);
+    uart_irq(UART_5);
 }
 #endif
 
+#if defined(USART6_BASE)
 static void uart6_irq(void)
 {
-    uart_irq(5);
+    uart_irq(UART_6);
 }
+#endif
 
 #if defined(UART7_BASE)
 static void uart7_irq(void)
 {
-    uart_irq(6);
+    uart_irq(UART_7);
 }
 #endif
 
 #if defined(UART8_BASE)
 static void uart8_irq(void)
 {
-    uart_irq(7);
+    uart_irq(UART_8);
 }
 #endif
 
@@ -132,15 +144,18 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     uint32_t vector = 0;
 
     switch (obj_s->uart) {
+#if defined(USART1_BASE)
         case UART_1:
             irq_n = USART1_IRQn;
             vector = (uint32_t)&uart1_irq;
             break;
-
+#endif
+#if defined(USART2_BASE)
         case UART_2:
             irq_n = USART2_IRQn;
             vector = (uint32_t)&uart2_irq;
             break;
+#endif
 #if defined(USART3_BASE)
         case UART_3:
             irq_n = USART3_IRQn;
@@ -159,10 +174,12 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             vector = (uint32_t)&uart5_irq;
             break;
 #endif
+#if defined(USART6_BASE)
         case UART_6:
             irq_n = USART6_IRQn;
             vector = (uint32_t)&uart6_irq;
             break;
+#endif
 #if defined(UART7_BASE)
         case UART_7:
             irq_n = UART7_IRQn;
@@ -318,55 +335,58 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
-
-        case 0:
+    switch (uart_name) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
-
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
+#endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             break;
 #endif
-        case 5:
+#if defined(USART6_BASE)
+        case UART_6:
             irq_n = USART6_IRQn;
             break;
+#endif
 #if defined(UART7_BASE)
-        case 6:
+        case UART_7:
             irq_n = UART7_IRQn;
             break;
 #endif
 #if defined(UART8_BASE)
-        case 7:
+        case UART_8:
             irq_n = UART8_IRQn;
             break;
 #endif
         default:
             irq_n = (IRQn_Type)0;
     }
-    
+
     return irq_n;
 }
 
@@ -411,7 +431,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -461,7 +481,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);

--- a/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/serial_device.c
@@ -45,69 +45,79 @@ UART_HandleTypeDef uart_handlers[UART_NUM];
 
 static uart_irq_handler irq_handler;
 
+// Defined in serial_api.c
+inline int8_t get_uart_index(UARTName uart_name);
+
 /******************************************************************************
  * INTERRUPTS HANDLING
  ******************************************************************************/
 
-static void uart_irq(int id)
+static void uart_irq(UARTName uart_name)
 {
-    UART_HandleTypeDef * huart = &uart_handlers[id];
-    
-    if (serial_irq_ids[id] != 0) {
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
-                irq_handler(serial_irq_ids[id], TxIrq);
+    int8_t id = get_uart_index(uart_name);
+
+    if (id >= 0) {
+        UART_HandleTypeDef * huart = &uart_handlers[id];
+        if (serial_irq_ids[id] != 0) {
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_TXE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_TXE) != RESET) {
+                    irq_handler(serial_irq_ids[id], TxIrq);
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
-                irq_handler(serial_irq_ids[id], RxIrq);
-                /*  Flag has been cleared when reading the content */
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_RXNE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_RXNE) != RESET) {
+                    irq_handler(serial_irq_ids[id], RxIrq);
+                    /* Flag has been cleared when reading the content */
+                }
             }
-        }
-        if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
-            if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
-                volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear ORE flag
+            if (__HAL_UART_GET_FLAG(huart, UART_FLAG_ORE) != RESET) {
+                if (__HAL_UART_GET_IT(huart, UART_IT_ORE) != RESET) {
+                    volatile uint32_t tmpval __attribute__((unused)) = huart->Instance->RDR; // Clear ORE flag
+                }
             }
         }
     }
 }
 
+#if defined(USART1_BASE)
 static void uart1_irq(void)
 {
-    uart_irq(0);
+    uart_irq(UART_1);
 }
+#endif
 
+#if defined(USART2_BASE)
 static void uart2_irq(void)
 {
-    uart_irq(1);
+    uart_irq(UART_2);
 }
+#endif
 
 #if defined(USART3_BASE)
 static void uart3_irq(void)
 {
-    uart_irq(2);
+    uart_irq(UART_3);
 }
 #endif
 
 #if defined(UART4_BASE)
 static void uart4_irq(void)
 {
-    uart_irq(3);
+    uart_irq(UART_4);
 }
 #endif
 
 #if defined(UART5_BASE)
 static void uart5_irq(void)
 {
-    uart_irq(4);
+    uart_irq(UART_5);
 }
 #endif
 
 #if defined(LPUART1_BASE)
 static void lpuart1_irq(void)
 {
-    uart_irq(5);
+    uart_irq(LPUART_1);
 }
 #endif
 
@@ -126,41 +136,44 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
     IRQn_Type irq_n = (IRQn_Type)0;
     uint32_t vector = 0;
 
-    if (obj_s->uart == UART_1) {
-        irq_n = USART1_IRQn;
-        vector = (uint32_t)&uart1_irq;
-    }
-
-    if (obj_s->uart == UART_2) {
-        irq_n = USART2_IRQn;
-        vector = (uint32_t)&uart2_irq;
-    }
+    switch (obj_s->uart) {
+#if defined(USART1_BASE)
+        case UART_1:
+            irq_n = USART1_IRQn;
+            vector = (uint32_t)&uart1_irq;
+            break;
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
+            irq_n = USART2_IRQn;
+            vector = (uint32_t)&uart2_irq;
+            break;
+#endif
 #if defined(USART3_BASE)
-    if (obj_s->uart == UART_3) {
-        irq_n = USART3_IRQn;
-        vector = (uint32_t)&uart3_irq;
-    }
+        case UART_3:
+            irq_n = USART3_IRQn;
+            vector = (uint32_t)&uart3_irq;
+            break;
 #endif
 #if defined(UART4_BASE)
-    if (obj_s->uart == UART_4) {
-        irq_n = UART4_IRQn;
-        vector = (uint32_t)&uart4_irq;
-    }
+        case UART_4:
+            irq_n = UART4_IRQn;
+            vector = (uint32_t)&uart4_irq;
+            break;
 #endif
-
 #if defined(UART5_BASE)
-    if (obj_s->uart == UART_5) {
-        irq_n = UART5_IRQn;
-        vector = (uint32_t)&uart5_irq;
-    }
+        case UART_5:
+            irq_n = UART5_IRQn;
+            vector = (uint32_t)&uart5_irq;
+            break;
 #endif
-
 #if defined(LPUART1_BASE)
-    if (obj_s->uart == LPUART_1) {
-        irq_n = LPUART1_IRQn;
-        vector = (uint32_t)&lpuart1_irq;
-    }
+        case LPUART_1:
+            irq_n = LPUART1_IRQn;
+            vector = (uint32_t)&lpuart1_irq;
+            break;
 #endif
+    }
 
     if (enable) {
         if (irq == RxIrq) {
@@ -311,48 +324,48 @@ static void serial_enable_event(serial_t *obj, int event, uint8_t enable)
 /**
 * Get index of serial object TX IRQ, relating it to the physical peripheral.
 *
-* @param obj pointer to serial object
+* @param uart_name i.e. UART_1, UART_2, ...
 * @return internal NVIC TX IRQ index of U(S)ART peripheral
 */
-static IRQn_Type serial_get_irq_n(serial_t *obj)
+static IRQn_Type serial_get_irq_n(UARTName uart_name)
 {
-    struct serial_s *obj_s = SERIAL_S(obj);
     IRQn_Type irq_n;
 
-    switch (obj_s->index) {
-        case 0:
+    switch (uart_name) {
+#if defined(USART1_BASE)
+        case UART_1:
             irq_n = USART1_IRQn;
             break;
-
-        case 1:
+#endif
+#if defined(USART2_BASE)
+        case UART_2:
             irq_n = USART2_IRQn;
             break;
-
+#endif
 #if defined(USART3_BASE)
-        case 2:
+        case UART_3:
             irq_n = USART3_IRQn;
             break;
 #endif
 #if defined(UART4_BASE)
-        case 3:
+        case UART_4:
             irq_n = UART4_IRQn;
             break;
 #endif
 #if defined(UART5_BASE)
-        case 4:
+        case UART_5:
             irq_n = UART5_IRQn;
             break;
 #endif
 #if defined(LPUART1_BASE)
-        case 5:
+        case LPUART_1:
             irq_n = LPUART1_IRQn;
             break;
 #endif
-
         default:
             irq_n = (IRQn_Type)0;
     }
-    
+
     return irq_n;
 }
 
@@ -397,7 +410,7 @@ int serial_tx_asynch(serial_t *obj, const void *tx, size_t tx_length, uint8_t tx
     serial_enable_event(obj, event, 1); // Set only the wanted events
     
     // Enable interrupt
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 1);
@@ -447,7 +460,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     
     serial_rx_buffer_set(obj, rx, rx_length, rx_width);
 
-    IRQn_Type irq_n = serial_get_irq_n(obj);
+    IRQn_Type irq_n = serial_get_irq_n(obj_s->uart);
     NVIC_ClearPendingIRQ(irq_n);
     NVIC_DisableIRQ(irq_n);
     NVIC_SetPriority(irq_n, 0);

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -563,77 +563,107 @@ int8_t get_uart_index(UARTName uart_name)
     uint8_t index = 0;
 
 #if defined(USART1_BASE)
-    if (uart_name == UART_1) return index;
+    if (uart_name == UART_1) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART2_BASE)
-    if (uart_name == UART_2) return index;
+    if (uart_name == UART_2) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART3_BASE)
-    if (uart_name == UART_3) return index;
+    if (uart_name == UART_3) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART4_BASE)
-    if (uart_name == UART_4) return index;
+    if (uart_name == UART_4) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART4_BASE)
-    if (uart_name == UART_4) return index;
+    if (uart_name == UART_4) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART5_BASE)
-    if (uart_name == UART_5) return index;
+    if (uart_name == UART_5) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART5_BASE)
-    if (uart_name == UART_5) return index;
+    if (uart_name == UART_5) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART6_BASE)
-    if (uart_name == UART_6) return index;
+    if (uart_name == UART_6) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART7_BASE)
-    if (uart_name == UART_7) return index;
+    if (uart_name == UART_7) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART7_BASE)
-    if (uart_name == UART_7) return index;
+    if (uart_name == UART_7) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART8_BASE)
-    if (uart_name == UART_8) return index;
+    if (uart_name == UART_8) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(USART8_BASE)
-    if (uart_name == UART_8) return index;
+    if (uart_name == UART_8) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART9_BASE)
-    if (uart_name == UART_9) return index;
+    if (uart_name == UART_9) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(UART10_BASE)
-    if (uart_name == UART_10) return index;
+    if (uart_name == UART_10) {
+        return index;
+    }
     index++;
 #endif
 
 #if defined(LPUART1_BASE)
-    if (uart_name == LPUART_1) return index;
+    if (uart_name == LPUART_1) {
+        return index;
+    }
     index++;
 #endif
 

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -558,81 +558,82 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
 
 // Warning: the list of UART/USART in this function must be aligned with the list
 // written in serial_init function.
-inline int8_t get_uart_index(int uart_base)
+inline int8_t get_uart_index(UARTName uart_name)
 {
     uint8_t index = 0;
+
 #if defined(USART1_BASE)
-    if (uart_base == USART1_BASE) return index;
+    if (uart_name == UART_1) return index;
     index++;
 #endif
 
 #if defined(USART2_BASE)
-    if (uart_base == USART2_BASE) return index;
+    if (uart_name == UART_2) return index;
     index++;
 #endif
 
 #if defined(USART3_BASE)
-    if (uart_base == USART3_BASE) return index;
+    if (uart_name == UART_3) return index;
     index++;
 #endif
 
 #if defined(UART4_BASE)
-    if (uart_base == UART4_BASE) return index;
+    if (uart_name == UART_4) return index;
     index++;
 #endif
 
 #if defined(USART4_BASE)
-    if (uart_base == USART4_BASE) return index;
+    if (uart_name == UART_4) return index;
     index++;
 #endif
 
 #if defined(UART5_BASE)
-    if (uart_base == UART5_BASE) return index;
+    if (uart_name == UART_5) return index;
     index++;
 #endif
 
 #if defined(USART5_BASE)
-    if (uart_base == USART5_BASE) return index;
+    if (uart_name == UART_5) return index;
     index++;
 #endif
 
 #if defined(USART6_BASE)
-    if (uart_base == USART6_BASE) return index;
+    if (uart_name == UART_6) return index;
     index++;
 #endif
 
 #if defined(UART7_BASE)
-    if (uart_base == UART7_BASE) return index;
+    if (uart_name == UART_7) return index;
     index++;
 #endif
 
 #if defined(USART7_BASE)
-    if (uart_base == USART7_BASE) return index;
+    if (uart_name == UART_7) return index;
     index++;
 #endif
 
 #if defined(UART8_BASE)
-    if (uart_base == UART8_BASE) return index;
+    if (uart_name == UART_8) return index;
     index++;
 #endif
 
 #if defined(USART8_BASE)
-    if (uart_base == USART8_BASE) return index;
+    if (uart_name == UART_8) return index;
     index++;
 #endif
 
 #if defined(UART9_BASE)
-    if (uart_base == UART9_BASE) return index;
+    if (uart_name == UART_9) return index;
     index++;
 #endif
 
 #if defined(UART10_BASE)
-    if (uart_base == UART10_BASE) return index;
+    if (uart_name == UART_10) return index;
     index++;
 #endif
 
 #if defined(LPUART1_BASE)
-    if (uart_base == LPUART1_BASE) return index;
+    if (uart_name == LPUART_1) return index;
     index++;
 #endif
 

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -44,7 +44,6 @@ HAL_StatusTypeDef init_uart(serial_t *obj);
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
-    int IndexNumber = 0;
     uint8_t stdio_config = 0;
 
     // Determine the UART to use (UART_1, UART_2, ...)
@@ -64,15 +63,13 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         }
     }
 
-    // Enable USART clock
+    // Reset and enable clock
 #if defined(USART1_BASE)
     if (obj_s->uart == UART_1) {
         __HAL_RCC_USART1_FORCE_RESET();
         __HAL_RCC_USART1_RELEASE_RESET();
         __HAL_RCC_USART1_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined (USART2_BASE)
@@ -80,9 +77,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART2_FORCE_RESET();
         __HAL_RCC_USART2_RELEASE_RESET();
         __HAL_RCC_USART2_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART3_BASE)
@@ -90,9 +85,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART3_FORCE_RESET();
         __HAL_RCC_USART3_RELEASE_RESET();
         __HAL_RCC_USART3_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART4_BASE)
@@ -100,9 +93,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART4_FORCE_RESET();
         __HAL_RCC_UART4_RELEASE_RESET();
         __HAL_RCC_UART4_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART4_BASE)
@@ -110,9 +101,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART4_FORCE_RESET();
         __HAL_RCC_USART4_RELEASE_RESET();
         __HAL_RCC_USART4_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART5_BASE)
@@ -120,9 +109,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART5_FORCE_RESET();
         __HAL_RCC_UART5_RELEASE_RESET();
         __HAL_RCC_UART5_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART5_BASE)
@@ -130,9 +117,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART5_FORCE_RESET();
         __HAL_RCC_USART5_RELEASE_RESET();
         __HAL_RCC_USART5_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART6_BASE)
@@ -140,9 +125,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART6_FORCE_RESET();
         __HAL_RCC_USART6_RELEASE_RESET();
         __HAL_RCC_USART6_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART7_BASE)
@@ -150,9 +133,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART7_FORCE_RESET();
         __HAL_RCC_UART7_RELEASE_RESET();
         __HAL_RCC_UART7_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART7_BASE)
@@ -160,9 +141,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART7_FORCE_RESET();
         __HAL_RCC_USART7_RELEASE_RESET();
         __HAL_RCC_USART7_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART8_BASE)
@@ -170,9 +149,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART8_FORCE_RESET();
         __HAL_RCC_UART8_RELEASE_RESET();
         __HAL_RCC_UART8_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(USART8_BASE)
@@ -180,9 +157,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART8_FORCE_RESET();
         __HAL_RCC_USART8_RELEASE_RESET();
         __HAL_RCC_USART8_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART9_BASE)
@@ -190,9 +165,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART9_FORCE_RESET();
         __HAL_RCC_UART9_RELEASE_RESET();
         __HAL_RCC_UART9_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(UART10_BASE)
@@ -200,9 +173,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_UART10_FORCE_RESET();
         __HAL_RCC_UART10_RELEASE_RESET();
         __HAL_RCC_UART10_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
 
 #if defined(LPUART1_BASE)
@@ -210,10 +181,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_LPUART1_FORCE_RESET();
         __HAL_RCC_LPUART1_RELEASE_RESET();
         __HAL_RCC_LPUART1_CLK_ENABLE();
-        obj_s->index = IndexNumber;
     }
-    IndexNumber++;
 #endif
+
+    // Assign serial object index
+    obj_s->index = get_uart_index(obj_s->uart);
+    MBED_ASSERT(obj_s->index >= 0);
 
     // Configure UART pins
     pinmap_pinout(tx, PinMap_UART_TX);
@@ -556,8 +529,6 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
     return HAL_UART_Init(huart);
 }
 
-// Warning: the list of UART/USART in this function must be aligned with the list
-// written in serial_init function.
 int8_t get_uart_index(UARTName uart_name)
 {
     uint8_t index = 0;

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -38,6 +38,9 @@ serial_t stdio_uart;
 extern UART_HandleTypeDef uart_handlers[];
 extern uint32_t serial_irq_ids[];
 
+// Utility functions
+HAL_StatusTypeDef init_uart(serial_t *obj);
+
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
@@ -201,7 +204,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     }
     IndexNumber++;
 #endif
-
 
 #if defined(LPUART1_BASE)
     if (obj_s->uart == LPUART_1) {
@@ -423,38 +425,6 @@ void serial_baud(serial_t *obj, int baudrate)
     }
 }
 
-HAL_StatusTypeDef init_uart(serial_t *obj)
-{
-    struct serial_s *obj_s = SERIAL_S(obj);
-    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
-    huart->Instance = (USART_TypeDef *)(obj_s->uart);
-
-    huart->Init.BaudRate     = obj_s->baudrate;
-    huart->Init.WordLength   = obj_s->databits;
-    huart->Init.StopBits     = obj_s->stopbits;
-    huart->Init.Parity       = obj_s->parity;
-#if DEVICE_SERIAL_FC
-    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
-#else
-    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
-#endif
-    huart->Init.OverSampling = UART_OVERSAMPLING_16;
-    huart->TxXferCount       = 0;
-    huart->TxXferSize        = 0;
-    huart->RxXferCount       = 0;
-    huart->RxXferSize        = 0;
-
-    if (obj_s->pin_rx == NC) {
-        huart->Init.Mode = UART_MODE_TX;
-    } else if (obj_s->pin_tx == NC) {
-        huart->Init.Mode = UART_MODE_RX;
-    } else {
-        huart->Init.Mode = UART_MODE_TX_RX;
-    }
-
-    return HAL_UART_Init(huart);
-}
-
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits)
 {
     struct serial_s *obj_s = SERIAL_S(obj);
@@ -549,5 +519,42 @@ void serial_break_clear(serial_t *obj)
 {
     (void)obj;
 }
+
+/******************************************************************************
+ * UTILITY FUNCTIONS
+ ******************************************************************************/
+
+HAL_StatusTypeDef init_uart(serial_t *obj)
+{
+    struct serial_s *obj_s = SERIAL_S(obj);
+    UART_HandleTypeDef *huart = &uart_handlers[obj_s->index];
+    huart->Instance = (USART_TypeDef *)(obj_s->uart);
+
+    huart->Init.BaudRate     = obj_s->baudrate;
+    huart->Init.WordLength   = obj_s->databits;
+    huart->Init.StopBits     = obj_s->stopbits;
+    huart->Init.Parity       = obj_s->parity;
+#if DEVICE_SERIAL_FC
+    huart->Init.HwFlowCtl    = obj_s->hw_flow_ctl;
+#else
+    huart->Init.HwFlowCtl    = UART_HWCONTROL_NONE;
+#endif
+    huart->Init.OverSampling = UART_OVERSAMPLING_16;
+    huart->TxXferCount       = 0;
+    huart->TxXferSize        = 0;
+    huart->RxXferCount       = 0;
+    huart->RxXferSize        = 0;
+
+    if (obj_s->pin_rx == NC) {
+        huart->Init.Mode = UART_MODE_TX;
+    } else if (obj_s->pin_tx == NC) {
+        huart->Init.Mode = UART_MODE_RX;
+    } else {
+        huart->Init.Mode = UART_MODE_TX_RX;
+    }
+
+    return HAL_UART_Init(huart);
+}
+
 
 #endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -558,7 +558,7 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
 
 // Warning: the list of UART/USART in this function must be aligned with the list
 // written in serial_init function.
-inline int8_t get_uart_index(UARTName uart_name)
+int8_t get_uart_index(UARTName uart_name)
 {
     uint8_t index = 0;
 

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -40,6 +40,7 @@ extern uint32_t serial_irq_ids[];
 
 // Utility functions
 HAL_StatusTypeDef init_uart(serial_t *obj);
+int8_t get_uart_index(UARTName uart_name);
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)
 {

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -556,5 +556,87 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
     return HAL_UART_Init(huart);
 }
 
+// Warning: the list of UART/USART in this function must be aligned with the list
+// written in serial_init function.
+inline int8_t get_uart_index(int uart_base)
+{
+    uint8_t index = 0;
+#if defined(USART1_BASE)
+    if (uart_base == USART1_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART2_BASE)
+    if (uart_base == USART2_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART3_BASE)
+    if (uart_base == USART3_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART4_BASE)
+    if (uart_base == UART4_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART4_BASE)
+    if (uart_base == USART4_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART5_BASE)
+    if (uart_base == UART5_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART5_BASE)
+    if (uart_base == USART5_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART6_BASE)
+    if (uart_base == USART6_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART7_BASE)
+    if (uart_base == UART7_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART7_BASE)
+    if (uart_base == USART7_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART8_BASE)
+    if (uart_base == UART8_BASE) return index;
+    index++;
+#endif
+
+#if defined(USART8_BASE)
+    if (uart_base == USART8_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART9_BASE)
+    if (uart_base == UART9_BASE) return index;
+    index++;
+#endif
+
+#if defined(UART10_BASE)
+    if (uart_base == UART10_BASE) return index;
+    index++;
+#endif
+
+#if defined(LPUART1_BASE)
+    if (uart_base == LPUART1_BASE) return index;
+    index++;
+#endif
+
+    return -1;
+}
 
 #endif /* DEVICE_SERIAL */


### PR DESCRIPTION
## Description

- There was an issue with the `serial irq index` used in the STM32 serial api implementation. On some platforms the indexes was wrong and this results to wrong usart access.
- The issue has been flagged in #5916 and #5931
- A fix has been found by @marcemmers (thanks again!) and done for STM32L0 devices in PR #5917. But this PR has been closed due to this one covering all STM32 devices.

## Status
**READY**

## Migrations
NO

## Todos
- [ ] Tests

@marcemmers can you please test it in your application for the STM32L0 ?

