### PR TITLE
NRF52X SPI Implementation

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/config/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/config/sdk_config.h
@@ -2666,7 +2666,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -2694,7 +2694,7 @@
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2722,7 +2722,7 @@
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <o> SPI2_DEFAULT_FREQUENCY  - SPI frequency

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
@@ -2666,7 +2666,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -2694,7 +2694,7 @@
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2722,7 +2722,7 @@
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <o> SPI2_DEFAULT_FREQUENCY  - SPI frequency

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/device/nrf52832_peripherals.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/device/nrf52832_peripherals.h
@@ -165,7 +165,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SPI_COUNT 3
 
 /* Serial Peripheral Interface Master with DMA */
-#define SPIM_PRESENT
+#define SPIM_PRESENT 0
 #define SPIM_COUNT 3
 
 #define SPIM0_MAX_DATARATE  8

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/device/nrf52840_peripherals.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/device/nrf52840_peripherals.h
@@ -167,7 +167,7 @@ OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define SPI_COUNT 3
 
 /* Serial Peripheral Interface Master with DMA */
-#define SPIM_PRESENT
+#define SPIM_PRESENT 0
 #define SPIM_COUNT 4
 
 #define SPIM0_MAX_DATARATE  8

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/spi_master/nrf_drv_spi.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/spi_master/nrf_drv_spi.c
@@ -63,7 +63,7 @@ NRF_LOG_MODULE_REGISTER();
 
 #define SPIM_ONLY        ( defined(SPIM_PRESENT)  && !defined(SPI_PRESENT))
 #define SPI_SPIM_PRESENT ( defined(SPIM_PRESENT)  &&  defined(SPI_PRESENT))
-#define SPI_ONLY         (!defined(SPIM_PRESENT) &&   defined(SPI_PRESENT))
+#define SPI_ONLY         (!SPIM_PRESENT &&   defined(SPI_PRESENT))
 
 #define SPI0_WITH_DMA (defined(SPI0_USE_EASY_DMA) && SPI0_USE_EASY_DMA && SPI0_ENABLED)
 #define SPI1_WITH_DMA (defined(SPI1_USE_EASY_DMA) && SPI1_USE_EASY_DMA && SPI1_ENABLED)
@@ -344,6 +344,12 @@ void nrf_drv_spi_uninit(nrf_drv_spi_t const * const p_instance)
 #endif
 
     p_cb->state = NRF_DRV_STATE_UNINITIALIZED;
