### PR TITLE
Nuvoton: Rework us_ticker, lp_ticker and RTC

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "lp_ticker_api.h"
 
 #if DEVICE_LOWPOWERTIMER
 
 #include "sleep_api.h"
+#include "mbed_wait_api.h"
+#include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// lp_ticker tick = us = timestamp
-#define US_PER_TICK             (1)
-#define US_PER_SEC              (1000 * 1000)
-
-#define US_PER_TMR2_INT         (US_PER_SEC * 10)
-#define TMR2_CLK_PER_SEC        (__LXT)
-#define TMR2_CLK_PER_TMR2_INT   ((uint32_t) ((uint64_t) US_PER_TMR2_INT * TMR2_CLK_PER_SEC / US_PER_SEC))
-#define TMR3_CLK_PER_SEC        (__LXT)
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per lp_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (__LXT)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr2_vec(void);
 static void tmr3_vec(void);
-static void lp_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int lp_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_clks = 0;
-static volatile uint32_t cd_minor_clks = 0;
-static volatile uint32_t wakeup_tick = (uint32_t) -1;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC.
-// NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled wakeup
+/* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
 static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
 static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
 
@@ -52,20 +53,17 @@ static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLK
 
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    lp_ticker_inited = 1;
-    
-    counter_major = 0;
-    cd_major_minor_clks = 0;
-    cd_minor_clks = 0;
-    wakeup_tick = (uint32_t) -1;
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
 
     // Reset module
     SYS_ResetModule(timer2_modinit.rsetidx);
     SYS_ResetModule(timer3_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
     CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
@@ -75,93 +73,114 @@ void lp_ticker_init(void)
 
     // Configure clock
     uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / TMR2_CLK_PER_SEC - 1;
+    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % TMR2_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR2_CLK_PER_TMR2_INT;
+    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer2 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
     // Continuous mode
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer2/* | TIMER_CTL_CNTDATEN_Msk*/;
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMP = cmp_timer2;
-    
+
     // Set vector
     NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
     NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
-    
+
     NVIC_EnableIRQ(timer2_modinit.irq_n);
     NVIC_EnableIRQ(timer3_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // NOTE: TIMER_Start() first and then lp_ticker_set_interrupt(); otherwise, we may get stuck in lp_ticker_read() because
-    //       timer is not running.
-    
-    // Start timer
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // Schedule wakeup to match semantics of lp_ticker_get_compare_match()
-    lp_ticker_set_interrupt(wakeup_tick);
 }
 
 timestamp_t lp_ticker_read()
-{    
-    if (! lp_ticker_inited) {
+{
+    if (! ticker_inited) {
         lp_ticker_init();
     }
-    
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
-    
-    do {
-        uint64_t major_minor_clks;
-        uint32_t minor_clks;
-        
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-        
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_clks = TIMER_GetCounter(timer2_base);
-            uint32_t carry = (timer2_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Hanlde carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_clks > (TMR2_CLK_PER_TMR2_INT / 2)) {
-                major_minor_clks = (counter_major + 1) * TMR2_CLK_PER_TMR2_INT;
-            }
-            else {
-                major_minor_clks = (counter_major + carry) * TMR2_CLK_PER_TMR2_INT + minor_clks;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_clks == 0 || minor_clks == TMR2_CLK_PER_TMR2_INT);
 
-        // Add power-down compensation
-        return ((uint64_t) major_minor_clks * US_PER_SEC / TMR2_CLK_PER_SEC / US_PER_TICK);
-    }
-    while (0);
+    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t delta = timestamp - lp_ticker_read();
-    wakeup_tick = timestamp;
-    
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    
-    cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
-    lp_ticker_arm_cd();
-}
 
-void lp_ticker_fire_interrupt(void)
-{
-    cd_major_minor_clks = cd_minor_clks = 0;
-    /**
-     * This event was in the past. Set the interrupt as pending, but don't process it here.
-     * This prevents a recurive loop under heavy load which can lead to a stack overflow.
-     */  
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+     
+    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
+    }
+
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        lp_ticker_fire_interrupt();
+    }
 }
 
 void lp_ticker_disable_interrupt(void)
@@ -174,48 +193,64 @@ void lp_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
 }
 
+void lp_ticker_fire_interrupt(void)
+{
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
+    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+}
+
 static void tmr2_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr3_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (cd_major_minor_clks > cd_minor_clks) ? (cd_major_minor_clks - cd_minor_clks) : 0;
-    if (cd_major_minor_clks == 0) {
-        // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-        lp_ticker_irq_handler();
-    }
-    else {
-        lp_ticker_arm_cd();
-    }
+
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
+    
 }
 
-static void lp_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-    
+
     // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
     timer3_base->CTL |= TIMER_CTL_RSTCNT_Msk;
     // One-shot mode, Clock = 1 KHz 
     uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / TMR3_CLK_PER_SEC - 1;
+    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % TMR3_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
     timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
     timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3/* | TIMER_CTL_CNTDATEN_Msk*/;
-    
-    cd_minor_clks = cd_major_minor_clks;
-    cd_minor_clks = NU_CLAMP(cd_minor_clks, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cd_minor_clks;
-    
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer3 = cd_clk;
+    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer3_base->CMP = cmp_timer3;
+
     TIMER_EnableInt(timer3_base);
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start(timer3_base);
 }
+
+const ticker_info_t* lp_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
+}
+
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M451/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/rtc_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "rtc_api.h"
 
 #if DEVICE_RTC
@@ -24,8 +24,65 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
-#define YEAR0       1900
-//#define EPOCH_YR    1970
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per second
+ *
+ * NOTE: This dependents on real hardware.
+ */
+#define NU_RTCCLK_PER_SEC           ((CLK->CLKSEL3 & CLK_CLKSEL3_SC0SEL_Msk) ? __LIRC : __LXT)
+
+/* Strategy for implementation of RTC HAL
+ *
+ * H/W RTC just supports year range 2000~2099, which cannot fully cover POSIX time (starting since 2970)
+ * and date time of struct TM (starting since 1900).
+ *
+ * To conquer the difficulty, we don't use H/W RTC to keep real date time. Instead, we use it to keep
+ * elapsed time in seconds since one reference time point. The strategy would be:
+ *
+ * 1. Choose DATETIME_HWRTC_ORIGIN (00:00:00 UTC, Saturday, 1 January 2000) as reference time point of H/W RTC.
+ * 2. t_hwrtc_origin = DATETIME_HWRTC_ORIGIN in POSIX time
+ * 3. t_hwrtc_elapsed = t_hwrtc_origin + elapsed time since t_hwrtc_origin
+ * 4. t_write = POSIX time set by rtc_write().
+ * 5. t_present = rtc_read() = t_write + (t_hwrtc_elapsed - t_hwrtc_origin)
+ *
+ * 1900
+ * |---------------------------------------------------------------------------------|
+ *           1970    t_write           t_present
+ * |---------|-------|-----------------|---------------------------------------------|
+ * 
+ * 2000 
+ * |-----------------|---------------------------------------------------------------|
+ * t_hwrtc_origin    t_hwrtc_elapsed
+ *
+ */
+/* Start year of struct TM*/
+#define NU_TM_YEAR0         1900
+/* Start year of POSIX time (set_time()/time()) */
+#define NU_POSIX_YEAR0      1970
+/* Start year of H/W RTC */
+#define NU_HWRTC_YEAR0      2000
+
+/* RTC H/W origin time: 00:00:00 UTC, Saturday, 1 January 2000 */
+static const S_RTC_TIME_DATA_T DATETIME_HWRTC_ORIGIN = {
+    2000,           /* Year value, range between 2000 ~ 2099 */
+    1,              /* Month value, range between 1 ~ 12 */
+    1,              /* Day value, range between 1 ~ 31 */
+    RTC_SATURDAY,   /* Day of the week */
+    0,              /* Hour value, range between 0 ~ 23 */
+    0,              /* Minute value, range between 0 ~ 59 */
+    0,              /* Second value, range between 0 ~ 59 */
+    RTC_CLOCK_24,   /* 12-Hour (RTC_CLOCK_12) / 24-Hour (RTC_CLOCK_24) */
+    0               /* RTC_AM / RTC_PM (used only for 12-Hour) */
+};
+/* t_hwrtc_origin initialized or not? */
+static bool t_hwrtc_origin_inited = 0;
+/* POSIX time of DATETIME_HWRTC_ORIGIN (since 00:00:00 UTC, Thursday, 1 January 1970) */
+static time_t t_hwrtc_origin = 0;
+/* POSIX time set by rtc_write() */
+static time_t t_write = 0;
+/* Convert date time from H/W RTC to struct TM */
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc);
 
 static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, 0, 0, 0, RTC_IRQn, NULL};
 
@@ -34,8 +91,11 @@ void rtc_init(void)
     if (rtc_isenabled()) {
         return;
     }
-    
+
     RTC_Open(NULL);
+
+    /* POSIX time origin (00:00:00 UTC, Thursday, 1 January 1970) */
+    rtc_write(0);
 }
 
 void rtc_free(void)
@@ -50,9 +110,60 @@ int rtc_isenabled(void)
         // Enable IP clock
         CLK_EnableModuleClock(rtc_modinit.clkidx);
     }
-    
+
     // NOTE: Check RTC Init Active flag to support crossing reset cycle.
     return  !! (RTC->INIT & RTC_INIT_ACTIVE_Msk);
