### PR TITLE
expose SerialBase interrupt control methods in UARTSerial

### DIFF
--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -69,6 +69,18 @@ public:
     using FileHandle::readable;
     using FileHandle::writable;
 
+    /* Expose these methods
+     */
+    using SerialBase::attach;
+    using SerialBase::_irq_handler;
+
+    // Need this type for attach()
+    using SerialBase::IrqType;
+    // In C++11, we wouldn't need to also have using directives for each value
+    using SerialBase::RxIrq;
+    using SerialBase::TxIrq;
+    using SerialBase::IrqCnt;
+
     /** Write the contents of a buffer to a file
      *
      *  Follows POSIX semantics:


### PR DESCRIPTION
### Description

These methods should be exposed in `UARTSerial` like they are in `Serial`, right?

I haven't tested this yet, since I'm still trying to figure out [how to conditionally sleep / wake on interrupt](https://os.mbed.com/forum/mbed/topic/29547/). Input on that question thread is welcome, so that I can test this PR.

It builds, though, and seems like it ought to work.


### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
