### PR TITLE
spi_api bugfix - many targets

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/spi_api.c
@@ -223,9 +223,8 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 int spi_slave_receive(spi_t *obj)
 {
     int32_t status = spi_pl022_get_status(obj->spi);
-    /* Rx FIFO not empty and device not busy */
-    int32_t ret = ((status & SPI_PL022_SSPSR_RNE_MSK) &&
-                        !(status & SPI_PL022_SSPSR_BSY_MSK));
+    /* Rx FIFO not empty */
+    int32_t ret = (status & SPI_PL022_SSPSR_RNE_MSK);
     return ret;
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/spi_api.c
@@ -284,7 +284,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/spi_api.c
@@ -284,7 +284,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -206,7 +206,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -172,7 +172,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -200,7 +200,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -265,7 +265,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer,
 
 int spi_slave_receive(spi_t *obj)
 {
-    return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
+    return spi_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj)

--- a/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -206,7 +206,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -214,7 +214,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -212,7 +212,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -194,7 +194,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -197,7 +197,7 @@ int spi_busy(spi_t *obj)
 
 int spi_slave_receive(spi_t *obj)
 {
-    return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj)

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
@@ -233,7 +233,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (spi_readable(obj) && !spi_busy(obj)) ? (1) : (0);
+    return spi_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/spi_api.c
@@ -266,14 +266,12 @@ int spi_slave_receive (spi_t *obj)
     PHAL_SSI_ADAPTOR pHalSsiAdaptor;
     PHAL_SSI_OP pHalSsiOp;
     int Readable;
-    int Busy;
 
     pHalSsiAdaptor = &obj->spi_adp;
     pHalSsiOp = &obj->spi_op;
 
     Readable = pHalSsiOp->HalSsiReadable(pHalSsiAdaptor);
-    Busy     = (int)pHalSsiOp->HalSsiBusy(pHalSsiAdaptor);
-    return ((Readable && !Busy) ? 1 : 0);
+    return (Readable ? 1 : 0);
 }
 
 int spi_slave_read (spi_t *obj)

--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -454,7 +454,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 
 int spi_slave_receive(spi_t *obj)
 {
-    return ((ssp_readable(obj) && !ssp_busy(obj)) ? 1 : 0);
+    return (ssp_readable(obj) ? 1 : 0);
 };
 
 int spi_slave_read(spi_t *obj)

--- a/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/spi_api.c
@@ -199,7 +199,7 @@ int spi_master_block_write(spi_t *obj, const char *tx_buffer, int tx_length,
 }
 
 int spi_slave_receive(spi_t *obj) {
-    return (ssp_readable(obj) && !ssp_busy(obj)) ? (1) : (0);
+    return ssp_readable(obj) ? (1) : (0);
 }
 
 int spi_slave_read(spi_t *obj) {


### PR DESCRIPTION
NB: **NOT FULLY TESTED; REVIEW NEEDED.**

### Description

In [`hal/spi_api.h`](https://github.com/ARMmbed/mbed-os/blob/master/hal/spi_api.h), the `spi_slave_receive()` function reportedly "Check[s] if a value is available to read". In `spi_api.c` of many targets, a return value of `1` (`true`) from this function is dependent on the SPI peripheral being "not busy". I think this is incorrect logic. This PR attempts to fix the issue.

Briefly, my reasoning is captured in the commit comment:

> Don't wait for "not busy" in `spi_slave_receive()`. Busy-ness is with respect to SPI bus activity, but we can read whenever there is something in the receive buffer, regardless of whether bus activity is (still) occurring.

## Background / Context

In a project, I'm working on adding interrupt-based asynchronous SPI slave code, on an Embedded Artists' [LPC4088 QuickStart Board](https://www.embeddedartists.com/products/boards/lpc4088_qsb.php) (which uses an NXP LPC4088 micro). (I've also slowed down the micro clocks.) In the interrupt handler, I'm basically doing this:

```
      while (spi_slave_receive(&spi))
      {
         RdRingBuf.push(spi_slave_read(&spi));
      }

      SPIHandlingThread.signal_set(SPI_DATA_RCVD_FLAG);
```

With the current implementation, that makes for a race condition in the interrupt handler. AFAICT, sometimes it'll exit the handler early - potentially without even grabbing any data - because the SPI bus happens to have activity at the moment, even though I could still read from the FIFO. Consequently, it intermittently misses data.

With this patch, it seems to be working reliably on my target.

### Evidence

For a bit of supporting evidence that this is true across platforms, see for instance section 28.3.7 of ST's [RM0090.pdf](http://www.st.com/content/ccc/resource/technical/document/reference_manual/3d/6d/5a/66/b4/99/40/d4/DM00031020.pdf/files/DM00031020.pdf/jcr:content/translations/en.DM00031020.pdf) (for STM32F405, etc.), which says,

> Note: Do not use the BSY flag to handle each data transmission or reception. It is better to use the TXE and RXNE flags instead.

EDIT: For the NXP LPC408x/407x, see section 21.6 of [UM10562.pdf](https://www.nxp.com/docs/en/user-guide/UM10562.pdf).

### Change details

In this PR, I took the liberty of making the changes that I think need to be made on all the targets I could find. **I have only personally tested on the LPC4088.** I'm hoping the Mbed OS team can pick up verification from here.

For LPC15XX and LPC81X, I removed the "busy" test from `spi_slave_receive()` as I did for the others. However, I think the `spi_busy()` return value is determined incorrectly. (I did not change that.) Currently, it is based on the "Receive Overrun" status. (See section 25.6.3 of [UM10736.pdf](https://www.nxp.com/docs/en/user-guide/UM10736.pdf) for LPC15XX.) I don't think that the overflow status ("you missed data") is related to "busy-ness".

EDIT: The change I'm least sure of is `TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A`. It's the most different from the others, and I couldn't find the corresponding documentation easily.

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
