### PR TITLE
Nordic BLE: Allow configuration of softdevice parameters (old)

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -113,20 +113,6 @@ error_t btle_init(void)
     SOFTDEVICE_HANDLER_INIT(&clockConfiguration, signalEvent);
 
     // Enable BLE stack
-    /**
-     * Using this call, the application can select whether to include the
-     * Service Changed characteristic in the GATT Server. The default in all
-     * previous releases has been to include the Service Changed characteristic,
-     * but this affects how GATT clients behave. Specifically, it requires
-     * clients to subscribe to this attribute and not to cache attribute handles
-     * between connections unless the devices are bonded. If the application
-     * does not need to change the structure of the GATT server attributes at
-     * runtime this adds unnecessary complexity to the interaction with peer
-     * clients. If the SoftDevice is enabled with the Service Changed
-     * Characteristics turned off, then clients are allowed to cache attribute
-     * handles making applications simpler on both sides.
-     */
-    static const bool IS_SRVC_CHANGED_CHARACT_PRESENT = true;
 
     ble_enable_params_t ble_enable_params;
     uint32_t err_code = softdevice_enable_get_default_config(CENTRAL_LINK_COUNT,

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -127,7 +127,11 @@ error_t btle_init(void)
         return ERROR_INVALID_PARAM;
     }
 
