### PR TITLE
fix for issue "serial example callback not working"

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
@@ -103,7 +103,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         return;
     }
 #ifdef CONFIG_MBED_ENABLED 
-    else if(uart_idx == UART_3){
+    else if (uart_idx == UART_3) {
         obj->index = UART_3;
         goto init_stdio;
     }
@@ -162,11 +162,11 @@ void serial_free(serial_t *obj)
 {
     PHAL_RUART_ADAPTER pHalRuartAdapter;
 #ifdef CONFIG_GDMA_EN
-    u8  uart_idx;
+    u8 uart_idx;
     PUART_DMA_CONFIG   pHalRuartDmaCfg;
 #endif
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_free(&stdio_uart_log);
         return;
     }
@@ -193,7 +193,7 @@ void serial_free(serial_t *obj)
 void serial_baud(serial_t *obj, int baudrate)
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         return;
     }
 #endif
@@ -208,7 +208,7 @@ void serial_baud(serial_t *obj, int baudrate)
 void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_format(&stdio_uart_log, data_bits, parity, stop_bits);
         return;
     }
@@ -260,8 +260,7 @@ static void SerialTxDoneCallBack(VOID *pAdapter)
     pHalRuartAdapter->Interrupts &= ~RUART_IER_ETBEI;
     HalRuartSetIMRRtl8195a (pHalRuartAdapter);
 
-    if (irq_handler[uart_idx] != NULL) 
-    {
+    if (irq_handler[uart_idx] != NULL) {
         irq_handler[uart_idx](serial_irq_ids[uart_idx], TxIrq);
     }
 }
@@ -271,8 +270,7 @@ static void SerialRxDoneCallBack(VOID *pAdapter)
     PHAL_RUART_ADAPTER pHalRuartAdapter = pAdapter;
     u8 uart_idx = pHalRuartAdapter->UartIndex;
     
-    if (irq_handler[uart_idx] != NULL)
-    {
+    if (irq_handler[uart_idx] != NULL) {
         irq_handler[uart_idx](serial_irq_ids[uart_idx], RxIrq);
     }
 }
