### PR TITLE
rtl8195am - fix gpio toggle slow

### DIFF
--- a/events/README.md
+++ b/events/README.md
@@ -113,7 +113,7 @@ queue.dispatch();
 
 // Events can also pass arguments to the underlying callback when both
 // initially constructed and posted.
-Event<void(int, int)> event(&queue, printf, "recieved %d and %d\n");
+Event<void(int, int)> event(&queue, printf, "received %d and %d\n");
 
 // Events can be posted multiple times and enqueue gracefully until
 // the dispatch function is called.

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/README.md
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/README.md
@@ -1,10 +1,10 @@
 # BLE API Cordio Implementation 
 
 The BLE API Cordio implementation allows Cordio licensee to easily deliver a 
-complete and up to date implementation of mbed BLE to their custommers using 
+complete and up to date implementation of mbed BLE to their customers using 
 mbed OS. 
 
-To deliver a BLE port, vendors simply have to provide an HCI driver taillored 
+To deliver a BLE port, vendors simply have to provide an HCI driver tailored 
 for the BLE module present on the board they want to support. 
 
 ## Source Organization 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/README.md
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/sdk/README.md
@@ -8,7 +8,7 @@ The files are kept the same as much as possible to the Nordic SDK. Modifications
 
 
 ## Porting new versions of Nordic SDK
