### PR TITLE
Interrupt in pin mode

### DIFF
--- a/drivers/InterruptIn.cpp
+++ b/drivers/InterruptIn.cpp
@@ -19,14 +19,31 @@
 
 namespace mbed {
 
+// Note: This single-parameter constructor exists to maintain binary
+//       compatibility.
+//       If not for that, we could simplify by having only the 2-param
+//       constructor, with a default value for the PinMode.
+InterruptIn::InterruptIn(PinName pin) : gpio(),
+                                        gpio_irq(),
+                                        _rise(NULL),
+                                        _fall(NULL) {
+    // No lock needed in the constructor
+    irq_init(pin);
+    gpio_init_in(&gpio, pin);
+}
+
 InterruptIn::InterruptIn(PinName pin, PinMode mode) :
                                         gpio(),
                                         gpio_irq(),
                                         _rise(NULL),
                                         _fall(NULL) {
     // No lock needed in the constructor
-    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
+    irq_init(pin);
     gpio_init_in_ex(&gpio, pin, mode);
+}
+
+void InterruptIn::irq_init(PinName pin) {
+   gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
 }
 
 InterruptIn::~InterruptIn() {

--- a/drivers/InterruptIn.cpp
+++ b/drivers/InterruptIn.cpp
@@ -24,9 +24,18 @@ InterruptIn::InterruptIn(PinName pin) : gpio(),
                                         _rise(NULL),
                                         _fall(NULL) {
     // No lock needed in the constructor
-
     gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
     gpio_init_in(&gpio, pin);
+}
+
+InterruptIn::InterruptIn(PinName pin, PinMode mode) :
+                                        gpio(),
+                                        gpio_irq(),
+                                        _rise(NULL),
+                                        _fall(NULL) {
+    // No lock needed in the constructor
+    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
+    gpio_init_in_ex(&gpio, pin, mode);
 }
 
 InterruptIn::~InterruptIn() {

--- a/drivers/InterruptIn.cpp
+++ b/drivers/InterruptIn.cpp
@@ -19,27 +19,14 @@
 
 namespace mbed {
 
-InterruptIn::InterruptIn(PinName pin) : gpio(),
-                                        gpio_irq(),
-                                        _rise(NULL),
-                                        _fall(NULL) {
-    // No lock needed in the constructor
-    irq_init(pin);
-    gpio_init_in(&gpio, pin);
-}
-
 InterruptIn::InterruptIn(PinName pin, PinMode mode) :
                                         gpio(),
                                         gpio_irq(),
                                         _rise(NULL),
                                         _fall(NULL) {
     // No lock needed in the constructor
-    irq_init(pin);
+    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
     gpio_init_in_ex(&gpio, pin, mode);
-}
-
-void InterruptIn::irq_init(PinName pin) {
-   gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
 }
 
 InterruptIn::~InterruptIn() {

--- a/drivers/InterruptIn.cpp
+++ b/drivers/InterruptIn.cpp
@@ -24,7 +24,7 @@ InterruptIn::InterruptIn(PinName pin) : gpio(),
                                         _rise(NULL),
                                         _fall(NULL) {
     // No lock needed in the constructor
-    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
+    irq_init(pin);
     gpio_init_in(&gpio, pin);
 }
 
@@ -34,8 +34,12 @@ InterruptIn::InterruptIn(PinName pin, PinMode mode) :
                                         _rise(NULL),
                                         _fall(NULL) {
     // No lock needed in the constructor
-    gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
+    irq_init(pin);
     gpio_init_in_ex(&gpio, pin, mode);
+}
+
+void InterruptIn::irq_init(PinName pin) {
+   gpio_irq_init(&gpio_irq, pin, (&InterruptIn::_irq_handler), (uint32_t)this);
 }
 
 InterruptIn::~InterruptIn() {

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -61,14 +61,18 @@ class InterruptIn : private NonCopyable<InterruptIn> {
 
 public:
 
+    /** Create an InterruptIn connected to the specified pin
+     *
+     *  @param pin InterruptIn pin to connect to
+     */
+    InterruptIn(PinName pin);
     /** Create an InterruptIn connected to the specified pin,
-     *  with the pin configured to the specified mode.
+     *  and the pin configured to the specified mode.
      *
      *  @param pin InterruptIn pin to connect to
      *  @param mode The mode to set the pin to (PullUp/PullDown/etc.)
      */
-    InterruptIn(PinName pin, PinMode mode = PullDefault);
-
+    InterruptIn(PinName pin, PinMode mode);
     virtual ~InterruptIn();
 
     /** Read the input, represented as 0 or 1 (int)
@@ -156,6 +160,8 @@ protected:
 
     Callback<void()> _rise;
     Callback<void()> _fall;
+
+    void irq_init(PinName pin);
 };
 
 } // namespace mbed

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -65,6 +65,7 @@ public:
      *  with the pin configured to the specified mode.
      *
      *  @param pin InterruptIn pin to connect to
+     *  @param mode The mode to set the pin to (PullUp/PullDown/etc.)
      */
     InterruptIn(PinName pin, PinMode mode = PullDefault);
     virtual ~InterruptIn();

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -66,6 +66,7 @@ public:
      *  @param pin InterruptIn pin to connect to
      */
     InterruptIn(PinName pin);
+
     /** Create an InterruptIn connected to the specified pin,
      *  and the pin configured to the specified mode.
      *
@@ -73,6 +74,7 @@ public:
      *  @param mode The mode to set the pin to (PullUp/PullDown/etc.)
      */
     InterruptIn(PinName pin, PinMode mode);
+
     virtual ~InterruptIn();
 
     /** Read the input, represented as 0 or 1 (int)

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -68,6 +68,7 @@ public:
      *  @param mode The mode to set the pin to (PullUp/PullDown/etc.)
      */
     InterruptIn(PinName pin, PinMode mode = PullDefault);
+
     virtual ~InterruptIn();
 
     /** Read the input, represented as 0 or 1 (int)

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -66,6 +66,12 @@ public:
      *  @param pin InterruptIn pin to connect to
      */
     InterruptIn(PinName pin);
+    /** Create an InterruptIn connected to the specified pin,
+     *  and the pin configured to the specified mode.
+     *
+     *  @param pin InterruptIn pin to connect to
+     */
+    InterruptIn(PinName pin, PinMode mode);
     virtual ~InterruptIn();
 
     /** Read the input, represented as 0 or 1 (int)

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -61,17 +61,12 @@ class InterruptIn : private NonCopyable<InterruptIn> {
 
 public:
 
-    /** Create an InterruptIn connected to the specified pin
-     *
-     *  @param pin InterruptIn pin to connect to
-     */
-    InterruptIn(PinName pin);
     /** Create an InterruptIn connected to the specified pin,
-     *  and the pin configured to the specified mode.
+     *  with the pin configured to the specified mode.
      *
      *  @param pin InterruptIn pin to connect to
      */
-    InterruptIn(PinName pin, PinMode mode);
+    InterruptIn(PinName pin, PinMode mode = PullDefault);
     virtual ~InterruptIn();
 
     /** Read the input, represented as 0 or 1 (int)
@@ -159,8 +154,6 @@ protected:
 
     Callback<void()> _rise;
     Callback<void()> _fall;
-
-    void irq_init(PinName pin);
 };
 
 } // namespace mbed

--- a/drivers/InterruptIn.h
+++ b/drivers/InterruptIn.h
@@ -159,6 +159,8 @@ protected:
 
     Callback<void()> _rise;
     Callback<void()> _fall;
+
+    void irq_init(PinName pin);
 };
 
 } // namespace mbed


### PR DESCRIPTION
# Description

Currently there's no way to specify the `PinMode` (`PullUp`, `PullDown`, etc.) in the `InterruptIn` constructor. So I added one, like `DigitalIn`.

Later: Would it make even more sense to have `InterruptIn` inherit from `DigitalIn`?

# Pull request type

- [ ] Fix (arguably)
- [ ] Refactor
- [ ] New Target
- [x] Feature
