### PR TITLE
tools: Let unicode error messages through

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -19,6 +19,7 @@ limitations under the License.
 TEST BUILD & RUN
 """
 from __future__ import print_function
+from builtins import str
 import sys
 import json
 from time import sleep


### PR DESCRIPTION
Some toolchains (GCC) may emit error messages with unicode symbols based on the your localization settings. Instead of being passed to the user as is, the unicode causes an exception.

I'm not sure exactly what the correct fix is regarding python2+3 compat, but changing `str` to `unicode` seems to work on my setup (x86_64-linux-gnu-gcc 5.4.0 + python 2.7.12 + mbed-os-5c7cd1f + LANG=en_US.UTF-8)

cc @theotherjimmy 

