### PR TITLE
Cellular: BC95 echo test fixes

### DIFF
--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -29,9 +29,9 @@
 #include "CellularLog.h"
 #include "mbed_wait_api.h"
 
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
 #include "APN_db.h"
-#endif //MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif //USE_APN_LOOKUP
 
 namespace mbed {
 
@@ -59,9 +59,9 @@ EasyCellularConnection::EasyCellularConnection(bool debug) :
                 NSAPI_ERROR_OK)
 {
     tr_info("EasyCellularConnection()");
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
     _credentials_set = false;
-#endif // #if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif // #if USE_APN_LOOKUP
     modem_debug_on(debug);
 }
 
@@ -102,11 +102,11 @@ void EasyCellularConnection::set_credentials(const char *apn, const char *uname,
         CellularNetwork * network = _cellularConnectionFSM.get_network();
         if (network) {
             _credentials_err = network->set_credentials(apn, uname, pwd);
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
             if (_credentials_err == NSAPI_ERROR_OK) {
                 _credentials_set = true;
             }
-#endif // #if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif // #if USE_APN_LOOKUP
         } else {
             tr_error("NO Network...");
         }
@@ -163,7 +163,7 @@ nsapi_error_t EasyCellularConnection::connect()
     if (err) {
         return err;
     }
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
     if (!_credentials_set) {
         _target_state = CellularConnectionFSM::STATE_SIM_PIN;
         err = _cellularConnectionFSM.continue_to_state(_target_state);
@@ -193,7 +193,7 @@ nsapi_error_t EasyCellularConnection::connect()
             return err;
         }
     }
-#endif // MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif // USE_APN_LOOKUP
 
     _target_state = CellularConnectionFSM::STATE_CONNECTED;
     err = _cellularConnectionFSM.continue_to_state(_target_state);
