### PR TITLE
RTX5: Pre-processor defines used for assembly

### DIFF
--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl.S
@@ -24,9 +24,9 @@
 ; */
 
 
-                IF       :LNOT::DEF:__DOMAIN_NS
+#ifndef __DOMAIN_NS
 __DOMAIN_NS     EQU      0
-                ENDIF
+#endif
 
 I_T_RUN_OFS     EQU      20                     ; osRtxInfo.thread.run offset
 TCB_SM_OFS      EQU      48                     ; TCB.stack_mem offset

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl.S
@@ -225,8 +225,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if non-secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M23/irq_armv8mbl_ns.S
@@ -1,3 +1,0 @@
-__DOMAIN_NS     EQU      1
-                INCLUDE  irq_armv8mbl.s
-                END

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml.S
@@ -24,15 +24,13 @@
 ; */
 
 
-                IF       :LNOT::DEF:__DOMAIN_NS
+#ifndef __DOMAIN_NS
 __DOMAIN_NS     EQU      0
-                ENDIF
+#endif
 
-                IF       ({FPU}="FPv5-SP") || ({FPU}="FPv5_D16")
-__FPU_USED      EQU      1
-                ELSE
+#ifndef __FPU_USED
 __FPU_USED      EQU      0
-                ENDIF
+#endif
 
 I_T_RUN_OFS     EQU      20                     ; osRtxInfo.thread.run offset
 TCB_SM_OFS      EQU      48                     ; TCB.stack_mem offset

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_ARM/TARGET_M33/irq_armv8mml_ns.S
@@ -1,3 +1,0 @@
-__DOMAIN_NS     EQU      1
-                INCLUDE  irq_armv8mml.s
-                END

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl.S
@@ -229,8 +229,9 @@ Sys_ContextSave:
         BL       TZ_StoreContext_S      // Store secure context
         MOV      LR,R7                  // Set EXC_RETURN
         POP      {R1,R2,R3,R7}          // Restore registers
-        LSLS     R7,R7,#25              // Check domain of interrupted thread
-        BMI      Sys_ContextSave1       // Branch if secure
+        MOV      R0,LR                  // Get EXC_RETURN
+        LSLS     R0,R0,#25              // Check domain of interrupted thread
+        BPL      Sys_ContextSave1       // Branch if not secure
         MRS      R0,PSP                 // Get PSP
         STR      R0,[R1,#TCB_SP_OFS]    // Store SP
         B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl.S
@@ -27,9 +27,9 @@
         .file    "irq_armv8mbl.S"
         .syntax  unified
 
-        .ifndef  __DOMAIN_NS
+#ifndef  __DOMAIN_NS
         .equ     __DOMAIN_NS, 0
-        .endif
+#endif
 
         .equ     I_T_RUN_OFS, 20        // osRtxInfo.thread.run offset
         .equ     TCB_SM_OFS,  48        // TCB.stack_mem offset

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M23/irq_armv8mbl_ns.S
@@ -1,3 +1,0 @@
-        .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mbl.S"
-        .end

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml.S
@@ -27,13 +27,13 @@
         .file    "irq_armv8mml.S"
         .syntax  unified
 
-        .ifndef  __DOMAIN_NS
++#ifndef __DOMAIN_NS
         .equ     __DOMAIN_NS, 0
-        .endif
+#endif
 
-        .ifndef  __FPU_USED
+#ifndef  __FPU_USED
         .equ     __FPU_USED,  0
-        .endif
+#endif
 
         .equ     I_T_RUN_OFS, 20        // osRtxInfo.thread.run offset
         .equ     TCB_SM_OFS,  48        // TCB.stack_mem offset

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_fp.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_fp.S
@@ -1,3 +1,0 @@
-        .equ     __FPU_USED,  1
-        .include "../Source/GCC/irq_armv8mml.S"
-        .end

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_fp_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_fp_ns.S
@@ -1,4 +1,0 @@
-        .equ     __FPU_USED,  1
-        .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mml.S"
-        .end

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_GCC/TARGET_M33/irq_armv8mml_ns.S
@@ -1,3 +1,0 @@
-        .equ     __DOMAIN_NS, 1
-        .include "../Source/GCC/irq_armv8mml.S"
-        .end

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl.S
@@ -1,5 +1,0 @@
-                NAME irq_armv8mbl.s
-#define __DOMAIN_NS 0
-                INCLUDE  irq_armv8mbl_common.s
-
-                END

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl_common.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl_common.S
@@ -218,8 +218,9 @@ Sys_ContextSave
                 BL       TZ_StoreContext_S      ; Store secure context
                 MOV      LR,R7                  ; Set EXC_RETURN
                 POP      {R1,R2,R3,R7}          ; Restore registers
-                LSLS     R7,R7,#25              ; Check domain of interrupted thread
-                BMI      Sys_ContextSave1       ; Branch if secure
+                MOV      R0,LR                  ; Get EXC_RETURN
+                LSLS     R0,R0,#25              ; Check domain of interrupted thread
+                BPL      Sys_ContextSave1       ; Branch if not secure
                 MRS      R0,PSP                 ; Get PSP
                 STR      R0,[R1,#TCB_SP_OFS]    ; Store SP
                 B        Sys_ContextSave2

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M23/irq_armv8mbl_ns.S
@@ -1,5 +1,0 @@
-                NAME irq_armv8mbl_ns.s
-#define __DOMAIN_NS 1
-                INCLUDE  irq_armv8mbl_common.s
-
-                END

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M33/irq_armv8mml.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M33/irq_armv8mml.S
@@ -1,5 +1,0 @@
-                NAME     irq_armv8mml.s
-#define __DOMAIN_NS 0
-                INCLUDE  irq_armv8mml_common.s
-        END
-	

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M33/irq_armv8mml_ns.S
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/TOOLCHAIN_IAR/TARGET_M33/irq_armv8mml_ns.S
@@ -1,5 +1,0 @@
-                NAME irq_armv8mml_ns.s
-#define __DOMAIN_NS 1
-                INCLUDE  irq_armv8mml_common.s
-        END
-	

--- a/tools/importer/cmsis_importer.json
+++ b/tools/importer/cmsis_importer.json
@@ -148,7 +148,8 @@
       "e83fd0099a69e6eb865e4e6fcadbfb1328c04c85",
       "a019acaf8d6fb1f0512414d072f667cc2749b1d9",
       "a884fdc0639ae4e17299838ec9de4fddd83cf93c",
-      "6c827cb5879bc096e45efd992dfadcb96c1d50bc"
+      "6c827cb5879bc096e45efd992dfadcb96c1d50bc",
+      "919282322e106b82fea50878f41b6c75a7eb356b"
     ]
 }
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -93,6 +93,8 @@ class GCC(mbedToolchain):
 
         if target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.cpu.append("-mcmse")
+        elif target.core == "Cortex-M23-NS" or target.core == "Cortex-M33-NS":
+             self.flags["ld"].append("-D__DOMAIN_NS=1")
 
         self.flags["common"] += self.cpu
 


### PR DESCRIPTION
CMSIS repo does not support pre-processor defines, hence multiple assembly files are added for secure/non-secure and floating point tools.

Mbed OS tools support assembly file pre-processing, but the build system does not support multiple assembly files for each target, hence updating the assembly files.

@0xc0170 @bulislaw 

Once this PR is merged to the master, SHA should be recorded in `cmsis_importer.json` script so that files are not over-written in next CMSIS update.