-    if (softdevice_enable(&ble_enable_params) != NRF_SUCCESS) {
+    err_code = softdevice_enable(&ble_enable_params);
+    if (err_code == NRF_ERROR_NO_MEM) {
+        error("Linker file has not enough ram assigned for softdevice config");
+    }
+    if (err_code != NRF_SUCCESS) {
         return ERROR_INVALID_PARAM;
     }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -133,9 +133,11 @@ uint32_t btle_softdevice_enable(ble_enable_params_t * p_ble_enable_params)
     } 
     else if (app_ram_base != ram_start)
     {
-        #ifndef NDEBUG
+        #if MBED_CONF_DEBUG_SD_RAM_ALLOC
+        volatile uint32_t softdevice_ram_alloc = app_ram_base-ram_base;
+        __BKPT('0');
         printf("sd_ble_enable: target.softdevice_ram_alloc should be set to 0x%x\r\n",
-                app_ram_base-ram_base);
+               softdevice_ram_alloc);
         #endif
     }
 #else

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
@@ -26,33 +26,49 @@ extern "C" {
 #include "ble_srv_common.h"
 #include "headers/nrf_ble.h"
 
-#ifndef CENTRAL_LINK_COUNT
-#define CENTRAL_LINK_COUNT    3  /**<number of central links used by the application. When changing this number remember to adjust the RAM settings */
-#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_PERIPHERAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+/* number of central links used by the application. 
+ * When changing this number remember to adjust the RAM settings */
+#ifndef MBED_CONF_NRF_CENTRAL_LINK_COUNT
+    #define CENTRAL_LINK_COUNT    3  
+#else
+    #define CENTRAL_LINK_COUNT    MBED_CONF_NRF_CENTRAL_LINK_COUNT  
+#endif
 
-#ifndef PERIPHERAL_LINK_COUNT
-#define PERIPHERAL_LINK_COUNT 1     /**<number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
-#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_CENTRAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+/* number of peripheral links used by the application. 
+ * When changing this number remember to adjust the RAM settings */
+#ifndef MBED_CONF_NRF_PERIPHERAL_LINK_COUNT
+    #define PERIPHERAL_LINK_COUNT    1  
+#else
+    #define PERIPHERAL_LINK_COUNT    MBED_CONF_NRF_PERIPHERAL_LINK_COUNT  
+#endif
 
-#ifndef GATTS_ATTR_TAB_SIZE
-#define GATTS_ATTR_TAB_SIZE 0x600 /**< GATTS attribite table size. */
-#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
 
-    /**
-     * Using this call, the application can select whether to include the
-     * Service Changed characteristic in the GATT Server. The default in all
-     * previous releases has been to include the Service Changed characteristic,
-     * but this affects how GATT clients behave. Specifically, it requires
-     * clients to subscribe to this attribute and not to cache attribute handles
-     * between connections unless the devices are bonded. If the application
-     * does not need to change the structure of the GATT server attributes at
-     * runtime this adds unnecessary complexity to the interaction with peer
-     * clients. If the SoftDevice is enabled with the Service Changed
-     * Characteristics turned off, then clients are allowed to cache attribute
-     * handles making applications simpler on both sides.
-     */
-#ifndef IS_SRVC_CHANGED_CHARACT_PRESENT
-#define IS_SRVC_CHANGED_CHARACT_PRESENT 0
+/* GATTS attribite table size. 
+ * When changing this number remember to adjust the RAM settings */
+#ifndef MBED_CONF_NRF_GATTS_ATTR_TAB_SIZE
+    #define GATTS_ATTR_TAB_SIZE    0x600  
+#else
+    #define GATTS_ATTR_TAB_SIZE    MBED_CONF_NRF_GATTS_ATTR_TAB_SIZE  
+#endif
+
+
+/**
+ * Using this call, the application can select whether to include the
+ * Service Changed characteristic in the GATT Server. The default in all
+ * previous releases has been to include the Service Changed characteristic,
+ * but this affects how GATT clients behave. Specifically, it requires
+ * clients to subscribe to this attribute and not to cache attribute handles
+ * between connections unless the devices are bonded. If the application
+ * does not need to change the structure of the GATT server attributes at
+ * runtime this adds unnecessary complexity to the interaction with peer
+ * clients. If the SoftDevice is enabled with the Service Changed
+ * Characteristics turned off, then clients are allowed to cache attribute
+ * handles making applications simpler on both sides.
+ */
+#ifndef MBED_CONF_NRF_IS_SRVC_CHANGED_CHARACT_PRESENT
+    #define IS_SRVC_CHANGED_CHARACT_PRESENT    1  
+#else
+    #define IS_SRVC_CHANGED_CHARACT_PRESENT    MBED_CONF_NRF_IS_SRVC_CHANGED_CHARACT_PRESENT  
 #endif
 
 error_t     btle_init(void);

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.h
@@ -26,12 +26,34 @@ extern "C" {
 #include "ble_srv_common.h"
 #include "headers/nrf_ble.h"
 
+#ifndef CENTRAL_LINK_COUNT
 #define CENTRAL_LINK_COUNT    3  /**<number of central links used by the application. When changing this number remember to adjust the RAM settings */
-                                                                       /** If value for YOTTA_CFG_NORDIC_BLE_PERIPHERAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_PERIPHERAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+
+#ifndef PERIPHERAL_LINK_COUNT
 #define PERIPHERAL_LINK_COUNT 1     /**<number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
-                                                                       /** If value for YOTTA_CFG_NORDIC_BLE_CENTRAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_CENTRAL_LINKS was used, ram settings are adjusted by the yotta target module. */
+
+#ifndef GATTS_ATTR_TAB_SIZE
 #define GATTS_ATTR_TAB_SIZE 0x600 /**< GATTS attribite table size. */
-                                                                       /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
+#endif                                                                 /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
+
+    /**
+     * Using this call, the application can select whether to include the
+     * Service Changed characteristic in the GATT Server. The default in all
+     * previous releases has been to include the Service Changed characteristic,
+     * but this affects how GATT clients behave. Specifically, it requires
+     * clients to subscribe to this attribute and not to cache attribute handles
+     * between connections unless the devices are bonded. If the application
+     * does not need to change the structure of the GATT server attributes at
+     * runtime this adds unnecessary complexity to the interaction with peer
+     * clients. If the SoftDevice is enabled with the Service Changed
+     * Characteristics turned off, then clients are allowed to cache attribute
+     * handles making applications simpler on both sides.
+     */
+#ifndef IS_SRVC_CHANGED_CHARACT_PRESENT
+#define IS_SRVC_CHANGED_CHARACT_PRESENT 0
+#endif
 
 error_t     btle_init(void);
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
@@ -26,9 +26,13 @@
 extern "C" {
 #endif
 
-#ifndef UUID_TABLE_MAX_ENTRIES
-#define UUID_TABLE_MAX_ENTRIES  (4) /* This is the maximum number of 128-bit UUIDs with distinct bases that */
-#endif                                            /* we expect to be in use; increase this limit if needed. */
+/* This is the maximum number of 128-bit UUIDs with distinct bases that *
+ * we expect to be in use; increase this limit if needed. */
+#ifdef MBED_CONF_NRF_UUID_TABLE_MAX_ENTRIES
+    #define UUID_TABLE_MAX_ENTRIES  MBED_CONF_NRF_UUID_TABLE_MAX_ENTRIES
+#else
+    #define UUID_TABLE_MAX_ENTRIES  (4)
+#endif
 
 /**
  * Reset the table of 128bits uuids.

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/custom/custom_helper.h
@@ -26,8 +26,9 @@
 extern "C" {
 #endif
 
-#define UUID_TABLE_MAX_ENTRIES  (4) /* This is the maximum number of 128-bit UUIDs with distinct bases that
-                                                   * we expect to be in use; increase this limit if needed. */
+#ifndef UUID_TABLE_MAX_ENTRIES
+#define UUID_TABLE_MAX_ENTRIES  (4) /* This is the maximum number of 128-bit UUIDs with distinct bases that */
+#endif                                            /* we expect to be in use; increase this limit if needed. */
 
 /**
  * Reset the table of 128bits uuids.

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NORDIC_32K/nRF51822.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NORDIC_32K/nRF51822.sct
@@ -12,16 +12,22 @@
 ;
 ;WITH SOFTDEVICE:
 
+#if defined(MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+  #define APP_RAM_BASE 0x20002ef8
+#endif
+
 LR_IROM1 0x1B000 0x0025000  {
   ER_IROM1 0x1B000 0x0025000  {
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM0 0x20002ef8 UNINIT 0x000000c0  { ;no init section
+  RW_IRAM0 APP_RAM_BASE UNINIT 0x000000c0  { ;no init section
         *(*noinit)
   }
-  RW_IRAM1 0x20002FB8 0x00005048  {
+  RW_IRAM1 (APP_RAM_BASE + 0xC0) (0x20008000 - APP_RAM_BASE - 0xC0)  {
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NRF51_16K_S110/nRF51822.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NRF51_16K_S110/nRF51822.sct
@@ -12,16 +12,22 @@
 ;
 ;WITH SOFTDEVICE:
 
+#if defined(MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+  #define APP_RAM_BASE 0x20002000
+#endif
+
 LR_IROM1 0x18000 0x0028000  {
   ER_IROM1 0x18000 0x0028000  {
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM0 0x20002000 UNINIT 0x000000c0  { ;no init section
+  RW_IRAM0 APP_RAM_BASE UNINIT 0x000000c0  { ;no init section
         *(*noinit)
   }
-  RW_IRAM1 0x200020C0 0x00001F40  {
+  RW_IRAM1 (APP_RAM_BASE + 0xC0) (0x20004000 - APP_RAM_BASE - 0xC0)  {    
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NRF51_16K_S130/nRF51822.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_ARM_STD/TARGET_MCU_NRF51_16K_S130/nRF51822.sct
@@ -12,16 +12,22 @@
 ;
 ;WITH SOFTDEVICE:
 
+#if defined(MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+  #define APP_RAM_BASE 0x20002ef8
+#endif
+
 LR_IROM1 0x0001B000 0x0025000  {
   ER_IROM1 0x0001B000 0x0025000  {
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM0 0x20002ef8 UNINIT 0x000000c0  { ;no init section
+  RW_IRAM0 APP_RAM_BASE UNINIT 0x000000c0  { ;no init section
         *(*noinit)
   }
-  RW_IRAM1 0x20002FB8 0x00001048  {
+  RW_IRAM1 (APP_RAM_BASE + 0xC0) (0x20004000 - APP_RAM_BASE - 0xC0)  {
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
@@ -1,6 +1,5 @@
 /* Linker script to configure memory regions. */
 
-#include "mbed_config.h"
 #ifdef MBED_CONF_SD_RAM_ALLOC
 #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
 #else

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NORDIC_32K/NRF51822.ld
@@ -1,9 +1,16 @@
 /* Linker script to configure memory regions. */
 
+#include "mbed_config.h"
+#ifdef MBED_CONF_SD_RAM_ALLOC
+#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+#define APP_RAM_BASE 0x20002ef8
+#endif
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x0001B000, LENGTH = 0x25000
-  RAM (rwx) :  ORIGIN = 0x20002ef8, LENGTH = 0x5108
+  RAM (rwx) :  ORIGIN = APP_RAM_BASE, LENGTH = 0x20008000-APP_RAM_BASE
 }
 
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S110/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S110/NRF51822.ld
@@ -1,6 +1,5 @@
 /* Linker script to configure memory regions. */
 
-#include "mbed_config.h"
 #ifdef MBED_CONF_SD_RAM_ALLOC
 #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
 #else

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S110/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S110/NRF51822.ld
@@ -1,9 +1,16 @@
 /* Linker script to configure memory regions. */
 
+#include "mbed_config.h"
+#ifdef MBED_CONF_SD_RAM_ALLOC
+#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+#define APP_RAM_BASE 0x20002000
+#endif
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x00018000, LENGTH = 0x28000
-  RAM (rwx) :  ORIGIN = 0x20002000, LENGTH = 0x2000
+  RAM (rwx) :  ORIGIN = APP_RAM_BASE, LENGTH = 0x20004000-APP_RAM_BASE
 }
 
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
@@ -1,6 +1,5 @@
 /* Linker script to configure memory regions. */
 
-#include "mbed_config.h"
 #ifdef MBED_CONF_SD_RAM_ALLOC
 #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
 #else

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_GCC_ARM/TARGET_MCU_NRF51_16K_S130/NRF51822.ld
@@ -1,9 +1,16 @@
 /* Linker script to configure memory regions. */
 
+#include "mbed_config.h"
+#ifdef MBED_CONF_SD_RAM_ALLOC
+#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+#define APP_RAM_BASE 0x20002800
+#endif
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x0001C000, LENGTH = 0x24000
-  RAM (rwx) :  ORIGIN = 0x20002800, LENGTH = 0x1800
+  RAM (rwx) :  ORIGIN = APP_RAM_BASE, LENGTH = 0x20004000-APP_RAM_BASE
 }
 
 OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_16K/nRF51822_QFAA.icf
