### PR TITLE
nanostack-hal: add alternative critical section implementation

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/arm_hal_interrupt.c
@@ -4,9 +4,24 @@
 
 #include "arm_hal_interrupt.h"
 #include "arm_hal_interrupt_private.h"
+
+#if MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT
+#include "platform/mbed_critical.h"
+#else
 #include "cmsis_os2.h"
 #include "mbed_rtos_storage.h"
+#endif
+
 #include <mbed_assert.h>
+
+
+// The critical section has two alternative implementations, the default which uses mutex
+// as locking primitive and the optional, which will bluntly disable interrupts
+// for the critical section. The mutex version will not cause issues by delaying
+// interrupts, but it has a down side that it can not be used from the interrupt
+// service routines. The IRQ-safe version will do the mutual exclusion by temporarily
+// disabling the interrupts, so it will have effect on interrupt latency.
+#if !MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT
 
 static uint8_t sys_irq_disable_counter;
 
@@ -19,20 +34,34 @@ static const osMutexAttr_t critical_mutex_attr = {
 };
 static osMutexId_t critical_mutex_id;
 
+#endif
+
 void platform_critical_init(void)
 {
+#if MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT
+    // nothing to do here
+#else
     critical_mutex_id = osMutexNew(&critical_mutex_attr);
     MBED_ASSERT(critical_mutex_id);
+#endif
 }
 
 void platform_enter_critical(void)
 {
+#if MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT
+    core_util_critical_section_enter();
+#else
     osMutexAcquire(critical_mutex_id, osWaitForever);
     sys_irq_disable_counter++;
+#endif
 }
 
 void platform_exit_critical(void)
 {
+#if MBED_CONF_NANOSTACK_HAL_CRITICAL_SECTION_USABLE_FROM_INTERRUPT
+    core_util_critical_section_exit();
+#else
     --sys_irq_disable_counter;
     osMutexRelease(critical_mutex_id);
+#endif
 }

--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/mbed_lib.json
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/mbed_lib.json
@@ -8,6 +8,10 @@
         "event_loop_thread_stack_size": {
             "help": "Define event-loop thread stack size.",
             "value": 6144
+        },
+        "critical-section-usable-from-interrupt": {
+            "help": "Make critical section API usable from interrupt context. Else a mutex is used as locking primitive. Consult arm_hal_interrupt.c for possible side effects on interrupt latency.",
+            "value": false
         }
     }
 }


### PR DESCRIPTION
## Description
(This PR has the same content as already merged https://github.com/ARMmbed/mbed-os-confidential-m/pull/8 and
https://github.com/ARMmbed/mbed-os/pull/5754, only the target branch differs)

The nanostack hal's critical section uses a mutex for mutual exclusion,
which is nice for many use cases. But when one needs to use the critical
section from interrupts, the RTX will have a assertion failure and panic.

Add a configurable for mbed_lib, which can be used to enable a alternative
version of critical section, which uses the underlying OS primitives, which
disables the interrupts.

Note: the default behavior is not changed, one needs to override the
"nanostack-hal.critical-section-usable-from-interrupt" to have "true".

Reason for this change is that there is a need for sending events using
nanostack event queue from interrupt context, eg. from a socket callback.

## Status

**READY**

## Migrations

YES | NO

## Related PRs

## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

Note: this should not be the first and/or only fix, as it may cause troubles on drivers which can not tolerate delays on interrupt deliveries.

## Steps to test or reproduce

K64F with ESP8266, debug profile:
"Mutex 0x200017ec error -6: Not allowed in ISR context"