### PR TITLE
Fix a bug using ELF as output extension

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1129,8 +1129,10 @@ class mbedToolchain:
         mkdir(new_path)
 
         filename = name+'.'+ext
+        # Absolute path of the final linked file
+        full_path = join(tmp_path, filename)
         elf = join(tmp_path, name + '.elf')
-        bin = None if ext is 'elf' else join(tmp_path, filename)
+        bin = None if ext == 'elf' else full_path
         map = join(tmp_path, name + '.map')
 
         r.objects = sorted(set(r.objects))
@@ -1154,7 +1156,7 @@ class mbedToolchain:
         self.var("compile_succeded", True)
         self.var("binary", filename)
 
-        return bin, needed_update
+        return full_path, needed_update
 
     # THIS METHOD IS BEING OVERRIDDEN BY THE MBED ONLINE BUILD SYSTEM
     # ANY CHANGE OF PARAMETERS OR RETURN VALUES WILL BREAK COMPATIBILITY


### PR DESCRIPTION
When overriding the OUTPUT_EXT variable in compilation configuration,
bugs appear:

* The bin variable is not None as the 'elf' string is not interned.
* When that is fixed, the function returns None instead of returning the
path of the ELF file.

The bug fix in this pull request is needed to make the changes of the pull request #6168 work.

@theotherjimmy 