### PR TITLE
LPC546XX: Add TRNG support

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/objects.h
@@ -58,8 +58,14 @@ struct spi_s {
     uint8_t bits;
 };
 
-#if DEVICE_FLASH
+#if defined(DEVICE_FLASH)
 struct flash_s {
+    uint8_t dummy;
+};
+#endif
+
+#if defined(DEVICE_TRNG)
+struct trng_s {
     uint8_t dummy;
 };
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/trng_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/trng_api.c
@@ -1,0 +1,59 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "trng_api.h"
+
+#if defined(DEVICE_TRNG)
+#include "fsl_rng.h"
+
+void trng_init(trng_t *obj)
+{
+}
+
+void trng_free(trng_t *obj)
+{
+}
+
+int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_length)
+{
+    uint32_t skip;
+    uint32_t data;
+    size_t idx = 0;
+    int i;
+
+    /* Get Random data */
+    while (idx < length) {
+
+        data = RNG_GetRandomData();
+
+        for (i = 0; ((i < 4) && (idx < length)); i++) {
+            output[idx++] = (data >> (i * 8)) & 0xFF;
+        }
+
+        /* Skip next 32 random numbers for better entropy */
+        for (skip = 0; skip < 32; skip++) {
+            RNG_GetRandomData();
+        }
+    }
+
+    *output_length = idx;
+
+    /* Zeroize to avoid leakage of entropy on the stack. Also ensure this is not removed by compiler optimizations */
+    *((volatile uint32_t*) &data) = 0;
+
+    return (idx == length ? 0 : -1);
+}
+#endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -747,7 +747,7 @@
         "is_disk_virtual": true,
         "macros": ["CPU_LPC54628J512ET180", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH", "TRNG"],
         "features": ["LWIP"],
         "device_name" : "LPC54628J512ET180"
     },


### PR DESCRIPTION
LPC546XX: Add TRNG support

| LPC546XX-ARM | LPC546XX      | mbed-os-tests-mbedtls-multi                                                          |
Crypto: sha256_multi                                                                              | 1      | 0      | OK
      | 0.82               |
| LPC546XX-ARM | LPC546XX      | mbed-os-tests-mbedtls-multi                                                          |
Crypto: sha256_split                                                                              | 1      | 0      | OK
      | 0.28               |
| LPC546XX-ARM | LPC546XX      | mbed-os-tests-mbedtls-selftest                                                       |
mbedtls_entropy_self_test                                                                         | 1      | 0      | OK
      | 0.12               |
| LPC546XX-ARM | LPC546XX      | mbed-os-tests-mbedtls-selftest                                                       |
mbedtls_sha256_self_test                                                                          | 1      | 0      | OK
      | 0.98               |
| LPC546XX-ARM | LPC546XX      | mbed-os-tests-mbedtls-selftest                                                       |
mbedtls_sha512_self_test                                                                          | 1      | 0      | OK
      | 2.1                |