+}
+
+time_t rtc_read(void)
+{
+    /* NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
+     *       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
+     */
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    /* Used for intermediary between date time of H/W RTC and POSIX time */
+    struct tm datetime_tm;
+
+    if (! t_hwrtc_origin_inited) {
+        t_hwrtc_origin_inited = 1;
+        
+        /* Convert date time from H/W RTC to struct TM */     
+        rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &DATETIME_HWRTC_ORIGIN);
+        /* Convert date time of struct TM to POSIX time */
+        if (! _rtc_maketime(&datetime_tm, &t_hwrtc_origin, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+            return 0;
+        }
+    }
+
+    S_RTC_TIME_DATA_T hwrtc_datetime_2K_present;
+    RTC_GetDateAndTime(&hwrtc_datetime_2K_present);
+    /* Convert date time from H/W RTC to struct TM */
+    rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &hwrtc_datetime_2K_present);
+    /* Convert date time of struct TM to POSIX time */
+    time_t t_hwrtc_elapsed;
+    if (! _rtc_maketime(&datetime_tm, &t_hwrtc_elapsed, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+        return 0;
+    }
+
+    /* Present time in POSIX time */
+    time_t t_present = t_write + (t_hwrtc_elapsed - t_hwrtc_origin);
+    return t_present;
+}
+
+void rtc_write(time_t t)
+{
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    t_write = t;
+
+    RTC_SetDateAndTime((S_RTC_TIME_DATA_T *) &DATETIME_HWRTC_ORIGIN);
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_RTCCLK_PER_SEC) * 3);
 }
 
 /*
@@ -67,69 +178,18 @@ int rtc_isenabled(void)
    tm_yday     days since January 1 0-365
    tm_isdst    Daylight Saving Time flag
 */
-
-time_t rtc_read(void)
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc)
 {
-    // NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
-    //       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
-    if (! rtc_isenabled()) {
-        rtc_init();
+    datetime_tm->tm_year = datetime_hwrtc->u32Year - NU_TM_YEAR0;
+    datetime_tm->tm_mon  = datetime_hwrtc->u32Month - 1;
+    datetime_tm->tm_mday = datetime_hwrtc->u32Day;
+    datetime_tm->tm_wday = datetime_hwrtc->u32DayOfWeek;
+    datetime_tm->tm_hour = datetime_hwrtc->u32Hour;
+    if (datetime_hwrtc->u32TimeScale == RTC_CLOCK_12 && datetime_hwrtc->u32AmPm == RTC_PM) {
+        datetime_tm->tm_hour += 12;
     }
-    
-    S_RTC_TIME_DATA_T rtc_datetime;
-    RTC_GetDateAndTime(&rtc_datetime);
-    
-    struct tm timeinfo;
-
-    // Convert struct tm to S_RTC_TIME_DATA_T
-    timeinfo.tm_year = rtc_datetime.u32Year - YEAR0;
-    timeinfo.tm_mon  = rtc_datetime.u32Month - 1;
-    timeinfo.tm_mday = rtc_datetime.u32Day;
-    timeinfo.tm_wday = rtc_datetime.u32DayOfWeek;
-    timeinfo.tm_hour = rtc_datetime.u32Hour;
-    if (rtc_datetime.u32TimeScale == RTC_CLOCK_12 && rtc_datetime.u32AmPm == RTC_PM) {
-        timeinfo.tm_hour += 12;
-    }
-    timeinfo.tm_min  = rtc_datetime.u32Minute;
-    timeinfo.tm_sec  = rtc_datetime.u32Second;
-
-    // Convert to timestamp
-    time_t t;
-    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return 0;
-    }
-
-    return t;
-}
-
-void rtc_write(time_t t)
-{
-    if (! rtc_isenabled()) {
-        rtc_init();
-    }
-
-    // Convert timestamp to struct tm
-    struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return;
-    }
-
-    S_RTC_TIME_DATA_T rtc_datetime;
-    
-    // Convert S_RTC_TIME_DATA_T to struct tm
-    rtc_datetime.u32Year        = timeinfo.tm_year + YEAR0;
-    rtc_datetime.u32Month       = timeinfo.tm_mon + 1;
-    rtc_datetime.u32Day         = timeinfo.tm_mday;
-    rtc_datetime.u32DayOfWeek   = timeinfo.tm_wday;
-    rtc_datetime.u32Hour        = timeinfo.tm_hour;
-    rtc_datetime.u32Minute      = timeinfo.tm_min;
-    rtc_datetime.u32Second      = timeinfo.tm_sec;
-    rtc_datetime.u32TimeScale   = RTC_CLOCK_24;
-    
-    // NOTE: Timing issue with write to RTC registers. This delay is empirical, not rational.
-    RTC_SetDateAndTime(&rtc_datetime);
-    //nu_nop(6000);
-    wait_us(100);
+    datetime_tm->tm_min  = datetime_hwrtc->u32Minute;
+    datetime_tm->tm_sec  = datetime_hwrtc->u32Second;
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
@@ -13,43 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "us_ticker_api.h"
 #include "sleep_api.h"
 #include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// us_ticker tick = us = timestamp
-#define US_PER_TICK             1
-#define US_PER_SEC              (1000 * 1000)
-
-#define TMR0HIRES_CLK_PER_SEC           (1000 * 1000)
-#define TMR1HIRES_CLK_PER_SEC           (1000 * 1000)
-
-#define US_PER_TMR0HIRES_CLK            (US_PER_SEC / TMR0HIRES_CLK_PER_SEC)
-#define US_PER_TMR1HIRES_CLK            (US_PER_SEC / TMR1HIRES_CLK_PER_SEC)
-
-#define US_PER_TMR0HIRES_INT            (1000 * 1000 * 10)
-#define TMR0HIRES_CLK_PER_TMR0HIRES_INT ((uint32_t) ((uint64_t) US_PER_TMR0HIRES_INT * TMR0HIRES_CLK_PER_SEC / US_PER_SEC))
-
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per us_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (1000 * 1000)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
 static void tmr1_vec(void);
-static void us_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int us_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_us = 0;
-static volatile uint32_t cd_minor_us = 0;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: PCLK is set up in mbed_sdk_init(), invocation of which must be before C++ global object constructor. See init_api.c for details.
-// NOTE: Choose clock source of timer:
-//       1. HIRC: Be the most accurate but might cause unknown HardFault.
-//       2. HXT: Less accurate and cannot pass mbed-drivers test.
-//       3. PCLK(HXT): Less accurate but can pass mbed-drivers test.
-// NOTE: TIMER_0 for normal counter, TIMER_1 for countdown.
+/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
 static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
 static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK0, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
@@ -58,19 +48,17 @@ static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CL
 
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    
-    counter_major = 0;
-    cd_major_minor_us = 0;
-    cd_minor_us = 0;
-    us_ticker_inited = 1;
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
     
     // Reset IP
     SYS_ResetModule(timer0hires_modinit.rsetidx);
     SYS_ResetModule(timer1hires_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
     CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
@@ -80,60 +68,109 @@ void us_ticker_init(void)
 
     // Timer for normal counter
     uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / TMR0HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % TMR0HIRES_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR0HIRES_CLK_PER_TMR0HIRES_INT;
+    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer0 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0/* | TIMER_CTL_CNTDATEN_Msk*/;
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMP = cmp_timer0;
-    
+
     NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
     NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
-    
+
     NVIC_EnableIRQ(timer0hires_modinit.irq_n);
     NVIC_EnableIRQ(timer1hires_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
     TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
 }
 
 uint32_t us_ticker_read()
 {
-    if (! us_ticker_inited) {
+    if (! ticker_inited) {
         us_ticker_init();
     }
-    
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
-        
-    do {
-        uint32_t major_minor_us;
-        uint32_t minor_us;
 
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-            
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_us = TIMER_GetCounter(timer0_base) * US_PER_TMR0HIRES_CLK;
-            uint32_t carry = (timer0_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Hanlde carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_us > (US_PER_TMR0HIRES_INT / 2)) {
-                major_minor_us = (counter_major + 1) * US_PER_TMR0HIRES_INT;
-            }
-            else {
-                major_minor_us = (counter_major + carry) * US_PER_TMR0HIRES_INT + minor_us;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_us == 0 || minor_us == US_PER_TMR0HIRES_INT);
-        
-        return (major_minor_us / US_PER_TICK);
+    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+}
+
+void us_ticker_set_interrupt(timestamp_t timestamp)
+{
+    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+    
+    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
     }
-    while (0);
+
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        us_ticker_fire_interrupt();
+    }
 }
 
 void us_ticker_disable_interrupt(void)
@@ -146,65 +183,56 @@ void us_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
 }
 
-void us_ticker_set_interrupt(timestamp_t timestamp)
-{
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    
-    uint32_t delta = timestamp - us_ticker_read();
-    cd_major_minor_us = delta * US_PER_TICK;
-    us_ticker_arm_cd();
-}
-
 void us_ticker_fire_interrupt(void)
 {
-    cd_major_minor_us = cd_minor_us = 0;
-    /**
-     * This event was in the past. Set the interrupt as pending, but don't process it here.
-     * This prevents a recurive loop under heavy load which can lead to a stack overflow.
-     */  
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
     NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
 }
 
 static void tmr0_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr1_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    cd_major_minor_us = (cd_major_minor_us > cd_minor_us) ? (cd_major_minor_us - cd_minor_us) : 0;
-    if (cd_major_minor_us == 0) {
-        // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-        us_ticker_irq_handler();
-    }
-    else {
-        us_ticker_arm_cd();
-    }
+
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }
 
-static void us_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-    
-    cd_minor_us = cd_major_minor_us;
 
     // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
     timer1_base->CTL |= TIMER_CTL_RSTCNT_Msk;
     // One-shot mode, Clock = 1 MHz 
     uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / TMR1HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % TMR1HIRES_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
     timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
     timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1/* | TIMER_CTL_CNTDATEN_Msk*/;
