### PR TITLE
STM32 STDIO pin redefinition

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -710,6 +710,12 @@
             "lse_available": {
                 "help": "Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used",
                 "value": "1"
+            },
+            "stdio_uart_tx": {
+                "help": "default TX STDIO pins is defined in PinNames.h file, but it can be overridden"
+            },
+            "stdio_uart_rx": {
+                "help": "default RX STDIO pins is defined in PinNames.h file, but it can be overridden"
             }
         },
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"]
@@ -1103,14 +1109,6 @@
         "device_name": "STM32F412ZG",
         "bootloader_supported": true,
         "config": {
-            "stdio_uart_tx": {
-                "help": "Value PB_6",
-                "value": "PB_6"
-            },
-            "stdio_uart_rx": {
-                "help": "Value PB_7",
-                "value": "PB_7"
-            },
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSI",
@@ -1946,14 +1944,6 @@
                 "help": "Value: Defines how an on-board modem is wired up to the MCU, e.g., data connection can be a UART or USB and so forth.",
                 "value": 1,
                 "macro_name": "MODEM_ON_BOARD_UART"
-            },
-            "stdio_uart_tx": {
-                "help": "Value PB_6",
-                "value": "PB_6"
-            },
-            "stdio_uart_rx": {
-                "help": "Value PB_7",
-                "value": "PB_7"
             }
         },
         "overrides": {
@@ -1999,15 +1989,11 @@
             "hse_value": {
             "value": "24000000",
             "macro_name": "HSE_VALUE"
-            },
-            "stdio_uart_tx": {
-                "help": "Value PA_2",
-                "value": "PA_2"
-            },
-            "stdio_uart_rx": {
-                "help": "Value PA_3",
-                "value": "PA_3"
             }
+        },
+        "overrides": {
+            "stdio_uart_tx": "PA_2",
+            "stdio_uart_rx": "PA_3"
         },
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has_add": ["ANALOGOUT", "FLASH"],
@@ -2052,28 +2038,32 @@
         "supported_form_factors": ["ARDUINO"],
         "release_versions": ["5"],
         "config": {
-            "stdio_uart_tx": {
-                "help": "Value: D8(default) or D1",
-                "value": "D8"
+            "stdio_uart_tx_help": {
+                "help": "Value: D8(default) or D1"
             },
-            "stdio_uart_rx": {
-                "help": "Value: D2(default) or D0",
-                "value": "D2"
+            "stdio_uart_rx_help": {
+                "help": "Value: D2(default) or D0"
             }
+        },
+        "overrides": {
+            "stdio_uart_tx": "D8",
+            "stdio_uart_rx": "D2"
         }
     },
     "MBED_CONNECT_ODIN": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "release_versions": ["5"],
         "config": {
-            "stdio_uart_tx": {
-                "help": "Value: PA_9(default) or PD_8",
-                "value": "PA_9"
+            "stdio_uart_tx_help": {
+                "help": "Value: PA_9(default) or PD_8"
             },
-            "stdio_uart_rx": {
-                "help": "Value: PA_10(default) or PD_9",
-                "value": "PA_10"
+            "stdio_uart_rx_help": {
+                "help": "Value: PA_10(default) or PD_9"
             }
+        },
+        "overrides": {
+            "stdio_uart_tx": "PA_9",
+            "stdio_uart_rx": "PA_10"
         }
     },
     "MTB_UBLOX_ODIN_W2": {


### PR DESCRIPTION
## Description

Issue reported by @atoy40 in
https://github.com/ARMmbed/mbed-os/pull/5795#issuecomment-363441054

wiki page https://os.mbed.com/teams/ST/wiki/STDIO will be updated

Correct mbed_app.json format is :

"target_overrides": {
        "NUCLEO_L073RZ": {
             "target.stdio_uart_tx": "tx pin name",
             "target.stdio_uart_rx": "rx pin name",
        }
    }


## Status

**READY**