+}
+
+bool nrf_drv_spi_busy(nrf_drv_spi_t const * const p_instance)
+{
+    spi_control_block_t * p_cb = &m_cb[p_instance->drv_inst_idx];
+    return p_cb->transfer_in_progress;
 }
 
 ret_code_t nrf_drv_spi_transfer(nrf_drv_spi_t const * const p_instance,

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/spi_master/nrf_drv_spi.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/spi_master/nrf_drv_spi.h
@@ -352,6 +352,14 @@ ret_code_t nrf_drv_spi_init(nrf_drv_spi_t const * const p_instance,
 void       nrf_drv_spi_uninit(nrf_drv_spi_t const * const p_instance);
 
 /**
+ * @brief Function to return whether there is a transfer in progress 
+ *
+ *
+ * @param[in] p_instance Pointer to the driver instance structure.
+ */
+bool       nrf_drv_spi_busy(nrf_drv_spi_t const * const p_instance);
+
+/**
  * @brief Function for starting the SPI data transfer.
  *
  * If an event handler was provided in the @ref nrf_drv_spi_init call, this function

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/objects.h
@@ -43,6 +43,7 @@
 #include "PortNames.h"
 #include "PeripheralNames.h"
 #include "PinNames.h"
+#include "nrf_drv_spi.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +54,9 @@ struct serial_s {
 };                        // but it must be not empty (required by strict compiler - IAR)
 
 struct spi_s {
-    uint8_t spi_idx;
+    nrf_drv_spi_t spi_drv_inst;
+    nrf_drv_spi_config_t config;    
+    int instance;
 };
 
 struct port_s {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/spi_api.c
@@ -1,585 +1,184 @@
-/* 
- * Copyright (c) 2013 Nordic Semiconductor ASA
- * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without modification,
- * are permitted provided that the following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list 
- *      of conditions and the following disclaimer.
- *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA 
- *      integrated circuit in a product or a software update for such product, must reproduce 
- *      the above copyright notice, this list of conditions and the following disclaimer in 
- *      the documentation and/or other materials provided with the distribution.
- *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be 
- *      used to endorse or promote products derived from this software without specific prior 
- *      written permission.
- *
- *   4. This software, with or without modification, must only be used with a 
- *      Nordic Semiconductor ASA integrated circuit.
- *
- *   5. Any software provided in binary or object form under this license must not be reverse 
- *      engineered, decompiled, modified and/or disassembled. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
- */
-
-#warning arm porting pending
+#include "spi_api.h"
+#include "nrf_drv_spi.h"
+#include "nrf_drv_spis.h"
+#include "nrf_drv_common.h"
 
 #if DEVICE_SPI
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_assert.h"
-#include "mbed_error.h"
-#include "nrf_drv_spi.h"
-#include "nrf_drv_spis.h"
-#include "app_util_platform.h"
-#include "sdk_config.h"
+#define SPI_INSTANCE_COUNT 3
+#define INSTANCE_ID 0
 
-#include "spi_api.h"
-#include "irq_handlers_hw.h"
+static const nrf_drv_spi_t nordic_nrf5_spi_instance[3] = {NRF_DRV_SPI_INSTANCE(0), NRF_DRV_SPI_INSTANCE(1), NRF_DRV_SPI_INSTANCE(2)};
 
-#if DEVICE_SPI_ASYNCH
-    #define SPI_IDX(obj)    ((obj)->spi.spi_idx)
-#else
-    #define SPI_IDX(obj)    ((obj)->spi_idx)
-#endif
-#define SPI_INFO(obj)       (&m_spi_info[SPI_IDX(obj)])
-#define MASTER_INST(obj)    (&m_instances[SPI_IDX(obj)].master)
-#define SLAVE_INST(obj)     (&m_instances[SPI_IDX(obj)].slave)
+/* Current obj owner of the peripheral. By default the peripheral is configured at the beginning
+   of each transaction. If the owner and mode hasn't changed the settings are kept as-is.
+*/
+static spi_t *nordic_nrf5_owner[3] = { NULL, NULL, NULL };
 
-typedef struct {
-    bool    initialized;
-    bool    master;
-    uint8_t sck_pin;
-    uint8_t mosi_pin;
-    uint8_t miso_pin;
-    uint8_t ss_pin;
-    uint8_t spi_mode;
-    nrf_drv_spi_frequency_t frequency;
-    volatile union {
-        bool busy;     // master
-        bool readable; // slave
-    } flag;
-    volatile uint8_t tx_buf;
-    volatile uint8_t rx_buf;
-
-#if DEVICE_SPI_ASYNCH
-    uint32_t handler;
-    uint32_t event;
-#endif
-} spi_info_t;
-static spi_info_t m_spi_info[SPI_COUNT];
-
-typedef struct {
-    nrf_drv_spi_t  master;
-    nrf_drv_spis_t slave;
-} sdk_driver_instances_t;
-
-void SPI0_TWI0_IRQHandler(void);
-void SPI1_TWI1_IRQHandler(void);
-void SPIM2_SPIS2_SPI2_IRQHandler(void);
-
-static const peripheral_handler_desc_t spi_handler_desc[SPI_COUNT] = {
-#if SPI0_ENABLED
-    {
-        SPI0_IRQ,
-        (uint32_t) SPI0_TWI0_IRQHandler
-    },
-#endif
-#if SPI1_ENABLED
-    {
-        SPI1_IRQ,
-        (uint32_t) SPI1_TWI1_IRQHandler
-    },
-#endif
-#if SPI2_ENABLED
-    {
-        SPI2_IRQ,
-        (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler
-    },
-#endif    
-};
-
-
-static sdk_driver_instances_t m_instances[SPI_COUNT] = {
-#if SPI0_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(0),
-        NRF_DRV_SPIS_INSTANCE(0)
-    },
-#endif
-#if SPI1_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(1),
-        NRF_DRV_SPIS_INSTANCE(1)
-    },
-#endif
-#if SPI2_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(2),
-        NRF_DRV_SPIS_INSTANCE(2)
-    },
-#endif
-};
-
-static void master_event_handler(uint8_t spi_idx,
-                                 nrf_drv_spi_evt_t const *p_event)
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
 {
-    spi_info_t *p_spi_info = &m_spi_info[spi_idx];
-
-    if (p_event->type == NRF_DRV_SPI_EVENT_DONE) {
-        p_spi_info->flag.busy = false;
-#if DEVICE_SPI_ASYNCH
-        if (p_spi_info->handler) {
-            void (*handler)(void) = (void (*)(void))p_spi_info->handler;
-            p_spi_info->handler = 0;
-            handler();
-        }
-#endif
-    }
-}
-#define MASTER_EVENT_HANDLER(idx) \
-    static void master_event_handler_##idx(nrf_drv_spi_evt_t const *p_event, void *p_context) { \
-        master_event_handler(SPI##idx##_INSTANCE_INDEX, p_event); \
-    }
-#if SPI0_ENABLED
-    MASTER_EVENT_HANDLER(0)
-#endif
-#if SPI1_ENABLED
-    MASTER_EVENT_HANDLER(1)
-#endif
-#if SPI2_ENABLED
-    MASTER_EVENT_HANDLER(2)
-#endif
-
-static nrf_drv_spi_evt_handler_t const m_master_event_handlers[SPI_COUNT] = {
-#if SPI0_ENABLED
-    master_event_handler_0,
-#endif
-#if SPI1_ENABLED
-    master_event_handler_1,
-#endif
-#if SPI2_ENABLED
-    master_event_handler_2,
-#endif
-};
-
-
-static void slave_event_handler(uint8_t spi_idx,
-                                nrf_drv_spis_event_t event)
-{
-    spi_info_t *p_spi_info = &m_spi_info[spi_idx];
-
-    if (event.evt_type == NRF_DRV_SPIS_XFER_DONE) {
-        // Signal that there is some data received that could be read.
-        p_spi_info->flag.readable = true;
-
-        // And prepare for the next transfer.
-        // Previous data set in 'spi_slave_write' (if any) has been transmitted,
-        // now use the default one, until some new is set by 'spi_slave_write'.
-        p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
-        nrf_drv_spis_buffers_set(&m_instances[spi_idx].slave,
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
-    }
-}
-#define SLAVE_EVENT_HANDLER(idx) \
-    static void slave_event_handler_##idx(nrf_drv_spis_event_t event) { \
-        slave_event_handler(SPIS##idx##_INSTANCE_INDEX, event); \
-    }
-#if SPIS0_ENABLED
-    SLAVE_EVENT_HANDLER(0)
-#endif
-#if SPIS1_ENABLED
-    SLAVE_EVENT_HANDLER(1)
-#endif
-#if SPIS2_ENABLED
-    SLAVE_EVENT_HANDLER(2)
-#endif
-
-static nrf_drv_spis_event_handler_t const m_slave_event_handlers[SPIS_COUNT] = {
-#if SPIS0_ENABLED
-    slave_event_handler_0,
-#endif
-#if SPIS1_ENABLED
-    slave_event_handler_1,
-#endif
-#if SPIS2_ENABLED
-    slave_event_handler_2,
-#endif
-};
-
-static void prepare_master_config(nrf_drv_spi_config_t *p_config,
-                                  spi_info_t const *p_spi_info)
-{
-    p_config->sck_pin   = p_spi_info->sck_pin;
-    p_config->mosi_pin  = p_spi_info->mosi_pin;
-    p_config->miso_pin  = p_spi_info->miso_pin;
-    p_config->ss_pin    = p_spi_info->ss_pin;
-    p_config->frequency = p_spi_info->frequency;
-    p_config->mode      = (nrf_drv_spi_mode_t)p_spi_info->spi_mode;
-
-    p_config->irq_priority = SPI_DEFAULT_CONFIG_IRQ_PRIORITY;
-    p_config->orc          = 0xFF;
-    p_config->bit_order    = NRF_DRV_SPI_BIT_ORDER_MSB_FIRST;
-}
-
-static void prepare_slave_config(nrf_drv_spis_config_t *p_config,
-                                 spi_info_t const *p_spi_info)
-{
-    p_config->sck_pin   = p_spi_info->sck_pin;
-    p_config->mosi_pin  = p_spi_info->mosi_pin;
-    p_config->miso_pin  = p_spi_info->miso_pin;
-    p_config->csn_pin   = p_spi_info->ss_pin;
-    p_config->mode      = (nrf_drv_spis_mode_t)p_spi_info->spi_mode;
-
-    p_config->irq_priority = SPIS_DEFAULT_CONFIG_IRQ_PRIORITY;
-    p_config->orc          = SPIS_DEFAULT_ORC;
-    p_config->def          = SPIS_DEFAULT_DEF;
-    p_config->bit_order    = NRF_DRV_SPIS_BIT_ORDER_MSB_FIRST;
-    p_config->csn_pullup   = NRF_DRV_SPIS_DEFAULT_CSN_PULLUP;
-    p_config->miso_drive   = NRF_DRV_SPIS_DEFAULT_MISO_DRIVE;
-}
-
-void spi_init(spi_t *obj,
-              PinName mosi, PinName miso, PinName sclk, PinName ssel)
-{
-#warning
-#if 0    
-    int i;
-
-    // This block is only a workaround that allows to create SPI object several
-    // times, what would be otherwise impossible in the current implementation
-    // of mbed driver that does not call spi_free() from SPI destructor.
-    // Once this mbed's imperfection is corrected, this block should be removed.
-    for (i = 0; i < SPI_COUNT; ++i) {
-        spi_info_t *p_spi_info = &m_spi_info[i];
-        if (p_spi_info->initialized &&
-            p_spi_info->mosi_pin == (uint8_t)mosi &&
-            p_spi_info->miso_pin == (uint8_t)miso &&
-            p_spi_info->sck_pin  == (uint8_t)sclk &&
-            p_spi_info->ss_pin   == (uint8_t)ssel) {
-            // Reuse the already allocated SPI instance (instead of allocating
-            // a new one), if it appears to be initialized with exactly the same
-            // pin assignments.
-            SPI_IDX(obj) = i;
-            return;
-        }
-    }
-
-    for (i = SPI_COUNT - 1; i >= 0; i--) {
-        spi_info_t *p_spi_info = &m_spi_info[i];
-
-        if (!p_spi_info->initialized) {
-
-            p_spi_info->sck_pin   = (uint8_t)sclk;
-            p_spi_info->mosi_pin  = (mosi != NC) ?
-                (uint8_t)mosi : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->miso_pin  = (miso != NC) ?
-                (uint8_t)miso : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->ss_pin    = (ssel != NC) ?
-                (uint8_t)ssel : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->spi_mode  = (uint8_t)NRF_DRV_SPI_MODE_0;
-            p_spi_info->frequency = NRF_DRV_SPI_FREQ_1M;
-
-            // By default each SPI instance is initialized to work as a master.
-            // Should the slave mode be used, the instance will be reconfigured
-            // appropriately in 'spi_format'.
-            nrf_drv_spi_config_t config;
-            prepare_master_config(&config, p_spi_info);
-
-            nrf_drv_spi_t const *p_spi = &m_instances[i].master;
-            ret_code_t ret_code = nrf_drv_spi_init(p_spi,
-                &config, m_master_event_handlers[i]);
-            if (ret_code == NRF_SUCCESS) {
-                p_spi_info->initialized = true;
-                p_spi_info->master      = true;
-                p_spi_info->flag.busy   = false;
-#if DEVICE_SPI_ASYNCH
-                p_spi_info->handler     = 0;
-#endif
-                SPI_IDX(obj) = i;
-                NVIC_SetVector(spi_handler_desc[i].IRQn, spi_handler_desc[i].vector);
-                return;
-            }
-        }
-    }
-
-    // No available peripheral
-    error("No available SPI peripheral\r\n");
-#endif    
+    struct spi_s *spi_inst = obj;
+    // Use the default config 
+    nrf_drv_spi_config_t config = NRF_DRV_SPI_DEFAULT_CONFIG;
+    config.sck_pin = sclk;
+    config.mosi_pin = mosi;
+    config.miso_pin = miso;
+    config.ss_pin = ssel; 
+    memcpy(&(spi_inst->config), &config, sizeof(nrf_drv_spi_config_t));
+    /* TODO: use pin configuration to choose instance instead of hard coded value */
+    int instance = 0;
+    nrf_drv_spi_t spi_drv_inst = nordic_nrf5_spi_instance[instance];
+    spi_inst->instance = instance;
+    memcpy(&(spi_inst->spi_drv_inst), &spi_drv_inst, sizeof(nrf_drv_spi_t)); 
+    
 }
 
 void spi_free(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    if (p_spi_info->master) {
-        nrf_drv_spi_uninit(MASTER_INST(obj));
-    }
-    else {
-        nrf_drv_spis_uninit(SLAVE_INST(obj));
-    }
-    p_spi_info->initialized = false;
-}
-
-int spi_busy(spi_t *obj)
-{
-    return (int)(SPI_INFO(obj)->flag.busy);
+    struct spi_s *spi_inst = obj;
+    nrf_drv_spi_uninit(&(spi_inst->spi_drv_inst)); 
 }
 
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
-#warning
-#if 0    
+    struct spi_s *spi_inst = obj;
+    nrf_drv_spi_config_t *config = &(spi_inst->config);
+    if(mode == 0)
+        config->mode = NRF_DRV_SPI_MODE_0;
+    else if(mode == 1)
+        config->mode = NRF_DRV_SPI_MODE_1;
+    else if(mode == 2)
+        config->mode = NRF_DRV_SPI_MODE_2;
+    else if(mode == 3)
+        config->mode = NRF_DRV_SPI_MODE_3;
+    int instance = spi_inst->instance;
+    nordic_nrf5_owner[instance] = NULL;
 
-    if (bits != 8) {
-        error("Only 8-bits SPI is supported\r\n");
-    }
-    if (mode > 3) {
-        error("SPI format error\r\n");
-    }
-
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-
-    if (slave)
-    {
-        nrf_drv_spis_mode_t spi_modes[4] = {
-            NRF_DRV_SPIS_MODE_0,
-            NRF_DRV_SPIS_MODE_1,
-            NRF_DRV_SPIS_MODE_2,
-            NRF_DRV_SPIS_MODE_3,
-        };
-        nrf_drv_spis_mode_t new_mode = spi_modes[mode];
-
-        // If the peripheral is currently working as a master, the SDK driver
-        // it uses needs to be switched from SPI to SPIS.
-        if (p_spi_info->master) {
-            nrf_drv_spi_uninit(MASTER_INST(obj));
-        }
-        // I the SPI mode has to be changed, the SDK's SPIS driver needs to be
-        // re-initialized (there is no other way to change its configuration).
-        else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
-            nrf_drv_spis_uninit(SLAVE_INST(obj));
-        }
-        else {
-            return;
-        }
-
-        p_spi_info->spi_mode = (uint8_t)new_mode;
-        p_spi_info->master = false;
-        p_spi_info->flag.readable = false;
-
-        // Initialize SDK's SPIS driver with the new configuration.
-        nrf_drv_spis_config_t config;
-        prepare_slave_config(&config, p_spi_info);
-        (void)nrf_drv_spis_init(SLAVE_INST(obj), &config,
-            m_slave_event_handlers[SPI_IDX(obj)]);
-
-        // Prepare the slave for transfer.
-        p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
-        nrf_drv_spis_buffers_set(SLAVE_INST(obj),
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
-    }
-    else // master
-    {
-        nrf_drv_spi_mode_t spi_modes[4] = {
-            NRF_DRV_SPI_MODE_0,
-            NRF_DRV_SPI_MODE_1,
-            NRF_DRV_SPI_MODE_2,
-            NRF_DRV_SPI_MODE_3,
-        };
-        nrf_drv_spi_mode_t new_mode = spi_modes[mode];
-
-        // If the peripheral is currently working as a slave, the SDK driver
-        // it uses needs to be switched from SPIS to SPI.
-        if (!p_spi_info->master) {
-            nrf_drv_spis_uninit(SLAVE_INST(obj));
-        }
-        // I the SPI mode has to be changed, the SDK's SPI driver needs to be
-        // re-initialized (there is no other way to change its configuration).
-        else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
-            nrf_drv_spi_uninit(MASTER_INST(obj));
-        }
-        else {
-            return;
-        }
-
-        p_spi_info->spi_mode = (uint8_t)new_mode;
-        p_spi_info->master = true;
-        p_spi_info->flag.busy = false;
-
-        // Initialize SDK's SPI driver with the new configuration.
-        nrf_drv_spi_config_t config;
-        prepare_master_config(&config, p_spi_info);
-        (void)nrf_drv_spi_init(MASTER_INST(obj), &config,
-            m_master_event_handlers[SPI_IDX(obj)]);
-    }
-#endif
+    //TODO: bits???
 }
