### PR TITLE
equeue: Removed RTOS dependencies with RTOS not present

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,6 +108,10 @@ matrix:
         # Check that example compiles
         - sed -n '/``` cpp/,/```/{/```$/Q;/```/d;p;}' $EVENTS/README.md > main.cpp
         - python tools/make.py -t GCC_ARM -m K64F --source=. --build=BUILD/K64F/GCC_ARM -j0
+        # Check that example compiles without rtos
+        - sed -n '/``` cpp/,/```/{/```$/Q;/```/d;p;}' $EVENTS/README.md > main.cpp
+        - rm -r rtos features/netsocket features/frameworks BUILD
+        - python tools/make.py -t GCC_ARM -m DISCO_F401VC --source=. --build=BUILD/DISCO_F401VC/GCC_ARM -j0
         # Run local equeue tests
         - make -C $EVENTS/equeue test
 

--- a/events/equeue/equeue_platform.h
+++ b/events/equeue/equeue_platform.h
@@ -49,7 +49,7 @@ extern "C" {
 // Platform includes
 #if defined(EQUEUE_PLATFORM_POSIX)
 #include <pthread.h>
-#elif defined(EQUEUE_PLATFORM_MBED)
+#elif defined(EQUEUE_PLATFORM_MBED) && defined(MBED_CONF_RTOS_PRESENT)
 #include "cmsis_os2.h"
 #include "mbed_rtos_storage.h"
 #endif


### PR DESCRIPTION
Removed the dependencies and added a compilation test in Travis to protect against this regression in the future.

cc @janjongboom, @kjbracey-arm 
should fix https://github.com/ARMmbed/mbed-os/issues/6100