### PR TITLE
Cellular: update attach test

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -546,14 +546,12 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
 
     if (!plmn) {
         tr_debug("Automatic network registration");
-        uint8_t len=8;
-        uint8_t buf[8];
         _at.cmd_start("AT+COPS?");
         _at.cmd_stop();
-        _at.resp_start();
-        _at.read_bytes(buf,len);
+        _at.resp_start("AT+COPS:");
+        int mode = _at.read_int();
         _at.resp_stop();
-        if (strncmp((char*)buf,"+COPS: 0",len) != 0) {
+        if (mode != 0) {
             _at.clear_error();
             _at.cmd_start("AT+COPS=0");
             _at.cmd_stop();

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -546,10 +546,20 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
 
     if (!plmn) {
         tr_debug("Automatic network registration");
-        _at.cmd_start("AT+COPS=0");
+        uint8_t len=8;
+        uint8_t buf[8];
+        _at.cmd_start("AT+COPS?");
         _at.cmd_stop();
         _at.resp_start();
+        _at.read_bytes(buf,len);
         _at.resp_stop();
+        if (strncmp((char*)buf,"+COPS: 0",len) != 0) {
+            _at.clear_error();
+            _at.cmd_start("AT+COPS=0");
+            _at.cmd_stop();
+            _at.resp_start();
+            _at.resp_stop();
+        }
     } else {
         tr_debug("Manual network registration to %s", plmn);
         _at.cmd_start("AT+COPS=4,2,");


### PR DESCRIPTION
## Description

This pull request resolves the problem of test case 'attach' of cellular test suite introduced by ARM.

If AT+COPS=0 is sent and modem is already in automatic selection mode, the modem starts searching for another PLMN (different to that already in use) and takes some time. This is not required if the module is already in automatic selection mode. In this pull request, AT+COPS? is sent first to check if the module is already in automatic selection mode or not. If it is, there is no need for AT+COPS=0, otherwise it is sent and then waits for the module to register. 

## Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change