### PR TITLE
Add parameter in tools settings to show error/warning as Link

### DIFF
--- a/tools/default_settings.py
+++ b/tools/default_settings.py
@@ -43,3 +43,6 @@ from os.path import join, abspath, dirname
 
 # mbed.org username
 #MBED_ORG_USER = ""
+
+# Print compiler warnings and errors as link format
+#PRINT_COMPILER_OUTPUT_AS_LINK = False

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -54,6 +54,9 @@ BUILD_OPTIONS = []
 # mbed.org username
 MBED_ORG_USER = ""
 
+# Print compiler warnings and errors as link format
+PRINT_COMPILER_OUTPUT_AS_LINK = False
+
 CLI_COLOR_MAP = {
     "warning": "yellow",
     "error"  : "red"
@@ -74,7 +77,7 @@ except ImportError:
 # User Settings (env vars)
 ##############################################################################
 _ENV_PATHS = ['ARM_PATH', 'GCC_ARM_PATH', 'GCC_CR_PATH', 'IAR_PATH',
-              'ARMC6_PATH']
+              'ARMC6_PATH', 'PRINT_COMPILER_OUTPUT_AS_LINK']
 
 for _n in _ENV_PATHS:
     if getenv('MBED_'+_n):

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -35,7 +35,7 @@ import fnmatch
 
 from ..utils import (run_cmd, mkdir, rel_path, ToolException,
                     NotSupportedException, split_path, compile_worker)
-from ..settings import MBED_ORG_USER
+from ..settings import MBED_ORG_USER, PRINT_COMPILER_OUTPUT_AS_LINK
 from .. import hooks
 from ..memap import MemapParser
 
@@ -460,8 +460,13 @@ class mbedToolchain:
 
         elif event['type'] == 'cc':
             event['severity'] = event['severity'].title()
-            event['file'] = basename(event['file'])
-            msg = '[%(severity)s] %(file)s@%(line)s,%(col)s: %(message)s' % event
+
+            if PRINT_COMPILER_OUTPUT_AS_LINK:
+                event['file'] = getcwd() + event['file'].strip('.')
+                msg = '[%(severity)s] %(file)s:%(line)s:%(col)s: %(message)s' % event
+            else:
+                event['file'] = basename(event['file'])
+                msg = '[%(severity)s] %(file)s@%(line)s,%(col)s: %(message)s' % event
 
         elif event['type'] == 'progress':
             if 'percent' in event:


### PR DESCRIPTION
## Description
This feature increases the comfortability of the mbed-cli within an offline IDE.
It allows the developer to jump directly to the error/warning instead of searching for the file and position.

Per default, mbed compile prints errors/warnings on output not in a link format, therefore it is not possible to click, i.e. in an IDE, on the errors/warnings and jump to the position of the file, or even know where (path) it is.
This feature generates an absolute path, because some IDEs are not parsing relatives paths correctly (i.e. VSCode).

In the linked picture, a compare between the default compile output and the newly one with the link is visualized.
[compare mbed compile output](http://www.screencast.com/t/6Aiy7brcWC7)

It is possible to activate/deactive the feature by setting this define
`PRINT_COMPILER_OUTPUT_AS_LINK = False`
in the application specific "mbed_settings.py" to true

## Status

**READY**

## Migrations

I think nothing has to be changed, it just makes the error/warning output from "mbed-cli compile" more useful in an offline IDE.

NO

## Steps to test or reproduce

Insert in the application specific "mbed_settings.py":
`PRINT_COMPILER_OUTPUT_AS_LINK = True`

Start mbed compile with:
`mbed compile -t GCC_ARM`
note: mcu (TARGET) must/should be configured in ".mbed"