### PR TITLE
CM3DS Maintenance Pull Request: Memory changes (2/4)

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
@@ -2,13 +2,13 @@
 
 This folder includes the port of mbed OS on the example system of the Cortex-M3
 Design Start Eval package. This example is implemented in FPGA on the MPS2+
-board. Please check the [mbed page](https://os.mbed.com/platforms/ARM-CM3DS/) of
+board. Please check the [Mbed page](https://os.mbed.com/platforms/ARM-CM3DS/) of
 this target for more information.
 For convenience, this target is called **CM3DS**.
 
-## Compiling :construction_worker:
+## Compiling
 
-The target name is `ARM_CM3DS_MPS2`, you should be able to compile mbed OS
+The target name is `ARM_CM3DS_MPS2`, you should be able to compile Mbed OS
 projects for CM3DS with:
 
 ```bash
@@ -17,28 +17,28 @@ mbed compile -t COMPILER -m ARM_CM3DS_MPS2
 
 The following compilers are supported (replace `COMPILER` with):
 
-* `ARM` for Arm Compiler version 5
-* `GCC_ARM` for GNU Compiler for Arm
-* `IAR` for IAR compiler
+* `ARM` for Arm Compiler version 5.
+* `GCC_ARM` for GNU Compiler for Arm.
+* `IAR` for IAR compiler.
 
-## Running :running:
+## Running
 
 Because of the new memory configuration introduced in commit `CM3DS: switch to
-larger memories for code and data` it
-has become more easy (and portable amoung all compilers) to use `.elf` files
+larger memories for code and data`, it
+has become easier (and portable amoung all compilers) to use `.elf` files
 instead of `.bin`. `.elf` files are now the default for CM3DS projects and only
-they will be generated out of the compilation.
-For `.elf` files to work, you will need **at least version 2.2.5** of the MPS2+
-firmware. You can find firmware version 2.2.6 and instructions on how to put it
-in the MPS2+ board [here](https://community.arm.com/processors/designstart/f/discussions/9727/mps2-firmware-for-mbed).
+they will be generated from the compilation.
+For `.elf` files to work, you need **at least version 2.2.5** of the MPS2+
+firmware. For more information, please see the [firmware version 2.2.6 and instructions on how to put it
+in the MPS2+ board](https://community.arm.com/processors/designstart/f/discussions/9727/mps2-firmware-for-mbed).
 
-## Testing :zap:
+## Testing
 
-If you want to execute the mbed OS greentea tests on CM3DS, you will need
+If you want to execute the Mbed OS greentea tests on CM3DS, you need
 **at least firmware version 2.2.6**.
 
 * `mbedls` does not automatically recognize which serial port is linked to the
-board. Check it manually and create a file named `mbedls.json` containing
+board. Check it manually, and create a file named `mbedls.json` containing
 (at the same level than where you execute all commands):
 ```bash
 {
@@ -50,12 +50,12 @@ board. Check it manually and create a file named `mbedls.json` containing
 Replace `/dev/ttyUSB0` with your correct serial port
 (something like `COM6` on Windows).
 
-* `mbedls` does not link CM3DS target ID with its name so execute the command:
+* `mbedls` does not link CM3DS target ID with its name, so execute the command:
 ```bash
 mbedls --mock 5004:ARM_CM3DS_MPS2
 ```
 
-* You can now compile and run the tests :+1: :
+* You can now compile and run the tests
 ```bash
 mbed test -m ARM_CM3DS_MPS2 -t COMPILER
 ```

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
@@ -1,0 +1,62 @@
+# Cortex-M3 Design Start Eval package example on MPS2+ board
+
+This folder includes the port of mbed OS on the example system of the Cortex-M3
+Design Start Eval package. This example is implemented in FPGA on the MPS2+
+board. Please check the [mbed page](https://os.mbed.com/platforms/ARM-CM3DS/) of
+this target for more information.
+For convenience, this target is called **CM3DS**.
+
+## Compiling :construction_worker:
+
+The target name is `ARM_CM3DS_MPS2`, you should be able to compile mbed OS
+projects for CM3DS with:
+
+```bash
+mbed compile -t COMPILER -m ARM_CM3DS_MPS2
+```
+
+The following compilers are supported (replace `COMPILER` with):
+
+* `ARM` for Arm Compiler version 5
+* `GCC_ARM` for GNU Compiler for Arm
+* `IAR` for IAR compiler
+
+## Running :running:
+
+Because of the new memory configuration introduced in commit `CM3DS: switch to
+larger memories for code and data` it
+has become more easy (and portable amoung all compilers) to use `.elf` files
+instead of `.bin`. `.elf` files are now the default for CM3DS projects and only
+they will be generated out of the compilation.
+For `.elf` files to work, you will need **at least version 2.2.5** of the MPS2+
+firmware. You can find firmware version 2.2.6 and instructions on how to put it
+in the MPS2+ board [here](https://community.arm.com/processors/designstart/f/discussions/9727/mps2-firmware-for-mbed).
+
+## Testing :zap:
+
+If you want to execute the mbed OS greentea tests on CM3DS, you will need
+**at least firmware version 2.2.6**.
+
+* `mbedls` does not automatically recognize which serial port is linked to the
+board. Check it manually and create a file named `mbedls.json` containing
+(at the same level than where you execute all commands):
+```bash
+{
+    "50040200074D652F3828F333": {
+        "serial_port": "/dev/ttyUSB0"
+    }
+}
+```
+Replace `/dev/ttyUSB0` with your correct serial port
+(something like `COM6` on Windows).
+
+* `mbedls` does not link CM3DS target ID with its name so execute the command:
+```bash
+mbedls --mock 5004:ARM_CM3DS_MPS2
+```
+
+* You can now compile and run the tests :+1: :
+```bash
+mbed test -m ARM_CM3DS_MPS2 -t COMPILER
+```
+

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/README.md
@@ -1,21 +1,21 @@
 # Cortex-M3 Design Start Eval package example on MPS2+ board
 
-This folder includes the port of mbed OS on the example system of the Cortex-M3
+This folder includes the port of Mbed OS on the example system of the Cortex-M3
 Design Start Eval package. This example is implemented in FPGA on the MPS2+
-board. Please check the [Mbed page](https://os.mbed.com/platforms/ARM-CM3DS/) of
-this target for more information.
+board. Please see this target's [Mbed page](https://os.mbed.com/platforms/ARM-CM3DS/)
+for more information.
 For convenience, this target is called **CM3DS**.
 
 ## Compiling
 
-The target name is `ARM_CM3DS_MPS2`, you should be able to compile Mbed OS
+The target name is `ARM_CM3DS_MPS2`. You can compile Mbed OS
 projects for CM3DS with:
 
 ```bash
 mbed compile -t COMPILER -m ARM_CM3DS_MPS2
 ```
 
-The following compilers are supported (replace `COMPILER` with):
+Mbed OS supports the following compilers (replace `COMPILER` with):
 
 * `ARM` for Arm Compiler version 5.
 * `GCC_ARM` for GNU Compiler for Arm.
@@ -25,9 +25,9 @@ The following compilers are supported (replace `COMPILER` with):
 
 Because of the new memory configuration introduced in commit `CM3DS: switch to
 larger memories for code and data`, it
-has become easier (and portable amoung all compilers) to use `.elf` files
-instead of `.bin`. `.elf` files are now the default for CM3DS projects and only
-they will be generated from the compilation.
+has become easier (and portable among all compilers) to use `.elf` files
+instead of `.bin`. `.elf` files are now the default for CM3DS projects, and compilation
+generates only them.
 For `.elf` files to work, you need **at least version 2.2.5** of the MPS2+
 firmware. For more information, please see the [firmware version 2.2.6 and instructions on how to put it
 in the MPS2+ board](https://community.arm.com/processors/designstart/f/discussions/9727/mps2-firmware-for-mbed).
@@ -40,6 +40,7 @@ If you want to execute the Mbed OS greentea tests on CM3DS, you need
 * `mbedls` does not automatically recognize which serial port is linked to the
 board. Check it manually, and create a file named `mbedls.json` containing
 (at the same level than where you execute all commands):
+
 ```bash
 {
     "50040200074D652F3828F333": {
@@ -47,16 +48,18 @@ board. Check it manually, and create a file named `mbedls.json` containing
     }
 }
 ```
+
 Replace `/dev/ttyUSB0` with your correct serial port
 (something like `COM6` on Windows).
 
 * `mbedls` does not link CM3DS target ID with its name, so execute the command:
+
 ```bash
 mbedls --mock 5004:ARM_CM3DS_MPS2
 ```
 
-* You can now compile and run the tests
+* You can now compile and run the tests:
+
 ```bash
 mbed test -m ARM_CM3DS_MPS2 -t COMPILER
 ```
-

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/MPS2.sct
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/MPS2.sct
@@ -1,7 +1,9 @@
+#! armcc -E
+
 /*
  * MPS2 CMSIS Library
  *
- * Copyright (c) 2006-2017 ARM Limited. All rights reserved.
+ * Copyright (c) 2006-2018 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -22,16 +24,25 @@
  *************************************************************
  */
 
-LR_IROM1 0x00000000 0x00040000  {    ; load region size_region
-  ER_IROM1 0x00000000 0x00040000  {  ; load address = execution address
+#include "../memory_zones.h"
+#include "../cmsis_nvic.h"
+
+; The vector table is loaded at address 0x00000000 in Flash memory region.
+LR_IROM1 FLASH_START FLASH_SIZE  {
+  ER_IROM1 FLASH_START FLASH_SIZE  {
    *.o (RESET, +First)
+  }
+}
+
+; Rest of the code is loaded to the ZBT SSRAM1.
+LR_IROM2 ZBT_SSRAM1_START ZBT_SSRAM1_SIZE {
+  ER_IROM2 ZBT_SSRAM1_START ZBT_SSRAM1_SIZE  {
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-  ; Total: 80 vectors = 320 bytes (0x140) to be reserved in RAM
-  ; This is a bit more than is necessary based on the number of 
-  ; exception handlers.
-  RW_IRAM1 (0x20000000+0x140) (0x20000-0x140)  {  ; RW data
+  ; At execution, RAM is set to be in ZBT SSRAM2 and 3, just after the vector
+  ; table previously moved from Flash.
+  RW_IRAM1 (ZBT_SSRAM23_START + NVIC_VECTORS_SIZE) (ZBT_SSRAM23_SIZE - NVIC_VECTORS_SIZE)  {
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -1,7 +1,7 @@
 /*
  * MPS2 CMSIS Library
  *
- * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -20,11 +20,11 @@
  *
  * This file is derivative of CMSIS V5.00 startup_ARMCM3.s
  *
-//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
  */
 
+#include "memory_zones.h"
 
-__initial_sp        EQU     0x20020000  ; Top of RAM
+__initial_sp    EQU     ZBT_SSRAM23_START + ZBT_SSRAM23_SIZE ; Top of ZBT SSRAM2 and 3, used for data
 
                 PRESERVE8
                 THUMB

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -1,8 +1,5 @@
 /*
- * MPS2 CMSIS Library
- */
-/*
- * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -17,21 +14,20 @@
  * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- */
-/*
+ *
  * This file is derivative of CMSIS V5.00 gcc_arm.ld
+ *
+ * Linker script for mbed CM3DS on MPS2
  */
-/* Linker script for mbed CM3DS on MPS2 */
 
-/* Linker script to configure memory regions. */
-/* The length of the VECTORS region is a bit larger than
- * is necessary based on the number of exception handlers.
- */
+#include "../memory_zones.h"
+#include "../cmsis_nvic.h"
+
 MEMORY
 {
-  VECTORS (rx)          : ORIGIN = 0x00000000, LENGTH = 0x00000400
-  FLASH (rx)            : ORIGIN = 0x00000400, LENGTH = 0x00040000 - 0x00000400
-  RAM (rwx)             : ORIGIN = 0x20000000, LENGTH = 0x00020000
+  VECTORS (rx)          : ORIGIN = FLASH_START,       LENGTH = FLASH_SIZE
+  FLASH (rx)            : ORIGIN = ZBT_SSRAM1_START,  LENGTH = ZBT_SSRAM1_SIZE
+  RAM (rwx)             : ORIGIN = ZBT_SSRAM23_START, LENGTH = ZBT_SSRAM23_SIZE
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -66,7 +62,7 @@ HEAP_SIZE  = 0x4000;
 STACK_SIZE = 0x1000;
 
 /* Size of the vector table in SRAM */
-M_VECTOR_RAM_SIZE = 0x140;
+M_VECTOR_RAM_SIZE = NVIC_VECTORS_SIZE;
 
 SECTIONS
 {

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_IAR/MPS2.icf
@@ -1,8 +1,5 @@
 /*
- * MPS2 CMSIS Library
- */
-/*
- * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ * Copyright (c) 2009-2018 ARM Limited. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -19,26 +16,49 @@
  * limitations under the License.
  */
 
-/* The RAM region doesn't start at the beginning of the RAM address
- * space to create space for the vector table copied over to the RAM by mbed.
- * The space left is a bit bigger than is necessary based on the number of
- * interrupt handlers.
+/*
+ * WARNING: these symbols are the same as the defines in ../memory_zones.h but
+ * can not be included here. Please make sure that the two definitions match.
  */
-/*###ICF### Section handled by ICF editor, don't touch! ****/
-/*-Editor annotation file-*/
-/* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
-/*-Specials-*/
-define symbol __ICFEDIT_intvec_start__ = 0x00000000;
-/*-Memory Regions-*/
-define symbol __ICFEDIT_region_ROM_start__    = 0x00000000;
-define symbol __ICFEDIT_region_ROM_end__      = 0x0003FFFF;
-define symbol __ICFEDIT_region_RAM_start__    = 0x20000140;
-define symbol __ICFEDIT_region_RAM_end__      = 0x2001FFFF;
-/*-Sizes-*/
+/* Code memory zones */
+define symbol FLASH_START       = 0x00000000;
+define symbol FLASH_SIZE        = 0x00040000; /* 256 KiB */
+define symbol ZBT_SSRAM1_START  = 0x00400000;
+define symbol ZBT_SSRAM1_SIZE   = 0x00400000; /* 4 MiB */
+
+/* Data memory zones */
+define symbol SRAM0_START       = 0x20000000;
+define symbol SRAM0_SIZE        = 0x00008000; /* 32 KiB */
+define symbol SRAM1_START       = 0x20008000;
+define symbol SRAM1_SIZE        = 0x00008000; /* 32 KiB */
+define symbol SRAM2_START       = 0x20010000;
+define symbol SRAM2_SIZE        = 0x00008000; /* 32 KiB */
+define symbol SRAM3_START       = 0x20018000;
+define symbol SRAM3_SIZE        = 0x00008000; /* 32 KiB */
+define symbol ZBT_SSRAM23_START = 0x20400000;
+define symbol ZBT_SSRAM23_SIZE  = 0x00400000; /* 4 MiB */
+
+/* NVIC vector numbers and size. */
+define symbol NVIC_NUM_VECTORS        = 16 + 57;
+define symbol NVIC_VECTORS_SIZE       = NVIC_NUM_VECTORS * 4;
+
+/* Specials */
+define symbol __ICFEDIT_intvec_start__ = FLASH_START;
+
+/* Memory Regions */
+define symbol __ICFEDIT_region_ROM_start__    = ZBT_SSRAM1_START;
+define symbol __ICFEDIT_region_ROM_end__      = ZBT_SSRAM1_START + ZBT_SSRAM1_SIZE - 1;
+/*
+ * At execution, RAM is set to be in ZBT SSRAM2 and 3, just after the vector
+ * table previously moved from Flash.
+ */
+define symbol __ICFEDIT_region_RAM_start__    = ZBT_SSRAM23_START + NVIC_VECTORS_SIZE;
+define symbol __ICFEDIT_region_RAM_end__      = ZBT_SSRAM23_START + ZBT_SSRAM23_SIZE;
+
+/* Sizes */
 /* Heap and Stack size */
-define symbol __ICFEDIT_size_heap__   = 0x4000;
+define symbol __ICFEDIT_size_heap__   = 0xF000;
 define symbol __ICFEDIT_size_cstack__ = 0x1000;
-/**** End of ICF editor section. ###ICF###*/
 
 define memory mem with size = 4G;
 define region ROM_region      = mem:[from __ICFEDIT_region_ROM_start__   to __ICFEDIT_region_ROM_end__];

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/cmsis_nvic.h
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/cmsis_nvic.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2015-2017 ARM Limited
+ * Copyright (c) 2015-2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,12 +14,35 @@
  * limitations under the License.
  *
  * CMSIS-style functionality to support dynamic vectors
+ *
+ * This file is included in ARM and GCC_ARM linker scripts.
+ *
+ * WARNING: IAR does not include this file and re-define these values in
+ * MPS2.icf file. Please make sure that the two files share the same values.
  */
+
+#include "memory_zones.h"
 
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
-#define NVIC_NUM_VECTORS        (16 + 48)
-#define NVIC_RAM_VECTOR_ADDRESS 0x20000000   /* Location of vectors in RAM */
+/*
+ * 16 vectors for initial stack pointer and internal exceptions (defined in
+ * Armv7-M ARM).
+ * 57 vectors for external interrupts (defined in CM3DS Eval RTL and Testbench
+ * User Guide).
+ */
+#define NVIC_NUM_VECTORS        (16 + 57)
+
+/*
+ * Location of vectors in RAM, they are copied at boot from adress 0x00000000 to
+ * that address.
+ */
+#define NVIC_RAM_VECTOR_ADDRESS ZBT_SSRAM23_START
+
+/*
+ * Size of the whole vector table in bytes. Each vector is on 32 bits.
+ */
+#define NVIC_VECTORS_SIZE       (NVIC_NUM_VECTORS * 4)
 
 #endif /* MBED_CMSIS_NVIC_H */

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/memory_zones.h
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/memory_zones.h
@@ -1,0 +1,56 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * This file contains the information of memory zones for code and data on
+ * CM3DS.
+ * It is used in startup code and linker scripts of supported compilers (ARM and
+ * GCC_ARM).
+ *
+ * WARNING: IAR does not include this file and re-define these values in
+ * MPS2.icf file. Please make sure that the two files share the same values.
+ *
+ * These memory zones are defined in section 4.1.1 of CM3DS Eval RTL and
+ * Testbench User Guide.
+ */
+
+#ifndef MEMORY_ZONES_H
+#define MEMORY_ZONES_H
+
+/*
+ * Code memory zones
+ * Please note that CM3DS on MPS2 does not contain any persistent flash memory.
+ * The FLASH memory zone is a 256 KiB SRAM block in the FPGA and named FLASH
+ * only to keep the same name than in the CM3DS Eval RTL and Testbench User
+ * Guide.
+ */
+#define FLASH_START       0x00000000
+#define FLASH_SIZE        0x00040000 /* 256 KiB */
+#define ZBT_SSRAM1_START  0x00400000
+#define ZBT_SSRAM1_SIZE   0x00400000 /* 4 MiB */
+
+/* Data memory zones */
+#define SRAM0_START       0x20000000
+#define SRAM0_SIZE        0x00008000 /* 32 KiB */
+#define SRAM1_START       0x20008000
+#define SRAM1_SIZE        0x00008000 /* 32 KiB */
+#define SRAM2_START       0x20010000
+#define SRAM2_SIZE        0x00008000 /* 32 KiB */
+#define SRAM3_START       0x20018000
+#define SRAM3_SIZE        0x00008000 /* 32 KiB */
+#define ZBT_SSRAM23_START 0x20400000
+#define ZBT_SSRAM23_SIZE  0x00400000 /* 4 MiB */
+
+#endif /* MEMORY_ZONES_H */
+

--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2016-2017 ARM Limited
+ * Copyright (c) 2016-2018 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,12 +17,20 @@
 #ifndef MBED_MBED_RTX_H
 #define MBED_MBED_RTX_H
 
-#if defined(TARGET_BEETLE) || defined(TARGET_CM3DS_MPS2)
+#if defined(TARGET_BEETLE)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
 
+#elif defined(TARGET_CM3DS_MPS2)
+
+#include "memory_zones.h"
+
+#ifndef INITIAL_SP
+#define INITIAL_SP              (ZBT_SSRAM23_START + ZBT_SSRAM23_SIZE)
 #endif
 
-#endif  // MBED_MBED_RTX_H
+#endif /* defined(TARGET_...) */
+
+#endif  /* MBED_MBED_RTX_H */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2663,6 +2663,7 @@
         "core": "Cortex-M3",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["ARM_SSG", "CM3DS_MPS2"],
+        "OUTPUT_EXT": "elf",
         "macros": ["CMSDK_CM3DS"],
         "device_has": ["ANALOGIN", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI", "RTC", "LOWPOWERTIMER"],
         "release_versions": ["2", "5"],


### PR DESCRIPTION
This pull request contains memory changes for the CM3DS target.
It is the pull request 2 among the 4 concerning CM3DS Maintenance. Please check #6119 for the full scope.

Other pull requests regarding this target:

* CM3DS Maintenance Pull Request: Bug fixes (1/4) #6167
* CM3DS Maintenance Pull Request: Memory changes (2/4) #6168
* CM3DS Maintenance Pull Request: TRNG support (3/4) #6169
* CM3DS Maintenance Pull Request: Driver updates (4/4) #6170 