### PR TITLE
[feature-nrf528xx] NRF52 SPI and I2C re-implementation

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
@@ -1,0 +1,42 @@
+## Mbed HAL Implementation Details
+
+### SPI and I2C
+
+The TWI/TWIM (I2C) and SPI/SPIM module shares the same underlying hardware and each instance can only provide one functionality at a time. Both the NRF52832 and NRF52840 have 2 TWI/TWIM modules and 3 SPI/SPIM:
+
+| Instance 0 | Instance 1 | Instance 2 |
+| :---:      | :---:      | :---:      |
+| SPI0/SPIM0 | SPI1/SPIM1 | SPI2/SPIM2 |
+| TWI0/TWIM0 | TWI1/TWIM1 |            |
+
+When instantiating a new Mbed SPI object or I2C object, the object will be assigned a hardware instance. By default, the HAL implementation will automatically pick a hardware instance based on the assigned pins in the following order:
+
+1. The driver will look up the pins in the configuration table and pick a pre-assigned instance.
+1. If the pins can't be found in the configuration table, the driver will check if a hardware instance has already been assigned to those pins so that objects using the same pins will share the same instance.
+1. If no instance has been assigned, the driver will look for a free instane. For I2C objects instances are assigned from 0 to 1. For SPI objects instances are assigned from 2 to 0. This ensures that no matter the order of instantiation the first three objects can be guaranteed to be on separate instances no matter the pins being used. 
+1. If no unused instance can be found, objects not sharing any pins will be assigned to the same default instance, which is `Instance 0` for I2C and `Instance 2` for SPI.
+
+#### Customization
+
+A custom configuration table can be provided by overriding the weakly defined default empty table. In the example below, I2C objects using pins `p1` and `p2` for `SDA` and `SCL` will always be assigned to `Instance 1` and SPI objects using pins `p3`, `p4`, `p5` for `MOSI`, `MISO`, and `CLOCK` will be assigned to `Instance 2` and SPI objects using pins `p6`, `p7`, and `p8` will be assigned to `Instance 0`. The custom configuration table must always be terminated with a row of `NC`.
+
+```
+const PinMapI2C PinMap_I2C[] = { 
+    {p1, p2, 1},
+    {NC, NC, NC}
+};
+
+const PinMapSPI PinMap_SPI[] = {
+    {p3, p4, p5, 2},
+    {p6, p7, p8, 0},
+    {NC, NC, NC, NC}
+};
+```
+
+The tables must be placed in a C compilation file.
+
+#### Concurrency
+
+1. When called from the same thread, it is safe to assign I2C and SPI objects to the same instance. 
+1. If an instance is being used exclusively for either I2C or SPI, the objects can safely be called from multiple threads.
+1. If an instance is being used for both I2C and SPI, the user must provide thread safety between the objects.

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/config/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/config/sdk_config.h
@@ -2666,7 +2666,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -2688,13 +2688,13 @@
 // <e> SPI1_ENABLED - Enable SPI1 instance
 //==========================================================
 #ifndef SPI1_ENABLED
-#define SPI1_ENABLED 0
+#define SPI1_ENABLED 1
 #endif
 // <q> SPI1_USE_EASY_DMA  - Use EasyDMA
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2716,13 +2716,13 @@
 // <e> SPI2_ENABLED - Enable SPI2 instance
 //==========================================================
 #ifndef SPI2_ENABLED
-#define SPI2_ENABLED 0
+#define SPI2_ENABLED 1
 #endif
 // <q> SPI2_USE_EASY_DMA  - Use EasyDMA
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <o> SPI2_DEFAULT_FREQUENCY  - SPI frequency
@@ -2928,7 +2928,7 @@
 // <e> TWI_ENABLED - nrf_drv_twi - TWI/TWIM peripheral driver
 //==========================================================
 #ifndef TWI_ENABLED
-#define TWI_ENABLED 0
+#define TWI_ENABLED 1
 #endif
 // <o> TWI_DEFAULT_CONFIG_FREQUENCY  - Frequency
  
@@ -2988,7 +2988,7 @@
 // <e> TWI1_ENABLED - Enable TWI1 instance
 //==========================================================
 #ifndef TWI1_ENABLED
-#define TWI1_ENABLED 0
+#define TWI1_ENABLED 1
 #endif
 // <q> TWI1_USE_EASY_DMA  - Use EasyDMA (if present)
  

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/config/sdk_config.h
@@ -2666,7 +2666,7 @@
  
 
 #ifndef SPI0_USE_EASY_DMA
-#define SPI0_USE_EASY_DMA 1
+#define SPI0_USE_EASY_DMA 0
 #endif
 
 // <o> SPI0_DEFAULT_FREQUENCY  - SPI frequency
@@ -2688,13 +2688,13 @@
 // <e> SPI1_ENABLED - Enable SPI1 instance
 //==========================================================
 #ifndef SPI1_ENABLED
-#define SPI1_ENABLED 0
+#define SPI1_ENABLED 1
 #endif
 // <q> SPI1_USE_EASY_DMA  - Use EasyDMA
  
 
 #ifndef SPI1_USE_EASY_DMA
-#define SPI1_USE_EASY_DMA 1
+#define SPI1_USE_EASY_DMA 0
 #endif
 
 // <o> SPI1_DEFAULT_FREQUENCY  - SPI frequency
@@ -2716,13 +2716,13 @@
 // <e> SPI2_ENABLED - Enable SPI2 instance
 //==========================================================
 #ifndef SPI2_ENABLED
-#define SPI2_ENABLED 0
+#define SPI2_ENABLED 1
 #endif
 // <q> SPI2_USE_EASY_DMA  - Use EasyDMA
  
 
 #ifndef SPI2_USE_EASY_DMA
-#define SPI2_USE_EASY_DMA 1
+#define SPI2_USE_EASY_DMA 0
 #endif
 
 // <o> SPI2_DEFAULT_FREQUENCY  - SPI frequency
@@ -2928,7 +2928,7 @@
 // <e> TWI_ENABLED - nrf_drv_twi - TWI/TWIM peripheral driver
 //==========================================================
 #ifndef TWI_ENABLED
-#define TWI_ENABLED 0
+#define TWI_ENABLED 1
 #endif
 // <o> TWI_DEFAULT_CONFIG_FREQUENCY  - Frequency
  
@@ -2988,7 +2988,7 @@
 // <e> TWI1_ENABLED - Enable TWI1 instance
 //==========================================================
 #ifndef TWI1_ENABLED
-#define TWI1_ENABLED 0
+#define TWI1_ENABLED 1
 #endif
 // <q> TWI1_USE_EASY_DMA  - Use EasyDMA (if present)
  

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/i2c_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/i2c_api.c
@@ -1,28 +1,28 @@
-/* 
+/*
  * Copyright (c) 2017 Nordic Semiconductor ASA
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list 
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list
  *      of conditions and the following disclaimer.
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA 
- *      integrated circuit in a product or a software update for such product, must reproduce 
- *      the above copyright notice, this list of conditions and the following disclaimer in 
+ *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
+ *      integrated circuit in a product or a software update for such product, must reproduce
+ *      the above copyright notice, this list of conditions and the following disclaimer in
  *      the documentation and/or other materials provided with the distribution.
  *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be 
- *      used to endorse or promote products derived from this software without specific prior 
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without specific prior
  *      written permission.
  *
- *   4. This software, with or without modification, must only be used with a 
+ *   4. This software, with or without modification, must only be used with a
  *      Nordic Semiconductor ASA integrated circuit.
  *
- *   5. Any software provided in binary or object form under this license must not be reverse 
- *      engineered, decompiled, modified and/or disassembled. 
- * 
+ *   5. Any software provided in binary or object form under this license must not be reverse
+ *      engineered, decompiled, modified and/or disassembled.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,691 +33,920 @@
  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
-
-#warning arm porting pending
-
-#include "i2c_api.h"
 
 #if DEVICE_I2C
 
-#include "mbed_assert.h"
-#include "mbed_error.h"
-#include "nrf_twi.h"
-#include "nrf_drv_common.h"
-#include "sdk_config.h"
-#include "app_util_platform.h"
-#include "nrf_gpio.h"
-#include "nrf_delay.h"
+/* I2C
+ *
+ * This HAL implementation uses the nrf_drv_twi.h API primarily but switches to TWI for the
+ * low-level HAL functions. These calls can't be implemented with the TWIM due to the
+ * different API.
+ *
+ * Known limitations:
+ *  * The TWI/TWIM only supports 7-bit addresses.
+ *  * The TWI API doesn't allow reading 1 byte. At least 2 bytes will be read.
+ */
+
+#include "i2c_api.h"
+#include "lp_ticker_api.h"
+
+#include "object_owners.h"
+#include "pinmap_ex.h"
+
 #include "nrf_drv_twi.h"
+#include "nrf_drv_common.h"
+#include "app_util_platform.h"
 
-#include "us_ticker_api.h"
-#include "irq_handlers_hw.h"
-
-// An arbitrary value used as the timeout in loops waiting for given event
-// (e.g. STOPPED), needed to avoid infinite loops.
-// This value might be defined externally.
-#ifndef I2C_TIMEOUT_VALUE_US
-    #define I2C_TIMEOUT_VALUE_US 1000000
-#endif
-
-#if DEVICE_I2C_ASYNCH
-    #define TWI_IDX(obj)    ((obj)->i2c.twi_idx)
+#if 0
+#define DEBUG_PRINTF(...) printf(__VA_ARGS__)
 #else
-    #define TWI_IDX(obj)    ((obj)->twi_idx)
-#endif
-#define TWI_INFO(obj)   (&m_twi_info[TWI_IDX(obj)])
-
-#ifdef TARGET_SDK13
-    #define TWI0_INSTANCE_INDEX 0
-    #define TWI1_INSTANCE_INDEX TWI0_INSTANCE_INDEX+TWI0_ENABLED
+#define DEBUG_PRINTF(...)
 #endif
 
-typedef struct {
-    bool                initialized;
-    uint32_t            pselsda;
-    uint32_t            pselscl;
-    nrf_twi_frequency_t frequency;
-    bool                start_twi;
+#define DEFAULT_TIMEOUT_US (1000)   // timeout for waiting for address NACK
+#define MAXIMUM_TIMEOUT_US (10000)  // timeout for waiting for RX
+#define I2C_READ_BIT 0x01           // read bit
 
-#if DEVICE_I2C_ASYNCH
-    volatile bool   active;
-    uint8_t const  *tx;
-    size_t          tx_length;
-    uint8_t        *rx;
-    size_t          rx_length;
-    bool            stop;
+/* Keep track of what mode the peripheral is in. On NRF52, Driver mode can use TWIM. */
+typedef enum {
+    NORDIC_I2C_MODE_NONE,
+    NORDIC_I2C_MODE_TWI,
+    NORDIC_I2C_MODE_DRIVER
+} nordic_nrf5_mode_t;
 
-    volatile uint32_t   events;
-    void              (*handler)(void);
-    uint32_t            evt_mask;
-#endif // DEVICE_I2C_ASYNCH
-} twi_info_t;
-static twi_info_t m_twi_info[TWI_COUNT];
+/* In simple mode, the Start signal is sent on the first write call due to hardware limitations. */
+typedef enum {
+    NORDIC_TWI_STATE_IDLE,
+    NORDIC_TWI_STATE_START,
+    NORDIC_TWI_STATE_BUSY
+} nordic_nrf5_twi_state_t;
 
-static NRF_TWI_Type * const m_twi_instances[TWI_COUNT] = {
-#if TWI0_ENABLED
-    NRF_TWI0,
-#endif
-#if TWI1_ENABLED
-    NRF_TWI1,
-#endif
-};
+/* Forward declaration. These functions are implemented in the driver but not
+ * set up in the NVIC due to it being relocated.
+ */
+void SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler(void);
+void SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler(void);
 
