### PR TITLE
NRF5x: Fix `error_t` conflict with gcc std>=gnu++11

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5XPalGattClient.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5XPalGattClient.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <memory>
+#include <new>
 
 #include "nRF5XPalGattClient.h"
 


### PR DESCRIPTION
## Description

The Nordic implementation of FEATURE_BLE includes a typedef `error_h` which conflicts with a gcc standard implementation of `error_h` when compiled by GCC with newer standards enabled `-std=gnu++11` or above.

The conflict is traced to  `nRF5XPalGattClient.cpp`  importing `<memory.h>`
This file does not actually need anything from this include however, it only requires `<new.h>` (for some compilers).

See #5979 for original fix and detailed discussion

## Status

**READY**

## Migrations
There should be no changes to end user code.

## Related PRs
#5979


