### PR TITLE
add few files to gitignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ BUILD/
 .mbed
 venv/
 
+# Mbedls
+.mbedls-mock.lock
+
 # Eclipse Project Files
 .cproject
 .project
@@ -44,6 +47,8 @@ pip-log.txt
 .coverage
 .tox
 nosetests.xml
+.cache
+.hypothesis
 
 # Translations
 *.mo
@@ -71,6 +76,9 @@ debug.log
 
 # Cscope
 cscope.*
+
+# Ctags
+tags
 
 # vim swap files
 *.swp


### PR DESCRIPTION
## Description

This PR adds some files to the .gitignore list :
- `.mbedls-mock.lock` : generated by `mbedls -m id:name`
- `.hypothesis` : generated by api_tests
- `.cache` : generated by pytest
- `tags` : generated by ctags

## Status

READY

