### PR TITLE
fatfs: Remove extra MBR block

### DIFF
--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -211,7 +211,11 @@ int MBRBlockDevice::init()
     }
 
     // Check for valid entry
-    if (table->entries[_part-1].type == 0x00) {
+    // 0x00 = no entry
+    // 0x05, 0x0f = extended partitions, currently not supported
+    if ((table->entries[_part-1].type == 0x00 ||
+         table->entries[_part-1].type == 0x05 ||
+         table->entries[_part-1].type == 0x0f)) {
         delete[] buffer;
         return BD_ERROR_INVALID_PARTITION;
     }

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -340,7 +340,7 @@ int FATFileSystem::format(BlockDevice *bd, bd_size_t cluster_size)
 
     // Logical drive number, Partitioning rule, Allocation unit size (bytes per cluster)
     fs.lock();
-    FRESULT res = f_mkfs(fs._fsid, FM_ANY, cluster_size, NULL, 0);
+    FRESULT res = f_mkfs(fs._fsid, FM_ANY | FM_SFD, cluster_size, NULL, 0);
     fs.unlock();
     if (res != FR_OK) {
         return fat_error_remap(res);


### PR DESCRIPTION
Regression after ChanFS update ([here](https://github.com/ARMmbed/mbed-os/pull/5490)): Due to parameter changes in the f_mkfs function, the option to use a separate block for MBR (FDISK) was turned back on. This should be off (SFD) as it conflicts with an explicit MBR when using the MBRBlockDevice.

For more info see https://github.com/ARMmbed/mbed-os/pull/3936/commits/d1468a68ab123de353ea83ad93b07db267408602

I also added a test that prevents this regression in the future, but at the moment it can't run in CI due to memory restrictions. (related: https://github.com/ARMmbed/mbed-os/issues/6008, [IOTMORF-2062](https://jira.arm.com/browse/IOTMORF-2062))

cc @deepikabhavnani 
should fix https://github.com/ARMmbed/mbed-os/issues/5999