-
-static nrf_drv_spi_frequency_t freq_translate(int hz)
-{
-    nrf_drv_spi_frequency_t frequency;
-    if (hz<250000) { //125Kbps
-        frequency = NRF_DRV_SPI_FREQ_125K;
-    } else if (hz<500000) { //250Kbps
-        frequency = NRF_DRV_SPI_FREQ_250K;
-    } else if (hz<1000000) { //500Kbps
-        frequency = NRF_DRV_SPI_FREQ_500K;
-    } else if (hz<2000000) { //1Mbps
-        frequency = NRF_DRV_SPI_FREQ_1M;
-    } else if (hz<4000000) { //2Mbps
-        frequency = NRF_DRV_SPI_FREQ_2M;
-    } else if (hz<8000000) { //4Mbps
-        frequency = NRF_DRV_SPI_FREQ_4M;
-    } else { //8Mbps
-        frequency = NRF_DRV_SPI_FREQ_8M;
-    }
-    return frequency;
-}
+         
 
 void spi_frequency(spi_t *obj, int hz)
 {
-#warning
-#if 0    
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    nrf_drv_spi_frequency_t new_frequency = freq_translate(hz);
+    struct spi_s *spi_inst = obj;
+    nrf_drv_spi_config_t *config = &(spi_inst->config);
+    nrf_drv_spi_frequency_t new_freq;
+    if (hz < 250000) {
+        new_freq = NRF_DRV_SPI_FREQ_125K;
+    } else if (hz < 500000) {
+        new_freq = NRF_DRV_SPI_FREQ_250K;
+    } else if (hz < 1000000) {
+        new_freq = NRF_DRV_SPI_FREQ_500K;
+    } else if (hz < 2000000) {
+        new_freq = NRF_DRV_SPI_FREQ_1M;
+    } else if (hz < 4000000) {
+        new_freq = NRF_DRV_SPI_FREQ_2M;
+    } else if (hz < 8000000) {
+        new_freq = NRF_DRV_SPI_FREQ_4M;
+    } else {
+        new_freq = NRF_DRV_SPI_FREQ_8M;
+    }
+    config->frequency = new_freq;
+    int instance = spi_inst->instance;
+    nordic_nrf5_owner[instance] = NULL;
+}
+         
 
