### PR TITLE
Fix for Crash dump formatting issues and adding more info to crash dump

### DIFF
--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
@@ -144,13 +144,18 @@ Fault_Handler_Continue2
                 MRS      R2,MSP                   ; Get MSP           
                 STR      R2,[R1]
                 ADDS     R1,#4
-                LDR      R3,=mbed_fault_handler     ; Load address of mbedFaultHandler
+                MOV      R2,LR                    ; Get current LR(EXC_RETURN)           
+                STR      R2,[R1]
+                ADDS     R1,#4
+                MRS      R2,CONTROL               ; Get CONTROL Reg
+                STR      R2,[R1]
+                LDR      R3,=mbed_fault_handler   ; Load address of mbedFaultHandler
                 MOV      R0,R12
                 LDR      R1,=mbed_fault_context
                 LDR      R2,=osRtxInfo
                 BLX      R3
 #endif                    
-                B        .                         ; Just in case we come back here                
+                B        .                        ; Just in case we come back here                
                 ENDP
                     
 #endif

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
@@ -176,7 +176,12 @@ Fault_Handler_Continue2:
         MRS      R2,MSP                   // Get MSP           
         STR      R2,[R1]
         ADDS     R1,#4
-        LDR      R3,=mbed_fault_handler     // Load address of mbedFaultHandler
+        MOV      R2,LR                    // Get current LR(EXC_RETURN)           
+        STR      R2,[R1]
+        ADDS     R1,#4
+        MRS      R2,CONTROL               // Get CONTROL Reg
+        STR      R2,[R1]
+        LDR      R3,=mbed_fault_handler   // Load address of mbedFaultHandler
         MOV      R0,R12
         LDR      R1,=mbed_fault_context
         LDR      R2,=osRtxInfo

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
@@ -139,13 +139,18 @@ Fault_Handler_Continue2
                 MRS     R2,MSP                   ; Get MSP           
                 STR     R2,[R1]
                 ADDS    R1,#4
-                LDR     R3,=mbed_fault_handler     ; Load address of mbedFaultHandler
+                MOV     R2,LR                    ; Get current LR(EXC_RETURN)           
+                STR     R2,[R1]
+                ADDS    R1,#4
+                MRS     R2,CONTROL               ; Get CONTROL Reg
+                STR     R2,[R1]
+                LDR     R3,=mbed_fault_handler   ; Load address of mbedFaultHandler
                 MOV     R0,R12
                 LDR     R1,=mbed_fault_context
                 LDR     R2,=osRtxInfo
                 BLX     R3 
 #endif                
-                B       .                         ; Just in case we come back here    
-#endif                                            ; #if (MBED_FAULT_HANDLER_SUPPORT == 1) 
+                B       .                        ; Just in case we come back here    
+#endif                                           ; #if (MBED_FAULT_HANDLER_SUPPORT == 1) 
 
                 END

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -143,7 +143,27 @@ void print_context_info()
         fault_print_str("\nBFAR : %",(uint32_t *)&SCB->BFAR); 
     }
 #endif
-    
+    //Print Mode
+    if(mbed_fault_context.EXC_RETURN & 0x8) {
+        fault_print_str("\nMode : Thread", NULL);
+        //Print Priv level in Thread mode - We capture CONTROL reg which reflects the privilege.
+        //Note that the CONTROL register captured still reflects the privilege status of the 
+        //thread mode eventhough we are in Handler mode by the time we capture it.
+        if(mbed_fault_context.CONTROL & 0x1) {
+            fault_print_str("\nPriv : User", NULL); 
+        } else {
+            fault_print_str("\nPriv : Privileged", NULL); 
+        }        
+    } else {
+        fault_print_str("\nMode : Handler", NULL); 
+        fault_print_str("\nPriv : Privileged", NULL); 
+    }
+    //Print Return Stack
+    if(mbed_fault_context.EXC_RETURN & 0x4) {
+        fault_print_str("\nStack: PSP", NULL); 
+    } else {
+        fault_print_str("\nStack: MSP", NULL); 
+    }
 }
 
 /* Prints thread info from a list */

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -194,17 +194,13 @@ void fault_print_str(char *fmtstr, uint32_t *values)
     char hex_str[9]={0};
         
     while(fmtstr[i] != '\0') {
-        if(fmtstr[i] == '\n' || fmtstr[i] == '\r') {
-            serial_putc(&stdio_uart, '\r');
-        } else {
-            if(fmtstr[i]=='%') {
-                hex_to_str(values[vidx++],hex_str);
-                for(idx=7; idx>=0; idx--) {
-                    serial_putc(&stdio_uart, hex_str[idx]);
-                }
-            } else {
-                serial_putc(&stdio_uart, fmtstr[i]);
+        if(fmtstr[i]=='%') {
+            hex_to_str(values[vidx++],hex_str);
+            for(idx=7; idx>=0; idx--) {
+                serial_putc(&stdio_uart, hex_str[idx]);
             }
+        } else {
+            serial_putc(&stdio_uart, fmtstr[i]);
         }
         i++;
     }

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
@@ -37,6 +37,8 @@ typedef struct {
   uint32_t xPSR;
   uint32_t PSP;
   uint32_t MSP;
+  uint32_t EXC_RETURN;
+  uint32_t CONTROL;    
 } mbed_fault_context_t;
 
 //Fault type definitions


### PR DESCRIPTION
This fixes some formatting issues in crash dump and also adds more info like return stack info, privilege level and mode to the crash dump. 