### PR TITLE
Remove windup behavior from break_dispatch

### DIFF
--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -418,6 +418,7 @@ void equeue_dispatch(equeue_t *q, int ms) {
                     q->background.active = true;
                     equeue_mutex_unlock(&q->queuelock);
                 }
+                q->break_requested = false;
                 return;
             }
         }

--- a/events/equeue/equeue.h
+++ b/events/equeue/equeue.h
@@ -58,7 +58,7 @@ struct equeue_event {
 typedef struct equeue {
     struct equeue_event *queue;
     unsigned tick;
-    unsigned breaks;
+    bool break_requested;
     uint8_t generation;
 
     unsigned char *buffer;

--- a/events/equeue/tests/tests.c
+++ b/events/equeue/tests/tests.c
@@ -707,17 +707,15 @@ void multithreaded_barrage_test(int N) {
     equeue_destroy(&q);
 }
 
-struct sCaQ
+struct count_and_queue
 {
     int p;
     equeue_t* q;
 };
 
-typedef struct sCaQ CountAndQueue;
-
 void simple_breaker(void *p) {
-	CountAndQueue* caq = (CountAndQueue*)p;
-	equeue_break(caq->q);
+    struct count_and_queue* caq = (struct count_and_queue*)p;
+    equeue_break(caq->q);
     usleep(10000);
     caq->p++;
 }
@@ -727,7 +725,7 @@ void break_request_cleared_on_timeout(void) {
     int err = equeue_create(&q, 2048);
     test_assert(!err);
 
-    CountAndQueue pq;
+    struct count_and_queue pq;
     pq.p = 0;
     pq.q = &q;
 

--- a/events/equeue/tests/tests.c
+++ b/events/equeue/tests/tests.c
@@ -687,6 +687,45 @@ void multithreaded_barrage_test(int N) {
     equeue_destroy(&q);
 }
 
+struct sCaQ
+{
+    int p;
+    equeue_t* q;
+};
+
+typedef struct sCaQ CountAndQueue;
+
+void simple_breaker(void *p) {
+	CountAndQueue* caq = (CountAndQueue*)p;
+	equeue_break(caq->q);
+    usleep(10000);
+    caq->p++;
+}
+
+void break_request_cleared_on_timeout(void) {
+    equeue_t q;
+    int err = equeue_create(&q, 2048);
+    test_assert(!err);
+
+    CountAndQueue pq;
+    pq.p = 0;
+    pq.q = &q;
+
+    int id = equeue_call_every(&q, 10, simple_breaker, &pq);
+
+    equeue_dispatch(&q, 10);
+    test_assert(pq.p == 1);
+
+    equeue_cancel(&q, id);
+
+    int count = 0;
+    equeue_call_every(&q, 10, simple_func, &count);
+
+    equeue_dispatch(&q, 55);
+    test_assert(count > 1);
+
+    equeue_destroy(&q);
+}
 
 int main() {
     printf("beginning tests...\n");
@@ -712,6 +751,7 @@ int main() {
     test_run(simple_barrage_test, 20);
     test_run(fragmenting_barrage_test, 20);
     test_run(multithreaded_barrage_test, 20);
+    test_run(break_request_cleared_on_timeout);
 
     printf("done!\n");
     return test_failure;

--- a/events/equeue/tests/tests.c
+++ b/events/equeue/tests/tests.c
@@ -391,6 +391,26 @@ void break_test(void) {
     equeue_destroy(&q);
 }
 
+void break_no_windup_test(void) {
+    equeue_t q;
+    int err = equeue_create(&q, 2048);
+    test_assert(!err);
+
+    int count = 0;
+    equeue_call_every(&q, 0, simple_func, &count);
+
+    equeue_break(&q);
+    equeue_break(&q);
+    equeue_dispatch(&q, -1);
+    test_assert(count == 1);
+
+    count = 0;
+    equeue_dispatch(&q, 55);
+    test_assert(count > 1);
+
+    equeue_destroy(&q);
+}
+
 void period_test(void) {
     equeue_t q;
     int err = equeue_create(&q, 2048);
@@ -741,6 +761,7 @@ int main() {
     test_run(cancel_unnecessarily_test);
     test_run(loop_protect_test);
     test_run(break_test);
+    test_run(break_no_windup_test);
     test_run(period_test);
     test_run(nested_test);
     test_run(sloth_test);


### PR DESCRIPTION
Change break_dispatch from a counting semaphore which needs the same number of calls to dispatch_forever() as number of calls to break_dispatch() to a squashable flag which will only break once for any number of calls to break_dispatch()  between calls to dispatch_forever()

Resolves #6204

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [x] Breaking change