@@ -1,12 +1,17 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+if (isdefinedsymbol(MBED_CONF_SD_RAM_ALLOC)) {
+    define symbol APP_RAM_BASE = (0x20000000 + MBED_CONF_SD_RAM_ALLOC);
+} else {
+    define symbol APP_RAM_BASE = 0x20002ef8;
+}
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = 0x0001b000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x0001b0c0;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0003FFFF;
-define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
+define symbol __ICFEDIT_region_RAM_start__ = APP_RAM_BASE;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20003FFF;
 export symbol __ICFEDIT_region_RAM_start__;
 export symbol __ICFEDIT_region_RAM_end__;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF51822_UNIFIED/device/TOOLCHAIN_IAR/TARGET_MCU_NORDIC_32K/nRF51822_QFAA.icf
@@ -1,12 +1,17 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+if (isdefinedsymbol(MBED_CONF_SD_RAM_ALLOC)) {
+    define symbol APP_RAM_BASE = (0x20000000 + MBED_CONF_SD_RAM_ALLOC);
+} else {
+    define symbol APP_RAM_BASE = 0x20002ef8;
+}
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = 0x0001b000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__ = 0x0001b0c0;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0003FFFF;
-define symbol __ICFEDIT_region_RAM_start__ = 0x20002ef8;
+define symbol __ICFEDIT_region_RAM_start__ = APP_RAM_BASE;
 define symbol __ICFEDIT_region_RAM_end__   = 0x20007FFF;
 export symbol __ICFEDIT_region_RAM_start__;
 export symbol __ICFEDIT_region_RAM_end__;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -12,16 +12,22 @@
 ;
 ;WITH SOFTDEVICE:
 
