### PR TITLE
NRF52: Customize STDIO pins from config system

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/PeripheralNames.h
@@ -45,8 +45,14 @@
 extern "C" {
 #endif
 
+#ifndef STDIO_UART_TX
 #define STDIO_UART_TX     TX_PIN_NUMBER
+#endif
+
+#ifndef STDIO_UART_RX
 #define STDIO_UART_RX     RX_PIN_NUMBER
+#endif
+
 #define STDIO_UART        UART_0
 
 typedef enum {

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/PeripheralNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52840/PeripheralNames.h
@@ -45,8 +45,14 @@
 extern "C" {
 #endif
 
+#ifndef STDIO_UART_TX
 #define STDIO_UART_TX     TX_PIN_NUMBER
+#endif
+
+#ifndef STDIO_UART_RX
 #define STDIO_UART_RX     RX_PIN_NUMBER
+#endif
+
 #define STDIO_UART        UART_0
 
 typedef enum


### PR DESCRIPTION
This change makes it possible to customize the STDIO pins, which is needed by the Client Lite.