### PR TITLE
ADI: Fix on chip flash minimal programmable unit size

### DIFF
--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/flash_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/flash_api.c
@@ -76,7 +76,7 @@ static const sector_info_t sectors_info[] = {
 };
 
 static const flash_target_config_t flash_target_config = {
-    .page_size   = 0x800,
+    .page_size   = 0x8,                       // minimal programmable unit size
     .flash_start = 0x0,
     .flash_size  = 0x00040000,
     .sectors     = sectors_info,

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/flash_api.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/flash_api.c
@@ -74,7 +74,7 @@ static const sector_info_t sectors_info[] = {
 };
 
 static const flash_target_config_t flash_target_config = {
-    .page_size   = 0x800,
+    .page_size   = 0x8,                       // minimal programmable unit size
     .flash_start = 0x0,
     .flash_size  = 0x0007F000,
     .sectors     = sectors_info,


### PR DESCRIPTION
### Description

- sector size is 0x800 bytes
- writeable unit size is 0x8 bytes
- flash start address is 0x0
- total ADuCM3029 on chip flash size is 0x40000 bytes
- total ADuCM4050 on chip flash size is 0x7F000 bytes
- #6318

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
### Step to reproduce

`mbed test -t gcc_arm -m EV_COG_AD3029LZ -n mbed-os-features-nvstore-tests-nvstore-functionality,mbed-os-tests-mbed_drivers-flashiap,mbed-os-tests-mbed_hal-flash`