### PR TITLE
Nuvoton: Rework us_ticker/lp_ticker with one H/W timer

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
@@ -35,18 +35,14 @@
 /* Timer max counter */
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
-static void tmr2_vec(void);
-static void tmr3_vec(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
-
-static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
+static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
-/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
-static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
-static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+
+#define TIMER_MODINIT      timer1_modinit
+
+static int ticker_inited = 0;
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -58,43 +54,37 @@ void lp_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-
     // Reset module
-    SYS_ResetModule(timer2_modinit.rsetidx);
-    SYS_ResetModule(timer3_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
-    CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer2_modinit.clkidx);
-    CLK_EnableModuleClock(timer3_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Configure clock
-    uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // Continuous mode
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer2/* | TIMER_CTL_CNTDATEN_Msk*/;
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMP = cmp_timer2;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer/* | TIMER_CTL_CNTDATEN_Msk*/;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
     // Set vector
-    NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
-    NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer2_modinit.irq_n);
-    NVIC_EnableIRQ(timer3_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
     /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
     wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 timestamp_t lp_ticker_read()
@@ -103,145 +93,49 @@ timestamp_t lp_ticker_read()
         lp_ticker_init();
     }
 
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-     
-    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        lp_ticker_fire_interrupt();
-    }
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
+    TIMER_Start(timer_base);
 }
 
 void lp_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
-}
-
-static void tmr2_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-}
-
-static void tmr3_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-
-    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-    lp_ticker_irq_handler();
-    
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    timer3_base->CTL |= TIMER_CTL_RSTCNT_Msk;
-    // One-shot mode, Clock = 1 KHz 
-    uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
-    // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
-    timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
-    timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3/* | TIMER_CTL_CNTDATEN_Msk*/;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer3 = cd_clk;
-    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cmp_timer3;
-
-    TIMER_EnableInt(timer3_base);
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start(timer3_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* lp_ticker_get_info()
@@ -251,6 +145,15 @@ const ticker_info_t* lp_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr1_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
@@ -32,16 +32,12 @@
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
-static void tmr1_vec(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
+
+static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
+
+#define TIMER_MODINIT      timer0_modinit
 
 static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
-
-/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
-static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
-static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK0, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -53,38 +49,32 @@ void us_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-    
     // Reset IP
-    SYS_ResetModule(timer0hires_modinit.rsetidx);
-    SYS_ResetModule(timer1hires_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
-    CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer0hires_modinit.clkidx);
-    CLK_EnableModuleClock(timer1hires_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Timer for normal counter
-    uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0/* | TIMER_CTL_CNTDATEN_Msk*/;
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMP = cmp_timer0;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer/* | TIMER_CTL_CNTDATEN_Msk*/;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
-    NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
-    NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer0hires_modinit.irq_n);
-    NVIC_EnableIRQ(timer1hires_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 uint32_t us_ticker_read()
@@ -93,139 +83,45 @@ uint32_t us_ticker_read()
         us_ticker_init();
     }
 
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-    
-    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
-
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        us_ticker_fire_interrupt();
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 }
 
 void us_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
-}
-
-static void tmr0_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-}
-
-static void tmr1_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-    us_ticker_irq_handler();
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    timer1_base->CTL |= TIMER_CTL_RSTCNT_Msk;
-    // One-shot mode, Clock = 1 MHz 
-    uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
-    // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451. In M451, TIMER_CNT is updated continuously by default.
-    timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
-    timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1/* | TIMER_CTL_CNTDATEN_Msk*/;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer1 = cd_clk;
-    cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer1_base->CMP = cmp_timer1;
-
-    TIMER_EnableInt(timer1_base);
-    TIMER_Start(timer1_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* us_ticker_get_info()
@@ -235,4 +131,12 @@ const ticker_info_t* us_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr0_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -35,18 +35,14 @@
 /* Timer max counter */
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
-static void tmr2_vec(void);
-static void tmr3_vec(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
-
-static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
+static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
-/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
-static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
-static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+
+#define TIMER_MODINIT      timer1_modinit
+
+static int ticker_inited = 0;
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -58,43 +54,37 @@ void lp_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-
     // Reset module
-    SYS_ResetModule(timer2_modinit.rsetidx);
-    SYS_ResetModule(timer3_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
-    CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer2_modinit.clkidx);
-    CLK_EnableModuleClock(timer3_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Configure clock
-    uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // Continuous mode
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer2/* | TIMER_CTL_CNTDATEN_Msk*/;
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMP = cmp_timer2;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer/* | TIMER_CTL_CNTDATEN_Msk*/;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
     // Set vector
-    NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
-    NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer2_modinit.irq_n);
-    NVIC_EnableIRQ(timer3_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
     /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
     wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 timestamp_t lp_ticker_read()
@@ -103,148 +93,49 @@ timestamp_t lp_ticker_read()
         lp_ticker_init();
     }
 
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-     
-    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        lp_ticker_fire_interrupt();
-    }
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
+    TIMER_Start(timer_base);
 }
 
 void lp_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
