### PR TITLE
Changed HAL_MspInit to mbed_main

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.cpp
@@ -17,11 +17,11 @@
 #include "min_battery_voltage.h"
 #include "battery_charger_i2c.h"
 
-/** Defining HAL_MspInit strong function
+/** Defining mbed_main strong function
  * in user defined file as described in documentation
  */
 
-void HAL_MspInit(void)
+void mbed_main(void)
 {
 	set_minimum_battery_voltage();
 }


### PR DESCRIPTION
## Description
Bug fix for C030 battery charger. There is a wait function being called in the boot process (inside HAL_MspInit) and at that stage, the kernel has not been initialised. A fix for this would be to use mbed_main() instead of HAL_MspInit() in user file as mbed_main() is being called at a later stage in the boot process. 

@RobMeades is already following up this issue, please refer to #5995 