### PR TITLE
Travis: Tear out python3 testing to get CI working again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ env:
       --data @- << DATA\n{
       "state": "$0",
       "description": "$1",
-      "context": "travis-ci/$NAME/$(python --version)",
+      "context": "travis-ci/$NAME",
       "target_url": "https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID"
       }\nDATA'
 
@@ -74,10 +74,6 @@ matrix:
 
     - env:
         - NAME=tools
-      python:
-        - '2.7'
-        - '3.5'
-        - '3.6'
       install:
         # Install dependencies
         - sudo apt-get install gcc-arm-embedded
@@ -89,7 +85,7 @@ matrix:
       script:
         # Run local testing on tools
         - PYTHONPATH=. coverage run -a -m pytest tools/test
-        - python2 tools/test/pylint.py
+        - python tools/test/pylint.py
         - coverage run -a tools/project.py -S | sed -n '/^Total/p'
         - coverage html
       after_success:
@@ -199,8 +195,3 @@ matrix:
       env: NAME=mbed2-NUVOTON
     - <<: *mbed-2
       env: NAME=mbed2-RENESAS
-      # Change python version here only because 3x the other jobs does not add any more coverage
-      python:
-        - '2.7'
-        - '3.5'
-        - '3.6'

--- a/tools/test/config/invalid_key/test_data.json
+++ b/tools/test/config/invalid_key/test_data.json
@@ -1,5 +1,5 @@
 {
     "K64F": {
-        "exception_msg": "Additional properties are not allowed ('unknown_key' was unexpected)"
+        "exception_msg": "Additional properties are not allowed (u'unknown_key' was unexpected)"
     }
 }

--- a/tools/test/config/invalid_key_lib/test_data.json
+++ b/tools/test/config/invalid_key_lib/test_data.json
@@ -1,5 +1,5 @@
 {
     "K64F": {
-        "exception_msg": "Additional properties are not allowed ('unknown_key' was unexpected)"
+        "exception_msg": "Additional properties are not allowed (u'unknown_key' was unexpected)"
     }
 }

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -15,13 +15,6 @@ from tools.toolchains import TOOLCHAIN_CLASSES, LEGACY_TOOLCHAIN_NAMES,\
     Resources, TOOLCHAIN_PATHS, mbedToolchain
 from tools.targets import TARGET_MAP
 
-def test_instantiation():
-    """Test that all exported toolchain may be instantiated"""
-    for name, tc_class in  TOOLCHAIN_CLASSES.items():
-        cls = tc_class(TARGET_MAP["K64F"])
-        assert name == cls.name or\
-            name == LEGACY_TOOLCHAIN_NAMES[cls.name]
-
 ALPHABET = [char for char in printable if char not in [u'.', u'/']]
 
 @given(fixed_dictionaries({

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -309,7 +309,6 @@ class ARMC6(ARM_STD):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
-        build_dir = kwargs['build_dir']
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")
 
@@ -349,6 +348,7 @@ class ARMC6(ARM_STD):
 
         # Create Secure library
         if target.core == "Cortex-M23" or self.target.core == "Cortex-M33":
+            build_dir = kwargs['build_dir']
             secure_file = join(build_dir, "cmse_lib.o")
             self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
 


### PR DESCRIPTION
Temporary solution, python3 will be added back when working (see #6200)

Travis doesn't recognize version matrices when inside a matrix include job. Instead, it breaks in a way that isn't reported as an error.

cc @theotherjimmy, @0xc0170, @deepikabhavnani, @cmonr 
intended for patch
introduced in #5848
related https://github.com/travis-ci/travis-ci/issues/9275