### PR TITLE
fatfs: Update error code mapping

### DIFF
--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -35,39 +35,48 @@
 static int fat_error_remap(FRESULT res)
 {
     switch(res) {
-        case FR_OK:                     /* (0) Succeeded */
-            return 0;                   /* no error */
-        case FR_DISK_ERR:               /* (1) A hard error occurred in the low level disk I/O layer */
-        case FR_NOT_READY:              /* (3) The physical drive cannot work */
-            return -EIO;                /* I/O error */
-        case FR_NO_FILE:                /* (4) Could not find the file */
-        case FR_NO_PATH:                /* (5) Could not find the path */
-        case FR_INVALID_NAME:           /* (6) The path name format is invalid */
-        case FR_INVALID_DRIVE:          /* (11) The logical drive number is invalid */
-        case FR_NO_FILESYSTEM:          /* (13) There is no valid FAT volume */
-            return -ENOENT;             /* No such file or directory */
-        case FR_DENIED:                 /* (7) Access denied due to prohibited access or directory full */
-            return -EACCES;             /* Permission denied */
-        case FR_EXIST:                  /* (8) Access denied due to prohibited access */
-            return -EEXIST;             /* File exists */
-        case FR_WRITE_PROTECTED:        /* (10) The physical drive is write protected */
-        case FR_LOCKED:                 /* (16) The operation is rejected according to the file sharing policy */
-            return -EACCES;             /* Permission denied */
-        case FR_INVALID_OBJECT:         /* (9) The file/directory object is invalid */
-            return -EFAULT;             /* Bad address */
-        case FR_NOT_ENABLED:            /* (12) The volume has no work area */
-            return -ENXIO;              /* No such device or address */
-        case FR_NOT_ENOUGH_CORE:        /* (17) LFN working buffer could not be allocated */
-            return -ENOMEM;             /* Not enough space */
-        case FR_TOO_MANY_OPEN_FILES:    /* (18) Number of open files > _FS_LOCK */
-            return -ENFILE;             /* Too many open files in system */
-        case FR_INVALID_PARAMETER:      /* (19) Given parameter is invalid */
-            return -ENOEXEC;            /* Exec format error */
-        case FR_INT_ERR:                /* (2) Assertion failed */
-        case FR_MKFS_ABORTED:           /* (14) The f_mkfs() aborted due to any parameter error */
-        case FR_TIMEOUT:                /* (15) Could not get a grant to access the volume within defined period */
-        default:                        /* Bad file number */
+        case FR_OK:                   // (0) Succeeded
+            return 0;
+        case FR_DISK_ERR:             // (1) A hard error occurred in the low level disk I/O layer
+            return -EIO;
+        case FR_INT_ERR:              // (2) Assertion failed
+            return -1;
+        case FR_NOT_READY:            // (3) The physical drive cannot work
+            return -EIO;
+        case FR_NO_FILE:              // (4) Could not find the file
+            return -ENOENT;
+        case FR_NO_PATH:              // (5) Could not find the path
+            return -ENOTDIR;
+        case FR_INVALID_NAME:         // (6) The path name format is invalid
+            return -EINVAL;
+        case FR_DENIED:               // (7) Access denied due to prohibited access or directory full
+            return -EACCES;
+        case FR_EXIST:                // (8) Access denied due to prohibited access
+            return -EEXIST;
+        case FR_INVALID_OBJECT:       // (9) The file/directory object is invalid
             return -EBADF;
+        case FR_WRITE_PROTECTED:      // (10) The physical drive is write protected
+            return -EACCES;
+        case FR_INVALID_DRIVE:        // (11) The logical drive number is invalid
+            return -ENODEV;
+        case FR_NOT_ENABLED:          // (12) The volume has no work area
+            return -ENODEV;
+        case FR_NO_FILESYSTEM:        // (13) There is no valid FAT volume
+            return -EINVAL;
+        case FR_MKFS_ABORTED:         // (14) The f_mkfs() aborted due to any problem
+            return -EIO;
+        case FR_TIMEOUT:              // (15) Could not get a grant to access the volume within defined period
+            return -ETIMEDOUT;
+        case FR_LOCKED:               // (16) The operation is rejected according to the file sharing policy
+            return -EBUSY;
+        case FR_NOT_ENOUGH_CORE:      // (17) LFN working buffer could not be allocated
+            return -ENOMEM;
+        case FR_TOO_MANY_OPEN_FILES:  // (18) Number of open files > FF_FS_LOCK
+            return -ENFILE;
+        case FR_INVALID_PARAMETER:    // (19) Given parameter is invalid
+            return -EINVAL;
+        default:
+            return -res;
     }
 }
 

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -404,6 +404,10 @@ int FATFileSystem::remove(const char *path)
 
     if (res != FR_OK) {
         debug_if(FFS_DBG, "f_unlink() failed: %d\n", res);
+        if (res == FR_DENIED) {
+            printf("hi %d -> %d\n", FR_DENIED, -ENOTEMPTY);
+            return -ENOTEMPTY;
+        }
     }
     return fat_error_remap(res);
 }

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -26,6 +26,7 @@
 #endif //__cplusplus
 #include <stdint.h>
 #include <stddef.h>
