### PR TITLE
Fix for #6252

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1609,7 +1609,7 @@
             }
         },
         "detect_code": ["0827"],
-        "macros_add": ["USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
+        "macros_add": ["USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L486RG"
@@ -1626,7 +1626,7 @@
             }
         },
         "detect_code": ["0460"],
-        "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "WISE_1570"],
+        "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "WISE_1570", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["5"],
         "device_name": "STM32L486RG"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1629,7 +1629,8 @@
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "WISE_1570", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "LOWPOWERTIMER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["5"],
-        "device_name": "STM32L486RG"
+        "device_name": "STM32L486RG",
+        "OUTPUT_EXT": "hex"
     },
     "ARCH_MAX": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

This fixes #6252 .  2 fixes here:

- two ram region used for L486 based targets (linker already defined two regions, macro was not set)
- the most important - use hex for Wise 1570 target

cc @ARMmbed/team-st-mcd 

@kimlep01 @mirelachirica @kivaisan I do not have the board to test it, please can you?

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
