### PR TITLE
Fix NVIC Wrapper include for Renesas

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/inc/RZ_A1LU.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/inc/RZ_A1LU.h
@@ -649,6 +649,7 @@ typedef enum IRQn
 #define __L2C_PRESENT        1U    /* L2C present                                   */
 
 #include "core_ca.h"
+#include "nvic_wrapper.h"
 #include <system_RZ_A1LU.h>
 #include "iodefine.h"
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/inc/RZ_A1H.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/inc/RZ_A1H.h
@@ -649,6 +649,7 @@ typedef enum IRQn
 #define __L2C_PRESENT        1U    /* L2C present                                   */
 
 #include "core_ca.h"
+#include "nvic_wrapper.h"
 #include <system_RZ_A1H.h>
 #include "iodefine.h"
 


### PR DESCRIPTION
Renesas mbed boards incorporate NVIC Wrapper because Cortex-A9 use GIC. For example, `NVIC_SystemReset()` is defined in `nvic_wrapper.c` and declared in `nvic_wrapper.h`.
Because I removed one of include processing accidentally, I fixed the lack.

In relation to Issue #5886.