### PR TITLE
Use SRAM2 32Kbytes on STM32L475 / L476 and L486 devices

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1053,12 +1053,13 @@ extern "C" uint32_t  __HeapLimit;
 extern "C" int errno;
 
 // Dynamic memory allocation related syscall.
-#if defined(TARGET_NUVOTON)
+#if (defined(TARGET_NUVOTON) || defined(TWO_RAM_REGIONS))
 
 // Overwrite _sbrk() to support two region model (heap and stack are two distinct regions).
 // __wrap__sbrk() is implemented in:
 // TARGET_NUMAKER_PFM_NUC472    targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/TOOLCHAIN_GCC_ARM/nuc472_retarget.c
 // TARGET_NUMAKER_PFM_M453      targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/TOOLCHAIN_GCC_ARM/m451_retarget.c
+// TARGET_STM32L4               targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4/l4_retarget.c
 extern "C" void *__wrap__sbrk(int incr);
 extern "C" caddr_t _sbrk(int incr) {
     return (caddr_t) __wrap__sbrk(incr);

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
@@ -139,24 +139,29 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*)
+        . += (ORIGIN(SRAM1) + LENGTH(SRAM1) - .);
         __HeapLimit = .;
     } > SRAM1
-
+    PROVIDE(__heap_size = SIZEOF(.heap));
+    PROVIDE(__mbed_sbrk_start = ADDR(.heap));
+    PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
+    /* Check if data + heap exceeds RAM1 limit */
+    ASSERT((ORIGIN(SRAM1)+LENGTH(SRAM1)) >= __HeapLimit, "SRAM1 overflow")
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
      * values to stack symbols later */
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > SRAM1
+    } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(SRAM1) + LENGTH(SRAM1);
+    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
+    /* Check if stack exceeds RAM2 limit */
+    ASSERT((ORIGIN(SRAM2)+LENGTH(SRAM2)) >= __StackLimit, "SRAM2 overflow")
 
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -139,24 +139,29 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*)
+        . += (ORIGIN(SRAM1) + LENGTH(SRAM1) - .);
         __HeapLimit = .;
     } > SRAM1
-
+    PROVIDE(__heap_size = SIZEOF(.heap));
+    PROVIDE(__mbed_sbrk_start = ADDR(.heap));
+    PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
+    /* Check if data + heap exceeds RAM1 limit */
+    ASSERT((ORIGIN(SRAM1)+LENGTH(SRAM1)) >= __HeapLimit, "SRAM1 overflow")
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
      * values to stack symbols later */
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > SRAM1
+    } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(SRAM1) + LENGTH(SRAM1);
+    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
+    /* Check if stack exceeds RAM2 limit */
+    ASSERT((ORIGIN(SRAM2)+LENGTH(SRAM2)) >= __StackLimit, "SRAM2 overflow")
 
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_GCC_ARM/STM32L486XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_GCC_ARM/STM32L486XX.ld
@@ -131,24 +131,29 @@ SECTIONS
         __end__ = .;
         end = __end__;
         *(.heap*)
+        . += (ORIGIN(SRAM1) + LENGTH(SRAM1) - .);
         __HeapLimit = .;
     } > SRAM1
-
+    PROVIDE(__heap_size = SIZEOF(.heap));
+    PROVIDE(__mbed_sbrk_start = ADDR(.heap));
+    PROVIDE(__mbed_krbs_start = ADDR(.heap) + SIZEOF(.heap));
+    /* Check if data + heap exceeds RAM1 limit */
+    ASSERT((ORIGIN(SRAM1)+LENGTH(SRAM1)) >= __HeapLimit, "SRAM1 overflow")
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
      * values to stack symbols later */
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > SRAM1
+    } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(SRAM1) + LENGTH(SRAM1);
+    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
+    /* Check if stack exceeds RAM2 limit */
+    ASSERT((ORIGIN(SRAM2)+LENGTH(SRAM2)) >= __StackLimit, "SRAM2 overflow")
 
