### PR TITLE
Update mbed-coap to version 4.4.0

### DIFF
--- a/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v4.4.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.4.0) 
+**New feature:**
+- Make sn_coap_protocol_send_rst as public needed for CoAP ping sending
+- Allow disabling resendings by defining SN_COAP_DISABLE_RESENDINGS
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.3.0...v4.4.0)
+
 ## [v4.3.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.3.0) 
 **New feature:**
 -  Add new API which clears the whole sent blockwise message list

--- a/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -256,6 +256,18 @@ extern int8_t sn_coap_protocol_handle_block2_response_internally(struct coap_s *
  */
 extern void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle);
 
+/**
+ * \fn void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param)
+ *
+ * \brief This function sends a RESET message.
+ *
+ * \param *handle Pointer to CoAP library handle
+ * \param msg_id Message id.
+ * \param addr_ptr Pointer to destination address where CoAP message will be sent
+ * \param param Pointer that will be passed to tx function callback
+ */
+extern void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param);
+
 #endif /* SN_COAP_PROTOCOL_H_ */
 
 #ifdef __cplusplus

--- a/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_config.h
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/mbed-coap/sn_config.h
@@ -55,6 +55,15 @@
 #undef COAP_DISABLE_OBS_FEATURE
 
 /**
+ * \def SN_COAP_DISABLE_RESENDINGS
+ *
+ * \brief Disables resending feature. Resending feature should not be needed
+ * when using CoAP with TCP transport for example. By default resendings are
+ * enabled. Set to 1 to disable.
+ */
+#undef SN_COAP_DISABLE_RESENDINGS          /* 0 */ // < Default re-sending are not disabled. Set to 1 to disable re-sendings
+
+/**
  * \def SN_COAP_RESENDING_QUEUE_SIZE_MSGS
  *
  * \brief Sets the number of messages stored

--- a/features/FEATURE_COMMON_PAL/mbed-coap/module.json
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/FEATURE_COMMON_PAL/mbed-coap/source/include/sn_coap_protocol_internal.h
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/source/include/sn_coap_protocol_internal.h
@@ -39,7 +39,11 @@ struct sn_coap_hdr_;
 /* * * * * * * * * * * */
 
 /* * For Message resending * */
+#ifdef SN_COAP_DISABLE_RESENDINGS
+#define ENABLE_RESENDINGS                               0 /* Disable resendings */
+#else
 #define ENABLE_RESENDINGS                               1   /**< Enable / Disable resending from library in building */
+#endif
 
 #define SN_COAP_RESENDING_MAX_COUNT                     3   /**< Default number of re-sendings  */
 

--- a/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
+++ b/features/FEATURE_COMMON_PAL/mbed-coap/source/sn_coap_protocol.c
@@ -47,7 +47,6 @@
 /* * * * LOCAL FUNCTION PROTOTYPES * * * */
 /* * * * * * * * * * * * * * * * * * * * */
 
-static void                  sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param);
 #if SN_COAP_DUPLICATION_MAX_MSGS_COUNT/* If Message duplication detection is not used at all, this part of code will not be compiled */
 static void                  sn_coap_protocol_linked_list_duplication_info_store(struct coap_s *handle, sn_nsdl_addr_s *src_addr_ptr, uint16_t msg_id, void *param);
 static coap_duplication_info_s *sn_coap_protocol_linked_list_duplication_info_search(struct coap_s *handle, sn_nsdl_addr_s *scr_addr_ptr, uint16_t msg_id);
@@ -667,6 +666,8 @@ sn_coap_hdr_s *sn_coap_protocol_parse(struct coap_s *handle, sn_nsdl_addr_s *src
 
             /* Check if there is no room to store message for duplication detection purposes */
             if (stored_duplication_msgs_count >= handle->sn_coap_duplication_buffer_size) {
+                tr_debug("sn_coap_protocol_parse - duplicate list full, dropping oldest");
+
                 /* Get oldest stored duplication message */
                 coap_duplication_info_s *stored_duplication_info_ptr = ns_list_get_first(&handle->linked_list_duplication_msgs);
 
@@ -1028,7 +1029,7 @@ uint32_t sn_coap_calculate_new_resend_time(const uint32_t current_time, const ui
 
 #endif /* ENABLE_RESENDINGS */
 
-static void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param)
+void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param)
 {
     uint8_t packet_ptr[4];
 


### PR DESCRIPTION
### Description

Make sn_coap_protocol_send_rst as public needed for CoAP ping sending
Allow disabling resendings by defining SN_COAP_DISABLE_RESENDINGS

### Pull request type

- [X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
