### PR TITLE
rtl8195am : fix gpio toggle slow

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -18,6 +18,8 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
   }
 
   ER_IRAM +0 FIXED {
+    *(.ARM.exidx)
+    *(.init_array)
     *rtl8195a_crypto*.o (+RO)
     *(i.mbedtls*)
     *libc.a (+RO)

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -22,17 +22,23 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
     *(i.mbedtls*)
     *libc.a (+RO)
     *rtx_*.o (+RO)
+    *main*.o (+RO)
+    *lib_peripheral_mbed_arm.ar (+RO)
+    *_api*.o (+RO)
   }
 
   RW_IRAM1 +0 UNINIT FIXED {
     *rtl8195a_crypto*.o(+RW)
     *libc.a (+RW)
-    *(.sdram.data*)
+    *main*.o (+RW)
     *lib_peripheral_mbed_arm.ar (+RW)
-    *rtl8195a_crypto*.o(+ZI, COMMON)
-    *libc.a (+ZI, COMMON)
-    *(.bss.thread_stack_main)
-    *lib_peripheral_mbed_arm.ar (+ZI, COMMON)
+    *_api*.o (+RW)
+    *rtl8195a_crypto*.o(+ZI)
+    *libc.a (+ZI)
+    *main*.o (+ZI)
+    *lib_peripheral_mbed_arm.ar (+ZI)
+    *_api*.o (+ZI)
+    *mbed_boot*.o (+ZI)
   }
 
   ARM_LIB_STACK (0x10070000 - 0x1000) EMPTY 0x1000 {
@@ -41,8 +47,8 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
 
 LR_TCM 0x1FFF0000 0x10000 {
     TCM_OVERLAY 0x1FFF0000 0x10000 {
-        *lwip_mem*.o(.bss*)
-        *lwip_memp*.o(.bss*)
+        *lwip_mem*.o(+ZI)
+        *lwip_memp*.o(+ZI)
         *.o(.tcm.heap*)
     }
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_GCC_ARM/rtl8195a.ld
@@ -67,18 +67,17 @@ SECTIONS
     .text.sram1 :
     {
         . = ALIGN(4);
-        *rtl8195a_crypto.o (.text* .rodata*)
+        *rtl8195a_crypto*.o (.text* .rodata*)
         *mbedtls*.o (.text* .rodata*)
         *libc.a: (.text* .rodata*)
+        *lib_peripheral_mbed_gcc.a: (.text* .rodata*)
+        *_api*.o (.text* .rodata*)
+        *main*.o (.text* .rodata*)
     } > SRAM1
 
     .text.sram2 :
     {
         . = ALIGN(4);
-        *(.mon.ram.text*)
-        *(.hal.flash.text*)
-        *(.hal.sdrc.text*)
-        *(.hal.gpio.text*)
         *(.text*)
 
         KEEP(*(.init))
@@ -165,9 +164,11 @@ SECTIONS
     .bss.sram1 (NOLOAD) :
     {
         __bss_sram_start__ = .;
-        *rtl8195a_crypto.o (.bss* COMMON)
+        *rtl8195a_crypto*.o (.bss* COMMON)
         *mbedtls*.o (.bss* COMMON)
         *(.bss.thread_stack_main)
+        *lib_peripheral_mbed_gcc.a: (.bss* COMMON)
+        *mbed_boot*.o (.bss* COMMON)
         __bss_sram_end__ = .;
     } > SRAM1
 
@@ -198,11 +199,11 @@ SECTIONS
         __HeapLimit = .;
     } > SRAM1
     
-    .TCM_overlay :
+    .TCM_overlay (NOLOAD):
     {
         __bss_dtcm_start__ = .;
-        *lwip_mem.o (.bss*)
-        *lwip_memp.o (.bss*)
+        *lwip_mem*.o (.bss* COMMON)
+        *lwip_memp*.o (.bss* COMMON)
         *(.tcm.heap*)
         __bss_dtcm_end__ = .;
     } > TCM


### PR DESCRIPTION
### Description

Ameba has two memory blocks: SDRAM(2M) and SRAM(512KB). SRAM has better access performance than SDRAM. So some timing critical codes must be moved to SRAM.

fix for mbed-os issue #5778

rebase for #6289


### Pull request type

- [x] Fix

