### PR TITLE
armcc - remove fromelf output before regenerating one

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -16,9 +16,10 @@ limitations under the License.
 """
 import re
 from copy import copy
-from os.path import join, dirname, splitext, basename, exists, relpath
-from os import makedirs, write, curdir
+from os.path import join, dirname, splitext, basename, exists, relpath, isfile
+from os import makedirs, write, curdir, remove
 from tempfile import mkstemp
+from shutil import rmtree
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -251,6 +252,14 @@ class ARM(mbedToolchain):
         bin_arg = {".bin": "--bin", ".hex": "--i32"}[fmt]
         cmd = [self.elf2bin, bin_arg, '-o', bin, elf]
         cmd = self.hook.get_cmdline_binary(cmd)
+
+        # remove target binary file/path
+        if exists(bin):
+            if isfile(bin):
+                remove(bin)
+            else:
+                rmtree(bin)
+
         self.cc_verbose("FromELF: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
 


### PR DESCRIPTION
### Description

Fix armcc recompile errors during elf2bin stage. Errors shown as follows:

Elf2Bin: mbed-os-example-wifi
Error: Q0147E: Failed to create Directory .\BUILD\REALTEK_RTL8195AM\ARM\mbed-os-example-wifi.bin\IMAGE2_TABLE: File exists
Finished: 0 information, 0 warning and 1 error messages.
[ERROR] Error: Q0147E: Failed to create Directory .\BUILD\REALTEK_RTL8195AM\ARM\mbed-os-example-wifi.bin\IMAGE2_TABLE: File exists
Finished: 0 information, 0 warning and 1 error messages.

Fix issue #6306 

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