-    
-    uint32_t cmp_timer1 = cd_minor_us / US_PER_TMR1HIRES_CLK;
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer1 = cd_clk;
     cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
     timer1_base->CMP = cmp_timer1;
-    
+
     TIMER_EnableInt(timer1_base);
     TIMER_Start(timer1_base);
+}
+
+const ticker_info_t* us_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -19,31 +19,32 @@
 #if DEVICE_LOWPOWERTIMER
 
 #include "sleep_api.h"
+#include "mbed_wait_api.h"
+#include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// lp_ticker tick = us = timestamp
-#define US_PER_TICK             (1)
-#define US_PER_SEC              (1000 * 1000)
-
-#define US_PER_TMR2_INT         (US_PER_SEC * 10)
-#define TMR2_CLK_PER_SEC        (__LXT)
-#define TMR2_CLK_PER_TMR2_INT   ((uint32_t) ((uint64_t) US_PER_TMR2_INT * TMR2_CLK_PER_SEC / US_PER_SEC))
-#define TMR3_CLK_PER_SEC        (__LXT)
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per lp_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (__LXT)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr2_vec(void);
 static void tmr3_vec(void);
-static void lp_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int lp_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_clks = 0;
-static volatile uint32_t cd_minor_clks = 0;
-static volatile uint32_t wakeup_tick = (uint32_t) -1;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC.
-// NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled wakeup
+/* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
 static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
 static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
 
@@ -52,15 +53,12 @@ static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLK
 
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    lp_ticker_inited = 1;
+    ticker_inited = 1;
 
-    counter_major = 0;
-    cd_major_minor_clks = 0;
-    cd_minor_clks = 0;
-    wakeup_tick = (uint32_t) -1;
+    ticker_last_read_clk = 0;
 
     // Reset module
     SYS_ResetModule(timer2_modinit.rsetidx);
@@ -75,10 +73,10 @@ void lp_ticker_init(void)
 
     // Configure clock
     uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / TMR2_CLK_PER_SEC - 1;
+    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % TMR2_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR2_CLK_PER_TMR2_INT;
+    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer2 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
     // Continuous mode
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
@@ -94,69 +92,95 @@ void lp_ticker_init(void)
 
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-
-    // NOTE: TIMER_Start() first and then lp_ticker_set_interrupt(); otherwise, we may get stuck in lp_ticker_read() because
-    //       timer is not running.
-
-    // Start timer
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-
-    // Schedule wakeup to match semantics of lp_ticker_get_compare_match()
-    lp_ticker_set_interrupt(wakeup_tick);
 }
 
 timestamp_t lp_ticker_read()
 {
-    if (! lp_ticker_inited) {
+    if (! ticker_inited) {
         lp_ticker_init();
     }
 
     TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
 
-    do {
-        uint64_t major_minor_clks;
-        uint32_t minor_clks;
-
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_clks = TIMER_GetCounter(timer2_base);
-            uint32_t carry = (timer2_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Handle carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_clks > (TMR2_CLK_PER_TMR2_INT / 2)) {
-                major_minor_clks = (counter_major + 1) * TMR2_CLK_PER_TMR2_INT;
-            } else {
-                major_minor_clks = (counter_major + carry) * TMR2_CLK_PER_TMR2_INT + minor_clks;
-            }
-
-            core_util_critical_section_exit();
-        } while (minor_clks == 0 || minor_clks == TMR2_CLK_PER_TMR2_INT);
-
-        // Add power-down compensation
-        return ((uint64_t) major_minor_clks * US_PER_SEC / TMR2_CLK_PER_SEC / US_PER_TICK);
-    } while (0);
+    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t delta = timestamp - lp_ticker_read();
-    wakeup_tick = timestamp;
-
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
 
-    cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
-    lp_ticker_arm_cd();
-}
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+     
+    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
+    }
 
-void lp_ticker_fire_interrupt(void)
-{
-    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
-    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    cd_major_minor_clks = cd_minor_clks = 0;
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        lp_ticker_fire_interrupt();
+    }
 }
 
 void lp_ticker_disable_interrupt(void)
@@ -169,27 +193,30 @@ void lp_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
 }
 
+void lp_ticker_fire_interrupt(void)
+{
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
+    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+}
+
 static void tmr2_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr3_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (cd_major_minor_clks > cd_minor_clks) ? (cd_major_minor_clks - cd_minor_clks) : 0;
-    if (cd_major_minor_clks == 0) {
-        // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-        lp_ticker_irq_handler();
-    } else {
-        lp_ticker_arm_cd();
-    }
+
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
+    
 }
 
-static void lp_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
 
@@ -200,19 +227,33 @@ static void lp_ticker_arm_cd(void)
     while (timer3_base->CNT & TIMER_CNT_RSTACT_Msk);
     // One-shot mode, Clock = 1 KHz
     uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / TMR3_CLK_PER_SEC - 1;
+    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % TMR3_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
     timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
     timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3/* | TIMER_CTL_CNTDATEN_Msk*/;
 
-    cd_minor_clks = cd_major_minor_clks;
-    cd_minor_clks = NU_CLAMP(cd_minor_clks, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cd_minor_clks;
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer3 = cd_clk;
+    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer3_base->CMP = cmp_timer3;
 
     TIMER_EnableInt(timer3_base);
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start(timer3_base);
 }
+
+const ticker_info_t* lp_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
+}
+
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/rtc_api.c
@@ -24,8 +24,65 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
-#define YEAR0       1900
-//#define EPOCH_YR    1970
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per second
+ *
+ * NOTE: This dependents on real hardware.
+ */
+#define NU_RTCCLK_PER_SEC           ((CLK->CLKSEL3 & CLK_CLKSEL3_SC0SEL_Msk) ? __LIRC : __LXT)
+
+/* Strategy for implementation of RTC HAL
+ *
+ * H/W RTC just supports year range 2000~2099, which cannot fully cover POSIX time (starting since 2970)
+ * and date time of struct TM (starting since 1900).
+ *
+ * To conquer the difficulty, we don't use H/W RTC to keep real date time. Instead, we use it to keep
+ * elapsed time in seconds since one reference time point. The strategy would be:
+ *
+ * 1. Choose DATETIME_HWRTC_ORIGIN (00:00:00 UTC, Saturday, 1 January 2000) as reference time point of H/W RTC.
+ * 2. t_hwrtc_origin = DATETIME_HWRTC_ORIGIN in POSIX time
+ * 3. t_hwrtc_elapsed = t_hwrtc_origin + elapsed time since t_hwrtc_origin
+ * 4. t_write = POSIX time set by rtc_write().
+ * 5. t_present = rtc_read() = t_write + (t_hwrtc_elapsed - t_hwrtc_origin)
+ *
+ * 1900
+ * |---------------------------------------------------------------------------------|
+ *           1970    t_write           t_present
+ * |---------|-------|-----------------|---------------------------------------------|
+ * 
+ * 2000 
+ * |-----------------|---------------------------------------------------------------|
+ * t_hwrtc_origin    t_hwrtc_elapsed
+ *
+ */
+/* Start year of struct TM*/
+#define NU_TM_YEAR0         1900
+/* Start year of POSIX time (set_time()/time()) */
+#define NU_POSIX_YEAR0      1970
+/* Start year of H/W RTC */
+#define NU_HWRTC_YEAR0      2000
+
+/* RTC H/W origin time: 00:00:00 UTC, Saturday, 1 January 2000 */
+static const S_RTC_TIME_DATA_T DATETIME_HWRTC_ORIGIN = {
+    2000,           /* Year value, range between 2000 ~ 2099 */
+    1,              /* Month value, range between 1 ~ 12 */
+    1,              /* Day value, range between 1 ~ 31 */
+    RTC_SATURDAY,   /* Day of the week */
+    0,              /* Hour value, range between 0 ~ 23 */
+    0,              /* Minute value, range between 0 ~ 59 */
+    0,              /* Second value, range between 0 ~ 59 */
+    RTC_CLOCK_24,   /* 12-Hour (RTC_CLOCK_12) / 24-Hour (RTC_CLOCK_24) */
+    0               /* RTC_AM / RTC_PM (used only for 12-Hour) */
+};
+/* t_hwrtc_origin initialized or not? */
+static bool t_hwrtc_origin_inited = 0;
+/* POSIX time of DATETIME_HWRTC_ORIGIN (since 00:00:00 UTC, Thursday, 1 January 1970) */
+static time_t t_hwrtc_origin = 0;
+/* POSIX time set by rtc_write() */
+static time_t t_write = 0;
+/* Convert date time from H/W RTC to struct TM */
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc);
 
 static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, 0, 0, 0, RTC_IRQn, NULL};
 
@@ -36,6 +93,9 @@ void rtc_init(void)
     }
 
     RTC_Open(NULL);
+
+    /* POSIX time origin (00:00:00 UTC, Thursday, 1 January 1970) */
+    rtc_write(0);
 }
 
 void rtc_free(void)
@@ -54,6 +114,58 @@ int rtc_isenabled(void)
     // NOTE: Check RTC Init Active flag to support crossing reset cycle.
     return !! (RTC->INIT & RTC_INIT_ACTIVE_Msk);
 }
