### PR TITLE
Remove ticker interface initialization while Ticker creation.

### DIFF
--- a/drivers/Ticker.h
+++ b/drivers/Ticker.h
@@ -71,7 +71,6 @@ public:
 
     // When low power ticker is in use, then do not disable deep-sleep.
     Ticker(const ticker_data_t *data) : TimerEvent(data), _function(0), _lock_deepsleep(true)  {
-        data->interface->init();
 #if DEVICE_LOWPOWERTIMER
         _lock_deepsleep = (data != get_lp_ticker_data());
 #endif


### PR DESCRIPTION
## Description

Ticker constructor calls directly target specific ticker init function. Currently there is no problem, since ticker interface initialization functions are protected against multi-calls and simply returns if not called for the first time (interface initialization can be performed only once). According to the new Thicker HAL API requirements:

> The function ticker_init allows the ticker to keep counting and disables the ticker interrupt.

Disabling interrupts while some Ticker interrupts are already scheduled for sure will destroy the schedule. Ticker interface should be initialized only here:
https://github.com/ARMmbed/mbed-os/blob/ccff46d9a3c960dae72d08c399e214a3eaeb63c7/hal/mbed_ticker_api.c#L36

This function is protected against multi-calls and ensures that ticker interface will be initialized only once. 
## Status

**READY**

## Migrations

NO

## Related PRs

List related PRs against other branches:

branch | PR
------ | ------
ARMmbed:feature-hal-spec-ticker | [https://github.com/ARMmbed/mbed-os/pull/6052]()
ARMmbed:feature-hal-spec-ticker | [https://github.com/ARMmbed/mbed-os/pull/5629]()