### PR TITLE
C030 platform I2C initialisation fix

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/min_battery_voltage.c
@@ -27,10 +27,10 @@ void HAL_MspInit(void)
 
 void set_minimum_battery_voltage()
 {
-    i2c_t i2c_obj;
+    i2c_t i2c_obj = {0};
     int data_read;
-    i2c_frequency(&i2c_obj, I2C_FREQUENCY);
     i2c_init(&i2c_obj, I2C_SDA_B, I2C_SCL_B);
+    i2c_frequency(&i2c_obj, I2C_FREQUENCY);
 
     if (read_from_i2c(BQ24295_I2C_ADDRESS, 0, &data_read, i2c_obj)) {
         data_read = data_read & MIN_BATTERY_VOLTAGE_MASK;


### PR DESCRIPTION
### Description
In pull request #6117 a better mechanism for the I2C initialisation that is required for all C030 platforms was introduced.  However, there was a bug in that mechanism which, depending on an uninitialised stack variable, could result in a failure to boot.  This PR fixes that bug.

In `set_minimum_battery_voltage()` change the order of initialisation so that `i2c_init()` is called before `i2c_frequency()` as `i2c_frequency()` requires a valid I2C object.  Zero the I2C object since `i2c_init()` has to set a default frequency for its timeouts to work and it will only do that if the `hz` field of the object was zero to begin with.

All platform tests pass reliably after this change.

[C030_U201_Mbed_Tests_Logs.txt](https://github.com/ARMmbed/mbed-os/files/1771520/C030_U201_Mbed_Tests_Logs.txt)

### Pull request type
- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change