### PR TITLE
BLE: Add address type in AdvertisementCallbackParams_t.

### DIFF
--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -237,7 +237,7 @@ class GapAdvertisingData;
  *    // Initiate the connection procedure
  *    gap.connect(
  *       packet->peerAddr,
- *       BLEProtocol::RANDOM_STATIC,
+ *       packet->addressType,
  *       &connection_parameters,
  *       &scanning_params
  *    );
@@ -608,6 +608,11 @@ public:
          * Pointer to the advertisement packet's data.
          */
         const uint8_t *advertisingData;
+
+        /**
+         * Type of the address received
+         */
+        AddressType_t addressType;
     };
 
     /**
@@ -2349,7 +2354,8 @@ public:
         bool isScanResponse,
         GapAdvertisingParams::AdvertisingType_t type,
         uint8_t advertisingDataLen,
-        const uint8_t *advertisingData
+        const uint8_t *advertisingData,
+        BLEProtocol::AddressType_t addressType
     ) {
         AdvertisementCallbackParams_t params;
         memcpy(params.peerAddr, peerAddr, ADDR_LEN);
@@ -2358,6 +2364,7 @@ public:
         params.type = type;
         params.advertisingDataLen = advertisingDataLen;
         params.advertisingData = advertisingData;
+        params.addressType = addressType;
         onAdvertisementReport.call(&params);
     }
 

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2356,8 +2356,12 @@ public:
         GapAdvertisingParams::AdvertisingType_t type,
         uint8_t advertisingDataLen,
         const uint8_t *advertisingData,
-        BLEProtocol::AddressType_t addressType
+        BLEProtocol::AddressType_t addressType = BLEProtocol::RANDOM_STATIC
     ) {
+       // FIXME: remove default parameter for addressType when ST shield is merged; 
+       // this has been added to mitigate the lack of dependency management in 
+       // testing jobs ....
+       
         AdvertisementCallbackParams_t params;
         memcpy(params.peerAddr, peerAddr, ADDR_LEN);
         params.rssi = rssi;

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2356,7 +2356,7 @@ public:
         GapAdvertisingParams::AdvertisingType_t type,
         uint8_t advertisingDataLen,
         const uint8_t *advertisingData,
-        BLEProtocol::AddressType_t addressType = BLEProtocol::RANDOM_STATIC
+        BLEProtocol::AddressType_t addressType = BLEProtocol::AddressType::RANDOM_STATIC
     ) {
        // FIXME: remove default parameter for addressType when ST shield is merged; 
        // this has been added to mitigate the lack of dependency management in 

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2347,6 +2347,7 @@ public:
      * @param[in] type Advertising type of the packet.
      * @param[in] advertisingDataLen Length of the advertisement data received.
      * @param[in] advertisingData Pointer to the advertisement packet's data.
+     * @param[in] addressType Type of the address of the peer that has emitted the packet.
      */
     void processAdvertisementReport(
         const BLEProtocol::AddressBytes_t peerAddr,

--- a/features/FEATURE_BLE/source/generic/GenericGap.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGap.cpp
@@ -972,7 +972,8 @@ void GenericGap::on_advertising_report(const pal::GapAdvertisingReportEvent& e)
             advertising.type == pal::received_advertising_type_t::SCAN_RESPONSE,
             (GapAdvertisingParams::AdvertisingType_t) advertising.type.value(),
             advertising.data.size(),
-            advertising.data.data()
+            advertising.data.data(),
+            (BLEProtocol::AddressType_t) advertising.address_type.value()
         );
     }
 }

--- a/features/FEATURE_BLE/targets/TARGET_ARM_SSG/TARGET_BEETLE/source/ArmBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_ARM_SSG/TARGET_BEETLE/source/ArmBLE.cpp
@@ -332,7 +332,8 @@ static void armHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
                                                                         (scan->scanReport.eventType == DM_ADV_SCAN_RESPONSE) ? true : false,
                                                                         (GapAdvertisingParams::AdvertisingType_t)scan->scanReport.eventType,
                                                                         scan->scanReport.len,
-                                                                        scan->scanReport.pData);
+                                                                        scan->scanReport.pData,
+                                                                        (BLEProtocol::AddressType_t) scan->scanReport.addrType);
                 }
                 break;
             case DM_CONN_OPEN_IND:

--- a/features/FEATURE_BLE/targets/TARGET_Maxim/MaximBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Maxim/MaximBLE.cpp
@@ -169,7 +169,7 @@ static void maximHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
                                                                         (GapAdvertisingParams::AdvertisingType_t)scanReport->eventType,
                                                                         scanReport->len,
                                                                         scanReport->pData,
-                                                                        (BLEProtocol::AddressType_t) scan->scanReport.addrType);
+                                                                        (BLEProtocol::AddressType_t) scanReport->addrType);
                 }
                 break;
             case DM_CONN_OPEN_IND:

--- a/features/FEATURE_BLE/targets/TARGET_Maxim/MaximBLE.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_Maxim/MaximBLE.cpp
@@ -168,7 +168,8 @@ static void maximHandler(wsfEventMask_t event, wsfMsgHdr_t *pMsg)
                                                                         (scanReport->eventType == DM_ADV_SCAN_RESPONSE) ? true : false,
                                                                         (GapAdvertisingParams::AdvertisingType_t)scanReport->eventType,
                                                                         scanReport->len,
-                                                                        scanReport->pData);
+                                                                        scanReport->pData,
+                                                                        (BLEProtocol::AddressType_t) scan->scanReport.addrType);
                 }
                 break;
             case DM_CONN_OPEN_IND:
@@ -281,7 +282,7 @@ ble_error_t MaximBLE::init(BLE::InstanceID_t instanceID, FunctionPointerWithCont
     DmRegister(DmCback);
     DmConnRegister(DM_CLIENT_ID_APP, DmCback);
     AttConnRegister(AppServerConnCback);
-    
+
     /* Reset the device */
     reset_complete = 0;
     DmDevReset();

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/btle/btle.cpp
@@ -220,7 +220,8 @@ static void btle_handler(ble_evt_t *p_ble_evt)
                                            advReport->scan_rsp,
                                            static_cast<GapAdvertisingParams::AdvertisingType_t>(advReport->type),
                                            advReport->dlen,
-                                           advReport->data);
+                                           advReport->data,
+                                           static_cast<BLEProtocol::AddressType_t>(advReport->peer_addr.addr_type));
             break;
         }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle.cpp
@@ -287,7 +287,8 @@ static void btle_handler(ble_evt_t *p_ble_evt)
                                            advReport->scan_rsp,
                                            static_cast<GapAdvertisingParams::AdvertisingType_t>(advReport->type),
                                            advReport->dlen,
-                                           advReport->data);
+                                           advReport->data,
+                                           static_cast<BLEProtocol::AddressType_t>(advReport->peer_addr.addr_type));
             break;
         }
 


### PR DESCRIPTION
## Description

Add the address type of the broadcaster in advertising packets received.

## Status

**READY**

## Migrations

NO, vendors code is updated in this PR.

Outline the steps to test or reproduce the PR here.
