### PR TITLE
Add quotes around MBED_BOT parameter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 env:
   global:
     - >
-      STATUS=$'curl -so/dev/null --user $MBED_BOT --request POST
+      STATUS=$'curl -so/dev/null --user "$MBED_BOT" --request POST
       https://api.github.com/repos/$TRAVIS_REPO_SLUG/statuses/${TRAVIS_PULL_REQUEST_SHA:-$TRAVIS_COMMIT}
       --data @- << DATA\n{
       "state": "$0",


### PR DESCRIPTION
## Description

If $MBED_BOT is not configured in Travis (ie: if mbed-os is forked and the user had not setup a token yet), the build will fail in a non-obvious way.

## Status

**READY**