### PR TITLE
Support for nRF52x BLE 4.2 and 5 events

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5x/source/nRF5xn.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5x/source/nRF5xn.cpp
@@ -222,8 +222,10 @@ nRF5xn::waitForEvent(void)
 }
 
 void nRF5xn::processEvents() {
-    if (isEventsSignaled) {
+    core_util_critical_section_enter();
+    while (isEventsSignaled) {
         isEventsSignaled = false;
+        core_util_critical_section_exit();
         #if NRF_SD_BLE_API_VERSION >= 5
         // We use the "polling" dispatch model
         // http://infocenter.nordicsemi.com/topic/com.nordic.infocenter.sdk5.v14.2.0/group__nrf__sdh.html?cp=4_0_0_6_11_60_20#gab4d7be69304d4f5feefd1d440cc3e6c7
@@ -232,5 +234,8 @@ void nRF5xn::processEvents() {
         #else
         intern_softdevice_events_execute();
         #endif
+
+        core_util_critical_section_enter();
     }
+    core_util_critical_section_exit();
 }


### PR DESCRIPTION
### Description

This pull requests adds handling of 3 BLE 4.2 & 5 events generated by the NRF S132 and S140 softdevices:
* BLE_GAP_EVT_PHY_UPDATE_REQUEST: BLE PHY negotiation - for instance Coded or 2M PHY (BLE 5)
* BLE_GAP_EVT_DATA_LENGTH_UPDATE_REQUEST: LL data length negotiation (Data packet length extension, BLE 4.2)
* BLE_GATTS_EVT_EXCHANGE_MTU_REQUEST: Extended ATT MTU negotiation (Data packet length extension, BLE 4.2)

It fixes issues encountered when using a device (phone, etc) issuing these requests to the Nordic stack that will issue these events that need to be handled by the application for a connection to be established successfully.

### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [x] Feature
- [ ] Breaking change