### PR TITLE
Enable iar export option for MTB_ADV_WISE_1510

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -1,4 +1,7 @@
 {
+    "STM32L443RC": {
+        "OGChipSelectEditMenu": "STM32L443RC\tST STM32L443RC"
+    },
     "STM32L496ZG": {
         "OGChipSelectEditMenu": "STM32L496ZG\tST STM32L496ZG"
     },


### PR DESCRIPTION
### Description

<!-- 
    Enable the exporter support for IAR System IDE on MTB_ADV_WISE_1510 target (STM32L443RC chipset).
-->


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
