### PR TITLE
Nuvoton: Add I2C & Serial Pin Name

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/PinNames.h
@@ -104,13 +104,18 @@ typedef enum {
     D13 = PC_5,
     D14 = PE_5,
     D15 = PE_4,
+
+    I2C_SCL = D15,
+    I2C_SDA = D14,
     
-    // FIXME: other board-specific naming
+    // NOTE: board-specific naming
     // UART naming
     USBTX = PA_8,
     USBRX = PA_9,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
+    SERIAL_TX = USBTX,
+    SERIAL_RX = USBRX,
     // LED naming
     LED1 = PD_2,
     LED2 = PD_3,

--- a/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/TARGET_NUMAKER_PFM_M487/PinNames.h
@@ -105,12 +105,17 @@ typedef enum {
     D14 = PG_3,
     D15 = PG_2,
 
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+    
     // Note: board-specific
     // UART naming
     USBTX = PD_3,
     USBRX = PD_2,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
+    SERIAL_TX = USBTX,
+    SERIAL_RX = USBRX,    
     // LED naming
     LED_RED = PH_0,
     LED_YELLOW = PH_1,

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/TARGET_NUMAKER_PFM_NANO130/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/TARGET_NUMAKER_PFM_NANO130/PinNames.h
@@ -102,13 +102,18 @@ typedef enum {
     D13 = PC_1,
     D14 = PC_8,
     D15 = PC_9,
-    
+
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+        
     // NOTE: other board-specific naming
     // UART naming
     USBTX = PB_1,
     USBRX = PB_0,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
+    SERIAL_TX = USBTX,
+    SERIAL_RX = USBRX,    
     // LED naming
     LED1 = PE_11,
     LED2 = PE_10,

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/PinNames.h
@@ -107,13 +107,18 @@ typedef enum {
     D13 = PD_0,
     D14 = PD_12,
     D15 = PD_10,
-    
-    // FIXME: other board-specific naming
+
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+     
+    // NOTE: other board-specific naming
     // UART naming
     USBTX = PD_5,
     USBRX = PD_4,
     STDIO_UART_TX   = USBTX,
     STDIO_UART_RX   = USBRX,
+    SERIAL_TX = USBTX,
+    SERIAL_RX = USBRX,    
     // LED naming
     LED1 = PD_9,
     LED2 = PA_4,


### PR DESCRIPTION
This PR is to add I2C & Serial pin name definition for compatibility in existing mbed samples.
It updates the following Nuvoton targets and passed Greentea test:

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487
- NUMAKER_PFM_NANO130