+time_t rtc_read(void)
+{
+    /* NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
+     *       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
+     *       NUC472/M453: Known issue
+     *       M487: Fixed
+     */
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    /* Used for intermediary between date time of H/W RTC and POSIX time */
+    struct tm datetime_tm;
+
+    if (! t_hwrtc_origin_inited) {
+        t_hwrtc_origin_inited = 1;
+        
+        /* Convert date time from H/W RTC to struct TM */     
+        rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &DATETIME_HWRTC_ORIGIN);
+        /* Convert date time of struct TM to POSIX time */
+        if (! _rtc_maketime(&datetime_tm, &t_hwrtc_origin, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+            return 0;
+        }
+    }
+
+    S_RTC_TIME_DATA_T hwrtc_datetime_2K_present;
+    RTC_GetDateAndTime(&hwrtc_datetime_2K_present);
+    /* Convert date time from H/W RTC to struct TM */
+    rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &hwrtc_datetime_2K_present);
+    /* Convert date time of struct TM to POSIX time */
+    time_t t_hwrtc_elapsed;
+    if (! _rtc_maketime(&datetime_tm, &t_hwrtc_elapsed, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+        return 0;
+    }
+
+    /* Present time in POSIX time */
+    time_t t_present = t_write + (t_hwrtc_elapsed - t_hwrtc_origin);
+    return t_present;
+}
+
+void rtc_write(time_t t)
+{
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    t_write = t;
+
+    RTC_SetDateAndTime((S_RTC_TIME_DATA_T *) &DATETIME_HWRTC_ORIGIN);
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_RTCCLK_PER_SEC) * 3);
+}
 
 /*
  struct tm
@@ -67,70 +179,18 @@ int rtc_isenabled(void)
    tm_yday     days since January 1 0-365
    tm_isdst    Daylight Saving Time flag
 */
-
-time_t rtc_read(void)
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc)
 {
-    // NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
-    //       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
-    //       NUC472/M453: Known issue
-    //       M487: Fixed
-    if (! rtc_isenabled()) {
-        rtc_init();
+    datetime_tm->tm_year = datetime_hwrtc->u32Year - NU_TM_YEAR0;
+    datetime_tm->tm_mon  = datetime_hwrtc->u32Month - 1;
+    datetime_tm->tm_mday = datetime_hwrtc->u32Day;
+    datetime_tm->tm_wday = datetime_hwrtc->u32DayOfWeek;
+    datetime_tm->tm_hour = datetime_hwrtc->u32Hour;
+    if (datetime_hwrtc->u32TimeScale == RTC_CLOCK_12 && datetime_hwrtc->u32AmPm == RTC_PM) {
+        datetime_tm->tm_hour += 12;
     }
-
-    S_RTC_TIME_DATA_T rtc_datetime;
-    RTC_GetDateAndTime(&rtc_datetime);
-
-    struct tm timeinfo;
-
-    // Convert struct tm to S_RTC_TIME_DATA_T
-    timeinfo.tm_year = rtc_datetime.u32Year - YEAR0;
-    timeinfo.tm_mon  = rtc_datetime.u32Month - 1;
-    timeinfo.tm_mday = rtc_datetime.u32Day;
-    timeinfo.tm_wday = rtc_datetime.u32DayOfWeek;
-    timeinfo.tm_hour = rtc_datetime.u32Hour;
-    if (rtc_datetime.u32TimeScale == RTC_CLOCK_12 && rtc_datetime.u32AmPm == RTC_PM) {
-        timeinfo.tm_hour += 12;
-    }
-    timeinfo.tm_min  = rtc_datetime.u32Minute;
-    timeinfo.tm_sec  = rtc_datetime.u32Second;
-
-    // Convert to timestamp
-    time_t t;
-    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return 0;
-    }
-
-    return t;
-}
-
-void rtc_write(time_t t)
-{
-    if (! rtc_isenabled()) {
-        rtc_init();
-    }
-
-    // Convert timestamp to struct tm
-    struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return;
-    }
-
-    S_RTC_TIME_DATA_T rtc_datetime;
-
-    // Convert S_RTC_TIME_DATA_T to struct tm
-    rtc_datetime.u32Year        = timeinfo.tm_year + YEAR0;
-    rtc_datetime.u32Month       = timeinfo.tm_mon + 1;
-    rtc_datetime.u32Day         = timeinfo.tm_mday;
-    rtc_datetime.u32DayOfWeek   = timeinfo.tm_wday;
-    rtc_datetime.u32Hour        = timeinfo.tm_hour;
-    rtc_datetime.u32Minute      = timeinfo.tm_min;
-    rtc_datetime.u32Second      = timeinfo.tm_sec;
-    rtc_datetime.u32TimeScale   = RTC_CLOCK_24;
-
-    // NOTE: Timing issue with write to RTC registers. This delay is empirical, not rational.
-    RTC_SetDateAndTime(&rtc_datetime);
-    wait_us(100);
+    datetime_tm->tm_min  = datetime_hwrtc->u32Minute;
+    datetime_tm->tm_sec  = datetime_hwrtc->u32Second;
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -19,37 +19,27 @@
 #include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// us_ticker tick = us = timestamp
-#define US_PER_TICK             1
-#define US_PER_SEC              (1000 * 1000)
-
-#define TMR0HIRES_CLK_PER_SEC           (1000 * 1000)
-#define TMR1HIRES_CLK_PER_SEC           (1000 * 1000)
-
-#define US_PER_TMR0HIRES_CLK            (US_PER_SEC / TMR0HIRES_CLK_PER_SEC)
-#define US_PER_TMR1HIRES_CLK            (US_PER_SEC / TMR1HIRES_CLK_PER_SEC)
-
-#define US_PER_TMR0HIRES_INT            (1000 * 1000 * 10)
-#define TMR0HIRES_CLK_PER_TMR0HIRES_INT ((uint32_t) ((uint64_t) US_PER_TMR0HIRES_INT * TMR0HIRES_CLK_PER_SEC / US_PER_SEC))
-
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per us_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (1000 * 1000)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
 static void tmr1_vec(void);
-static void us_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int us_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_us = 0;
-static volatile uint32_t cd_minor_us = 0;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: PCLK is set up in mbed_sdk_init(), invocation of which must be before C++ global object constructor. See init_api.c for details.
-// NOTE: Choose clock source of timer:
-//       1. HIRC: Be the most accurate but might cause unknown HardFault.
-//       2. HXT: Less accurate and cannot pass mbed-drivers test.
-//       3. PCLK(HXT): Less accurate but can pass mbed-drivers test.
-// NOTE: TIMER_0 for normal counter, TIMER_1 for countdown.
+/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
 static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
 static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK0, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
@@ -58,15 +48,13 @@ static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CL
 
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
+    ticker_inited = 1;
 
-    counter_major = 0;
-    cd_major_minor_us = 0;
-    cd_minor_us = 0;
-    us_ticker_inited = 1;
-
+    ticker_last_read_clk = 0;
+    
     // Reset IP
     SYS_ResetModule(timer0hires_modinit.rsetidx);
     SYS_ResetModule(timer1hires_modinit.rsetidx);
@@ -80,10 +68,10 @@ void us_ticker_init(void)
 
     // Timer for normal counter
     uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / TMR0HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % TMR0HIRES_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR0HIRES_CLK_PER_TMR0HIRES_INT;
+    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer0 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0/* | TIMER_CTL_CNTDATEN_Msk*/;
@@ -101,36 +89,88 @@ void us_ticker_init(void)
 
 uint32_t us_ticker_read()
 {
-    if (! us_ticker_inited) {
+    if (! ticker_inited) {
         us_ticker_init();
     }
 
     TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
 
-    do {
-        uint32_t major_minor_us;
-        uint32_t minor_us;
+    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+}
 
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
+void us_ticker_set_interrupt(timestamp_t timestamp)
+{
+    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
 
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_us = TIMER_GetCounter(timer0_base) * US_PER_TMR0HIRES_CLK;
-            uint32_t carry = (timer0_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Hanlde carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_us > (US_PER_TMR0HIRES_INT / 2)) {
-                major_minor_us = (counter_major + 1) * US_PER_TMR0HIRES_INT;
-            } else {
-                major_minor_us = (counter_major + carry) * US_PER_TMR0HIRES_INT + minor_us;
-            }
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+    
+    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
+    }
 
-            core_util_critical_section_exit();
-        } while (minor_us == 0 || minor_us == US_PER_TMR0HIRES_INT);
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
 
-        return (major_minor_us / US_PER_TICK);
-    } while (0);
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        us_ticker_fire_interrupt();
+    }
 }
 
 void us_ticker_disable_interrupt(void)
@@ -143,46 +183,29 @@ void us_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
 }
 
-void us_ticker_set_interrupt(timestamp_t timestamp)
-{
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    uint32_t delta = timestamp - us_ticker_read();
-    cd_major_minor_us = delta * US_PER_TICK;
-    us_ticker_arm_cd();
-}
-
 void us_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    cd_major_minor_us = cd_minor_us = 0;
     NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
 }
 
 static void tmr0_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr1_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    cd_major_minor_us = (cd_major_minor_us > cd_minor_us) ? (cd_major_minor_us - cd_minor_us) : 0;
-    if (cd_major_minor_us == 0) {
-        // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-        us_ticker_irq_handler();
-    } else {
-        us_ticker_arm_cd();
-    }
+
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }
 
-static void us_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-
-    cd_minor_us = cd_major_minor_us;
 
     // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
     // NUC472/M451: See TIMER_CTL_RSTCNT_Msk
@@ -191,17 +214,28 @@ static void us_ticker_arm_cd(void)
     while (timer1_base->CNT & TIMER_CNT_RSTACT_Msk);
     // One-shot mode, Clock = 1 MHz
     uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / TMR1HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % TMR1HIRES_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
     timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
     timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1/* | TIMER_CTL_CNTDATEN_Msk*/;
 
-    uint32_t cmp_timer1 = cd_minor_us / US_PER_TMR1HIRES_CLK;
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer1 = cd_clk;
     cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
     timer1_base->CMP = cmp_timer1;
 
     TIMER_EnableInt(timer1_base);
     TIMER_Start(timer1_base);
