### PR TITLE
fatfs: Revert "Update error code mapping"

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -35,48 +35,39 @@
 static int fat_error_remap(FRESULT res)
 {
     switch(res) {
-        case FR_OK:                   // (0) Succeeded
-            return 0;
-        case FR_DISK_ERR:             // (1) A hard error occurred in the low level disk I/O layer
-            return -EIO;
-        case FR_INT_ERR:              // (2) Assertion failed
-            return -1;
-        case FR_NOT_READY:            // (3) The physical drive cannot work
-            return -EIO;
-        case FR_NO_FILE:              // (4) Could not find the file
-            return -ENOENT;
-        case FR_NO_PATH:              // (5) Could not find the path
-            return -ENOTDIR;
-        case FR_INVALID_NAME:         // (6) The path name format is invalid
-            return -EINVAL;
-        case FR_DENIED:               // (7) Access denied due to prohibited access or directory full
-            return -EACCES;
-        case FR_EXIST:                // (8) Access denied due to prohibited access
-            return -EEXIST;
-        case FR_INVALID_OBJECT:       // (9) The file/directory object is invalid
+        case FR_OK:                     /* (0) Succeeded */
+            return 0;                   /* no error */
+        case FR_DISK_ERR:               /* (1) A hard error occurred in the low level disk I/O layer */
+        case FR_NOT_READY:              /* (3) The physical drive cannot work */
+            return -EIO;                /* I/O error */
+        case FR_NO_FILE:                /* (4) Could not find the file */
+        case FR_NO_PATH:                /* (5) Could not find the path */
+        case FR_INVALID_NAME:           /* (6) The path name format is invalid */
+        case FR_INVALID_DRIVE:          /* (11) The logical drive number is invalid */
+        case FR_NO_FILESYSTEM:          /* (13) There is no valid FAT volume */
+            return -ENOENT;             /* No such file or directory */
+        case FR_DENIED:                 /* (7) Access denied due to prohibited access or directory full */
+            return -EACCES;             /* Permission denied */
+        case FR_EXIST:                  /* (8) Access denied due to prohibited access */
+            return -EEXIST;             /* File exists */
+        case FR_WRITE_PROTECTED:        /* (10) The physical drive is write protected */
+        case FR_LOCKED:                 /* (16) The operation is rejected according to the file sharing policy */
+            return -EACCES;             /* Permission denied */
+        case FR_INVALID_OBJECT:         /* (9) The file/directory object is invalid */
+            return -EFAULT;             /* Bad address */
+        case FR_NOT_ENABLED:            /* (12) The volume has no work area */
+            return -ENXIO;              /* No such device or address */
+        case FR_NOT_ENOUGH_CORE:        /* (17) LFN working buffer could not be allocated */
+            return -ENOMEM;             /* Not enough space */
+        case FR_TOO_MANY_OPEN_FILES:    /* (18) Number of open files > _FS_LOCK */
+            return -ENFILE;             /* Too many open files in system */
+        case FR_INVALID_PARAMETER:      /* (19) Given parameter is invalid */
+            return -ENOEXEC;            /* Exec format error */
+        case FR_INT_ERR:                /* (2) Assertion failed */
+        case FR_MKFS_ABORTED:           /* (14) The f_mkfs() aborted due to any parameter error */
+        case FR_TIMEOUT:                /* (15) Could not get a grant to access the volume within defined period */
+        default:                        /* Bad file number */
             return -EBADF;
-        case FR_WRITE_PROTECTED:      // (10) The physical drive is write protected
-            return -EACCES;
-        case FR_INVALID_DRIVE:        // (11) The logical drive number is invalid
-            return -ENODEV;
-        case FR_NOT_ENABLED:          // (12) The volume has no work area
-            return -ENODEV;
-        case FR_NO_FILESYSTEM:        // (13) There is no valid FAT volume
-            return -EINVAL;
-        case FR_MKFS_ABORTED:         // (14) The f_mkfs() aborted due to any problem
-            return -EIO;
-        case FR_TIMEOUT:              // (15) Could not get a grant to access the volume within defined period
-            return -ETIMEDOUT;
-        case FR_LOCKED:               // (16) The operation is rejected according to the file sharing policy
-            return -EBUSY;
-        case FR_NOT_ENOUGH_CORE:      // (17) LFN working buffer could not be allocated
-            return -ENOMEM;
-        case FR_TOO_MANY_OPEN_FILES:  // (18) Number of open files > FF_FS_LOCK
-            return -ENFILE;
-        case FR_INVALID_PARAMETER:    // (19) Given parameter is invalid
-            return -EINVAL;
-        default:
-            return -res;
     }
 }
 


### PR DESCRIPTION
### Description

Reverts https://github.com/ARMmbed/mbed-os/pull/6120

This pr was a part of work spanning 5.7-5.9. There is not an immediate urgency for it to land on 5.8. During the review process of the 5.8 release it was noted that this change may cause problems for users that are relying on the existing (but broken) error codes.

To minimize noise, the plan is to revert the error code changes until 5.9, where it can land along with proper testing and documentation from related filesystem work.

I'll recreate https://github.com/ARMmbed/mbed-os/pull/6120 targeting 5.9 if this revert makes it into 5.8.

cc @kegilbert, @deepikabhavnani, @adbridge, @sg-, @kjbracey-arm, @JanneKiiskila 

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [x] Breaking change
