### PR TITLE
tools: Bring back memap output by default

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -531,13 +531,11 @@ def build_project(src_paths, build_path, target, toolchain_name,
             real_stats_depth = stats_depth if stats_depth is not None else 2
             memap_table = memap_instance.generate_output('table', real_stats_depth)
             if not silent:
-                if not stats_depth:
-                    memap_bars = memap_instance.generate_output('bars',
-                            real_stats_depth, None,
-                            getattr(toolchain.target, 'device_name', None))
-                    print(memap_bars)
-                else:
-                    print(memap_table)
+                memap_bars = memap_instance.generate_output('bars',
+                        real_stats_depth, None,
+                        getattr(toolchain.target, 'device_name', None))
+                print(memap_table)
+                print(memap_bars)
 
             # Write output to file in JSON format
             map_out = join(build_path, name + "_map.json")

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -618,9 +618,9 @@ class MemapParser(object):
         output += "Total Flash memory (text + data): %s bytes\n" % \
                         str(self.mem_summary['total_flash'])
 
-        return output
+        return output.strip()
 
-    def generate_bars(self, file_desc, device_name=None):
+    def generate_bars(self, file_desc, device_name=None, show_totals=False):
         """ Generates nice looking bars that represent the memory consumption
 
         Returns: string containing nice looking bars
@@ -663,10 +663,12 @@ class MemapParser(object):
             scale = math.floor(math.log(n, 1024))
             return '{1:.{0}g}{2}{3}'.format(p, n/(1024**scale), PREFIXES[int(scale)], u)
 
-        usage = "Text {} Data {} BSS {}".format(unit(text), unit(data), unit(bss))
-        avail = "ROM {} RAM {}".format(unit(rom_used), unit(ram_used))
-        output = ["{0} {1:>{2}}".format(usage, avail,
-            abs(WIDTH-len(usage)-1) if device_name is not None else 0)]
+        output =[]
+        if show_totals:
+            usage = "Text {} Data {} BSS {}".format(unit(text), unit(data), unit(bss))
+            avail = "ROM {} RAM {}".format(unit(rom_used), unit(ram_used))
+            output.append("{0} {1:>{2}}".format(usage, avail,
+                abs(WIDTH-len(usage)-1) if device_name is not None else 0))
 
         if device_name is not None:
             for region, avail, uses in [


### PR DESCRIPTION
Back due to popular demand (and because #5929 accidentally ended up in a patch release). 

Now compile jobs print both the table and bars if available:
```
$ mbed compile -m K64F -t GCC_ARM
Building project mbed-os-prettyoutput (ARCH_PRO, GCC_ARM)
Scan: .
Scan: env
Scan: mbed
Scan: FEATURE_LWIP
Link: mbed-os-02
Elf2Bin: mbed-os-02
+---------------------------------+-------+-------+------+
| Module                          | .text | .data | .bss |
+---------------------------------+-------+-------+------+
| [fill]                          |   653 |    10 |   40 |
| [lib]/c.a                       | 25404 |  2208 |   56 |
| [lib]/gcc.a                     |  5508 |     0 |    0 |
| [lib]/m.a                       |  6735 |     1 |    0 |
| [lib]/misc                      |   296 |    12 |   28 |
| drivers/BusOut.o                |   388 |     0 |    0 |
| drivers/CAN.o                   |   442 |     0 |    0 |
| drivers/InterruptIn.o           |    20 |     0 |    0 |
| drivers/RawSerial.o             |   500 |     0 |    0 |
| drivers/Serial.o                |   144 |     0 |    0 |
| drivers/SerialBase.o            |   768 |     0 |    0 |
| drivers/Ticker.o                |   368 |     0 |    0 |
| drivers/Timeout.o               |   136 |     0 |    0 |
| drivers/Timer.o                 |   488 |     0 |    0 |
| drivers/TimerEvent.o            |   280 |     0 |    0 |
| drivers/UARTSerial.o            |   188 |     0 |    0 |
| events/equeue                   |   576 |     0 |  101 |
| features/frameworks             | 11491 |    69 |  420 |
| hal/mbed_critical_section_api.o |   210 |     0 |    2 |
| hal/mbed_gpio.o                 |   382 |     0 |    0 |
| hal/mbed_pinmap_common.o        |   374 |     0 |    0 |
| hal/mbed_sleep_manager.o        |   202 |     0 |    2 |
| hal/mbed_ticker_api.o           |  2068 |     0 |    0 |
| hal/mbed_us_ticker_api.o        |    76 |     4 |   64 |
| main.o                          |  1729 |     4 |  205 |
| platform/FileHandle.o           |   180 |     0 |    0 |
| platform/mbed_alloc_wrappers.o  |   216 |     0 |    0 |
| platform/mbed_assert.o          |    89 |     0 |    0 |
| platform/mbed_board.o           |   418 |     0 |    0 |
| platform/mbed_critical.o        |   383 |     0 |    4 |
| platform/mbed_error.o           |    56 |     0 |    1 |
| platform/mbed_retarget.o        |  3122 |   260 |  144 |
| platform/mbed_wait_api_rtos.o   |   148 |     0 |    0 |
| rtos/TARGET_CORTEX              | 18409 |   168 | 6061 |
| rtos/Thread.o                   |    56 |     0 |    4 |
| targets/TARGET_NXP              |  5793 |     4 |  244 |
| Subtotals                       | 88296 |  2740 | 7376 |
+---------------------------------+-------+-------+------+
Total Static RAM memory (data + bss): 10116 bytes
Total Flash memory (text + data): 91036 bytes
ROM [||||||||                                            ]  88.9KB/512KB
RAM [|||||||||||||||                                     ]   9.88KB/32KB
Image: BUILD/ARCH_PRO/GCC_ARM/mbed-os-02.bin
```

related https://github.com/ARMmbed/mbed-os/pull/5929
release patch?
cc @screamerbg, @MarceloSalazar, @theotherjimmy 