### PR TITLE
MIMXRT: define PullUp default value

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
@@ -217,7 +217,8 @@ typedef enum {
     PullUp_47K  = 2,
     PullUp_100K = 3,
     PullUp_22K  = 4,
-    PullDefault = PullUp_47K
+    PullDefault = PullUp_47K,
+    PullUp = PullUp_47K
 } PinMode;
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

This target defines few PullUp values, one should be defined to be PullUp that
an application can use. We use the same value as PullDefault

@ARMmbed/team-nxp Please review

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
