### PR TITLE
us/lp ticker - port K64F platform to new HAL api

### DIFF
--- a/TESTS/mbed_drivers/rtc/main.cpp
+++ b/TESTS/mbed_drivers/rtc/main.cpp
@@ -21,7 +21,7 @@
 #include "rtos.h"
 #include "rtc_api.h"
 
-#if !DEVICE_RTC
+#if !DEVICE_RTC || !DEVICE_USTICKER
 #error [NOT_SUPPORTED] test not supported
 #endif
 

--- a/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
+++ b/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
@@ -44,7 +44,13 @@ void lp_ticker_info_test(void);
  */
 void lp_ticker_deepsleep_test(void);
 
-
+/** Test that the ticker does not glitch backwards due to an incorrectly implemented ripple counter driver.
+ *
+ * Given ticker is available.
+ * When ticker is enabled and counts.
+ * Then ticker does not glitch backwards due to an incorrectly implemented ripple counter driver.
+ */
+void lp_ticker_glitch_test(void);
 /**@}*/
 
 #ifdef __cplusplus

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -86,6 +86,24 @@ void lp_ticker_deepsleep_test()
     TEST_ASSERT_EQUAL(1, intFlag);
 }
 
+/* Test that the ticker does not glitch backwards due to an incorrectly implemented ripple counter driver. */
+void lp_ticker_glitch_test()
+{
+    lp_ticker_init();
+
+    const ticker_info_t* p_ticker_info = lp_ticker_get_info();
+
+    uint32_t last = lp_ticker_read();
+    const uint32_t start = last;
+
+    /* Set test time to 2 sec. */
+    while (last < (start + p_ticker_info->frequency * 2)) {
+        const uint32_t cur = lp_ticker_read();
+        TEST_ASSERT(cur >= last);
+        last = cur;
+    }
+}
+
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(20, "default_auto");
@@ -95,6 +113,7 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 Case cases[] = {
     Case("lp ticker info test", lp_ticker_info_test),
     Case("lp ticker sleep test", lp_ticker_deepsleep_test),
+    Case("lp ticker glitch test", lp_ticker_glitch_test)
 };
 
 Specification specification(test_setup, cases);

--- a/TESTS/mbed_hal/lp_us_tickers/main.cpp
+++ b/TESTS/mbed_hal/lp_us_tickers/main.cpp
@@ -27,7 +27,7 @@
 
 #define FORCE_OVERFLOW_TEST (false)
 #define TICKER_INT_VAL 500
-#define TICKER_DELTA 50
+#define TICKER_DELTA 10
 
 #define LP_TICKER_OVERFLOW_DELTA 0 // this will allow to detect that ticker counter rollovers to 0
 #define HF_TICKER_OVERFLOW_DELTA 50
@@ -147,17 +147,17 @@ void ticker_interrupt_test(void)
             TEST_ASSERT_EQUAL_INT_MESSAGE(0, intFlag, "Interrupt fired too early");
         }
 
-        /* Wait until ticker count reach value: tick_count + ticker_timeout[i].
+        /* Wait until ticker count reach value: tick_count + ticker_timeout[i] + TICKER_DELTA.
          * Interrupt should be fired after this time. */
