### PR TITLE
Eventloop in main thread to master

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/mbed_lib.json
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/mbed_lib.json
@@ -9,5 +9,10 @@
             "help": "Define event-loop thread stack size.",
             "value": 6144
         }
+        ,
+        "event-loop-dispatch-from-application": {
+            "help": "Application is responsible of message dispatch loop. Else launch a separate thread for event-loop.",
+            "value": false
+        }
     }
 }

--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.h
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.h
@@ -6,6 +6,7 @@
 extern "C" {
 #endif
 
+void ns_event_loop_init(void);
 void ns_event_loop_thread_create(void);
 void ns_event_loop_thread_start(void);
 

--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_hal_init.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_hal_init.c
@@ -32,10 +32,19 @@ void ns_hal_init(void *heap, size_t h_size, void (*passed_fptr)(heap_fail_t), me
     ns_dyn_mem_init(heap, h_size, passed_fptr, info_ptr);
     platform_timer_enable();
     eventOS_scheduler_init();
+
     // We do not initialise randlib, as it should be done after
     // RF driver has started, to get MAC address and RF noise as seed.
     // We do not initialise trace - left to application.
+
+    // Prepare the event loop lock which is used even if the loop
+    // is not ran in a separate thread.
+    ns_event_loop_init();
+
+#if !MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION
     ns_event_loop_thread_create();
     ns_event_loop_thread_start();
+#endif
+
     initted = true;
 }


### PR DESCRIPTION
## Description

This has the same content as ARMmbed/mbed-os-confidential-m#7 and https://github.com/ARMmbed/mbed-os/pull/5752, just the target repo and branch are different.

Copypasta from commit:
--8<--8<--8<--8<--8<
The separate eventloop thread may not be necessary on all uses, as one
can use the existing main thread for event dispatching. Add a
conditional nanostack-hal.event-loop-dispatch-from-application, which
disables the thread creation.

Note: the ns_hal_init must be ran from the same thread which will be
used to execute the event loop later.
--8<--8<--8<--8<--8<

By removing the separate event loop thread, one saves about 6KB of RAM in mbed cloud client example side.

## Status

**READY**

## Migrations

Unless one sets the "nanostack-hal.event-loop-dispatch-from-application" to true, the existing behavior is not changed.

NO

## Related PRs

<none in public repos>


## Todos

- [ ] Tests
- [ ] Documentation

## Deploy notes

## Steps to test or reproduce

Testing can be done by adding following code to the end of main(), where one has already initialized the event loop and the application code:
```
#if MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION

    printf("Starting eventloop..\n");
    eventOS_scheduler_mutex_wait();
    // this will block for ever
    eventOS_scheduler_run();

#else
<normal wait-forever code>
#endif
```