-void SPI0_TWI0_IRQHandler(void);
-void SPI1_TWI1_IRQHandler(void);
-
-static const peripheral_handler_desc_t twi_handlers[TWI_COUNT] =
-{
-#if TWI0_ENABLED
-    {
-        SPI0_TWI0_IRQn,
-        (uint32_t) SPI0_TWI0_IRQHandler
-    },
-#endif
-#if TWI1_ENABLED
-    {
-        SPI1_TWI1_IRQn,
-        (uint32_t) SPI1_TWI1_IRQHandler
-    }
-#endif
-};
-#ifdef NRF51
-    #define TWI_IRQ_PRIORITY  APP_IRQ_PRIORITY_LOW
-#elif defined(NRF52) || defined(NRF52840_XXAA)
-    #define TWI_IRQ_PRIORITY  APP_IRQ_PRIORITY_LOWEST
-#endif
-
-
-#if DEVICE_I2C_ASYNCH
-static void start_asynch_rx(twi_info_t *twi_info, NRF_TWI_Type *twi)
-{
-    if (twi_info->rx_length == 1 && twi_info->stop) {
-        nrf_twi_shorts_set(twi, NRF_TWI_SHORT_BB_STOP_MASK);
-    } else {
-        nrf_twi_shorts_set(twi, NRF_TWI_SHORT_BB_SUSPEND_MASK);
-    }
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_STARTRX);
-}
-
-static void twi_irq_handler(uint8_t instance_idx)
-{
-    twi_info_t *twi_info = &m_twi_info[instance_idx];
-
-    NRF_TWI_Type *twi = m_twi_instances[instance_idx];
-    if (nrf_twi_event_check(twi, NRF_TWI_EVENT_ERROR)) {
-        nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-
-        // In case of an error, force STOP.
-        // The current transfer may be suspended (if it is RX), so it must be
-        // resumed before the STOP task is triggered.
-        nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-        nrf_twi_task_trigger(twi, NRF_TWI_TASK_STOP);
-
-        uint32_t errorsrc = nrf_twi_errorsrc_get_and_clear(twi);
-        twi_info->events |= I2C_EVENT_ERROR;
-        if (errorsrc & NRF_TWI_ERROR_ADDRESS_NACK) {
-            twi_info->events |= I2C_EVENT_ERROR_NO_SLAVE;
-        }
-        if (errorsrc & NRF_TWI_ERROR_DATA_NACK) {
-            twi_info->events |= I2C_EVENT_TRANSFER_EARLY_NACK;
-        }
-    }
-
-    bool finished = false;
-
-    if (nrf_twi_event_check(twi, NRF_TWI_EVENT_TXDSENT)) {
-        nrf_twi_event_clear(twi, NRF_TWI_EVENT_TXDSENT);
-
-        MBED_ASSERT(twi_info->tx_length > 0);
-        --(twi_info->tx_length);
-        // Send next byte if there is still something to be sent.
-        if (twi_info->tx_length > 0) {
-            nrf_twi_txd_set(twi, *(twi_info->tx));
-            ++(twi_info->tx);
-        // It TX is done, start RX if requested.
-        } else if (twi_info->rx_length > 0) {
-            start_asynch_rx(twi_info, twi);
-        // If there is nothing more to do, finalize the transfer.
-        } else {
-            if (twi_info->stop) {
-                nrf_twi_task_trigger(twi, NRF_TWI_TASK_STOP);
-            } else {
-                nrf_twi_task_trigger(twi, NRF_TWI_TASK_SUSPEND);
-                finished = true;
-            }
-            twi_info->events |= I2C_EVENT_TRANSFER_COMPLETE;
-        }
-    }
-
-    if (nrf_twi_event_check(twi, NRF_TWI_EVENT_RXDREADY)) {
-        nrf_twi_event_clear(twi, NRF_TWI_EVENT_RXDREADY);
-
-        MBED_ASSERT(twi_info->rx_length > 0);
-        *(twi_info->rx) = nrf_twi_rxd_get(twi);
-        ++(twi_info->rx);
-        --(twi_info->rx_length);
-
-        if (twi_info->rx_length > 0) {
-            // If more bytes should be received, resume the transfer
-            // (in case the stop condition should be generated after the next
-            // byte, change the shortcuts configuration first).
-            if (twi_info->rx_length == 1 && twi_info->stop) {
-                nrf_twi_shorts_set(twi, NRF_TWI_SHORT_BB_STOP_MASK);
-            }
-            nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-        } else {
-            // If all requested bytes were received, finalize the transfer.
-            finished = true;
-            twi_info->events |= I2C_EVENT_TRANSFER_COMPLETE;
-        }
-    }
-
-    if (finished ||
-        nrf_twi_event_check(twi, NRF_TWI_EVENT_STOPPED) ||
-        (nrf_twi_int_enable_check(twi, NRF_TWI_INT_SUSPENDED_MASK) &&
-         nrf_twi_event_check(twi, NRF_TWI_EVENT_SUSPENDED))) {
-        // There is no need to clear the STOPPED and SUSPENDED events here,
-        // they will no longer generate the interrupt - see below.
-
-        nrf_twi_shorts_set(twi, 0);
-        // Disable all interrupt sources.
-        nrf_twi_int_disable(twi, UINT32_MAX);
-        twi_info->active = false;
-
-        if (twi_info->handler) {
-            twi_info->handler();
-        }
-    }
-}
-
-#if TWI0_ENABLED
-static void irq_handler_twi0(void)
-{
-    twi_irq_handler(TWI0_INSTANCE_INDEX);
-}
-#endif
-#if TWI1_ENABLED
-static void irq_handler_twi1(void)
-{
-    twi_irq_handler(TWI1_INSTANCE_INDEX);
-}
-#endif
-static nrf_drv_irq_handler_t const m_twi_irq_handlers[TWI_COUNT] =
-{
-#if TWI0_ENABLED
-    irq_handler_twi0,
-#endif
-#if TWI1_ENABLED
-    irq_handler_twi1,
-#endif
-};
-#endif // DEVICE_I2C_ASYNCH
-
-
-static void configure_twi_pin(uint32_t pin, nrf_gpio_pin_dir_t dir)
-{
-    nrf_gpio_cfg(pin,
-        dir,
-        NRF_GPIO_PIN_INPUT_CONNECT,
-        NRF_GPIO_PIN_PULLUP,
-        NRF_GPIO_PIN_S0D1,
-        NRF_GPIO_PIN_NOSENSE);
-}
-
-static void twi_clear_bus(twi_info_t *twi_info)
-{
-    // Try to set SDA high, and check if no slave tries to drive it low.
-    nrf_gpio_pin_set(twi_info->pselsda);
-    configure_twi_pin(twi_info->pselsda, NRF_GPIO_PIN_DIR_OUTPUT);
-    // In case SDA is low, make up to 9 cycles on SCL line to help the slave
-    // that pulls SDA low release it.
-    if (!nrf_gpio_pin_read(twi_info->pselsda)) {
-        nrf_gpio_pin_set(twi_info->pselscl);
-        configure_twi_pin(twi_info->pselscl, NRF_GPIO_PIN_DIR_OUTPUT);
-        nrf_delay_us(4);
-
-        for (int i = 0; i < 9; i++) {
-            if (nrf_gpio_pin_read(twi_info->pselsda)) {
-                break;
-            }
-            nrf_gpio_pin_clear(twi_info->pselscl);
-            nrf_delay_us(4);
-            nrf_gpio_pin_set(twi_info->pselscl);
-            nrf_delay_us(4);
-        }
-
-        // Finally, generate STOP condition to put the bus into initial state.
-        nrf_gpio_pin_clear(twi_info->pselsda);
-        nrf_delay_us(4);
-        nrf_gpio_pin_set(twi_info->pselsda);
-    }
-}
-
+/** Initialize the I2C peripheral. It sets the default parameters for I2C
+ *  peripheral, and configures its specifieds pins.
+ *
+ *  @param obj  The I2C object
+ *  @param sda  The sda pin
+ *  @param scl  The scl pin
+ */
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
-    ret_code_t ret;
-    int i;
-
-    for (i = 0; i < TWI_COUNT; ++i) {
-        if (m_twi_info[i].initialized &&
-            m_twi_info[i].pselsda == (uint32_t)sda &&
-            m_twi_info[i].pselscl == (uint32_t)scl) {
-            TWI_IDX(obj) = i;
-            TWI_INFO(obj)->frequency = NRF_TWI_FREQ_100K;
-            i2c_reset(obj);
-            return;
-        }
-    }
-
-    for (i = 0; i < TWI_COUNT; ++i) {
-        if (!m_twi_info[i].initialized) {
-            ret = nrf_drv_common_per_res_acquire(m_twi_instances[i],
-                    m_twi_irq_handlers[i]);
-
-            if (ret != NRF_SUCCESS) {
-                continue; /* the hw resource is busy - test another one */
-            }
-
-            TWI_IDX(obj) = i;
-
-            twi_info_t *twi_info = TWI_INFO(obj);
-            twi_info->initialized = true;
-            twi_info->pselsda     = (uint32_t)sda;
-            twi_info->pselscl     = (uint32_t)scl;
-            twi_info->frequency   = NRF_TWI_FREQ_100K;
-            twi_info->start_twi   = false;
-#if DEVICE_I2C_ASYNCH
-            twi_info->active      = false;
-#endif
-
-            twi_clear_bus(twi_info);
-
-            configure_twi_pin(twi_info->pselsda, NRF_GPIO_PIN_DIR_INPUT);
-            configure_twi_pin(twi_info->pselscl, NRF_GPIO_PIN_DIR_INPUT);
-
-            i2c_reset(obj);
+    DEBUG_PRINTF("i2c_init: %p %d %d\r\n", obj, sda, scl);
 
 #if DEVICE_I2C_ASYNCH
-            NVIC_SetVector(twi_handlers[i].IRQn, twi_handlers[i].vector);
-            nrf_drv_common_irq_enable(twi_handlers[i].IRQn, TWI_IRQ_PRIORITY);
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
 #endif
 
-            return;
-        }
-    }
+    /* Get instance from pin configuration. */
+    int instance = pin_instance_i2c(sda, scl);
+    MBED_ASSERT(instance < ENABLED_TWI_COUNT);
 
-    error("No available I2C peripheral\r\n");
+    /* Initialize i2c_t object */
+    config->instance = instance;
+    config->sda = sda;
+    config->scl = scl;
+    config->frequency = NRF_TWI_FREQ_100K;
+    config->state = NORDIC_TWI_STATE_IDLE;
+    config->mode = NORDIC_I2C_MODE_NONE;
+
+#if DEVICE_I2C_ASYNCH
+    config->handler = 0;
+    config->event = 0;
+    config->mask = 0;
+#endif
+
+    /* Force reconfiguration */
+    config->update = true;
+
+    static bool first_init = true;
+
+    if (first_init) {
+        first_init = false;
+        /* Initialize low power ticker. Used for timeouts. */
+        lp_ticker_init();
+
+        /* Register interrupt handlers in driver with the NVIC. */
+        NVIC_SetVector(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn, (uint32_t) SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler);
+        NVIC_SetVector(SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn, (uint32_t) SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler);
+    }
 }
 
-void i2c_reset(i2c_t *obj)
+/** Configure the I2C frequency
+ *
+ *  @param obj The I2C object
+ *  @param hz  Frequency in Hz
+ */
+void i2c_frequency(i2c_t *obj, int hz)
 {
-    twi_info_t *twi_info = TWI_INFO(obj);
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
+    DEBUG_PRINTF("i2c_frequency: %p %d\r\n", obj, hz);
 
-    nrf_twi_disable(twi);
-    nrf_twi_pins_set(twi, twi_info->pselscl, twi_info->pselsda);
-    nrf_twi_frequency_set(twi, twi_info->frequency);
-    nrf_twi_enable(twi);
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    /* Round down to nearest valid frequency. */
+    nrf_twi_frequency_t new_frequency;
+
+    if (hz < 250000) {
+        new_frequency = NRF_TWI_FREQ_100K;
+    } else if (hz < 400000) {
+        new_frequency = NRF_TWI_FREQ_250K;
+    } else {
+        new_frequency = NRF_TWI_FREQ_400K;
+    }
+
+    /* Only store frequency in object. Configuration happens at the beginning of each transaction. */
+    config->frequency = new_frequency;
+    config->update = true;
 }
 
+
+/***
+ *       _____ _                 _        _________          _______
+ *      / ____(_)               | |      |__   __\ \        / /_   _|
+ *     | (___  _ _ __ ___  _ __ | | ___     | |   \ \  /\  / /  | |
+ *      \___ \| | '_ ` _ \| '_ \| |/ _ \    | |    \ \/  \/ /   | |
+ *      ____) | | | | | | | |_) | |  __/    | |     \  /\  /   _| |_
+ *     |_____/|_|_| |_| |_| .__/|_|\___|    |_|      \/  \/   |_____|
+ *                        | |
+ *                        |_|
+ */
+
+/*****************************************************************************/
+/* Simple API implementation using TWI                                       */
+/*****************************************************************************/
+
+/* Global array for easy register selection for each instance. */
+static NRF_TWI_Type * nordic_nrf5_twi_register[2] = { NRF_TWI0, NRF_TWI1 };
+
+/**
+ * @brief      Reconfigure TWI register.
+ *
+ *             If the peripheral is enabled, it will be disabled first. All
+ *             registers are cleared to their default values unless replaced
+ *             by new configuration.
+ *
+ *             If the object is the owner, the mode hasn't changed, and the
+ *             force change flag is false, all settings are kept unchanged.
+ *
+ * @param      obj           The object
+ */
+void i2c_configure_twi_instance(i2c_t *obj)
+{
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+
+    /* Get pointer to object of the current owner of the peripheral. */
+    void *current_owner = object_owner_spi2c_get(instance);
+
+    /* Check if reconfiguration is actually necessary. */
+    if ((obj != current_owner) || (config->mode != NORDIC_I2C_MODE_TWI) || config->update) {
+
+        DEBUG_PRINTF("i2c_configure_twi_instance: %p %p\r\n", obj, current_owner);
+
+        /* Claim ownership of peripheral. */
+        object_owner_spi2c_set(instance, obj);
+
+        /* Set current mode. */
+        config->mode = NORDIC_I2C_MODE_TWI;
+
+        /* Disable peripheral if it is currently enabled. */
+        if (nordic_nrf5_twi_register[instance]->ENABLE) {
+            nrf_twi_disable(nordic_nrf5_twi_register[instance]);
+        }
+
+        /* Force resource release. This is necessary because mbed drivers don't
+         * deinitialize on object destruction.
+         */
+        nrf_drv_common_irq_disable(nrf_drv_get_IRQn((void *) nordic_nrf5_twi_register[instance]));
+        nrf_drv_common_per_res_release(nordic_nrf5_twi_register[instance]);
+
+        /* Reset shorts register. */
+        nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], 0);
+
+        /* Disable all TWI interrupts. */
+        nrf_twi_int_disable(nordic_nrf5_twi_register[instance],
+                            NRF_TWI_INT_STOPPED_MASK  |
+                            NRF_TWI_INT_RXDREADY_MASK |
+                            NRF_TWI_INT_TXDSENT_MASK  |
+                            NRF_TWI_INT_ERROR_MASK    |
+                            NRF_TWI_INT_BB_MASK       |
+                            NRF_TWI_INT_SUSPENDED_MASK);
+
+        /* Clear error register. */
+        nrf_twi_errorsrc_get_and_clear(nordic_nrf5_twi_register[instance]);
+
+        /* Clear all previous events. */
+        nrf_twi_event_clear(nordic_nrf5_twi_register[instance],
+                            NRF_TWI_EVENT_STOPPED  |
+                            NRF_TWI_EVENT_RXDREADY |
+                            NRF_TWI_EVENT_TXDSENT  |
+                            NRF_TWI_EVENT_ERROR    |
+                            NRF_TWI_EVENT_BB       |
+                            NRF_TWI_EVENT_SUSPENDED);
+
+        /* Configure SDA and SCL pins. */
+        nrf_twi_pins_set(nordic_nrf5_twi_register[instance],
+                         config->scl,
+                         config->sda);
+
+        /* Set frequency. */
+        nrf_twi_frequency_set(nordic_nrf5_twi_register[instance],
+                              config->frequency);
+
+        /* Enable TWI peripheral with new settings. */
+        nrf_twi_enable(nordic_nrf5_twi_register[instance]);
+    }
+}
+
+/** Send START command
+ *
+ *  @param obj The I2C object
+ */
 int i2c_start(i2c_t *obj)
 {
-    twi_info_t *twi_info = TWI_INFO(obj);
+    DEBUG_PRINTF("i2c_start: %p\r\n", obj);
+
 #if DEVICE_I2C_ASYNCH
-    if (twi_info->active) {
-        return I2C_ERROR_BUS_BUSY;
-    }
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
 #endif
-    twi_info->start_twi = true;
+
+    /* Change state but defer actual signaling until the first byte (the address)
+       is transmitted. This is due to hardware limitations.
+    */
+    config->state = NORDIC_TWI_STATE_START;
 
     return 0;
 }
 
