### PR TITLE
sleep_manager_racecondition test fix for devices with low CPU clock

### DIFF
--- a/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -67,12 +67,12 @@ void sleep_manager_irq_test()
         Ticker ticker1;
         Timer timer;
 
-        ticker1.attach_us(&sleep_manager_locking_irq_test, 500);
+        ticker1.attach_us(&sleep_manager_locking_irq_test, 1000);
 
-        // run this for 5 seconds
+        // run this for 10 seconds
         timer.start();
         int start = timer.read();
-        int end = start + 5;
+        int end = start + 10;
         while (timer.read() < end) {
             sleep_manager_locking_irq_test();
         }


### PR DESCRIPTION
# Description

This RP contains fix for `sleep_manager_racecondition` test for very slow devices (like NRF51)
It fixes the test itself as well as side effects of fix introduced in #5046 (us ticker: fix fire interrupt handling)

The idea of the test was to test race condition between main thread and interrupt handler calling the same function. To efficiently test this, each handler call should interrupt main thread to make race more likely. On very slow devices (like NRF51) when we set very low ticker period (e.g less then 1000us for NRF51) there is no much time for thread scheduling. On such slow devices, setting period to 500 us cause that main thread is scheduled very rarely and only handler is constantly called making test unreliable. Fix introduced in #5046 (us ticker: fix fire interrupt handling) changed `fire_interrupt` function implementation causing more interrupt tailing thus even less time for main thread scheduling.

After introduction of #5046 (us ticker: fix fire interrupt handling) when running `sleep_manager_racecondition` test on NRF51 (with `ticker1.attach_us(&sleep_manager_locking_irq_test, 500);`) test is failing with timeout due to the fact that interrupt handler is constantly called and main thread is never scheduled.

#Related issues
#5284
#5046

# Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New Target
- [ ] Feature