-    if (p_spi_info->master)
-    {
-        if (p_spi_info->frequency != new_frequency) {
-            p_spi_info->frequency = new_frequency;
+int  spi_master_write(spi_t *obj, int value)
+{
+    struct spi_s *spi_obj = obj;
+    const uint8_t tx_buff[1] = {(uint8_t) value};
+    uint8_t rx_buff[1];
+    int instance = spi_obj->instance;
+    if(nordic_nrf5_owner[instance] != obj) {
+        spi_free(obj);
+        uint32_t err = nrf_drv_spi_init(&(spi_obj->spi_drv_inst), &(spi_obj->config), NULL, NULL); 
+        nordic_nrf5_owner[instance] = obj;
+    }
+    nrf_drv_spi_transfer(&(spi_obj->spi_drv_inst), tx_buff, 1, rx_buff, 1);
+    return rx_buff[0];
+}
 
-            nrf_drv_spi_config_t config;
-            prepare_master_config(&config, p_spi_info);
-
-            nrf_drv_spi_t const *p_spi = MASTER_INST(obj);
-            nrf_drv_spi_uninit(p_spi);
-            (void)nrf_drv_spi_init(p_spi, &config,
-                m_master_event_handlers[SPI_IDX(obj)]);
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)
+{
+    struct spi_s *spi_obj = obj;
+    int instance = spi_obj->instance;
+    if(nordic_nrf5_owner[instance] != obj) {
+        spi_free(obj);
+        uint32_t err = nrf_drv_spi_init(&(spi_obj->spi_drv_inst), &(spi_obj->config), NULL, NULL); 
+        nordic_nrf5_owner[instance] = obj;
+    }
+    int max = (rx_length < tx_length) ? tx_length : rx_length;
+    
+    int tx_offset = 0;
+    int rx_offset = 0;
+    // The following code will write/read the data 255 bytes at a time
+    // Check if the tx_length > 255
+    while(tx_length > 255) {
+        // Read all of rx_length or 255 
+        int rx_read_ln = rx_length > 255 ? 255 : rx_length;
+        nrf_drv_spi_transfer(&(spi_obj->spi_drv_inst), (const uint8_t*)(tx_buffer+tx_offset), 255, (uint8_t *)(rx_buffer+rx_offset), rx_read_ln);
+        tx_offset += 255;
+        tx_length -= 255;
+        rx_length -= rx_read_ln;
+        rx_offset += rx_read_ln;
+    }
+    // Handle extra tx/rx data
+    if(tx_length > 0) {
+        int rx_read_ln = rx_length > 255 ? 255 : rx_length;
+        rx_offset = rx_read_ln > 0 ? rx_offset : 0;
+        nrf_drv_spi_transfer(&(spi_obj->spi_drv_inst), (const uint8_t*)(tx_buffer+tx_offset), tx_length, (uint8_t*)(rx_buffer+rx_offset), rx_read_ln);
+        rx_length -= rx_read_ln;
+    }
+    
+    if (rx_length > 0) { 
+        while(rx_length > 255){
+            nrf_drv_spi_transfer(&(spi_obj->spi_drv_inst), (const uint8_t*)tx_buffer, 0, (uint8_t*)(rx_buffer+rx_offset), 255);
+            rx_offset += 255;
+            rx_length -= 255;
         }
+        nrf_drv_spi_transfer(&(spi_obj->spi_drv_inst), (const uint8_t*)tx_buffer, 0, (uint8_t*)(rx_buffer+rx_offset), rx_length);
     }
-    // There is no need to set anything in slaves when it comes to frequency,
-    // since slaves just synchronize with the clock provided by a master.
-#endif
-}
+    
+    return max; 
+} 
 