-int i2c_stop(i2c_t *obj)
-{
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-    uint32_t t0;
-
-    // The current transfer may be suspended (if it is RX), so it must be
-    // resumed before the STOP task is triggered.
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_STOP);
-
-    t0 = ticker_read(get_us_ticker_data());
-
-    do {
-        if (nrf_twi_event_check(twi, NRF_TWI_EVENT_STOPPED)) {
-            return 0;
-        }
-    } while (((uint32_t)ticker_read(get_us_ticker_data()) - t0) < I2C_TIMEOUT_VALUE_US);
-
-    return 1;
-}
-
-void i2c_frequency(i2c_t *obj, int hz)
-{
-    twi_info_t *twi_info = TWI_INFO(obj);
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-
-    if (hz < 250000) {
-        twi_info->frequency = NRF_TWI_FREQ_100K;
-    } else if (hz < 400000) {
-        twi_info->frequency = NRF_TWI_FREQ_250K;
-    } else {
-        twi_info->frequency = NRF_TWI_FREQ_400K;
-    }
-    nrf_twi_frequency_set(twi, twi_info->frequency);
-}
-
-static uint8_t twi_address(int i2c_address)
-{
-    // The TWI peripheral requires 7-bit slave address (without R/W bit).
-    return (i2c_address >> 1);
-}
-
-static void start_twi_read(NRF_TWI_Type *twi, int address)
-{
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_STOPPED);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_RXDREADY);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-    (void)nrf_twi_errorsrc_get_and_clear(twi);
-
-    nrf_twi_shorts_set(twi, NRF_TWI_SHORT_BB_SUSPEND_MASK);
-
-    nrf_twi_address_set(twi, twi_address(address));
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_STARTRX);
-}
-
-int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
-{
-    // Zero-length RX transfers are not supported. Such transfers cannot
-    // be easily achieved with TWI peripheral (some dirty tricks would be
-    // required for this), and they are actually useless (TX can be used
-    // to check if the address is acknowledged by a slave).
-    MBED_ASSERT(length > 0);
-
-    twi_info_t *twi_info = TWI_INFO(obj);
-#if DEVICE_I2C_ASYNCH
-    if (twi_info->active) {
-        return I2C_ERROR_BUS_BUSY;
-    }
-#endif
-    twi_info->start_twi = false;
-
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-    start_twi_read(twi, address);
-
-    int result = length;
-    while (length > 0) {
-        int byte_read_result = i2c_byte_read(obj, (stop && length == 1));
-        if (byte_read_result < 0) {
-            // When an error occurs, return the number of bytes that have been
-            // received successfully.
-            result -= length;
-            // Force STOP condition.
-            stop = 1;
-            break;
-        }
-        *data++ = (uint8_t)byte_read_result;
-        --length;
-    }
-
-    if (stop) {
-        (void)i2c_stop(obj);
-    }
-
-    return result;
-}
-
-static uint8_t twi_byte_write(NRF_TWI_Type *twi, uint8_t data)
-{
-    uint32_t t0;
-
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_TXDSENT);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-
-    nrf_twi_txd_set(twi, data);
-
-    t0 = ticker_read(get_us_ticker_data());
-
-    do {
-        if (nrf_twi_event_check(twi, NRF_TWI_EVENT_TXDSENT)) {
-            nrf_twi_event_clear(twi, NRF_TWI_EVENT_TXDSENT);
-            return 1; // ACK received
-        }
-        if (nrf_twi_event_check(twi, NRF_TWI_EVENT_ERROR)) {
-            nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-            return 0; // some error occurred
-        }
-    } while (((uint32_t)ticker_read(get_us_ticker_data()) - t0) < I2C_TIMEOUT_VALUE_US);
-
-    return 2; // timeout;
-}
-
-static void start_twi_write(NRF_TWI_Type *twi, int address)
-{
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_STOPPED);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_TXDSENT);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-    (void)nrf_twi_errorsrc_get_and_clear(twi);
-
-    nrf_twi_shorts_set(twi, 0);
-
-    nrf_twi_address_set(twi, twi_address(address));
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_STARTTX);
-}
-
-int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
-{
-    twi_info_t *twi_info = TWI_INFO(obj);
-    bool timeout = false;
-    uint32_t t0, t1;
-
-#if DEVICE_I2C_ASYNCH
-    if (twi_info->active) {
-        return I2C_ERROR_BUS_BUSY;
-    }
-#endif
-    twi_info->start_twi = false;
-
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-    start_twi_write(twi, address);
-
-    // Special case - transaction with no data.
-    // It can be used to check if a slave acknowledges the address.
-    if (length == 0) {
-        nrf_twi_event_t event;
-        if (stop) {
-            event = NRF_TWI_EVENT_STOPPED;
-            nrf_twi_task_trigger(twi, NRF_TWI_TASK_STOP);
-        } else {
-            event = NRF_TWI_EVENT_SUSPENDED;
-            nrf_twi_event_clear(twi, event);
-            nrf_twi_task_trigger(twi, NRF_TWI_TASK_SUSPEND);
-        }
-
-        t0 = ticker_read(get_us_ticker_data());
-
-        do {
-            if (nrf_twi_event_check(twi, event)) {
-                break;
-            }
-            t1 = ticker_read(get_us_ticker_data());
-            timeout = (t1 - t0) >= I2C_TIMEOUT_VALUE_US;
-        } while (!timeout);
-
-        uint32_t errorsrc = nrf_twi_errorsrc_get_and_clear(twi);
-        if (errorsrc & NRF_TWI_ERROR_ADDRESS_NACK) {
-            if (!stop) {
-                i2c_stop(obj);
-            }
-            return I2C_ERROR_NO_SLAVE;
-        }
-
-        return (timeout ? I2C_ERROR_BUS_BUSY : 0);
-    }
-
-    int result = length;
-    do {
-        uint8_t byte_write_result = twi_byte_write(twi, (uint8_t)*data++);
-        if (byte_write_result != 1) {
-            if (byte_write_result == 0) {
-                // Check what kind of error has been signaled by TWI.
-                uint32_t errorsrc = nrf_twi_errorsrc_get_and_clear(twi);
-                if (errorsrc & NRF_TWI_ERROR_ADDRESS_NACK) {
-                    result = I2C_ERROR_NO_SLAVE;
-                } else {
-                    // Some other error - return the number of bytes that
-                    // have been sent successfully.
-                    result -= length;
-                }
-            } else {
-                result = I2C_ERROR_BUS_BUSY;
-            }
-            // Force STOP condition.
-            stop = 1;
-            break;
-        }
-        --length;
-    } while (length > 0);
-
-    if (stop) {
-        (void)i2c_stop(obj);
-    }
-
-    return result;
-}
-
-int i2c_byte_read(i2c_t *obj, int last)
-{
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-    uint32_t t0;
-
-    if (last) {
-        nrf_twi_shorts_set(twi, NRF_TWI_SHORT_BB_STOP_MASK);
-    }
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-
-    t0 = ticker_read(get_us_ticker_data());
-
-    do {
-        if (nrf_twi_event_check(twi, NRF_TWI_EVENT_RXDREADY)) {
-            nrf_twi_event_clear(twi, NRF_TWI_EVENT_RXDREADY);
-            return nrf_twi_rxd_get(twi);
-        }
-        if (nrf_twi_event_check(twi, NRF_TWI_EVENT_ERROR)) {
-            nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-            return I2C_ERROR_NO_SLAVE;
-        }
-    } while (((uint32_t)ticker_read(get_us_ticker_data()) - t0) < I2C_TIMEOUT_VALUE_US);
-
-    return I2C_ERROR_BUS_BUSY;
-}
-
+/** Write one byte
+ *
+ *  @param obj The I2C object
+ *  @param data Byte to be written
+ *  @return 0 if NAK was received, 1 if ACK was received, 2 for timeout.
+ */
 int i2c_byte_write(i2c_t *obj, int data)
 {
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
-    twi_info_t *twi_info = TWI_INFO(obj);
-    if (twi_info->start_twi) {
-        twi_info->start_twi = false;
+    DEBUG_PRINTF("i2c_byte_write: %p %d\r\n", obj, data);
 
-        if (data & 1) {
-            start_twi_read(twi, data);
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+    int result = 1; // default to ACK
+
+    /* Check if this is the first byte to be transferred. If it is, then send start signal and address. */
+    if (config->state == NORDIC_TWI_STATE_START) {
+        config->state = NORDIC_TWI_STATE_BUSY;
+
+        /* Beginning of new transaction, configure peripheral if necessary. */
+        i2c_configure_twi_instance(obj);
+
+        /* Set I2C device address. NOTE: due to hardware limitations only 7-bit addresses are supported. */
+        nrf_twi_address_set(nordic_nrf5_twi_register[instance], data >> 1);
+
+        /* If read bit is set, trigger read task otherwise trigger write task. */
+        if (data & I2C_READ_BIT) {
+            /* For timing reasons, reading bytes requires shorts to suspend peripheral after each byte. */
+            nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], NRF_TWI_SHORT_BB_SUSPEND_MASK);
+            nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_STARTRX);
         } else {
-            start_twi_write(twi, data);
+            /* Reset shorts register. */
+            nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], 0);
+            nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_STARTTX);
         }
-        return 1;
+
+        /* Setup stop watch for timeout. */
+        uint32_t start_us = lp_ticker_read();
+        uint32_t now_us = start_us;
+
+        /* Block until timeout or an address error has been detected. */
+        while (((now_us - start_us) < DEFAULT_TIMEOUT_US) &&
+               !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_ERROR))) {
+            now_us = lp_ticker_read();
+        }
+
+        /* Check error register and update return value if an address NACK was detected. */
+        uint32_t error = nrf_twi_errorsrc_get_and_clear(nordic_nrf5_twi_register[instance]);
+
+        if (error & NRF_TWI_ERROR_ADDRESS_NACK) {
+            result = 0; // set NACK
+        }
     } else {
-        nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-        // 0 - TWI signaled error (NAK is the only possibility here)
-        // 1 - ACK received
-        // 2 - timeout (clock stretched for too long?)
-        return twi_byte_write(twi, (uint8_t)data);
+
+        /* Normal write. Send next byte after clearing event flag. */
+        nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_TXDSENT);
+        nrf_twi_txd_set(nordic_nrf5_twi_register[instance], data);
+
+        /* Setup stop watch for timeout. */
+        uint32_t start_us = lp_ticker_read();
+        uint32_t now_us = start_us;
+
+        /* Block until timeout or the byte has been sent. */
+        while (((now_us - start_us) < MAXIMUM_TIMEOUT_US) &&
+               !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_TXDSENT))) {
+            now_us = lp_ticker_read();
+        }
+
+        /* Check the error code to see if the byte was acknowledged. */
+        uint32_t error = nrf_twi_errorsrc_get_and_clear(nordic_nrf5_twi_register[instance]);
+
+        if (error & NRF_TWI_ERROR_DATA_NACK) {
+            result = 0; // set NACK
+        } else if (now_us - start_us >= MAXIMUM_TIMEOUT_US) {
+            result = 2; // set timeout
+        }
     }