-        while (intf->read() < (tick_count + ticker_timeout[i])) {
+        while (intf->read() < (tick_count + ticker_timeout[i] + TICKER_DELTA)) {
             /* Just wait. */
         }
 
         TEST_ASSERT_EQUAL(1, intFlag);
 
-        /* Wait until ticker count reach value: tick_count + 3 * ticker_timeout[i].
+        /* Wait until ticker count reach value: tick_count + 2 * ticker_timeout[i] + TICKER_DELTA.
          * Interrupt should not be triggered again. */
-        while (intf->read() < (tick_count + 3 * ticker_timeout[i])) {
+        while (intf->read() < (tick_count + 2 * ticker_timeout[i] + TICKER_DELTA)) {
             /* Just wait. */
         }
 

--- a/TESTS/mbed_hal/lp_us_tickers/main.cpp
+++ b/TESTS/mbed_hal/lp_us_tickers/main.cpp
@@ -49,8 +49,10 @@ unsigned int ticker_overflow_delta;
 
 /* Auxiliary function to count ticker ticks elapsed during execution of N cycles of empty while loop.
  * Parameter <step> is used to disable compiler optimisation. */
-uint32_t count_ticks(volatile uint32_t cycles, uint32_t step)
+uint32_t count_ticks(uint32_t cycles, uint32_t step)
 {
+    register uint32_t reg_cycles = cycles;
+
     core_util_critical_section_enter();
 
     const uint32_t start = intf->read();

--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -43,6 +43,9 @@ extern "C" {
  * * See the @ref hal_ticker_shared "ticker specification"
  * * Calling any function other than lp_ticker_init after calling lp_ticker_free
  *
+ * # Potential bugs
+ * * Glitches due to ripple counter - Verified by ::lp_ticker_glitch_test
+ *
  * @see hal_lp_ticker_tests
  *
  * @{

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,16 @@
 #include "fsl_pit.h"
 #include "fsl_clock_config.h"
 
-static int us_ticker_inited = 0;
+const ticker_info_t* us_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        1000000,    // 1 MHz
+             32     // 32 bit counter
+    };
+    return &info;
+}
+
+static bool us_ticker_inited = false;
 
 static void pit_isr(void)
 {
@@ -31,15 +40,14 @@ static void pit_isr(void)
     us_ticker_irq_handler();
 }
 
+/** Initialize the high frequency ticker
+ *
+ */
 void us_ticker_init(void)
 {
-    if (us_ticker_inited) {
-        return;
-    }
-    us_ticker_inited = 1;
-    //Common for ticker/timer
+    /* Common for ticker/timer. */
     uint32_t busClock;
-    // Structure to initialize PIT
+    /* Structure to initialize PIT. */
     pit_config_t pitConfig;
 
     PIT_GetDefaultConfig(&pitConfig);
@@ -47,56 +55,83 @@ void us_ticker_init(void)
 
     busClock = CLOCK_GetFreq(kCLOCK_BusClk);
 
-    //Timer
-    PIT_SetTimerPeriod(PIT, kPIT_Chnl_0, busClock / 1000000 - 1);
-    PIT_SetTimerPeriod(PIT, kPIT_Chnl_1, 0xFFFFFFFF);
-    PIT_SetTimerChainMode(PIT, kPIT_Chnl_1, true);
-    PIT_StartTimer(PIT, kPIT_Chnl_0);
-    PIT_StartTimer(PIT, kPIT_Chnl_1);
-
-    //Ticker
-    PIT_SetTimerPeriod(PIT, kPIT_Chnl_2, busClock / 1000000 - 1);
-    PIT_SetTimerChainMode(PIT, kPIT_Chnl_3, true);
-    NVIC_SetVector(PIT3_IRQn, (uint32_t)pit_isr);
-    NVIC_EnableIRQ(PIT3_IRQn);
-}
-
-
-uint32_t us_ticker_read()
-{
+    /* Let the timer to count if re-init. */
     if (!us_ticker_inited) {
-        us_ticker_init();
+
+        PIT_SetTimerPeriod(PIT, kPIT_Chnl_0, busClock / 1000000 - 1);
+        PIT_SetTimerPeriod(PIT, kPIT_Chnl_1, 0xFFFFFFFF);
+        PIT_SetTimerChainMode(PIT, kPIT_Chnl_1, true);
+        PIT_StartTimer(PIT, kPIT_Chnl_0);
+        PIT_StartTimer(PIT, kPIT_Chnl_1);
     }
 
+    /* Configure interrupt generation counters and disable ticker interrupts. */
+    PIT_StopTimer(PIT, kPIT_Chnl_3);
+    PIT_StopTimer(PIT, kPIT_Chnl_2);
+    PIT_SetTimerPeriod(PIT, kPIT_Chnl_2, busClock / 1000000 - 1);
+    PIT_SetTimerChainMode(PIT, kPIT_Chnl_3, true);
+    NVIC_SetVector(PIT3_IRQn, (uint32_t) pit_isr);
+    NVIC_EnableIRQ(PIT3_IRQn);
+    PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
+
+    us_ticker_inited = true;
+}
+
+/** Read the current counter
+ *
+ * @return The current timer's counter value in ticks
+ */
+uint32_t us_ticker_read()
+{
     return ~(PIT_GetCurrentTimerCount(PIT, kPIT_Chnl_1));
 }
 
+/** Disable us ticker interrupt
+ *
+ */
 void us_ticker_disable_interrupt(void)
 {
     PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
 }
 
+/** Clear us ticker interrupt
+ *
+ */
 void us_ticker_clear_interrupt(void)
 {
     PIT_ClearStatusFlags(PIT, kPIT_Chnl_3, PIT_TFLG_TIF_MASK);
 }
 
+/** Set interrupt for specified timestamp
+ *
+ * @param timestamp The time in ticks when interrupt should be generated
+ */
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    uint32_t now_us, delta_us;
+    /* We get here absolute interrupt time which takes into account counter overflow.
+     * Since we use additional count-down timer to generate interrupt we need to calculate
+     * load value based on time-stamp.
+     */
+    const uint32_t now_ticks = us_ticker_read();
+    uint32_t delta_ticks =
+            timestamp >= now_ticks ? timestamp - now_ticks : (uint32_t)((uint64_t) timestamp + 0xFFFFFFFF - now_ticks);
 
-    now_us = us_ticker_read();
-    delta_us = timestamp >= now_us ? timestamp - now_us : (uint32_t)((uint64_t)timestamp + 0xFFFFFFFF - now_us);
+    if (delta_ticks == 0) {
+        /* The requested delay is less than the minimum resolution of this counter. */
+        delta_ticks = 1;
+    }
 
-    uint32_t delta = timestamp - us_ticker_read();
     PIT_StopTimer(PIT, kPIT_Chnl_3);
     PIT_StopTimer(PIT, kPIT_Chnl_2);
-    PIT_SetTimerPeriod(PIT, kPIT_Chnl_3, (uint32_t)delta_us);
+    PIT_SetTimerPeriod(PIT, kPIT_Chnl_3, delta_ticks);
     PIT_EnableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
     PIT_StartTimer(PIT, kPIT_Chnl_3);
     PIT_StartTimer(PIT, kPIT_Chnl_2);
 }
 
+/** Fire us ticker interrupt
+ *
+ */
 void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1195,7 +1195,7 @@
         },
         "extra_labels_add": ["STM32F4", "STM32F429", "STM32F429ZI", "STM32F429xx", "STM32F429xI"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "device_has_remove": ["USTICKER"],
         "detect_code": ["0796"],
         "features": ["LWIP"],
@@ -3479,7 +3479,7 @@
         "inherits": ["MCU_NRF52"],
         "macros_remove": ["MBED_TICKLESS"],
         "macros_add": ["BOARD_PCA10040", "NRF52_PAN_12", "NRF52_PAN_15", "NRF52_PAN_58", "NRF52_PAN_55", "NRF52_PAN_54", "NRF52_PAN_31", "NRF52_PAN_30", "NRF52_PAN_51", "NRF52_PAN_36", "NRF52_PAN_53", "S132", "CONFIG_GPIO_AS_PINRESET", "BLE_STACK_SUPPORT_REQD", "SWI_DISABLE0", "NRF52_PAN_20", "NRF52_PAN_64", "NRF52_PAN_62", "NRF52_PAN_63"],
-        "device_has_add": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "FLASH"],
+        "device_has_add": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
         "device_has_remove": ["USTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "nRF52832_xxAA"
@@ -3664,7 +3664,7 @@
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
-        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
+        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "TRNG", "SPISLAVE"],
         "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -615,7 +615,7 @@
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0240"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
+        "device_has": ["USTICKER", "LOWPOWERTIMER", "ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
         "features": ["LWIP", "STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK64FN1M0xxx12",


### PR DESCRIPTION
## Description

This PR ports us/lp ticker K64F drivers to the new HAL API, enables support for ticker on K64F and also provides little modifications to the HAL ticker tests (resolve issues found while porting ticker driver).

1. Adapt K64F us ticker driver to the new standards.

Here only cosmetic changes were required since US ticker is already driven by 1MHz clock, so us <-> ticks conversion is not required.
Init routine needed to be modified since according to the requirements init should disable us ticker interrupt.

2. Adapt K64F lp ticker driver to the new standards.

Low power ticker time counter is created based on RTC which is driven by 32KHz clock. Additional low power timer is used to generate interrupts (in case when sleep time does not exceed 2 sec otherwise interrupt is scheduled in two steps - first full seconds are scheduled using RTC Alarm interrupt and then remaining time using LPTMR).

In previous version RTC time was converted to us before was passed to the upper layer and vice versa. In the new version upper layer is informed that lp ticker is driven by 32KHz clock, ticker driver operates on ticks and ticks <-> us conversion is handled by the upper ticker layer.
Init routine needed to be modified since according to the requirements init should disable lp ticker interrupt.

3. lp_us_tickers test - provide counter overflow protection.

Since counter overflow is handled by the upper layer new drivers does not check if counter has overflown. Added protection against counter overflow during test case execution.

4. lp_us_tickers test - add tolerance to interrupt time.

On some platforms (e.g. K64F) different counters are used for time measurement and interrupt generation.
Because of that we should relax "interrupt test case" and give additional time before checking if interrupt handler has been executed.

## Status

**HOLD**

## Migrations

YES

Low power ticker K64F drivers operates now on ticks and ticks <--> us conversion is done in the upper layer.
