### PR TITLE
[ATCmdParser]: Align `process_oob()` to `vrecv()`'s newline handling

### DIFF
--- a/platform/ATCmdParser.cpp
+++ b/platform/ATCmdParser.cpp
@@ -394,6 +394,19 @@ bool ATCmdParser::process_oob()
         if (c < 0) {
             return false;
         }
+        // Simplify newlines (borrowed from retarget.cpp)
+        if ((c == CR && _in_prev != LF) ||
+            (c == LF && _in_prev != CR)) {
+            _in_prev = c;
+            c = '\n';
+        } else if ((c == CR && _in_prev == LF) ||
+                   (c == LF && _in_prev == CR)) {
+            _in_prev = c;
+            // onto next character
+            continue;
+        } else {
+            _in_prev = c;
+        }
         _buffer[i++] = c;
         _buffer[i] = 0;
 
@@ -411,9 +424,7 @@ bool ATCmdParser::process_oob()
         
         // Clear the buffer when we hit a newline or ran out of space
         // running out of space usually means we ran into binary data
-        if (i+1 >= _buffer_size ||
-            strcmp(&_buffer[i-_output_delim_size], _output_delimiter) == 0) {
-
+        if (((i+1) >= _buffer_size) || (c == '\n')) {
             debug_if(_dbg_on, "AT< %s", _buffer);
             i = 0;
         }


### PR DESCRIPTION
### Description

The newline handling between methods `ATCmdParser::process_oob()` and `ATCmdParser::vrecv()` is not aligned among those in the sense that in `ATCmdParser::process_oob()`:
- the newline characters _'\n'_ and _'\r'_ are **not** handled in a unified way
- the `_output_delimiter` is used to detect the end-of incoming messages, which is **not** correct for every kind of AT commands based modules (instead a kind of _input delimiter_ would be required) and as a consequnce
- method `ATCmdParser::process_oob()` might **fail** to correctly recognize `oobs` under certain runtime conditions

### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
