### PR TITLE
Allow build profiles to omit language entries

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -330,7 +330,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     profile = {'c': [], 'cxx': [], 'common': [], 'asm': [], 'ld': []}
     for contents in build_profile or []:
         for key in profile:
-            profile[key].extend(contents[toolchain_name][key])
+            profile[key].extend(contents[toolchain_name].get(key, []))
 
     toolchain = cur_tc(target, notify, macros, silent, build_dir=build_dir,
                        extra_verbose=extra_verbose, build_profile=profile)


### PR DESCRIPTION
Allow toolchain build profiles to omit language entries

### Description

Currently the `prepare_toolchain` function in `build_api.py` expects all profiles to contain all language keys. When writing a toolchain profile to overlay on the default profiles this can cause unexpected behaviour: ie. if you don't have an entry for the key there is an opaque error.

The workaround is to have a profile.json file that looks like this:

    "TOOLCHAIN": {
        "common": [],
        "asm": [],
        "c": [],
        "cxx": ["-flag"],
        "ld": []
    }

but it would be nice to allow this

    "TOOLCHAIN": {
        "cxx": ["-flag"],
    }

This pull request allows this by modifying the code that gets the language key from the dictionary.

### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
