### PR TITLE
feature_ble: rename error_t to nrf_error_t

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.cpp
@@ -75,7 +75,7 @@ static uint32_t signalEvent()
     return NRF_SUCCESS;
 }
 
-error_t btle_init(void)
+nrf_error_t btle_init(void)
 {
     nrf_clock_lfclksrc_t clockSource;
     if (NRF_CLOCK->LFCLKSRC & (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos)) {

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.h
@@ -26,7 +26,7 @@ extern "C" {
 #include "ble_srv_common.h"
 #include "nrf_ble.h"
 
-error_t     btle_init(void);
+nrf_error_t     btle_init(void);
 
 // flag indicating if events have been signaled or not
 // It is used by processEvents and signalEventsToProcess

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_advertising.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_advertising.cpp
@@ -25,7 +25,7 @@
     @returns
 */
 /**************************************************************************/
-error_t btle_advertising_start(void)
+nrf_error_t btle_advertising_start(void)
 {
     ble_gap_adv_params_t adv_para = {0};
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_advertising.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_advertising.h
@@ -19,6 +19,6 @@
 
 #include "common/common.h"
 
-error_t btle_advertising_start(void);
+nrf_error_t btle_advertising_start(void);
 
 #endif // ifndef _BTLE_ADVERTISING_H_

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_gap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_gap.cpp
@@ -30,7 +30,7 @@ static void   error_callback(uint32_t nrf_error);
     @returns
 */
 /**************************************************************************/
-error_t btle_gap_init(void)
+nrf_error_t btle_gap_init(void)
 {
     ble_gap_conn_params_t gap_conn_params = {0};
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_gap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle_gap.h
@@ -19,6 +19,6 @@
 
 #include "common/common.h"
 
-error_t btle_gap_init(void);
+nrf_error_t btle_gap_init(void);
 
 #endif // ifndef _BTLE_GAP_H_

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/custom/custom_helper.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/custom/custom_helper.cpp
@@ -162,7 +162,7 @@ uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base)
 
 */
 /**************************************************************************/
-error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
                                 ble_uuid_t          *p_uuid)
 {
     UUID::LongUUIDBytes_t uuid_base_le;
@@ -197,7 +197,7 @@ error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t       requiredSecurity,
@@ -326,7 +326,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_descriptor(uint16_t    char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t    char_handle,
                                  ble_uuid_t *p_uuid,
                                  uint8_t    *p_data,
                                  uint16_t    length,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/custom/custom_helper.h
@@ -27,11 +27,11 @@ extern "C" {
 #endif
 
 uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base);
-error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
                            ble_uuid_t          *p_uuid);
 ble_uuid_t custom_convert_to_nordic_uuid(const UUID &uuid);
 
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t requiredSecurity,
@@ -45,7 +45,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      bool                      writeAuthorization,
                                      ble_gatts_char_handles_t *p_char_handle);
 
-error_t custom_add_in_descriptor(uint16_t                      char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t                      char_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/assertion.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/assertion.h
@@ -108,18 +108,18 @@ static inline void debugger_breakpoint(void)
 #define ASSERT_DEFINE(...) ASSERT_DEFINE_WITH_HANDLER(ASSERT_ERROR_HANDLER, NULL, __VA_ARGS__)
 
 //--------------------------------------------------------------------+
-// error_t Status Assert TODO use ASSERT_DEFINE
+// nrf_error_t Status Assert TODO use ASSERT_DEFINE
 //--------------------------------------------------------------------+
 #define ASSERT_STATUS_MESSAGE(sts, message) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "%s: %s", ErrorStr[status], message)
 
 #define ASSERT_STATUS(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "error = %d", status)
 
 #define ASSERT_STATUS_RET_VOID(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, (void) 0, "error = %d", status)
 
 //--------------------------------------------------------------------+

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/ble_error.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/common/ble_error.h
@@ -140,7 +140,7 @@ typedef enum
   ERROR_BLEGATTS_INVALID_ATTR_TYPE              = 0x3400 , /**< Invalid attribute type. */
   ERROR_BLEGATTS_SYS_ATTR_MISSING               = 0x3401 , /**< System Attributes missing. */
 
-}error_t;
+}nrf_error_t;
 
 #ifdef __cplusplus
  }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.cpp
@@ -292,7 +292,7 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
         }
 
         if (updatesEnabled) {
-            error_t error = (error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
+            nrf_error_t error = (nrf_error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
             if (error != ERROR_NONE) {
                 switch (error) {
                     case ERROR_BLE_NO_TX_BUFFERS: /*  Notifications consume application buffers. The return value can be used for resending notifications. */

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -96,7 +96,7 @@ static uint32_t signalEvent()
 }
 
 
-error_t btle_init(void)
+nrf_error_t btle_init(void)
 {
     nrf_clock_lf_cfg_t clockConfiguration;
 
@@ -126,7 +126,7 @@ error_t btle_init(void)
      * Characteristics turned off, then clients are allowed to cache attribute
      * handles making applications simpler on both sides.
      */
-    static const bool IS_SRVC_CHANGED_CHARACT_PRESENT = true;
+    static const bool IS_SRVC_CHANGED_CHARACT_PRESENT = false;
 
     ble_enable_params_t ble_enable_params;
     uint32_t err_code = softdevice_enable_get_default_config(CENTRAL_LINK_COUNT,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -126,7 +126,7 @@ nrf_error_t btle_init(void)
      * Characteristics turned off, then clients are allowed to cache attribute
      * handles making applications simpler on both sides.
      */
-    static const bool IS_SRVC_CHANGED_CHARACT_PRESENT = false;
+    static const bool IS_SRVC_CHANGED_CHARACT_PRESENT = true;
 
     ble_enable_params_t ble_enable_params;
     uint32_t err_code = softdevice_enable_get_default_config(CENTRAL_LINK_COUNT,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
@@ -33,7 +33,7 @@ extern "C" {
 #define GATTS_ATTR_TAB_SIZE 0x600 /**< GATTS attribite table size. */
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
 
-error_t     btle_init(void);
+nrf_error_t     btle_init(void);
 
 // flag indicating if events have been signaled or not
 // It is used by processEvents and signalEventsToProcess

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_gap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_gap.cpp
@@ -30,7 +30,7 @@ static void   error_callback(uint32_t nrf_error);
     @returns
 */
 /**************************************************************************/
-error_t btle_gap_init(void)
+nrf_error_t btle_gap_init(void)
 {
     ble_gap_conn_params_t gap_conn_params = {0};
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_gap.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_gap.h
@@ -19,6 +19,6 @@
 
 #include "common/common.h"
 
-error_t btle_gap_init(void);
+nrf_error_t btle_gap_init(void);
 
 #endif // ifndef _BTLE_GAP_H_

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.cpp
@@ -165,7 +165,7 @@ uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base)
 
 */
 /**************************************************************************/
-error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
                                 ble_uuid_t          *p_uuid)
 {
     UUID::LongUUIDBytes_t uuid_base_le;
@@ -200,7 +200,7 @@ error_t custom_decode_uuid_base(uint8_t const *const p_uuid_base,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t       requiredSecurity,
@@ -336,7 +336,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
     @retval     ERROR_NONE        Everything executed normally
 */
 /**************************************************************************/
-error_t custom_add_in_descriptor(uint16_t    char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t    char_handle,
                                  ble_uuid_t *p_uuid,
                                  uint8_t    *p_data,
                                  uint16_t    length,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
@@ -38,11 +38,11 @@ extern "C" {
  */
 void custom_reset_128bits_uuid_table();
 uint8_t custom_add_uuid_base(uint8_t const *const p_uuid_base);
-error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
+nrf_error_t custom_decode_uuid(uint8_t const *const p_uuid_base,
                            ble_uuid_t          *p_uuid);
 ble_uuid_t custom_convert_to_nordic_uuid(const UUID &uuid);
 
-error_t custom_add_in_characteristic(uint16_t                  service_handle,
+nrf_error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                   properties,
                                      SecurityManager::SecurityMode_t requiredSecurity,
@@ -58,7 +58,7 @@ error_t custom_add_in_characteristic(uint16_t                  service_handle,
                                      bool                      writeAuthorization,
                                      ble_gatts_char_handles_t *p_char_handle);
 
-error_t custom_add_in_descriptor(uint16_t                      char_handle,
+nrf_error_t custom_add_in_descriptor(uint16_t                      char_handle,
                                      ble_uuid_t               *p_uuid,
                                      uint8_t                  *p_data,
                                      uint16_t                  length,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/assertion.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/assertion.h
@@ -108,18 +108,18 @@ static inline void debugger_breakpoint(void)
 #define ASSERT_DEFINE(...) ASSERT_DEFINE_WITH_HANDLER(ASSERT_ERROR_HANDLER, NULL, __VA_ARGS__)
 
 //--------------------------------------------------------------------+
-// error_t Status Assert TODO use ASSERT_DEFINE
+// nrf_error_t Status Assert TODO use ASSERT_DEFINE
 //--------------------------------------------------------------------+
 #define ASSERT_STATUS_MESSAGE(sts, message) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "%s: %s", ErrorStr[status], message)
 
 #define ASSERT_STATUS(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, status, "error = %d", status)
 
 #define ASSERT_STATUS_RET_VOID(sts) \
-    ASSERT_DEFINE(error_t status = (error_t)(sts),\
+    ASSERT_DEFINE(nrf_error_t status = (nrf_error_t)(sts),\
                   ERROR_NONE == status, (void) 0, "error = %d", status)
 
 //--------------------------------------------------------------------+

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/ble_error.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/ble_error.h
@@ -140,7 +140,7 @@ typedef enum
   ERROR_BLEGATTS_INVALID_ATTR_TYPE              = 0x3400 , /**< Invalid attribute type. */
   ERROR_BLEGATTS_SYS_ATTR_MISSING               = 0x3401 , /**< System Attributes missing. */
 
-}error_t;
+}nrf_error_t;
 
 #ifdef __cplusplus
  }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.cpp
@@ -346,7 +346,7 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
         }
 
         if (updatesEnabled) {
-            error_t error = (error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
+            nrf_error_t error = (nrf_error_t) sd_ble_gatts_hvx(connectionHandle, &hvx_params);
             if (error != ERROR_NONE) {
                 switch (error) {
                     case ERROR_BLE_NO_TX_BUFFERS: /*  Notifications consume application buffers. The return value can be used for resending notifications. */


### PR DESCRIPTION
## Description

I just updated to mbed-os-5.7.3 and could no longer build for NRF51  (windows, offline, gcc 6 2017-q1-update).
```
./mbed-os/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/common/ble_error.h:143:2: error: conflicting declaration 'typedef enum error_t error_t'
 }error_t;
  ^~~~~~~
In file included from f:\program files (x86)\gnu tools arm embedded\6 2017-q1-update\arm-none-eabi\include\c++\6.3.1\cerrno:42:0,
    ...
                 from f:\program files (x86)\gnu tools arm embedded\6 2017-q1-update\arm-none-eabi\include\c++\6.3.1\memory:79,
                 from .\mbed-os\features\FEATURE_BLE\targets\TARGET_NORDIC\TARGET_NRF5\source\nRF5XPalGattClient.cpp:17:
f:\program files (x86)\gnu tools arm embedded\6 2017-q1-update\arm-none-eabi\include\errno.h:5:13: note: previous declaration as 'typedef int error_t'
 typedef int error_t;

```

The definition of the new `error_t` type in `TARGET_NRF5/source/common/ble_error.h` states that the enum has been mapped from nrf_error.h (softdevice code) so in this PR I've simply renamed `error_t` to `nrf_error_t` to avoid conflicting with the standard library type

## Status

**READY**

## Migrations

There should be no changes to end user code.

NO

## Related PRs

None

## Deploy notes

Notes regarding the deployment of this PR. These should note any required changes in the build environment, tools, compilers and so on.

## Steps to test or reproduce

Any code using the unified nordic target and ble should trigger this issue when compiled with gcc. 
I've only tested with arm's distribution of gcc 6 2017-q1-update on windows 10 x64.