+
+    return result;
+}
+
+/** Read one byte
+ *
+ *  @param obj The I2C object
+ *  @param last Acknoledge
+ *  @return The read byte
+ */
+int i2c_byte_read(i2c_t *obj, int last)
+{
+    DEBUG_PRINTF("i2c_byte_read: %p %d\r\n", obj, last);
+
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+    int retval = I2C_ERROR_NO_SLAVE;
+
+    uint32_t start_us = 0;
+    uint32_t now_us = 0;
+
+    /* Due to hardware limitations, the stop condition must triggered through a short before
+     * reading the last byte.
+     */
+    if (last) {
+        nrf_twi_shorts_set(nordic_nrf5_twi_register[instance], NRF_TWI_SHORT_BB_STOP_MASK);
+
+        /* Transaction will be complete after this call, reset state. */
+        config->state = NORDIC_TWI_STATE_IDLE;
+    }
+
+    /* Due to the way events are generated, if a byte is available it should be read directly
+     * but without resuming reading. Otherwise the TWI will read one byte too many.
+     */
+    if (nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY)) {
+        retval = nrf_twi_rxd_get(nordic_nrf5_twi_register[instance]);
+        nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY);
+    } else {
+
+        /* No data available, resume reception. */
+        nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_RESUME);
+
+        /* Setup timeout */
+        start_us = lp_ticker_read();
+        now_us = start_us;
+
+        /* Block until timeout or data ready event has been signaled. */
+        while (((now_us - start_us) < MAXIMUM_TIMEOUT_US) &&
+               !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY))) {
+            now_us = lp_ticker_read();
+        }
+
+        /* Retrieve data from buffer. */
+        if ((now_us - start_us) < MAXIMUM_TIMEOUT_US) {
+            retval = nrf_twi_rxd_get(nordic_nrf5_twi_register[instance]);
+            nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_RXDREADY);
+        }
+    }
+
+    return retval;
+}
+
+/** Send STOP command
+ *
+ *  @param obj The I2C object
+ */
+int i2c_stop(i2c_t *obj)
+{
+    DEBUG_PRINTF("i2c_stop: %p\r\n", obj);
+
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+
+    /* Set explicit stop signal. */
+    nrf_twi_event_clear(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED);
+    nrf_twi_task_trigger(nordic_nrf5_twi_register[instance], NRF_TWI_TASK_STOP);
+
+    /* Block until stop signal has been generated. */
+    uint32_t start_us = lp_ticker_read();
+    uint32_t now_us = start_us;
+
+    while (((now_us - start_us) < MAXIMUM_TIMEOUT_US) &&
+           !(nrf_twi_event_check(nordic_nrf5_twi_register[instance], NRF_TWI_EVENT_STOPPED))) {
+        now_us = lp_ticker_read();
+    }
+
+    /* Reset state. */
+    config->state = NORDIC_TWI_STATE_IDLE;
+
+    return 0;
+}
+
+/** Reset I2C peripheral. TODO: The action here. Most of the implementation sends stop()
+ *
+ *  @param obj The I2C object
+ */
+void i2c_reset(i2c_t *obj)
+{
+    DEBUG_PRINTF("i2c_reset: %p\r\n", obj);
+
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    /* Force reconfiguration to reset peripheral completely. */
+    config->update = true;
+    i2c_configure_twi_instance(obj);
+}
+
+
+
+/***
+ *      _____       _                  _________          _______
+ *     |  __ \     (_)                |__   __\ \        / /_   _|
+ *     | |  | |_ __ ___   _____ _ __     | |   \ \  /\  / /  | |
+ *     | |  | | '__| \ \ / / _ \ '__|    | |    \ \/  \/ /   | |
+ *     | |__| | |  | |\ V /  __/ |       | |     \  /\  /   _| |_
+ *     |_____/|_|  |_| \_/ \___|_|       |_|      \/  \/   |_____|
+ *
+ *
+ */
+
+/* Global array holding driver configuration for easy access. */
+static const nrf_drv_twi_t nordic_nrf5_instance[2] = { NRF_DRV_TWI_INSTANCE(0), NRF_DRV_TWI_INSTANCE(1) };
+
+/* Forward declare interrupt handler. */
+#if DEVICE_I2C_ASYNCH
+static void nordic_nrf5_twi_event_handler(nrf_drv_twi_evt_t const *p_event, void *p_context);
+#endif
+
+/**
+ * @brief      Reconfigure driver.
+ *
+ *             If the peripheral is enabled, it will be disabled first. All
+ *             registers are cleared to their default values unless replaced
+ *             by new configuration.
+ *
+ *             If the object is the owner, the mode hasn't changed, and the
+ *             force change flag is false, all settings are kept unchanged.
+ *
+ * @param      obj           The object
+ * @param[in]  force_change  Set to true to force a reconfiguration.
+ */
+static void i2c_configure_driver_instance(i2c_t *obj)
+{
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+
+    /* Get pointer to object of the current owner of the peripheral. */
+    void *current_owner = object_owner_spi2c_get(instance);
+
+    /* Check if reconfiguration is actually necessary. */
+    if ((obj != current_owner) || (config->mode != NORDIC_I2C_MODE_DRIVER) || config->update) {
+
+        DEBUG_PRINTF("i2c_configure_driver_instance: %p %p\r\n", obj, current_owner);
+
+        /* Claim ownership of peripheral. */
+        object_owner_spi2c_set(instance, obj);
+
+        /* Set current mode. */
+        config->mode = NORDIC_I2C_MODE_DRIVER;
+
+        /* If the peripheral is already running, then disable it and use the driver API to uninitialize it.*/
+        if (nordic_nrf5_instance[instance].reg.p_twi->ENABLE) {
+            nrf_drv_twi_disable(&nordic_nrf5_instance[instance]);
+            nrf_drv_twi_uninit(&nordic_nrf5_instance[instance]);
+        }
+
+        /* Force resource release. This is necessary because mbed drivers don't
+         * deinitialize on object destruction.
+         */
+        nrf_drv_common_irq_disable(nrf_drv_get_IRQn((void *) nordic_nrf5_twi_register[instance]));
+        nrf_drv_common_per_res_release(nordic_nrf5_twi_register[instance]);
+
+        /* Configure driver with new settings. */
+        nrf_drv_twi_config_t twi_config = {
+            .scl = config->scl,
+            .sda = config->sda,
+            .frequency = config->frequency,
+            .interrupt_priority = APP_IRQ_PRIORITY_LOWEST,
+            .clear_bus_init = false,
+            .hold_bus_uninit = false
+        };
+
+#if DEVICE_I2C_ASYNCH
+        /* Set callback handler in asynchronous mode. */
+        if (config->handler) {
+
+            /* Initialze driver in non-blocking mode. */
+            nrf_drv_twi_init(&nordic_nrf5_instance[instance],
+                             &twi_config,
+                             nordic_nrf5_twi_event_handler,
+                             obj);
+        } else {
+
+            /* Initialze driver in blocking mode. */
+            nrf_drv_twi_init(&nordic_nrf5_instance[instance],
+                             &twi_config,
+                             NULL,
+                             NULL);
+        }
+#else
+        /* Initialze driver in blocking mode. */
+        nrf_drv_twi_init(&nordic_nrf5_instance[instance],
+                         &twi_config,
+                         NULL,
+                         NULL);
+#endif
+
+        /* Enable peripheral. */
+        nrf_drv_twi_enable(&nordic_nrf5_instance[instance]);
+    }
+}
+
+/** Blocking reading data
+ *
+ *  @param obj     The I2C object
+ *  @param address 7-bit address (last bit is 1)
+ *  @param data    The buffer for receiving
+ *  @param length  Number of bytes to read
+ *  @param stop    Stop to be generated after the transfer is done
+ *  @return Number of read bytes
+ */
+int i2c_read(i2c_t *obj, int address, char *data, int length, int stop)
+{
+    DEBUG_PRINTF("i2c_read: %p %d %p %d %d\r\n", obj, address, data, length, stop);
+
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+    int result = I2C_ERROR_NO_SLAVE;
+
+    /* Force peripheral configuration to avoid timing errors. */
+    config->update = true;
+    i2c_configure_driver_instance(obj);
+
+    /* Initialize transaction. */
+    ret_code_t retval = nrf_drv_twi_rx(&nordic_nrf5_instance[instance],
+                                       address >> 1,
+                                       (uint8_t *) data,
+                                       length);
+
+    /* Set return value on success. */
+    if (retval == NRF_SUCCESS) {
+        result = length;
+    }
+
+    DEBUG_PRINTF("result: %lu %d\r\n", retval, result);
+
+    return result;
+}
+
+/** Blocking sending data
+ *
+ *  @param obj     The I2C object
+ *  @param address 7-bit address (last bit is 0)
+ *  @param data    The buffer for sending
+ *  @param length  Number of bytes to write
+ *  @param stop    Stop to be generated after the transfer is done
+ *  @return
+ *      zero or non-zero - Number of written bytes
+ *      negative - I2C_ERROR_XXX status
+ */
+int i2c_write(i2c_t *obj, int address, const char *data, int length, int stop)
+{
+    DEBUG_PRINTF("i2c_write: %p %d %p %d %d\r\n", obj, address, data, length, stop);
+
+#if DEVICE_I2C_ASYNCH
+    struct i2c_s *config = &obj->i2c;
+#else
+    struct i2c_s *config = obj;
+#endif
+
+    int instance = config->instance;
+    int result = I2C_ERROR_NO_SLAVE;
+
+    /* Force peripheral configuration to avoid timing errors. */
+    config->update = true;
+    i2c_configure_driver_instance(obj);
+
+    /* Initialize transaction. */
+    ret_code_t retval = nrf_drv_twi_tx(&nordic_nrf5_instance[instance],
+                                       address >> 1,
+                                       (const uint8_t *) data,
+                                       length,
+                                       !stop);
+
+    /* Set return value on success. */
+    if (retval == NRF_SUCCESS) {
+        result = length;
+    }
+
+    DEBUG_PRINTF("result: %lu %d\r\n", retval, result);
+
+    return result;
 }
 
 
 #if DEVICE_I2C_ASYNCH
-void i2c_transfer_asynch(i2c_t *obj, const void *tx, size_t tx_length,
-                         void *rx, size_t rx_length, uint32_t address,
-                         uint32_t stop, uint32_t handler,
-                         uint32_t event, DMAUsage hint)
+
+/***
+ *                                               _____ _____
+ *         /\                              /\   |  __ \_   _|
+ *        /  \   ___ _   _ _ __   ___     /  \  | |__) || |
+ *       / /\ \ / __| | | | '_ \ / __|   / /\ \ |  ___/ | |
+ *      / ____ \\__ \ |_| | | | | (__   / ____ \| |    _| |_
+ *     /_/    \_\___/\__, |_| |_|\___| /_/    \_\_|   |_____|
+ *                    __/ |
+ *                   |___/
+ */
+
+/* Callback function for driver calls. This is called from ISR context. */
+static void nordic_nrf5_twi_event_handler(nrf_drv_twi_evt_t const *p_event, void *p_context)
 {
-    (void)hint;
+    // Only safe to use with mbed-printf.
+    //DEBUG_PRINTF("nordic_nrf5_twi_event_handler: %d %p\r\n", p_event->type, p_context);
 
-    twi_info_t *twi_info = TWI_INFO(obj);
-    if (twi_info->active) {
-        return;
-    }
-    twi_info->active    = true;
-    twi_info->events    = 0;
-    twi_info->handler   = (void (*)(void))handler;
-    twi_info->evt_mask  = event;
-    twi_info->tx_length = tx_length;
-    twi_info->tx        = tx;
-    twi_info->rx_length = rx_length;
-    twi_info->rx        = rx;
-    twi_info->stop      = stop;
+    i2c_t *obj = (i2c_t *) p_context;
+    struct i2c_s *config = &obj->i2c;
 
-    NRF_TWI_Type *twi = m_twi_instances[TWI_IDX(obj)];
+    /* Translate event type from NRF driver values to mbed HAL values. */
+    switch (p_event->type)
+    {
+        /* Transfer completed event. */
+        case NRF_DRV_TWI_EVT_DONE:
+            config->event = I2C_EVENT_TRANSFER_COMPLETE;
+            break;
 
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_TXDSENT);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_RXDREADY);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_STOPPED);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_SUSPENDED);
-    nrf_twi_event_clear(twi, NRF_TWI_EVENT_ERROR);
-    (void)nrf_twi_errorsrc_get_and_clear(twi);
+        /* Error event: NACK received after sending the address. */
+        case NRF_DRV_TWI_EVT_ADDRESS_NACK:
+            config->event = I2C_EVENT_ERROR_NO_SLAVE;
+            break;
 
-    nrf_twi_address_set(twi, twi_address(address));
-    nrf_twi_task_trigger(twi, NRF_TWI_TASK_RESUME);
-    // TX only, or TX + RX (after a repeated start).
-    if (tx_length > 0) {
-        nrf_twi_task_trigger(twi, NRF_TWI_TASK_STARTTX);
-        nrf_twi_txd_set(twi, *(twi_info->tx));
-        ++(twi_info->tx);
-    // RX only.
-    } else if (rx_length > 0) {
-        start_asynch_rx(twi_info, twi);
-    // Both 'tx_length' and 'rx_length' are 0 - this case may be used
-    // to test if the slave is presentand ready for transfer (by just
-    // sending the address and checking if it is acknowledged).
-    } else {
-        nrf_twi_task_trigger(twi, NRF_TWI_TASK_STARTTX);
-        if (stop) {
-            nrf_twi_task_trigger(twi, NRF_TWI_TASK_STOP);
-        } else {
-            nrf_twi_task_trigger(twi, NRF_TWI_TASK_SUSPEND);
-            nrf_twi_int_enable(twi, NRF_TWI_INT_SUSPENDED_MASK);
-        }
-        twi_info->events |= I2C_EVENT_TRANSFER_COMPLETE;
+        /* Error event: NACK received after sending a data byte. */
+        case NRF_DRV_TWI_EVT_DATA_NACK:
+            config->event = I2C_EVENT_TRANSFER_EARLY_NACK;
+            break;
+
+        default:
+            config->event = I2C_EVENT_ERROR;
+            break;
     }
 