+}
+
+const ticker_info_t* us_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
 }

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
@@ -13,38 +13,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "lp_ticker_api.h"
 
 #if DEVICE_LOWPOWERTIMER
 
 #include "sleep_api.h"
+#include "mbed_wait_api.h"
+#include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
-#include "mbed_wait_api.h"
 
-// lp_ticker tick = us = timestamp
-#define US_PER_TICK             (1)
-#define US_PER_SEC              (1000 * 1000)
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per lp_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (__LXT)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
-#define US_PER_TMR2_INT         (US_PER_SEC * 10)
-#define TMR2_CLK_PER_SEC        (__LXT)
-#define TMR2_CLK_PER_TMR2_INT   ((uint32_t) ((uint64_t) US_PER_TMR2_INT * TMR2_CLK_PER_SEC / US_PER_SEC))
-#define TMR3_CLK_PER_SEC        (__LXT)
-
+/* NOTE: Don't add static modifier here. These IRQ handler symbols are for linking. 
+         Vector table relocation is not actually supported for low-resource target. */
 void TMR2_IRQHandler(void);
 void TMR3_IRQHandler(void);
-static void lp_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int lp_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_clks = 0;
-static volatile uint32_t cd_minor_clks = 0;
-static volatile uint32_t wakeup_tick = (uint32_t) -1;
+static uint32_t ticker_last_read_clk = 0;
+static int ticker_inited = 0;
 
-// NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC.
-// NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled wakeup
+/* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
 static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL2_TMR2_S_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) TMR2_IRQHandler};
 static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL2_TMR3_S_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) TMR3_IRQHandler};
 
@@ -53,20 +55,17 @@ static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLK
 
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    lp_ticker_inited = 1;
-    
-    counter_major = 0;
-    cd_major_minor_clks = 0;
-    cd_minor_clks = 0;
-    wakeup_tick = (uint32_t) -1;
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
 
     // Reset module
     SYS_ResetModule(timer2_modinit.rsetidx);
     SYS_ResetModule(timer3_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
     CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
@@ -76,95 +75,114 @@ void lp_ticker_init(void)
 
     // Configure clock
     uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / TMR2_CLK_PER_SEC - 1;
+    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % TMR2_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR2_CLK_PER_TMR2_INT;
+    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer2 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
     // Continuous mode
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE;
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->PRECNT = prescale_timer2;
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMPR = cmp_timer2;
-    
+
     // Set vector
     NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
     NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
-    
+
     NVIC_EnableIRQ(timer2_modinit.irq_n);
     NVIC_EnableIRQ(timer3_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // NOTE: TIMER_Start() first and then lp_ticker_set_interrupt(); otherwise, we may get stuck in lp_ticker_read() because
-    //       timer is not running.
-
-    // Wait 3 cycles of engine clock to ensure previous CTL write action is finish
-    nu_nop(SystemCoreClock / __LXT * 3);
-    // Start timer
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // Schedule wakeup to match semantics of lp_ticker_get_compare_match()
-    lp_ticker_set_interrupt(wakeup_tick);
 }
 
 timestamp_t lp_ticker_read()
-{    
-    if (! lp_ticker_inited) {
+{
+    if (! ticker_inited) {
         lp_ticker_init();
     }
-    
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
-    
-    do {
-        uint64_t major_minor_clks;
-        uint32_t minor_clks;
-        
-        // NOTE: As TIMER_DR = TIMER_CMPR and counter_major has increased by one, TIMER_DR doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_DR = TIMER_CMPR or TIMER_DR = 0, counter_major (ISR) may not sync with TIMER_DR. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-        
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_clks = TIMER_GetCounter(timer2_base);
-            uint32_t carry = (timer2_base->ISR & TIMER_ISR_TMR_IS_Msk) ? 1 : 0;
-            // When TIMER_DR approaches TIMER_CMPR and will wrap soon, we may get carry but TIMER_DR not wrapped. Hanlde carefully carry == 1 && TIMER_DR is near TIMER_CMPR.
-            if (carry && minor_clks > (TMR2_CLK_PER_TMR2_INT / 2)) {
-                major_minor_clks = (counter_major + 1) * TMR2_CLK_PER_TMR2_INT;
-            }
-            else {
-                major_minor_clks = (counter_major + carry) * TMR2_CLK_PER_TMR2_INT + minor_clks;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_clks == 0 || minor_clks == TMR2_CLK_PER_TMR2_INT);
 
-        // Add power-down compensation
-        return ((uint64_t) major_minor_clks * US_PER_SEC / TMR2_CLK_PER_SEC / US_PER_TICK);
-    }
-    while (0);
+    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t delta = timestamp - lp_ticker_read();
-    wakeup_tick = timestamp;
-    
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
-    lp_ticker_arm_cd();
 
-}
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+     
+    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
+    }
 
-void lp_ticker_fire_interrupt(void)
-{
-    cd_major_minor_clks = cd_minor_clks = 0;
-    /**
-     * This event was in the past. Set the interrupt as pending, but don't process it here.
-     * This prevents a recurive loop under heavy load which can lead to a stack overflow.
-     */  
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        lp_ticker_fire_interrupt();
+    }
 }
 
 void lp_ticker_disable_interrupt(void)
@@ -177,28 +195,29 @@ void lp_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
 }
 
+void lp_ticker_fire_interrupt(void)
+{
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
+    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+}
 void TMR2_IRQHandler(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    counter_major ++;
 }
 
 void TMR3_IRQHandler(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (cd_major_minor_clks > cd_minor_clks) ? (cd_major_minor_clks - cd_minor_clks) : 0;
-    if (cd_major_minor_clks == 0) {
-        // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-        lp_ticker_irq_handler();
-    }
-    else {
-        lp_ticker_arm_cd();
-    }
+
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
+    
 }
 
-static void lp_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
     
@@ -206,22 +225,33 @@ static void lp_ticker_arm_cd(void)
     timer3_base->CTL |= TIMER_CTL_SW_RST_Msk;
     // One-shot mode, Clock = 1 KHz 
     uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / TMR3_CLK_PER_SEC - 1;
+    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % TMR3_CLK_PER_SEC) == 0);
-    uint32_t ctl_timer3 = timer3_base->CTL;
-    ctl_timer3 &= ~TIMER_CTL_MODE_SEL_Msk;
-    ctl_timer3 |= TIMER_ONESHOT_MODE;
+    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
+    timer3_base->CTL &= ~TIMER_CTL_MODE_SEL_Msk;
+    timer3_base->CTL |= TIMER_ONESHOT_MODE;
     timer3_base->PRECNT = prescale_timer3;
-    
-    cd_minor_clks = cd_major_minor_clks;
-    cd_minor_clks = NU_CLAMP(cd_minor_clks, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMPR = cd_minor_clks;
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer3 = cd_clk;
+    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer3_base->CMPR = cmp_timer3;
     
     TIMER_EnableInt(timer3_base);
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    // Wait 2 cycles of engine clock to ensure previous CTL write action is finish
-    wait_us(30 * 2);
-    timer3_base->CTL |= ctl_timer3 | TIMER_CTL_TMR_EN_Msk;
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
+    TIMER_Start(timer3_base);
 }
+
+const ticker_info_t* lp_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
+}
+
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
@@ -13,41 +13,35 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "us_ticker_api.h"
 #include "sleep_api.h"
 #include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// us_ticker tick = us = timestamp
-#define US_PER_TICK             1
-#define US_PER_SEC              (1000 * 1000)
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per us_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (1000 * 1000)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
-#define TMR0HIRES_CLK_PER_SEC           (1000 * 1000)
-#define TMR1HIRES_CLK_PER_SEC           (1000 * 1000)
-
-#define US_PER_TMR0HIRES_CLK            (US_PER_SEC / TMR0HIRES_CLK_PER_SEC)
-#define US_PER_TMR1HIRES_CLK            (US_PER_SEC / TMR1HIRES_CLK_PER_SEC)
-
-#define US_PER_TMR0HIRES_INT            (1000 * 1000 * 10)
-#define TMR0HIRES_CLK_PER_TMR0HIRES_INT ((uint32_t) ((uint64_t) US_PER_TMR0HIRES_INT * TMR0HIRES_CLK_PER_SEC / US_PER_SEC))
-
-
+/* NOTE: Don't add static modifier here. These IRQ handler symbols are for linking. 
+         Vector table relocation is not actually supported for low-resource target. */
 void TMR0_IRQHandler(void);
 void TMR1_IRQHandler(void);
-static void us_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int us_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_us = 0;
-static volatile uint32_t cd_minor_us = 0;
+static uint32_t ticker_last_read_clk = 0;
+static int ticker_inited = 0;
 
-// NOTE: Choose clock source of timer:
-//       1. HIRC: Be the most accurate but might cause unknown HardFault.
-//       2. HXT: Less accurate and cannot pass mbed-drivers test.
-// NOTE: TIMER_0 for normal counter, TIMER_1 for countdown.
+/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
 static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0_S_HXT, 0, TMR0_RST, TMR0_IRQn, (void *) TMR0_IRQHandler};
 static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1_S_HXT, 0, TMR1_RST, TMR1_IRQn, (void *) TMR1_IRQHandler};
 
