### PR TITLE
 RTX changes pulled in from d20b8aa 

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -54,4 +54,7 @@
 # define OS_PRIVILEGE_MODE           0
 #endif
 
+#define OS_IDLE_THREAD_TZ_MOD_ID     1
+#define OS_TIMER_THREAD_TZ_MOD_ID    1
+
 #endif /* MBED_RTX_CONF_H */

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Config/RTX_Config.h
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Config/RTX_Config.h
@@ -17,7 +17,7 @@
  *
  * -----------------------------------------------------------------------------
  *
- * $Revision:   V5.1.0
+ * $Revision:   V5.2.0
  *
  * Project:     CMSIS-RTOS RTX
  * Title:       RTX Configuration definitions
@@ -181,6 +181,14 @@
 #define OS_IDLE_THREAD_STACK_SIZE   200
 #endif
  
+//   <o>Idle Thread TrustZone Module Identifier
+//   <i> Defines TrustZone Thread Context Management Identifier.
+//   <i> Applies only to cores with TrustZone technology.
+//   <i> Default: 0 (not used)
+#ifndef OS_IDLE_THREAD_TZ_MOD_ID
+#define OS_IDLE_THREAD_TZ_MOD_ID    0
+#endif
+ 
 //   <q>Stack overrun checking
 //   <i> Enable stack overrun checks at thread switch.
 //   <i> Enabling this option increases slightly the execution time of a thread switch.
@@ -240,6 +248,14 @@
 //   <i> Default: 200
 #ifndef OS_TIMER_THREAD_STACK_SIZE
 #define OS_TIMER_THREAD_STACK_SIZE  200
+#endif
+ 
+//   <o>Timer Thread TrustZone Module Identifier
+//   <i> Defines TrustZone Thread Context Management Identifier.
+//   <i> Applies only to cores with TrustZone technology.
+//   <i> Default: 0 (not used)
+#ifndef OS_TIMER_THREAD_TZ_MOD_ID
+#define OS_TIMER_THREAD_TZ_MOD_ID   0
 #endif
  
 //   <o>Timer Callback Queue entries <0-256>

--- a/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.c
+++ b/rtos/TARGET_CORTEX/rtx5/RTX/Source/rtx_lib.c
@@ -128,7 +128,12 @@ static const osThreadAttr_t os_idle_thread_attr = {
   &os_idle_thread_stack,
   (uint32_t)sizeof(os_idle_thread_stack),
   osPriorityIdle,
-  0U, 0U
+#if defined(OS_IDLE_THREAD_TZ_MOD_ID)
+  (uint32_t)OS_IDLE_THREAD_TZ_MOD_ID,
+#else
+  0U,
+#endif
+  0U
 };
 
 
@@ -176,7 +181,12 @@ static const osThreadAttr_t os_timer_thread_attr = {
   &os_timer_thread_stack,
   (uint32_t)sizeof(os_timer_thread_stack),
   (osPriority_t)OS_TIMER_THREAD_PRIO,
-  0U, 0U
+#if defined(OS_TIMER_THREAD_TZ_MOD_ID)
+  (uint32_t)OS_TIMER_THREAD_TZ_MOD_ID,
+#else
+  0U,
+#endif
+  0U
 };
 
 // Timer Message Queue Control Block


### PR DESCRIPTION
Secure functions were not accessible from Timer/Idle thread this PR should fix that with changes from CMSIS and config options in mbed-os

Pulling in https://github.com/ARM-software/CMSIS_5/commit/d20b8aad7f5e4188608ff0c26246cc6e4961b1ba#diff-7467c87f859f0e1a8e5f93ef0c118c43

Resolves: https://github.com/ARM-software/CMSIS_5/issues/252

@bulislaw - I am not sure if we should add conf options (MBED_CONF_APP_IDLE_THREAD_TZ_MOD_ID / MBED_CONF_APP_TIMER_THREAD_TZ_MOD_ID) or simply set OS_TIMER_THREAD_TZ_MOD_ID / 
 OS_IDLE_THREAD_TZ_MOD_ID as 1.