### PR TITLE
STM32 Family: update tests and enable RTC support

### DIFF
--- a/TESTS/mbed_hal/rtc/main.cpp
+++ b/TESTS/mbed_hal/rtc/main.cpp
@@ -217,11 +217,15 @@ void rtc_write_read_test()
     rtc_free();
 }
 
-/* Test that ::is_enabled function returns 1 if the RTC is counting and the time has been set, 0 otherwise. */
+/* Test that ::is_enabled function returns 1 if the RTC is counting and the time has been set. */
 void rtc_enabled_test()
 {
+    /* Since some platforms use RTC for low power timer RTC may be already enabled.
+     * Because of that we will only verify if rtc_isenabled() returns 1 in case when init is done
+     * and RTC time is set.
+     */
+
     rtc_init();
-    TEST_ASSERT_EQUAL_INT(0, rtc_isenabled());
     rtc_write(0);
     TEST_ASSERT_EQUAL_INT(1, rtc_isenabled());
     rtc_free();

--- a/TESTS/mbed_hal/rtc/main.cpp
+++ b/TESTS/mbed_hal/rtc/main.cpp
@@ -246,7 +246,7 @@ Case cases[] = {
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(30, "default_auto");
+    GREENTEA_SETUP(60, "default_auto");
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/mbed_hal/rtc_reset/main.cpp
+++ b/TESTS/mbed_hal/rtc_reset/main.cpp
@@ -38,10 +38,12 @@ static cmd_status_t handle_command(const char *key, const char *value)
 {
     if (strcmp(key, "init") == 0) {
         rtc_init();
+        greentea_send_kv("ack", 0);
         return CMD_STATUS_CONTINUE;
 
     } else if (strcmp(key, "free") == 0) {
         rtc_free();
+        greentea_send_kv("ack", 0);
         return CMD_STATUS_CONTINUE;
 
     } else if (strcmp(key, "read") == 0) {
@@ -55,6 +57,7 @@ static cmd_status_t handle_command(const char *key, const char *value)
         uint32_t time;
         sscanf(value, "%lu", &time);
         rtc_write(time);
+        greentea_send_kv("ack", 0);
         return CMD_STATUS_CONTINUE;
 
     } else if (strcmp(key, "reset") == 0) {
@@ -74,7 +77,7 @@ static cmd_status_t handle_command(const char *key, const char *value)
 /* Test that software reset doesn't stop RTC from counting. */
 void rtc_reset_test()
 {
-    GREENTEA_SETUP(60, "rtc_reset");
+    GREENTEA_SETUP(100, "rtc_reset");
 
     static char _key[10 + 1] = {};
     static char _value[128 + 1] = {};

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2045,6 +2045,7 @@
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
         "supported_form_factors": ["ARDUINO"],
         "release_versions": ["5"],
+        "device_has_remove": ["RTC"],
         "config": {
             "stdio_uart_tx_help": {
                 "help": "Value: D8(default) or D1"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -729,7 +729,7 @@
         "macros": ["CPU_MIMXRT1052DVL6A", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0227"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "ERROR_RED", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "ERROR_RED", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
         "device_name": "MIMXRT1052"
     },
@@ -2647,7 +2647,6 @@
         "extra_labels": ["ARM_SSG", "CM3DS_MPS2"],
         "macros": ["CMSDK_CM3DS"],
         "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI", "LOWPOWERTIMER"],
-        "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI"],
         "release_versions": ["2", "5"],
         "copy_method": "mps2",
         "reset_method": "reboot.txt"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2646,7 +2646,7 @@
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["ARM_SSG", "CM3DS_MPS2"],
         "macros": ["CMSDK_CM3DS"],
-        "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI", "RTC", "LOWPOWERTIMER"],
+        "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI", "LOWPOWERTIMER"],
         "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI"],
         "release_versions": ["2", "5"],
         "copy_method": "mps2",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -718,7 +718,7 @@
                 "help": "default RX STDIO pins is defined in PinNames.h file, but it can be overridden"
             }
         },
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"]
+        "device_has": ["RTC", "ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"]
     },
     "MIMXRT1050_EVK": {
         "supported_form_factors": ["ARDUINO"],


### PR DESCRIPTION
# Description

This PR provides the following changes:
- Enable RTC support for STM32 family,
- Adapt RTC drivers to the new RTC HAL API standards (free function keeps RTC time and disables only access to the backup domain) - skipped this has been already done by @jeromecoutant in this commit https://github.com/ARMmbed/mbed-os/pull/6217/commits/45cbdc889ff1f80e257f7db1eb1146765f633336 - Thank you!.
- RTC test fix: verify if rtc_isenabled() returns 1 in case when init is done and RTC time is set. Some platforms use RTC for low power timer, so RTC may be already enabled.
- RTC test fix: increase test timeout (verified that on some platforms 30s is not enough).

