### PR TITLE
Mesh-api setters for eui64 and pskd

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -82,7 +82,7 @@ protected:
     int8_t _network_interface_id;
     /** Registered device ID */
     int8_t _device_id;
-    uint8_t eui64[8];
+    uint8_t _eui64[8];
     char ip_addr_str[40];
     char mac_addr_str[24];
     Semaphore connect_semaphore;

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
@@ -34,6 +34,25 @@ public:
     ThreadInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy) { }
 
     nsapi_error_t initialize(NanostackRfPhy *phy);
+
+    /**
+     * \brief Sets the eui64 for the device configuration.
+     * By default this value is read from the radio driver.
+     * The value must be set before calling the connect function.
+     * */
+    void device_eui64_set(const uint8_t *eui64);
+
+    /**
+     * \brief sets the PSKd for the device configuration.
+     * The default value is overwritten, which is defined in the mbed_lib.json file in the mesh-api
+     * The value must be set before calling the connect function.
+     * \return MESH_ERROR_NONE on success.
+     * \return MESH_ERROR_PARAM in case of illegal parameters.
+     * \return MESH_ERROR_MEMORY in case of memory error.
+     * */
+
+    mesh_error_t device_pskd_set(const char *pskd);
+
     virtual int connect();
     virtual int disconnect();
 private:

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -19,7 +19,7 @@
 #include "mesh_system.h"
 
 MeshInterfaceNanostack::MeshInterfaceNanostack()
-    : phy(NULL), _network_interface_id(-1), _device_id(-1), eui64(),
+    : phy(NULL), _network_interface_id(-1), _device_id(-1), _eui64(),
       ip_addr_str(), mac_addr_str(), connect_semaphore(0)
 {
     // Nothing to do
@@ -62,8 +62,13 @@ nsapi_error_t MeshInterfaceNanostack::register_phy()
         return -1;
     }
     // Read mac address after registering the device.
-    phy->get_mac_address(eui64);
-    sprintf(mac_addr_str, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", eui64[0], eui64[1], eui64[2], eui64[3], eui64[4], eui64[5], eui64[6], eui64[7]);
+    const uint8_t empty_eui64[8] = {0,0,0,0,0,0,0,0};
+    // if not set by application then read from rf driver
+    if(!memcmp(_eui64, empty_eui64,8)) {
+        phy->get_mac_address(_eui64);
+    }
+
+    sprintf(mac_addr_str, "%02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x", _eui64[0], _eui64[1], _eui64[2], _eui64[3], _eui64[4], _eui64[5], _eui64[6], _eui64[7]);
 
     nanostack_unlock();
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -20,7 +20,6 @@ int ThreadInterface::connect()
         nanostack_unlock();
         return NSAPI_ERROR_DEVICE_ERROR;
     }
-
     // After the RF is up, we can seed the random from it.
     randLIB_seed_random();
 
@@ -64,12 +63,9 @@ int ThreadInterface::disconnect()
 
 mesh_error_t ThreadInterface::init()
 {
-    if (eui64 == NULL) {
-        return MESH_ERROR_PARAM;
-    }
     thread_tasklet_init();
     __mesh_handler_set_callback(this);
-    thread_tasklet_device_config_set(eui64, NULL);
+    thread_tasklet_device_eui64_set(_eui64);
     _network_interface_id = thread_tasklet_network_init(_device_id);
 
     if (_network_interface_id == -2) {
@@ -111,6 +107,15 @@ mesh_error_t ThreadInterface::mesh_connect()
     }
 }
 
+void ThreadInterface::device_eui64_set(const uint8_t *eui64)
+{
+    memcpy(_eui64, eui64, 8);
+}
+
+mesh_error_t ThreadInterface::device_pskd_set(const char *pskd)
+{
+    return (mesh_error_t)thread_tasklet_device_pskd_set(pskd);
+}
 
 mesh_error_t ThreadInterface::mesh_disconnect()
 {

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/include/thread_tasklet.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/include/thread_tasklet.h
@@ -68,11 +68,17 @@ void thread_tasklet_init(void);
 int8_t thread_tasklet_network_init(int8_t device_id);
 
 /*
- * \brief Set device configuration for thread network
- * \param eui64 mac address of the registered rf device
+ * \brief Sets eui64 for the device configuration
+ * \param eui64 eui64 to be set
  * \param pskd private shared key
  */
-void thread_tasklet_device_config_set(uint8_t *eui64, char *pskd);
+void thread_tasklet_device_eui64_set(const uint8_t *eui64);
+
+/*
+ * \brief Sets PSKd for the device configuration
+ * \param pskd private shared key to be set
+ */
+uint8_t thread_tasklet_device_pskd_set(const char *pskd);
 
 /*
  * \brief Disconnect network interface.


### PR DESCRIPTION
Notes:

## Description

New setters for mesh-api to be used by the Thread network.
Needed by customers when deploying devices for commissioning.

## Status

**IN DEVELOPMENT**

## Migrations

 NO

## Related PRs

## Todos


## Deploy notes

## Steps to test or reproduce


