### PR TITLE
platform: FileHandle test - remove optimization for stdlib diversity

### DIFF
--- a/TESTS/mbed_platform/FileHandle/main.cpp
+++ b/TESTS/mbed_platform/FileHandle/main.cpp
@@ -90,17 +90,15 @@ void test_fwrite_fread()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_EQUAL_INT(str1_size, write_ret);
 
-#ifndef __ICCARM__ // prevents IAR infinite loop
     // write 3; expected written 2
     TestFile<FS>::resetFunctionCallHistory();
     write_ret = std::fwrite(str2, 1, str2_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
-    std::clearerr(file); // for ARMCC
-#ifndef __ARMCC_VERSION
-    // ARMCC returns 0 here instead of number of elements successfully written
-    TEST_ASSERT_EQUAL_INT(str2_size - 1, write_ret);
-#endif
+    std::clearerr(file);
+
+    // ARMCC/IAR returns 0 here instead of number of elements successfully written !!!
+    TEST_ASSERT_TRUE(write_ret >= 0 && write_ret <= (str2_size - 1));
 
     // write 3; expected written 0
     TestFile<FS>::resetFunctionCallHistory();
@@ -108,7 +106,6 @@ void test_fwrite_fread()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
     TEST_ASSERT_EQUAL_INT(0, write_ret);
-#endif
 
     std::rewind(file);
 
@@ -119,13 +116,12 @@ void test_fwrite_fread()
     TEST_ASSERT_EQUAL_INT(str1_size, read_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(str1, read_buf, str1_size));
 
-#ifndef __ICCARM__
     // read 3; expected read 2
     TestFile<FS>::resetFunctionCallHistory();
     read_ret = std::fread(read_buf, 1, str2_size, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
-    std::clearerr(file); // for ARMCC
+    std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(str2_size - 1, read_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(str2, read_buf, str2_size - 1));
 
@@ -135,10 +131,11 @@ void test_fwrite_fread()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
     TEST_ASSERT_EQUAL_INT(0, read_ret);
-#endif
 
     std::fclose(file);
 }
+
+
 
 /** Test fputc and fgetc
  *
@@ -168,7 +165,6 @@ void test_fputc_fgetc()
     TEST_ASSERT_NOT_NULL(file);
     std::setbuf(file, NULL);
 
-
     // write 1; expected written 1
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fputc(char_buf[0], file);
@@ -187,14 +183,12 @@ void test_fputc_fgetc()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_EQUAL_INT(char_buf[2], ret);
 
-#ifndef __ICCARM__ // prevents IAR infinite loop
     // write 1; expected written 0
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fputc(char_buf[0], file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
     TEST_ASSERT_EQUAL_INT(EOF, ret);
-#endif
 
     std::rewind(file);
 
@@ -207,29 +201,19 @@ void test_fputc_fgetc()
     // read 1; expected read 1
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fgetc(file);
-#ifndef __ICCARM__
-    // IAR optimize reads
-    TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
-#endif
     TEST_ASSERT_EQUAL_INT(char_buf[1], ret);
 
     // read 1; expected read 1
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fgetc(file);
-#ifndef __ICCARM__
-    // IAR optimize reads
-    TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
-#endif
     TEST_ASSERT_EQUAL_INT(char_buf[2], ret);
 
-#ifndef __ICCARM__
     // read 1; expected read 0
     TestFile<FS>::resetFunctionCallHistory();
     ret = std::fgetc(file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
     TEST_ASSERT_EQUAL_INT(EOF, ret);
-#endif
 
     std::fclose(file);
 }
@@ -273,13 +257,12 @@ void test_fputs_fgets()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(fputs_ret >= 0);
 
-#ifndef __ICCARM__ // prevents IAR infinite loop
     // write 3; expected written 2
     TestFile<FS>::resetFunctionCallHistory();
     fputs_ret = std::fputs(str2, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
-    std::clearerr(file); // for ARMCC
+    std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(EOF, fputs_ret);
 
     // write 3; expected written 0
@@ -288,7 +271,6 @@ void test_fputs_fgets()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
     TEST_ASSERT_EQUAL_INT(EOF, fputs_ret);
-#endif
 
     std::rewind(file);
 
@@ -299,13 +281,12 @@ void test_fputs_fgets()
     TEST_ASSERT_EQUAL_INT(read_buf, fgets_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str1, str1_size));
 
-#ifndef __ICCARM__
     // read 3; expected read 2
     TestFile<FS>::resetFunctionCallHistory();
     fgets_ret = std::fgets(read_buf, str2_size + 1, file);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
-    std::clearerr(file); // for ARMCC
+    std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(read_buf, fgets_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str2, str2_size - 2));
 
@@ -315,7 +296,6 @@ void test_fputs_fgets()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
     TEST_ASSERT_EQUAL_INT(NULL, fgets_ret);
-#endif
 
     std::fclose(file);
 }
@@ -359,13 +339,12 @@ void test_fprintf_fscanf()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_EQUAL_INT(str1_size, fprintf_ret);
 
-#ifndef __ICCARM__ // prevents IAR infinite loop
     // write 3; expected written 2
     TestFile<FS>::resetFunctionCallHistory();
     fprintf_ret = fprintf(file, "%s", str2);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
-    std::clearerr(file); // for ARMCC
+    std::clearerr(file);
     TEST_ASSERT_TRUE(fprintf_ret < 0);
 
     // write 3; expected written 0
@@ -374,7 +353,6 @@ void test_fprintf_fscanf()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnWrite));
     TEST_ASSERT_TRUE(std::ferror(file) != 0);
     TEST_ASSERT_TRUE(fprintf_ret < 0);
-#endif
 
     std::rewind(file);
 
@@ -385,13 +363,12 @@ void test_fprintf_fscanf()
     TEST_ASSERT_EQUAL_INT(1, fscanf_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str1, str1_size));
 
-#ifndef __ICCARM__
     // read 3; expected read 2
     TestFile<FS>::resetFunctionCallHistory();
     fscanf_ret = fscanf(file, "%3s", read_buf);
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
-    std::clearerr(file); // for ARMCC
+    std::clearerr(file);
     TEST_ASSERT_EQUAL_INT(1, fscanf_ret);
     TEST_ASSERT_EQUAL_INT(0, strncmp(read_buf, str2, str2_size - 1));
 
@@ -401,7 +378,6 @@ void test_fprintf_fscanf()
     TEST_ASSERT_TRUE(TestFile<FS>::functionCalled(TestFile<FS>::fnRead));
     TEST_ASSERT_TRUE(std::feof(file) != 0);
     TEST_ASSERT_EQUAL_INT(EOF, fscanf_ret);
-#endif
 
     std::fclose(file);
 }


### PR DESCRIPTION
# Description

It removes test customisation against different c stdlibs behaviour under ARMCC/IAR/GCC compilers.
Now the test flow is the same on all compilers

# Related PRs
#5895
#5571

# Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New Target
- [ ] Feature
