### PR TITLE
rtl8195am: fix ARM section error

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/analogin_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/analogin_api.c
@@ -19,7 +19,9 @@
 #include "hal_adc.h"
 #include "analogin_api.h"
 
-
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
 
 #if CONFIG_ADC_EN
 #include "pinmap.h"

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -29,9 +29,6 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
     *libc.a (+RW)
     *(.sdram.data*)
     *lib_peripheral_mbed_arm.ar (+RW)
-  }
-
-  RW_IRAM2 +0 UNINIT FIXED {
     *rtl8195a_crypto*.o(+ZI, COMMON)
     *libc.a (+ZI, COMMON)
     *(.bss.thread_stack_main)

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
@@ -18,14 +18,14 @@
 #if defined(__CC_ARM) || \
     (defined (__ARMCC_VERSION) && __ARMCC_VERSION >= 6010050)
 
-extern uint8_t Image$$RW_IRAM2$$ZI$$Base[];
-extern uint8_t Image$$RW_IRAM2$$ZI$$Limit[];
+extern uint8_t Image$$RW_IRAM1$$ZI$$Base[];
+extern uint8_t Image$$RW_IRAM1$$ZI$$Limit[];
 extern uint8_t Image$$TCM_OVERLAY$$ZI$$Base[];
 extern uint8_t Image$$TCM_OVERLAY$$ZI$$Limit[];
 extern uint8_t Image$$RW_DRAM2$$ZI$$Base[];
 extern uint8_t Image$$RW_DRAM2$$ZI$$Limit[];
-#define __bss_sram_start__ Image$$RW_IRAM2$$ZI$$Base
-#define __bss_sram_end__   Image$$RW_IRAM2$$ZI$$Limit
+#define __bss_sram_start__ Image$$RW_IRAM1$$ZI$$Base
+#define __bss_sram_end__   Image$$RW_IRAM1$$ZI$$Limit
 #define __bss_dtcm_start__ Image$$TCM_OVERLAY$$ZI$$Base
 #define __bss_dtcm_end__   Image$$TCM_OVERLAY$$ZI$$Limit
 #define __bss_dram_start__ Image$$RW_DRAM2$$ZI$$Base

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/log_uart_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/log_uart_api.c
@@ -17,6 +17,10 @@
 #include "objects.h"
 #include "log_uart_api.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #include <string.h>
 
 const u32 log_uart_support_rate[] = {

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/pwmout_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/pwmout_api.c
@@ -18,6 +18,10 @@
 #include "objects.h"
 #include "pinmap.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #if DEVICE_PWMOUT
 
 #ifdef CONFIG_PWM_EN

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
@@ -17,6 +17,11 @@
 #include "rtl8195a.h"
 #include "objects.h"
 #include "serial_api.h"
+
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #if CONFIG_UART_EN
 
 #include "pinmap.h"

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
@@ -21,6 +21,10 @@
 #include "pinmap.h"
 #include "hal_ssi.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 extern u32 SystemGetCpuClk(VOID);
 extern VOID HAL_GPIO_PullCtrl(u32 pin, u32 mode);
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/trng_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/trng_api.c
@@ -17,6 +17,10 @@
 #include "analogin_api.h"
 #include "analogin_ext.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #ifdef DEVICE_TRNG
 
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/sdk/common/api/platform/platform_stdlib.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/sdk/common/api/platform/platform_stdlib.h
@@ -51,6 +51,7 @@
 	#include <stdint.h>
 	#include "diag.h"
 	#define strsep(str, delim)      	_strsep(str, delim)
+	#define _memset(dst, val, sz)		memset(dst, val, sz)
 #else
 	#include <stdio.h>
 	#include <stdlib.h>


### PR DESCRIPTION
# Description

fix section error, ARM compiler uses IRAM1.bss to calculate the heap size

fix conflict of _memset between Ameba's library and ARM compiler's library, use standard memset() instead of _memset() in case of ARM compiler

rebase update for #6061

# Pull request type

- [x] Fix