+#if defined(MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+  #define APP_RAM_BASE 0x20002EF8
+#endif
+
 LR_IROM1 0x1C000 0x0064000  {
   ER_IROM1 0x1C000 0x0064000  {
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM0 0x20002EF8 UNINIT 0x000000D8  { ;no init section
+  RW_IRAM0 APP_RAM_BASE UNINIT 0x000000D8  { ;no init section
         *(*noinit)
   }
-  RW_IRAM1 0x20002FD0 0x0000D030  {
+  RW_IRAM1 (APP_RAM_BASE + 0xD8) (0x20010000 - APP_RAM_BASE - 0xD8)  {
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -16,7 +16,6 @@
 
 /* Linker script to configure memory regions. */
 
-#include "mbed_config.h"
 #ifdef MBED_CONF_SD_RAM_ALLOC
 #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
 #else

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -16,10 +16,17 @@
 
 /* Linker script to configure memory regions. */
 
+#include "mbed_config.h"
+#ifdef MBED_CONF_SD_RAM_ALLOC
+#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+#define APP_RAM_BASE 0x20002ef8
+#endif
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = 0x1C000, LENGTH = 0x64000
-  RAM (rwx) :  ORIGIN = 0x20002ef8, LENGTH = 0xd108
+  RAM (rwx) :  ORIGIN = APP_RAM_BASE, LENGTH = 0x20010000-APP_RAM_BASE
 }
 
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -1,12 +1,17 @@
 /*###ICF### Section handled by ICF editor, don't touch! ****/
 /*-Editor annotation file-*/
 /* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+if (isdefinedsymbol(MBED_CONF_SD_RAM_ALLOC)) {
+    define symbol APP_RAM_BASE = (0x20000000 + MBED_CONF_SD_RAM_ALLOC);
+} else {
+    define symbol APP_RAM_BASE = 0x20002ef8;
+}
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = 0x1c000;
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__   = 0x1c000;
 define symbol __ICFEDIT_region_ROM_end__     = 0x7ffff;
-define symbol __ICFEDIT_region_RAM_start__   = 0x20002ef8;
+define symbol __ICFEDIT_region_RAM_start__   = APP_RAM_BASE;
 define symbol __ICFEDIT_region_RAM_end__     = 0x2000ffff;
 export symbol __ICFEDIT_region_RAM_start__;
 export symbol __ICFEDIT_region_RAM_end__;

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
@@ -8,16 +8,22 @@
   #define MBED_APP_SIZE 0xDF000
 #endif
 
+#if defined(MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+  #define APP_RAM_BASE 0x20003288
+#endif
+
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE  {
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  RW_IRAM0 0x20003288 UNINIT 0x000000F8  { ;no init section
+  RW_IRAM0 APP_RAM_BASE UNINIT 0x000000F8  { ;no init section
         *(*noinit)
   }
-  RW_IRAM1 0x20003380 0x0003cc80  {
+  RW_IRAM1 (APP_RAM_BASE + 0xF8) (0x20040000 - APP_RAM_BASE - 0xF8)  {
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -24,11 +24,10 @@
   #define MBED_APP_SIZE 0xDF000
 #endif
 
-#include "mbed_config.h"
 #ifdef MBED_CONF_SD_RAM_ALLOC
-#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+  #define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
 #else
-#define APP_RAM_BASE 0x20003288
+  #define APP_RAM_BASE 0x20003288
 #endif
 
 MEMORY

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -24,10 +24,17 @@
   #define MBED_APP_SIZE 0xDF000
 #endif
 
+#include "mbed_config.h"
+#ifdef MBED_CONF_SD_RAM_ALLOC
+#define APP_RAM_BASE (0x20000000 + MBED_CONF_SD_RAM_ALLOC)
+#else
+#define APP_RAM_BASE 0x20003288
+#endif
+
 MEMORY
 {
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx) :  ORIGIN = 0x20003288, LENGTH = 0x3cd78
+  RAM (rwx) :  ORIGIN = APP_RAM_BASE, LENGTH = 0x20040000-APP_RAM_BASE
 }
 
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
@@ -10,13 +10,20 @@ if (!isdefinedsymbol(MBED_APP_SIZE)) {
     define symbol MBED_APP_SIZE = 0xDF000;
 }
 
+if (isdefinedsymbol(MBED_CONF_SD_RAM_ALLOC)) {
+    define symbol APP_RAM_BASE = (0x20000000 + MBED_CONF_SD_RAM_ALLOC);
+}
+else {
+    define symbol APP_RAM_BASE = 0x20003288;
+}
+
 /*-Specials-*/
 define symbol __ICFEDIT_intvec_start__ = MBED_APP_START;
 
 /*-Memory Regions-*/
 define symbol __ICFEDIT_region_ROM_start__   = MBED_APP_START;
 define symbol __ICFEDIT_region_ROM_end__     = MBED_APP_START + MBED_APP_SIZE - 1;
-define symbol __ICFEDIT_region_RAM_start__   = 0x20003288;
+define symbol __ICFEDIT_region_RAM_start__   = APP_RAM_BASE;
 define symbol __ICFEDIT_region_RAM_end__     = 0x2003ffff;
 export symbol __ICFEDIT_region_RAM_start__;
 export symbol __ICFEDIT_region_RAM_end__;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2078,6 +2078,10 @@
             }
         ],
         "detect_code": ["1070"],
+        "pre_link_hook": {
+            "function": "MCU_NRF51Code.linker_hook",
+            "toolchains": ["GCC_ARM"]
+        },
         "post_binary_hook": {
             "function": "MCU_NRF51Code.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM"]
@@ -3325,6 +3329,10 @@
             }
         ],
         "detect_code": ["1070"],
