### PR TITLE
Reduce .text footprint of the network stack

### DIFF
--- a/features/cellular/UNITTESTS/stubs/SocketAddress_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/SocketAddress_stub.cpp
@@ -22,38 +22,14 @@
 #include "mbed.h"
 
 
-static bool ipv4_is_valid(const char *addr)
-{
-    return false;
-}
-
 static bool ipv6_is_valid(const char *addr)
 {
     return false;
 }
 
-static void ipv4_from_address(uint8_t *bytes, const char *addr)
-{
-
-}
-
 static int ipv6_scan_chunk(uint16_t *shorts, const char *chunk)
 {
     return 0;
-}
-
-static void ipv6_from_address(uint8_t *bytes, const char *addr)
-{
-
-}
-
-static void ipv4_to_address(char *addr, const uint8_t *bytes)
-{
-
-}
-
-static void ipv6_to_address(char *addr, const uint8_t *bytes)
-{
 }
 
 

--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -19,28 +19,10 @@
 #include "NetworkStack.h"
 #include <string.h>
 #include <stdio.h>
+#include "ip4string.h"
 #include "ip6string.h"
 
 
-
-static bool ipv4_is_valid(const char *addr)
-{
-    int i = 0;
-
-    // Check each digit for [0-9.]
-    for (; addr[i]; i++) {
-        if (!(addr[i] >= '0' && addr[i] <= '9') && addr[i] != '.') {
-            return false;
-        }
-    }
-
-    // Ending with '.' garuntees host
-    if (i > 0 && addr[i - 1] == '.') {
-        return false;
-    }
-
-    return true;
-}
 
 static bool ipv6_is_valid(const char *addr)
 {
@@ -61,48 +43,6 @@ static bool ipv6_is_valid(const char *addr)
 
     return colons >= 2;
 }
-
-static void ipv4_from_address(uint8_t *bytes, const char *addr)
-{
-    int count = 0;
-    int i = 0;
-
-    for (; count < NSAPI_IPv4_BYTES; count++) {
-        unsigned d;
-        // Not using %hh, since it might be missing in newlib-based toolchains.
-        // See also: https://git.io/vxiw5
-        int scanned = sscanf(&addr[i], "%u", &d);
-        if (scanned < 1) {
-            return;
-        }
-
-        bytes[count] = static_cast<uint8_t>(d);
-
-        for (; addr[i] != '.'; i++) {
-            if (!addr[i]) {
-                return;
-            }
-        }
-
-        i++;
-    }
-}
-
-static void ipv6_from_address(uint8_t *bytes, const char *addr)
-{
-    stoip6(addr, strlen(addr), bytes);
-}
-
-static void ipv4_to_address(char *addr, const uint8_t *bytes)
-{
-    sprintf(addr, "%d.%d.%d.%d", bytes[0], bytes[1], bytes[2], bytes[3]);
-}
-
-static void ipv6_to_address(char *addr, const uint8_t *bytes)
-{
-    ip6tos(bytes, addr);
-}
-
 
 SocketAddress::SocketAddress(nsapi_addr_t addr, uint16_t port)
 {
@@ -137,13 +77,12 @@ bool SocketAddress::set_ip_address(const char *addr)
     delete[] _ip_address;
     _ip_address = NULL;
 
-    if (addr && ipv4_is_valid(addr)) {
+    if (addr && stoip4(addr, strlen(addr), _addr.bytes)) {
         _addr.version = NSAPI_IPv4;
-        ipv4_from_address(_addr.bytes, addr);
         return true;
     } else if (addr && ipv6_is_valid(addr)) {
         _addr.version = NSAPI_IPv6;
-        ipv6_from_address(_addr.bytes, addr);
+        stoip6(addr, strlen(addr), _addr.bytes);
         return true;
     } else {
         _addr = nsapi_addr_t();
@@ -186,9 +125,9 @@ const char *SocketAddress::get_ip_address() const
     if (!_ip_address) {
         _ip_address = new char[NSAPI_IP_SIZE];
         if (_addr.version == NSAPI_IPv4) {
-            ipv4_to_address(_ip_address, _addr.bytes);
+            ip4tos(_addr.bytes, _ip_address);
         } else if (_addr.version == NSAPI_IPv6) {
-            ipv6_to_address(_ip_address, _addr.bytes);
+            ip6tos(_addr.bytes, _ip_address);
         }
     }
 


### PR DESCRIPTION
### Description

Patches to LWIP and some code from netsocket was using `s[n]printf` and `sscanf` to generate and parse strings based on integers. Specifically, converting MAC addresses and IPv6 addresses to and from their hexadecimal form and IPv4 addresses to and from their printable decimal form.

The use of those functions in public APIs forced the compiler to bring the full parser necessary to make `*printf/sscanf` work. This parser is massive (in order to handle floating point for instance) and several of its components were in the largest functions in the final binary *independently*, despite the monolithics `tcp_input` and `tcp_output`. 

The small test program I was using had the following memory breakdown before linking to the network stack when compiling with GCC and a release profile:
```
Text 38.2KB Data 1.23KB BSS 9.21KB
ROM 39.5KB RAM 10.4KB
```
The same program using the default network stack (K64F & Ethernet):
```
Text 114KB Data 1.76KB BSS 54.4KB
ROM 116KB RAM 56.1KB
```
Then the same program using the network stack included in the PR, not using `*printf/sscanf` and thus not linking with the expensive parser:
```
Text 87.3KB Data 1.4KB BSS 54.3KB
ROM 88.7KB RAM 55.7KB
```

Although the RAM change is negligeable (but still down), the .text impact is massive (-23%).

|   | No network  | Default network | Patched network | `*printf` parser only |
| ------- | ----------- | --------------- | --------------- | ------------------- |
| ROM change | 1x | 3.03x | 2.24x | 0.71x |
| Overhead | 0kB | 76.5kB | 49.2kB | 27.3kB |

I couldn't find where to put the small utils I had to write (a basic itoa and two bin2hex) so they are inline and bin2hex had to be duplicated.

### Pull request type

- [ ] Fix
- [x] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
