### PR TITLE
ARMCC5 does not like folder-prefixed header names

### DIFF
--- a/features/lorawan/LoRaRadio.h
+++ b/features/lorawan/LoRaRadio.h
@@ -18,7 +18,7 @@
 #ifndef LORARADIO_H_
 #define LORARADIO_H_
 
-#include "platform/Callback.h"
+#include "Callback.h"
 #include "PinNames.h"
 
 /**


### PR DESCRIPTION
## Description 

Without this fix I cannot compile the mbed-os-example-lorawan in the online compiler. We need this fixed before SXSW happens, as when I'm using my own fork of Mbed OS it takes 5 minutes to clone the repository in the compiler.

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change

@sg- @hasnainvirk 