### PR TITLE
EFM32: make gpio interrupts faster by offloading expected pin state check to user

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_irq_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_irq_api.c
@@ -61,15 +61,11 @@ static void handle_interrupt_in(uint8_t pin)
         return;
     }
 
-    //we are storing two ports in each uint8, so we must aquire the one we want.
-    // If pin is odd, the port is encoded in the 4 most significant bits. If pin is even, the port is encoded in the 4 least significant bits
-    uint8_t isRise = GPIO_PinInGet((pin & 0x1) ? channel_ports[(pin>>1) & 0x7] >> 4 & 0xF : channel_ports[(pin>>1) & 0x7] & 0xF, pin);
-
     // Get trigger event
     gpio_irq_event event = IRQ_NONE;
-    if ((GPIO->EXTIFALL & (1 << pin)) && !isRise) {
+    if (GPIO->EXTIFALL & (1 << pin)) {
         event = IRQ_FALL;
-    } else if ((GPIO->EXTIRISE & (1 << pin)) && isRise) {
+    } else if (GPIO->EXTIRISE & (1 << pin)) {
         event = IRQ_RISE;
     }
     GPIO_IntClear(pin);


### PR DESCRIPTION
### Description

Resolves https://github.com/ARMmbed/mbed-os/issues/6205

Background: I have a peripheral which generates interrupts with pulses of 50 µs. When using `MBED_TICKLESS` with the MCU in deep sleep, the ISR wouldn't be called. It was found out that the MCU wakes, but misses the pulse, resulting in `IRQ_NONE`.

This is a performance optimization which removes a check of the expected pin state, offloading it to the user. See more [here](https://github.com/ARMmbed/mbed-os/issues/6205#issuecomment-371825072).

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
