### PR TITLE
Travis: Fix tools testing breakage due to multiple python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
         # Install dependencies
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
-        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6} python{2.7,3.5,3.6}-pip
+        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6} python{2,3}-pip
         - pip2.7 install -r requirements.txt
         - pip3.5 install -r requirements.txt
         - pip3.6 install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,8 +79,12 @@ matrix:
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
         - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6}
-        - pip install -r requirements.txt
-        - pip install pytest pylint hypothesis mock coverage coveralls
+        - pip2.7 install -r requirements.txt
+        - pip3.5 install -r requirements.txt
+        - pip3.6 install -r requirements.txt
+        - pip2.7 install pytest pylint hypothesis mock coverage coveralls
+        - pip3.5 install pytest pylint hypothesis mock coverage coveralls
+        - pip3.6 install pytest pylint hypothesis mock coverage coveralls
         # Print versions we use
         - arm-none-eabi-gcc --version
         - python2.7 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
       --data @- << DATA\n{
       "state": "$0",
       "description": "$1",
-      "context": "travis-ci/$NAME/$(python --version)",
+      "context": "travis-ci/$NAME",
       "target_url": "https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID"
       }\nDATA'
 
@@ -74,23 +74,27 @@ matrix:
 
     - env:
         - NAME=tools
-      python:
-        - '2.7'
-        - '3.5'
-        - '3.6'
       install:
         # Install dependencies
-        - sudo apt-get install gcc-arm-embedded
+        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6}
         - pip install -r requirements.txt
         - pip install pytest pylint hypothesis mock coverage coveralls
         # Print versions we use
         - arm-none-eabi-gcc --version
-        - python --version
+        - python2.7 --version
+        - python3.5 --version
+        - python3.6 --version
       script:
         # Run local testing on tools
-        - PYTHONPATH=. coverage run -a -m pytest tools/test
-        - python2 tools/test/pylint.py
-        - coverage run -a tools/project.py -S | sed -n '/^Total/p'
+        - PYTHONPATH=. coverage-2.7 run -a -m pytest tools/test
+        - PYTHONPATH=. coverage-3.5 run -a -m pytest tools/test
+        - PYTHONPATH=. coverage-3.6 run -a -m pytest tools/test
+        - python2.7 tools/test/pylint.py
+        - python3.5 tools/test/pylint.py
+        - python3.6 tools/test/pylint.py
+        - coverage-2.7 run -a tools/project.py -S | sed -n '/^Total/p'
+        - coverage-3.5 run -a tools/project.py -S | sed -n '/^Total/p'
+        - coverage-3.6 run -a tools/project.py -S | sed -n '/^Total/p'
         - coverage html
       after_success:
         # Coverage for tools
@@ -199,8 +203,3 @@ matrix:
       env: NAME=mbed2-NUVOTON
     - <<: *mbed-2
       env: NAME=mbed2-RENESAS
-      # Change python version here only because 3x the other jobs does not add any more coverage
-      python:
-        - '2.7'
-        - '3.5'
-        - '3.6'

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,13 +78,11 @@ matrix:
         # Install dependencies
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
-        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6} python{2,3}-pip
-        - pip2.7 install -r requirements.txt
-        - pip3.5 install -r requirements.txt
-        - pip3.6 install -r requirements.txt
-        - pip2.7 install pytest pylint hypothesis mock coverage coveralls
-        - pip3.5 install pytest pylint hypothesis mock coverage coveralls
-        - pip3.6 install pytest pylint hypothesis mock coverage coveralls
+        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6} python{,3}-pip
+        - pip2 install -r requirements.txt
+        - pip3 install -r requirements.txt
+        - pip2 install pytest pylint hypothesis mock coverage coveralls
+        - pip3 install pytest pylint hypothesis mock coverage coveralls
         # Print versions we use
         - arm-none-eabi-gcc --version
         - python2.7 --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ matrix:
         # Install dependencies
         - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
-        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6}
+        - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6} python{2.7,3.5,3.6}-pip
         - pip2.7 install -r requirements.txt
         - pip3.5 install -r requirements.txt
         - pip3.6 install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,6 +76,8 @@ matrix:
         - NAME=tools
       install:
         # Install dependencies
+        - sudo add-apt-repository -y ppa:fkrull/deadsnakes
+        - sudo apt-get update
         - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6}
         - pip install -r requirements.txt
         - pip install pytest pylint hypothesis mock coverage coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,7 +76,7 @@ matrix:
         - NAME=tools
       install:
         # Install dependencies
-        - sudo add-apt-repository -y ppa:fkrull/deadsnakes
+        - sudo add-apt-repository -y ppa:deadsnakes/ppa
         - sudo apt-get update
         - sudo apt-get install gcc-arm-embedded python{2.7,3.5,3.6}
         - pip install -r requirements.txt


### PR DESCRIPTION
Travis doesn't recognize version matrices when inside a matrix include job. Instead, it breaks in a way that isn't reported as an error.

Fix is to just manually run the python versions we want to test.

Note: This **will** result in failures, as it already has for https://github.com/ARMmbed/mbed-os/pull/6195. Will fix as failures are reported.

Please ignore the commit noise for now, will squash at the end.

introduced in https://github.com/ARMmbed/mbed-os/pull/5848
intended for patch
cc @deepikabhavnani, @cmonr, @theotherjimmy
related https://github.com/travis-ci/travis-ci/issues/9275