-    nrf_twi_int_enable(twi, NRF_TWI_INT_TXDSENT_MASK |
-                            NRF_TWI_INT_RXDREADY_MASK |
-                            NRF_TWI_INT_STOPPED_MASK |
-                            NRF_TWI_INT_ERROR_MASK);
+    /* If event matches event mask and event handler is set, signal event. */
+    if ((config->event & config->mask) && config->handler) {
+
+        /* Cast handler to function pointer. */
+        void (*callback)(void) = (void (*)(void)) config->handler;
+
+        /* Reset handler and force reconfiguration. */
+        config->handler = 0;
+        config->update = true;
+
+        /* Signal callback handler. */
+        callback();
+    }
 }
 
+/** Start I2C asynchronous transfer
+ *
+ *  @param obj       The I2C object
+ *  @param tx        The transmit buffer
+ *  @param tx_length The number of bytes to transmit
+ *  @param rx        The receive buffer
+ *  @param rx_length The number of bytes to receive
+ *  @param address   The address to be set - 7bit or 9bit
+ *  @param stop      If true, stop will be generated after the transfer is done
+ *  @param handler   The I2C IRQ handler to be set
+ *  @param event     Event mask for the transfer. See \ref hal_I2CEvents
+ *  @param hint      DMA hint usage
+ */
+void i2c_transfer_asynch(i2c_t *obj,
+                         const void *tx,
+                         size_t tx_length,
+                         void *rx,
+                         size_t rx_length,
+                         uint32_t address,
+                         uint32_t stop,
+                         uint32_t handler,
+                         uint32_t mask,
+                         DMAUsage hint)
+{
+    DEBUG_PRINTF("i2c_transfer_asynch\r\n");
+
+    /* TWI only supports 7 bit addresses. */
+    MBED_ASSERT(address < 0xFF);
+
+    struct i2c_s *config = &obj->i2c;
+    int instance = config->instance;
+
+    /* Save event handler and event mask in global variables so they can be called from interrupt handler. */
+    config->handler = handler;
+    config->mask = mask;
+
+    /* Clear event flag. */
+    config->event = 0;
+
+    /* Configure peripheral. */
+    config->update = true;
+    i2c_configure_driver_instance(obj);
+
+    /* Configure TWI transfer. */
+    const nrf_drv_twi_xfer_desc_t twi_config = NRF_DRV_TWI_XFER_DESC_TXRX(address >> 1,
+                                                                          (uint8_t*) tx,
+                                                                          tx_length,
+                                                                          rx,
+                                                                          rx_length);
+
+    uint32_t flags = (stop) ? 0 : NRF_DRV_TWI_FLAG_TX_NO_STOP;
+
+    /* Initiate TWI transfer using NRF driver. */
+    ret_code_t result = nrf_drv_twi_xfer(&nordic_nrf5_instance[instance],
+                                         &twi_config,
+                                         flags);
+
+    /* Signal error if event mask matches and event handler is set. */
+    if ((result != NRF_SUCCESS) && (mask & I2C_EVENT_ERROR) && handler) {
+
+        /* Store event value so it can be read back. */
+        config->event = I2C_EVENT_ERROR;
+
+        /* Cast handler to function pointer. */
+        void (*callback)(void) = (void (*)(void)) handler;
+
+        /* Reset handler and force reconfiguration. */
+        config->handler = 0;
+        config->update = true;
+
+        /* Signal callback handler. */
+        callback();
+    }
+}
+
+/** The asynchronous IRQ handler
+ *
+ *  @param obj The I2C object which holds the transfer information
+ *  @return Event flags if a transfer termination condition was met, otherwise return 0.
+ */
 uint32_t i2c_irq_handler_asynch(i2c_t *obj)
 {
-    twi_info_t *twi_info = TWI_INFO(obj);
-    return (twi_info->events & twi_info->evt_mask);
+    DEBUG_PRINTF("i2c_irq_handler_asynch\r\n");
+
+    /* Return latest event. */
+    return obj->i2c.event;
 }
 
+/** Attempts to determine if the I2C peripheral is already in use
+ *
+ *  @param obj The I2C object
+ *  @return Non-zero if the I2C module is active or zero if it is not
+ */
 uint8_t i2c_active(i2c_t *obj)
 {
-    twi_info_t *twi_info = TWI_INFO(obj);
-    return twi_info->active;
+    DEBUG_PRINTF("i2c_active\r\n");
+
+    /* Query NRF driver if transaction is in progress. */
+    return nrf_drv_twi_is_busy(&nordic_nrf5_instance[obj->i2c.instance]);
 }
 
+/** Abort asynchronous transfer
+ *
+ *  This function does not perform any check - that should happen in upper layers.
+ *  @param obj The I2C object
+ */
 void i2c_abort_asynch(i2c_t *obj)
 {
-    i2c_reset(obj);
+    DEBUG_PRINTF("i2c_abort_asynch\r\n");
+
+    /* Reconfiguration will disable and enable the TWI module. */
+    obj->i2c.update = true;
+    i2c_configure_driver_instance(obj);
 }
+
 #endif // DEVICE_I2C_ASYNCH
+
+#if DEVICE_I2CSLAVE
+#warning DEVICE_I2CSLAVE
+
+/***
+ *      _____ ___   _____    _____ _
+ *     |_   _|__ \ / ____|  / ____| |
+ *       | |    ) | |      | (___ | | __ ___   _____
+ *       | |   / /| |       \___ \| |/ _` \ \ / / _ \
+ *      _| |_ / /_| |____   ____) | | (_| |\ V /  __/
+ *     |_____|____|\_____| |_____/|_|\__,_| \_/ \___|
+ *
+ *
+ */
+
+/** Configure I2C as slave or master.
+ *  @param obj The I2C object
+ *  @param enable_slave Enable i2c hardware so you can receive events with ::i2c_slave_receive
+ *  @return non-zero if a value is available
+ */
+void i2c_slave_mode(i2c_t *obj, int enable_slave)
+{
+    DEBUG_PRINTF("i2c_slave_mode\r\n");
+}
+
+/** Check to see if the I2C slave has been addressed.
+ *  @param obj The I2C object
+ *  @return The status - 1 - read addresses, 2 - write to all slaves,
+ *         3 write addressed, 0 - the slave has not been addressed
+ */
+int i2c_slave_receive(i2c_t *obj)
+{
+    DEBUG_PRINTF("i2c_slave_receive\r\n");
+
+    return 0;
+}
+
+/** Configure I2C as slave or master.
+ *  @param obj The I2C object
+ *  @param data    The buffer for receiving
+ *  @param length  Number of bytes to read
+ *  @return non-zero if a value is available
+ */
+int i2c_slave_read(i2c_t *obj, char *data, int length)
+{
+    DEBUG_PRINTF("i2c_slave_read\r\n");
+
+    return 0;
+}
+
+/** Configure I2C as slave or master.
+ *  @param obj The I2C object
+ *  @param data    The buffer for sending
+ *  @param length  Number of bytes to write
+ *  @return non-zero if a value is available
+ */
+int i2c_slave_write(i2c_t *obj, const char *data, int length)
+{
+    DEBUG_PRINTF("i2c_slave_write\r\n");
+
+    return 0;
+}
+
+/** Configure I2C address.
+ *  @param obj     The I2C object
+ *  @param idx     Currently not used
+ *  @param address The address to be set
+ *  @param mask    Currently not used
+ */
+void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask)
+{
+    DEBUG_PRINTF("i2c_slave_address\r\n");
+}
+
+#endif // DEVICE_I2CSLAVE
 
 #endif // DEVICE_I2C

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/objects.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/objects.h
@@ -43,6 +43,8 @@
 #include "PortNames.h"
 #include "PeripheralNames.h"
 #include "PinNames.h"
