### PR TITLE
nrf5x: fix array overflow in gpio configuration code 

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/gpio_api.c
@@ -112,7 +112,7 @@ static void gpiote_pin_uninit(uint8_t pin)
         if ((m_gpio_cfg[pin].direction == PIN_OUTPUT) && (!m_gpio_cfg[pin].used_as_irq)) {
             nrf_drv_gpiote_out_uninit(pin);
         }
-        else {
+        else if (m_gpio_cfg[pin].used_as_irq) {
             nrf_drv_gpiote_in_uninit(pin);
         }
     }


### PR DESCRIPTION
## Description

nrf5x: gpiote uninit only needs to be run if input pin is configured for irq (or output)

Refer to #6020 for more details

## Status

**READY**

## Migrations

NO

## Related PRs

 #5207
