### PR TITLE
Fix issue in fault handler

### DIFF
--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -196,6 +196,9 @@ void fault_print_str(char *fmtstr, uint32_t *values)
     while(fmtstr[i] != '\0') {
         if(fmtstr[i] == '\n' || fmtstr[i] == '\r') {
             serial_putc(&stdio_uart, '\r');
+            if (fmtstr[i] == '\n') {
+        	    serial_putc(&stdio_uart, '\n');
+            }
         } else {
             if(fmtstr[i]=='%') {
                 hex_to_str(values[vidx++],hex_str);


### PR DESCRIPTION
### Description

Incase used \r or \n inside the prints of the fault handler
fault_print_str function would only \r.
The fix is adding \n if needed

### Pull request type

- [x] Fix