-int spi_master_write(spi_t *obj, int value)
+int  spi_slave_receive(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-
-#if DEVICE_SPI_ASYNCH
-    while (p_spi_info->flag.busy) {
-    }
-#endif
-
-    p_spi_info->tx_buf = value;
-    p_spi_info->flag.busy = true;
-    (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)&p_spi_info->tx_buf, 1,
-        (uint8_t *)&p_spi_info->rx_buf, 1);
-    while (p_spi_info->flag.busy) {
-    }
-
-    return p_spi_info->rx_buf;
+    return 0;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
-    int total = (tx_length > rx_length) ? tx_length : rx_length;
-
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
-    }
-
-    return total;
-}
-
-int spi_slave_receive(spi_t *obj)
+int  spi_slave_read(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-    return p_spi_info->flag.readable;
-;
-}
-
-int spi_slave_read(spi_t *obj)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-    while (!p_spi_info->flag.readable) {
-    }
-    p_spi_info->flag.readable = false;
-    return p_spi_info->rx_buf;
+    return 0;
 }
 
 void spi_slave_write(spi_t *obj, int value)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-
-    p_spi_info->tx_buf = (uint8_t)value;
+    return;
 }
+
+int  spi_busy(spi_t *obj)
+{
+    struct spi_s *spi_obj = obj;
+    return nrf_drv_spi_busy(&(spi_obj->spi_drv_inst)); 
+}
+
+uint8_t spi_get_module(spi_t *obj)
+{
+    return 0;
+}
+
 
 #if DEVICE_SPI_ASYNCH
 