+#include "nrf_drv_spi.h"
+#include "nrf_twi.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -53,7 +55,16 @@ struct serial_s {
 };                        // but it must be not empty (required by strict compiler - IAR)
 
 struct spi_s {
-    uint8_t spi_idx;
+    int instance;
+    PinName cs;
+    nrf_drv_spi_config_t config;
+    bool update;
+
+#if DEVICE_SPI_ASYNCH
+    uint32_t handler;
+    uint32_t mask;
+    uint32_t event;
+#endif
 };
 
 struct port_s {
@@ -69,7 +80,19 @@ struct pwmout_s {
 };
 
 struct i2c_s {
-    uint8_t twi_idx;
+    int instance;
+    PinName sda;
+    PinName scl;
+    nrf_twi_frequency_t frequency;
+    int state;
+    int mode;
+    bool update;
+
+#if DEVICE_I2C_ASYNCH
+    uint32_t handler;
+    uint32_t mask;
+    uint32_t event;
+#endif
 };
 
 struct analogin_s {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/spi_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/spi_api.c
@@ -1,28 +1,28 @@
-/* 
- * Copyright (c) 2013 Nordic Semiconductor ASA
+/*
+ * Copyright (c) 2017 Nordic Semiconductor ASA
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without modification,
  * are permitted provided that the following conditions are met:
- * 
- *   1. Redistributions of source code must retain the above copyright notice, this list 
+ *
+ *   1. Redistributions of source code must retain the above copyright notice, this list
  *      of conditions and the following disclaimer.
  *
- *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA 
- *      integrated circuit in a product or a software update for such product, must reproduce 
- *      the above copyright notice, this list of conditions and the following disclaimer in 
+ *   2. Redistributions in binary form, except as embedded into a Nordic Semiconductor ASA
+ *      integrated circuit in a product or a software update for such product, must reproduce
+ *      the above copyright notice, this list of conditions and the following disclaimer in
  *      the documentation and/or other materials provided with the distribution.
  *
- *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be 
- *      used to endorse or promote products derived from this software without specific prior 
+ *   3. Neither the name of Nordic Semiconductor ASA nor the names of its contributors may be
+ *      used to endorse or promote products derived from this software without specific prior
  *      written permission.
  *
- *   4. This software, with or without modification, must only be used with a 
+ *   4. This software, with or without modification, must only be used with a
  *      Nordic Semiconductor ASA integrated circuit.
  *
- *   5. Any software provided in binary or object form under this license must not be reverse 
- *      engineered, decompiled, modified and/or disassembled. 
- * 
+ *   5. Any software provided in binary or object form under this license must not be reverse
+ *      engineered, decompiled, modified and/or disassembled.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
@@ -33,552 +33,695 @@
  * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- * 
+ *
  */
-
-#warning arm porting pending
 
 #if DEVICE_SPI
 
-#include "cmsis.h"
-#include "pinmap.h"
-#include "mbed_assert.h"
-#include "mbed_error.h"
+#include "hal/spi_api.h"
+
+#include "object_owners.h"
+#include "pinmap_ex.h"
+
 #include "nrf_drv_spi.h"
-#include "nrf_drv_spis.h"
-#include "app_util_platform.h"
-#include "sdk_config.h"
 
-#include "spi_api.h"
-#include "irq_handlers_hw.h"
+/* Pre-allocate instances and share them globally. */
+static const nrf_drv_spi_t nordic_nrf5_spi_instance[3] = {
+    NRF_DRV_SPI_INSTANCE(0),
+    NRF_DRV_SPI_INSTANCE(1),
+    NRF_DRV_SPI_INSTANCE(2)
+};
 
+/* Forware declare interrupt handler. */
 #if DEVICE_SPI_ASYNCH
-    #define SPI_IDX(obj)    ((obj)->spi.spi_idx)
-#else
-    #define SPI_IDX(obj)    ((obj)->spi_idx)
+static void nordic_nrf5_spi_event_handler(nrf_drv_spi_evt_t const *p_event, void *p_context);
 #endif
-#define SPI_INFO(obj)       (&m_spi_info[SPI_IDX(obj)])
-#define MASTER_INST(obj)    (&m_instances[SPI_IDX(obj)].master)
-#define SLAVE_INST(obj)     (&m_instances[SPI_IDX(obj)].slave)
 
-typedef struct {
-    bool    initialized;
-    bool    master;
-    uint8_t sck_pin;
-    uint8_t mosi_pin;
-    uint8_t miso_pin;
-    uint8_t ss_pin;
-    uint8_t spi_mode;
-    nrf_drv_spi_frequency_t frequency;
-    volatile union {
-        bool busy;     // master
-        bool readable; // slave
-    } flag;
-    volatile uint8_t tx_buf;
-    volatile uint8_t rx_buf;
-
-#if DEVICE_SPI_ASYNCH
-    uint32_t handler;
-    uint32_t event;
-#endif
-} spi_info_t;
-static spi_info_t m_spi_info[SPI_COUNT];
-
-typedef struct {
-    nrf_drv_spi_t  master;
-    nrf_drv_spis_t slave;
-} sdk_driver_instances_t;
-
-void SPI0_TWI0_IRQHandler(void);
-void SPI1_TWI1_IRQHandler(void);
+/* Forward declaration. These functions are implemented in the driver but not
+ * set up in the NVIC due to it being relocated.
+ */
+void SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler(void);
+void SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler(void);
 void SPIM2_SPIS2_SPI2_IRQHandler(void);
 
-static const peripheral_handler_desc_t spi_handler_desc[SPI_COUNT] = {
-#if SPI0_ENABLED
-    {
-        SPI0_IRQ,
-        (uint32_t) SPI0_TWI0_IRQHandler
-    },
-#endif
-#if SPI1_ENABLED
-    {
-        SPI1_IRQ,
-        (uint32_t) SPI1_TWI1_IRQHandler
-    },
-#endif
-#if SPI2_ENABLED
-    {
-        SPI2_IRQ,
-        (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler
-    },
-#endif    
-};
-
-
-static sdk_driver_instances_t m_instances[SPI_COUNT] = {
-#if SPI0_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(0),
-        NRF_DRV_SPIS_INSTANCE(0)
-    },
-#endif
-#if SPI1_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(1),
-        NRF_DRV_SPIS_INSTANCE(1)
-    },
-#endif
-#if SPI2_ENABLED
-    {
-        NRF_DRV_SPI_INSTANCE(2),
-        NRF_DRV_SPIS_INSTANCE(2)
-    },
-#endif
-};
-
-static void master_event_handler(uint8_t spi_idx,
-                                 nrf_drv_spi_evt_t const *p_event)
+/**
+ * Brief       Reconfigure peripheral.
+ *
+ *             If the peripheral has changed ownership clear old configuration and
+ *             re-initialize the peripheral with the new settings.
+ *
+ * Parameter   obj           The object
+ * Parameter   handler       Optional callback handler.
+ * Parameter   force_change  Force change regardless of ownership.
+ */
+static void spi_configure_driver_instance(spi_t *obj)
 {
-    spi_info_t *p_spi_info = &m_spi_info[spi_idx];
-
-    if (p_event->type == NRF_DRV_SPI_EVENT_DONE) {
-        p_spi_info->flag.busy = false;
 #if DEVICE_SPI_ASYNCH
-        if (p_spi_info->handler) {
-            void (*handler)(void) = (void (*)(void))p_spi_info->handler;
-            p_spi_info->handler = 0;
-            handler();
-        }
-#endif
-    }
-}
-#define MASTER_EVENT_HANDLER(idx) \
-    static void master_event_handler_##idx(nrf_drv_spi_evt_t const *p_event, void *p_context) { \
-        master_event_handler(SPI##idx##_INSTANCE_INDEX, p_event); \
-    }
-#if SPI0_ENABLED
-    MASTER_EVENT_HANDLER(0)
-#endif
-#if SPI1_ENABLED
-    MASTER_EVENT_HANDLER(1)
-#endif
-#if SPI2_ENABLED
-    MASTER_EVENT_HANDLER(2)
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
 #endif
 
-static nrf_drv_spi_evt_handler_t const m_master_event_handlers[SPI_COUNT] = {
-#if SPI0_ENABLED
-    master_event_handler_0,
-#endif
-#if SPI1_ENABLED
-    master_event_handler_1,
-#endif
-#if SPI2_ENABLED
-    master_event_handler_2,
-#endif
-};
+    int instance = spi_inst->instance;
 
+    /* Get pointer to object of the current owner of the peripheral. */
+    void *current_owner = object_owner_spi2c_get(instance);
 
-static void slave_event_handler(uint8_t spi_idx,
-                                nrf_drv_spis_event_t event)
-{
-    spi_info_t *p_spi_info = &m_spi_info[spi_idx];
+    /* Check if reconfiguration is actually necessary. */
+    if ((obj != current_owner) || spi_inst->update) {
 
-    if (event.evt_type == NRF_DRV_SPIS_XFER_DONE) {
-        // Signal that there is some data received that could be read.
-        p_spi_info->flag.readable = true;
+        /* Update applied, reset flag. */
+        spi_inst->update = false;
 
-        // And prepare for the next transfer.
-        // Previous data set in 'spi_slave_write' (if any) has been transmitted,
-        // now use the default one, until some new is set by 'spi_slave_write'.
-        p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
-        nrf_drv_spis_buffers_set(&m_instances[spi_idx].slave,
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
-    }
-}
-#define SLAVE_EVENT_HANDLER(idx) \
-    static void slave_event_handler_##idx(nrf_drv_spis_event_t event) { \
-        slave_event_handler(SPIS##idx##_INSTANCE_INDEX, event); \
-    }
-#if SPIS0_ENABLED
-    SLAVE_EVENT_HANDLER(0)
-#endif
-#if SPIS1_ENABLED
-    SLAVE_EVENT_HANDLER(1)
-#endif
-#if SPIS2_ENABLED
-    SLAVE_EVENT_HANDLER(2)
-#endif
+        /* clean up and initialize peripheral. */
+        nrf_drv_spi_uninit(&nordic_nrf5_spi_instance[instance]);
 
-static nrf_drv_spis_event_handler_t const m_slave_event_handlers[SPIS_COUNT] = {
-#if SPIS0_ENABLED
-    slave_event_handler_0,
-#endif
-#if SPIS1_ENABLED
-    slave_event_handler_1,
-#endif
-#if SPIS2_ENABLED
-    slave_event_handler_2,
-#endif
-};
-
-static void prepare_master_config(nrf_drv_spi_config_t *p_config,
-                                  spi_info_t const *p_spi_info)
-{
-    p_config->sck_pin   = p_spi_info->sck_pin;
-    p_config->mosi_pin  = p_spi_info->mosi_pin;
-    p_config->miso_pin  = p_spi_info->miso_pin;
-    p_config->ss_pin    = p_spi_info->ss_pin;
-    p_config->frequency = p_spi_info->frequency;
-    p_config->mode      = (nrf_drv_spi_mode_t)p_spi_info->spi_mode;
-
-    p_config->irq_priority = SPI_DEFAULT_CONFIG_IRQ_PRIORITY;
-    p_config->orc          = 0xFF;
-    p_config->bit_order    = NRF_DRV_SPI_BIT_ORDER_MSB_FIRST;
-}
-
-static void prepare_slave_config(nrf_drv_spis_config_t *p_config,
-                                 spi_info_t const *p_spi_info)
-{
-    p_config->sck_pin   = p_spi_info->sck_pin;
-    p_config->mosi_pin  = p_spi_info->mosi_pin;
-    p_config->miso_pin  = p_spi_info->miso_pin;
-    p_config->csn_pin   = p_spi_info->ss_pin;
-    p_config->mode      = (nrf_drv_spis_mode_t)p_spi_info->spi_mode;
-
-    p_config->irq_priority = SPIS_DEFAULT_CONFIG_IRQ_PRIORITY;
-    p_config->orc          = SPIS_DEFAULT_ORC;
-    p_config->def          = SPIS_DEFAULT_DEF;
-    p_config->bit_order    = NRF_DRV_SPIS_BIT_ORDER_MSB_FIRST;
-    p_config->csn_pullup   = NRF_DRV_SPIS_DEFAULT_CSN_PULLUP;
-    p_config->miso_drive   = NRF_DRV_SPIS_DEFAULT_MISO_DRIVE;
-}
-
-void spi_init(spi_t *obj,
-              PinName mosi, PinName miso, PinName sclk, PinName ssel)
-{
-#warning
-#if 0    
-    int i;
-
-    // This block is only a workaround that allows to create SPI object several
-    // times, what would be otherwise impossible in the current implementation
-    // of mbed driver that does not call spi_free() from SPI destructor.
-    // Once this mbed's imperfection is corrected, this block should be removed.
-    for (i = 0; i < SPI_COUNT; ++i) {
-        spi_info_t *p_spi_info = &m_spi_info[i];
-        if (p_spi_info->initialized &&
-            p_spi_info->mosi_pin == (uint8_t)mosi &&
-            p_spi_info->miso_pin == (uint8_t)miso &&
-            p_spi_info->sck_pin  == (uint8_t)sclk &&
-            p_spi_info->ss_pin   == (uint8_t)ssel) {
-            // Reuse the already allocated SPI instance (instead of allocating
-            // a new one), if it appears to be initialized with exactly the same
-            // pin assignments.
-            SPI_IDX(obj) = i;
-            return;
-        }
-    }
-
-    for (i = SPI_COUNT - 1; i >= 0; i--) {
-        spi_info_t *p_spi_info = &m_spi_info[i];
-
-        if (!p_spi_info->initialized) {
-
-            p_spi_info->sck_pin   = (uint8_t)sclk;
-            p_spi_info->mosi_pin  = (mosi != NC) ?
-                (uint8_t)mosi : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->miso_pin  = (miso != NC) ?
-                (uint8_t)miso : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->ss_pin    = (ssel != NC) ?
-                (uint8_t)ssel : NRF_DRV_SPI_PIN_NOT_USED;
-            p_spi_info->spi_mode  = (uint8_t)NRF_DRV_SPI_MODE_0;
-            p_spi_info->frequency = NRF_DRV_SPI_FREQ_1M;
-
-            // By default each SPI instance is initialized to work as a master.
-            // Should the slave mode be used, the instance will be reconfigured
-            // appropriately in 'spi_format'.
-            nrf_drv_spi_config_t config;
-            prepare_master_config(&config, p_spi_info);
-
-            nrf_drv_spi_t const *p_spi = &m_instances[i].master;
-            ret_code_t ret_code = nrf_drv_spi_init(p_spi,
-                &config, m_master_event_handlers[i]);
-            if (ret_code == NRF_SUCCESS) {
-                p_spi_info->initialized = true;
-                p_spi_info->master      = true;
-                p_spi_info->flag.busy   = false;
 #if DEVICE_SPI_ASYNCH
-                p_spi_info->handler     = 0;
-#endif
-                SPI_IDX(obj) = i;
-                NVIC_SetVector(spi_handler_desc[i].IRQn, spi_handler_desc[i].vector);
-                return;
-            }
+        /* Set callback handler in asynchronous mode. */
+        if (spi_inst->handler) {
+            nrf_drv_spi_init(&nordic_nrf5_spi_instance[instance], &(spi_inst->config), nordic_nrf5_spi_event_handler, obj);
+        } else {
+            nrf_drv_spi_init(&nordic_nrf5_spi_instance[instance], &(spi_inst->config), NULL, NULL);
         }
+#else
+        /* Set callback handler to NULL in synchronous mode. */
+        nrf_drv_spi_init(&nordic_nrf5_spi_instance[instance], &(spi_inst->config), NULL, NULL);
+#endif
+        /* Claim ownership of peripheral. */
+        object_owner_spi2c_set(instance, obj);
     }
-
-    // No available peripheral
-    error("No available SPI peripheral\r\n");
-#endif    
 }
 
+/** Initialize the SPI peripheral
+ *
+ * Configures the pins used by SPI, sets a default format and frequency, and enables the peripheral
+ * Parameter   obj  The SPI object to initialize
+ * Parameter   mosi The pin to use for MOSI
+ * Parameter   miso The pin to use for MISO
+ * Parameter   sclk The pin to use for SCLK
+ * Parameter   ssel The pin to use for SSEL
+ */
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel)
+{
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
+#endif
+
+    /* Get instance based on requested pins. */
+    spi_inst->instance = pin_instance_spi(mosi, miso, sclk);
+    MBED_ASSERT(spi_inst->instance < ENABLED_SPI_COUNT);
+
+    /* Store chip select separately for manual enabling. */
+    spi_inst->cs = ssel;
+
+    /* Store pins except chip select. */
+    spi_inst->config.sck_pin        = sclk;
+    spi_inst->config.mosi_pin       = mosi;
+    spi_inst->config.miso_pin       = miso;
+    spi_inst->config.ss_pin         = NRF_DRV_SPI_PIN_NOT_USED;
+
+    /* Use the default config. */
+    spi_inst->config.irq_priority   = SPI_DEFAULT_CONFIG_IRQ_PRIORITY;
+    spi_inst->config.orc            = SPI_FILL_CHAR;
+    spi_inst->config.frequency      = NRF_DRV_SPI_FREQ_1M;
+    spi_inst->config.mode           = NRF_DRV_SPI_MODE_0;
+    spi_inst->config.bit_order      = NRF_DRV_SPI_BIT_ORDER_MSB_FIRST;
+
+#if DEVICE_SPI_ASYNCH
+    /* Set default values for asynchronous variables. */
+    spi_inst->handler = 0;
+    spi_inst->mask = 0;
+    spi_inst->event = 0;
+#endif
+
+    /* Configuration has changed, set flag to force update. */
+    spi_inst->update = true;
+
+    /* Configure GPIO pin if chip select has been set. */
+    if (ssel != NC) {
+        nrf_gpio_pin_set(ssel);
+        nrf_gpio_cfg_output(ssel);
+    }
+
+    static bool first_init = true;
+
+    if (first_init) {
+        first_init = false;
+
+        /* Register interrupt handlers in driver with the NVIC. */
+        NVIC_SetVector(SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQn, (uint32_t) SPIM0_SPIS0_TWIM0_TWIS0_SPI0_TWI0_IRQHandler);
+        NVIC_SetVector(SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQn, (uint32_t) SPIM1_SPIS1_TWIM1_TWIS1_SPI1_TWI1_IRQHandler);
+        NVIC_SetVector(SPIM2_SPIS2_SPI2_IRQn,                  (uint32_t) SPIM2_SPIS2_SPI2_IRQHandler);
+    }
+}
+
+/** Release a SPI object
+ *
+ * TODO: spi_free is currently unimplemented
+ * This will require reference counting at the C++ level to be safe
+ *
+ * Return the pins owned by the SPI object to their reset state
+ * Disable the SPI peripheral
+ * Disable the SPI clock
+ * Parameter  obj The SPI object to deinitialize
+ */
 void spi_free(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    if (p_spi_info->master) {
-        nrf_drv_spi_uninit(MASTER_INST(obj));
-    }
-    else {
-        nrf_drv_spis_uninit(SLAVE_INST(obj));
-    }
-    p_spi_info->initialized = false;
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
+#endif
+
+    int instance = spi_inst->instance;
+
+    /* Use driver uninit to free instance. */
+    nrf_drv_spi_uninit(&nordic_nrf5_spi_instance[instance]);
 }
 
-int spi_busy(spi_t *obj)
-{
-    return (int)(SPI_INFO(obj)->flag.busy);
-}
-
+/** Configure the SPI format
+ *
+ * Set the number of bits per frame, configure clock polarity and phase, shift order and master/slave mode.
+ * The default bit order is MSB.
+ * Parameter      obj   The SPI object to configure
+ * Parameter      bits  The number of bits per frame
+ * Parameter      mode  The SPI mode (clock polarity, phase, and shift direction)
+ * Parameter      slave Zero for master mode or non-zero for slave mode
+ */
 void spi_format(spi_t *obj, int bits, int mode, int slave)
 {
-#warning
-#if 0    
+    /* SPI module only supports 8 bit transfers. */
+    MBED_ASSERT(bits == 8);
+    /* SPI module doesn't support Mbed HAL Slave API. */
+    MBED_ASSERT(slave == 0);
 
-    if (bits != 8) {
-        error("Only 8-bits SPI is supported\r\n");
-    }
-    if (mode > 3) {
-        error("SPI format error\r\n");
-    }
-
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-
-    if (slave)
-    {
-        nrf_drv_spis_mode_t spi_modes[4] = {
-            NRF_DRV_SPIS_MODE_0,
-            NRF_DRV_SPIS_MODE_1,
-            NRF_DRV_SPIS_MODE_2,
-            NRF_DRV_SPIS_MODE_3,
-        };
-        nrf_drv_spis_mode_t new_mode = spi_modes[mode];
-
-        // If the peripheral is currently working as a master, the SDK driver
-        // it uses needs to be switched from SPI to SPIS.
-        if (p_spi_info->master) {
-            nrf_drv_spi_uninit(MASTER_INST(obj));
-        }
-        // I the SPI mode has to be changed, the SDK's SPIS driver needs to be
-        // re-initialized (there is no other way to change its configuration).
-        else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
-            nrf_drv_spis_uninit(SLAVE_INST(obj));
-        }
-        else {
-            return;
-        }
-
-        p_spi_info->spi_mode = (uint8_t)new_mode;
-        p_spi_info->master = false;
-        p_spi_info->flag.readable = false;
-
-        // Initialize SDK's SPIS driver with the new configuration.
-        nrf_drv_spis_config_t config;
-        prepare_slave_config(&config, p_spi_info);
-        (void)nrf_drv_spis_init(SLAVE_INST(obj), &config,
-            m_slave_event_handlers[SPI_IDX(obj)]);
-
-        // Prepare the slave for transfer.
-        p_spi_info->tx_buf = SPIS_DEFAULT_ORC;
-        nrf_drv_spis_buffers_set(SLAVE_INST(obj),
-            (uint8_t const *)&p_spi_info->tx_buf, 1,
-            (uint8_t *)&p_spi_info->rx_buf, 1);
-    }
-    else // master
-    {
-        nrf_drv_spi_mode_t spi_modes[4] = {
-            NRF_DRV_SPI_MODE_0,
-            NRF_DRV_SPI_MODE_1,
-            NRF_DRV_SPI_MODE_2,
-            NRF_DRV_SPI_MODE_3,
-        };
-        nrf_drv_spi_mode_t new_mode = spi_modes[mode];
-
-        // If the peripheral is currently working as a slave, the SDK driver
-        // it uses needs to be switched from SPIS to SPI.
-        if (!p_spi_info->master) {
-            nrf_drv_spis_uninit(SLAVE_INST(obj));
-        }
-        // I the SPI mode has to be changed, the SDK's SPI driver needs to be
-        // re-initialized (there is no other way to change its configuration).
-        else if (p_spi_info->spi_mode != (uint8_t)new_mode) {
-            nrf_drv_spi_uninit(MASTER_INST(obj));
-        }
-        else {
-            return;
-        }
-
-        p_spi_info->spi_mode = (uint8_t)new_mode;
-        p_spi_info->master = true;
-        p_spi_info->flag.busy = false;
-
-        // Initialize SDK's SPI driver with the new configuration.
-        nrf_drv_spi_config_t config;
-        prepare_master_config(&config, p_spi_info);
-        (void)nrf_drv_spi_init(MASTER_INST(obj), &config,
-            m_master_event_handlers[SPI_IDX(obj)]);
-    }
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
 #endif
-}
 
-static nrf_drv_spi_frequency_t freq_translate(int hz)
-{
-    nrf_drv_spi_frequency_t frequency;
-    if (hz<250000) { //125Kbps
-        frequency = NRF_DRV_SPI_FREQ_125K;
-    } else if (hz<500000) { //250Kbps
-        frequency = NRF_DRV_SPI_FREQ_250K;
-    } else if (hz<1000000) { //500Kbps
-        frequency = NRF_DRV_SPI_FREQ_500K;
-    } else if (hz<2000000) { //1Mbps
-        frequency = NRF_DRV_SPI_FREQ_1M;
-    } else if (hz<4000000) { //2Mbps
-        frequency = NRF_DRV_SPI_FREQ_2M;
-    } else if (hz<8000000) { //4Mbps
-        frequency = NRF_DRV_SPI_FREQ_4M;
-    } else { //8Mbps
-        frequency = NRF_DRV_SPI_FREQ_8M;
+    /* Convert Mbed HAL mode to Nordic mode. */
+    if(mode == 0) {
+        spi_inst->config.mode = NRF_DRV_SPI_MODE_0;
+    } else if(mode == 1) {
+        spi_inst->config.mode = NRF_DRV_SPI_MODE_1;
+    } else if(mode == 2) {
+        spi_inst->config.mode = NRF_DRV_SPI_MODE_2;
+    } else if(mode == 3) {
+        spi_inst->config.mode = NRF_DRV_SPI_MODE_3;
     }
-    return frequency;
+
+    /* Configuration has changed, set flag to force application. */
+    spi_inst->update = true;
 }
 
+/** Set the SPI baud rate
+ *
+ * Actual frequency may differ from the desired frequency due to available dividers and bus clock
+ * Configures the SPI peripheral's baud rate
+ * Parameter      obj The SPI object to configure
+ * Parameter      hz  The baud rate in Hz
+ */
 void spi_frequency(spi_t *obj, int hz)
 {
-#warning
-#if 0    
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    nrf_drv_spi_frequency_t new_frequency = freq_translate(hz);
-
-    if (p_spi_info->master)
-    {
-        if (p_spi_info->frequency != new_frequency) {
-            p_spi_info->frequency = new_frequency;
-
-            nrf_drv_spi_config_t config;
-            prepare_master_config(&config, p_spi_info);
-
-            nrf_drv_spi_t const *p_spi = MASTER_INST(obj);
-            nrf_drv_spi_uninit(p_spi);
-            (void)nrf_drv_spi_init(p_spi, &config,
-                m_master_event_handlers[SPI_IDX(obj)]);
-        }
-    }
-    // There is no need to set anything in slaves when it comes to frequency,
-    // since slaves just synchronize with the clock provided by a master.
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
 #endif
+
+    /* Convert frequency to Nordic enum type. */
+    if (hz < 250000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_125K;
+    } else if (hz < 500000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_250K;
+    } else if (hz < 1000000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_500K;
+    } else if (hz < 2000000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_1M;
+    } else if (hz < 4000000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_2M;
+    } else if (hz < 8000000) {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_4M;
+    } else {
+        spi_inst->config.frequency = NRF_DRV_SPI_FREQ_8M;
+    }
+
+    /* Configuration has changed, set flag to force application. */
+    spi_inst->update = true;
 }
 
+/** Write a byte out in master mode and receive a value
+ *
+ * Parameter  obj   The SPI peripheral to use for sending
+ * Parameter  value The value to send
+ * Return     Returns the value received during send
+ */
 int spi_master_write(spi_t *obj, int value)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-
 #if DEVICE_SPI_ASYNCH
-    while (p_spi_info->flag.busy) {
-    }
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
 #endif
 
-    p_spi_info->tx_buf = value;
-    p_spi_info->flag.busy = true;
-    (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)&p_spi_info->tx_buf, 1,
-        (uint8_t *)&p_spi_info->rx_buf, 1);
-    while (p_spi_info->flag.busy) {
+    int instance = spi_inst->instance;
+
+    /* Manually clear chip select pin if defined. */
+    if (spi_inst->cs != NC) {
+        nrf_gpio_pin_clear(spi_inst->cs);
     }
 
-    return p_spi_info->rx_buf;
+    /* Local variables used in transfer. */
+    const uint8_t tx_buff = (uint8_t) value;
+    uint8_t rx_buff;
+
+    /* Configure peripheral if necessary. */
+    spi_configure_driver_instance(obj);
+
+    /* Transfer 1 byte. */
+    nrf_drv_spi_transfer(&nordic_nrf5_spi_instance[instance], &tx_buff, 1, &rx_buff, 1);
+
+    /* Manually set chip select pin if defined. */
+    if (spi_inst->cs != NC) {
+        nrf_gpio_pin_set(spi_inst->cs);
+    }
+
+    return rx_buff;
 }
 
-int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
-                           char *rx_buffer, int rx_length, char write_fill) {
-    int total = (tx_length > rx_length) ? tx_length : rx_length;
+/** Write a block out in master mode and receive a value
+ *
+ *  The total number of bytes sent and recieved will be the maximum of
+ *  tx_length and rx_length. The bytes written will be padded with the
+ *  value 0xff.
+ *
+ * Parameter  obj        The SPI peripheral to use for sending
+ * Parameter  tx_buffer  Pointer to the byte-array of data to write to the device
+ * Parameter  tx_length  Number of bytes to write, may be zero
+ * Parameter  rx_buffer  Pointer to the byte-array of data to read from the device
+ * Parameter  rx_length  Number of bytes to read, may be zero
+ * Parameter  write_fill Default data transmitted while performing a read
+ * @returns
+ *      The number of bytes written and read from the device. This is
+ *      maximum of tx_length and rx_length.
+ */
+int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length, char *rx_buffer, int rx_length, char write_fill)
+{
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
+#endif
 
-    for (int i = 0; i < total; i++) {
-        char out = (i < tx_length) ? tx_buffer[i] : write_fill;
-        char in = spi_master_write(obj, out);
-        if (i < rx_length) {
-            rx_buffer[i] = in;
+    int instance = spi_inst->instance;
+
+    /* Check if overflow character has changed. */
+    if (spi_inst->config.orc != write_fill) {
+
+        /* Store new overflow character and force reconfiguration. */
+        spi_inst->update = true;
+        spi_inst->config.orc = write_fill;
+    }
+
+    /* Configure peripheral if necessary. */
+    spi_configure_driver_instance(obj);
+
+    /* Manually clear chip select pin if defined. */
+    if (spi_inst->cs != NC) {
+        nrf_gpio_pin_clear(spi_inst->cs);
+    }
+
+    /* The Nordic SPI driver is only able to transfer 255 bytes at a time.
+     * The following code will write/read the data 255 bytes at a time and
+     * ensure that asymmetrical transfers are handled properly.
+     */
+    int tx_offset = 0;
+    int rx_offset = 0;
+
+    ret_code_t result = NRF_SUCCESS;
+
+    /* Loop until all data is sent and received. */
+    while (((tx_length > 0) || (rx_length > 0)) && (result == NRF_SUCCESS)) {
+
+        /* Check if tx_length is larger than 255 and if so, limit to 255. */
+        int tx_actual_length = (tx_length > 255) ? 255 : tx_length;
+
+        /* Set tx buffer pointer. Set to NULL if no data is going to be transmitted. */
+        const uint8_t * tx_actual_buffer = (tx_actual_length > 0) ?
+                                           (const uint8_t *)(tx_buffer + tx_offset) :
+                                           NULL;
+
+        /* Check if rx_length is larger than 255 and if so, limit to 255. */
+        int rx_actual_length = (rx_length > 255) ? 255 : rx_length;
+
+        /* Set rx buffer pointer. Set to NULL if no data is going to be received. */
+        uint8_t * rx_actual_buffer = (rx_actual_length > 0) ?
+                                     (uint8_t *)(rx_buffer + rx_offset) :
+                                     NULL;
+
+        /* Blocking transfer. */
+        result = nrf_drv_spi_transfer(&nordic_nrf5_spi_instance[instance],
+                                      tx_actual_buffer,
+                                      tx_actual_length,
+                                      rx_actual_buffer,
+                                      rx_actual_length);
+
+        /* Update loop variables. */
+        tx_length -= tx_actual_length;
+        tx_offset += tx_actual_length;
+
+        rx_length -= rx_actual_length;
+        rx_offset += rx_actual_length;
+    }
+
+    /* Manually set chip select pin if defined. */
+    if (spi_inst->cs != NC) {
+        nrf_gpio_pin_set(spi_inst->cs);
+    }
+
+    return (rx_offset < tx_offset) ? tx_offset : rx_offset;
+}
+
+/** Checks if the specified SPI peripheral is in use
+ *
+ * Parameter  obj The SPI peripheral to check
+ * Return     non-zero if the peripheral is currently transmitting
+ */
+int spi_busy(spi_t *obj)
+{
+    /* Legacy API call. Always return zero. */
+    return 0;
+}
+
+/** Get the module number
+ *
+ * Parameter  obj The SPI peripheral to check
+ * Return     The module number
+ */
+uint8_t spi_get_module(spi_t *obj)
+{
+#if DEVICE_SPI_ASYNCH
+    struct spi_s *spi_inst = &obj->spi;
+#else
+    struct spi_s *spi_inst = obj;
+#endif
+
+    return spi_inst->instance;
+}
+
+#if DEVICE_SPISLAVE
+
+/** Check if a value is available to read
+ *
+ * Parameter  obj The SPI peripheral to check
+ * Return     non-zero if a value is available
+ */
+int spi_slave_receive(spi_t *obj)
+{
+    return 0;
+}
+
+/** Get a received value out of the SPI receive buffer in slave mode
+ *
+ * Blocks until a value is available
+ * Parameter  obj The SPI peripheral to read
+ * Return     The value received
+ */
+int spi_slave_read(spi_t *obj)
+{
+    return 0;
+}
+
+/** Write a value to the SPI peripheral in slave mode
+ *
+ * Blocks until the SPI peripheral can be written to
+ * Parameter  obj   The SPI peripheral to write
+ * Parameter  value The value to write
+ */
+void spi_slave_write(spi_t *obj, int value)
+{
+    return;
+}
+
+#endif
+
+#if DEVICE_SPI_ASYNCH
+
+/***
+ *                                               _____ _____
+ *         /\                              /\   |  __ \_   _|
+ *        /  \   ___ _   _ _ __   ___     /  \  | |__) || |
+ *       / /\ \ / __| | | | '_ \ / __|   / /\ \ |  ___/ | |
+ *      / ____ \\__ \ |_| | | | | (__   / ____ \| |    _| |_
+ *     /_/    \_\___/\__, |_| |_|\___| /_/    \_\_|   |_____|
+ *                    __/ |
+ *                   |___/
+ */
+
+static ret_code_t spi_master_transfer_async_continue(spi_t *obj)
+{
+    /* Remaining data to be transferred. */
+    size_t tx_length = obj->tx_buff.length - obj->tx_buff.pos;
+    size_t rx_length = obj->rx_buff.length - obj->rx_buff.pos;
+
+    /* Cap TX length to 255 bytes. */
+    if (tx_length > 255) {
+        tx_length = 255;
+    }
+
+    /* Cap RX length to 255 bytes. */
+    if (rx_length > 255) {
+        rx_length = 255;
+    }
+
+    ret_code_t result = nrf_drv_spi_transfer(&nordic_nrf5_spi_instance[obj->spi.instance],
+                                             ((const uint8_t *)(obj->tx_buff.buffer) + obj->tx_buff.pos),
+                                             tx_length,
+                                             ((uint8_t *)(obj->rx_buff.buffer) + obj->rx_buff.pos),
+                                             rx_length);
+
+    return result;
+}
+
+/* Callback function for driver calls. This is called from ISR context. */
+static void nordic_nrf5_spi_event_handler(nrf_drv_spi_evt_t const *p_event, void *p_context)
+{
+    // Only safe to use with mbed-printf.
+    //DEBUG_PRINTF("nordic_nrf5_twi_event_handler: %d %p\r\n", p_event->type, p_context);
+
+    bool signal_complete = false;
+    bool signal_error = false;
+
+    spi_t *obj = (spi_t *) p_context;
+    struct spi_s *spi_inst = &obj->spi;
+
+    if (p_event->type == NRF_DRV_SPI_EVENT_DONE) {
+
+        /* Update buffers with new positions. */
+        obj->tx_buff.pos += p_event->data.done.tx_length;
+        obj->rx_buff.pos += p_event->data.done.rx_length;
+
+        /* Setup a new transfer if more data is pending. */
+        if ((obj->tx_buff.pos < obj->tx_buff.length) || (obj->rx_buff.pos < obj->tx_buff.length)) {
+
+            /* Initiate SPI transfer. */
+            ret_code_t result = spi_master_transfer_async_continue(obj);
+
+            /* Abort if transfer wasn't accepted. */
+            if (result != NRF_SUCCESS) {
+
+                /* Signal callback handler that transfer failed. */
+                signal_error = true;
+            }
+
+        } else {
+
+            /* Signal callback handler that transfer is complete. */
+            signal_complete = true;
+        }
+    } else {
+
+        /* Unexpected event, signal callback handler that transfer failed. */
+        signal_error = true;
+    }
+
+    /* Transfer complete, signal success if mask is set.*/
+    if (signal_complete) {
+
+        /* Signal success if event mask matches and event handler is set. */
+        if ((spi_inst->mask & SPI_EVENT_COMPLETE) && spi_inst->handler) {
+
+            /* Cast handler to callback function pointer. */
+            void (*callback)(void) = (void (*)(void)) spi_inst->handler;
+
+            /* Reset object. */
+            spi_inst->handler = 0;
+            spi_inst->update = true;
+
+            /* Store event value so it can be read back. */
+            spi_inst->event = SPI_EVENT_COMPLETE;
+
+            /* Signal callback handler. */
+            callback();
+        }
+
+    /* Transfer failed, signal error if mask is set. */
+    } else if (signal_error) {
+
+        /* Signal error if event mask matches and event handler is set. */
+        if ((spi_inst->mask & SPI_EVENT_ERROR) && spi_inst->handler) {
+
+            /* Cast handler to callback function pointer. */
+            void (*callback)(void) = (void (*)(void)) spi_inst->handler;
+
+            /* Reset object. */
+            spi_inst->handler = 0;
+            spi_inst->update = true;
+
+            /* Store event value so it can be read back. */
+            spi_inst->event = SPI_EVENT_ERROR;
+
+            /* Signal callback handler. */
+            callback();
         }
     }
 
-    return total;
-}
+    /* Transfer completed one way or another. Set chip select manually if defined. */
+    if (signal_complete || signal_error) {
 
-int spi_slave_receive(spi_t *obj)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-    return p_spi_info->flag.readable;
-;
-}
-
-int spi_slave_read(spi_t *obj)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-    while (!p_spi_info->flag.readable) {
+        if (spi_inst->cs != NC) {
+            nrf_gpio_pin_set(spi_inst->cs);
+        }
     }
-    p_spi_info->flag.readable = false;
-    return p_spi_info->rx_buf;
 }
 
-void spi_slave_write(spi_t *obj, int value)
-{
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(!p_spi_info->master);
-
-    p_spi_info->tx_buf = (uint8_t)value;
-}
-
-#if DEVICE_SPI_ASYNCH
-
+/** Begin the SPI transfer. Buffer pointers and lengths are specified in tx_buff and rx_buff
+ *
+ * Parameter  obj       The SPI object that holds the transfer information
+ * Parameter  tx        The transmit buffer
+ * Parameter  tx_length The number of bytes to transmit
+ * Parameter  rx        The receive buffer
+ * Parameter  rx_length The number of bytes to receive
+ * Parameter  bit_width The bit width of buffer words
+ * Parameter  event     The logical OR of events to be registered
+ * Parameter  handler   SPI interrupt handler
+ * Parameter  hint      A suggestion for how to use DMA with this transfer
+ */
 void spi_master_transfer(spi_t *obj,
-                         const void *tx, size_t tx_length,
-                         void *rx, size_t rx_length, uint8_t bit_width,
-                         uint32_t handler, uint32_t event, DMAUsage hint)
+                         const void *tx,
+                         size_t tx_length,
+                         void *rx,
+                         size_t rx_length,
+                         uint8_t bit_width,
+                         uint32_t handler,
+                         uint32_t mask,
+                         DMAUsage hint)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    (void)hint;
-    (void)bit_width;
+    /* SPI peripheral only supports 8 bit transfers. */
+    MBED_ASSERT(bit_width == 8);
 
-    p_spi_info->handler = handler;
-    p_spi_info->event   = event;
+    /* Setup buffers for transfer. */
+    struct buffer_s *buffer_pointer;
 
-    p_spi_info->flag.busy = true;
-    (void)nrf_drv_spi_transfer(MASTER_INST(obj),
-        (uint8_t const *)tx, tx_length,
-        (uint8_t *)rx, rx_length);
+    buffer_pointer = &obj->tx_buff;
+    buffer_pointer->buffer = (void*) tx;
+    buffer_pointer->length = tx_length;
+    buffer_pointer->pos    = 0;
+    buffer_pointer->width  = 8;
+
+    buffer_pointer = &obj->rx_buff;
+    buffer_pointer->buffer = rx;
+    buffer_pointer->length = rx_length;
+    buffer_pointer->pos    = 0;
+    buffer_pointer->width  = 8;
+
+    /* Save event handler and event mask so they can be called from interrupt handler. */
+    struct spi_s *spi_inst = &obj->spi;
+    spi_inst->handler = handler;
+    spi_inst->mask = mask;
+
+    /* Clear event flag. */
+    spi_inst->event = 0;
+
+    /* Force reconfiguration. */
+    spi_inst->update = true;
+
+    /* Configure peripheral if necessary. */
+    spi_configure_driver_instance(obj);
+
+    /* Manually clear chip select pin if defined. */
+    if (spi_inst->cs != NC) {
+        nrf_gpio_pin_clear(spi_inst->cs);
+    }
+
+    /* Initiate SPI transfer. */
+    ret_code_t result = spi_master_transfer_async_continue(obj);
+
+    /* Signal error if event mask matches and event handler is set. */
+    if ((result != NRF_SUCCESS) && (mask & SPI_EVENT_ERROR) && handler) {
+
+        /* Cast handler to callback function pointer. */
+        void (*callback)(void) = (void (*)(void)) handler;
+
+        /* Reset object. */
+        spi_inst->handler = 0;
+        spi_inst->update = true;
+
+        /* Store event value so it can be read back. */
+        spi_inst->event = SPI_EVENT_ERROR;
+
+        /* Signal callback handler. */
+        callback();
+    }
 }
 
