### PR TITLE
Add NetworkInterface::get_default_instance()

### DIFF
--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -154,3 +154,14 @@ bool LoWPANNDInterface::getRouterIpAddress(char *address, int8_t len)
 {
     return _interface->get_gateway(address, len);
 }
+
+#define MESH 0x2345
+#define LOWPAN 0x2345
+#if MBED_CONF_NSAPI_DEFAULT_INTERFACE_TYPE == MESH && MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == LOWPAN
+MBED_WEAK NetworkInterface &NetworkInterface::get_default_instance()
+{
+    static LoWPANNDInterface lowpan(NanostackRfPhy::get_default_instance());
+
+    return lowpan;
+}
+#endif

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/ThreadInterface.cpp
@@ -215,3 +215,14 @@ mesh_error_t Nanostack::ThreadInterface::device_pskd_set(const char *pskd)
 {
     return (mesh_error_t)thread_tasklet_device_pskd_set(pskd);
 }
+
+#define MESH 0x2345
+#define THREAD 0x2345
+#if MBED_CONF_NSAPI_DEFAULT_INTERFACE_TYPE == MESH && MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == THREAD
+MBED_WEAK NetworkInterface &NetworkInterface::get_default_instance()
+{
+    static ThreadInterface thread(NanostackRfPhy::get_default_instance());
+
+    return thread;
+}
+#endif

--- a/features/netsocket/EthernetInterface.cpp
+++ b/features/netsocket/EthernetInterface.cpp
@@ -1,0 +1,31 @@
+/* LWIP implementation of NetworkInterfaceAPI
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "EthernetInterface.h"
+
+/* No actual interface implementation here, as EthernetInterface is
+ * just an EMACInterface. But we can be the default NetworkInterface - step up
+ * if the target has a default EMAC.
+ */
+
+#define ETHERNET 0x2345
+#if DEVICE_EMAC && MBED_CONF_NSAPI_DEFAULT_INTERFACE_TYPE == ETHERNET
+MBED_WEAK NetworkInterface &NetworkInterface::get_default_instance()
+{
+    static EthernetInterface ethernet;
+    return ethernet;
+}
+#endif

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -37,6 +37,33 @@ class NetworkInterface {
 public:
     virtual ~NetworkInterface() {};
 
+    /** Return the default network interface
+     *
+     * Returns the default network interface, as determined by JSON option
+     * nsapi.default-interface-type and other overrides.
+     *
+     * The core code provides default weak implementations of this in a number
+     * of circumstances:
+     *   * if default-interface-type is ETHERNET and target has DEVICE_EMAC
+     *   * if default-interface-type is MESH and the RF phy has been located
+     *   * if default-interface-type is CELLULAR and OnboardCellularModem is available
+     *
+     * Targets can guide this default behaviour by setting nsapi.default-interface-type
+     * in their targets.json. Or they can completely override by implementing
+     * NetworkInterface::get_default_instance() themselves - they should do this
+     * weakly, and not to conflict with the core definition.
+     *
+     * For example, a device with both Ethernet and Wi-fi could be set up so that
+     *    * DEVICE_EMAC is set, pointing at the Ethernet MAC
+     *    * The core will automatically provide EthernetInterface if default-interface-type is ETHERNET
+     *    * The target should provide its Wi-Fi driver if default-interface-type is WIFI
+     *    * The target could dynamically provide either depending on Ethernet cable detect if default-interface-type was AUTO
+     *
+     * Targets and core both provide weak definitions, so that an application or library
+     * can provide an overriding normal definition.
+     */
+    static NetworkInterface &get_default_instance();
+
     /** Get the local MAC address
      *
      *  Provided MAC address is intended for info or debug purposes and

--- a/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.cpp
@@ -52,3 +52,22 @@ void OnboardCellularInterface::modem_power_down()
     ::onboard_modem_power_down();
 }
 #endif
+
+#define CELLULAR 0x2345
+#if ONBOARD_CELLULAR_INTERFACE_AVAILABLE && MBED_CONF_NSAPI_DEFAULT_INTERFACE_TYPE == CELLULAR
+MBED_WEAK NetworkInterface &NetworkInterface::get_default_instance()
+{
+    static OnboardCellularInterface cellular;
+
+#ifdef MBED_CONF_DEFAULT_CELLULAR_APN
+#ifndef MBED_CONF_DEFAULT_CELLULAR_USERNAME
+#define MBED_CONF_DEFAULT_CELLULAR_USERNAME NULL
+#endif
+#ifndef MBED_CONF_DEFAULT_CELLULAR_PASSWORD
+#define MBED_CONF_DEFAULT_CELLULAR_PASSWORD NULL
+#endif
+    cellular.set_credentials(MBED_CONF_DEFAULT_CELLULAR_APN, MBED_CONF_DEFAULT_CELLULAR_USERNAME, MBED_CONF_DEFAULT_CELLULAR_PASSWORD);
+#endif
+
+    return cellular;
+}

--- a/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
@@ -69,5 +69,7 @@ protected:
     virtual void modem_power_down();
 };
 
+#define ONBOARD_CELLULAR_INTERFACE_AVAILABLE
+
 #endif //MODEM_ON_BOARD && MODEM_ON_BOARD_UART && NSAPI_PPP_AVAILABLE
 #endif //ONBOARD_CELLULAR_INTERFACE_

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -2,6 +2,16 @@
     "name": "nsapi",
     "config": {
         "present": 1,
-        "default-stack": "LWIP"
+        "default-stack": "LWIP",
+        "default-interface-type": {
+            "help": "This guides the choice of the default NetworkInterface. Exactly what effect it has, and what settings are available, will depend on the target platform. Suggested values: ETHERNET, WIFI, CELLULAR, MESH.",
+            "value": "ETHERNET"
+        },
+        "default-wifi-ssid": null,
+        "default-wifi-password": null,
+        "default-cellular-apn": null,
+        "default-cellular-username": null,
+        "default-cellular-password": null,
+        "default-mesh-type": "THREAD",
     }
 }


### PR DESCRIPTION
Provide an initial framework to make it easier to find a default network
interface.

This is the germ of a concept. Follows the same pattern as just established for `EMAC::get_default_instance()` and `OnboardNetworkStack::get_default_instance()`.

Envisaged use:

    NetworkInterface &net = NetworkInterface::get_default_instance();
    net.connect();

    // for advanced users:
    WiFiInterface *wifi = net.wifiInterface();
    if (wifi) {
        wifi->do_something_wifiy();
    }
