### PR TITLE
SPM client: doc edit

### DIFF
--- a/spm/spm_client.h
+++ b/spm/spm_client.h
@@ -86,7 +86,7 @@ psa_handle_t psa_connect(uint32_t sfid, uint32_t minor_version);
  *                            (pointing to non-existent memory or lack of permission for this memory).
  *         @a PSA_MSG_PAYLOAD_TOO_LARGE/PSA_MSG_PAYLOAD_TOO_SMALL if there is an issue with the payload size.@n
  *         @a PSA_INVALID_HANDLE if the handle is not valid.@n
- *         @a PSA_RESPONSE_PAYLOAD_UNSUPPORTED if the caller specified a response buffer but the Secure Function does not send response payloads.
+ *         @a PSA_RESPONSE_PAYLOAD_UNSUPPORTED if the caller specified a response buffer but the Secure Function has not sent a response payload.
  */
 psa_error_t psa_call(
     psa_handle_t handle,


### PR DESCRIPTION
#### Description

I haven't changed anything in this file but I've got a couple of observations:

Line 77 - should this comment be removed?
Line 89 - I'm not sure that I understand - "but the Secure Function does not send response payloads."  Is this saying that the response buffer has not been created by the Secure Function? Or that it's not recognized by the Secure Function?  I've suggested a re-word but I'm not sure it's correct.

### Pull request type

- [ X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