-A list of files currently requierd by mbed is maintained in [script/required_files.txt](https://github.com/ARMmbed/nrf51-sdk/blob/master/script/required_files.txt). [A python script](https://github.com/ARMmbed/nrf51-sdk/blob/master/script/pick_nrf51_files.py) is written to help porting from nordic sdk releases. **required_files.txt** is parsed to find a list of filenames. The script searches for these filenames in the sdk folder, and copy then into the yotta module mirroring the folder structure in the sdk. **extraIncludes** is automatically added to module.json to allow direct inclusion of noridc headers with just the filename.
+A list of files currently required by mbed is maintained in [script/required_files.txt](https://github.com/ARMmbed/nrf51-sdk/blob/master/script/required_files.txt). [A python script](https://github.com/ARMmbed/nrf51-sdk/blob/master/script/pick_nrf51_files.py) is written to help porting from nordic sdk releases. **required_files.txt** is parsed to find a list of filenames. The script searches for these filenames in the sdk folder, and copy then into the yotta module mirroring the folder structure in the sdk. **extraIncludes** is automatically added to module.json to allow direct inclusion of noridc headers with just the filename.
 
 ### Script usage
 ```

--- a/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.3.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.3.0) 
+**New feature:**
+-  Add new API which clears the whole sent blockwise message list
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.2.0...v4.3.0)
+
 ## [v4.2.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.2.0) 
 **New feature:**
 -  Add new API to remove sent blockwise message from the linked list

--- a/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -247,6 +247,15 @@ extern int8_t sn_coap_convert_block_size(uint16_t block_size);
  */
 extern int8_t sn_coap_protocol_handle_block2_response_internally(struct coap_s *handle, uint8_t handle_response);
 
+/**
+ * \fn void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle)
+ *
+ * \brief This function clears all the sent blockwise messages from the linked list.
+ *
+ * \param *handle Pointer to CoAP library handle
+ */
+extern void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle);
+
 #endif /* SN_COAP_PROTOCOL_H_ */
 
 #ifdef __cplusplus

--- a/features/FEATURE_COMMON_PAL/mbed-coap/module.json
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
@@ -256,6 +256,27 @@ int8_t sn_coap_protocol_set_block_size(struct coap_s *handle, uint16_t block_siz
 
 }
 
+void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle)
+{
+    (void) handle;
+#if SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+    if (handle == NULL) {
+        return;
+    }
+
+    /* Loop all stored Blockwise messages in Linked list */
+    ns_list_foreach_safe(coap_blockwise_msg_s, removed_blocwise_msg_ptr, &handle->linked_list_blockwise_sent_msgs) {
+        if (removed_blocwise_msg_ptr->coap_msg_ptr) {
+            handle->sn_coap_protocol_free(removed_blocwise_msg_ptr->coap_msg_ptr->payload_ptr);
+            removed_blocwise_msg_ptr->coap_msg_ptr->payload_ptr = 0;
+            sn_coap_parser_release_allocated_coap_msg_mem(handle, removed_blocwise_msg_ptr->coap_msg_ptr);
+            removed_blocwise_msg_ptr->coap_msg_ptr = 0;
+        }
+        sn_coap_protocol_linked_list_blockwise_msg_remove(handle, removed_blocwise_msg_ptr);
+    }
+#endif
+}
+
 int8_t sn_coap_protocol_set_duplicate_buffer_size(struct coap_s *handle, uint8_t message_count)
 {
     (void) handle;

--- a/features/mbedtls/README.md
+++ b/features/mbedtls/README.md
@@ -10,7 +10,7 @@ This edition of mbed TLS has been adapted for mbed OS and imported from its stan
 Getting Help and Support
 ------------------------
 
-The [mbed TLS website](https://tls.mbed.org/) contains fulll documentation for the library, including function by function descriptions, knowledgebase articles, blogs and a support forum for questions to the community.
+The [mbed TLS website](https://tls.mbed.org/) contains full documentation for the library, including function by function descriptions, knowledgebase articles, blogs and a support forum for questions to the community.
 
 
 Contributing to the Project

--- a/features/nvstore/README.md
+++ b/features/nvstore/README.md
@@ -33,7 +33,7 @@ Each item is kept in an entry containing a header and data, where the header hol
 ### Enabling NVStore and configuring it for your board
 NVStore is enabled by default for all devices with the internal flash driver (have "FLASH" in the device_has attribute).
 One can disable it by setting its "enabled" attribute to false.
-Unless specifically configured by the user, NVStore selects the last two flash sectors as its areas, with the mininum size of 4KBs,
+Unless specifically configured by the user, NVStore selects the last two flash sectors as its areas, with the minimum size of 4KBs,
 meaning that if the sectors are smaller, few continuous ones will be used for each area.
 The user can override this by setting the addresses and sizes of both areas in` mbed_lib.json` on a per board basis.
 In this case, all following four attributes need to be set:

--- a/features/nvstore/source/nvstore.h
+++ b/features/nvstore/source/nvstore.h
@@ -23,7 +23,7 @@
 #define NVSTORE_ENABLED 0
 #endif
 
-#if NVSTORE_ENABLED
+#if (NVSTORE_ENABLED) || defined(DOXYGEN_ONLY)
 #include <stdint.h>
 #include <stdio.h>
 #include "platform/NonCopyable.h"
@@ -286,8 +286,6 @@ private:
     /**
      * @brief Calculate addresses and sizes of areas (in case no user configuration is given),
      *        or validate user configuration (if given).
-     *
-     * @param[in]  area                   Area.
      */
     void calc_validate_area_params();
 
@@ -310,7 +308,7 @@ private:
      * @param[in]  buf                    Output Buffer.
      * @param[out] actual_size            Actual data size (bytes).
      * @param[in]  validate_only          Just validate (without reading to buffer).
-     * @param[out] validate               Is the record valid.
+     * @param[out] valid                  Is the record valid.
      * @param[out] key                    Record key.
      * @param[out] flags                  Record flags.
      * @param[out] next_offset            Offset of next record.

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_ARM/except.S
@@ -144,13 +144,18 @@ Fault_Handler_Continue2
                 MRS      R2,MSP                   ; Get MSP           
                 STR      R2,[R1]
                 ADDS     R1,#4
-                LDR      R3,=mbed_fault_handler     ; Load address of mbedFaultHandler
+                MOV      R2,LR                    ; Get current LR(EXC_RETURN)           
+                STR      R2,[R1]
+                ADDS     R1,#4
+                MRS      R2,CONTROL               ; Get CONTROL Reg
+                STR      R2,[R1]
+                LDR      R3,=mbed_fault_handler   ; Load address of mbedFaultHandler
                 MOV      R0,R12
                 LDR      R1,=mbed_fault_context
                 LDR      R2,=osRtxInfo
                 BLX      R3
 #endif                    
-                B        .                         ; Just in case we come back here                
+                B        .                        ; Just in case we come back here                
                 ENDP
                     
 #endif

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_GCC/except.S
@@ -176,7 +176,12 @@ Fault_Handler_Continue2:
         MRS      R2,MSP                   // Get MSP           
         STR      R2,[R1]
         ADDS     R1,#4
-        LDR      R3,=mbed_fault_handler     // Load address of mbedFaultHandler
+        MOV      R2,LR                    // Get current LR(EXC_RETURN)           
+        STR      R2,[R1]
+        ADDS     R1,#4
+        MRS      R2,CONTROL               // Get CONTROL Reg
+        STR      R2,[R1]
+        LDR      R3,=mbed_fault_handler   // Load address of mbedFaultHandler
         MOV      R0,R12
         LDR      R1,=mbed_fault_context
         LDR      R2,=osRtxInfo

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/TOOLCHAIN_IAR/except.S
@@ -139,13 +139,18 @@ Fault_Handler_Continue2
                 MRS     R2,MSP                   ; Get MSP           
                 STR     R2,[R1]
                 ADDS    R1,#4
-                LDR     R3,=mbed_fault_handler     ; Load address of mbedFaultHandler
+                MOV     R2,LR                    ; Get current LR(EXC_RETURN)           
+                STR     R2,[R1]
+                ADDS    R1,#4
+                MRS     R2,CONTROL               ; Get CONTROL Reg
+                STR     R2,[R1]
+                LDR     R3,=mbed_fault_handler   ; Load address of mbedFaultHandler
                 MOV     R0,R12
                 LDR     R1,=mbed_fault_context
                 LDR     R2,=osRtxInfo
                 BLX     R3 
 #endif                
-                B       .                         ; Just in case we come back here    
-#endif                                            ; #if (MBED_FAULT_HANDLER_SUPPORT == 1) 
+                B       .                        ; Just in case we come back here    
+#endif                                           ; #if (MBED_FAULT_HANDLER_SUPPORT == 1) 
 
                 END

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
@@ -37,6 +37,8 @@ typedef struct {
   uint32_t xPSR;
   uint32_t PSP;
   uint32_t MSP;
+  uint32_t EXC_RETURN;
+  uint32_t CONTROL;    
 } mbed_fault_context_t;
 
 //Fault type definitions

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_MTB_LAIRD_BL652/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_MTB_LAIRD_BL652/PinNames.h
@@ -1,0 +1,243 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2013 Nordic Semiconductor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+    p31 = 31,
+
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+    
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+    
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+    
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,
+    P0_31 = p31,
+
+   // Module pins. Refer datasheet for pin numbers.
+    SIO_1 = P0_1,
+    SIO_2 = P0_2,
+    SIO_3 = P0_3,
+    SIO_4 = P0_4,
+    SIO_5 = P0_5,
+    SIO_6 = P0_6,
+    SIO_7 = P0_7,
+    SIO_8 = P0_8,
+    SIO_9 = P0_9,   //NFC1
+    SIO_10 = P0_10,  //NFC2
+    SIO_11 = P0_11,
+    SIO_12 = P0_12,
+    SIO_13 = P0_13,
+    SIO_14 = P0_14,
+    SIO_15 = P0_15,
+    SIO_16 = P0_16,
+    SIO_17 = P0_17,
+    SIO_18 = P0_18,
+    SIO_19 = P0_19,
+    SIO_20 = P0_20,
+
+    SIO_22 = P0_22,
+    SIO_23 = P0_23,
+    SIO_24 = P0_24,
+    SIO_25 = P0_25,
+    SIO_26 = P0_26,
+    SIO_27 = P0_27,
+    SIO_28 = P0_28,
+    SIO_29 = P0_29,
+    SIO_30 = P0_30,
+    SIO_31 = P0_31,
+    SIO_0 = P0_0,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    //Mbed MTB pin defines.
+    P_1 = NC,
+    P_2 = SIO_24,  //MISO
+    P_3 = SIO_23,  //MOSI
+    P_4 = SIO_22,
+//    P_5 = SWDIO,
+//    P_6 = SWDCLK,
+//    P_7 = NRST,
+    P_8 = SIO_20,
+    P_9 = SIO_18,
+    P_10 = SIO_16,
+    P_11 = SIO_14,
+    P_12 = SIO_12,
+    P_13 = SIO_11,
+    P_14 = SIO_10,
+    P_15 = SIO_9,
+    P_16 = NC,
+    P_17 = SIO_8,
+    P_18 = SIO_7,
+    P_19 = SIO_6,
+    P_20 = SIO_5,
+    P_21 = SIO_4,
+    P_22 = SIO_3,
+    P_23 = SIO_2,
+    P_24 = SIO_1,
+    P_25 = SIO_0,
+    P_26 = NC,
+    P_27 = NC,
+    P_28 = SIO_13,
+    P_29 = SIO_15,
+    P_30 = SIO_17,
+    P_31 = SIO_19,
+    P_32 = SIO_31,
+    P_33 = SIO_30,
+    P_34 = SIO_29,
+    P_35 = SIO_28,
+    P_36 = SIO_27,
+    P_37 = SIO_26,
+    P_38 = SIO_25,
+    P_39 = NC,
+
+    //LEDs
+    LED1 = SIO_28,
+    LED2 = SIO_29,
+    LED3 = SIO_30,
+    LED_RED = LED1,
+    LED_GREEN = LED2,
+    LED_BLUE = LED3,
+    
+    GP0 = SIO_11,
+    //Standardized button name
+    BUTTON1 = GP0,
+
+    //Nordic SDK pin names 
+    RX_PIN_NUMBER = SIO_8,
+    TX_PIN_NUMBER = SIO_6,
+    CTS_PIN_NUMBER = SIO_7,
+    RTS_PIN_NUMBER = SIO_5,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+
+    SPI_MOSI = SIO_23,
+    SPI_MISO = SIO_24,
+    SPI_SS0 = SIO_17, //CS for LCD on MTB
+    SPI_SS1 = SIO_10, //CS for SD card on MTB
+    SPI_SCK1 = SIO_25,
+    SPI_SCK2 = SIO_31,
+
+    //Default SPI
+    SPI_SCK = SPI_SCK1,
+    SPI_CS = SPI_SS1,
+
+    I2C_SDA = SIO_26,
+    I2C_SCL = SIO_27,
+
+    //MTB aliases
+    GP1    = SIO_13,
+    AIN0  = SIO_2,
+    AIN1  = SIO_3,
+    AIN2  = SIO_4,
+    GP2    = SIO_10,
+    GP3    = SIO_9,
+    GP4     = SIO_22,
+    GP5     = SIO_19, //A0 for LCD on MTB
+    GP6     = SIO_18, //RESET for LCD on MTB
+    GP7     = SIO_17,
+    GP8     = SIO_15,
+
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_MTB_LAIRD_BL652/device.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5/TARGET_MCU_NRF52832/TARGET_MTB_LAIRD_BL652/device.h
@@ -1,0 +1,23 @@
+// The 'features' section in 'target.json' is now used to create the device's hardware preprocessor switches.
+// Check the 'features' section of the target description in 'targets.json' for more details.
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#include "objects.h"
+
+#endif

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/analogin_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/analogin_api.c
@@ -19,7 +19,9 @@
 #include "hal_adc.h"
 #include "analogin_api.h"
 
-
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
 
 #if CONFIG_ADC_EN
 #include "pinmap.h"

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -22,17 +22,23 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
     *(i.mbedtls*)
     *libc.a (+RO)
     *rtx_*.o (+RO)
+    *main*.o (+RO)
+    *lib_peripheral_mbed_arm.ar (+RO)
+    *_api*.o (+RO)
   }
 
   RW_IRAM1 +0 UNINIT FIXED {
     *rtl8195a_crypto*.o(+RW)
     *libc.a (+RW)
-    *(.sdram.data*)
+    *main*.o (+RW)
     *lib_peripheral_mbed_arm.ar (+RW)
-    *rtl8195a_crypto*.o(+ZI, COMMON)
-    *libc.a (+ZI, COMMON)
-    *(.bss.thread_stack_main)
-    *lib_peripheral_mbed_arm.ar (+ZI, COMMON)
+    *_api*.o (+RW)
+    *rtl8195a_crypto*.o(+ZI)
+    *libc.a (+ZI)
+    *main*.o (+ZI)
+    *lib_peripheral_mbed_arm.ar (+ZI)
+    *_api*.o (+ZI)
+    *mbed_boot*.o (+ZI)
   }
 
   ARM_LIB_STACK (0x10070000 - 0x1000) EMPTY 0x1000 {
@@ -41,8 +47,8 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
 
 LR_TCM 0x1FFF0000 0x10000 {
     TCM_OVERLAY 0x1FFF0000 0x10000 {
-        *lwip_mem*.o(.bss*)
-        *lwip_memp*.o(.bss*)
+        *lwip_mem*.o(+ZI)
+        *lwip_memp*.o(+ZI)
         *.o(.tcm.heap*)
     }
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -29,9 +29,6 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
     *libc.a (+RW)
     *(.sdram.data*)
     *lib_peripheral_mbed_arm.ar (+RW)
-  }
-
-  RW_IRAM2 +0 UNINIT FIXED {
     *rtl8195a_crypto*.o(+ZI, COMMON)
     *libc.a (+ZI, COMMON)
     *(.bss.thread_stack_main)

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
@@ -67,18 +67,17 @@ SECTIONS
     .text.sram1 :
     {
         . = ALIGN(4);
-        *rtl8195a_crypto.o (.text* .rodata*)
+        *rtl8195a_crypto*.o (.text* .rodata*)
         *mbedtls*.o (.text* .rodata*)
         *libc.a: (.text* .rodata*)
+        *lib_peripheral_mbed_gcc.a: (.text* .rodata*)
+        *_api*.o (.text* .rodata*)
+        *main*.o (.text* .rodata*)
     } > SRAM1
 
     .text.sram2 :
     {
         . = ALIGN(4);
-        *(.mon.ram.text*)
-        *(.hal.flash.text*)
-        *(.hal.sdrc.text*)
-        *(.hal.gpio.text*)
         *(.text*)
 
         KEEP(*(.init))
@@ -165,9 +164,11 @@ SECTIONS
     .bss.sram1 (NOLOAD) :
     {
         __bss_sram_start__ = .;
-        *rtl8195a_crypto.o (.bss* COMMON)
+        *rtl8195a_crypto*.o (.bss* COMMON)
         *mbedtls*.o (.bss* COMMON)
         *(.bss.thread_stack_main)
+        *lib_peripheral_mbed_gcc.a: (.bss* COMMON)
+        *mbed_boot*.o (.bss* COMMON)
         __bss_sram_end__ = .;
     } > SRAM1
 
@@ -198,11 +199,11 @@ SECTIONS
         __HeapLimit = .;
     } > SRAM1
     
-    .TCM_overlay :
+    .TCM_overlay (NOLOAD):
     {
         __bss_dtcm_start__ = .;
-        *lwip_mem.o (.bss*)
-        *lwip_memp.o (.bss*)
+        *lwip_mem*.o (.bss* COMMON)
+        *lwip_memp*.o (.bss* COMMON)
         *(.tcm.heap*)
         __bss_dtcm_end__ = .;
     } > TCM

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/rtl8195a_init.c
@@ -18,14 +18,14 @@
 #if defined(__CC_ARM) || \
     (defined (__ARMCC_VERSION) && __ARMCC_VERSION >= 6010050)
 
-extern uint8_t Image$$RW_IRAM2$$ZI$$Base[];
-extern uint8_t Image$$RW_IRAM2$$ZI$$Limit[];
+extern uint8_t Image$$RW_IRAM1$$ZI$$Base[];
+extern uint8_t Image$$RW_IRAM1$$ZI$$Limit[];
 extern uint8_t Image$$TCM_OVERLAY$$ZI$$Base[];
 extern uint8_t Image$$TCM_OVERLAY$$ZI$$Limit[];
 extern uint8_t Image$$RW_DRAM2$$ZI$$Base[];
 extern uint8_t Image$$RW_DRAM2$$ZI$$Limit[];
-#define __bss_sram_start__ Image$$RW_IRAM2$$ZI$$Base
-#define __bss_sram_end__   Image$$RW_IRAM2$$ZI$$Limit
+#define __bss_sram_start__ Image$$RW_IRAM1$$ZI$$Base
+#define __bss_sram_end__   Image$$RW_IRAM1$$ZI$$Limit
 #define __bss_dtcm_start__ Image$$TCM_OVERLAY$$ZI$$Base
 #define __bss_dtcm_end__   Image$$TCM_OVERLAY$$ZI$$Limit
 #define __bss_dram_start__ Image$$RW_DRAM2$$ZI$$Base

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/log_uart_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/log_uart_api.c
@@ -17,6 +17,10 @@
 #include "objects.h"
 #include "log_uart_api.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #include <string.h>
 
 const u32 log_uart_support_rate[] = {

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/pwmout_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/pwmout_api.c
@@ -18,6 +18,10 @@
 #include "objects.h"
 #include "pinmap.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #if DEVICE_PWMOUT
 
 #ifdef CONFIG_PWM_EN

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/serial_api.c
@@ -17,6 +17,11 @@
 #include "rtl8195a.h"
 #include "objects.h"
 #include "serial_api.h"
+
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #if CONFIG_UART_EN
 
 #include "pinmap.h"

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
@@ -21,6 +21,10 @@
 #include "pinmap.h"
 #include "hal_ssi.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 extern u32 SystemGetCpuClk(VOID);
 extern VOID HAL_GPIO_PullCtrl(u32 pin, u32 mode);
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/trng_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/trng_api.c
@@ -17,6 +17,10 @@
 #include "analogin_api.h"
 #include "analogin_ext.h"
 
+#ifdef CONFIG_MBED_ENABLED
+#include "platform_stdlib.h"
+#endif
+
 #ifdef DEVICE_TRNG
 
 

--- a/targets/TARGET_Realtek/TARGET_AMEBA/sdk/common/api/platform/platform_stdlib.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/sdk/common/api/platform/platform_stdlib.h
@@ -51,6 +51,7 @@
 	#include <stdint.h>
 	#include "diag.h"
 	#define strsep(str, delim)      	_strsep(str, delim)
+	#define _memset(dst, val, sz)		memset(dst, val, sz)
 #else
 	#include <stdio.h>
 	#include <stdlib.h>

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3535,6 +3535,29 @@
             }
         }
     },
+    "MTB_LAIRD_BL652": {
+        "inherits": ["MCU_NRF52"],
+        "macros_add": ["BOARD_PCA10040", "NRF52_PAN_12", "NRF52_PAN_15", "NRF52_PAN_58", "NRF52_PAN_55", "NRF52_PAN_54", "NRF52_PAN_31", "NRF52_PAN_30", "NRF52_PAN_51", "NRF52_PAN_36", "NRF52_PAN_53", "S132", "CONFIG_GPIO_AS_PINRESET", "BLE_STACK_SUPPORT_REQD", "SWI_DISABLE0", "NRF52_PAN_20", "NRF52_PAN_64", "NRF52_PAN_62", "NRF52_PAN_63"],
+        "device_has_add": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "extra_labels_add": ["MTB_LAIRD_BL652"],
+        "release_versions": ["5"],
+        "device_name": "nRF52832_xxAA",
+        "bootloader_supported": true,
+        "config": {
+            "usb_tx": {
+                "help": "Value SIO_06",
+                "value": "SIO_6"
+            },
+            "usb_rx": {
+                "help": "Value SIO_08",
+                "value": "SIO_8"
+            }
+        },
+        "overrides": {
+            "lf_clock_src": "NRF_LF_SRC_RC",
+            "uart_hwfc": 0
+        }
+    },
     "DELTA_DFBM_NQ620": {
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF52"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -330,7 +330,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     profile = {'c': [], 'cxx': [], 'common': [], 'asm': [], 'ld': []}
     for contents in build_profile or []:
         for key in profile:
-            profile[key].extend(contents[toolchain_name][key])
+            profile[key].extend(contents[toolchain_name].get(key, []))
 
     toolchain = cur_tc(target, notify, macros, silent, build_dir=build_dir,
                        extra_verbose=extra_verbose, build_profile=profile)


### PR DESCRIPTION
### Description

Ameba has two memory blocks: SDRAM(2M) and SRAM(512KB). SRAM has better access performance than SDRAM. So some timing critical codes must be moved to SRAM.

fix for mbed-os issue #5778 


### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
