### PR TITLE
ODIN MTB LEDs Fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_MTB_UBLOX_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_MTB_UBLOX_ODIN_W2/PinNames.h
@@ -148,16 +148,14 @@ typedef enum {
     //P_TP11,         // BOOT0
 
     // Internal
-    LED1       = PD_9,
-    LED2       = PA_12,
-    LED3       = PD_8,
-    LED4       = PA_11,
-    LED5       = PC_2,
-    LED6       = PA_3,
-    LED7       = PF_6,
     LED_RED    = PE_0,
     LED_GREEN  = PB_6,
     LED_BLUE   = PB_8,
+
+    LED1       = LED_RED,
+    LED2       = LED_GREEN,
+    LED3       = LED_BLUE,
+
     SW1        = PF_2,
     SW2        = PG_4,
 


### PR DESCRIPTION
# Description

Clean up of Pin names for ODIN MTB. Required to build examples from online compiler.

# Pull request type

- [x] Fix

