### PR TITLE
Trustzone function support

### DIFF
--- a/platform/mbed_tz_context.c
+++ b/platform/mbed_tz_context.c
@@ -1,0 +1,200 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+
+#include "cmsis.h"
+#include "mbed_rtx.h"
+#include "tz_context.h"
+
+
+/// Number of process slots (threads may call secure library code)
+#ifndef TZ_PROCESS_STACK_SLOTS
+#define TZ_PROCESS_STACK_SLOTS     8U
+#endif
+
+/// Stack size of the secure library code
+#ifndef TZ_PROCESS_STACK_SIZE
+#define TZ_PROCESS_STACK_SIZE      512U
+#endif
+
+typedef struct {
+    uint32_t sp_top;              // stack space top
+    uint32_t sp_limit;            // stack space limit
+    uint32_t sp;                  // current stack pointer
+} stack_info_t;
+
+static stack_info_t ProcessStackInfo  [TZ_PROCESS_STACK_SLOTS];
+static uint64_t     ProcessStackMemory[TZ_PROCESS_STACK_SLOTS][TZ_PROCESS_STACK_SIZE/8U];
+static uint32_t     ProcessStackFreeSlot = 0xFFFFFFFFU;
+
+
+/// Initialize secure context memory system
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_InitContextSystem_S (void)
+{
+    uint32_t n;
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    for (n = 0U; n < TZ_PROCESS_STACK_SLOTS; n++) {
+        ProcessStackInfo[n].sp = 0U;
+        ProcessStackInfo[n].sp_limit = (uint32_t)&ProcessStackMemory[n];
+        ProcessStackInfo[n].sp_top     = (uint32_t)&ProcessStackMemory[n] + TZ_PROCESS_STACK_SIZE;
+        *((uint32_t *)ProcessStackMemory[n]) = n + 1U;
+    }
+    *((uint32_t *)ProcessStackMemory[--n]) = 0xFFFFFFFFU;
+
+    ProcessStackFreeSlot = 0U;
+
+    // Default process stack pointer and stack limit
+    __set_PSPLIM ((uint32_t)ProcessStackMemory);
+    __set_PSP ((uint32_t)ProcessStackMemory);
+
+    // Privileged Thread Mode using PSP
+    __set_CONTROL(0x02U);
+
+    return 1U;        // Success
+}
+
+
+/// Allocate context memory for calling secure software modules in TrustZone
+/// \param[in]  module   identifies software modules called from non-secure mode
+/// \return value != 0 id TrustZone memory slot identifier
+/// \return value 0    no memory available or internal error
+__attribute__((cmse_nonsecure_entry))
+TZ_MemoryId_t TZ_AllocModuleContext_S (TZ_ModuleId_t module)
+{
+    uint32_t slot;
+
+    (void)module;   // Ignore (fixed Stack size)
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    if (ProcessStackFreeSlot == 0xFFFFFFFFU) {
+        return 0U;    // No slot available
+    }
+
+    slot = ProcessStackFreeSlot;
+    ProcessStackFreeSlot = *((uint32_t *)ProcessStackMemory[slot]);
+
+    ProcessStackInfo[slot].sp = ProcessStackInfo[slot].sp_top;
+
+    return (slot + 1U);
+}
+
+/// Free context memory that was previously allocated with \ref TZ_AllocModuleContext_S
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_FreeModuleContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+
+    if (__get_IPSR() == 0U) {
+        return 0U;    // Thread Mode
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+    ProcessStackInfo[slot].sp = 0U;
+
+    *((uint32_t *)ProcessStackMemory[slot]) = ProcessStackFreeSlot;
+    ProcessStackFreeSlot = slot;
+
+    return 1U;        // Success
+}
+
+
+/// Load secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_LoadContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+
+    if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+        return 0U;    // Thread Mode or using Main Stack for threads
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+
+    // Setup process stack pointer and stack limit
+    __set_PSPLIM(ProcessStackInfo[slot].sp_limit);
+    __set_PSP     (ProcessStackInfo[slot].sp);
+
+    return 1U;        // Success
+}
+
+
+/// Store secure context (called on RTOS thread context switch)
+/// \param[in]  id  TrustZone memory slot identifier
+/// \return execution status (1: success, 0: error)
+__attribute__((cmse_nonsecure_entry))
+uint32_t TZ_StoreContext_S (TZ_MemoryId_t id)
+{
+    uint32_t slot;
+    uint32_t sp;
+
+    if ((__get_IPSR() == 0U) || ((__get_CONTROL() & 2U) == 0U)) {
+        return 0U;    // Thread Mode or using Main Stack for threads
+    }
+
+    if ((id == 0U) || (id > TZ_PROCESS_STACK_SLOTS)) {
+        return 0U;    // Invalid ID
+    }
+
+    slot = id - 1U;
+
+    if (ProcessStackInfo[slot].sp == 0U) {
+        return 0U;    // Inactive slot
+    }
+
+    sp = __get_PSP();
+    if ((sp < ProcessStackInfo[slot].sp_limit) ||
+            (sp > ProcessStackInfo[slot].sp_top)) {
+        return 0U;    // SP out of range
+    }
+    ProcessStackInfo[slot].sp = sp;
+
+    // Default process stack pointer and stack limit
+    __set_PSPLIM((uint32_t)ProcessStackMemory);
+    __set_PSP     ((uint32_t)ProcessStackMemory);
+
+    return 1U;        // Success
+}
+#endif

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -321,6 +321,12 @@ void mbed_start_main(void)
     _main_thread_attr.cb_mem = &_main_obj;
     _main_thread_attr.priority = osPriorityNormal;
     _main_thread_attr.name = "main_thread";
