### PR TITLE
VS Code exporter: do not overwrite existing (launch|settings|tasks).json

### DIFF
--- a/tools/export/vscode/__init__.py
+++ b/tools/export/vscode/__init__.py
@@ -40,12 +40,13 @@ class VSCode(Makefile):
         if not exists(join(self.export_dir, '.vscode')):
             makedirs(join(self.export_dir, '.vscode'))
 
-        self.gen_file('vscode/tasks.tmpl', ctx,
-                      join('.vscode', 'tasks.json'))
-        self.gen_file('vscode/launch.tmpl', ctx,
-                      join('.vscode', 'launch.json'))
-        self.gen_file('vscode/settings.tmpl', ctx,
-                      join('.vscode', 'settings.json'))
+        config_files = ['launch', 'settings', 'tasks']
+        for file in config_files:
+            if not exists('.vscode/%s.json' % file):
+                self.gen_file('vscode/%s.tmpl' % file, ctx,
+                              '.vscode/%s.json' % file)
+            else:
+                print 'Keeping existing %s.json' % file
 
         # So.... I want all .h and .hpp files in self.resources.inc_dirs
         all_directories = []


### PR DESCRIPTION
## Description

Prevents overwriting VS Code files which are customizable by the user. `launch.json` is used to define the debugger and target, `settings.json` includes all possible project-specific VS Code settings, `tasks.json` defines the build tasks.

The only file which is still being overwritten is the list of includes: `c_cpp_properties.json`

Fixes https://github.com/ARMmbed/mbed-os/issues/5958

## Status

**READY**

## Migrations

NO