### PR TITLE
K64F: adapt RTC drivers to the new standards

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
@@ -37,7 +37,10 @@ void rtc_init(void)
 
 void rtc_free(void)
 {
-    RTC_Deinit(RTC);
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
+    /* Gate the module clock */
+    CLOCK_DisableClock(kCLOCK_Rtc0);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 }
 
 /*

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -614,7 +614,7 @@
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0240"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
+        "device_has": ["RTC", "ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
         "features": ["LWIP", "STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK64FN1M0xxx12",


### PR DESCRIPTION
# Description

This PR enables RTC support for K64F board and adapts RTC driver to the new standards:
- rtc_free() does not stop the RTC from counting. Only disables clock gate since processor no longer needs to read RTC registers
- rtc_isenabled() returns 1 if the RTC is initialized and the time has been set; 0 otherwise.

Needs preceding PR: https://github.com/ARMmbed/mbed-os/pull/6161 which provides minor updates in RTC test.

# Pull request type

- [x] Fix