@@ -56,19 +50,17 @@ static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CL
 
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    
-    counter_major = 0;
-    cd_major_minor_us = 0;
-    cd_minor_us = 0;
-    us_ticker_inited = 1;
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
     
     // Reset IP
     SYS_ResetModule(timer0hires_modinit.rsetidx);
     SYS_ResetModule(timer1hires_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
     CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
@@ -78,60 +70,109 @@ void us_ticker_init(void)
 
     // Timer for normal counter
     uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / TMR0HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % TMR0HIRES_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR0HIRES_CLK_PER_TMR0HIRES_INT;
+    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer0 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE;
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->PRECNT = prescale_timer0;
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMPR = cmp_timer0;
-    
+
     NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
     NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
-    
+
     NVIC_EnableIRQ(timer0hires_modinit.irq_n);
     NVIC_EnableIRQ(timer1hires_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
     TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
 }
 
 uint32_t us_ticker_read()
 {
-    if (! us_ticker_inited) {
+    if (! ticker_inited) {
         us_ticker_init();
     }
-    
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
-        
-    do {
-        uint32_t major_minor_us;
-        uint32_t minor_us;
 
-        // NOTE: As TIMER_DR = TIMER_CMPR and counter_major has increased by one, TIMER_DR doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_DR = TIMER_CMPR or TIMER_DR = 0, counter_major (ISR) may not sync with TIMER_DR. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-            
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_us = TIMER_GetCounter(timer0_base) * US_PER_TMR0HIRES_CLK;
-            uint32_t carry = (timer0_base->ISR & TIMER_ISR_TMR_IS_Msk) ? 1 : 0;
-            // When TIMER_DR approaches TIMER_CMPR and will wrap soon, we may get carry but TIMER_DR not wrapped. Hanlde carefully carry == 1 && TIMER_DR is near TIMER_CMPR.
-            if (carry && minor_us > (US_PER_TMR0HIRES_INT / 2)) {
-                major_minor_us = (counter_major + 1) * US_PER_TMR0HIRES_INT;
-            }
-            else {
-                major_minor_us = (counter_major + carry) * US_PER_TMR0HIRES_INT + minor_us;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_us == 0 || minor_us == US_PER_TMR0HIRES_INT);
-        
-        return (major_minor_us / US_PER_TICK);
+    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+}
+
+void us_ticker_set_interrupt(timestamp_t timestamp)
+{
+    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+    
+    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
     }
-    while (0);
+
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        us_ticker_fire_interrupt();
+    }
 }
 
 void us_ticker_disable_interrupt(void)
@@ -144,61 +185,56 @@ void us_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
 }
 
-void us_ticker_set_interrupt(timestamp_t timestamp)
-{
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    
-    uint32_t delta = timestamp - us_ticker_read();
-    cd_major_minor_us = delta * US_PER_TICK;
-    us_ticker_arm_cd();
-}
-
 void us_ticker_fire_interrupt(void)
 {
-    cd_major_minor_us = cd_minor_us = 0;
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
     NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
 }
 
 void TMR0_IRQHandler(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    counter_major ++;
 }
 
 void TMR1_IRQHandler(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    cd_major_minor_us = (cd_major_minor_us > cd_minor_us) ? (cd_major_minor_us - cd_minor_us) : 0;
-    if (cd_major_minor_us == 0) {
-        // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-        us_ticker_irq_handler();
-    }
-    else {
-        us_ticker_arm_cd();
-    }
+
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }
 
-static void us_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-    
-    cd_minor_us = cd_major_minor_us;
 
     // Reset Timer's pre-scale counter, internal 24-bit up-counter and TMR_CTL [TMR_EN] bit
     timer1_base->CTL |= TIMER_CTL_SW_RST_Msk;
     // One-shot mode, Clock = 1 MHz 
     uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / TMR1HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % TMR1HIRES_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
     timer1_base->CTL &= ~TIMER_CTL_MODE_SEL_Msk;
     timer1_base->CTL |= TIMER_ONESHOT_MODE;
     timer1_base->PRECNT = prescale_timer1;
-    
-    uint32_t cmp_timer1 = cd_minor_us / US_PER_TMR1HIRES_CLK;
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer1 = cd_clk;
     cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
     timer1_base->CMPR = cmp_timer1;
-    
+
     TIMER_EnableInt(timer1_base);
     TIMER_Start(timer1_base);
+}
+
+const ticker_info_t* us_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
@@ -13,37 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "lp_ticker_api.h"
 
 #if DEVICE_LOWPOWERTIMER
 
 #include "sleep_api.h"
+#include "mbed_wait_api.h"
+#include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// lp_ticker tick = us = timestamp
-#define US_PER_TICK             (1)
-#define US_PER_SEC              (1000 * 1000)
-
-#define US_PER_TMR2_INT         (US_PER_SEC * 10)
-#define TMR2_CLK_PER_SEC        (__LXT)
-#define TMR2_CLK_PER_TMR2_INT   ((uint32_t) ((uint64_t) US_PER_TMR2_INT * TMR2_CLK_PER_SEC / US_PER_SEC))
-#define TMR3_CLK_PER_SEC        (__LXT)
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per lp_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (__LXT)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr2_vec(void);
 static void tmr3_vec(void);
-static void lp_ticker_arm_cd(void);
+/* Configure scheduled alarm */
+static void arm_alarm(uint32_t cd_clk);
 
-static int lp_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_clks = 0;
-static volatile uint32_t cd_minor_clks = 0;
-static volatile uint32_t wakeup_tick = (uint32_t) -1;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC.
-// NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled wakeup
+/* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
+/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
 static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
 static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
 
@@ -52,20 +53,17 @@ static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLK
 
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    lp_ticker_inited = 1;
-    
-    counter_major = 0;
-    cd_major_minor_clks = 0;
-    cd_minor_clks = 0;
-    wakeup_tick = (uint32_t) -1;
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
 
     // Reset module
     SYS_ResetModule(timer2_modinit.rsetidx);
     SYS_ResetModule(timer3_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
     CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
@@ -75,92 +73,113 @@ void lp_ticker_init(void)
 
     // Configure clock
     uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / TMR2_CLK_PER_SEC - 1;
+    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % TMR2_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR2_CLK_PER_TMR2_INT;
+    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer2 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
     // Continuous mode
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer2 | TIMER_CTL_CNTDATEN_Msk;
     ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMP = cmp_timer2;
-    
+
     // Set vector
     NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
     NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
-    
+
     NVIC_EnableIRQ(timer2_modinit.irq_n);
     NVIC_EnableIRQ(timer3_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // NOTE: TIMER_Start() first and then lp_ticker_set_interrupt(); otherwise, we may get stuck in lp_ticker_read() because
-    //       timer is not running.
-    
-    // Start timer
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    
-    // Schedule wakeup to match semantics of lp_ticker_get_compare_match()
-    lp_ticker_set_interrupt(wakeup_tick);
 }
 
 timestamp_t lp_ticker_read()
-{    
-    if (! lp_ticker_inited) {
+{
+    if (! ticker_inited) {
         lp_ticker_init();
     }
-    
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
-    
-    do {
-        uint64_t major_minor_clks;
-        uint32_t minor_clks;
-        
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-        
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_clks = TIMER_GetCounter(timer2_base);
-            uint32_t carry = (timer2_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Hanlde carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_clks > (TMR2_CLK_PER_TMR2_INT / 2)) {
-                major_minor_clks = (counter_major + 1) * TMR2_CLK_PER_TMR2_INT;
-            }
-            else {
-                major_minor_clks = (counter_major + carry) * TMR2_CLK_PER_TMR2_INT + minor_clks;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_clks == 0 || minor_clks == TMR2_CLK_PER_TMR2_INT);
 
-        // Add power-down compensation
-        return ((uint64_t) major_minor_clks * US_PER_SEC / TMR2_CLK_PER_SEC / US_PER_TICK);
-    }
-    while (0);
+    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t delta = timestamp - lp_ticker_read();
-    wakeup_tick = timestamp;
-    
     TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (uint64_t) delta * US_PER_TICK * TMR3_CLK_PER_SEC / US_PER_SEC;
-    lp_ticker_arm_cd();
 
-}
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+     
+    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
+    }
 
-void lp_ticker_fire_interrupt(void)
-{
-    cd_major_minor_clks = cd_minor_clks = 0;
-    /**
-     * This event was in the past. Set the interrupt as pending, but don't process it here.
-     * This prevents a recurive loop under heavy load which can lead to a stack overflow.
-     */  
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        lp_ticker_fire_interrupt();
+    }
 }
 
 void lp_ticker_disable_interrupt(void)
@@ -173,47 +192,63 @@ void lp_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
 }
 
+void lp_ticker_fire_interrupt(void)
+{
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
+    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
+}
+
 static void tmr2_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr3_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
     TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    cd_major_minor_clks = (cd_major_minor_clks > cd_minor_clks) ? (cd_major_minor_clks - cd_minor_clks) : 0;
-    if (cd_major_minor_clks == 0) {
-        // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-        lp_ticker_irq_handler();
-    }
-    else {
-        lp_ticker_arm_cd();
-    }
+
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
+    
 }
 
-static void lp_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-    
+
     // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
     timer3_base->CTL |= TIMER_CTL_RSTCNT_Msk;
     // One-shot mode, Clock = 1 KHz 
     uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / TMR3_CLK_PER_SEC - 1;
+    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % TMR3_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
     timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk | TIMER_CTL_CNTDATEN_Msk);
     timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3 | TIMER_CTL_CNTDATEN_Msk;
-    
-    cd_minor_clks = cd_major_minor_clks;
-    cd_minor_clks = NU_CLAMP(cd_minor_clks, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cd_minor_clks;
-    
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer3 = cd_clk;
+    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer3_base->CMP = cmp_timer3;
+
     TIMER_EnableInt(timer3_base);
     TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
     TIMER_Start(timer3_base);
 }
+
+const ticker_info_t* lp_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
+}
+
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/rtc_api.c
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "rtc_api.h"
 
 #if DEVICE_RTC
@@ -24,8 +24,65 @@
 #include "nu_miscutil.h"
 #include "mbed_mktime.h"
 
