### PR TITLE
STM32F7: Add bootloader support (new trial)

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/system_clock.c
@@ -30,6 +30,7 @@
 **/
 
 #include "stm32f7xx.h"
+#include "nvic_addr.h"
 #include "mbed_assert.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -92,7 +93,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = RAMDTCM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_MICRO/stm32f746xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_MICRO/stm32f746xg.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F746NG: 1024 KB FLASH (0x100000) + 320 KB SRAM (0x50000)
-LR_IROM1 0x08000000 0x100000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
+
+; STM32F746NG: 1024 KB FLASH (0x100000) + 320 KB SRAM (0x50000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_STD/stm32f746xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_ARM_STD/stm32f746xg.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F746NG: 1024 KB FLASH (0x100000) + 320 KB SRAM (0x50000)
-LR_IROM1 0x08000000 0x100000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
+
+; STM32F746NG: 1024 KB FLASH (0x100000) + 320 KB SRAM (0x50000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
@@ -1,7 +1,16 @@
 /* Linker script to configure memory regions. */
+
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 1024K
+#endif
+
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   RAM (rwx)  : ORIGIN = 0x200001C8, LENGTH = 320K - 0x1C8
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_IAR/stm32f746xg.icf
@@ -1,7 +1,10 @@
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
+
 /* [ROM = 1024kb = 0x100000] */
-define symbol __intvec_start__     = 0x08000000;
-define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x080FFFFF;
+define symbol __intvec_start__     = MBED_APP_START;
+define symbol __region_ROM_start__ = MBED_APP_START;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 320kb = 0x50000] Vector table dynamic copy: 114 vectors = 456 bytes (0x1C8) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
@@ -30,6 +30,7 @@
 **/
 
 #include "stm32f7xx.h"
+#include "nvic_addr.h"
 #include "mbed_assert.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -92,7 +93,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = RAMDTCM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
 }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_MICRO/stm32f767xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_MICRO/stm32f767xi.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
-LR_IROM1 0x08000000 0x200000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x200000
+#endif
+
+; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_ARM_STD/stm32f767xi.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -27,10 +28,18 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
-LR_IROM1 0x08000000 0x200000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x200000  {  ; load address = execution address
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x200000
+#endif
+
+; STM32F767ZI: 2048 KB FLASH (0x200000) + 512 KB SRAM (0x80000)
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
@@ -1,7 +1,16 @@
 /* Linker script to configure memory regions. */
+
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 2048K
+#endif
+
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2048K
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   RAM (rwx)  : ORIGIN = 0x200001F8, LENGTH = 512K - 0x1F8
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_IAR/stm32f767xi.icf
@@ -1,7 +1,10 @@
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x200000; }
+
 /* [ROM = 2048kb = 0x200000] */
-define symbol __intvec_start__     = 0x08000000;
-define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x081FFFFF;
+define symbol __intvec_start__     = MBED_APP_START;
+define symbol __region_ROM_start__ = MBED_APP_START;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 512kb = 0x80000] Vector table dynamic copy: 126 vectors = 504 bytes (0x1F8) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -35,9 +35,16 @@ void mbed_sdk_init()
     HAL_Init();
 
 #if TARGET_STM32F7
-    // Enable CPU L1-Cache
-    SCB_EnableICache();
-    SCB_EnableDCache();
+    // The mbed_sdk_init can be called either during cold boot or during
+    // application boot after bootloader has been executed.
+    // In case the bootloader has already enabled the cache,
+    // is is needed to not enable it again.
+    if (SCB->CCR & (uint32_t)SCB_CCR_IC_Msk == 0) { // If ICache is disabled
+        SCB_EnableICache();
+    }
+    if (SCB->CCR & (uint32_t)SCB_CCR_DC_Msk == 0) { // If DCache is disabled
+        SCB_EnableDCache();
+    }
 #endif /* TARGET_STM32F7 */
 
     /* Configure the System clock source, PLL Multiplier and Divider factors,

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -30,22 +30,22 @@
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
 {
-    // Update the SystemCoreClock variable.
-    SystemCoreClockUpdate();
-    HAL_Init();
-
 #if TARGET_STM32F7
     // The mbed_sdk_init can be called either during cold boot or during
     // application boot after bootloader has been executed.
     // In case the bootloader has already enabled the cache,
     // is is needed to not enable it again.
-    if (SCB->CCR & (uint32_t)SCB_CCR_IC_Msk == 0) { // If ICache is disabled
+    if ((SCB->CCR & (uint32_t)SCB_CCR_IC_Msk) == 0) { // If ICache is disabled
         SCB_EnableICache();
     }
-    if (SCB->CCR & (uint32_t)SCB_CCR_DC_Msk == 0) { // If DCache is disabled
+    if ((SCB->CCR & (uint32_t)SCB_CCR_DC_Msk) == 0) { // If DCache is disabled
         SCB_EnableDCache();
     }
 #endif /* TARGET_STM32F7 */
+
+    // Update the SystemCoreClock variable.
+    SystemCoreClockUpdate();
+    HAL_Init();
 
     /* Configure the System clock source, PLL Multiplier and Divider factors,
        AHB/APBx prescalers and Flash settings */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1346,7 +1346,8 @@
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F767ZI"
+        "device_name": "STM32F767ZI",
+        "bootloader_supported": true
     },
     "NUCLEO_L011K4": {
         "inherits": ["FAMILY_STM32"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1289,7 +1289,8 @@
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F746ZG"
+        "device_name": "STM32F746ZG",
+        "bootloader_supported": true
     },
     "NUCLEO_F756ZG": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
## Description
- First trial done in PR #5821 but reverted in PR #5932 due to a sync issue with CI tests on ARM side. Not reproduce on my side.
- The only thing I changed compared to the previous PR is the Cache initialization which is done first in the mbed_sdk_init function.

## Status
**IN DEVELOPMENT**

Waiting ci-test result to see if sync issue is still present or not.


