### PR TITLE
BLE: Fix generic gap connect

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -44,7 +44,6 @@ static const uint16_t advertising_interval_max = 0x4000;
 static const uint16_t supervision_timeout_min = 0x000A;
 static const uint16_t supervision_timeout_max = 0x0C80;
 
-
 /*
  * Return true if value is included in the range [lower_bound : higher_bound]
  */
@@ -491,6 +490,22 @@ ble_error_t GenericGap::connect(
     const ConnectionParams_t* connectionParams,
     const GapScanningParams* scanParams
 ) {
+    ConnectionParams_t default_connection_params = {
+        /* min conn interval */ 50,
+        /* max  conn interval */ 100,
+        /* slave latency */ 0,
+        /* supervision timeout */ 600
+    };
+    GapScanningParams default_scan_params;
+
+    if (connectionParams == NULL) {
+        connectionParams = &default_connection_params;
+    }
+
+    if (scanParams == NULL) {
+        scanParams = &default_scan_params;
+    }
+
     if (is_scan_params_valid(scanParams) == false) {
         return BLE_ERROR_PARAM_OUT_OF_RANGE;
     }

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -501,6 +501,9 @@ ble_error_t GenericGap::connect(
 
     // TODO fix upper layer API, address type factorization is incorrect.
 
+    // Force scan stop before initiating the scan used for connection
+    stopScan();
+
     return _pal_gap.create_connection(
         scanParams->getInterval(),
         scanParams->getWindow(),

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -44,7 +44,7 @@ static const uint16_t advertising_interval_max = 0x4000;
 static const uint16_t supervision_timeout_min = 0x000A;
 static const uint16_t supervision_timeout_max = 0x0C80;
 
-static const ConnectionParams_t default_connection_params = {
+static const Gap::ConnectionParams_t default_connection_params = {
     /* min conn interval */ 50,
     /* max  conn interval */ 100,
     /* slave latency */ 0,

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -44,6 +44,15 @@ static const uint16_t advertising_interval_max = 0x4000;
 static const uint16_t supervision_timeout_min = 0x000A;
 static const uint16_t supervision_timeout_max = 0x0C80;
 
+static const ConnectionParams_t default_connection_params = {
+    /* min conn interval */ 50,
+    /* max  conn interval */ 100,
+    /* slave latency */ 0,
+    /* supervision timeout */ 600
+};
+
+static const GapScanningParams default_scan_params;
+
 /*
  * Return true if value is included in the range [lower_bound : higher_bound]
  */
@@ -490,14 +499,6 @@ ble_error_t GenericGap::connect(
     const ConnectionParams_t* connectionParams,
     const GapScanningParams* scanParams
 ) {
-    ConnectionParams_t default_connection_params = {
-        /* min conn interval */ 50,
-        /* max  conn interval */ 100,
-        /* slave latency */ 0,
-        /* supervision timeout */ 600
-    };
-    GapScanningParams default_scan_params;
-
     if (connectionParams == NULL) {
         connectionParams = &default_connection_params;
     }


### PR DESCRIPTION
## Description

This PR contains two _fixes_ for GenericGap::connect: 
* Accept NULL values passed as connection and scan parameters
* Blindly stop ongoing scan process otherwise if the user didn't stop the scan process before the connection; the connect operation fails.


## Status

**READY**

## Migrations

NO