-    /* Check if data + heap + stack exceeds RAM limit */
-    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
@@ -1,0 +1,68 @@
+/**
+  ******************************************************************************
+  * @file    l4_retarget.c
+ * @author   MCD Application Team
+  * @brief   CMSIS Cortex-M4 Core Peripheral Access Layer Source File for STM32L475xG
+  ******************************************************************************  
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2018 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************  
+  */ 
+#if defined(TWO_RAM_REGIONS)
+#if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR)
+
+#include <errno.h>
+#include "stm32l4xx.h"
+extern uint32_t __mbed_sbrk_start;
+extern uint32_t __mbed_krbs_start;
+
+#define STM32L4_HEAP_ALIGN               32
+#define STM32L4_ALIGN_UP(X, ALIGN)       (((X) + (ALIGN) - 1) & ~((ALIGN) - 1))
+/**
+ * The default implementation of _sbrk() (in platform/mbed_retarget.cpp) for GCC_ARM requires one-region model (heap and 
+ * stack share one region), which doesn't fit two-region model (heap and stack are two distinct regions), for example, 
+ * STM32L475xG locates heap on SRAM1 and stack on SRAM2. 
+ * Define __wrap__sbrk() to override the default _sbrk(). It is expected to get called through gcc 
+ * hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+ */
+void *__wrap__sbrk(int incr)
+{
+    static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
+    uint32_t heap_ind_old = STM32L4_ALIGN_UP(heap_ind, STM32L4_HEAP_ALIGN);
+    uint32_t heap_ind_new = STM32L4_ALIGN_UP(heap_ind_old + incr, STM32L4_HEAP_ALIGN);
+    
+    if (heap_ind_new > &__mbed_krbs_start) {
+        errno = ENOMEM;
+        return (void *) -1;
+    } 
+    
+    heap_ind = heap_ind_new;
+    
+    return (void *) heap_ind_old;
+}
+#endif /* GCC_ARM toolchain */
+#endif /* TWO_RAM_REGIONS */

--- a/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
@@ -32,9 +32,7 @@
   *
   ******************************************************************************  
   */ 
-#if defined(TWO_RAM_REGIONS)
-#if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR)
-
+#if (defined(TWO_RAM_REGIONS) && defined(__GNUC__) && !defined(__CC_ARM))
 #include <errno.h>
 #include "stm32l4xx.h"
 extern uint32_t __mbed_sbrk_start;
@@ -64,5 +62,5 @@ void *__wrap__sbrk(int incr)
     
     return (void *) heap_ind_old;
 }
-#endif /* GCC_ARM toolchain */
-#endif /* TWO_RAM_REGIONS */
+#endif /* GCC_ARM toolchain && TWO_RAM_REGIONS*/
+

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -20,8 +20,10 @@
 #ifndef INITIAL_SP
 
 #if (defined(TARGET_STM32L475VG))
-/* only GCC_ARM and IAR toolchain have the stack on SRAM2 */
-#if (defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR) || defined(__IAR_SYSTEMS_ICC__ ))
+/* only GCC_ARM and IAR toolchains have the stack on SRAM2 */
+#if (((defined(__GNUC__) && !defined(__CC_ARM)) ||\
+       defined(__IAR_SYSTEMS_ICC__ )) &&\
+       defined(TWO_RAM_REGIONS))
 #define INITIAL_SP              (0x10008000UL)
 #else
 #define INITIAL_SP              (0x20018000UL)
@@ -117,7 +119,7 @@
 #endif
 
 #endif // INITIAL_SP
-#if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR)
+#if (defined(__GNUC__) && !defined(__CC_ARM))
     extern uint32_t               __StackLimit[];
     extern uint32_t               __StackTop[];
     extern uint32_t               __end__[];
@@ -126,8 +128,6 @@
     #define HEAP_SIZE             ((uint32_t)((uint32_t)__HeapLimit - (uint32_t)HEAP_START))
     #define ISR_STACK_START       ((unsigned char*)__StackLimit)
     #define ISR_STACK_SIZE        ((uint32_t)((uint32_t)__StackTop - (uint32_t)__StackLimit))
-#elif defined(__ICCARM__)
-    /* No region declarations needed */
 #endif
 
 #endif  // MBED_MBED_RTX_H

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -19,7 +19,15 @@
 
 #ifndef INITIAL_SP
 
-#if (defined(TARGET_STM32F051R8) ||\
+#if (defined(TARGET_STM32L475VG))
+/* only GCC_ARM and IAR toolchain have the stack on SRAM2 */
+#if (defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR) || defined(__IAR_SYSTEMS_ICC__ ))
+#define INITIAL_SP              (0x10008000UL)
+#else
+#define INITIAL_SP              (0x20018000UL)
+#endif /* toolchains */
+
+#elif (defined(TARGET_STM32F051R8) ||\
      defined(TARGET_STM32F100RB) ||\
      defined(TARGET_STM32L031K6) ||\
      defined(TARGET_STM32L053C8) ||\
