### PR TITLE
Generate/Link secure object file

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -304,6 +304,7 @@ class ARMC6(ARM_STD):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
+        build_dir = kwargs['build_dir']
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
 
@@ -336,6 +337,11 @@ class ARMC6(ARM_STD):
 
         if target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.flags['common'].append("-mcmse")
+
+        # Create Secure library
+        if target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = join(build_dir, "cmse_lib.o")
+            self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 
         asm_cpu = {
             "Cortex-M0+": "Cortex-M0",

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -219,6 +219,12 @@ class GCC(mbedToolchain):
         # Build linker command
         map_file = splitext(output)[0] + ".map"
         cmd = self.ld + ["-o", output, "-Wl,-Map=%s" % map_file] + objects + ["-Wl,--start-group"] + libs + ["-Wl,--end-group"]
+        # Create Secure library
+        if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = join(dirname(output), "cmse_lib.o")
+            cmd.extend(["-Wl,--cmse-implib"])
+            cmd.extend(["-Wl,--out-implib=%s" % secure_file])
+
         if mem_map:
             cmd.extend(['-T', mem_map])
 
@@ -238,6 +244,8 @@ class GCC(mbedToolchain):
         # Exec command
         self.cc_verbose("Link: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
+        if self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            self.info("Secure Library Object %s" %secure_file)
 
     @hook_tool
     def archive(self, objects, lib_path):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -74,6 +74,12 @@ class IAR(mbedToolchain):
             c_flags_cmd.append("--fpu=VFPv5_sp")
         elif target.core == "Cortex-M23" or target.core == "Cortex-M33":
             self.flags["asm"] += ["--cmse"]
+            self.flags["common"] += ["--cmse"]
+
+        # Create Secure library
+        if target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            secure_file = join(build_dir, "cmse_lib.o")
+            self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 
         IAR_BIN = join(TOOLCHAIN_PATHS['IAR'], "bin")
         main_cc = join(IAR_BIN, "iccarm")


### PR DESCRIPTION
Cortex v8 architecture based devices support secure/non-secure builds. Secure build should generate the object file/library from elf during link process which is used by non-secure binary during linking.

--out-implib=file specifies output library in which symbols are exported --cmse-implib requests libraries mentioned above are secure gateway libraries

Creation of secure library is done as part of linking process in GCC/ARMC6/IAR Non-Secure project should add this secure object file as part of the linking process.
Secure library is named as cmse_lib.o.