-#define YEAR0       1900
-//#define EPOCH_YR    1970
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per second
+ *
+ * NOTE: This dependents on real hardware.
+ */
+#define NU_RTCCLK_PER_SEC           (__LXT)
+
+/* Strategy for implementation of RTC HAL
+ *
+ * H/W RTC just supports year range 2000~2099, which cannot fully cover POSIX time (starting since 2970)
+ * and date time of struct TM (starting since 1900).
+ *
+ * To conquer the difficulty, we don't use H/W RTC to keep real date time. Instead, we use it to keep
+ * elapsed time in seconds since one reference time point. The strategy would be:
+ *
+ * 1. Choose DATETIME_HWRTC_ORIGIN (00:00:00 UTC, Saturday, 1 January 2000) as reference time point of H/W RTC.
+ * 2. t_hwrtc_origin = DATETIME_HWRTC_ORIGIN in POSIX time
+ * 3. t_hwrtc_elapsed = t_hwrtc_origin + elapsed time since t_hwrtc_origin
+ * 4. t_write = POSIX time set by rtc_write().
+ * 5. t_present = rtc_read() = t_write + (t_hwrtc_elapsed - t_hwrtc_origin)
+ *
+ * 1900
+ * |---------------------------------------------------------------------------------|
+ *           1970    t_write           t_present
+ * |---------|-------|-----------------|---------------------------------------------|
+ * 
+ * 2000 
+ * |-----------------|---------------------------------------------------------------|
+ * t_hwrtc_origin    t_hwrtc_elapsed
+ *
+ */
+/* Start year of struct TM*/
+#define NU_TM_YEAR0         1900
+/* Start year of POSIX time (set_time()/time()) */
+#define NU_POSIX_YEAR0      1970
+/* Start year of H/W RTC */
+#define NU_HWRTC_YEAR0      2000
+
+/* RTC H/W origin time: 00:00:00 UTC, Saturday, 1 January 2000 */
+static const S_RTC_TIME_DATA_T DATETIME_HWRTC_ORIGIN = {
+    2000,           /* Year value, range between 2000 ~ 2099 */
+    1,              /* Month value, range between 1 ~ 12 */
+    1,              /* Day value, range between 1 ~ 31 */
+    RTC_SATURDAY,   /* Day of the week */
+    0,              /* Hour value, range between 0 ~ 23 */
+    0,              /* Minute value, range between 0 ~ 59 */
+    0,              /* Second value, range between 0 ~ 59 */
+    RTC_CLOCK_24,   /* 12-Hour (RTC_CLOCK_12) / 24-Hour (RTC_CLOCK_24) */
+    0               /* RTC_AM / RTC_PM (used only for 12-Hour) */
+};
+/* t_hwrtc_origin initialized or not? */
+static bool t_hwrtc_origin_inited = 0;
+/* POSIX time of DATETIME_HWRTC_ORIGIN (since 00:00:00 UTC, Thursday, 1 January 1970) */
+static time_t t_hwrtc_origin = 0;
+/* POSIX time set by rtc_write() */
+static time_t t_write = 0;
+/* Convert date time from H/W RTC to struct TM */
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc);
 
 static const struct nu_modinit_s rtc_modinit = {RTC_0, RTC_MODULE, 0, 0, 0, RTC_IRQn, NULL};
 
@@ -34,8 +91,11 @@ void rtc_init(void)
     if (rtc_isenabled()) {
         return;
     }
-    
+
     RTC_Open(NULL);
+
+    /* POSIX time origin (00:00:00 UTC, Thursday, 1 January 1970) */
+    rtc_write(0);
 }
 
 void rtc_free(void)
@@ -55,6 +115,57 @@ int rtc_isenabled(void)
     return !! (RTC->INIT & RTC_INIT_INIT_Active_Msk);
 }
 
+time_t rtc_read(void)
+{
+    /* NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
+     *       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
+     */
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    /* Used for intermediary between date time of H/W RTC and POSIX time */
+    struct tm datetime_tm;
+
+    if (! t_hwrtc_origin_inited) {
+        t_hwrtc_origin_inited = 1;
+        
+        /* Convert date time from H/W RTC to struct TM */     
+        rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &DATETIME_HWRTC_ORIGIN);
+        /* Convert date time of struct TM to POSIX time */
+        if (! _rtc_maketime(&datetime_tm, &t_hwrtc_origin, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+            return 0;
+        }
+    }
+
+    S_RTC_TIME_DATA_T hwrtc_datetime_2K_present;
+    RTC_GetDateAndTime(&hwrtc_datetime_2K_present);
+    /* Convert date time from H/W RTC to struct TM */
+    rtc_convert_datetime_hwrtc_to_tm(&datetime_tm, &hwrtc_datetime_2K_present);
+    /* Convert date time of struct TM to POSIX time */
+    time_t t_hwrtc_elapsed;
+    if (! _rtc_maketime(&datetime_tm, &t_hwrtc_elapsed, RTC_FULL_LEAP_YEAR_SUPPORT)) {
+        return 0;
+    }
+
+    /* Present time in POSIX time */
+    time_t t_present = t_write + (t_hwrtc_elapsed - t_hwrtc_origin);
+    return t_present;
+}
+
+void rtc_write(time_t t)
+{
+    if (! rtc_isenabled()) {
+        rtc_init();
+    }
+
+    t_write = t;
+
+    RTC_SetDateAndTime((S_RTC_TIME_DATA_T *) &DATETIME_HWRTC_ORIGIN);
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_RTCCLK_PER_SEC) * 3);
+}
+
 /*
  struct tm
    tm_sec      seconds after the minute 0-61
@@ -67,69 +178,18 @@ int rtc_isenabled(void)
    tm_yday     days since January 1 0-365
    tm_isdst    Daylight Saving Time flag
 */
