### PR TITLE
STM32L476/486: Improve SRAM usage for IAR

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -21,12 +21,11 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
 define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
-/* Stack 1/8 and Heap 1/4 of RAM */
-define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0xa000;
+/* Stack complete SRAM2 and Heap 2/3 of SRAM1 */
+define symbol __size_cstack__ = 0x7e00;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
-define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -34,5 +33,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in SRAM1_region { readwrite, block HEAP };
+place in SRAM2_region { block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
@@ -18,12 +18,11 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
 define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
-/* Stack 1/8 and Heap 1/4 of RAM */
-define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0xa000;
+/* Stack complete SRAM2 and Heap 2/3 of SRAM1 */
+define symbol __size_cstack__ = 0x7e00;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
-define block STACKHEAP with fixed order { block HEAP, block CSTACK };
 
 initialize by copy with packing = zeros { readwrite };
 do not initialize  { section .noinit };
@@ -31,5 +30,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM1_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in SRAM1_region { readwrite, block HEAP };
+place in SRAM2_region { block CSTACK };


### PR DESCRIPTION
## Description
- These devices have 2 SRAM areas
- Before this PR only SRAM1 was used for Stack and Heap
- Now both SRAM are used: Stack placed in SRAM2 and Heap in SRAM1
- Continuation of PR #5844 done for STM32L475 device

## Status
**READY**

Tested OK on NUCLEO_L476RG

## Migrations
NO

Fixes https://github.com/ARMmbed/mbed-os/issues/5859.
