### PR TITLE
Feature QSPI: add address to command transfer

### DIFF
--- a/drivers/QSPI.cpp
+++ b/drivers/QSPI.cpp
@@ -194,14 +194,14 @@ qspi_status_t QSPI::write(unsigned int instruction, unsigned int alt, unsigned i
     return ret_status;
 }
 
-qspi_status_t QSPI::command_transfer(unsigned int instruction, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length) 
+qspi_status_t QSPI::command_transfer(unsigned int instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length) 
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
     
     if (_initialized) {
         lock();
         if (true == _acquire()) {
-            _build_qspi_command(instruction, -1, -1); //We just need the command
+            _build_qspi_command(instruction, address, -1); //We just need the command
             if (QSPI_STATUS_OK == qspi_command_transfer(&_qspi, &_qspi_command, (const void *)tx_buffer, tx_length, (void *)rx_buffer, rx_length)) {
                 ret_status = QSPI_STATUS_OK;
             }

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -159,6 +159,7 @@ public:
     /** Perform a transaction to write to an address(a control register) and get the status results
      *
      *  @param instruction Instruction value to be used in instruction phase
+     *  @param address Some instruction might require address. Use -1 for ignoring the address value
      *  @param tx_buffer Buffer containing data to be sent to peripheral                          
      *  @param tx_length Pointer to a variable containing the length of data to be transmitted, and on return this variable will be updated with the actual number of bytes written
      *  @param rx_buffer Buffer for data to be read from the peripheral                          
@@ -167,7 +168,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t command_transfer(unsigned int instruction, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length);
+    qspi_status_t command_transfer(unsigned int instruction, int address, const char *tx_buffer, size_t tx_length, const char *rx_buffer, size_t rx_length);
 
     /** Acquire exclusive access to this SPI bus
      */


### PR DESCRIPTION
The current `command_transfer` assumes that address is first 4 bytes in the tx buffer but not yet documented.

We need to provide address somehow, for commands like erase sector or similar where address should be passed.  How this address is passed?

I can change this to document what buffer should contain or we provide address as an argument (to be aligned with other API). 