+        "pre_link_hook": {
+            "function": "MCU_NRF51Code.linker_hook",
+            "toolchains": ["GCC_ARM"]
+        },
         "post_binary_hook": {
             "function": "MCU_NRF51Code.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
@@ -3372,6 +3380,10 @@
                 "offset": 114688
             }
         ],
+        "pre_link_hook": {
+            "function": "MCU_NRF51Code.linker_hook",
+            "toolchains": ["GCC_ARM"]
+        },
         "post_binary_hook": {
             "function": "MCU_NRF51Code.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
@@ -3443,6 +3455,10 @@
             }
         ],
         "bootloader_select_index": 0,
+        "pre_link_hook": {
+            "function": "MCU_NRF51Code.linker_hook",
+            "toolchains": ["GCC_ARM"]
+        },
         "post_binary_hook": {
             "function": "MCU_NRF51Code.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3289,7 +3289,32 @@
                 "help": "Value: 1 for enable, 0 for disable",
                 "value": 1,
                 "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
-            }
+            },
+            "nrf_central_link_count": {
+                "help": "When acting as BLE central, how many peripherals can connect",
+                "macro_name": "MBED_CONF_NRF_CENTRAL_LINK_COUNT",
+                "value": "3"
+            },
+            "nrf_peripheral_link_count": {
+                "help": "When acting as BLE peripheral, how many centrals can we conenct to",
+                "macro_name": "MBED_CONF_NRF_PERIPHERAL_LINK_COUNT",
+                "value": "1"
+            },
+            "nrf_gatt_attr_tab_size": {
+                "help": "The size of the table used to hold gatts. Can be adjusted by trial and error",
+                "macro_name": "MBED_CONF_NRF_GATTS_ATTR_TAB_SIZE",
+                "value": "0x600"
+            },
+            "nrf_uuid_table_max_entries": {
+                "help": "maximum number of 128-bit UUIDs with distinct bases that we expect to be in use",
+                "macro_name": "MBED_CONF_NRF_UUID_TABLE_MAX_ENTRIES",
+                "value": "4"
+            },
+            "nrf_is_srvc_changed_charact_present": {
+                "help": "select whether to include the Service Changed characteristic in the GATT Server",
+                "macro_name": "MBED_CONF_NRF_IS_SRVC_CHANGED_CHARACT_PRESENT",
+                "value": "1"
+            }           
         },
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3243,8 +3243,54 @@
         "default_lib": "std",
         "device_name": "ATSAMG55J19"
     },
