### PR TITLE
M33: -march not required if -mcpu is set

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -86,11 +86,6 @@ class GCC(mbedToolchain):
             self.cpu.append("-mfloat-abi=hard")
             self.cpu.append("-mno-unaligned-access")
 
-        if target.core.startswith("Cortex-M23"):
-            self.cpu.append("-march=armv8-m.base")
-        elif target.core.startswith("Cortex-M33"):
-            self.cpu.append("-march=armv8-m.main")
-
         if target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.cpu.append("-mcmse")
 


### PR DESCRIPTION
GCC_ARM throws warning if both architecture and core are set (though correct). If CPU option is set correctly, architecture is set by compiler itself.

@0xc0170 