### PR TITLE
Modified 'apt-get update' to loop until successful

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   # Setup ppa to make sure arm-none-eabi-gcc is correct version
   - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
   # Loop until update succeeds (timeouts can occur)
-  - while [ -n "$(sudo apt-get update 2>&1 |grep Failed)"; do :; done
+  - while [ -n "$(sudo apt-get update 2>&1 |grep Failed)" ]; do :; done
 
 after_success:
   - bash -c "$STATUS" success "Local $NAME testing has passed"

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ before_install:
   - sudo ln -s $HOME/.cache/apt /var/cache/apt/archives
   # Setup ppa to make sure arm-none-eabi-gcc is correct version
   - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
-  - sudo apt-get update -qq
+  # Loop until update succeeds (timeouts can occur)
+  - while [ -n "$(sudo apt-get update 2>&1 |grep Failed)"; do :; done
 
 after_success:
   - bash -c "$STATUS" success "Local $NAME testing has passed"


### PR DESCRIPTION
## Description
Every once in a while, Travis will fail on a `sudo apt-get update -qq` due to some connectivity issue to the default Ubuntu PPA URLs.

The problem is transient and not easily reproducible (suspect it's an issue with the remote server coming under sudden load), but makes the build appear to fail when it does occur. 

## Status

**READY**

## Testing
Tested within an Ubuntu VM. Command would continue until NAT was reconnected.