### PR TITLE
Removed TRNG peripheral from GR_LECHEE target

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2571,7 +2571,7 @@
         "inherits": ["RZ_A1XX"],
         "supported_form_factors": ["ARDUINO"],
         "extra_labels_add": ["RZA1UL", "MBRZA1LU"],
-        "device_has_add": ["TRNG"],
+        "device_has_add": [],
         "device_has_remove": ["ETHERNET"],
         "features_remove": ["LWIP"],
         "release_versions": ["2", "5"]


### PR DESCRIPTION
## Description

A continuation of the following PR: https://github.com/ARMmbed/mbed-os/pull/5857

Disabling TRNG for the GR_LYCHEE board until @hanno-arm comments are addressed in a separate PR.

## Status

**READY**