-}
-
-static void tmr2_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-}
-
-static void tmr3_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-
-    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-    lp_ticker_irq_handler();
-    
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    // NUC472/M451: See TIMER_CTL_RSTCNT_Msk
-    // M480
-    timer3_base->CNT = 0;
-    while (timer3_base->CNT & TIMER_CNT_RSTACT_Msk);
-    // One-shot mode, Clock = 1 KHz
-    uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
-    // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
-    timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
-    timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3/* | TIMER_CTL_CNTDATEN_Msk*/;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer3 = cd_clk;
-    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cmp_timer3;
-
-    TIMER_EnableInt(timer3_base);
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start(timer3_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* lp_ticker_get_info()
@@ -254,6 +145,15 @@ const ticker_info_t* lp_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr1_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -32,16 +32,12 @@
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
-static void tmr1_vec(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
+
+static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
+
+#define TIMER_MODINIT      timer0_modinit
 
 static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
-
-/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
-static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK0, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
-static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK0, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -53,38 +49,32 @@ void us_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-    
     // Reset IP
-    SYS_ResetModule(timer0hires_modinit.rsetidx);
-    SYS_ResetModule(timer1hires_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
-    CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer0hires_modinit.clkidx);
-    CLK_EnableModuleClock(timer1hires_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Timer for normal counter
-    uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0/* | TIMER_CTL_CNTDATEN_Msk*/;
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMP = cmp_timer0;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer/* | TIMER_CTL_CNTDATEN_Msk*/;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
-    NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
-    NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer0hires_modinit.irq_n);
-    NVIC_EnableIRQ(timer1hires_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 uint32_t us_ticker_read()
@@ -93,142 +83,45 @@ uint32_t us_ticker_read()
         us_ticker_init();
     }
 
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-    
-    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
-
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        us_ticker_fire_interrupt();
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 }
 
 void us_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
-}
-
-static void tmr0_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-}
-
-static void tmr1_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-    us_ticker_irq_handler();
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    // NUC472/M451: See TIMER_CTL_RSTCNT_Msk
-    // M480
-    timer1_base->CNT = 0;
-    while (timer1_base->CNT & TIMER_CNT_RSTACT_Msk);
-    // One-shot mode, Clock = 1 MHz
-    uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
-    // NOTE: TIMER_CTL_CNTDATEN_Msk exists in NUC472, but not in M451/M480. In M451/M480, TIMER_CNT is updated continuously by default.
-    timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk/* | TIMER_CTL_CNTDATEN_Msk*/);
-    timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1/* | TIMER_CTL_CNTDATEN_Msk*/;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer1 = cd_clk;
-    cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer1_base->CMP = cmp_timer1;
-
-    TIMER_EnableInt(timer1_base);
-    TIMER_Start(timer1_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* us_ticker_get_info()
@@ -238,4 +131,12 @@ const ticker_info_t* us_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr0_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
@@ -37,18 +37,14 @@
 
 /* NOTE: Don't add static modifier here. These IRQ handler symbols are for linking. 
          Vector table relocation is not actually supported for low-resource target. */
-void TMR2_IRQHandler(void);
-void TMR3_IRQHandler(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
-
-static uint32_t ticker_last_read_clk = 0;
-static int ticker_inited = 0;
+void TMR1_IRQHandler(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
-/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
-static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL2_TMR2_S_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) TMR2_IRQHandler};
-static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL2_TMR3_S_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) TMR3_IRQHandler};
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1_S_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) TMR1_IRQHandler};
+
+#define TIMER_MODINIT      timer1_modinit
+
+static int ticker_inited = 0;
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -60,43 +56,37 @@ void lp_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-
     // Reset module