+
+    /* Allow main thread to call secure functions */
+#if (__DOMAIN_NS == 1U)
+    _main_thread_attr.tz_module = 1U;
+#endif
+
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
         error("Pre main thread not created");

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -54,6 +54,8 @@
 # define OS_PRIVILEGE_MODE           0
 #endif
 
+#define OS_SECURE_CALLABLE_THREAD    1
+
 #if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
 
 /* Number of process slots (threads may call secure library code) */

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -54,4 +54,20 @@
 # define OS_PRIVILEGE_MODE           0
 #endif
 
+#if defined (__ARM_FEATURE_CMSE) &&  (__ARM_FEATURE_CMSE == 3U)
+
+/* Number of process slots (threads may call secure library code) */
+#ifndef MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS
+#define MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS     8U
+#endif
+
+/* Stack size of the secure library code */
+#ifndef MBED_CONF_APP_TZ_PROCESS_STACK_SIZE
+#define MBED_CONF_APP_TZ_PROCESS_STACK_SIZE      512U
+#endif
+
+#define TZ_PROCESS_STACK_SLOTS      MBED_CONF_APP_TZ_PROCESS_STACK_SLOTS
+#define TZ_PROCESS_STACK_SIZE       MBED_CONF_APP_TZ_PROCESS_STACK_SIZE
+#endif
+
 #endif /* MBED_RTX_CONF_H */

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -44,7 +44,7 @@ extern "C" void thread_terminate_hook(osThreadId_t id)
 namespace rtos {
 
 void Thread::constructor(osPriority priority,
-        uint32_t stack_size, unsigned char *stack_mem, const char *name) {
+        uint32_t stack_size, unsigned char *stack_mem, const char *name, uint32_t tz_module) {
 
     const uintptr_t unaligned_mem = reinterpret_cast<uintptr_t>(stack_mem);
     const uintptr_t aligned_mem = ALIGN_UP(unaligned_mem, 8);
@@ -60,11 +60,12 @@ void Thread::constructor(osPriority priority,
     _attr.stack_size = aligned_size;
     _attr.name = name ? name : "application_unnamed_thread";
     _attr.stack_mem = reinterpret_cast<uint32_t*>(aligned_mem);
+    _attr.tz_module = tz_module;
 }
 
 void Thread::constructor(Callback<void()> task,
-        osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name) {
-    constructor(priority, stack_size, stack_mem, name);
+        osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name, uint32_t tz_module) {
+    constructor(priority, stack_size, stack_mem, name, tz_module);
 
     switch (start(task)) {
         case osErrorResource:

--- a/rtos/Thread.h
+++ b/rtos/Thread.h
@@ -80,13 +80,14 @@ public:
       @param   stack_size     stack size (in bytes) requirements for the thread function. (default: OS_STACK_SIZE).
       @param   stack_mem      pointer to the stack area to be used by this thread (default: NULL).
       @param   name           name to be used for this thread. It has to stay allocated for the lifetime of the thread (default: NULL)
+      @param   tz_module      trustzone thread identifier (default: 0)
 
       @note You cannot call this function from ISR context.
     */
     Thread(osPriority priority=osPriorityNormal,
            uint32_t stack_size=OS_STACK_SIZE,
-           unsigned char *stack_mem=NULL, const char *name=NULL) {
-        constructor(priority, stack_size, stack_mem, name);
+           unsigned char *stack_mem=NULL, const char *name=NULL, uint32_t tz_module=0) {
+        constructor(priority, stack_size, stack_mem, name, tz_module);
     }
 
     /** Create a new thread, and start it executing the specified function.
@@ -408,12 +409,12 @@ private:
     void constructor(osPriority priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
                      unsigned char *stack_mem=NULL,
-                     const char *name=NULL);
+                     const char *name=NULL, uint32_t tz_module=0);
     void constructor(mbed::Callback<void()> task,
                      osPriority priority=osPriorityNormal,
                      uint32_t stack_size=OS_STACK_SIZE,
                      unsigned char *stack_mem=NULL,
-                     const char *name=NULL);
+                     const char *name=NULL, uint32_t tz_module=0);
     static void _thunk(void * thread_ptr);
 
     mbed::Callback<void()>     _task;


### PR DESCRIPTION
Add trustzone functions from CMSIS examples, required for creation of secure lib. Allow main thread to access non-secure code.
