### PR TITLE
Feature watchdog: Add definition of reset reason and watchdog doxy groups

### DIFF
--- a/hal/reset_reason_api.h
+++ b/hal/reset_reason_api.h
@@ -26,6 +26,11 @@
 extern "C" {
 #endif
 
+/**
+ * \defgroup hal_reset_reason Reset Reason HAL API
+ * @{
+ */
+
 typedef enum {
   RESET_REASON_POWER_ON,       /**< Set when power is initially applied to the board. The power-on-reset circuit causes a POWER_ON reset when this occurs */
   RESET_REASON_PIN_RESET,      /**< Set when a reset is triggered by the hardware pin on the board */

--- a/hal/watchdog_api.h
+++ b/hal/watchdog_api.h
@@ -24,6 +24,11 @@
 #include <stdbool.h>
 #include <stdint.h>
 
+/**
+ * \defgroup hal_watchdog Watchdog HAL API
+ * @{
+ */
+
 /** \file watchdog_api.h
  *
  * This module provides platform independent access to the system watchdog timer


### PR DESCRIPTION
Add missing doxy tags for HAL API groups, the closing tags are already there.
