### PR TITLE
[feature-nrf528xx] Switch to managed bootloader for SoftDevice merge on NRF52

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_S132/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_S132/mbed_lib.json
@@ -8,7 +8,7 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["BLE"],
-            "target.mbed_app_start": "0x23000"
+            "target.bootloader_img": "hex/s132_nrf52_5.0.0_softdevice.hex"
         }
     }
 }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_S140/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_S140/mbed_lib.json
@@ -10,7 +10,7 @@
     "target_overrides": {
         "*": {
             "target.features_add": ["BLE"],
-            "target.mbed_app_start": "0x22000"
+            "target.bootloader_img": "hex/s140_nrf52840_5.0.0-2.alpha_softdevice.hex"
         }
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3356,7 +3356,6 @@
             "NORDIC", 
             "NRF5x", 
             "NRF52", 
-            "MCU_NRF52832", 
             "SDK_14_2", 
             "SOFTDEVICE_COMMON", 
             "SOFTDEVICE_S132"
@@ -3367,20 +3366,7 @@
         "public": false,
         "detect_code": ["1101"],
         "program_cycle_s": 6,
-        "MERGE_SOFT_DEVICE": true,
-        "EXPECTED_SOFTDEVICES_WITH_OFFSETS": [
-            {
-                "boot": "",
-                "name": "s132_nrf52_5.0.0_softdevice.hex",
-                "offset": 143360
-            }
-        ],
-        "post_binary_hook": {
-            "function": "MCU_NRF51Code.binary_hook",
-            "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
-        },
         "bootloader_supported": true,
-        "MERGE_BOOTLOADER": false,
         "config": {
             "lf_clock_src": {
                 "value": "NRF_LF_SRC_XTAL",
@@ -3473,7 +3459,6 @@
             "NORDIC", 
             "NRF5x", 
             "NRF52", 
-            "MCU_NRF52840", 
             "SDK_14_2", 
             "SOFTDEVICE_COMMON", 
             "SOFTDEVICE_S140"
@@ -3484,21 +3469,7 @@
         "public": false,
         "detect_code": ["1101"],
         "program_cycle_s": 6,
-        "MERGE_SOFT_DEVICE": true,
-        "EXPECTED_SOFTDEVICES_WITH_OFFSETS": [
-            {
-                "boot": "",
-                "name": "s140_nrf52840_5.0.0-2.alpha_softdevice.hex",
-                "offset": 139264
-            }
-        ],
-        "bootloader_select_index": 0,
-        "post_binary_hook": {
-            "function": "MCU_NRF51Code.binary_hook",
-            "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
-        },
         "bootloader_supported": true,
-        "MERGE_BOOTLOADER": false,
         "config": {
             "lf_clock_src": {
                 "value": "NRF_LF_SRC_XTAL",


### PR DESCRIPTION
SoftDevice can be swapped even easier now:

    "target_overrides": {
        "*": {
            "target.extra_labels_remove": ["SOFTDEVICE_COMMON", "SOFTDEVICE_S140"],
            "target.extra_labels_add": ["SOFTDEVICE_NONE"]
        }
    }
