### PR TITLE
Fixes to LoRa PHY

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -657,11 +657,11 @@ bool LoRaPHY::verify(verification_params_t* verify, phy_attributes_t phy_attribu
             if (phy_params.dl_dwell_time_setting == 0) {
                 return val_in_range(verify->datarate,
                                     phy_params.min_rx_datarate,
-                                    phy_params.min_rx_datarate);
+                                    phy_params.max_rx_datarate);
             } else {
                 return val_in_range(verify->datarate,
                                     phy_params.dwell_limit_datarate,
-                                    phy_params.min_rx_datarate );
+                                    phy_params.max_rx_datarate);
             }
         }
         case PHY_DEF_TX_POWER:

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -280,7 +280,7 @@ LoRaPHYAS923::LoRaPHYAS923(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payload_table;
     phy_params.payloads.size = 8;
     phy_params.payloads_with_repeater.table = (void *) max_payload_table_with_repeater;
-    phy_params.payloads.size = 8;
+    phy_params.payloads_with_repeater.size = 8;
 
     // dwell time setting, 400 ms
     phy_params.ul_dwell_time_setting = 1;

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -279,7 +279,7 @@ LoRaPHYAU915::LoRaPHYAU915(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payload_AU915;
     phy_params.payloads.size = 16;
     phy_params.payloads_with_repeater.table = (void *) max_payload_with_repeater_AU915;
-    phy_params.payloads.size = 16;
+    phy_params.payloads_with_repeater.size = 16;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -252,7 +252,7 @@ LoRaPHYCN470::LoRaPHYCN470(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_CN470;
     phy_params.payloads.size = 6;
     phy_params.payloads_with_repeater.table = (void *)max_payloads_with_repeater_CN470;
-    phy_params.payloads.size = 6;
+    phy_params.payloads_with_repeater.size = 6;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
@@ -268,7 +268,7 @@ LoRaPHYCN779::LoRaPHYCN779(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_CN779;
     phy_params.payloads.size = 8;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater_CN779;
-    phy_params.payloads.size = 8;
+    phy_params.payloads_with_repeater.size = 8;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
@@ -269,7 +269,7 @@ LoRaPHYEU433::LoRaPHYEU433(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_EU433;
     phy_params.payloads.size = 8;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater_EU433;
-    phy_params.payloads.size = 8;
+    phy_params.payloads_with_repeater.size = 8;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
@@ -299,7 +299,7 @@ LoRaPHYEU868::LoRaPHYEU868(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_EU868;
     phy_params.payloads.size = 8;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_repeater_EU868;
-    phy_params.payloads.size = 8;
+    phy_params.payloads_with_repeater.size = 8;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
@@ -270,7 +270,7 @@ LoRaPHYIN865::LoRaPHYIN865(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_IN865;
     phy_params.payloads.size = 8;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater;
-    phy_params.payloads.size = 8;
+    phy_params.payloads_with_repeater.size = 8;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -279,7 +279,7 @@ LoRaPHYKR920::LoRaPHYKR920(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_KR920;
     phy_params.payloads.size = 6;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater_KR920;
-    phy_params.payloads.size = 6;
+    phy_params.payloads_with_repeater.size = 6;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -271,7 +271,7 @@ LoRaPHYUS915::LoRaPHYUS915(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_US915;
     phy_params.payloads.size = 16;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater_US915;
-    phy_params.payloads.size = 16;
+    phy_params.payloads_with_repeater.size = 16;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -269,7 +269,7 @@ LoRaPHYUS915Hybrid::LoRaPHYUS915Hybrid(LoRaWANTimeHandler &lora_time)
     phy_params.payloads.table = (void *) max_payloads_US915_HYBRID;
     phy_params.payloads.size = 16;
     phy_params.payloads_with_repeater.table = (void *) max_payloads_with_repeater_US915_HYBRID;
-    phy_params.payloads.size = 16;
+    phy_params.payloads_with_repeater.size = 16;
 
     // dwell time setting
     phy_params.ul_dwell_time_setting = 0;


### PR DESCRIPTION
### Description

Some fixes to LoRa PHY:
- Fix initialization of phy_params.payloads_with_repeater.size. This value was not set at all but instead a incorrect (phy_params.payloads.size) was set.

- Fix RX2 datarate verification. Earlier only the minimum datarate value was accepted.

### Pull request type

- [X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
