### PR TITLE
tests-events-timing - print debug info only in case of failure.

### DIFF
--- a/TESTS/events/timing/main.cpp
+++ b/TESTS/events/timing/main.cpp
@@ -107,7 +107,10 @@ void semaphore_timing_test() {
         equeue_sema_wait(&sema, delay);
         int taken = timer.read_us() - start;
 
-        printf("delay %dms => error %dus\r\n", delay, abs(1000*delay - taken));
+        if (taken < (delay * 1000 - 5000) || taken > (delay * 1000 + 5000)) {
+            printf("delay %dms => error %dus\r\n", delay, abs(1000 * delay - taken));
+        }
+
         TEST_ASSERT_INT_WITHIN(5000, taken, delay * 1000);
 
         led = !led;


### PR DESCRIPTION
## Description

In the `Testing accuracy of equeue semaphore` test case result is printed out in each loop iteration. This gives lots of prints during test case execution.
Since debug prints should not exist in the final test version I suggest to print information only in case of failure.
Additionally time needed to print single info is about ~25 ms (K64F/GCC_ARM). The while loop is designed to execute until 20000 ms elapses, so this print has also impact on number of times the loop is executed (number of semaphore accuracy checks).

## Status

**READY**

## Migrations

NO

