### PR TITLE
Update mbed-coap to version 4.2.0

### DIFF
--- a/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.2.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.2.0) 
+**New feature:**
+-  Add new API to remove sent blockwise message from the linked list
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.1.1...v4.2.0)
+
 ## [v4.1.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.1.1) 
 **Closed issues:**
 -  IOTCLT-2203 mbed-coap does not handle PUT or POST if they indicate a smaller block size preference (fixed regression) 

--- a/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -203,6 +203,17 @@ extern void sn_coap_protocol_clear_retransmission_buffer(struct coap_s *handle);
 extern void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source_address, uint16_t payload_length, void *payload);
 
 /**
+ * \fn sn_coap_protocol_remove_sent_blockwise_message
+ *
+ * \brief Remove sent blockwise message from the linked list.
+ *
+ * \param handle Pointer to CoAP library handle
+ * \param message_id Message id to be removed.
+ *
+ */
+extern void sn_coap_protocol_remove_sent_blockwise_message(struct coap_s *handle, uint16_t message_id);
+
+/**
  * \fn void sn_coap_protocol_delete_retransmission(struct coap_s *handle)
  *
  * \param *handle Pointer to CoAP library handle

--- a/features/FEATURE_COMMON_PAL/mbed-coap/module.json
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
@@ -1552,9 +1552,26 @@ static uint16_t sn_coap_count_linked_list_size(const coap_send_msg_list_t *linke
 #endif
 
 #if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+void sn_coap_protocol_remove_sent_blockwise_message(struct coap_s *handle, uint16_t message_id)
+{
+    if (!handle) {
+        return;
+    }
+
+    ns_list_foreach_safe(coap_blockwise_msg_s, tmp, &handle->linked_list_blockwise_sent_msgs) {
+        if (tmp->coap == handle && tmp->coap_msg_ptr && tmp->coap_msg_ptr->msg_id == message_id) {
+            handle->sn_coap_protocol_free(tmp->coap_msg_ptr->payload_ptr);
+            sn_coap_parser_release_allocated_coap_msg_mem(tmp->coap, tmp->coap_msg_ptr);
+            ns_list_remove(&handle->linked_list_blockwise_sent_msgs, tmp);
+            handle->sn_coap_protocol_free(tmp);
+            break;
+        }
+    }
+}
+
 void sn_coap_protocol_block_remove(struct coap_s *handle, sn_nsdl_addr_s *source_address, uint16_t payload_length, void *payload)
 {
-    if(!handle || !source_address || !payload){
+    if (!handle || !source_address || !payload) {
         return;
     }
 


### PR DESCRIPTION
## Description

Add new API to remove sent blockwise message from the linked list.
This change is related to ticket:
https://jira.arm.com/browse/IOTCLT-2376

## Status

**READY**

