### PR TITLE
Prevent detect_targets.py tool script from crashing on known targets

### DIFF
--- a/tools/detect_targets.py
+++ b/tools/detect_targets.py
@@ -79,7 +79,7 @@ def main():
 
         count = 0
         for mut in muts.values():
-            if re.match(mcu_filter, mut['mcu']):
+            if re.match(mcu_filter, mut['mcu'] or "Unknown"):
                 interface_version = get_interface_version(mut['disk'])
                 print ""
                 print "[mbed] Detected %s, port %s, mounted %s, interface version %s:" % \


### PR DESCRIPTION
As mut['mcu'] can be "None" on unknown targets, the detect_targets script crashes when one of these boards is connected.

This happens when "mbed-cli detect -vv" is ran when a STEVAL-3DP001V1 board is connected. Which does not provide a html file with a target_id, and thus cannot be looked up in the mbedls platform database.
http://www.st.com/en/evaluation-tools/steval-3dp001v1.html

Notes:
- Pull requests will not be accepted until the submitter has agreed to the [contributer agreement](https://github.com/ARMmbed/mbed-os/blob/master/CONTRIBUTING.md).
- This is just a template, so feel free to use/remove the unnecessary things

## Description

A few sentences describing the overall goals of the pull request's commits.

## Status

**READY/IN DEVELOPMENT/HOLD**

## Migrations

If this PR changes any APIs or behaviors, give a short description of what *API users* should do when this PR is merged.

YES | NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

Notes regarding the deployment of this PR. These should note any required changes in the build environment, tools, compilers and so on.

## Steps to test or reproduce

Outline the steps to test or reproduce the PR here.
