### PR TITLE
[feature-nrf528xx] Fix ISR stack size inconsistencies on NRF52 series

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -223,8 +223,8 @@ SECTIONS
         *(.heap*);
 
         /* Expand the heap to reach the stack boundary. */
-        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - 0x8000), "heap region overflowed into stack");
-        . += (ORIGIN(RAM) + LENGTH(RAM) - 0x8000) - .;
+        ASSERT(. <= (ORIGIN(RAM) + LENGTH(RAM) - 0x800), "heap region overflowed into stack");
+        . += (ORIGIN(RAM) + LENGTH(RAM) - 0x800) - .;
     } > RAM
     PROVIDE(__heap_start = ADDR(.heap));
     PROVIDE(__heap_size = SIZEOF(.heap));

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -40,8 +40,8 @@ export symbol __ICFEDIT_region_RAM_end__;
 
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/
-define symbol __ICFEDIT_size_cstack__   = 0x2000;
-define symbol __ICFEDIT_size_heap__     = 0x4000;
+define symbol __ICFEDIT_size_cstack__   = 0x800;
+define symbol __ICFEDIT_size_heap__     = 0x5800;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __code_start_soft_device__ = 0x0;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
@@ -40,8 +40,8 @@ export symbol __ICFEDIT_region_RAM_end__;
 
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/
-define symbol __ICFEDIT_size_cstack__   = 0x8000;
-define symbol __ICFEDIT_size_heap__     = 0x10000;
+define symbol __ICFEDIT_size_cstack__   = 0x800;
+define symbol __ICFEDIT_size_heap__     = 0x17800;
 /**** End of ICF editor section. ###ICF###*/
 
 define symbol __code_start_soft_device__ = 0x0;


### PR DESCRIPTION
GCC and IAR ISR stack sizes have been set to 0x800.
(ARM compiler does not set stack size explicitly).

Note that the GCC linker script for NRF52840 already has the correct stack size.