### PR TITLE
Fix max32625mbed

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32625/PeripheralPins.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/PeripheralPins.c
@@ -163,6 +163,10 @@ const PinMap PinMap_ADC[] = {
     { AIN_3, ADC, ADC_CH_3 },
     { AIN_4, ADC, ADC_CH_0_DIV_5 },
     { AIN_5, ADC, ADC_CH_1_DIV_5 },
+    { AIN_6, ADC, ADC_CH_VDDB_DIV_4 },
+    { AIN_7, ADC, ADC_CH_VDD18 },
+    { AIN_8, ADC, ADC_CH_VDD12 },
+    { AIN_9, ADC, ADC_CH_VRTC_DIV_2 },
     { NC,    NC,  0 }
 };
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/TARGET_MAX32625MBED/PinNames.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/TARGET_MAX32625MBED/PinNames.h
@@ -60,7 +60,7 @@ typedef enum {
     P4_0 = (4 << PORT_SHIFT), P4_1, P4_2, P4_3, P4_4, P4_5, P4_6, P4_7,
 
     // Analog input pins
-    AIN_0 = (0xA << PORT_SHIFT), AIN_1, AIN_2, AIN_3, AIN_4, AIN_5,
+    AIN_0 = (0xA << PORT_SHIFT), AIN_1, AIN_2, AIN_3, AIN_4, AIN_5, AIN_6, AIN_7, AIN_8, AIN_9,
 
     LED_GREEN  = P3_1,
     LED_RED    = P3_0,

--- a/targets/TARGET_Maxim/TARGET_MAX32625/TARGET_MAX32625NEXPAQ/PinNames.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/TARGET_MAX32625NEXPAQ/PinNames.h
@@ -60,7 +60,7 @@ typedef enum {
     P4_0 = (4 << PORT_SHIFT), P4_1, P4_2, P4_3, P4_4, P4_5, P4_6, P4_7,
 
     // Analog input pins
-    AIN_0 = (0xA << PORT_SHIFT), AIN_1, AIN_2, AIN_3, AIN_4, AIN_5,
+    AIN_0 = (0xA << PORT_SHIFT), AIN_1, AIN_2, AIN_3, AIN_4, AIN_5, AIN_6, AIN_7, AIN_8, AIN_9,
 
     // LEDs
     LED1 = P2_4,

--- a/targets/TARGET_Maxim/TARGET_MAX32625/analogin_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/analogin_api.c
@@ -65,7 +65,7 @@ float analogin_read(analogin_t *obj)
     float result;
 
     // Start conversion with no input scaling and no input buffer bypass
-    ADC_StartConvert(obj->channel, 0, 0);
+    ADC_StartConvert(obj->channel, 1, 0);
 
     if (ADC_GetData(&tmp) == E_OVERFLOW) {
         result = FLOAT_FULL_SCALE;
@@ -83,7 +83,7 @@ uint16_t analogin_read_u16(analogin_t *obj)
     uint16_t result;
 
     // Start conversion with no input scaling and no input buffer bypass
-    ADC_StartConvert(obj->channel, 0, 0);
+    ADC_StartConvert(obj->channel, 1, 0);
 
     if (ADC_GetData(&tmp) == E_OVERFLOW) {
         result = INT_FULL_SCALE;

--- a/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
@@ -101,7 +101,6 @@ int i2c_stop(i2c_t *obj)
 //******************************************************************************
 int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
 {
-    MBED_ASSERT(stop != 0);
     return I2CM_Read(obj->i2c, address >> 1, NULL, 0, (uint8_t *)data, length);
 }
 
@@ -145,11 +144,6 @@ int i2c_byte_read(i2c_t *obj, int last)
     if (last) {
         // NACK the last read byte
         if (I2CM_WriteTxFifo(i2cm, fifo, MXC_S_I2CM_TRANS_TAG_RXDATA_NACK) != E_NO_ERROR) {
-            goto byte_write_err;
-        }
-
-        // Send the stop condition
-        if (I2CM_WriteTxFifo(i2cm, fifo, MXC_S_I2CM_TRANS_TAG_STOP) != E_NO_ERROR) {
             goto byte_write_err;
         }
     } else {

--- a/targets/TARGET_Maxim/TARGET_MAX32625/serial_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/serial_api.c
@@ -48,8 +48,8 @@
                          MXC_F_UART_INTFL_RX_FIFO_OVERFLOW)
 
 // Variables for managing the stdio UART
-int stdio_uart_inited;
-serial_t stdio_uart;
+int stdio_uart_inited = 0;
+serial_t stdio_uart = {0};
 
 // Variables for interrupt driven
 static uart_irq_handler irq_handler;
@@ -74,12 +74,6 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Set the uart index
     obj->index = MXC_UART_GET_IDX(obj->uart);
     obj->fifo = (mxc_uart_fifo_regs_t*)MXC_UART_GET_BASE_FIFO(obj->index);
-
-    // Manage stdio UART
-    if (uart == STDIO_UART) {
-        stdio_uart_inited = 1;
-        memcpy(&stdio_uart, obj, sizeof(serial_t));
-    }
 
     // Record the pins requested
     obj->tx = tx;
@@ -110,6 +104,12 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     obj->cfg.baud = DEFAULT_BAUD;
     obj->cfg.size = UART_DATA_SIZE_8_BITS;
     obj->cfg.parity = UART_PARITY_DISABLE;
+
+    // Manage stdio UART
+    if (uart == STDIO_UART) {
+        stdio_uart_inited = 1;
+        stdio_uart = *obj;
+    }
 
     int retval = UART_Init(obj->uart, &obj->cfg, &obj->sys_cfg);
     MBED_ASSERT(retval == E_NO_ERROR);
@@ -181,7 +181,16 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
 void uart_handler(serial_t *obj)
 {
     if (obj && obj->id) {
-        irq_handler(obj->id, RxIrq);
+        // Check for errors or RX Threshold
+        if (obj->uart->intfl & (MXC_F_UART_INTFL_RX_FIFO_NOT_EMPTY | UART_ERRORS)) {
+            irq_handler(obj->id, RxIrq);
+            obj->uart->intfl = (MXC_F_UART_INTFL_RX_FIFO_NOT_EMPTY | UART_ERRORS);
+        }
+        // Check for TX Threshold
+        if (obj->uart->intfl & MXC_F_UART_INTFL_TX_FIFO_AE) {
+            irq_handler(obj->id, TxIrq);
+            obj->uart->intfl = MXC_F_UART_INTFL_TX_FIFO_AE;
+        }
     }
 }
 
@@ -199,6 +208,9 @@ void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id)
 //******************************************************************************
 void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 {
+    MBED_ASSERT(obj->index < MXC_CFG_UART_INSTANCES);
+    objs[obj->index] = obj;
+
     switch (obj->index) {
         case 0:
             NVIC_SetVector(UART0_IRQn, (uint32_t)uart0_handler);
@@ -250,7 +262,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
 //******************************************************************************
 int serial_getc(serial_t *obj)
 {
-    int c = 0;
+    int c = -1;
 
     if (obj->rx != NC) {
         // Wait for data to be available

--- a/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
@@ -183,7 +183,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
     req.deass = 1;
     req.callback = NULL;
 
-    __disable_irq();
+    core_util_critical_section_enter();
     if (tx_length == rx_length) {
         req.tx_data = (uint8_t *)tx_buffer;
         req.rx_data = (uint8_t *)rx_buffer;
@@ -214,7 +214,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, cha
             SPIM_Trans(obj->spi, &req);
         }
     }
-    __enable_irq();
+    core_util_critical_section_exit();
 
     while (SPIM_Busy(obj->spi));
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/spi_api.c
@@ -167,19 +167,58 @@ int spi_master_write(spi_t *obj, int value)
     return *req.rx_data;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
-    int total = (tx_length > rx_length) ? tx_length : rx_length;
+//******************************************************************************
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)
+{
+    spim_req_t req;
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
-        }
+    if (!(tx_length | rx_length) ||
+        (tx_length < 0) ||
+        (rx_length < 0)) {
+        return 0;
     }
 
-    return total;
+    req.width = SPIM_WIDTH_1;
+    req.ssel = 0;
+    req.deass = 1;
+    req.callback = NULL;
+
+    __disable_irq();
+    if (tx_length == rx_length) {
+        req.tx_data = (uint8_t *)tx_buffer;
+        req.rx_data = (uint8_t *)rx_buffer;
+        req.len = tx_length;
+        SPIM_Trans(obj->spi, &req);
+    } else if (tx_length < rx_length) {
+        req.tx_data = (tx_length > 0) ? (uint8_t *)tx_buffer : NULL;
+        req.rx_data = (uint8_t *)rx_buffer;
+        req.len = (tx_length > 0) ? tx_length : rx_length;
+        SPIM_Trans(obj->spi, &req);
+
+        if (tx_length) {
+            req.tx_data = NULL;
+            req.rx_data = (uint8_t *)(rx_buffer + tx_length);
+            req.len = rx_length - tx_length;
+            SPIM_Trans(obj->spi, &req);
+        }
+    } else {
+        req.tx_data = (uint8_t *)tx_buffer;
+        req.rx_data = (rx_length > 0) ? (uint8_t *)rx_buffer : NULL;
+        req.len = (rx_length > 0) ? rx_length : tx_length;
+        SPIM_Trans(obj->spi, &req);
+
+        if (rx_length) {
+            req.tx_data = (uint8_t *)(tx_buffer + rx_length);
+            req.rx_data = NULL;
+            req.len = tx_length - rx_length;
+            SPIM_Trans(obj->spi, &req);
+        }
+    }
+    __enable_irq();
+
+    while (SPIM_Busy(obj->spi));
+
+    return tx_length > rx_length ? tx_length : rx_length;
 }
 
 //******************************************************************************
@@ -193,4 +232,3 @@ uint8_t spi_get_module(spi_t *obj)
 {
     return obj->index;
 }
-

--- a/targets/TARGET_Maxim/TARGET_MAX32625/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/us_ticker.c
@@ -33,9 +33,11 @@
 
 #include <stddef.h>
 #include "mbed_error.h"
+#include "mbed_critical.h"
 #include "us_ticker_api.h"
 #include "PeripheralNames.h"
 #include "tmr.h"
+#include "assert.h"
 
 #define US_TIMER        MXC_TMR0
 #define US_TIMER_IRQn   TMR0_0_IRQn
@@ -49,13 +51,21 @@ static volatile uint64_t event_cnt;     // Holds the value of the next event
 #define MAX_TICK_VAL    ((uint64_t)0xFFFFFFFF * ticks_per_us)
 
 //******************************************************************************
-static inline void inc_current_cnt(uint32_t inc)
+static inline void inc_current_cnt_no_crit(uint32_t inc)
 {
     // Overflow the ticker when the us ticker overflows
     current_cnt += inc;
     if (current_cnt > MAX_TICK_VAL) {
         current_cnt -= (MAX_TICK_VAL + 1);
     }
+}
+
+//******************************************************************************
+static inline void inc_current_cnt(uint32_t inc)
+{
+    core_util_critical_section_enter();
+    inc_current_cnt_no_crit(inc);
+    core_util_critical_section_exit();
 }
 
 //******************************************************************************
@@ -89,10 +99,11 @@ static void tmr_handler(void)
 {
     uint32_t cmp = TMR32_GetCompare(US_TIMER);
     TMR32_SetCompare(US_TIMER, 0xFFFFFFFF); // reset to max value to prevent further interrupts
+    if (TMR32_GetFlag(US_TIMER)) {
+        inc_current_cnt_no_crit(cmp);
+    }
     TMR32_ClearFlag(US_TIMER);
     NVIC_ClearPendingIRQ(US_TIMER_IRQn);
-
-    inc_current_cnt(cmp);
 
     if (event_passed(current_cnt + TMR32_GetCount(US_TIMER), event_cnt)) {
         // the timestamp has expired
@@ -162,6 +173,7 @@ uint32_t us_ticker_read(void)
     uint64_t current_cnt1, current_cnt2;
     uint32_t cmp, cnt;
     uint32_t flag1, flag2;
+    static uint32_t last = 0;
 
     if (!us_ticker_inited) {
         us_ticker_init();
@@ -179,12 +191,19 @@ uint32_t us_ticker_read(void)
 
     // Account for an unserviced interrupt
     if (flag1) {
+        // Clear peripheral interrupt flag; leaving NVIC pending set
+        TMR32_ClearFlag(US_TIMER);
+        // Advance global count
+        inc_current_cnt(cmp + cnt);
+
         current_cnt1 += cmp;
     }
 
     current_cnt1 += cnt;
 
-    return (current_cnt1 / ticks_per_us);
+    assert(last <= (current_cnt1 / ticks_per_us));
+    last = (current_cnt1 / ticks_per_us);
+    return last;
 }
 
 //******************************************************************************
@@ -228,6 +247,7 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
     TMR32_Start(US_TIMER);
 }
 
+//******************************************************************************
 void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(US_TIMER_IRQn);


### PR DESCRIPTION
MAX32625: Fix serial interrupts and I2C master; Improve SPI block write, us ticker performance, ADC functionality 

# Description

Fix problems with missing serial objects for interrupts.
Remove automatic stop signaling after read transaction to allow repeated start after read.
Improve SPI block write by replacing byte write loop with hardware assisted block transaction.
Improve performance of us ticker.
Increase analog input range by 2x.

Tested all supported toolchains with MAX32625MBED.

# Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New Target
- [ ] Feature