-    "MCU_NRF51_UNIFIED": {
+    "MCU_NRF5": {
         "inherits": ["Target"],
+        "features": ["BLE"],
+        "config": {
+            "lf_clock_src": {
+                "value": "NRF_LF_SRC_XTAL",
+                "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
+            },
+            "uart_hwfc": {
+                "help": "Value: 1 for enable, 0 for disable",
+                "value": 1,
+                "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
+            },
+            "softdevice_ram_alloc": {
+                "help": "RAM set aside for the softdevice. 8 if no BLE/softdevice used else SD version specific. GCC only.",
+                "value": "8",
+                "macro_name": "MBED_CONF_SD_RAM_ALLOC"
+            },
+            "nrf_central_link_count": {
+                "help": "When acting as BLE central, how many peripherals can connect",
+                "value": "3",
+                "macro_name": "MBED_CONF_NRF_CENTRAL_LINK_COUNT"
+            },
+            "nrf_peripheral_link_count": {
+                "help": "When acting as BLE peripheral, how many centrals can we conenct to",
+                "value": "1",
+                "macro_name": "MBED_CONF_NRF_PERIPHERAL_LINK_COUNT"
+            },
+            "nrf_gatt_attr_tab_size": {
+                "help": "The size of the table used to hold gatts. Can be adjusted by trial and error",
+                "value": "0x600",
+                "macro_name": "MBED_CONF_NRF_GATTS_ATTR_TAB_SIZE"
+            },
+            "nrf_uuid_table_max_entries": {
+                "help": "maximum number of 128-bit UUIDs with distinct bases that we expect to be in use",
+                "value": "4",
+                "macro_name": "MBED_CONF_NRF_UUID_TABLE_MAX_ENTRIES"
+            },
+            "nrf_is_srvc_changed_charact_present": {
+                "help": "select whether to include the Service Changed characteristic in the GATT Server",
+                "value": "1",
+                "macro_name": "MBED_CONF_NRF_IS_SRVC_CHANGED_CHARACT_PRESENT"
+            }
+        },
+        "public": false
+    },
+    "MCU_NRF51_UNIFIED": {
+        "inherits": ["MCU_NRF5"],
         "core": "Cortex-M0",
         "OVERRIDE_BOOTLOADER_FILENAME": "nrf51822_bootloader.hex",
         "macros": [
@@ -3279,50 +3325,14 @@
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
         },
         "program_cycle_s": 6,
-        "features": ["BLE"],
-        "config": {
-            "lf_clock_src": {
-                "value": "NRF_LF_SRC_XTAL",
-                "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
-            },
-            "uart_hwfc": {
-                "help": "Value: 1 for enable, 0 for disable",
-                "value": 1,
-                "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
-            },
-            "nrf_central_link_count": {
-                "help": "When acting as BLE central, how many peripherals can connect",
-                "macro_name": "MBED_CONF_NRF_CENTRAL_LINK_COUNT",
-                "value": "3"
-            },
-            "nrf_peripheral_link_count": {
-                "help": "When acting as BLE peripheral, how many centrals can we conenct to",
-                "macro_name": "MBED_CONF_NRF_PERIPHERAL_LINK_COUNT",
-                "value": "1"
-            },
-            "nrf_gatt_attr_tab_size": {
-                "help": "The size of the table used to hold gatts. Can be adjusted by trial and error",
-                "macro_name": "MBED_CONF_NRF_GATTS_ATTR_TAB_SIZE",
-                "value": "0x600"
-            },
-            "nrf_uuid_table_max_entries": {
-                "help": "maximum number of 128-bit UUIDs with distinct bases that we expect to be in use",
-                "macro_name": "MBED_CONF_NRF_UUID_TABLE_MAX_ENTRIES",
-                "value": "4"
-            },
-            "nrf_is_srvc_changed_charact_present": {
-                "help": "select whether to include the Service Changed characteristic in the GATT Server",
-                "macro_name": "MBED_CONF_NRF_IS_SRVC_CHANGED_CHARACT_PRESENT",
-                "value": "1"
-            }           
-        },
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
     },
     "MCU_NRF51_32K_UNIFIED": {
         "inherits": ["MCU_NRF51_UNIFIED"],
         "extra_labels_add": ["MCU_NORDIC_32K", "MCU_NRF51_32K"],
         "macros_add": ["TARGET_MCU_NORDIC_32K", "TARGET_MCU_NRF51_32K"],
-        "public": false
+        "public": false,
+        "overrides": { "softdevice_ram_alloc": "0x2ef8" }
     },
     "NRF51_DK": {
         "supported_form_factors": ["ARDUINO"],
@@ -3338,7 +3348,7 @@
         "release_versions": ["2", "5"]
     },
     "MCU_NRF52": {
-        "inherits": ["Target"],
+        "inherits": ["MCU_NRF5"],
         "core": "Cortex-M4F",
         "macros": ["NRF52", "TARGET_NRF52832", "BLE_STACK_SUPPORT_REQD", "SOFTDEVICE_PRESENT", "S132", "CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\"", "MBED_TICKLESS"],
         "device_has": ["STCLK_OFF_DURING_SLEEP"],
@@ -3362,18 +3372,7 @@
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
         },
         "MERGE_BOOTLOADER": false,
-        "features": ["BLE"],
-        "config": {
-            "lf_clock_src": {
-                "value": "NRF_LF_SRC_XTAL",
-                "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
-            },
-            "uart_hwfc": {
-                "help": "Value: 1 for enable, 0 for disable",
-                "value": 1,
-                "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
-            }
-        }
+        "overrides": { "softdevice_ram_alloc": "0x2ef8" }
     },
     "NRF52_DK": {
         "supported_form_factors": ["ARDUINO"],
@@ -3455,7 +3454,8 @@
                 "value": 1,
                 "macro_name": "MBED_CONF_NORDIC_UART_HWFC"
             }
