### PR TITLE
Feature: device key HAL addition

### DIFF
--- a/TESTS/mbed_hal/device_key/main.cpp
+++ b/TESTS/mbed_hal/device_key/main.cpp
@@ -1,0 +1,123 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+#include "mbed.h"
+#include "device_key_api.h"
+
+#ifndef DEVICE_DEVKEY
+#error [NOT_SUPPORTED] DEVICE_KEY needs to be enabled for this test
+#endif
+
+using namespace utest::v1;
+
+#define DEVICE_KEY_16BYTE 16
+#define DEVICE_KEY_32BYTE 32
+
+/*
+ * Test if the platform return a valid device key size
+ */
+void device_key_get_size_test()
+{
+    size_t len = device_key_get_size_in_bytes();
+    TEST_ASSERT_FALSE_MESSAGE(DEVICE_KEY_16BYTE != len && DEVICE_KEY_32BYTE != len,
+                              "Device key length is not 16 or 32 Byte long");
+}
+
+/*
+ * Test that the platform return error when the buffer is to small
+ */
+void device_key_get_key_buffer_to_small_test()
+{
+    uint32_t buffer[(DEVICE_KEY_16BYTE / 2) / sizeof(uint32_t)];
+    size_t len = DEVICE_KEY_16BYTE / 2;
+
+    memset(buffer, 0, DEVICE_KEY_16BYTE / 2);
+    int status = device_key_get_value(buffer, &len);
+    TEST_ASSERT_EQUAL_INT32(DEVICEKEY_HAL_BUFFER_TOO_SMALL, status);
+}
+
+/*
+ * Test if the platform return a device key buffer with
+ * the correct length.
+ */
+void device_key_get_key_length_test()
+{
+    size_t expected = device_key_get_size_in_bytes();
+    uint32_t buffer[(DEVICE_KEY_32BYTE * 2) / sizeof(uint32_t)];
+    size_t len = (DEVICE_KEY_32BYTE * 2);
+
+    memset(buffer, 0, sizeof(buffer));
+    int status = device_key_get_value(buffer, &len);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+    TEST_ASSERT_EQUAL_INT32(expected, len);
+}
+
+/*
+ * Test if the platform returns the same key consistently.
+ */
+void device_key_check_consistency_key_test()
+{
+    uint32_t empty_buffer[DEVICE_KEY_32BYTE / sizeof(uint32_t)];
+    uint32_t buffer1[DEVICE_KEY_32BYTE / sizeof(uint32_t)];
+    uint32_t buffer2[DEVICE_KEY_32BYTE / sizeof(uint32_t)];
+    size_t len1 = DEVICE_KEY_32BYTE;
+    size_t len2 = DEVICE_KEY_32BYTE;
+
+    memset(empty_buffer, 0, sizeof(empty_buffer));
+    memset(buffer1, 0, sizeof(buffer1));
+    int status = device_key_get_value(buffer1, &len1);
+    TEST_ASSERT_EQUAL_INT32(0, status);
+    bool is_empty = !memcmp(empty_buffer, buffer1, sizeof(buffer1));
+    TEST_ASSERT_FALSE(is_empty);
+
+    for (int i = 0; i < 100; i++) {
+        memset(buffer2, 0, sizeof(buffer2));
+        status = device_key_get_value(buffer2, &len2);
+        TEST_ASSERT_EQUAL_INT32(0, status);
+        TEST_ASSERT_EQUAL_INT32(len2, len1);
+        TEST_ASSERT_EQUAL_INT32_ARRAY(buffer1, buffer2, len2 / sizeof(uint32_t));
+        len2 = DEVICE_KEY_32BYTE;
+    }
+}
+
+utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason) {
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_CONTINUE;
+}
+
+Case cases[] = {
+        Case("Device Key - get size",                device_key_get_size_test,                greentea_failure_handler),
+        Case("Device Key - get key buffer to small", device_key_get_key_buffer_to_small_test, greentea_failure_handler),
+        Case("Device Key - get key length",          device_key_get_key_length_test,          greentea_failure_handler),
+        Case("Device Key - check consistency key",   device_key_check_consistency_key_test,   greentea_failure_handler)
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(20, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main()
+{
+    return Harness::run(specification);
+}
+

--- a/hal/device-key.md
+++ b/hal/device-key.md
@@ -1,0 +1,31 @@
+### DeviceKey
+
+DeviceKey is a mechanism that can be used as a root of trust for key derivation, and is one of the most fundamental elements in the implementation of security in a device.
+The DeviceKey consists of a secret and unique value per board instance, containing 128 or 256 bits.
+There are several possible sources for this data, the preferred one is via this HAL API.
+If this HAL API is not implemented and the device supports TRNG, mbedos will generate a DeviceKey the first time it is requested, using the TRNG, and save the value in the internal memory using NVStore.
+As a last option, if none of the above is available, the DeviceKey can still be injected from outside the board and saved in NVStore using a dedicated API
+
+##### Defined behavior
+
+- The key should be 16 or 32 bytes long. Any other size is not supported. 
+- The function device_key_get_size_in_bytes must return the actual key size in bytes.  
+- The function device_key_get_value must return the key value in the provided buffer.
+- The function device_key_get_value must return the actual number of bytes written to the buffer in the provided length parameter.
+- If the size of the buffer is smaller than the available key, a DEVICEKEY_HAL_BUFFER_TOO_SMALL error code is must be returned.  
+- The returned values of the API must be consistent during the life cycle of the device. 
+
+##### Undefined behavior
+ - There should not be any undefined behavior
+
+#### Implementing the DeviceKey API
+
+To enable DeviceKey support in Mbed OS, add the `DEVKEY` label in the `device_has` option of the target's section in the `targets.json` file.
+
+#### Testing
+
+The Mbed OS HAL provides a set of conformance tests for DeviceKey. You can use these tests to validate the correctness of your implementation. To run the DeviceKey HAL tests, use the following command:
+
+```
+mbed test -t <toolchain> -m <target> -n "tests-mbed_hal-device_key"
+```

--- a/hal/device_key_api.h
+++ b/hal/device_key_api.h
@@ -1,0 +1,74 @@
+/** \addtogroup hal */
+/** @{*/
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* Device key - Root of Trust, when provided by the platform, is a
+ * secret and unique per-device value. The value must be 16
+ * or 32 bytes length, any other length is forbidden.
+ */
+
+#ifndef MBED_DEVICE_KEY_API_H
+#define MBED_DEVICE_KEY_API_H
+
+#include "stddef.h"
+#include "stdint.h"
+
+#if DEVICE_DEVKEY
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum DeviceKeyHalStatus {
+    DEVICEKEY_HAL_SUCCESS          =  0,
+    DEVICEKEY_HAL_FAILURE          = -1,
+    DEVICEKEY_HAL_BUFFER_TOO_SMALL = -2,
+};
+
+/**
+ * \defgroup hal_device_key DEVICE_KEY hal functions
+ * @{
+ */
+
+/** Return the size of the device key in bytes.
+ *
+ *
+ * @return the device key length. Only 16 or 32
+ * byte length are a legal return values
+ */
+int device_key_get_size_in_bytes();
+
+/** Retrieve a device key from the platform
+ *
+ * @param output The pointer to an output array
+ * @param length in: The size of output data buffer
+ *               out: The size of the actual data written
+ * @return DEVICEKEY_HAL_SUCCESS, DEVICEKEY_HAL_FAILURE or
+ *         DEVICEKEY_HAL_BUFFER_TOO_SMALL
+ */
+int device_key_get_value(uint32_t *output, size_t *size);
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif
+
+/** @}*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device_key_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device_key_api.c
@@ -1,0 +1,61 @@
+/*
+ *
+ *  Copyright (C) 2018, ARM Limited, All Rights Reserved
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
+ *  not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+/*
+ * Reference: "K64 Sub-Family Reference Manual, Rev. 2", chapter 12.2.19-12.2.22
+ */
+
+#if defined(DEVICE_DEVKEY)
+
+#include <stdlib.h>
+#include "fsl_common.h"
+#include "fsl_clock.h"
+#include "device_key_api.h"
+
+/* Key length in bytes. This is platform dependent and can be
+ * only 16 or 32 bytes long
+ */
+#define DEVICE_KEY_SIZE 16
+
+int device_key_get_size_in_bytes()
+{
+    return DEVICE_KEY_SIZE;
+}
+
+/*  The function return the values stored in registers
+ *  UIDH, UIDMH, UIDML and UIDL. Please notice: Part of this value
+ *  is the device serial number therefore predictable and unsecured.
+ *  This code is used as an example only.
+ */
+int device_key_get_value(uint32_t *output, size_t *size)
+{
+    if (*size < DEVICE_KEY_SIZE) {
+        return DEVICEKEY_HAL_BUFFER_TOO_SMALL;
+    }
+
+    memset(output, 0, *size);
+
+    *output++ = SIM->UIDH;
+    *output++ = SIM->UIDML;
+    *output++ = SIM->UIDMH;
+    *output++ = SIM->UIDL;
+    *size = sizeof(*output) * 4;
+
+    return DEVICEKEY_HAL_SUCCESS;
+}
+
+#endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -614,7 +614,7 @@
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0240"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
+        "device_has": ["DEVKEY", "ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE", "STDIO_MESSAGES", "STORAGE", "TRNG", "FLASH"],
         "features": ["LWIP", "STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK64FN1M0xxx12",


### PR DESCRIPTION
### Description

DeviceKey is a mechanism that can be used as a root of trust for key derivation, and is one of the most fundamental elements in the implementation of security in a device.


### Pull request type
- [x] Feature