+#include <errno.h>
 
 /* We can get the following standard types from sys/types for gcc, but we
  * need to define the types ourselves for the other compilers that normally

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -26,7 +26,18 @@
 #endif //__cplusplus
 #include <stdint.h>
 #include <stddef.h>
+
+/* Include logic for errno so we can get errno defined but not bring in error_t,
+ * including errno here prevents an include later, which would redefine our
+ * error codes
+ */
+#ifndef __error_t_defined
+#define __error_t_defined 1
 #include <errno.h>
+#undef __error_t_defined
+#else
+#include <errno.h>
+#endif
 
 /* We can get the following standard types from sys/types for gcc, but we
  * need to define the types ourselves for the other compilers that normally


### PR DESCRIPTION
### Description

Continues https://github.com/ARMmbed/mbed-os/issues/6072, https://github.com/ARMmbed/mbed-os/pull/6120, https://github.com/ARMmbed/mbed-os/pull/6323

A lot of the error codes in fatfs were mapped incorrectly. This patch revisits the error code mapping to try to correct these mistakes.

Note: This is required before we can test LittleFS + FAT consistently

| ChanFS                  | was        | should be  | ChanFS description                                               |
| ----------------------- | ---------- | ---------- | ---------------------------------------------------------------- |
| FR_OK                   | 0          | 0          | Succeeded                                                        |
| FR_DISK_ERR             | EIO        | EIO        | A hard error occurred in the low level disk I/O layer            |
| FR_INT_ERR              | ~EBADF~    | -1         | Assertion failed                                                 |
| FR_NOT_READY            | EIO        | EIO        | The physical drive cannot work                                   |
| FR_NO_FILE              | ENOENT     | ENOENT     | Could not find the file                                          |
| FR_NO_PATH              | ~ENOENT~   | ENOTDIR    | Could not find the path                                          |
| FR_INVALID_NAME         | ~ENOENT~   | EINVAL     | The path name format is invalid                                  |
| FR_DENIED               | EACCES     | EACCES     | Access denied due to prohibited access or directory full         |
| FR_EXIST                | EEXIST     | EEXIST     | Access denied due to prohibited access                           |
| FR_INVALID_OBJECT       | ~EFAULT~   | EBADF      | The file/directory object is invalid                             |
| FR_WRITE_PROTECTED      | EACCES     | EACCES     | The physical drive is write protected                            |
| FR_INVALID_DRIVE        | ~ENOENT~   | ENODEV     | The logical drive number is invalid                              |
| FR_NOT_ENABLED          | ~ENXIO~    | ENODEV     | The volume has no work area                                      |
| FR_NO_FILESYSTEM        | ~ENOENT~   | EINVAL     | There is no valid FAT volume                                     |
| FR_MKFS_ABORTED         | ~EBADF~    | EIO        | The f_mkfs() aborted due to any problem                          |
| FR_TIMEOUT              | ~EBADF~    | ETIMEDOUT     | Could not get a grant to access the volume within defined period |
| FR_LOCKED               | ~EACCES~   | EBUSY      | The operation is rejected according to the file sharing policy   |
| FR_NOT_ENOUGH_CORE      | ENOMEM     | ENOMEM     | LFN working buffer could not be allocated                        |
| FR_TOO_MANY_OPEN_FILES  | ENFILE     | ENFILE     | Number of open files > FF_FS_LOCK                                |
| FR_INVALID_PARAMETER    | ~ENOEXEC~  | EINVAL     | Given parameter is invalid                                       |

cc @kegilbert, @deepikabhavnani, @kjbracey-arm, @JanneKiiskila, @teetak01 
intended for minor release
should resolve https://github.com/ARMmbed/mbed-os/issues/6072, https://github.com/ARMmbed/mbed-os/issues/5653

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [x] Breaking change