-        }
+        },
+        "overrides": { "softdevice_ram_alloc": "0x3288" }
     },
     "NRF52840_DK": {
         "supported_form_factors": ["ARDUINO"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3261,6 +3261,11 @@
                 "value": "8",
                 "macro_name": "MBED_CONF_SD_RAM_ALLOC"
             },
+            "debug_softdevice_ram_alloc": {
+                "help": "If set, check RAM set aside for the softdevice. Will breakpoint/printf if a discrepancy is detected. GCC only.",
+                "value": "0",
+                "macro_name": "MBED_CONF_DEBUG_SD_RAM_ALLOC"
+            },
             "nrf_central_link_count": {
                 "help": "When acting as BLE central, how many peripherals can connect",
                 "value": "3",

--- a/tools/hooks.py
+++ b/tools/hooks.py
@@ -12,10 +12,10 @@ _HOOKS = {}
 _RUNNING_HOOKS = {}
 
 # Available hook types
-_HOOK_TYPES = ["binary", "compile", "link", "assemble"]
+HOOK_TYPES = ["binary", "compile", "link", "assemble"]
 
 # Available hook steps
-_HOOK_STEPS = ["pre", "replace", "post"]
+HOOK_STEPS = ["pre", "replace", "post"]
 
 # Hook the given function. Use this function as a decorator
 def hook_tool(function):
@@ -69,15 +69,15 @@ class Hook(object):
 
     # Hook various functions directly
     @staticmethod
-    def _hook_add(hook_type, hook_step, function):
+    def hook_add(hook_type, hook_step, function):
         """Add a hook to a compile function
 
         Positional arguments:
-        hook_type - one of the _HOOK_TYPES
-        hook_step - one of the _HOOK_STEPS
+        hook_type - one of the HOOK_TYPES
+        hook_step - one of the HOOK_STEPS
         function - the function to add to the list of hooks
         """
-        if hook_type not in _HOOK_TYPES or hook_step not in _HOOK_STEPS:
+        if hook_type not in HOOK_TYPES or hook_step not in HOOK_STEPS:
             return False
         if hook_type not in _HOOKS:
             _HOOKS[hook_type] = {}
@@ -88,47 +88,47 @@ class Hook(object):
         """Add a hook to the compiler
 
         Positional Arguments:
-        hook_step - one of the _HOOK_STEPS
+        hook_step - one of the HOOK_STEPS
         function - the function to add to the list of hooks
         """
-        return self._hook_add("compile", hook_step, function)
+        return self.hook_add("compile", hook_step, function)
 
     def hook_add_linker(self, hook_step, function):
         """Add a hook to the linker
 
         Positional Arguments:
-        hook_step - one of the _HOOK_STEPS
+        hook_step - one of the HOOK_STEPS
         function - the function to add to the list of hooks
         """
-        return self._hook_add("link", hook_step, function)
+        return self.hook_add("link", hook_step, function)
 
     def hook_add_assembler(self, hook_step, function):
         """Add a hook to the assemble
 
         Positional Arguments:
-        hook_step - one of the _HOOK_STEPS
+        hook_step - one of the HOOK_STEPS
         function - the function to add to the list of hooks
         """
-        return self._hook_add("assemble", hook_step, function)
+        return self.hook_add("assemble", hook_step, function)
 
     def hook_add_binary(self, hook_step, function):
         """Add a hook to the elf to binary tool
 
         Positional Arguments:
-        hook_step - one of the _HOOK_STEPS
+        hook_step - one of the HOOK_STEPS
         function - the function to add to the list of hooks
         """
-        return self._hook_add("binary", hook_step, function)
+        return self.hook_add("binary", hook_step, function)
 
     # Hook command lines
     def _hook_cmdline(self, hook_type, function):
         """Add a hook to a command line function
 
         Positional arguments:
-        hook_type - one of the _HOOK_TYPES
+        hook_type - one of the HOOK_TYPES
         function - the function to add to the list of hooks
         """
-        if hook_type not in _HOOK_TYPES:
+        if hook_type not in HOOK_TYPES:
             return False
         self._cmdline_hooks[hook_type] = function
         return True
@@ -170,7 +170,7 @@ class Hook(object):
         """Get the command line after running all hooks
 
         Positional arguments:
-        hook_type - one of the _HOOK_TYPES
+        hook_type - one of the HOOK_TYPES
         cmdline - the initial command line
         """
         if self._cmdline_hooks.has_key(hook_type):

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -211,7 +211,7 @@ class GCC(mbedToolchain):
         if mem_map:
             preproc_output = join(dirname(output), ".link_script.ld")
             cmd = (self.preproc + [mem_map] + self.ld[1:] +
-                   ["-I%s" % dirname(output), "-o", preproc_output])
+                   [ "-o", preproc_output])
             self.cc_verbose("Preproc: %s" % ' '.join(cmd))
             self.default_cmd(cmd)
             mem_map = preproc_output

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -211,7 +211,7 @@ class GCC(mbedToolchain):
         if mem_map:
             preproc_output = join(dirname(output), ".link_script.ld")
             cmd = (self.preproc + [mem_map] + self.ld[1:] +
-                   [ "-o", preproc_output])
+                   ["-I%s" % dirname(output), "-o", preproc_output])
             self.cc_verbose("Preproc: %s" % ' '.join(cmd))
             self.default_cmd(cmd)
             mem_map = preproc_output


