### PR TITLE
fix compiler warning

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -712,13 +712,14 @@ ssize_t FATFileSystem::dir_read(fs_dir_t dir, struct dirent *ent)
 void FATFileSystem::dir_seek(fs_dir_t dir, off_t offset)
 {
     FATFS_DIR *dh = static_cast<FATFS_DIR*>(dir);
+    off_t dptr = static_cast<off_t>(dh->dptr);
 
     lock();
 
-    if (offset < dh->dptr) {
+    if (offset < dptr) {
         f_rewinddir(dh);
     }
-    while (dh->dptr < offset) {
+    while (dptr < offset) {
         FILINFO finfo;
         FRESULT res;
 


### PR DESCRIPTION
Resolves the compiler warnings first mentioned [here](https://github.com/ARMmbed/mbed-os/pull/5503#issuecomment-356636356):

    ../mbed-os/features/filesystem/fat/FATFileSystem.cpp: In member function 'virtual void FATFileSystem::dir_seek(mbed::fs_dir_t, off_t)':
    ../mbed-os/features/filesystem/fat/FATFileSystem.cpp:661:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (offset < dh->dptr) {
             ~~~~~~~^~~~~~~~~~
    ../mbed-os/features/filesystem/fat/FATFileSystem.cpp:664:21: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         while (dh->dptr < offset) {
                ~~~~~~~~~^~~~~~~~

I don't actually understand how `dir_seek()` is doing its job, though. Can someone explain?