### PR TITLE
Feat/cmake memap

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -86,7 +86,7 @@ class _Parser(object):
 
 class _GccParser(_Parser):
     RE_OBJECT_FILE = re.compile(r'^(.+\/.+\.o(bj)?)$')
-    RE_LIBRARY_OBJECT = re.compile(r'^.+' + sep + r'lib((.+\.a)\((.+\.o(bj)?)\))$')
+    RE_LIBRARY_OBJECT = re.compile(r'^.+(\\|/)lib((.+\.a)\((.+\.o(bj)?)\))$')
     RE_STD_SECTION = re.compile(r'^\s+.*0x(\w{8,16})\s+0x(\w+)\s(.+)$')
     RE_FILL_SECTION = re.compile(r'^\s*\*fill\*\s+0x(\w{8,16})\s+0x(\w+).*$')
     OBJECT_EXTENSIONS = (".o", ".obj")

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -14,8 +14,15 @@ from argparse import ArgumentParser
 from copy import deepcopy
 from prettytable import PrettyTable
 
-from .utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
-                    argparse_uppercase_type)
+# Be sure that the tools directory is in the search path
+# import sys.path.insert
+import sys
+from os.path import abspath
+ROOT = abspath(join(dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from tools.utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
+                         argparse_uppercase_type)
 
 
 class _Parser(object):

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -14,8 +14,8 @@ from argparse import ArgumentParser
 from copy import deepcopy
 from prettytable import PrettyTable
 
-from .utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
-                    argparse_uppercase_type)
+from utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
+                   argparse_uppercase_type)
 
 
 class _Parser(object):

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -78,10 +78,11 @@ class _Parser(object):
 
 
 class _GccParser(_Parser):
-    RE_OBJECT_FILE = re.compile(r'^(.+\/.+\.o)$')
-    RE_LIBRARY_OBJECT = re.compile(r'^.+' + sep + r'lib((.+\.a)\((.+\.o)\))$')
+    RE_OBJECT_FILE = re.compile(r'^(.+\/.+\.o(bj)?)$')
+    RE_LIBRARY_OBJECT = re.compile(r'^.+' + sep + r'lib((.+\.a)\((.+\.o(bj)?)\))$')
     RE_STD_SECTION = re.compile(r'^\s+.*0x(\w{8,16})\s+0x(\w+)\s(.+)$')
     RE_FILL_SECTION = re.compile(r'^\s*\*fill\*\s+0x(\w{8,16})\s+0x(\w+).*$')
+    OBJECT_EXTENSIONS = (".o", ".obj")
 
     ALL_SECTIONS = _Parser.SECTIONS + _Parser.OTHER_SECTIONS + \
                    _Parser.MISC_FLASH_SECTIONS + ('unknown', 'OUTPUT')
@@ -185,12 +186,12 @@ class _GccParser(_Parser):
                 self.module_add(object_name, object_size, current_section)
 
         common_prefix = dirname(commonprefix([
-            o for o in self.modules.keys() if (o.endswith(".o") and not o.startswith("[lib]"))]))
+            o for o in self.modules.keys() if (o.endswith(self.OBJECT_EXTENSIONS) and not o.startswith("[lib]"))]))
         new_modules = {}
         for name, stats in self.modules.items():
             if name.startswith("[lib]"):
                 new_modules[name] = stats
-            elif name.endswith(".o"):
+            elif name.endswith(self.OBJECT_EXTENSIONS):
                 new_modules[relpath(name, common_prefix)] = stats
             else:
                 new_modules[name] = stats
@@ -200,7 +201,8 @@ class _GccParser(_Parser):
 class _ArmccParser(_Parser):
     RE = re.compile(
         r'^\s+0x(\w{8})\s+0x(\w{8})\s+(\w+)\s+(\w+)\s+(\d+)\s+[*]?.+\s+(.+)$')
-    RE_OBJECT = re.compile(r'(.+\.(l|ar))\((.+\.o)\)')
+    RE_OBJECT = re.compile(r'(.+\.(l|ar))\((.+\.o(bj)?)\)')
+    OBJECT_EXTENSIONS = (".o", ".obj")
 
     def parse_object_name(self, line):
         """ Parse object file
@@ -208,7 +210,7 @@ class _ArmccParser(_Parser):
         Positional arguments:
         line - the line containing the object or library
         """
-        if line.endswith(".o"):
+        if line.endswith(self.OBJECT_EXTENSIONS):
             return line
 
         else:
@@ -276,12 +278,12 @@ class _ArmccParser(_Parser):
                 self.module_add(*self.parse_section(line))
 
         common_prefix = dirname(commonprefix([
-            o for o in self.modules.keys() if (o.endswith(".o") and o != "anon$$obj.o" and not o.startswith("[lib]"))]))
+            o for o in self.modules.keys() if (o.endswith(self.OBJECT_EXTENSIONS) and o != "anon$$obj.o" and not o.startswith("[lib]"))]))
         new_modules = {}
         for name, stats in self.modules.items():
             if name == "anon$$obj.o" or name.startswith("[lib]"):
                 new_modules[name] = stats
-            elif name.endswith(".o"):
+            elif name.endswith(self.OBJECT_EXTENSIONS):
                 new_modules[relpath(name, common_prefix)] = stats
             else:
                 new_modules[name] = stats
@@ -293,9 +295,10 @@ class _IarParser(_Parser):
         r'^\s+(.+)\s+(zero|const|ro code|inited|uninit)\s'
         r'+0x(\w{8})\s+0x(\w+)\s+(.+)\s.+$')
 
-    RE_CMDLINE_FILE = re.compile(r'^#\s+(.+\.o)')
+    RE_CMDLINE_FILE = re.compile(r'^#\s+(.+\.o(bj)?)')
     RE_LIBRARY = re.compile(r'^(.+\.a)\:.+$')
-    RE_OBJECT_LIBRARY = re.compile(r'^\s+(.+\.o)\s.*')
+    RE_OBJECT_LIBRARY = re.compile(r'^\s+(.+\.o(bj)?)\s.*')
+    OBJECT_EXTENSIONS = (".o", ".obj")
 
     def __init__(self):
         _Parser.__init__(self)
@@ -309,7 +312,7 @@ class _IarParser(_Parser):
         Positional arguments:
         line - the line containing the object or library
         """
-        if object_name.endswith(".o"):
+        if object_name.endswith(self.OBJECT_EXTENSIONS):
             try:
                 return self.cmd_modules[object_name]
             except KeyError:
@@ -403,7 +406,7 @@ class _IarParser(_Parser):
                 break
             for arg in line.split(" "):
                 arg = arg.rstrip(" \n")
-                if (not arg.startswith("-")) and arg.endswith(".o"):
+                if (not arg.startswith("-")) and arg.endswith(self.OBJECT_EXTENSIONS):
                     self.cmd_modules[basename(arg)] = arg
 
         common_prefix = dirname(commonprefix(list(self.cmd_modules.values())))

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -14,8 +14,8 @@ from argparse import ArgumentParser
 from copy import deepcopy
 from prettytable import PrettyTable
 
-from utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
-                   argparse_uppercase_type)
+from .utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
+                    argparse_uppercase_type)
 
 
 class _Parser(object):


### PR DESCRIPTION
CMake exported builds generate .obj files instead of .o files. Updated RE and line endswith for supporting both extensions
### Description
Fixes ARMmbed/mbed-cli#632
@theotherjimmy ~~I've also partially reverted [this](https://github.com/ARMmbed/mbed-os/commit/c93a2bfa4c817d089715a93f5a576a14c2184df5#diff-f9cb941bde5647a5763e18fc220efc51) commit in this file due to relative import in non-package error in Python. Please see the comment on this commit for the full error message.~~

### Testing
1. Make sure to have a `project.cmake` with at least the following content to generate a .map file
```cmake
# Add a linker flag to generate a memory map file
SET(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} -Wl,-Map=${CMAKE_PROJECT_NAME}.map")
```
2. Export and compile a project (example blinky)
```shell
$ mbed export -i cmake_gcc_arm -m NUCLEO_F103RB
$ cmake .
$ make all
$ python mbed-os/tools/memap.py mbed-os-example-blinky.map -t GCC_ARM
+------------------+-------+-------+------+
| Module           | .text | .data | .bss |
+------------------+-------+-------+------+
| [fill]           |    91 |     4 |   13 |
| [lib]/c.a        | 24833 |  2472 |   89 |
| [lib]/gcc.a      |  3864 |     0 |    0 |
| [lib]/misc       |   208 |    12 |   28 |
| main.cpp.obj     |   328 |     4 |   28 |
| mbed-os/drivers  |   856 |     4 |  100 |
| mbed-os/hal      |  3072 |     4 |   68 |
| mbed-os/platform |  4488 |   260 |  149 |
| mbed-os/rtos     | 16845 |   168 | 6065 |
| mbed-os/targets  | 10345 |     4 |  360 |
| Subtotals        | 64930 |  2932 | 6900 |
+------------------+-------+-------+------+
Total Static RAM memory (data + bss): 9832 bytes
Total Flash memory (text + data): 67862 bytes
```
### Pull request type
- [ ] Fix
- [ ] Refactor
- [ ] New target
- [x] Feature
- [ ] Breaking change