### PR TITLE
tools: build: fix handing of "--stats-depth"

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -528,7 +528,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         memap_instance = getattr(toolchain, 'memap_instance', None)
         memap_table = ''
         if memap_instance:
-            real_stats_depth = stats_depth if stats_depth is None else 2
+            real_stats_depth = stats_depth if stats_depth is not None else 2
             memap_table = memap_instance.generate_output('table', real_stats_depth)
             if not silent:
                 if not stats_depth:


### PR DESCRIPTION
## Description

The introduction of pretty-bar had broken the handling of
"mbed compile"'s "--stats-depth" argument. No matter what one gave
as parameter to it, the result output is just using the default 2.
Fix the logic in build_api.

## Status

**READY**

## Migrations

NO

## Related PRs

<none>

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

<none>

## Steps to test or reproduce

```"mbed compile -m K64F -t GCC_ARM --stats-depth 1"``` and ```"mbed compile -m K64F  -t GCC_ARM --stats-depth 10"``` both give same output on current Mbed OS master. This PR fixes the parameter handing.