### PR TITLE
MCUXpresso: Fix test failures seen with ci-test shield

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/peripheral_clock_defines.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/peripheral_clock_defines.h
@@ -36,7 +36,7 @@
 /* Array for I2C module clocks */
 #define I2C_CLOCK_FREQS                                 \
     {                                              \
-        I2C0_CLK_SRC, I2C1_CLK_SRC, I2C2_CLK_SRC   \
+        I2C0_CLK_SRC, I2C1_CLK_SRC, I2C2_CLK_SRC, I2C3_CLK_SRC   \
     }
 
 /* Array for DSPI module clocks */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/i2c_api.c
@@ -36,6 +36,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
     uint32_t i2c_sda = pinmap_peripheral(sda, PinMap_I2C_SDA);
     uint32_t i2c_scl = pinmap_peripheral(scl, PinMap_I2C_SCL);
+    PORT_Type *port_addrs[] = PORT_BASE_PTRS;
+    PORT_Type *base = port_addrs[sda >> GPIO_PORT_SHIFT];
+
     obj->instance = pinmap_merge(i2c_sda, i2c_scl);
     obj->next_repeated_start = 0;
     MBED_ASSERT((int)obj->instance != NC);
@@ -49,10 +52,11 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
     pinmap_pinout(sda, PinMap_I2C_SDA);
     pinmap_pinout(scl, PinMap_I2C_SCL);
 
-#if defined(FSL_FEATURE_PORT_HAS_OPEN_DRAIN) && FSL_FEATURE_PORT_HAS_OPEN_DRAIN
-    PORT_Type *port_addrs[] = PORT_BASE_PTRS;
-    PORT_Type *base = port_addrs[sda >> GPIO_PORT_SHIFT];
+    /* Enable internal pullup resistor */
+    base->PCR[sda & 0xFF] |= (PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
+    base->PCR[scl & 0xFF] |= (PORT_PCR_PE_MASK | PORT_PCR_PS_MASK);
 
+#if defined(FSL_FEATURE_PORT_HAS_OPEN_DRAIN) && FSL_FEATURE_PORT_HAS_OPEN_DRAIN
     base->PCR[sda & 0xFF] |= PORT_PCR_ODE_MASK;
     base->PCR[scl & 0xFF] |= PORT_PCR_ODE_MASK;
 #endif


### PR DESCRIPTION
A. Enable internal pullup resistor for sda and scl lines.
B. Update the implmentation for byte read and write
   1. Start function: Issue repeat start when bus is busy
   2. Byte write function: Do not call SDK function as this does
      not work for some of the Kinetis device
   3. Byte read function: Do not call SDK function as this would
      issue a START and STOP signal which is not required for
      I2C byte functions
C. Fix K82F I2C ci-test shield failure


Ran the I2C ci-test shield tests to confirm

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