@@ -69,7 +77,6 @@
 #define INITIAL_SP              (0x20014000UL)
 
 #elif (defined(TARGET_STM32F401RE) ||\
-       defined(TARGET_STM32L475VG) ||\
        defined(TARGET_STM32L476RG) ||\
        defined(TARGET_STM32L476JG) ||\
        defined(TARGET_STM32L476VG) ||\
@@ -110,5 +117,17 @@
 #endif
 
 #endif // INITIAL_SP
+#if defined(TOOLCHAIN_GCC_ARM) || defined(TOOLCHAIN_GCC_CR)
+    extern uint32_t               __StackLimit[];
+    extern uint32_t               __StackTop[];
+    extern uint32_t               __end__[];
+    extern uint32_t               __HeapLimit[];
+    #define HEAP_START            ((unsigned char*)__end__)
+    #define HEAP_SIZE             ((uint32_t)((uint32_t)__HeapLimit - (uint32_t)HEAP_START))
+    #define ISR_STACK_START       ((unsigned char*)__StackLimit)
+    #define ISR_STACK_SIZE        ((uint32_t)((uint32_t)__StackTop - (uint32_t)__StackLimit))
+#elif defined(__ICCARM__)
+    /* No region declarations needed */
+#endif
 
 #endif  // MBED_MBED_RTX_H

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -119,7 +119,7 @@
 #endif
 
 #endif // INITIAL_SP
-#if (defined(__GNUC__) && !defined(__CC_ARM))
+#if (defined(__GNUC__) && !defined(__CC_ARM) && defined(TWO_RAM_REGIONS))
     extern uint32_t               __StackLimit[];
     extern uint32_t               __StackTop[];
     extern uint32_t               __end__[];

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -19,7 +19,11 @@
 
 #ifndef INITIAL_SP
 
-#if (defined(TARGET_STM32L475VG))
+#if (defined(TARGET_STM32L475VG) ||\
+     defined(TARGET_STM32L476RG) ||\
+     defined(TARGET_STM32L476JG) ||\
+     defined(TARGET_STM32L476VG) ||\
+     defined(TARGET_STM32L486RG))
 /* only GCC_ARM and IAR toolchains have the stack on SRAM2 */
 #if (((defined(__GNUC__) && !defined(__CC_ARM)) ||\
        defined(__IAR_SYSTEMS_ICC__ )) &&\
@@ -78,11 +82,7 @@
 #elif defined(TARGET_STM32L152RE)
 #define INITIAL_SP              (0x20014000UL)
 
-#elif (defined(TARGET_STM32F401RE) ||\
-       defined(TARGET_STM32L476RG) ||\
-       defined(TARGET_STM32L476JG) ||\
-       defined(TARGET_STM32L476VG) ||\
-       defined(TARGET_STM32L486RG))
+#elif defined(TARGET_STM32F401RE)
 #define INITIAL_SP              (0x20018000UL)
 
 #elif (defined(TARGET_STM32F207ZG) ||\

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1552,7 +1552,7 @@
             }
         },
         "detect_code": ["0765"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476RG",
@@ -1571,7 +1571,7 @@
             }
         },
         "detect_code": ["0766"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["5"],
         "device_name": "STM32L476JG"
@@ -1863,7 +1863,7 @@
         },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L475VG",
@@ -1885,7 +1885,7 @@
             }
         },
         "detect_code": ["0820"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476VG",


### PR DESCRIPTION
# Description
STM32L475 STM32L476 and STM32L486 devices have 32kbytes of SRAM2 that is used only for interrupt vector at the moment.
With this PR, the stack is now located in SRAM2.
This gives more space in SRAM1 for variables and heap. 
**It is mandatory for heavy applications like IOT connections**

This has already been pushed and merged for IAR toolchain. ARM Toolchain will come soon

Note that the mbed-os code for GCC_ARM is made for heap and stack in the same RAM area. I've rewritten __wrap__sbrk (code already available in mbed-os) and used a new define in targets.json : TWO_RAM_REGIONS

@ARMmbed/team-avnetsilica Please pay attention. I have modified your GCC_ARM linker file and added TWO_REGION_RAM in targets.json for SILICA_SENSOR_NODE. It compiles and link, but I can't test it.
If you don't want to benefit from it, you will have to remove this define and copy the previous GCC linker file in your own directory, instead of using ST' one.
(according to the use cases you are playing with this platform, I guess you would be happy to gain 32kbytes... up to you to decide)

@MarceloSalazar I'm sure you would like to use that...

kind regards
Armelle