-    SYS_ResetModule(timer2_modinit.rsetidx);
-    SYS_ResetModule(timer3_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
-    CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer2_modinit.clkidx);
-    CLK_EnableModuleClock(timer3_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Configure clock
-    uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // Continuous mode
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE;
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->PRECNT = prescale_timer2;
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMPR = cmp_timer2;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->PRECNT = prescale_timer;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMPR = cmp_timer;
 
     // Set vector
-    NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
-    NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer2_modinit.irq_n);
-    NVIC_EnableIRQ(timer3_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
     /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
     wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 timestamp_t lp_ticker_read()
@@ -105,144 +95,49 @@ timestamp_t lp_ticker_read()
         lp_ticker_init();
     }
 
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-     
-    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMPR = cmp_timer;
 
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        lp_ticker_fire_interrupt();
-    }
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
+    TIMER_Start(timer_base);
 }
 
 void lp_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
-}
-void TMR2_IRQHandler(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-}
-
-void TMR3_IRQHandler(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-
-    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-    lp_ticker_irq_handler();
-    
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-    
-    // Reset Timer's pre-scale counter, internal 24-bit up-counter and TMR_CTL [TMR_EN] bit
-    timer3_base->CTL |= TIMER_CTL_SW_RST_Msk;
-    // One-shot mode, Clock = 1 KHz 
-    uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
-    timer3_base->CTL &= ~TIMER_CTL_MODE_SEL_Msk;
-    timer3_base->CTL |= TIMER_ONESHOT_MODE;
-    timer3_base->PRECNT = prescale_timer3;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer3 = cd_clk;
-    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMPR = cmp_timer3;
-    
-    TIMER_EnableInt(timer3_base);
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start(timer3_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* lp_ticker_get_info()
@@ -252,6 +147,15 @@ const ticker_info_t* lp_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+void TMR1_IRQHandler(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
@@ -34,16 +34,12 @@
 /* NOTE: Don't add static modifier here. These IRQ handler symbols are for linking. 
          Vector table relocation is not actually supported for low-resource target. */
 void TMR0_IRQHandler(void);
-void TMR1_IRQHandler(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
 
-static uint32_t ticker_last_read_clk = 0;
+static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0_S_HXT, 0, TMR0_RST, TMR0_IRQn, (void *) TMR0_IRQHandler};
+
+#define TIMER_MODINIT      timer0_modinit
+
 static int ticker_inited = 0;
-
-/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
-static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0_S_HXT, 0, TMR0_RST, TMR0_IRQn, (void *) TMR0_IRQHandler};
-static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1_S_HXT, 0, TMR1_RST, TMR1_IRQn, (void *) TMR1_IRQHandler};
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -55,38 +51,32 @@ void us_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-    
     // Reset IP
-    SYS_ResetModule(timer0hires_modinit.rsetidx);
-    SYS_ResetModule(timer1hires_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
-    CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer0hires_modinit.clkidx);
-    CLK_EnableModuleClock(timer1hires_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Timer for normal counter
-    uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE;
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->PRECNT = prescale_timer0;
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMPR = cmp_timer0;
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->PRECNT = prescale_timer;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMPR = cmp_timer;
 
-    NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
-    NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer0hires_modinit.irq_n);
-    NVIC_EnableIRQ(timer1hires_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 uint32_t us_ticker_read()
@@ -95,139 +85,45 @@ uint32_t us_ticker_read()
         us_ticker_init();
     }
 
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-    
-    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
-
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        us_ticker_fire_interrupt();
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMPR = cmp_timer;
 }
 
 void us_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
