### PR TITLE
Sort out volatiles in the atomic functions

### DIFF
--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -119,26 +119,26 @@ void core_util_critical_section_exit(void)
 bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {
     do {
-        uint8_t currentValue = __LDREXB((volatile uint8_t*)ptr);
+        uint8_t currentValue = __LDREXB(ptr);
         if (currentValue != *expectedCurrentValue) {
             *expectedCurrentValue = currentValue;
             __CLREX();
             return false;
         }
-    } while (__STREXB(desiredValue, (volatile uint8_t*)ptr));
+    } while (__STREXB(desiredValue, ptr));
     return true;
 }
 
 bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue)
 {
     do {
-        uint16_t currentValue = __LDREXH((volatile uint16_t*)ptr);
+        uint16_t currentValue = __LDREXH(ptr);
         if (currentValue != *expectedCurrentValue) {
             *expectedCurrentValue = currentValue;
             __CLREX();
             return false;
         }
-    } while (__STREXH(desiredValue, (volatile uint16_t*)ptr));
+    } while (__STREXH(desiredValue, ptr));
     return true;
 }
 
@@ -146,13 +146,13 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
 bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue)
 {
     do {
-        uint32_t currentValue = __LDREXW((volatile uint32_t*)ptr);
+        uint32_t currentValue = __LDREXW(ptr);
         if (currentValue != *expectedCurrentValue) {
             *expectedCurrentValue = currentValue;
             __CLREX();
             return false;
         }
-    } while (__STREXW(desiredValue, (volatile uint32_t*)ptr));
+    } while (__STREXW(desiredValue, ptr));
     return true;
 }
 
@@ -160,8 +160,8 @@ uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     do {
-        newValue = __LDREXB((volatile uint8_t*)valuePtr) + delta;
-    } while (__STREXB(newValue, (volatile uint8_t*)valuePtr));
+        newValue = __LDREXB(valuePtr) + delta;
+    } while (__STREXB(newValue, valuePtr));
     return newValue;
 }
 
@@ -169,8 +169,8 @@ uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     do {
-        newValue = __LDREXH((volatile uint16_t*)valuePtr) + delta;
-    } while (__STREXH(newValue, (volatile uint16_t*)valuePtr));
+        newValue = __LDREXH(valuePtr) + delta;
+    } while (__STREXH(newValue, valuePtr));
     return newValue;
 }
 
@@ -178,8 +178,8 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     do {
-        newValue = __LDREXW((volatile uint32_t*)valuePtr) + delta;
-    } while (__STREXW(newValue, (volatile uint32_t*)valuePtr));
+        newValue = __LDREXW(valuePtr) + delta;
+    } while (__STREXW(newValue, valuePtr));
     return newValue;
 }
 
@@ -188,8 +188,8 @@ uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     do {
-        newValue = __LDREXB((volatile uint8_t*)valuePtr) - delta;
-    } while (__STREXB(newValue, (volatile uint8_t*)valuePtr));
+        newValue = __LDREXB(valuePtr) - delta;
+    } while (__STREXB(newValue, valuePtr));
     return newValue;
 }
 
@@ -197,8 +197,8 @@ uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     do {
-        newValue = __LDREXH((volatile uint16_t*)valuePtr) - delta;
-    } while (__STREXH(newValue, (volatile uint16_t*)valuePtr));
+        newValue = __LDREXH(valuePtr) - delta;
+    } while (__STREXH(newValue, valuePtr));
     return newValue;
 }
 
@@ -206,8 +206,8 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     do {
-        newValue = __LDREXW((volatile uint32_t*)valuePtr) - delta;
-    } while (__STREXW(newValue, (volatile uint32_t*)valuePtr));
+        newValue = __LDREXW(valuePtr) - delta;
+    } while (__STREXW(newValue, valuePtr));
     return newValue;
 }
 

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -116,7 +116,7 @@ void core_util_critical_section_exit(void)
 #pragma diag_suppress 3731
 #endif
 
-bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
+bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {
     do {
         uint8_t currentValue = __LDREXB(ptr);
@@ -129,7 +129,7 @@ bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_
     return true;
 }
 
-bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue)
+bool core_util_atomic_cas_u16(volatile uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue)
 {
     do {
         uint16_t currentValue = __LDREXH(ptr);
@@ -143,7 +143,7 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
 }
 
 
-bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue)
+bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue)
 {
     do {
         uint32_t currentValue = __LDREXW(ptr);
@@ -156,7 +156,7 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
     return true;
 }
 
-uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
+uint8_t core_util_atomic_incr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     do {
@@ -165,7 +165,7 @@ uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
     return newValue;
 }
 
-uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta)
+uint16_t core_util_atomic_incr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     do {
@@ -174,7 +174,7 @@ uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta)
     return newValue;
 }
 
-uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
+uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     do {
@@ -184,7 +184,7 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 
-uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta)
+uint8_t core_util_atomic_decr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     do {
@@ -193,7 +193,7 @@ uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta)
     return newValue;
 }
 
-uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta)
+uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     do {
@@ -202,7 +202,7 @@ uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta)
     return newValue;
 }
 
-uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
+uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     do {
@@ -213,7 +213,7 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
 
 #else
 
-bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
+bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {
     bool success;
     uint8_t currentValue;
@@ -230,7 +230,7 @@ bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_
     return success;
 }
 
-bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue)
+bool core_util_atomic_cas_u16(volatile uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue)
 {
     bool success;
     uint16_t currentValue;
@@ -248,7 +248,7 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
 }
 
 
-bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue)
+bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue)
 {
     bool success;
     uint32_t currentValue;
@@ -266,7 +266,7 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
 }
 
 
-uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
+uint8_t core_util_atomic_incr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     core_util_critical_section_enter();
@@ -276,7 +276,7 @@ uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
     return newValue;
 }
 
-uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta)
+uint16_t core_util_atomic_incr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     core_util_critical_section_enter();
@@ -286,7 +286,7 @@ uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta)
     return newValue;
 }
 
-uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
+uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     core_util_critical_section_enter();
@@ -297,7 +297,7 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 
-uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta)
+uint8_t core_util_atomic_decr_u8(volatile uint8_t *valuePtr, uint8_t delta)
 {
     uint8_t newValue;
     core_util_critical_section_enter();
@@ -307,7 +307,7 @@ uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta)
     return newValue;
 }
 
-uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta)
+uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta)
 {
     uint16_t newValue;
     core_util_critical_section_enter();
@@ -317,7 +317,7 @@ uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta)
     return newValue;
 }
 
-uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
+uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 {
     uint32_t newValue;
     core_util_critical_section_enter();
@@ -330,18 +330,18 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
 #endif
 
 
-bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *desiredValue) {
+bool core_util_atomic_cas_ptr(void * volatile *ptr, void **expectedCurrentValue, void *desiredValue) {
     return core_util_atomic_cas_u32(
-            (uint32_t *)ptr,
+            (volatile uint32_t *)ptr,
             (uint32_t *)expectedCurrentValue,
             (uint32_t)desiredValue);
 }
 
-void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return (void *)core_util_atomic_incr_u32((uint32_t *)valuePtr, (uint32_t)delta);
+void *core_util_atomic_incr_ptr(void * volatile *valuePtr, ptrdiff_t delta) {
+    return (void *)core_util_atomic_incr_u32((volatile uint32_t *)valuePtr, (uint32_t)delta);
 }
 
-void *core_util_atomic_decr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return (void *)core_util_atomic_decr_u32((uint32_t *)valuePtr, (uint32_t)delta);
+void *core_util_atomic_decr_ptr(void * volatile *valuePtr, ptrdiff_t delta) {
+    return (void *)core_util_atomic_decr_u32((volatile uint32_t *)valuePtr, (uint32_t)delta);
 }
 

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -144,7 +144,7 @@ bool core_util_in_critical_section(void);
  * always succeeds if the current value is expected, as per the pseudocode
  * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
  */
-bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue);
+bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue);
 
 /**
  * Atomic compare and set. It compares the contents of a memory location to a
@@ -201,7 +201,7 @@ bool core_util_atomic_cas_u8(uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_
  * always succeeds if the current value is expected, as per the pseudocode
  * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
  */
-bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue);
+bool core_util_atomic_cas_u16(volatile uint16_t *ptr, uint16_t *expectedCurrentValue, uint16_t desiredValue);
 
 /**
  * Atomic compare and set. It compares the contents of a memory location to a
@@ -258,7 +258,7 @@ bool core_util_atomic_cas_u16(uint16_t *ptr, uint16_t *expectedCurrentValue, uin
  * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
  * }
  */
-bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue);
+bool core_util_atomic_cas_u32(volatile uint32_t *ptr, uint32_t *expectedCurrentValue, uint32_t desiredValue);
 
 /**
  * Atomic compare and set. It compares the contents of a memory location to a
@@ -315,7 +315,7 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
  * always succeeds if the current value is expected, as per the pseudocode
  * above; it will not spuriously fail as "atomic_compare_exchange_weak" may.
  */
-bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *desiredValue);
+bool core_util_atomic_cas_ptr(void * volatile *ptr, void **expectedCurrentValue, void *desiredValue);
 
 /**
  * Atomic increment.
@@ -323,7 +323,7 @@ bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *des
  * @param  delta    The amount being incremented.
  * @return          The new incremented value.
  */
-uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta);
+uint8_t core_util_atomic_incr_u8(volatile uint8_t *valuePtr, uint8_t delta);
 
 /**
  * Atomic increment.
@@ -331,7 +331,7 @@ uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta);
  * @param  delta    The amount being incremented.
  * @return          The new incremented value.
  */
-uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta);
+uint16_t core_util_atomic_incr_u16(volatile uint16_t *valuePtr, uint16_t delta);
 
 /**
  * Atomic increment.
@@ -339,7 +339,7 @@ uint16_t core_util_atomic_incr_u16(uint16_t *valuePtr, uint16_t delta);
  * @param  delta    The amount being incremented.
  * @return          The new incremented value.
  */
-uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta);
+uint32_t core_util_atomic_incr_u32(volatile uint32_t *valuePtr, uint32_t delta);
 
 /**
  * Atomic increment.
@@ -350,7 +350,7 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta);
  * @note The type of the pointer argument is not taken into account
  *       and the pointer is incremented by bytes.
  */
-void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta);
+void *core_util_atomic_incr_ptr(void * volatile *valuePtr, ptrdiff_t delta);
 
 /**
  * Atomic decrement.
@@ -358,7 +358,7 @@ void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta);
  * @param  delta    The amount being decremented.
  * @return          The new decremented value.
  */
-uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta);
+uint8_t core_util_atomic_decr_u8(volatile uint8_t *valuePtr, uint8_t delta);
 
 /**
  * Atomic decrement.
@@ -366,7 +366,7 @@ uint8_t core_util_atomic_decr_u8(uint8_t *valuePtr, uint8_t delta);
  * @param  delta    The amount being decremented.
  * @return          The new decremented value.
  */
-uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta);
+uint16_t core_util_atomic_decr_u16(volatile uint16_t *valuePtr, uint16_t delta);
 
 /**
  * Atomic decrement.
@@ -374,7 +374,7 @@ uint16_t core_util_atomic_decr_u16(uint16_t *valuePtr, uint16_t delta);
  * @param  delta    The amount being decremented.
  * @return          The new decremented value.
  */
-uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta);
+uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta);
 
 /**
  * Atomic decrement.
@@ -385,7 +385,7 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta);
  * @note The type of the pointer argument is not taken into account
  *       and the pointer is decremented by bytes
  */
-void *core_util_atomic_decr_ptr(void **valuePtr, ptrdiff_t delta);
+void *core_util_atomic_decr_ptr(void * volatile *valuePtr, ptrdiff_t delta);
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
### Description

Code clean up - the atomic code is confused about the use and meaning of `volatile`. It's using casts internally where not necessary, and potentially forcing users to insert casts.

Only visible change to application code is that

    volatile uint8_t my_volatile;
    core_util_atomic_incr_u8(&my_volatile, 1);

will now work - previously it would have required

    core_util_atomic_incr_u8((uint8_t *)&my_volatile, 1);

This will continue to work:

    uint8_t my_non_volatile;
    core_util_atomic_incr_u8(&my_non_volatile, 1);

Change broken into two individual commits to try to avoid impression that the net change is just expecting users to be providing volatile objects - see commit messages for more detail.

(Given the lack of a full suite of atomic operations including load and store, it's probably the case that users will be currently needing to mark stuff volatile just to avoid compiler optimisations. If we do get a full suite of atomic operations, and that would be required for SMP, then there would usually be no need for volatile, but could be in some cases. This change makes us consistent with C11/C++11 regardless).

### Pull request type

- [ ] Fix
- [X] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
