### PR TITLE
MPS2_M4 porting to mbed-os 5.x

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -1,0 +1,203 @@
+/*
+ * MPS2 CMSIS Library
+ */
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+MEMORY
+{
+  VECTORS (rx)          : ORIGIN = 0x00000000, LENGTH = 0x00000100
+  FLASH (rx)            : ORIGIN = 0x00000400, LENGTH = 0x00400000 - 0x00000100
+  RAM (rwx)             : ORIGIN = 0x20000000, LENGTH = 0x00400000
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ *   Reset_Handler : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ *   __exidx_start
+ *   __exidx_end
+ *   __etext
+ *   __data_start__
+ *   __preinit_array_start
+ *   __preinit_array_end
+ *   __init_array_start
+ *   __init_array_end
+ *   __fini_array_start
+ *   __fini_array_end
+ *   __data_end__
+ *   __bss_start__
+ *   __bss_end__
+ *   __end__
+ *   end
+ *   __HeapLimit
+ *   __StackLimit
+ *   __StackTop
+ *   __stack
+ */
+ENTRY(Reset_Handler)
+
+HEAP_SIZE  = 0x4000;
+STACK_SIZE = 0x1000;
+
+/* Size of the vector table in SRAM */
+M_VECTOR_RAM_SIZE = 0x100;
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        __vector_table = .;
+        KEEP(*(.vector_table))
+         . = ALIGN(4);
+    } > VECTORS
+
+    .text :
+    {
+        . = ALIGN(4);
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    .interrupts_ram :
+    {
+        . = ALIGN(4);
+        __VECTOR_RAM__ = .;
+        __interrupts_ram_start__ = .;   /* Create a global symbol at data start */
+        . += M_VECTOR_RAM_SIZE;
+        . = ALIGN(4);
+        __interrupts_ram_end__ = .;     /* Define a global symbol at data end */
+    } > RAM
+
+    .data :
+    {
+        PROVIDE(__etext = LOADADDR(.data));
+        . = ALIGN(4);
+        __data_start__ = .;
+        *(vtable)
+        *(.data)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM AT > FLASH
+
+    .uninitialized (NOLOAD):
+    {
+        . = ALIGN(32);
+        __uninitialized_start = .;
+        *(.uninitialized)
+        KEEP(*(.keep.uninitialized))
+        . = ALIGN(32);
+        __uninitialized_end = .;
+    } > RAM
+
+    .bss :
+    {
+        . = ALIGN(4);
+        __START_BSS = .;
+        __bss_start__ = .;
+        *(.bss)
+        *(.bss*)
+        *(COMMON)
+        . = ALIGN(4);
+        __bss_end__ = .;
+        __END_BSS = .;
+
+    } > RAM
+
+    bss_size = __bss_end__ - __bss_start__;
+
+    .heap :
+    {
+        . = ALIGN(8);
+        __end__ = .;
+        PROVIDE(end = .);
+        __HeapBase = .;
+        . += HEAP_SIZE;
+        __HeapLimit = .;
+        __heap_limit = .; /* Add for _sbrk */
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - STACK_SIZE;
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+
+}   /* End of sections */

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -1,0 +1,184 @@
+/*
+ * MPS2 CMSIS Library
+ */
+/*
+ * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
+ * This file is derivative of CMSIS V5.00 startup_ARMCM3.S
+ */
+    .syntax unified
+    .arch armv7-m
+
+    .section .vector_table,"a",%progbits
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long    Reset_Handler         /* Reset Handler */
+    .long    NMI_Handler           /* NMI Handler */
+    .long    HardFault_Handler     /* Hard Fault Handler */
+    .long    MemManage_Handler     /* MPU Fault Handler */
+    .long    BusFault_Handler      /* Bus Fault Handler */
+    .long    UsageFault_Handler    /* Usage Fault Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    SVC_Handler           /* SVCall Handler */
+    .long    DebugMon_Handler      /* Debug Monitor Handler */
+    .long    0                     /* Reserved */
+    .long    PendSV_Handler        /* PendSV Handler */
+    .long    SysTick_Handler       /* SysTick Handler */
+
+    /* External Interrupts */
+    .long    UARTRX0_Handler           /* UART 0 RX Handler    */
+    .long    UARTTX0_Handler           /* UART 0 TX Handler    */
+    .long    UARTRX1_Handler           /* UART 1 RX Handler    */
+    .long    UARTTX1_Handler           /* UART 1 TX Handler    */
+    .long    UARTRX2_Handler           /* UART 2 RX Handler    */
+    .long    UARTTX2_Handler           /* UART 2 TX Handler    */
+    .long    PORT0_COMB_Handler        /* GPIO Port 0 Combined Handler    */
+    .long    PORT1_COMB_Handler        /* GPIO Port 1 Combined Handler    */
+    .long    TIMER0_Handler            /* TIMER 0 handler    */
+    .long    TIMER1_Handler            /* TIMER 1 handler    */
+    .long    DUALTIMER_HANDLER         /* Dual timer handler    */
+    .long    SPI_Handler               /* SPI exceptions Handler    */
+    .long    UARTOVF_Handler           /* UART 0,1,2 Overflow Handler    */
+    .long    ETHERNET_Handler          /* Ethernet Overflow Handler    */
+    .long    I2S_Handler               /* I2S Handler    */
+    .long    TSC_Handler               /* Touch Screen handler    */
+    .long    PORT2_COMB_Handler        /* GPIO Port 2 Combined Handler    */
+    .long    PORT3_COMB_Handler        /* GPIO Port 3 Combined Handler    */
+    .long    UARTRX3_Handler           /* UART 3 RX Handler    */
+    .long    UARTTX3_Handler           /* UART 3 TX Handler    */
+    .long    UARTRX4_Handler           /* UART 4 RX Handler    */
+    .long    UARTTX4_Handler           /* UART 4 TX Handler    */
+    .long    ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler    */
+    .long    SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler    */
+    .long    PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler               */
+    .long    PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler               */
+    .long    PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler               */
+    .long    PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler               */
+    .long    PORT0_4_Handler           /* GPIO Port 0 pin 4 Handler               */
+    .long    PORT0_5_Handler           /* GPIO Port 0 pin 5 Handler               */
+    .long    PORT0_6_Handler           /* GPIO Port 0 pin 6 Handler               */
+    .long    PORT0_7_Handler           /* GPIO Port 0 pin 7 Handler               */
+
+    .size    __isr_vector, . - __isr_vector
+
+    .section .text.Reset_Handler
+    .thumb
+    .thumb_func
+    .align  2
+    .globl   Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    ldr    r0, =SystemInit
+    blx    r0
+
+/* Initialize .bss */
+init_bss:
+    ldr   r1, =__bss_start__
+    ldr   r2, =__bss_end__
+    ldr   r3, =bss_size
+
+    cmp   r3, #0
+    beq   system_startup
+
+    mov   r4, #0
+zero:
+    strb  r4, [r1], #1
+    subs  r3, r3, #1
+    bne   zero
+
+system_startup:
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx    r0
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .text
+/*
+ * Macro to define default handlers. Default handler
+ * will be weak symbol and just dead loops. They can be
+ * overwritten by other handlers
+ */
+    .macro    def_default_handler    handler_name
+    .align 1
+    .thumb_func
+    .weak    \handler_name
+    .type    \handler_name, %function
+\handler_name :
+    b    .
+    .size    \handler_name, . - \handler_name
+    .endm
+
+    def_default_handler    NMI_Handler
+    def_default_handler    HardFault_Handler
+    def_default_handler    MemManage_Handler
+    def_default_handler    BusFault_Handler
+    def_default_handler    UsageFault_Handler
+    def_default_handler    SVC_Handler
+    def_default_handler    DebugMon_Handler
+    def_default_handler    PendSV_Handler
+    def_default_handler    SysTick_Handler
+    def_default_handler    Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+
+    /* External interrupts */
+
+    def_irq_default_handler UARTRX0_Handler
+    def_irq_default_handler UARTTX0_Handler
+    def_irq_default_handler UARTRX1_Handler
+    def_irq_default_handler UARTTX1_Handler
+    def_irq_default_handler UARTRX2_Handler
+    def_irq_default_handler UARTTX2_Handler
+    def_irq_default_handler PORT0_COMB_Handler
+    def_irq_default_handler PORT1_COMB_Handler
+    def_irq_default_handler TIMER0_Handler
+    def_irq_default_handler TIMER1_Handler
+    def_irq_default_handler DUALTIMER_HANDLER
+    def_irq_default_handler SPI_Handler
+    def_irq_default_handler UARTOVF_Handler
+    def_irq_default_handler ETHERNET_Handler
+    def_irq_default_handler I2S_Handler
+    def_irq_default_handler TSC_Handler
+    def_irq_default_handler PORT2_COMB_Handler
+    def_irq_default_handler PORT3_COMB_Handler
+    def_irq_default_handler UARTRX3_Handler
+    def_irq_default_handler UARTTX3_Handler
+    def_irq_default_handler UARTRX4_Handler
+    def_irq_default_handler UARTTX4_Handler
+    def_irq_default_handler ADCSPI_Handler
+    def_irq_default_handler SHIELDSPI_Handler
+    def_irq_default_handler PORT0_0_Handler
+    def_irq_default_handler PORT0_1_Handler
+    def_irq_default_handler PORT0_2_Handler
+    def_irq_default_handler PORT0_3_Handler
+    def_irq_default_handler PORT0_4_Handler
+    def_irq_default_handler PORT0_5_Handler
+    def_irq_default_handler PORT0_6_Handler
+    def_irq_default_handler PORT0_7_Handler
+
+    .end

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_IAR/MPS2.icf
@@ -1,0 +1,40 @@
+/* Device specific values */
+
+define symbol ROM_START   = 0x00000000;
+define symbol ROM_SIZE    = 0x00400000;
+define symbol RAM_START   = 0x20000000;
+define symbol RAM_SIZE    = 0X400000;
+define symbol VECTORS     = 64; /* This value must match NVIC_NUM_VECTORS */
+define symbol HEAP_SIZE   = 0x4000;
+
+/* Common - Do not change */
+
+if (!isdefinedsymbol(MBED_APP_START)) {
+    define symbol MBED_APP_START = ROM_START;
+}
+
+if (!isdefinedsymbol(MBED_APP_SIZE)) {
+    define symbol MBED_APP_SIZE = ROM_SIZE;
+}
+
+/* Round up VECTORS_SIZE to 8 bytes */
+define symbol VECTORS_SIZE = ((VECTORS * 4) + 7) & ~7;
+define symbol RAM_REGION_START = RAM_START + VECTORS_SIZE;
+define symbol RAM_REGION_SIZE = RAM_SIZE - VECTORS_SIZE;
+define symbol ISR_STACK_SIZE = 0x400;
+
+define memory mem with size = 4G;
+define region ROM_region = mem:[from MBED_APP_START size MBED_APP_SIZE];
+define region RAM_region = mem:[from RAM_REGION_START size RAM_REGION_SIZE];
+
+define block CSTACK    with alignment = 8, size = ISR_STACK_SIZE   { };
+define block HEAP      with alignment = 8, size = HEAP_SIZE     { };
+
+initialize by copy { readwrite };
+do not initialize  { section .noinit };
+
+place at address mem: MBED_APP_START { readonly section .intvec };
+
+place in ROM_region   { readonly };
+place in RAM_region   { readwrite,
+                        block CSTACK, block HEAP };

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_IAR/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_IAR/startup_MPS2.S
@@ -1,0 +1,336 @@
+;/*
+; * MPS2 CMSIS Library
+; */
+;/*
+; * Copyright (c) 2009-2017 ARM Limited. All rights reserved.
+; *
+; * SPDX-License-Identifier: Apache-2.0
+; *
+; * Licensed under the Apache License, Version 2.0 (the License); you may
+; * not use this file except in compliance with the License.
+; * You may obtain a copy of the License at
+; *
+; * http://www.apache.org/licenses/LICENSE-2.0
+; *
+; * Unless required by applicable law or agreed to in writing, software
+; * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+; * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; * See the License for the specific language governing permissions and
+; * limitations under the License.
+; */
+;/*
+; * This file is derivative of CMSIS V5.00 startup_Device.s
+; */
+
+
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler             ; Reset Handler
+        DCD     NMI_Handler               ; NMI Handler
+        DCD     HardFault_Handler         ; Hard Fault Handler
+        DCD     MemManage_Handler         ; MPU Fault Handler
+        DCD     BusFault_Handler          ; Bus Fault Handler
+        DCD     UsageFault_Handler        ; Usage Fault Handler
+__vector_table_0x1c
+        DCD     0                         ; Reserved
+        DCD     0                         ; Reserved
+        DCD     0                         ; Reserved
+        DCD     0                         ; Reserved
+        DCD     SVC_Handler               ; SVCall Handler
+        DCD     DebugMon_Handler          ; Debug Monitor Handler
+        DCD     0                         ; Reserved
+        DCD     PendSV_Handler            ; PendSV Handler
+        DCD     SysTick_Handler           ; SysTick Handler
+
+        ; External Interrupts
+        DCD     UARTRX0_Handler           ; UART 0 RX Handler
+        DCD     UARTTX0_Handler           ; UART 0 TX Handler
+        DCD     UARTRX1_Handler           ; UART 1 RX Handler
+        DCD     UARTTX1_Handler           ; UART 1 TX Handler
+        DCD     UARTRX2_Handler           ; UART 2 RX Handler
+        DCD     UARTTX2_Handler           ; UART 2 TX Handler
+        DCD     PORT0_COMB_Handler        ; GPIO Port 0 Combined Handler
+        DCD     PORT1_COMB_Handler        ; GPIO Port 1 Combined Handler
+        DCD     TIMER0_Handler            ; TIMER 0 handler
+        DCD     TIMER1_Handler            ; TIMER 1 handler
+        DCD     DUALTIMER_HANDLER         ; Dual timer handler
+        DCD     SPI_Handler               ; SPI exceptions Handler
+        DCD     UARTOVF_Handler           ; UART 0,1,2 Overflow Handler
+        DCD     ETHERNET_Handler          ; Ethernet Overflow Handler
+        DCD     I2S_Handler               ; I2S Handler
+        DCD     TSC_Handler               ; Touch Screen handler
+        DCD     PORT2_COMB_Handler        ; GPIO Port 2 Combined Handler
+        DCD     PORT3_COMB_Handler        ; GPIO Port 3 Combined Handler
+        DCD     UARTRX3_Handler           ; UART 3 RX Handler
+        DCD     UARTTX3_Handler           ; UART 3 TX Handler
+        DCD     UARTRX4_Handler           ; UART 4 RX Handler
+        DCD     UARTTX4_Handler           ; UART 4 TX Handler
+        DCD     ADCSPI_Handler            ; SHIELD ADC SPI exceptions Handler
+        DCD     SHIELDSPI_Handler         ; SHIELD SPI exceptions Handler
+        DCD     PORT0_0_Handler           ; GPIO Port 0 pin 0 Handler
+        DCD     PORT0_1_Handler           ; GPIO Port 0 pin 1 Handler
+        DCD     PORT0_2_Handler           ; GPIO Port 0 pin 2 Handler
+        DCD     PORT0_3_Handler           ; GPIO Port 0 pin 3 Handler
+        DCD     PORT0_4_Handler           ; GPIO Port 0 pin 4 Handler
+        DCD     PORT0_5_Handler           ; GPIO Port 0 pin 5 Handler
+        DCD     PORT0_6_Handler           ; GPIO Port 0 pin 6 Handler
+        DCD     PORT0_7_Handler           ; GPIO Port 0 pin 7 Handler
+__Vectors_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size  EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+	PUBWEAK NMI_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+	B NMI_Handler
+
+	PUBWEAK HardFault_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+HardFault_Handler
+	B HardFault_Handler
+
+	PUBWEAK MemManage_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+MemManage_Handler
+	B MemManage_Handler
+
+	PUBWEAK BusFault_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+BusFault_Handler
+	B BusFault_Handler
+
+	PUBWEAK UsageFault_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UsageFault_Handler
+	B UsageFault_Handler
+
+	PUBWEAK SVC_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+	B SVC_Handler
+
+	PUBWEAK DebugMon_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+DebugMon_Handler
+	B DebugMon_Handler
+
+	PUBWEAK PendSV_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+	B PendSV_Handler
+
+	PUBWEAK SysTick_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+	B SysTick_Handler
+
+	PUBWEAK UARTRX0_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTRX0_Handler
+	B UARTRX0_Handler
+
+	PUBWEAK UARTTX0_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTTX0_Handler
+	B UARTTX0_Handler
+
+	PUBWEAK UARTRX1_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTRX1_Handler
+	B UARTRX1_Handler
+
+	PUBWEAK UARTTX1_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTTX1_Handler
+	B UARTTX1_Handler
+
+	PUBWEAK UARTRX2_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTRX2_Handler
+	B UARTRX2_Handler
+
+	PUBWEAK UARTTX2_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTTX2_Handler
+	B UARTTX2_Handler
+
+	PUBWEAK PORT0_COMB_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_COMB_Handler
+	B PORT0_COMB_Handler
+
+	PUBWEAK PORT1_COMB_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT1_COMB_Handler
+	B PORT1_COMB_Handler
+
+	PUBWEAK TIMER0_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+TIMER0_Handler
+	B TIMER0_Handler
+
+	PUBWEAK TIMER1_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+TIMER1_Handler
+	B TIMER1_Handler
+
+	PUBWEAK DUALTIMER_HANDLER
+	SECTION .text:CODE:REORDER:NOROOT(1)
+DUALTIMER_HANDLER
+	B DUALTIMER_HANDLER
+
+	PUBWEAK SPI_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+SPI_Handler
+	B SPI_Handler
+
+	PUBWEAK UARTOVF_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTOVF_Handler
+	B UARTOVF_Handler
+
+	PUBWEAK ETHERNET_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+ETHERNET_Handler
+	B ETHERNET_Handler
+
+	PUBWEAK I2S_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+I2S_Handler
+	B I2S_Handler
+
+	PUBWEAK TSC_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+TSC_Handler
+	B TSC_Handler
+
+	PUBWEAK PORT2_COMB_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT2_COMB_Handler
+	B PORT2_COMB_Handler
+
+	PUBWEAK PORT3_COMB_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT3_COMB_Handler
+	B PORT3_COMB_Handler
+
+	PUBWEAK UARTRX3_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTRX3_Handler
+	B UARTRX3_Handler
+
+	PUBWEAK UARTTX3_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTTX3_Handler
+	B UARTTX3_Handler
+
+	PUBWEAK UARTRX4_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTRX4_Handler
+	B UARTRX4_Handler
+
+	PUBWEAK UARTTX4_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+UARTTX4_Handler
+	B UARTTX4_Handler
+
+	PUBWEAK ADCSPI_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+ADCSPI_Handler
+	B ADCSPI_Handler
+
+	PUBWEAK SHIELDSPI_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+SHIELDSPI_Handler
+	B SHIELDSPI_Handler
+
+	PUBWEAK PORT0_0_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_0_Handler
+	B PORT0_0_Handler
+
+	PUBWEAK PORT0_1_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_1_Handler
+	B PORT0_1_Handler
+
+	PUBWEAK PORT0_2_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_2_Handler
+	B PORT0_2_Handler
+
+	PUBWEAK PORT0_3_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_3_Handler
+	B PORT0_3_Handler
+
+	PUBWEAK PORT0_4_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_4_Handler
+	B PORT0_4_Handler
+
+	PUBWEAK PORT0_5_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_5_Handler
+	B PORT0_5_Handler
+
+	PUBWEAK PORT0_6_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_6_Handler
+	B PORT0_6_Handler
+
+	PUBWEAK PORT0_7_Handler
+	SECTION .text:CODE:REORDER:NOROOT(1)
+PORT0_7_Handler
+	B PORT0_7_Handler
+
+        END

--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -25,4 +25,12 @@
 
 #endif
 
+#if defined(TARGET_MPS2_M4)
+
+#ifndef INITIAL_SP
+#define INITIAL_SP              (0x20040000UL)
+#endif
+
+#endif
+
 #endif  // MBED_MBED_RTX_H

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2606,12 +2606,12 @@
     },
     "ARM_MPS2_M4": {
         "inherits": ["ARM_MPS2_Target"],
-        "core": "Cortex-M4F",
-        "supported_toolchains": ["ARM"],
+        "core": "Cortex-M4",
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
         "macros": ["CMSDK_CM4"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"]
     },
     "ARM_MPS2_M7": {
         "inherits": ["ARM_MPS2_Target"],


### PR DESCRIPTION
# Description
Initial support for MPS2_M4 target fro mbed-os 5
Uses the sources from mbed2 and adds support for all the supported toolchains


# Pull request type

- [ ] Fix
- [ ] Refactor
- [X] New Target
- [ ] Feature