-void spi_master_transfer(spi_t *obj,
-                         const void *tx, size_t tx_length,
-                         void *rx, size_t rx_length, uint8_t bit_width,
-                         uint32_t handler, uint32_t event, DMAUsage hint)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    (void)hint;
-    (void)bit_width;
+void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx, size_t rx_length, uint8_t bit_width, uint32_t handler, uint32_t event, DMAUsage hint);
 
-    p_spi_info->handler = handler;
-    p_spi_info->event   = event;
+uint32_t spi_irq_handler_asynch(spi_t *obj);
 
-    p_spi_info->flag.busy = true;
-    (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)tx, tx_length,
-        (uint8_t *)rx, rx_length);
-}
+uint8_t spi_active(spi_t *obj);
 
-uint32_t spi_irq_handler_asynch(spi_t *obj)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    return p_spi_info->event & SPI_EVENT_COMPLETE;
-}
-
-uint8_t spi_active(spi_t *obj)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    return p_spi_info->flag.busy;
-}
-
-void spi_abort_asynch(spi_t *obj)
-{
-    MBED_ASSERT(SPI_INFO(obj)->master);
-    nrf_drv_spi_abort(MASTER_INST(obj));
-}
+void spi_abort_asynch(spi_t *obj);
 
 #endif // DEVICE_SPI_ASYNCH
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3476,7 +3476,7 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52832"],
         "macros_add": ["BOARD_PCA10040", "NRF52_PAN_12", "NRF52_PAN_15", "NRF52_PAN_58", "NRF52_PAN_55", "NRF52_PAN_54", "NRF52_PAN_31", "NRF52_PAN_30", "NRF52_PAN_51", "NRF52_PAN_36", "NRF52_PAN_53", "S132", "CONFIG_GPIO_AS_PINRESET", "BLE_STACK_SUPPORT_REQD", "SWI_DISABLE0", "NRF52_PAN_20", "NRF52_PAN_64", "NRF52_PAN_62", "NRF52_PAN_63"],
-        "device_has_add": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "device_has_add": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
         "release_versions": ["5"],
         "device_name": "nRF52832_xxAA"
     },


### PR DESCRIPTION
Implement spi_api.c for NRF52X boards using SDK14.

This driver does not implement SPI slave functions and does not use SPIM.

@marcuschangarm 