### PR TITLE
retarget: Fix path behaviour without leading slash

### DIFF
--- a/platform/FilePath.cpp
+++ b/platform/FilePath.cpp
@@ -18,9 +18,10 @@
 namespace mbed {
 
 FilePath::FilePath(const char* file_path) : file_name(NULL), fb(NULL) {
-    if ((file_path[0] != '/') || (file_path[1] == 0)) return;
+    // skip slashes
+    file_path += strspn(file_path, "/");
 
-    const char* file_system = &file_path[1];
+    const char* file_system = file_path;
     file_name = file_system;
     int len = 0;
     while (true) {
@@ -36,6 +37,7 @@ FilePath::FilePath(const char* file_path) : file_name(NULL), fb(NULL) {
         file_name++;
     }
 
+    MBED_ASSERT(len != 0);
     fb = FileBase::lookup(file_system, len);
 }
 


### PR DESCRIPTION
Current behaviour ends up undefined when the constructor leaves early. Now FilePath just discards leading slashes and otherwise asserts if the path is bad.

Note: The correct behavior should be to return ENOENT in this case, but in order to propagate errors this layer would require quite a bit of restructuring. Since this is currently blocking https://github.com/ARMmbed/mbed-os/issues/5959 and assert is a good compromise.

related https://github.com/ARMmbed/mbed-os/issues/5959, https://github.com/ARMmbed/mbed-os/issues/6090
release patch
cc @deepikabhavnani, @kegilbert 