### PR TITLE
Add include search path when preprocessing assembly files for uvision and make_armc5 exports

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -121,6 +121,10 @@ class Makefile(Exporter):
                     'to_be_compiled']:
             ctx[key] = sorted(ctx[key])
         ctx.update(self.format_flags())
+        # Add the virtual path the the include option in the ASM flags
+        for index, flag in enumerate(ctx['asm_flags']):
+            if flag.startswith('-I'):
+                ctx['asm_flags'][index] = "-I" + ctx['vpath'][0] + "/" + ctx['asm_flags'][index][2:]
 
         for templatefile in \
             ['makefile/%s_%s.tmpl' % (self.TEMPLATE,

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -394,7 +394,7 @@
               <MiscControls>{{asm_flags}}</MiscControls>
               <Define></Define>
               <Undefine></Undefine>
-              <IncludePath></IncludePath>
+              <IncludePath>{{include_paths}}</IncludePath>
             </VariousControls>
           </Aads>
           <LDads>


### PR DESCRIPTION
Without that fix, the generated `uvision` and `make_armc5` exports would not include the different project folders in the search path of the assembly command line. It forces the user of using `#include` with relative path.
These issues were discovered while doing the export test if the pull request #6168 