### PR TITLE
Flash support: Add flash support for LPC54114 & LPC546XX

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/flash_api.c
@@ -1,0 +1,129 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "flash_api.h"
+#include "mbed_critical.h"
+
+#if DEVICE_FLASH
+
+#include "fsl_flashiap.h"
+
+int32_t flash_init(flash_t *obj)
+{
+    return 0;
+}
+
+int32_t flash_free(flash_t *obj)
+{
+    return 0;
+}
+
+int32_t flash_erase_sector(flash_t *obj, uint32_t address)
+{
+    uint32_t n;
+    uint32_t status;
+    int32_t ret = -1;
+
+    /* We need to prevent flash accesses during erase operation */
+    core_util_critical_section_enter();
+
+    n = address / FSL_FEATURE_SYSCON_FLASH_SECTOR_SIZE_BYTES;   // Get Sector Number
+
+    status = FLASHIAP_PrepareSectorForWrite(n, n);
+    if (status == kStatus_FLASHIAP_Success) {
+        status = FLASHIAP_EraseSector(n, n, SystemCoreClock);
+        if (status == kStatus_FLASHIAP_Success) {
+            ret = 0;
+        }
+    }
+
+    core_util_critical_section_exit();
+
+    return ret;
+}
+
+int32_t flash_program_page(flash_t *obj, uint32_t address, const uint8_t *data, uint32_t size)
+{
+    uint32_t n;
+    uint32_t sector_number;
+
+    uint32_t status;
+    int32_t ret = -1;
+    uint8_t buf[FSL_FEATURE_SYSCON_FLASH_PAGE_SIZE_BYTES];
+
+    if (address == 0) {                              // Check for Vector Table
+        n = *((unsigned long *)(data + 0)) +
+            *((unsigned long *)(data + 1)) +
+            *((unsigned long *)(data + 2)) +
+            *((unsigned long *)(data + 3)) +
+            *((unsigned long *)(data + 4)) +
+            *((unsigned long *)(data + 5)) +
+            *((unsigned long *)(data + 6));
+        *((unsigned long *)(data + 7)) = 0 - n;  // Signature at Reserved Vector
+    }
+
+    /* Copy into a local buffer to ensure address is word-aligned */
+    memcpy(&buf, data, FSL_FEATURE_SYSCON_FLASH_PAGE_SIZE_BYTES);
+
+    /* We need to prevent flash accesses during program operation */
+    core_util_critical_section_enter();
+
+    sector_number = address / FSL_FEATURE_SYSCON_FLASH_SECTOR_SIZE_BYTES;  // Get Sector Number
+
+    status = FLASHIAP_PrepareSectorForWrite(sector_number, sector_number);
+    if (status == kStatus_FLASHIAP_Success) {
+        status = FLASHIAP_CopyRamToFlash(address, (uint32_t *)&buf,
+                                        FSL_FEATURE_SYSCON_FLASH_PAGE_SIZE_BYTES, SystemCoreClock);
+        if (status == kStatus_FLASHIAP_Success) {
+            ret = 0;
+        }
+    }
+
+    core_util_critical_section_exit();
+
+    return ret;
+}
+
+uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
+{
+    uint32_t sectorsize = MBED_FLASH_INVALID_SIZE;
+    uint32_t devicesize = FSL_FEATURE_SYSCON_FLASH_SIZE_BYTES;
+    uint32_t startaddr = 0;
+
+    if ((address >= startaddr) && (address < (startaddr + devicesize))) {
+        sectorsize = FSL_FEATURE_SYSCON_FLASH_SECTOR_SIZE_BYTES;
+    }
+
+    return sectorsize;
+}
+
+uint32_t flash_get_page_size(const flash_t *obj)
+{
+    return FSL_FEATURE_SYSCON_FLASH_PAGE_SIZE_BYTES;
+}
+
+uint32_t flash_get_start_address(const flash_t *obj)
+{
+    uint32_t startaddr = 0;
+
+    return startaddr;
+}
+
+uint32_t flash_get_size(const flash_t *obj)
+{
+    return FSL_FEATURE_SYSCON_FLASH_SIZE_BYTES;
+}
+
+#endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
@@ -58,6 +58,12 @@ struct spi_s {
     uint8_t bits;
 };
 
+#if DEVICE_FLASH
+struct flash_s {
+    uint8_t dummy;
+};
+#endif
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -742,7 +742,7 @@
         "macros": ["CPU_LPC54114J256BD64_cm4", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["1054"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name" : "LPC54114J256BD64"
     },
@@ -753,7 +753,7 @@
         "is_disk_virtual": true,
         "macros": ["CPU_LPC54628J512ET180", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name" : "LPC54628J512ET180"


### PR DESCRIPTION
Passed the flash tests

1. LPC54114:
mbedgt: test on hardware with target id: 105400001b4ee77600000000000000000000000097969905
mbedgt: test suite 'mbed-os-tests-mbed_hal-flash' .................................................... OK in 14.28 sec
        test case: 'Flash - buffer alignment test' ................................................... OK in 0.14 sec
        test case: 'Flash - clock and cache test' .................................................... OK in 0.10 sec
        test case: 'Flash - erase sector' ............................................................ OK in 0.14 sec
        test case: 'Flash - init' .................................................................... OK in 0.08 sec
        test case: 'Flash - mapping alignment' ....................................................... OK in 0.05 sec
        test case: 'Flash - program page' ............................................................ OK in 0.24 sec
mbedgt: test case summary: 6 passes, 0 failures

2. LPC564XX:
mbedgt: test on hardware with target id: 105600001984a78e00000000000000000000000097969905
mbedgt: test suite 'mbed-os-tests-mbed_hal-flash' .................................................... OK in 14.01 sec
        test case: 'Flash - buffer alignment test' ................................................... OK in 0.14 sec
        test case: 'Flash - clock and cache test' .................................................... OK in 0.06 sec
        test case: 'Flash - erase sector' ............................................................ OK in 0.13 sec
        test case: 'Flash - init' .................................................................... OK in 0.04 sec
        test case: 'Flash - mapping alignment' ....................................................... OK in 0.05 sec
        test case: 'Flash - program page' ............................................................ OK in 0.23 sec
mbedgt: test case summary: 6 passes, 0 failures