@@ -281,15 +279,13 @@ static void SerialRxDoneCallBack(VOID *pAdapter)
 #ifdef CONFIG_MBED_ENABLED
 static void serial_loguart_irq_handler(uint32_t id, LOG_UART_INT_ID event)
 {
-    if(event == IIR_RX_RDY || event == IIR_CHAR_TIMEOUT)
+    if (event == IIR_RX_RDY || event == IIR_CHAR_TIMEOUT)
     {
-        if (log_irq_handler){
+        if (log_irq_handler) {
             log_irq_handler(serial_log_irq_ids, RxIrq);
             }
-    }
-    else if(event == IIR_THR_EMPTY)
-    {
-        if (log_irq_handler){
+    } else if (event == IIR_THR_EMPTY) {
+        if (log_irq_handler) {
                 log_irq_handler(serial_log_irq_ids, TxIrq);
             }
     }
@@ -303,94 +299,67 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 {
 
 #ifdef CONFIG_MBED_ENABLED
-            if(obj->index == UART_3)
-            {
+            if (obj->index == UART_3) {
                 log_irq_handler = handler;
-                serial_log_irq_ids = id;     
-    
+                serial_log_irq_ids = id;
                 log_uart_irq_handler(&stdio_uart_log, serial_loguart_irq_handler, id);
                 return;
             }             
 #endif
-
-
     PHAL_RUART_ADAPTER pHalRuartAdapter;
     u8 uart_idx;
-
-    pHalRuartAdapter = &(obj->hal_uart_adp);    
+    pHalRuartAdapter = &(obj->hal_uart_adp);
     uart_idx = pHalRuartAdapter->UartIndex;
-    
     irq_handler[uart_idx] = handler;
-    serial_irq_ids[uart_idx] = id;        
-
+    serial_irq_ids[uart_idx] = id;
     pHalRuartAdapter->TxTDCallback = SerialTxDoneCallBack;
     pHalRuartAdapter->TxTDCbPara = (void*)pHalRuartAdapter;
     pHalRuartAdapter->RxDRCallback = SerialRxDoneCallBack;
     pHalRuartAdapter->RxDRCbPara = (void*)pHalRuartAdapter;    
 }
 
-
 void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) 
 {
-
 #ifdef CONFIG_MBED_ENABLED
-        if(obj->index == UART_3)
-        {
-            if(irq == RxIrq)
-               {
-                   log_uart_irq_set(&stdio_uart_log, IIR_RX_RDY, enable);
-            }
-            else
-            {
+        if (obj->index == UART_3) {
+            if (irq == RxIrq) {
+                log_uart_irq_set(&stdio_uart_log, IIR_RX_RDY, enable);
+            } else {
                 log_uart_irq_set(&stdio_uart_log, IIR_THR_EMPTY, enable);
             }
             return;
         }
 #endif
-
     PHAL_RUART_ADAPTER pHalRuartAdapter;
     PHAL_RUART_OP pHalRuartOp;
     u8 uart_idx;
-
     pHalRuartAdapter = &(obj->hal_uart_adp);
     pHalRuartOp = &(obj->hal_uart_op);
     uart_idx = pHalRuartAdapter->UartIndex;
-
     
-    if (enable) 
-    {
-        if (irq == RxIrq) 
-        {
+    if (enable) {
+        if (irq == RxIrq) {
             pHalRuartAdapter->Interrupts |= RUART_IER_ERBI | RUART_IER_ELSI;
             serial_irq_en[uart_idx] |= SERIAL_RX_IRQ_EN;
             HalRuartSetIMRRtl8195a (pHalRuartAdapter);
-        } 
-        else 
-        {
+        } else {
             serial_irq_en[uart_idx] |= SERIAL_TX_IRQ_EN;
         }
          
         pHalRuartOp->HalRuartRegIrq(pHalRuartAdapter);
-         
         //log_uart
         pHalRuartOp->HalRuartIntEnable(pHalRuartAdapter);
-    } 
-    else 
-    { // disable
-        if (irq == RxIrq) 
-        {
+    } else { // disable
+        if (irq == RxIrq) {
             pHalRuartAdapter->Interrupts &= ~(RUART_IER_ERBI | RUART_IER_ELSI);
             serial_irq_en[uart_idx] &= ~SERIAL_RX_IRQ_EN;
-        } 
-        else 
-        {
+        } else {
             pHalRuartAdapter->Interrupts &= ~RUART_IER_ETBEI;
             serial_irq_en[uart_idx] &= ~SERIAL_TX_IRQ_EN;
         }
         HalRuartSetIMRRtl8195a (pHalRuartAdapter);
         
-        if (pHalRuartAdapter->Interrupts == 0) 
-        {
+        if (pHalRuartAdapter->Interrupts == 0) {
             InterruptUnRegister(&pHalRuartAdapter->IrqHandle);
             InterruptDis(&pHalRuartAdapter->IrqHandle);
         }
@@ -404,7 +373,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 int serial_getc(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         return log_uart_getc(&stdio_uart_log);
     }
 #endif
@@ -418,7 +387,7 @@ int serial_getc(serial_t *obj)
 void serial_putc(serial_t *obj, int c) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_putc(&stdio_uart_log, (char)c);
         return;
     }
@@ -439,7 +408,7 @@ void serial_putc(serial_t *obj, int c)
 int serial_readable(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         return log_uart_readable(&stdio_uart_log);
     }
 #endif
@@ -457,7 +426,7 @@ int serial_readable(serial_t *obj)
 int serial_writable(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         return log_uart_writable(&stdio_uart_log);
     }
 #endif
@@ -465,8 +434,7 @@ int serial_writable(serial_t *obj)
     PHAL_RUART_ADAPTER pHalRuartAdapter=(PHAL_RUART_ADAPTER)&(obj->hal_uart_adp);
     u8  uart_idx = pHalRuartAdapter->UartIndex;
 
-    if (HAL_RUART_READ32(uart_idx, RUART_LINE_STATUS_REG_OFF) & 
-                        (RUART_LINE_STATUS_REG_THRE)) {
+    if (HAL_RUART_READ32(uart_idx, RUART_LINE_STATUS_REG_OFF) & (RUART_LINE_STATUS_REG_THRE)) {
        return 1;
     } else {
         return 0;
@@ -476,7 +444,7 @@ int serial_writable(serial_t *obj)
 void serial_clear(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_clear(&stdio_uart_log);
         return;
     }
@@ -491,7 +459,7 @@ void serial_clear(serial_t *obj)
 void serial_break_set(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_break_set(&stdio_uart_log);
         return;
     }
@@ -500,7 +468,6 @@ void serial_break_set(serial_t *obj)
     PHAL_RUART_ADAPTER pHalRuartAdapter=(PHAL_RUART_ADAPTER)&(obj->hal_uart_adp);
     u8  uart_idx = pHalRuartAdapter->UartIndex;
     u32 RegValue;
-
     RegValue = HAL_RUART_READ32(uart_idx, RUART_LINE_CTL_REG_OFF);
     RegValue |= BIT_UART_LCR_BREAK_CTRL;
     HAL_RUART_WRITE32(uart_idx, RUART_LINE_CTL_REG_OFF, RegValue);
@@ -509,16 +476,14 @@ void serial_break_set(serial_t *obj)
 void serial_break_clear(serial_t *obj) 
 {
 #ifdef CONFIG_MBED_ENABLED
-    if(obj->index == UART_3){
+    if (obj->index == UART_3) {
         log_uart_break_clear(&stdio_uart_log);
         return;
     }
 #endif
-
     PHAL_RUART_ADAPTER pHalRuartAdapter=(PHAL_RUART_ADAPTER)&(obj->hal_uart_adp);
     u8  uart_idx = pHalRuartAdapter->UartIndex;
     u32 RegValue;
-
     RegValue = HAL_RUART_READ32(uart_idx, RUART_LINE_CTL_REG_OFF);
     RegValue &= ~(BIT_UART_LCR_BREAK_CTRL);
     HAL_RUART_WRITE32(uart_idx, RUART_LINE_CTL_REG_OFF, RegValue);


### PR DESCRIPTION
## Description
This PR fixes issue #5805. The changes have been made only in one file.

The "CONFIG_MBED_ENABLED" macro has been put so that the software is compatible with our own internal SDK.

The other changes is to add support for loguart hardware in the normal serial api. 

## Status
**READY/**

## Migrations
NO

