### PR TITLE
Make APN lookup the default behaviour for PPPCellularInterface

### DIFF
--- a/features/netsocket/cellular/generic_modem_driver/mbed_lib.json
+++ b/features/netsocket/cellular/generic_modem_driver/mbed_lib.json
@@ -2,7 +2,7 @@
 	"name": "ppp-cell-iface", 
 		"config": {
 			"baud-rate": 115200,
-			"apn-lookup": false,
+			"apn-lookup": true,
 			"at-parser-buffer-size": 256,
 			"at-parser-timeout": 8000
 	}


### PR DESCRIPTION
# Description
If the user does not provide an APN when using `PPPCellularInterface`, the driver currently uses the APN "internet" as a default.  It includes the capability to look up the APN based on the IMSI of the SIM however this behaviour is only available under the compilation switch `MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP`.

With this change APN look-up is the default behaviour.  If the user specifies an APN then that still takes precedence and if the look-up fails then, finally, "internet" is used, so this should have no adverse effect on existing users.

All of the cellular interface tests in `mbed-os-features-netsocket-cellular-generic_modem_driver-tests-unit_tests-default` pass after making this change.

# Pull request type
- [x] Enhancement to Feature

# Dependencies
This change depends upon the fix in #6160.
