### PR TITLE
Replace wait_us() calls in ST I2C HAL driver with RTOS-less/pure-C waits

### DIFF
--- a/targets/TARGET_STM/i2c_api.c
+++ b/targets/TARGET_STM/i2c_api.c
@@ -32,6 +32,7 @@
 #include "mbed_assert.h"
 #include "i2c_api.h"
 #include "platform/mbed_wait_api.h"
+#include "hal/us_ticker_api.h"
 
 #if DEVICE_I2C
 
@@ -754,7 +755,8 @@ int i2c_read(i2c_t *obj, int address, char *data, int length, int stop) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
         /*  transfer started : wait completion or timeout */
         while(!(obj_s->event & I2C_EVENT_ALL) && (--timeout != 0)) {
-            wait_us(1);
+            int start = us_ticker_read();
+            while ((us_ticker_read() - start) < 1);
         }
 
         i2c_ev_err_disable(obj);
@@ -805,7 +807,8 @@ int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
         /*  transfer started : wait completion or timeout */
         while(!(obj_s->event & I2C_EVENT_ALL) && (--timeout != 0)) {
-            wait_us(1);
+            int start = us_ticker_read();
+            while ((us_ticker_read() - start) < 1);
         }
 
         i2c_ev_err_disable(obj);
@@ -986,7 +989,8 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
     if(ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
         while(obj_s->pending_slave_rx_maxter_tx && (--timeout != 0)) {
-            wait_us(1);
+            int start = us_ticker_read();
+            while ((us_ticker_read() - start) < 1);
         }
 
          if(timeout != 0) {
@@ -1011,7 +1015,8 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
     if(ret == HAL_OK) {
         timeout = BYTE_TIMEOUT_US * (length + 1);
         while(obj_s->pending_slave_tx_master_rx && (--timeout != 0)) {
-            wait_us(1);
+            int start = us_ticker_read();
+            while ((us_ticker_read() - start) < 1);
         }
 
          if(timeout != 0) {


### PR DESCRIPTION
## Description
Replace the calls to `wait_us()` in `i2c_api.c` for the STM platforms with a microsecond-ticker-based wait (hence becoming RTOS-less and all pure-C code).  This is required because the `UBLOX_C030` family of boards (which use an STM32F437VG MCU) need to configure a voltage threshold via I2C for reliable operation.  Such Mbed target configuration can only be done in the `HAL_MspInit()` hook, which is called before either the RTOS or LIBC have been initialised.

## Status
Tested on C030 platform, @ARMmbed/team-st-mcd to regression test on other ST platforms.

## Related PRs
#5957, #5995, #6034

## Steps to test or reproduce
Run `mbed test` and the test `mbed_platform-critical_section` will now pass on a `UBLOX_C030` platform.

Test results attached (noting that the UDP test always fail on our network).

[waitless_i2c_test_output.txt](https://github.com/ARMmbed/mbed-os/files/1717038/waitless_i2c_test_output.txt)

CC @ARMmbed/team-ublox.