+/** The asynchronous IRQ handler
+ *
+ * Reads the received values out of the RX FIFO, writes values into the TX FIFO and checks for transfer termination
+ * conditions, such as buffer overflows or transfer complete.
+ * Parameter  obj     The SPI object that holds the transfer information
+ * Return     Event flags if a transfer termination condition was met; otherwise 0.
+ */
 uint32_t spi_irq_handler_asynch(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    return p_spi_info->event & SPI_EVENT_COMPLETE;
+    /* Return latest event. */
+    return obj->spi.event;
 }
 
+/** Attempts to determine if the SPI peripheral is already in use
+ *
+ * If a temporary DMA channel has been allocated, peripheral is in use.
+ * If a permanent DMA channel has been allocated, check if the DMA channel is in use.  If not, proceed as though no DMA
+ * channel were allocated.
+ * If no DMA channel is allocated, check whether tx and rx buffers have been assigned.  For each assigned buffer, check
+ * if the corresponding buffer position is less than the buffer length.  If buffers do not indicate activity, check if
+ * there are any bytes in the FIFOs.
+ * Parameter  obj The SPI object to check for activity
+ * Return     Non-zero if the SPI port is active or zero if it is not.
+ */
 uint8_t spi_active(spi_t *obj)
 {
-    spi_info_t *p_spi_info = SPI_INFO(obj);
-    MBED_ASSERT(p_spi_info->master);
-    return p_spi_info->flag.busy;
+    /* Callback handler is non-zero when a transfer is in progress. */
+    return (obj->spi.handler != 0);
 }
 