-}
-
-void TMR0_IRQHandler(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-}
-
-void TMR1_IRQHandler(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-    us_ticker_irq_handler();
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-
-    // Reset Timer's pre-scale counter, internal 24-bit up-counter and TMR_CTL [TMR_EN] bit
-    timer1_base->CTL |= TIMER_CTL_SW_RST_Msk;
-    // One-shot mode, Clock = 1 MHz 
-    uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
-    timer1_base->CTL &= ~TIMER_CTL_MODE_SEL_Msk;
-    timer1_base->CTL |= TIMER_ONESHOT_MODE;
-    timer1_base->PRECNT = prescale_timer1;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer1 = cd_clk;
-    cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer1_base->CMPR = cmp_timer1;
-
-    TIMER_EnableInt(timer1_base);
-    TIMER_Start(timer1_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* us_ticker_get_info()
@@ -237,4 +133,12 @@ const ticker_info_t* us_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+void TMR0_IRQHandler(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
@@ -35,18 +35,14 @@
 /* Timer max counter */
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
-static void tmr2_vec(void);
-static void tmr3_vec(void);
-/* Configure scheduled alarm */
-static void arm_alarm(uint32_t cd_clk);
-
-static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
+static void tmr1_vec(void);
 
 /* NOTE: To wake the system from power down mode, timer clock source must be ether LXT or LIRC. */
-/* NOTE: TIMER_2 for normal counting and TIMER_3 for scheduled alarm */
-static const struct nu_modinit_s timer2_modinit = {TIMER_2, TMR2_MODULE, CLK_CLKSEL1_TMR2SEL_LXT, 0, TMR2_RST, TMR2_IRQn, (void *) tmr2_vec};
-static const struct nu_modinit_s timer3_modinit = {TIMER_3, TMR3_MODULE, CLK_CLKSEL1_TMR3SEL_LXT, 0, TMR3_RST, TMR3_IRQn, (void *) tmr3_vec};
+static const struct nu_modinit_s timer1_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_LXT, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
+
+#define TIMER_MODINIT      timer1_modinit
+
+static int ticker_inited = 0;
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -58,42 +54,36 @@ void lp_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-
     // Reset module
-    SYS_ResetModule(timer2_modinit.rsetidx);
-    SYS_ResetModule(timer3_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer2_modinit.clkidx, timer2_modinit.clksrc, timer2_modinit.clkdiv);
-    CLK_SetModuleClock(timer3_modinit.clkidx, timer3_modinit.clksrc, timer3_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer2_modinit.clkidx);
-    CLK_EnableModuleClock(timer3_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Configure clock
-    uint32_t clk_timer2 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    uint32_t prescale_timer2 = clk_timer2 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer2 != (uint32_t) -1) && prescale_timer2 <= 127);
-    MBED_ASSERT((clk_timer2 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer2 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer2 >= TMR_CMP_MIN && cmp_timer2 <= TMR_CMP_MAX);
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
     // Continuous mode
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer2 | TIMER_CTL_CNTDATEN_Msk;
-    ((TIMER_T *) NU_MODBASE(timer2_modinit.modname))->CMP = cmp_timer2;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer | TIMER_CTL_CNTDATEN_Msk;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
     // Set vector
-    NVIC_SetVector(timer2_modinit.irq_n, (uint32_t) timer2_modinit.var);
-    NVIC_SetVector(timer3_modinit.irq_n, (uint32_t) timer3_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer2_modinit.irq_n);
-    NVIC_EnableIRQ(timer3_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
     /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
     wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 timestamp_t lp_ticker_read()
@@ -102,144 +92,49 @@ timestamp_t lp_ticker_read()
         lp_ticker_init();
     }
 
-    TIMER_T * timer2_base = (TIMER_T *) NU_MODBASE(timer2_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer2_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-     
-    /* ticker_last_read_clk will update in lp_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = lp_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        lp_ticker_fire_interrupt();
-    }
+    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
+    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
+    TIMER_Start(timer_base);
 }
 
 void lp_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void lp_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer3_modinit.irq_n);
-}
-
-static void tmr2_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer2_modinit.modname));
-}
-
-static void tmr3_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-
-    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
-    lp_ticker_irq_handler();
-    
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer3_base = (TIMER_T *) NU_MODBASE(timer3_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    timer3_base->CTL |= TIMER_CTL_RSTCNT_Msk;
-    // One-shot mode, Clock = 1 KHz 
-    uint32_t clk_timer3 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    uint32_t prescale_timer3 = clk_timer3 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer3 != (uint32_t) -1) && prescale_timer3 <= 127);
-    MBED_ASSERT((clk_timer3 % NU_TMRCLK_PER_SEC) == 0);
-    timer3_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk | TIMER_CTL_CNTDATEN_Msk);
-    timer3_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer3 | TIMER_CTL_CNTDATEN_Msk;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer3 = cd_clk;
-    cmp_timer3 = NU_CLAMP(cmp_timer3, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer3_base->CMP = cmp_timer3;
-
-    TIMER_EnableInt(timer3_base);
-    TIMER_EnableWakeup((TIMER_T *) NU_MODBASE(timer3_modinit.modname));
-    /* NOTE: When engine is clocked by low power clock source (LXT/LIRC), we need to wait for 3 engine clocks. */
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-    TIMER_Start(timer3_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* lp_ticker_get_info()
@@ -249,6 +144,15 @@ const ticker_info_t* lp_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr1_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_ClearWakeupFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: lp_ticker_set_interrupt() may get called in lp_ticker_irq_handler();
+    lp_ticker_irq_handler();
 }
 
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
@@ -32,16 +32,12 @@
 #define NU_TMR_MAXCNT               ((1 << NU_TMR_MAXCNT_BITSIZE) - 1)
 
 static void tmr0_vec(void);
-static void tmr1_vec(void);
-/* Configure alarm exactly after scheduled clocks */
-static void arm_alarm(uint32_t cd_clk);
+
+static const struct nu_modinit_s timer0_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
+
+#define TIMER_MODINIT      timer0_modinit
 
 static int ticker_inited = 0;
-static uint32_t ticker_last_read_clk = 0;
-
-/* NOTE: TIMER_0 for normal counting and TIMER_1 for scheduled alarm. */
-static const struct nu_modinit_s timer0hires_modinit = {TIMER_0, TMR0_MODULE, CLK_CLKSEL1_TMR0SEL_PCLK, 0, TMR0_RST, TMR0_IRQn, (void *) tmr0_vec};
-static const struct nu_modinit_s timer1hires_modinit = {TIMER_1, TMR1_MODULE, CLK_CLKSEL1_TMR1SEL_PCLK, 0, TMR1_RST, TMR1_IRQn, (void *) tmr1_vec};
 
 #define TMR_CMP_MIN         2
 #define TMR_CMP_MAX         0xFFFFFFu
@@ -53,37 +49,31 @@ void us_ticker_init(void)
     }
     ticker_inited = 1;
 
-    ticker_last_read_clk = 0;
-
     // Reset IP
-    SYS_ResetModule(timer0hires_modinit.rsetidx);
-    SYS_ResetModule(timer1hires_modinit.rsetidx);
+    SYS_ResetModule(TIMER_MODINIT.rsetidx);
 
     // Select IP clock source
-    CLK_SetModuleClock(timer0hires_modinit.clkidx, timer0hires_modinit.clksrc, timer0hires_modinit.clkdiv);
-    CLK_SetModuleClock(timer1hires_modinit.clkidx, timer1hires_modinit.clksrc, timer1hires_modinit.clkdiv);
+    CLK_SetModuleClock(TIMER_MODINIT.clkidx, TIMER_MODINIT.clksrc, TIMER_MODINIT.clkdiv);
+
     // Enable IP clock
-    CLK_EnableModuleClock(timer0hires_modinit.clkidx);
-    CLK_EnableModuleClock(timer1hires_modinit.clkidx);
+    CLK_EnableModuleClock(TIMER_MODINIT.clkidx);
 
     // Timer for normal counter
-    uint32_t clk_timer0 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    uint32_t prescale_timer0 = clk_timer0 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer0 != (uint32_t) -1) && prescale_timer0 <= 127);
-    MBED_ASSERT((clk_timer0 % NU_TMRCLK_PER_SEC) == 0);
-    uint32_t cmp_timer0 = TMR_CMP_MAX;
-    MBED_ASSERT(cmp_timer0 >= TMR_CMP_MIN && cmp_timer0 <= TMR_CMP_MAX);
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CTL = TIMER_PERIODIC_MODE | prescale_timer0 | TIMER_CTL_CNTDATEN_Msk;
-    ((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname))->CMP = cmp_timer0;
+    uint32_t clk_timer = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    uint32_t prescale_timer = clk_timer / NU_TMRCLK_PER_SEC - 1;
+    MBED_ASSERT((prescale_timer != (uint32_t) -1) && prescale_timer <= 127);
+    MBED_ASSERT((clk_timer % NU_TMRCLK_PER_SEC) == 0);
+    uint32_t cmp_timer = TMR_CMP_MAX;
+    MBED_ASSERT(cmp_timer >= TMR_CMP_MIN && cmp_timer <= TMR_CMP_MAX);
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CTL = TIMER_CONTINUOUS_MODE | prescale_timer | TIMER_CTL_CNTDATEN_Msk;
+    ((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname))->CMP = cmp_timer;
 
-    NVIC_SetVector(timer0hires_modinit.irq_n, (uint32_t) timer0hires_modinit.var);
-    NVIC_SetVector(timer1hires_modinit.irq_n, (uint32_t) timer1hires_modinit.var);
+    NVIC_SetVector(TIMER_MODINIT.irq_n, (uint32_t) TIMER_MODINIT.var);
 
-    NVIC_EnableIRQ(timer0hires_modinit.irq_n);
-    NVIC_EnableIRQ(timer1hires_modinit.irq_n);
+    NVIC_EnableIRQ(TIMER_MODINIT.irq_n);
 
-    TIMER_EnableInt((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-    TIMER_Start((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
+    TIMER_EnableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    TIMER_Start((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 uint32_t us_ticker_read()
@@ -92,138 +82,45 @@ uint32_t us_ticker_read()
         us_ticker_init();
     }
 
-    TIMER_T * timer0_base = (TIMER_T *) NU_MODBASE(timer0hires_modinit.modname);
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    ticker_last_read_clk = TIMER_GetCounter(timer0_base);
-    return  (ticker_last_read_clk / NU_TMRCLK_PER_TICK);
+    return  (TIMER_GetCounter(timer_base) / NU_TMRCLK_PER_TICK);
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
-    TIMER_Stop((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    /* In continuous mode, counter will be reset to zero with the following sequence: 
+     * 1. Stop counting
+     * 2. Configure new CMP value
+     * 3. Restart counting
+     *
+     * This behavior is not what we want. To fix it, we could configure new CMP value
+     * without stopping counting first.
+     */
+    TIMER_T * timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
 
-    /* We need to get alarm interval from alarm timestamp `timestamp` to configure H/W timer.
-     *  
-     * Because both `timestamp` and xx_ticker_read() would wrap around, we have difficulties in distinguishing
-     * long future event and past event. To distinguish them, we need `tick_last_read` against which 
-     * `timestamp` is calculated out. In timeline, we would always have below after fixing wrap-around:
-     * (1) tick_last_read <= present_clk
-     * (2) tick_last_read <= alarm_ts_clk
-     *
-     *
-     * 1. Future event case:
-     *
-     * tick_last_read     present_clk                         alarm_ts_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-alarm_intvl1_clk-|
-     * |-------------------alarm_intvl2_clk-------------------|
-     *
-     * 2. Past event case:
-     *
-     * tick_last_read     alarm_ts_clk                        present_clk
-     * |                  |                                   |
-     * --------------------------------------------------------
-     * |-------------------alarm_intvl1_clk-------------------|
-     * |-alarm_intvl2_clk-|
-     *
-     * Unfortunately, `tick_last_read` is not passed along the xx_ticker_set_interrupt() call. To solve it, we
-     * assume that `tick_last_read` tick is exactly the one returned by the last xx_ticker_read() call before
-     * xx_ticker_set_interrupt() is invoked. With this assumption, we can hold it via `xx_ticker_last_read_clk`
-     * in xx_ticker_read().
-     */
-    
-    /* ticker_last_read_clk will update in us_ticker_read(). Keep it beforehand. */
-    uint32_t last_read_clk = ticker_last_read_clk;
-    uint32_t present_clk = us_ticker_read() * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_ts_clk = timestamp * NU_TMRCLK_PER_TICK;
-    uint32_t alarm_intvl1_clk, alarm_intvl2_clk;
-    
-    /* alarm_intvl1_clk = present_clk - last_read_clk
-     *
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (present_clk >= last_read_clk) {
-        alarm_intvl1_clk = present_clk - last_read_clk;
-    } else {
-        alarm_intvl1_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + present_clk - last_read_clk);
-    }
-
-    /* alarm_intvl2_clk = alarm_ts_clk - last_read_clk
-     * 
-     * NOTE: Don't miss the `=` sign here. Otherwise, we would get the wrong result.
-     */
-    if (alarm_ts_clk >= last_read_clk) {
-        alarm_intvl2_clk = alarm_ts_clk - last_read_clk;
-    } else {
-        alarm_intvl2_clk = (uint32_t) (((uint64_t) NU_TMR_MAXCNT) + 1 + alarm_ts_clk - last_read_clk);
-    }
-
-    /* Distinguish (long) future event and past event
-     * 
-     * NOTE: No '=' sign here. Alarm should go off immediately in equal case.
-     */
-    if (alarm_intvl2_clk > alarm_intvl1_clk) {
-        /* Schedule for future event */
-        arm_alarm(alarm_intvl2_clk - alarm_intvl1_clk);
-    } else {
-        /* Go off immediately for past event, including equal case */
-        us_ticker_fire_interrupt();
-    }
+    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
+     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
+    uint32_t cmp_timer = timestamp * NU_TMRCLK_PER_TICK;
+    cmp_timer = NU_CLAMP(cmp_timer, TMR_CMP_MIN, TMR_CMP_MAX);
+    timer_base->CMP = cmp_timer;
 }
 
 void us_ticker_disable_interrupt(void)
 {
-    TIMER_DisableInt((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_DisableInt((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_clear_interrupt(void)
 {
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
 }
 
 void us_ticker_fire_interrupt(void)
 {
     // NOTE: This event was in the past. Set the interrupt as pending, but don't process it here.
     //       This prevents a recursive loop under heavy load which can lead to a stack overflow.
-    NVIC_SetPendingIRQ(timer1hires_modinit.irq_n);
-}
-
-static void tmr0_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer0hires_modinit.modname));
-}
-
-static void tmr1_vec(void)
-{
-    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-
-    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
-    us_ticker_irq_handler();
-}
-
-static void arm_alarm(uint32_t cd_clk)
-{
-    TIMER_T * timer1_base = (TIMER_T *) NU_MODBASE(timer1hires_modinit.modname);
-
-    // Reset 8-bit PSC counter, 24-bit up counter value and CNTEN bit
-    timer1_base->CTL |= TIMER_CTL_RSTCNT_Msk;
-    // One-shot mode, Clock = 1 MHz 
-    uint32_t clk_timer1 = TIMER_GetModuleClock((TIMER_T *) NU_MODBASE(timer1hires_modinit.modname));
-    uint32_t prescale_timer1 = clk_timer1 / NU_TMRCLK_PER_SEC - 1;
-    MBED_ASSERT((prescale_timer1 != (uint32_t) -1) && prescale_timer1 <= 127);
-    MBED_ASSERT((clk_timer1 % NU_TMRCLK_PER_SEC) == 0);
-    timer1_base->CTL &= ~(TIMER_CTL_OPMODE_Msk | TIMER_CTL_PSC_Msk | TIMER_CTL_CNTDATEN_Msk);
-    timer1_base->CTL |= TIMER_ONESHOT_MODE | prescale_timer1 | TIMER_CTL_CNTDATEN_Msk;
-
-    /* NOTE: Because H/W timer requests min compare value, our implementation would have alarm delay of 
-     *       (TMR_CMP_MIN - interval_clk) clocks when interval_clk is between [1, TMR_CMP_MIN). */
-    uint32_t cmp_timer1 = cd_clk;
-    cmp_timer1 = NU_CLAMP(cmp_timer1, TMR_CMP_MIN, TMR_CMP_MAX);
-    timer1_base->CMP = cmp_timer1;
-
-    TIMER_EnableInt(timer1_base);
-    TIMER_Start(timer1_base);
+    NVIC_SetPendingIRQ(TIMER_MODINIT.irq_n);
 }
 
 const ticker_info_t* us_ticker_get_info()
@@ -233,4 +130,12 @@ const ticker_info_t* us_ticker_get_info()
         NU_TMR_MAXCNT_BITSIZE
     };
     return &info;
+}
+
+static void tmr0_vec(void)
+{
+    TIMER_ClearIntFlag((TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname));
+    
+    // NOTE: us_ticker_set_interrupt() may get called in us_ticker_irq_handler();
+    us_ticker_irq_handler();
 }


### PR DESCRIPTION
## Description

Originally, we use 2 H/W timers to implement us_ticker/lp_ticker, one for counting and the other for alarm. With H/W timer running in continuous mode, we could use just one H/W timer for counting/alarm simultaneously.

## Target
NUMAKER_PFM_NUC472
NUMAKER_PFM_M453
NUMAKER_PFM_M487
NUMAKER_PFM_NANO130

### Toolchain
ARM
GCC_ARM
IAR

### Pull request type
- [ ] Feature
