### PR TITLE
Add missing Doxygen descriptions for Nanostack

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -847,7 +847,8 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */features/FEATURE_COMMON_PAL/* \
                          */features/FEATURE_LWIP/* \
                          */features/FEATURE_UVISOR/* \
-                         */features/nanostack/* \
+                         */features/nanostack/FEATURE_NANOSTACK/sal-stack-nanostack/* \
+                         */features/nanostack/FEATURE_NANOSTACK/coap-service/* \
                          */ble/generic/* \
                          */ble/pal/*
 

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -9,5 +9,5 @@
     "PREDEFINED": "DOXYGEN_ONLY DEVICE_ANALOGIN DEVICE_ANALOGOUT DEVICE_CAN DEVICE_ETHERNET DEVICE_EMAC DEVICE_FLASH  DEVICE_I2C DEVICE_I2CSLAVE DEVICE_I2C_ASYNCH DEVICE_INTERRUPTIN DEVICE_ITM DEVICE_LOWPOWERTIMER DEVICE_PORTIN DEVICE_PORTINOUT DEVICE_PORTOUT DEVICE_PWMOUT DEVICE_RTC DEVICE_TRNG DEVICE_SERIAL DEVICE_SERIAL_ASYNCH DEVICE_SERIAL_FC DEVICE_SLEEP DEVICE_SPI DEVICE_SPI_ASYNCH DEVICE_SPISLAVE DEVICE_STORAGE \"MBED_DEPRECATED_SINCE(f, g)=\" \"MBED_ENABLE_IF_CALLBACK_COMPATIBLE(F, M)=\" \"MBED_DEPRECATED(s)=\"",
     "EXPAND_AS_DEFINED": "", 
     "SKIP_FUNCTION_MACROS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/FEATURE_COMMON_PAL/* */features/FEATURE_LWIP/* */features/FEATURE_UVISOR/* */features/nanostack/* */ble/generic/* */ble/pal/*"
+    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/FEATURE_COMMON_PAL/* */features/FEATURE_LWIP/* */features/FEATURE_UVISOR/* */features/nanostack/FEATURE_NANOSTACK/sal-stack-nanostack/* */features/nanostack/FEATURE_NANOSTACK/coap-service/* */ble/generic/* */ble/pal/*"
 }

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/LoWPANNDInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/LoWPANNDInterface.h
@@ -19,6 +19,10 @@
 
 #include "MeshInterfaceNanostack.h"
 
+/** 6LoWPAN-ND mesh network interface class
+ *
+ * Configure Nanostack to use 6LoWPAN-ND protocol.
+ */
 class LoWPANNDInterface : public MeshInterfaceNanostack {
 public:
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -22,6 +22,10 @@
 #include "NanostackRfPhy.h"
 #include "mesh_interface_types.h"
 
+/** Nanostack's network interface class.
+ *
+ * Common class that is shared between mesh interface classes
+ */
 class MeshInterfaceNanostack : public MeshInterface {
 public:
 
@@ -63,7 +67,7 @@ public:
 
     /**
      * \brief Callback from C-layer
-     * \param state state of the network
+     * \param status state of the network
      * */
     void mesh_network_handler(mesh_connection_status_t status);
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
@@ -20,6 +20,10 @@
 #include "MeshInterfaceNanostack.h"
 #include "NanostackEthernetPhy.h"
 
+/** Ethernet interface for Nanostack.
+ *
+ * Configure Nanostack to use Ethernet connectivity.
+ */
 class NanostackEthernetInterface : public MeshInterfaceNanostack {
 public:
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
@@ -19,6 +19,10 @@
 
 #include "MeshInterfaceNanostack.h"
 
+/** Thread mesh network interface class
+ *
+ * Configure Nanostack to use Thread protocol.
+ */
 class ThreadInterface : public MeshInterfaceNanostack {
 public:
 

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/mesh_interface_types.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/mesh_interface_types.h
@@ -29,7 +29,7 @@ typedef enum {
     MESH_TYPE_THREAD
 } mesh_network_type_t;
 
-/*
+/**
  * Error status values returned by Mesh network API.
  */
 typedef enum {
@@ -40,7 +40,7 @@ typedef enum {
     MESH_ERROR_PARAM,       /*<! Illegal parameter */
 } mesh_error_t;
 
-/*
+/**
  * Mesh network connection status codes returned in callback.
  */
 typedef enum {
@@ -53,7 +53,7 @@ typedef enum {
     MESH_BOOTSTRAP_STARTED          /*<! bootstrap started */
 } mesh_connection_status_t;
 
-/*
+/**
  * Mesh device types
  */
 typedef enum {

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackEthernetPhy.h
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackEthernetPhy.h
@@ -20,6 +20,7 @@
 
 #include "NanostackPhy.h"
 
+/** Ethernet PHY driver class for Nanostack */
 class NanostackEthernetPhy : public NanostackPhy {
 };
 

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackInterface.h
@@ -29,6 +29,7 @@
 
 struct ns_address;
 
+/** Network interface class for Nanostack */
 class NanostackInterface : public NetworkStack {
 public:
     static NanostackInterface *get_stack();
@@ -179,7 +180,7 @@ protected:
      *
      *  @param handle   Socket handle
      *  @param address  Destination for the source address or NULL
-     *  @param data     Destination buffer for data received from the host
+     *  @param buffer   Destination buffer for data received from the host
      *  @param size     Size of the buffer in bytes
      *  @return         Number of received bytes on success, negative error
      *                  code on failure

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackPhy.h
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackPhy.h
@@ -18,6 +18,7 @@
 #ifndef NANOSTACK_PHY_H_
 #define NANOSTACK_PHY_H_
 
+/** PHY driver class for Nanostack */
 class NanostackPhy {
 public:
 

--- a/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackRfPhy.h
+++ b/features/nanostack/FEATURE_NANOSTACK/nanostack-interface/NanostackRfPhy.h
@@ -20,6 +20,7 @@
 
 #include "NanostackPhy.h"
 
+/** Radio PHY driver class for Nanostack */
 class NanostackRfPhy : public NanostackPhy {
 public:
 


### PR DESCRIPTION
### Description

* Add missing Doxygen descriptions for Nanostack and Mesh-API files.
* Enable building of Doxygen documentation for Nanostack related headers.