+/** Abort an SPI transfer
+ *
+ * Parameter  obj The SPI peripheral to stop
+ */
 void spi_abort_asynch(spi_t *obj)
 {
-    MBED_ASSERT(SPI_INFO(obj)->master);
-    nrf_drv_spi_abort(MASTER_INST(obj));
+    int instance = obj->spi.instance;
+
+    /* Abort transfer. */
+    nrf_drv_spi_abort(&nordic_nrf5_spi_instance[instance]);
+
+    /* Force reconfiguration. */
+    object_owner_spi2c_set(instance, NULL);
 }
 
 #endif // DEVICE_SPI_ASYNCH


### PR DESCRIPTION
This PR re-implements SPI and I2C in a way that lets both drivers share the underlying hardware. From the new README.md file:


### SPI and I2C

The TWI/TWIM (I2C) and SPI/SPIM module shares the same underlying hardware and each instance can only provide one functionality at a time. Both the NRF52832 and NRF52840 have 2 TWI/TWIM modules and 3 SPI/SPIM:

| Instance 0 | Instance 1 | Instance 2 |
| :---:      | :---:      | :---:      |
| SPI0/SPIM0 | SPI1/SPIM1 | SPI2/SPIM2 |
| TWI0/TWIM0 | TWI1/TWIM1 |            |

When instantiating a new Mbed SPI object or I2C object, the object will be assigned a hardware instance. By default, the HAL implementation will automatically pick a hardware instance based on the assigned pins in the following order:

1. The driver will look up the pins in the configuration table and pick a pre-assigned instance.
1. If the pins can't be found in the configuration table, the driver will check if a hardware instance has already been assigned to those pins so that objects using the same pins will share the same instance.
1. If no instance has been assigned, the driver will look for a free instane. For I2C objects instances are assigned from 0 to 1. For SPI objects instances are assigned from 2 to 0. This ensures that no matter the order of instantiation the first three objects can be guaranteed to be on separate instances no matter the pins being used. 
1. If no unused instance can be found, objects not sharing any pins will be assigned to the same default instance, which is `Instance 0` for I2C and `Instance 2` for SPI.

#### Customization

A custom configuration table can be provided by overriding the weakly defined default empty table. In the example below, I2C objects using pins `p1` and `p2` for `SDA` and `SCL` will always be assigned to `Instance 1` and SPI objects using pins `p3`, `p4`, `p5` for `MOSI`, `MISO`, and `CLOCK` will be assigned to `Instance 2` and SPI objects using pins `p6`, `p7`, and `p8` will be assigned to `Instance 0`. The custom configuration table must always be terminated with a row of `NC`.

```
const PinMapI2C PinMap_I2C[] = { 
    {p1, p2, 1},
    {NC, NC, NC}
};

const PinMapSPI PinMap_SPI[] = {
    {p3, p4, p5, 2},
    {p6, p7, p8, 0},
    {NC, NC, NC, NC}
};
```

The tables must be placed in a C compilation file.

#### Concurrency

1. When called from the same thread, it is safe to assign I2C and SPI objects to the same instance. 
1. If an instance is being used exclusively for either I2C or SPI, the objects can safely be called from multiple threads.
1. If an instance is being used for both I2C and SPI, the user must provide thread safety between the objects.
