### PR TITLE
allow use of external memory as heap with TOOLCHAIN_GCC_ARM

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -770,7 +770,8 @@ extern "C" caddr_t _sbrk(int incr) {
 #else
 // Linker defined symbol used by _sbrk to indicate where heap should start.
 extern "C" uint32_t __end__;
-extern "C" caddr_t _sbrk(int incr) {
+// Weak attribute allows user to override, e.g. to use external RAM for dynamic memory.
+extern "C" WEAK caddr_t _sbrk(int incr) {
     static unsigned char* heap = (unsigned char*)&__end__;
     unsigned char*        prev_heap = heap;
     unsigned char*        new_heap = heap + incr;


### PR DESCRIPTION
This PR addresses https://github.com/ARMmbed/mbed-os/issues/5638. It allows the user to optionally (with the right additional software) use external memory for all dynamic memory with `TOOLCHAIN_GCC_ARM`, by allowing the user to override the `_sbrk()` function defined in `platform/mbed_retarget.cpp`.

For example, when using the Embedded Artists' [LPC4088 QuickStart Board](https://www.embeddedartists.com/products/boards/lpc4088_qsb.php) with [EALib](https://os.mbed.com/users/embeddedartists/code/EALib/)'s SDRAM module ([cpp](https://os.mbed.com/users/embeddedartists/code/EALib/file/e1e36493f347/sdram.cpp/), [h](https://os.mbed.com/users/embeddedartists/code/EALib/file/e1e36493f347/sdram.h/)) and the Mbed online compiler (and Keil uVision offline IDE, I presume), dynamic memory uses the off-chip on-board 32 MB SDRAM. I assume there are other boards that can support this behavior too, but this is the one I know of for sure. This PR makes this behavior the same on `TOOLCHAIN_GCC_ARM`.