@@ -212,9 +212,9 @@ nsapi_error_t EasyCellularConnection::disconnect()
 {
     _credentials_err = NSAPI_ERROR_OK;
     _is_connected = false;
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
     _credentials_set = false;
-#endif // #if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif // #if USE_APN_LOOKUP
     if (!_cellularConnectionFSM.get_network()) {
         return NSAPI_ERROR_NO_CONNECTION;
     }

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -24,6 +24,8 @@
 
 #include "netsocket/CellularBase.h"
 
+#define USE_APN_LOOKUP (MBED_CONF_CELLULAR_USE_APN_LOOKUP || (NSAPI_PPP_AVAILABLE && MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP))
+
 namespace mbed
 {
 
@@ -145,9 +147,9 @@ private:
 
     bool _is_connected;
     bool _is_initialized;
-#if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#if USE_APN_LOOKUP
     bool _credentials_set;
-#endif // #if MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
+#endif // #if USE_APN_LOOKUP
     CellularConnectionFSM::CellularState _target_state;
 
     UARTSerial _cellularSerial;

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -133,6 +133,7 @@ nsapi_error_t AT_CellularNetwork::connect(const char *apn,
 
 nsapi_error_t AT_CellularNetwork::delete_current_context()
 {
+    tr_info("Delete context %d", _cid);
     _at.clear_error();
     _at.cmd_start("AT+CGDCONT=");
     _at.write_int(_cid);
@@ -236,12 +237,14 @@ nsapi_error_t AT_CellularNetwork::open_data_channel()
         int context_activation_state = _at.read_int();
         if (context_id == _cid && context_activation_state == 1) {
             is_context_active = true;
+            tr_debug("PDP context %d is active.", _cid);
+            break;
         }
     }
     _at.resp_stop();
 
     if (!is_context_active) {
-        tr_info("Activate PDP context");
+        tr_info("Activate PDP context %d", _cid);
         _at.cmd_start("AT+CGACT=1,");
         _at.write_int(_cid);
         _at.cmd_stop();
@@ -401,6 +404,7 @@ bool AT_CellularNetwork::set_new_context(int cid)
         _ip_stack_type = tmp_stack;
         _cid = cid;
         _new_context_set = true;
+        tr_info("New PDP context id %d was created", _cid);
     }
 
     return success;
@@ -408,6 +412,12 @@ bool AT_CellularNetwork::set_new_context(int cid)
 
 bool AT_CellularNetwork::get_context()
 {
+    if (_apn) {
+        tr_debug("APN in use: %s", _apn);
+    } else {
+        tr_debug("NO APN");
+    }
+
     _at.cmd_start("AT+CGDCONT?");
     _at.cmd_stop();
     _at.resp_start("+CGDCONT:");
@@ -429,7 +439,7 @@ bool AT_CellularNetwork::get_context()
         if (pdp_type_len > 0) {
             apn_len = _at.read_string(apn, sizeof(apn) - 1);
             if (apn_len >= 0) {
-                if (_apn && strcmp(apn, _apn) != 0 ) {
+                if (_apn && (strcmp(apn, _apn) != 0) ) {
                     continue;
                 }
                 nsapi_ip_stack_t pdp_stack = string_to_stack_type(pdp_type_from_context);

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -17,6 +17,7 @@
 
 #include "QUECTEL_BC95_CellularNetwork.h"
 #include "QUECTEL_BC95_CellularPower.h"
+#include "QUECTEL_BC95_CellularSIM.h"
 
 #include "QUECTEL_BC95.h"
 
@@ -41,7 +42,13 @@ QUECTEL_BC95::~QUECTEL_BC95()
 CellularNetwork *QUECTEL_BC95::open_network(FileHandle *fh)
 {
     if (!_network) {
-        _network = new QUECTEL_BC95_CellularNetwork(*get_at_handler(fh));
+        ATHandler *atHandler = get_at_handler(fh);
+        if (atHandler) {
+            _network = new QUECTEL_BC95_CellularNetwork(*atHandler);
+            if (!_network) {
+                release_at_handler(atHandler);
+            }
+        }
     }
     return _network;
 }
@@ -49,7 +56,27 @@ CellularNetwork *QUECTEL_BC95::open_network(FileHandle *fh)
 CellularPower *QUECTEL_BC95::open_power(FileHandle *fh)
 {
     if (!_power) {
-        _power = new QUECTEL_BC95_CellularPower(*get_at_handler(fh));
+        ATHandler *atHandler = get_at_handler(fh);
+        if (atHandler) {
+            _power = new QUECTEL_BC95_CellularPower(*atHandler);
+            if (!_power) {
+                release_at_handler(atHandler);
+            }
+        }
     }
     return _power;
+}
+
+CellularSIM *QUECTEL_BC95::open_sim(FileHandle *fh)
+{
+    if (!_sim) {
+        ATHandler *atHandler = get_at_handler(fh);
+        if (atHandler) {
+            _sim = new QUECTEL_BC95_CellularSIM(*atHandler);
+            if (!_sim) {
+                release_at_handler(atHandler);
+            }
+        }
+    }
+    return _sim;
 }

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularPower.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularPower.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef TELIT_HE910_CELLULAR_POWER_H_
-#define TELIT_HE910_CELLULAR_POWER_H_
+#ifndef QUECTEL_BC95_CELLULAR_POWER_H_
+#define QUECTEL_BC95_CELLULAR_POWER_H_
 
 #include "AT_CellularPower.h"
 
@@ -36,4 +36,4 @@ public: //from CellularPower
 
 } // namespace mbed
 
-#endif // TELIT_HE910_CELLULAR_POWER_H_
+#endif // QUECTEL_BC95_CELLULAR_POWER_H_

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QUECTEL_BC95_CellularSIM.h"
+#include "CellularLog.h"
+
+using namespace mbed;
+
+QUECTEL_BC95_CellularSIM::QUECTEL_BC95_CellularSIM(ATHandler &atHandler) : AT_CellularSIM(atHandler)
+{
+
+}
+
+QUECTEL_BC95_CellularSIM::~QUECTEL_BC95_CellularSIM()
+{
+
+}
+
+nsapi_error_t QUECTEL_BC95_CellularSIM::get_sim_state(SimState &state)
+{
+    _at.lock();
+    _at.flush();
+    _at.cmd_start("AT+NCCID?");
+    _at.cmd_stop();
+    _at.resp_start("+NCCID:");
+    if (_at.info_resp()) {
+        state = SimStateReady;
+    } else {
+        tr_warn("SIM not readable.");
+        state = SimStateUnknown; // SIM may not be ready yet
+    }
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}
+

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.h
@@ -15,27 +15,23 @@
  * limitations under the License.
  */
 
-#ifndef QUECTEL_BC95_H_
-#define QUECTEL_BC95_H_
+#ifndef QUECTEL_BC95_CELLULAR_SIM_H_
+#define QUECTEL_BC95_CELLULAR_SIM_H_
 
-#include "AT_CellularDevice.h"
+#include "AT_CellularSIM.h"
 
 namespace mbed {
 
-class QUECTEL_BC95 : public AT_CellularDevice
+class QUECTEL_BC95_CellularSIM : public AT_CellularSIM
 {
 public:
+    QUECTEL_BC95_CellularSIM(ATHandler &atHandler);
+    virtual ~QUECTEL_BC95_CellularSIM();
 
-    QUECTEL_BC95(events::EventQueue &queue);
-    virtual ~QUECTEL_BC95();
-
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
-    virtual CellularSIM *open_sim(FileHandle *fh);
-
-public: // NetworkInterface
-    void handle_urc(FileHandle *fh);
+public: //from CellularSIM
+    virtual nsapi_error_t get_sim_state(SimState &state);
 };
+
 } // namespace mbed
-#endif // QUECTEL_BC95_H_
+
+#endif // QUECTEL_BC95_CELLULAR_SIM_H_

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -150,7 +150,8 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
     _at.write_string(hexstr, false);
     _at.cmd_stop();
     _at.resp_start();
-    socket->id = _at.read_int();
+    // skip socket id
+    _at.skip_param();
     sent_len = _at.read_int();
     _at.resp_stop();
 
@@ -182,6 +183,7 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_recvfrom_impl(CellularS
     _at.read_string(hexstr, sizeof(hexstr));
     // remaining length
     _at.skip_param();
+    _at.resp_stop();
 
     if (!recv_len || (recv_len == -1) || (_at.get_last_error() != NSAPI_ERROR_OK)) {
         return NSAPI_ERROR_WOULD_BLOCK;

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -40,7 +40,13 @@ QUECTEL_BG96::~QUECTEL_BG96()
 CellularNetwork *QUECTEL_BG96::open_network(FileHandle *fh)
 {
     if (!_network) {
-        _network = new QUECTEL_BG96_CellularNetwork(*get_at_handler(fh));
+        ATHandler *atHandler = get_at_handler(fh);
+        if (atHandler) {
+            _network = new QUECTEL_BG96_CellularNetwork(*atHandler);
+            if (!_network) {
+                release_at_handler(atHandler);
+            }
+        }
     }
     return _network;
 }


### PR DESCRIPTION
### Description
Issues fixed:  getting host by name, socket send/recv iterations, SIM state retrieval. Additionaly, cellular APN lookup decision logic is fixed.

These issues were found when testing BC95 against https://github.com/ARMmbed/mbed-os-example-cellular.

### Pull request type
- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
