### PR TITLE
Optimise debugging experience when building with gcc

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -5,7 +5,7 @@
                    "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
                    "-ffunction-sections", "-fdata-sections", "-funsigned-char",
                    "-MMD", "-fno-delete-null-pointer-checks",
-                   "-fomit-frame-pointer", "-O0", "-g3", "-DMBED_DEBUG",
+                   "-fomit-frame-pointer", "-Og", "-g3", "-DMBED_DEBUG",
                    "-DMBED_TRAP_ERRORS_ENABLED=1"],
         "asm": ["-x", "assembler-with-cpp"],
         "c": ["-std=gnu99"],


### PR DESCRIPTION
### Description

The develop profile uses optimisation in size while the debug profile do not optimise at all.
There is a good trade off with `-Og` though.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

### Pull request type

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [x] Breaking change