### PR DESCRIPTION
## Description

Allow configuration (via defines) of some of the key settings for the nordic softdevice.
* CENTRAL_LINK_COUNT
* PERIPHERAL_LINK_COUNT
* gatts_enable_params.attr_tab_size
* gatts_enable_params.service_changed
* common_enable_params.vs_uuid_count

These settings control the range of functionality enabled in the softdevice as well as ram consumption.
In particular, reducing these values is critical to enable usage of 16K nrf51 devices.

The defaults have not been changed so this should not effect existing users.

The values can be adjusted on a per-project basis by adding some build defines or `mbed_app.json` configs, eg:
``` json
{
    "config": {
        "ble_central_link_count": {
            "help": "When acting as BLE central, how many peripherals can connect",
            "macro_name": "CENTRAL_LINK_COUNT",
            "value": "0"
        },
        "ble_peripheral_link_count": {
            "help": "When acting as BLE peripheral, how many centrals can we conenct to",
            "macro_name": "PERIPHERAL_LINK_COUNT",
            "value": "1"
        },
        "ble_gatt_attr_tab_size": {
            "help": "The size of the table used to hold gatts. Can be adjusted by trial and error",
            "macro_name": "GATTS_ATTR_TAB_SIZE",
            "value": "0x390"
        },
        "ble_uuid_table_max_entries": {
            "help": "maximum number of 128-bit UUIDs with distinct bases that we expect to be in use",
            "macro_name": "UUID_TABLE_MAX_ENTRIES",
            "value": "2"
        }
    }
}
```

## Status

**READY**

## Migrations

There should be no changes to end user code.

NO

## Related PRs

None

## Steps to test or reproduce

When debugging code, a breakpoint can be set in `softdevice_enable()` function in `mbed-os/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_SDK11/softdevice/common/softdevice_handler/softdevice_handler.c` 

Before `sd_ble_enable()` has been run in that function, `ram_start` variable holds the current length of ram being allocated for the softdevice. 
After `sd_ble_enable()`, `app_ram_base` variable is updated to hold the amount required by the softdevice for the current configuration. 

Changing the values above in defines/config should result in a change of ram requirements.

For use on smaller parts, once the values have been reduced and the softdevices' requirements have been measured as above, the RAM: ORIGIN and LENGTH definitions can be updated to suit in the linker file; `NRF51822.ld` (or equivalent)

