### PR TITLE
Clarify intention between comparison to zero and the shift operation

### DIFF
--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -37,7 +37,7 @@ static inline int equeue_clampdiff(unsigned a, unsigned b) {
 // Increment the unique id in an event, hiding the event from cancel
 static inline void equeue_incid(equeue_t *q, struct equeue_event *e) {
     e->id += 1;
-    if (0 == (e->id << q->npw2)) {
+    if ((e->id << q->npw2) == 0) {
         e->id = 1;
     }
 }
@@ -469,7 +469,7 @@ void equeue_event_dtor(void *p, void (*dtor)(void *)) {
 }
 
 
-// simple callbacks 
+// simple callbacks
 struct ecallback {
     void (*cb)(void*);
     void *data;

--- a/events/equeue/equeue.c
+++ b/events/equeue/equeue.c
@@ -37,7 +37,7 @@ static inline int equeue_clampdiff(unsigned a, unsigned b) {
 // Increment the unique id in an event, hiding the event from cancel
 static inline void equeue_incid(equeue_t *q, struct equeue_event *e) {
     e->id += 1;
-    if (!(e->id << q->npw2)) {
+    if (0 == (e->id << q->npw2)) {
         e->id = 1;
     }
 }


### PR DESCRIPTION
### Description

Building with (GNU Tools for Arm Embedded Processors 7-2017-q4-major) 7.2.1 20170904 gives this warning

../events/equeue/equeue.c: In function 'equeue_incid':
../events/equeue/equeue.c:40:17: warning: '<<' in boolean context, did you mean '<' ? [-Wint-in-bool-context]
     if (!(e->id << q->npw2)) {

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change