### PR TITLE
NUCLEO_L433RC_P: fix pins definitions

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
@@ -111,7 +111,6 @@ typedef enum {
   PC_14 = 0x2E,
   PC_15 = 0x2F,
 
-    
   PD_2  = 0x32,
 #ifdef STM32L433_100PINS // LQFP100 or UFBGA100 versions
   PD_0  = 0x30,
@@ -165,10 +164,6 @@ typedef enum {
   A3          = PC_2,
   A4          = PC_1,
   A5          = PC_0,
-    
-  A6          = PA_7,
-  A7          = PA_2,
-    
   D0          = PA_2,
   D1          = PA_3,
   D2          = PA_12,
@@ -183,8 +178,10 @@ typedef enum {
   D11         = PB_15,
   D12         = PB_14,
   D13         = PB_13,
+  D14         = PB_7,
+  D15         = PB_8,
 
-    // STDIO for console print
+  // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX
     STDIO_UART_TX = MBED_CONF_TARGET_STDIO_UART_TX,
 #else
@@ -197,12 +194,12 @@ typedef enum {
 #endif
 
   // Generic signals namings
-  LED1        = PA_5,
-  LED2        = PA_5,
-  LED3        = PA_5,
-  LED4        = PA_5,
+  LED1        = PB_13,
+  LED2        = PB_13,
+  LED3        = PB_13,
+  LED4        = PB_13,
   USER_BUTTON = PC_13,
-  BUTTON1 = USER_BUTTON,
+  BUTTON1     = USER_BUTTON,
   SERIAL_TX   = STDIO_UART_TX,
   SERIAL_RX   = STDIO_UART_RX,
   USBTX       = STDIO_UART_TX,
@@ -215,7 +212,7 @@ typedef enum {
   SPI_CS      = D10,
   PWM_OUT     = D9,
 
-  //USB pins
+  // USB pins
   USB_DM = PA_11,
   USB_DP = PA_12,
   USB_NOE = PA_13,


### PR DESCRIPTION
### Description

This PR makes some corrections on pins definitions:
- corrects the LEDs
- remove A6 and A7 (don't exist on Arduino connector)
- add D14 and D15

Problem with the LED has been identified here:
https://os.mbed.com/questions/80256/Cant-compile-NUCLEO-L433RC-P-board/

### Pull request type

[x] Fix
[  ] Refactor
[  ] New target
[  ] Feature
[  ] Breaking change
