### PR TITLE
NETSOCKET MBED_EXTENDED_TESTS json configuration

### DIFF
--- a/TESTS/netsocket/tcp_echo/main.cpp
+++ b/TESTS/netsocket/tcp_echo/main.cpp
@@ -16,7 +16,7 @@
  */
 
 #ifndef MBED_CONF_APP_CONNECT_STATEMENT
-    #error [NOT_SUPPORTED] No network configuration found for this target.
+#error [NOT_SUPPORTED] No network configuration found for this target.
 #endif
 
 #include "mbed.h"
@@ -32,18 +32,21 @@ using namespace utest::v1;
 #define MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE 256
 #endif
 
-namespace {
-    char tx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
-    char rx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
+namespace
+{
+char tx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
+char rx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE] = {0};
 }
 
-void prep_buffer(char *tx_buffer, size_t tx_size) {
-    for (size_t i=0; i<tx_size; ++i) {
+void prep_buffer(char *tx_buffer, size_t tx_size)
+{
+    for (size_t i = 0; i < tx_size; ++i) {
         tx_buffer[i] = (rand() % 10) + '0';
     }
 }
 
-void test_tcp_echo() {
+void test_tcp_echo()
+{
     int n = 0;
     NetworkInterface* net = MBED_CONF_APP_OBJECT_CONSTRUCTION;
     int err =  MBED_CONF_APP_CONNECT_STATEMENT;
@@ -119,7 +122,8 @@ void test_tcp_echo() {
 
 
 // Test setup
-utest::v1::status_t test_setup(const size_t number_of_cases) {
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
     GREENTEA_SETUP(240, "tcp_echo");
     return verbose_test_setup_handler(number_of_cases);
 }
@@ -130,6 +134,7 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-int main() {
+int main()
+{
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tcp_echo_parallel/main.cpp
+++ b/TESTS/netsocket/tcp_echo_parallel/main.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
- #ifndef MBED_CONF_APP_CONNECT_STATEMENT
-     #error [NOT_SUPPORTED] No network configuration found for this target.
- #endif
+#ifndef MBED_CONF_APP_CONNECT_STATEMENT
+#error [NOT_SUPPORTED] No network configuration found for this target.
+#endif
 
 #ifndef MBED_EXTENDED_TESTS
-    #error [NOT_SUPPORTED] Parallel tests are not supported by default
+#error [NOT_SUPPORTED] Parallel tests are not supported by default
 #endif
 
 #include "mbed.h"
@@ -33,12 +33,12 @@
 using namespace utest::v1;
 
 
-#ifndef MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE
-#define MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE 64
+#ifndef MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE
+#define MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE 64
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_ECHO_THREADS
-#define MBED_CFG_TCP_CLIENT_ECHO_THREADS 3
+#ifndef MBED_CONF_APP_TCP_CLIENT_ECHO_THREADS
+#define MBED_CONF_APP_TCP_CLIENT_ECHO_THREADS 3
 #endif
 
 #define STRINGIZE(x) STRINGIZE2(x)
@@ -49,51 +49,59 @@ NetworkInterface* net;
 SocketAddress tcp_addr;
 Mutex iomutex;
 
-void prep_buffer(char *tx_buffer, size_t tx_size) {
-    for (size_t i=0; i<tx_size; ++i) {
+void prep_buffer(char *tx_buffer, size_t tx_size)
+{
+    for (size_t i = 0; i < tx_size; ++i) {
         tx_buffer[i] = (rand() % 10) + '0';
     }
 }
 
 
 // Each echo class is in charge of one parallel transaction
-class Echo {
+class Echo
+{
 private:
-    char tx_buffer[MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE];
-    char rx_buffer[MBED_CFG_TCP_CLIENT_ECHO_BUFFER_SIZE];
+    char tx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE];
+    char rx_buffer[MBED_CONF_APP_TCP_CLIENT_ECHO_BUFFER_SIZE];
 
     TCPSocket sock;
     Thread thread;
 
 public:
     // Limiting stack size to 1k
-    Echo(): thread(osPriorityNormal, 1024) {
+    Echo(): thread(osPriorityNormal, 1024)
+    {
     }
 
-    void start() {
+    void start()
+    {
         osStatus status = thread.start(callback(this, &Echo::echo));
         TEST_ASSERT_EQUAL(osOK, status);
     }
 
-    void join() {
+    void join()
+    {
         osStatus status = thread.join();
         TEST_ASSERT_EQUAL(osOK, status);
     }
 
-    void echo() {
+    void echo()
+    {
         int err = sock.open(net);
         TEST_ASSERT_EQUAL(0, err);
 
         err = sock.connect(tcp_addr);
         TEST_ASSERT_EQUAL(0, err);
 
+#if defined(MBED_CONF_APP_TCP_ECHO_PREFIX)
         //recv connection prefix message
         sock.recv(rx_buffer, sizeof(MBED_CONF_APP_TCP_ECHO_PREFIX));
+#endif /* MBED_CONF_APP_TCP_ECHO_PREFIX */
         memset(rx_buffer, 0, sizeof(rx_buffer));
 
         iomutex.lock();
         printf("HTTP: Connected to %s:%d\r\n",
-                tcp_addr.get_ip_address(), tcp_addr.get_port());
+               tcp_addr.get_ip_address(), tcp_addr.get_port());
         printf("tx_buffer buffer size: %u\r\n", sizeof(tx_buffer));
         printf("rx_buffer buffer size: %u\r\n", sizeof(rx_buffer));
         iomutex.unlock();
@@ -112,26 +120,45 @@ public:
     }
 };
 
-Echo *echoers[MBED_CFG_TCP_CLIENT_ECHO_THREADS];
+Echo *echoers[MBED_CONF_APP_TCP_CLIENT_ECHO_THREADS];
 
 
-void test_tcp_echo_parallel() {
+void test_tcp_echo_parallel()
+{
     net = MBED_CONF_APP_OBJECT_CONSTRUCTION;
     int err =  MBED_CONF_APP_CONNECT_STATEMENT;
     TEST_ASSERT_EQUAL(0, err);
 
     printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
 
+#if defined(MBED_CONF_APP_ECHO_SERVER_ADDR) && defined(MBED_CONF_APP_ECHO_SERVER_PORT)
     tcp_addr.set_ip_address(MBED_CONF_APP_ECHO_SERVER_ADDR);
     tcp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+#else /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
+    char recv_key[] = "host_port";
+    char ipbuf[60] = {0};
+    char portbuf[16] = {0};
+    unsigned int port = 0;
+
+    greentea_send_kv("target_ip", net->get_ip_address());
+    greentea_send_kv("host_ip", " ");
+    greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
+
+    greentea_send_kv("host_port", " ");
+    greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
+    sscanf(portbuf, "%u", &port);
+
+    tcp_addr.set_ip_address(ipbuf);
+    tcp_addr.set_port(port);
+#endif /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
 
     // Startup echo threads in parallel
-    for (int i = 0; i < MBED_CFG_TCP_CLIENT_ECHO_THREADS; i++) {
+    for (int i = 0; i < MBED_CONF_APP_TCP_CLIENT_ECHO_THREADS; i++) {
         echoers[i] = new Echo;
         echoers[i]->start();
     }
 
-    for (int i = 0; i < MBED_CFG_TCP_CLIENT_ECHO_THREADS; i++) {
+    for (int i = 0; i < MBED_CONF_APP_TCP_CLIENT_ECHO_THREADS; i++) {
         echoers[i]->join();
         delete echoers[i];
     }
@@ -140,7 +167,8 @@ void test_tcp_echo_parallel() {
 }
 
 // Test setup
-utest::v1::status_t test_setup(const size_t number_of_cases) {
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
     GREENTEA_SETUP(120, "tcp_echo");
     return verbose_test_setup_handler(number_of_cases);
 }
@@ -151,6 +179,7 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-int main() {
+int main()
+{
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tcp_packet_pressure/main.cpp
+++ b/TESTS/netsocket/tcp_packet_pressure/main.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
- #ifndef MBED_CONF_APP_CONNECT_STATEMENT
-     #error [NOT_SUPPORTED] No network configuration found for this target.
- #endif
+#ifndef MBED_CONF_APP_CONNECT_STATEMENT
+#error [NOT_SUPPORTED] No network configuration found for this target.
+#endif
 
 #ifndef MBED_EXTENDED_TESTS
-    #error [NOT_SUPPORTED] Pressure tests are not supported by default
+#error [NOT_SUPPORTED] Pressure tests are not supported by default
 #endif
 
 #include "mbed.h"
@@ -33,20 +33,20 @@
 using namespace utest::v1;
 
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN 64
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN 64
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX 0x80000
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX 0x80000
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED 0x6d626564
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED 0x6d626564
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG false
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG false
 #endif
 
 #define STRINGIZE(x) STRINGIZE2(x)
@@ -54,7 +54,8 @@ using namespace utest::v1;
 
 
 // Simple xorshift pseudorandom number generator
-class RandSeq {
+class RandSeq
+{
 private:
     uint32_t x;
     uint32_t y;
@@ -63,23 +64,26 @@ private:
     static const int C = 11;
 
 public:
-    RandSeq(uint32_t seed=MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED)
+    RandSeq(uint32_t seed = MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED)
         : x(seed), y(seed) {}
 
-    uint32_t next(void) {
+    uint32_t next(void)
+    {
         x ^= x << A;
         x ^= x >> B;
         x ^= y ^ (y >> C);
         return x + y;
     }
 
-    void skip(size_t size) {
+    void skip(size_t size)
+    {
         for (size_t i = 0; i < size; i++) {
             next();
         }
     }
 
-    void buffer(uint8_t *buffer, size_t size) {
+    void buffer(uint8_t *buffer, size_t size)
+    {
         RandSeq lookahead = *this;
 
         for (size_t i = 0; i < size; i++) {
@@ -87,7 +91,8 @@ public:
         }
     }
 
-    int cmp(uint8_t *buffer, size_t size) {
+    int cmp(uint8_t *buffer, size_t size)
+    {
         RandSeq lookahead = *this;
 
         for (size_t i = 0; i < size; i++) {
@@ -107,7 +112,8 @@ size_t buffer_size;
 // Tries to get the biggest buffer possible on the device. Exponentially
 // grows a buffer until heap runs out of space, and uses half to leave
 // space for the rest of the program
-void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
+void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max)
+{
     size_t i = min;
     while (i < max) {
         void *b = malloc(i);
@@ -128,10 +134,11 @@ void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
 }
 
 
-void test_tcp_packet_pressure() {
+void test_tcp_packet_pressure()
+{
     generate_buffer(&buffer, &buffer_size,
-        MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN,
-        MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX);
+                    MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN,
+                    MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX);
     printf("MBED: Generated buffer %d\r\n", buffer_size);
 
     NetworkInterface* net = MBED_CONF_APP_OBJECT_CONSTRUCTION;
@@ -141,24 +148,43 @@ void test_tcp_packet_pressure() {
     printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
 
     TCPSocket sock;
+#if defined(MBED_CONF_APP_ECHO_SERVER_ADDR) && defined(MBED_CONF_APP_ECHO_SERVER_PORT)
     SocketAddress tcp_addr(MBED_CONF_APP_ECHO_SERVER_ADDR, MBED_CONF_APP_ECHO_SERVER_PORT);
+#else /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
+    char recv_key[] = "host_port";
+    char ipbuf[60] = {0};
+    char portbuf[16] = {0};
+    unsigned int port = 0;
+
+    greentea_send_kv("target_ip", net->get_ip_address());
+    greentea_send_kv("host_ip", " ");
+    greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
+
+    greentea_send_kv("host_port", " ");
+    greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
+    sscanf(portbuf, "%u", &port);
+
+    SocketAddress tcp_addr(ipbuf, port);
+#endif /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
 
     Timer timer;
     timer.start();
 
     // Tests exponentially growing sequences
-    for (size_t size = MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN;
-         size < MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX;
-         size *= 2) {
+    for (size_t size = MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN;
+            size < MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX;
+            size *= 2) {
         err = sock.open(net);
         TEST_ASSERT_EQUAL(0, err);
         err = sock.connect(tcp_addr);
         TEST_ASSERT_EQUAL(0, err);
         printf("TCP: %s:%d streaming %d bytes\r\n",
-            tcp_addr.get_ip_address(), tcp_addr.get_port(), size);
+               tcp_addr.get_ip_address(), tcp_addr.get_port(), size);
 
+#if defined(MBED_CONF_APP_TCP_ECHO_PREFIX)
         //recv connection prefix message
         sock.recv(buffer, sizeof(MBED_CONF_APP_TCP_ECHO_PREFIX));
+#endif /* MBED_CONF_APP_TCP_ECHO_PREFIX */
         memset(buffer, 0, sizeof(buffer));
 
         sock.set_blocking(false);
@@ -182,7 +208,7 @@ void test_tcp_packet_pressure() {
                 int td = sock.send(buffer, chunk_size);
 
                 if (td > 0) {
-                    if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                    if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                         printf("TCP: tx -> %d\r\n", td);
                     }
                     tx_seq.skip(td);
@@ -190,11 +216,11 @@ void test_tcp_packet_pressure() {
                 } else if (td != NSAPI_ERROR_WOULD_BLOCK) {
                     // We may fail to send because of buffering issues,
                     // cut buffer in half
-                    if (window > MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) {
+                    if (window > MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN) {
                         window /= 2;
                     }
 
-                    if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                    if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                         printf("TCP: Not sent (%d), window = %d\r\n", td, window);
                     }
                 }
@@ -205,7 +231,7 @@ void test_tcp_packet_pressure() {
                 int rd = sock.recv(buffer, buffer_size);
                 TEST_ASSERT(rd > 0 || rd == NSAPI_ERROR_WOULD_BLOCK);
                 if (rd > 0) {
-                    if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                    if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                         printf("TCP: rx <- %d\r\n", rd);
                     }
                     int diff = rx_seq.cmp(buffer, rd);
@@ -225,15 +251,16 @@ void test_tcp_packet_pressure() {
     timer.stop();
     printf("MBED: Time taken: %fs\r\n", timer.read());
     printf("MBED: Speed: %.3fkb/s\r\n",
-            8*(2*MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX -
-            MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
+           8 * (2 * MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX -
+                MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000 * timer.read()));
 
     net->disconnect();
 }
 
 
 // Test setup
-utest::v1::status_t test_setup(const size_t number_of_cases) {
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
     GREENTEA_SETUP(120, "tcp_echo");
     return verbose_test_setup_handler(number_of_cases);
 }
@@ -244,6 +271,7 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-int main() {
+int main()
+{
     return !Harness::run(specification);
 }

--- a/TESTS/netsocket/tcp_packet_pressure_parallel/main.cpp
+++ b/TESTS/netsocket/tcp_packet_pressure_parallel/main.cpp
@@ -15,12 +15,12 @@
  * limitations under the License.
  */
 
- #ifndef MBED_CONF_APP_CONNECT_STATEMENT
-     #error [NOT_SUPPORTED] No network configuration found for this target.
- #endif
+#ifndef MBED_CONF_APP_CONNECT_STATEMENT
+#error [NOT_SUPPORTED] No network configuration found for this target.
+#endif
 
 #ifndef MBED_EXTENDED_TESTS
-    #error [NOT_SUPPORTED] Parallel pressure tests are not supported by default
+#error [NOT_SUPPORTED] Parallel pressure tests are not supported by default
 #endif
 
 #include "mbed.h"
@@ -33,24 +33,24 @@
 using namespace utest::v1;
 
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN 64
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN 64
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX 0x80000
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX 0x80000
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED 0x6d626564
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED 0x6d626564
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS 3
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS 3
 #endif
 
-#ifndef MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG
-#define MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG false
+#ifndef MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG
+#define MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG false
 #endif
 
 #define STRINGIZE(x) STRINGIZE2(x)
@@ -58,7 +58,8 @@ using namespace utest::v1;
 
 
 // Simple xorshift pseudorandom number generator
-class RandSeq {
+class RandSeq
+{
 private:
     uint32_t x;
     uint32_t y;
@@ -67,23 +68,26 @@ private:
     static const int C = 11;
 
 public:
-    RandSeq(uint32_t seed=MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_SEED)
+    RandSeq(uint32_t seed = MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_SEED)
         : x(seed), y(seed) {}
 
-    uint32_t next(void) {
+    uint32_t next(void)
+    {
         x ^= x << A;
         x ^= x >> B;
         x ^= y ^ (y >> C);
         return x + y;
     }
 
-    void skip(size_t size) {
+    void skip(size_t size)
+    {
         for (size_t i = 0; i < size; i++) {
             next();
         }
     }
 
-    void buffer(uint8_t *buffer, size_t size) {
+    void buffer(uint8_t *buffer, size_t size)
+    {
         RandSeq lookahead = *this;
 
         for (size_t i = 0; i < size; i++) {
@@ -91,7 +95,8 @@ public:
         }
     }
 
-    int cmp(uint8_t *buffer, size_t size) {
+    int cmp(uint8_t *buffer, size_t size)
+    {
         RandSeq lookahead = *this;
 
         for (size_t i = 0; i < size; i++) {
@@ -108,7 +113,8 @@ public:
 // Tries to get the biggest buffer possible on the device. Exponentially
 // grows a buffer until heap runs out of space, and uses half to leave
 // space for the rest of the program
-void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max) {
+void generate_buffer(uint8_t **buffer, size_t *size, size_t min, size_t max)
+{
     size_t i = min;
     while (i < max) {
         void *b = malloc(i);
@@ -136,7 +142,8 @@ Timer timer;
 Mutex iomutex;
 
 // Single instance of a pressure test
-class PressureTest {
+class PressureTest
+{
 private:
     uint8_t *buffer;
     size_t buffer_size;
@@ -146,33 +153,40 @@ private:
 
 public:
     PressureTest(uint8_t *buffer, size_t buffer_size)
-        : buffer(buffer), buffer_size(buffer_size) {
+        : buffer(buffer), buffer_size(buffer_size)
+    {
     }
 
-    void start() {
+    void start()
+    {
         osStatus status = thread.start(callback(this, &PressureTest::run));
         TEST_ASSERT_EQUAL(osOK, status);
     }
 
-    void join() {
+    void join()
+    {
         osStatus status = thread.join();
         TEST_ASSERT_EQUAL(osOK, status);
     }
 
-    void run() {
+    void run()
+    {
         // Tests exponentially growing sequences
-        for (size_t size = MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN;
-             size < MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX;
-             size *= 2) {
+        for (size_t size = MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN;
+                size < MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX;
+                size *= 2) {
             int err = sock.open(net);
             TEST_ASSERT_EQUAL(0, err);
             err = sock.connect(tcp_addr);
             TEST_ASSERT_EQUAL(0, err);
+
+#if defined(MBED_CONF_APP_TCP_ECHO_PREFIX)
             sock.recv(buffer, sizeof(MBED_CONF_APP_TCP_ECHO_PREFIX));
+#endif /* MBED_CONF_APP_TCP_ECHO_PREFIX */
 
             iomutex.lock();
             printf("TCP: %s:%d streaming %d bytes\r\n",
-                tcp_addr.get_ip_address(), tcp_addr.get_port(), size);
+                   tcp_addr.get_ip_address(), tcp_addr.get_port(), size);
             iomutex.unlock();
 
             sock.set_blocking(false);
@@ -196,7 +210,7 @@ public:
                     int td = sock.send(buffer, chunk_size);
 
                     if (td > 0) {
-                        if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                        if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                             iomutex.lock();
                             printf("TCP: tx -> %d\r\n", td);
                             iomutex.unlock();
@@ -206,11 +220,11 @@ public:
                     } else if (td != NSAPI_ERROR_WOULD_BLOCK) {
                         // We may fail to send because of buffering issues,
                         // cut buffer in half
-                        if (window > MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) {
+                        if (window > MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN) {
                             window /= 2;
                         }
 
-                        if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                        if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                             iomutex.lock();
                             printf("TCP: Not sent (%d), window = %d\r\n", td, window);
                             iomutex.unlock();
@@ -223,7 +237,7 @@ public:
                     int rd = sock.recv(buffer, buffer_size);
                     TEST_ASSERT(rd > 0 || rd == NSAPI_ERROR_WOULD_BLOCK);
                     if (rd > 0) {
-                        if (MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
+                        if (MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_DEBUG) {
                             iomutex.lock();
                             printf("TCP: rx <- %d\r\n", rd);
                             iomutex.unlock();
@@ -244,21 +258,22 @@ public:
     }
 };
 
-PressureTest *pressure_tests[MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS];
+PressureTest *pressure_tests[MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS];
 
 
-void test_tcp_packet_pressure_parallel() {
+void test_tcp_packet_pressure_parallel()
+{
     uint8_t *buffer;
     size_t buffer_size;
     generate_buffer(&buffer, &buffer_size,
-        MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN,
-        MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX);
+                    MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN,
+                    MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX);
 
-    size_t buffer_subsize = buffer_size / MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS;
+    size_t buffer_subsize = buffer_size / MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS;
     printf("MBED: Generated buffer %d\r\n", buffer_size);
     printf("MBED: Split into %d buffers %d\r\n",
-            MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS,
-            buffer_subsize);
+           MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS,
+           buffer_subsize);
 
     net = MBED_CONF_APP_OBJECT_CONSTRUCTION;
     int err =  MBED_CONF_APP_CONNECT_STATEMENT;
@@ -266,18 +281,36 @@ void test_tcp_packet_pressure_parallel() {
 
     printf("MBED: TCPClient IP address is '%s'\n", net->get_ip_address());
 
+#if defined(MBED_CONF_APP_ECHO_SERVER_ADDR) && defined(MBED_CONF_APP_ECHO_SERVER_PORT)
     tcp_addr.set_ip_address(MBED_CONF_APP_ECHO_SERVER_ADDR);
     tcp_addr.set_port(MBED_CONF_APP_ECHO_SERVER_PORT);
+#else /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
+    char recv_key[] = "host_port";
+    char ipbuf[60] = {0};
+    char portbuf[16] = {0};
+    unsigned int port = 0;
+
+    greentea_send_kv("target_ip", net->get_ip_address());
+    greentea_send_kv("host_ip", " ");
+    greentea_parse_kv(recv_key, ipbuf, sizeof(recv_key), sizeof(ipbuf));
+
+    greentea_send_kv("host_port", " ");
+    greentea_parse_kv(recv_key, portbuf, sizeof(recv_key), sizeof(ipbuf));
+    sscanf(portbuf, "%u", &port);
+
+    tcp_addr.set_ip_address(ipbuf);
+    tcp_addr.set_port(port);
+#endif /* MBED_CONF_APP_ECHO_SERVER_ADDR && MBED_CONF_APP_ECHO_SERVER_PORT */
 
     timer.start();
 
     // Startup pressure tests in parallel
-    for (int i = 0; i < MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS; i++) {
-        pressure_tests[i] = new PressureTest(&buffer[i*buffer_subsize], buffer_subsize);
+    for (int i = 0; i < MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS; i++) {
+        pressure_tests[i] = new PressureTest(&buffer[i * buffer_subsize], buffer_subsize);
         pressure_tests[i]->start();
     }
 
-    for (int i = 0; i < MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS; i++) {
+    for (int i = 0; i < MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS; i++) {
         pressure_tests[i]->join();
         delete pressure_tests[i];
     }
@@ -285,16 +318,17 @@ void test_tcp_packet_pressure_parallel() {
     timer.stop();
     printf("MBED: Time taken: %fs\r\n", timer.read());
     printf("MBED: Speed: %.3fkb/s\r\n",
-            MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_THREADS*
-            8*(2*MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MAX -
-            MBED_CFG_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000*timer.read()));
+           MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_THREADS *
+           8 * (2 * MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MAX -
+                MBED_CONF_APP_TCP_CLIENT_PACKET_PRESSURE_MIN) / (1000 * timer.read()));
 
     net->disconnect();
 }
 
 
 // Test setup
-utest::v1::status_t test_setup(const size_t number_of_cases) {
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
     GREENTEA_SETUP(120, "tcp_echo");
     return verbose_test_setup_handler(number_of_cases);
 }
@@ -305,6 +339,7 @@ Case cases[] = {
 
 Specification specification(test_setup, cases);
 
-int main() {
+int main()
+{
     return !Harness::run(specification);
 }


### PR DESCRIPTION
## Description

Netsocket tests  with MBED_EXTENDED_TESTS were not configurable as "level 0" tests.

- All test parameters can be set now in mbed_app json file.
- Tests are also possible now in a local network (no internet access) by disabling ECHO_SERVER_ADDR in the json file.

Astyle has been applied

## Status

**READY**

## Tests

| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-connectivity                 | OK     | 21.66              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-gethostbyname                | OK     | 19.84              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-ip_parsing                   | OK     | 17.63              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-socket_sigio                 | OK     | 26.36              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-tcp_echo                     | OK     | 20.94              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-tcp_echo_parallel            | OK     | 25.07              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-tcp_hello_world              | OK     | 21.1               | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-tcp_packet_pressure          | OK     | 29.64              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-tcp_packet_pressure_parallel | OK     | 39.93              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-udp_dtls_handshake           | OK     | 22.02              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-udp_echo                     | OK     | 23.58              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-udp_echo_parallel            | OK     | 31.65              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-udp_packet_pressure          | OK     | 31.13              | default     |
| NUCLEO_F429ZI-GCC_ARM | NUCLEO_F429ZI | tests-netsocket-udp_packet_pressure_parallel | OK     | 41.42              | default     |

