### PR TITLE
mcu_lpc546xx: move "release_versions" to children and fix clock 

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/mbed_overrides.c
@@ -41,7 +41,6 @@ void ADC_ClockPower_Configuration(void)
     POWER_DisablePD(kPDRUNCFG_PD_TEMPS);    /* Power on the temperature sensor. */
 
     /* Enable the clock. */
-    CLOCK_AttachClk(kFRO12M_to_MAIN_CLK);
     CLOCK_EnableClock(kCLOCK_Adc0);
 }
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/mbed_overrides.c
@@ -73,8 +73,6 @@ void ADC_ClockPower_Configuration(void)
     POWER_DisablePD(kPDRUNCFG_PD_VREFP);   /* Power on the reference voltage source. */
     POWER_DisablePD(kPDRUNCFG_PD_TS);      /* Power on the temperature sensor. */
 
-    /* Enable the clock. */
-    CLOCK_AttachClk(kFRO12M_to_MAIN_CLK);
 
     /* CLOCK_AttachClk(kMAIN_CLK_to_ADC_CLK); */
     /* Sync clock source is not used. Using sync clock source and would be divided by 2.

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
@@ -121,8 +121,6 @@ void ADC_ClockPower_Configuration(void)
     POWER_DisablePD(kPDRUNCFG_PD_VREFP);   /* Power on the reference voltage source. */
     POWER_DisablePD(kPDRUNCFG_PD_TS);      /* Power on the temperature sensor. */
 
-    /* Enable the clock. */
-    CLOCK_AttachClk(kFRO12M_to_MAIN_CLK);
 
     /* CLOCK_AttachClk(kMAIN_CLK_to_ADC_CLK); */
     /* Sync clock source is not used. Using sync clock source and would be divided by 2.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -755,18 +755,19 @@
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
-        "release_versions": ["2", "5"],
         "device_name" : "LPC54628J512ET180"
     },
     "LPC546XX": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_LPC546XX"],
-        "detect_code": ["1056"]
+        "detect_code": ["1056"],
+        "release_versions": ["2", "5"]
     },
     "FF_LPC546XX": {
         "inherits": ["MCU_LPC546XX"],
         "extra_labels_remove" : ["LPCXpresso"],
-        "detect_code": ["8081"]
+        "detect_code": ["8081"],
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F030R8": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
## Abstract 

* mcu_lpc546xx: move "release_versions" to children
* fix clock in lpc546xx related boards. Namely the wait() function took longer when adc was enabled

related issues: #5887
cc: @mmahadevan108 