### PR TITLE
Fix for issue #6054 - interrupts scheduled in the past.

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -235,6 +235,14 @@ static void schedule_interrupt(const ticker_data_t *const ticker)
         }
 
         timestamp_t match_tick = compute_tick(ticker, match_time);
+        // The time has been checked to be future, but it could still round
+        // to the last tick as a result of us to ticks conversion
+        if (match_tick == queue->tick_last_read) {
+            // Match time has already expired so fire immediately
+            ticker->interface->fire_interrupt();
+            return;
+        }
+
         ticker->interface->set_interrupt(match_tick);
         timestamp_t cur_tick = ticker->interface->read();
 


### PR DESCRIPTION
## Description

When ticker is not driven by the 1 MHz clock and HAL driver need to perform conversion between microseconds and ticks, then the interrupt might be scheduled in the past. For details see issue https://github.com/ARMmbed/mbed-os/issues/6054.

This patch provides fix for such case. While scheduling next interrupt an interrupt is fired immediately when ticker last read tick is equal to the calculated tick when interrupt should be generated.

## Status

**READY**

## Migrations

NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
ARMmbed:feature-hal-spec-ticker | [https://github.com/ARMmbed/mbed-os/pull/5629]()
ARMmbed:feature-hal-spec-ticker| [https://github.com/ARMmbed/mbed-os/pull/6052]()
