### PR TITLE
Correct SW4STM32 supported check

### DIFF
--- a/tools/export/sw4stm32/__init__.py
+++ b/tools/export/sw4stm32/__init__.py
@@ -20,6 +20,7 @@ from tools.utils import mkdir
 from tools.export.gnuarmeclipse import GNUARMEclipse
 from tools.export.gnuarmeclipse import UID
 from tools.build_api import prepare_toolchain
+from tools.targets import TARGET_MAP
 from sys import flags, platform
 
 # Global random number generator instance.
@@ -281,7 +282,14 @@ class Sw4STM32(GNUARMEclipse):
         },
     }
 
-    TARGETS = BOARDS.keys()
+
+    @classmethod
+    def is_target_supported(cls, target_name):
+        target = TARGET_MAP[target_name]
+        target_supported = bool(set(target.resolution_order_names)
+                                .intersection(set(cls.BOARDS.keys())))
+        toolchain_supported = cls.TOOLCHAIN in target.supported_toolchains
+        return target_supported and toolchain_supported
 
     def __gen_dir(self, dir_name):
         """


### PR DESCRIPTION
The check was being inherited from GNUARMEclipse, which only checks for
toolchain support. This updated check takes the `BOARDS` dict into account