### PR TITLE
K64F lp ticker driver - calculation bug fix.

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
@@ -83,10 +83,15 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    uint32_t now_us, delta_us;
+
+    now_us = us_ticker_read();
+    delta_us = timestamp >= now_us ? timestamp - now_us : (uint32_t)((uint64_t)timestamp + 0xFFFFFFFF - now_us);
+
     uint32_t delta = timestamp - us_ticker_read();
     PIT_StopTimer(PIT, kPIT_Chnl_3);
     PIT_StopTimer(PIT, kPIT_Chnl_2);
-    PIT_SetTimerPeriod(PIT, kPIT_Chnl_3, (uint32_t)delta);
+    PIT_SetTimerPeriod(PIT, kPIT_Chnl_3, (uint32_t)delta_us);
     PIT_EnableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
     PIT_StartTimer(PIT, kPIT_Chnl_3);
     PIT_StartTimer(PIT, kPIT_Chnl_2);

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -135,7 +135,7 @@ void lp_ticker_set_interrupt(timestamp_t timestamp)
 
     lptmr_schedule = 0;
     now_us = lp_ticker_read();
-    delta_us = timestamp > now_us ? timestamp - now_us : (uint32_t)((uint64_t)timestamp + 0xFFFFFFFF - now_us);
+    delta_us = timestamp >= now_us ? timestamp - now_us : (uint32_t)((uint64_t)timestamp + 0xFFFFFFFF - now_us);
 
     /* Checking if LPTRM can handle this sleep */
     delta_ticks = USEC_TO_COUNT(delta_us, CLOCK_GetFreq(kCLOCK_Er32kClk));


### PR DESCRIPTION
## Description

Issue with interrupt scheduling has been found while working on PR https://github.com/ARMmbed/mbed-os/pull/6052.

Delta calculation from lp_ticker_set_interrupt() function:
https://github.com/ARMmbed/mbed-os/blob/04f0f2b1aa7abb6acb2dfcaa2cb2696520aa6e38/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c#L138

Lets assume that `timestam` == `now_us`.
Expected delta value should be `0` and in this current version is `0xFFFFFFFF`.

The following condition:
`timestamp > now_us`
should have the following form:
`timestamp >= now_us`

Additionally modified us ticker driver to provide the same logic.

## Status

**READY**

## Migrations

 NO
