### PR TITLE
Standardize pointer style on return types

### DIFF
--- a/drivers/InterruptManager.h
+++ b/drivers/InterruptManager.h
@@ -62,7 +62,7 @@ public:
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.6", "This class is not part of the "
         "public API of mbed-os and is being removed in the future.")
-    static InterruptManager* get();
+    static InterruptManager *get();
 
     /** Destroy the current instance of the interrupt manager
      */

--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -52,7 +52,7 @@ ticker_irq_handler_type set_lp_ticker_irq_handler(ticker_irq_handler_type ticker
  *
  * @return The low power ticker data
  */
-const ticker_data_t* get_lp_ticker_data(void);
+const ticker_data_t *get_lp_ticker_data(void);
 
 /** The wrapper for ticker_irq_handler, to pass lp ticker's data
  *
@@ -97,7 +97,7 @@ void lp_ticker_fire_interrupt(void);
 /** Get frequency and counter bits of this ticker.
  *
  */
-const ticker_info_t* lp_ticker_get_info(void);
+const ticker_info_t *lp_ticker_get_info(void);
 
 /**@}*/
 

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -36,7 +36,7 @@ static const ticker_data_t lp_data = {
     .queue = &events,
 };
 
-const ticker_data_t* get_lp_ticker_data(void)
+const ticker_data_t *get_lp_ticker_data(void)
 {
     return &lp_data;
 }

--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -34,7 +34,7 @@ static const ticker_data_t us_data = {
     .queue = &events
 };
 
-const ticker_data_t* get_us_ticker_data(void)
+const ticker_data_t *get_us_ticker_data(void)
 {
     return &us_data;
 }

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -49,7 +49,7 @@ ticker_irq_handler_type set_us_ticker_irq_handler(ticker_irq_handler_type ticker
  *
  * @return The low power ticker data
  */
-const ticker_data_t* get_us_ticker_data(void);
+const ticker_data_t *get_us_ticker_data(void);
 
 
 /** The wrapper for ticker_irq_handler, to pass us ticker's data
@@ -95,7 +95,7 @@ void us_ticker_fire_interrupt(void);
 /** Get frequency and counter bits of this ticker.
  *
  */
-const ticker_info_t* us_ticker_get_info(void);
+const ticker_info_t *us_ticker_get_info(void);
 
 /**@}*/
 

--- a/platform/FileBase.h
+++ b/platform/FileBase.h
@@ -48,7 +48,7 @@ public:
     FileBase(const char *name, PathType t);
     virtual ~FileBase();
 
-    const char* getName(void);
+    const char *getName(void);
     PathType    getPathType(void);
 
     static FileBase *lookup(const char *name, unsigned int len);

--- a/platform/FilePath.h
+++ b/platform/FilePath.h
@@ -42,13 +42,13 @@ public:
      */ 
     FilePath(const char* file_path);
 
-    const char* fileName(void);
+    const char *fileName(void);
 
     bool          isFileSystem(void);
-    FileSystemLike* fileSystem(void);
+    FileSystemLike *fileSystem(void);
 
     bool    isFile(void);
-    FileLike* file(void);
+    FileLike *file(void);
     bool    exists(void);
 
 private:

--- a/platform/SingletonPtr.h
+++ b/platform/SingletonPtr.h
@@ -80,7 +80,7 @@ struct SingletonPtr {
      * @returns
      *   A pointer to the singleton
      */
-    T* get() {
+    T *get() {
         if (NULL == _ptr) {
             singleton_lock();
             if (NULL == _ptr) {

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -33,7 +33,7 @@ namespace mbed {
 
 extern void mbed_set_unbuffered_stream(std::FILE *_file);
 extern int mbed_getc(std::FILE *_file);
-extern char* mbed_gets(char *s, int size, std::FILE *_file);
+extern char *mbed_gets(char *s, int size, std::FILE *_file);
 
 /** File stream
  *

--- a/platform/Transaction.h
+++ b/platform/Transaction.h
@@ -59,7 +59,7 @@ public:
      *
      * @return The object which was stored
      */
-    Class* get_object() {
+    Class *get_object() {
         return _obj;
     }
 
@@ -67,7 +67,7 @@ public:
      *
      * @return The transaction which was stored
      */
-    transaction_t* get_transaction() {
+    transaction_t *get_transaction() {
         return &_data;
     }
 

--- a/platform/mbed_alloc_wrappers.cpp
+++ b/platform/mbed_alloc_wrappers.cpp
@@ -76,12 +76,12 @@ void mbed_stats_heap_get(mbed_stats_heap_t *stats)
 #endif/* FEATURE_UVISOR */
 
 extern "C" {
-    void * __real__malloc_r(struct _reent * r, size_t size);
-    void * __real__memalign_r(struct _reent * r, size_t alignment, size_t bytes);
-    void * __real__realloc_r(struct _reent * r, void * ptr, size_t size);
+    void  *__real__malloc_r(struct _reent * r, size_t size);
+    void  *__real__memalign_r(struct _reent * r, size_t alignment, size_t bytes);
+    void  *__real__realloc_r(struct _reent * r, void * ptr, size_t size);
     void __real__free_r(struct _reent * r, void * ptr);
-    void* __real__calloc_r(struct _reent * r, size_t nmemb, size_t size);
-    void* malloc_wrapper(struct _reent * r, size_t size, void * caller);
+    void *__real__calloc_r(struct _reent * r, size_t nmemb, size_t size);
+    void *malloc_wrapper(struct _reent * r, size_t size, void * caller);
     void free_wrapper(struct _reent * r, void * ptr, void* caller);
 }
 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -933,7 +933,7 @@ int mbed_getc(std::FILE *_file){
 #endif
 }
 
-char* mbed_gets(char*s, int size, std::FILE *_file){
+char *mbed_gets(char*s, int size, std::FILE *_file){
 #if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
     /*This is only valid for unbuffered streams*/
     char *str = fgets(s,size,_file);
@@ -1191,7 +1191,7 @@ extern "C" clock_t clock()
 }
 
 // temporary - Default to 1MHz at 32 bits if target does not have us_ticker_get_info
-MBED_WEAK const ticker_info_t* us_ticker_get_info()
+MBED_WEAK const ticker_info_t *us_ticker_get_info()
 {
     static const ticker_info_t info = {
         1000000,
@@ -1201,7 +1201,7 @@ MBED_WEAK const ticker_info_t* us_ticker_get_info()
 }
 
 // temporary - Default to 1MHz at 32 bits if target does not have lp_ticker_get_info
-MBED_WEAK const ticker_info_t* lp_ticker_get_info()
+MBED_WEAK const ticker_info_t *lp_ticker_get_info()
 {
     static const ticker_info_t info = {
         1000000,

--- a/rtos/Mail.h
+++ b/rtos/Mail.h
@@ -87,7 +87,7 @@ public:
 
       @note You may call this function from ISR context if the millisec parameter is set to 0.
     */
-    T* alloc(uint32_t millisec=0) {
+    T *alloc(uint32_t millisec=0) {
         return _pool.alloc();
     }
 
@@ -97,7 +97,7 @@ public:
 
       @note You may call this function from ISR context if the millisec parameter is set to 0.
     */
-    T* calloc(uint32_t millisec=0) {
+    T *calloc(uint32_t millisec=0) {
         return _pool.calloc();
     }
 

--- a/rtos/MemoryPool.h
+++ b/rtos/MemoryPool.h
@@ -79,7 +79,7 @@ public:
 
       @note You may call this function from ISR context.
     */
-    T* alloc(void) {
+    T *alloc(void) {
         return (T*)osMemoryPoolAlloc(_id, 0);
     }
 
@@ -88,7 +88,7 @@ public:
 
       @note You may call this function from ISR context.
     */
-    T* calloc(void) {
+    T *calloc(void) {
         T *item = (T*)osMemoryPoolAlloc(_id, 0);
         if (item != NULL) {
             memset(item, 0, sizeof(T));

--- a/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
+++ b/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
@@ -79,7 +79,7 @@ __NO_RETURN uint32_t osRtxErrorNotify (uint32_t code, void *object_id)
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED
 
-static const char* error_msg(int32_t status)
+static const char *error_msg(int32_t status)
 {
     switch (status) {
     case osError:


### PR DESCRIPTION
See the related discussions in the handbook for more info:
https://github.com/ARMmbed/Handbook/issues/292, https://github.com/ARMmbed/Handbook/pull/382#discussion_r164111263

This patch standardizes the position of pointers in return types to be consistent with other variable declarations. @0xc0170 is also updating the Handbook to reflect this in https://github.com/ARMmbed/Handbook/pull/382.

Script: Note the list of directories used. Feel free to run on any other directories we want to standardize:
``` bash
for d in drivers platform hal rtos events ; do sed -i 's/^\( *[a-zA-Z_][a-zA-Z0-9_ ]*\)\([*&]\) \([a-zA-Z_][a-zA-Z0-9_]*(\)/\1 \2\3/' $(find -regex ./$d'.*\.\(h\|c\|hpp\|cpp\)') ; done
```

cc @0xc0170, @kjbracey-arm 