-
-time_t rtc_read(void)
+static void rtc_convert_datetime_hwrtc_to_tm(struct tm *datetime_tm, const S_RTC_TIME_DATA_T *datetime_hwrtc)
 {
-    // NOTE: After boot, RTC time registers are not synced immediately, about 1 sec latency.
-    //       RTC time got (through RTC_GetDateAndTime()) in this sec would be last-synced and incorrect.
-    if (! rtc_isenabled()) {
-        rtc_init();
+    datetime_tm->tm_year = datetime_hwrtc->u32Year - NU_TM_YEAR0;
+    datetime_tm->tm_mon  = datetime_hwrtc->u32Month - 1;
+    datetime_tm->tm_mday = datetime_hwrtc->u32Day;
+    datetime_tm->tm_wday = datetime_hwrtc->u32DayOfWeek;
+    datetime_tm->tm_hour = datetime_hwrtc->u32Hour;
+    if (datetime_hwrtc->u32TimeScale == RTC_CLOCK_12 && datetime_hwrtc->u32AmPm == RTC_PM) {
+        datetime_tm->tm_hour += 12;
     }
-    
-    S_RTC_TIME_DATA_T rtc_datetime;
-    RTC_GetDateAndTime(&rtc_datetime);
-    
-    struct tm timeinfo;
-
-    // Convert struct tm to S_RTC_TIME_DATA_T
-    timeinfo.tm_year = rtc_datetime.u32Year - YEAR0;
-    timeinfo.tm_mon  = rtc_datetime.u32Month - 1;
-    timeinfo.tm_mday = rtc_datetime.u32Day;
-    timeinfo.tm_wday = rtc_datetime.u32DayOfWeek;
-    timeinfo.tm_hour = rtc_datetime.u32Hour;
-    if (rtc_datetime.u32TimeScale == RTC_CLOCK_12 && rtc_datetime.u32AmPm == RTC_PM) {
-        timeinfo.tm_hour += 12;
-    }
-    timeinfo.tm_min  = rtc_datetime.u32Minute;
-    timeinfo.tm_sec  = rtc_datetime.u32Second;
-
-    // Convert to timestamp
-    time_t t;
-    if (_rtc_maketime(&timeinfo, &t, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return 0;
-    }
-
-    return t;
-}
-
-void rtc_write(time_t t)
-{
-    if (! rtc_isenabled()) {
-        rtc_init();
-    }
-
-    // Convert timestamp to struct tm
-    struct tm timeinfo;
-    if (_rtc_localtime(t, &timeinfo, RTC_FULL_LEAP_YEAR_SUPPORT) == false) {
-        return;
-    }
-
-    S_RTC_TIME_DATA_T rtc_datetime;
-    
-    // Convert S_RTC_TIME_DATA_T to struct tm
-    rtc_datetime.u32Year        = timeinfo.tm_year + YEAR0;
-    rtc_datetime.u32Month       = timeinfo.tm_mon + 1;
-    rtc_datetime.u32Day         = timeinfo.tm_mday;
-    rtc_datetime.u32DayOfWeek   = timeinfo.tm_wday;
-    rtc_datetime.u32Hour        = timeinfo.tm_hour;
-    rtc_datetime.u32Minute      = timeinfo.tm_min;
-    rtc_datetime.u32Second      = timeinfo.tm_sec;
-    rtc_datetime.u32TimeScale   = RTC_CLOCK_24;
-    
-    // NOTE: Timing issue with write to RTC registers. This delay is empirical, not rational.
-    RTC_SetDateAndTime(&rtc_datetime);
-    //nu_nop(6000);
-    wait_us(100);
+    datetime_tm->tm_min  = datetime_hwrtc->u32Minute;
+    datetime_tm->tm_sec  = datetime_hwrtc->u32Second;
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
@@ -13,43 +13,33 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 #include "us_ticker_api.h"
 #include "sleep_api.h"
 #include "mbed_assert.h"
 #include "nu_modutil.h"
 #include "nu_miscutil.h"
-#include "mbed_critical.h"
 
-// us_ticker tick = us = timestamp
-#define US_PER_TICK             1
-#define US_PER_SEC              (1000 * 1000)
-
-#define TMR0HIRES_CLK_PER_SEC           (1000 * 1000)
-#define TMR1HIRES_CLK_PER_SEC           (1000 * 1000)
-
-#define US_PER_TMR0HIRES_CLK            (US_PER_SEC / TMR0HIRES_CLK_PER_SEC)
-#define US_PER_TMR1HIRES_CLK            (US_PER_SEC / TMR1HIRES_CLK_PER_SEC)
-
-#define US_PER_TMR0HIRES_INT            (1000 * 1000 * 10)
-#define TMR0HIRES_CLK_PER_TMR0HIRES_INT ((uint32_t) ((uint64_t) US_PER_TMR0HIRES_INT * TMR0HIRES_CLK_PER_SEC / US_PER_SEC))
-
+/* Micro seconds per second */
+#define NU_US_PER_SEC               1000000
+/* Timer clock per us_ticker tick */
+#define NU_TMRCLK_PER_TICK          1
+/* Timer clock per second */
+#define NU_TMRCLK_PER_SEC           (1000 * 1000)
+/* Timer max counter bit size */
+#define NU_TMR_MAXCNT_BITSIZE       24
+/* Timer max counter */
+#define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
 static void tmr1_vec(void);
-static void us_ticker_arm_cd(void);
+/* Configure alarm exactly after scheduled clocks */
+static void arm_alarm(uint32_t cd_clk);
 
-static int us_ticker_inited = 0;
-static volatile uint32_t counter_major = 0;
-static volatile uint32_t cd_major_minor_us = 0;
-static volatile uint32_t cd_minor_us = 0;
+static int ticker_inited = 0;
+static uint32_t ticker_last_read_clk = 0;
 
-// NOTE: PCLK is set up in mbed_sdk_init(), invocation of which must be before C++ global object constructor. See init_api.c for details.
-// NOTE: Choose clock source of timer:
-//       1. HIRC: Be the most accurate but might cause unknown HardFault.
-//       2. HXT: Less accurate and cannot pass mbed-drivers test.
-//       3. PCLK(HXT): Less accurate but can pass mbed-drivers test.
-// NOTE: TIMER_0 for normal counter, TIMER_1 for countdown.
+/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
 static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
 static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
@@ -58,19 +48,17 @@ static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CL
 
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) {
+    if (ticker_inited) {
         return;
     }
-    
-    counter_major = 0;
-    cd_major_minor_us = 0;
-    cd_minor_us = 0;
-    us_ticker_inited = 1;
-    
+    ticker_inited = 1;
+
+    ticker_last_read_clk = 0;
+
     // Reset IP
     SYS_ResetModule(timer0hires_modinit.rsetidx);
     SYS_ResetModule(timer1hires_modinit.rsetidx);
-    
+
     // Select IP clock source
     CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
     CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
@@ -80,59 +68,108 @@ void us_ticker_init(void)
 
     // Timer for normal counter
     uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / TMR0HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % TMR0HIRES_CLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR0HIRES_CLK_PER_TMR0HIRES_INT;
+    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer0 = TMR_CMP_MAX;
     MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0 | TIMER_CTL_CNTDATEN_Msk;
     ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMP = cmp_timer0;
-    
+
     NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
     NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
-    
+
     NVIC_EnableIRQ(timer0hires_modinit.irq_n);
     NVIC_EnableIRQ(timer1hires_modinit.irq_n);
-    
+
     TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
     TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
 }
 
 uint32_t us_ticker_read()
 {
-    if (! us_ticker_inited) {
+    if (! ticker_inited) {
         us_ticker_init();
     }
-    
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
-        
-    do {
-        uint32_t major_minor_us;
-        uint32_t minor_us;
 
-        // NOTE: As TIMER_CNT = TIMER_CMP and counter_major has increased by one, TIMER_CNT doesn't change to 0 for one tick time.
-        // NOTE: As TIMER_CNT = TIMER_CMP or TIMER_CNT = 0, counter_major (ISR) may not sync with TIMER_CNT. So skip and fetch stable one at the cost of 1 clock delay on this read.
-        do {
-            core_util_critical_section_enter();
-            
-            // NOTE: Order of reading minor_us/carry here is significant.
-            minor_us = TIMER_GetCounter(timer0_base) * US_PER_TMR0HIRES_CLK;
-            uint32_t carry = (timer0_base->INTSTS & TIMER_INTSTS_TIF_Msk) ? 1 : 0;
-            // When TIMER_CNT approaches TIMER_CMP and will wrap soon, we may get carry but TIMER_CNT not wrapped. Hanlde carefully carry == 1 && TIMER_CNT is near TIMER_CMP.
-            if (carry && minor_us > (US_PER_TMR0HIRES_INT / 2)) {
-                major_minor_us = (counter_major + 1) * US_PER_TMR0HIRES_INT;
-            }
-            else {
-                major_minor_us = (counter_major + carry) * US_PER_TMR0HIRES_INT + minor_us;
-            }
-            
-            core_util_critical_section_exit();
-        }
-        while (minor_us == 0 || minor_us == US_PER_TMR0HIRES_INT);
-        
-        return (major_minor_us / US_PER_TICK);
+    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+
+    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
+    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+}
+
+void us_ticker_set_interrupt(timestamp_t timestamp)
+{
+    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+
+    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
+     *  
+     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
+     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
+     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
+     * (1) tick_last_read <= present_clk
+     * (2) tick_last_read <= alarm_ts_clk
+     *
+     *
+     * 1. Future event case:
+     *
+     * tick_last_read     present_clk                         alarm_ts_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-alarm_intvl1_clk-|
+     * |-------------------alarm_intvl2_clk-------------------|
+     *
+     * 2. Past event case:
+     *
+     * tick_last_read     alarm_ts_clk                        present_clk
+     * |                  |                                   |
+     * --------------------------------------------------------
+     * |-------------------alarm_intvl1_clk-------------------|
+     * |-alarm_intvl2_clk-|
+     *
+     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
+     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
+     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
+     * in xx_ticker_read().
+     */
+    
+    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
+    uint32_t last_read_clk = ticker_last_read_clk;
+    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
+    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
+    
+    /* alarm_intvl1_clk = present_clk - last_read_clk
+     *
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (present_clk >= last_read_clk) {
+        alarm_intvl1_clk = present_clk - last_read_clk;
+    } else {
+        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
     }
-    while (0);
+
+    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
+     * 
+     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
+     */
+    if (alarm_ts_clk >= last_read_clk) {
+        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
+    } else {
+        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
+    }
+
+    /* Distinguish (long) future event and past event
+     * 
+     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
+     */
+    if (alarm_intvl2_clk > alarm_intvl1_clk) {
+        /* Schedule for future event */
+        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
+    } else {
+        /* Go off immediately for past event, including equal case */
+        us_ticker_fire_interrupt();
+    }
 }
 
 void us_ticker_disable_interrupt(void)
@@ -145,60 +182,55 @@ void us_ticker_clear_interrupt(void)
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
 }
 
-void us_ticker_set_interrupt(timestamp_t timestamp)
-{
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    
-    uint32_t delta = timestamp - us_ticker_read();
-    cd_major_minor_us = delta * US_PER_TICK;
-    us_ticker_arm_cd();
-}
-
 void us_ticker_fire_interrupt(void)
 {
-    cd_major_minor_us = cd_minor_us = 0;
+    // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
+    //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
     NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
 }
 
 static void tmr0_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    counter_major ++;
 }
 
 static void tmr1_vec(void)
 {
     TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    cd_major_minor_us = (cd_major_minor_us > cd_minor_us) ? (cd_major_minor_us - cd_minor_us) : 0;
-    if (cd_major_minor_us == 0) {
-        // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-        us_ticker_irq_handler();
-    }
-    else {
-        us_ticker_arm_cd();
-    }
+
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }
 
-static void us_ticker_arm_cd(void)
+static void arm_alarm(uint32_t cd_clk)
 {
     TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-    
-    cd_minor_us = cd_major_minor_us;   
-      
+
     // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
     timer1_base->CTL |= TIMER_CTL_RSTCNT_Msk;
     // One-shot mode, Clock = 1 MHz 
     uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / TMR1HIRES_CLK_PER_SEC - 1;
+    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
     MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % TMR1HIRES_CLK_PER_SEC) == 0);
+    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
     timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk | TIMER_CTL_CNTDATEN_Msk);
     timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1 | TIMER_CTL_CNTDATEN_Msk;
-    
-    uint32_t cmp_timer1 = cd_minor_us / US_PER_TMR1HIRES_CLK;
+
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer1 = cd_clk;
     cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
     timer1_base->CMP = cmp_timer1;
-    
+
     TIMER_EnableInt(timer1_base);
     TIMER_Start(timer1_base);
+}
+
+const ticker_info_t* us_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        NU_TMRCLK_PER_SEC / NU_TMRCLK_PER_TICK,
+        NU_TMR_MAXCNT_BITSIZE
+    };
+    return &info;
 }


### PR DESCRIPTION
## Description

This PR updates for all Nuvoton targets:
- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487
- NUMAKER_PFM_NANO130

It has the following updates:
1. Rework us_ticker/lp_ticker. Because upper layer (`hal`/`mbed_ticker_api.c`) has addressed ticker frequency/bit size/some wrap-around issues, us_ticker/lp_ticker are reworked to make code more concise and reasonable.
1. Rework RTC. H/W RTC just supports year range 2000~2099, but `time`/`set_time` requires POSIX time which starts from 1970. The rework fixes it by using H/W RTC to keep elapsed time since some time point rather than real date time.