### PR TITLE
Fix watchdog timing accuracy test for UBLOX_EVK_ODIN_W2

### DIFF
--- a/TESTS/mbed_hal/watchdog_timing/main.cpp
+++ b/TESTS/mbed_hal/watchdog_timing/main.cpp
@@ -134,9 +134,9 @@ int testsuite_setup(const size_t number_of_cases)
 
 Case cases[] = {
     Case("Timing, 200 ms", case_setup, test_timing<200UL, 55UL>),
-    Case("Timing, 500 ms", case_setup, test_timing<500UL, 65UL>),
-    Case("Timing, 1000 ms", case_setup, test_timing<1000UL, 130UL>),
-    Case("Timing, 3000 ms", case_setup, test_timing<3000UL, 190UL>),
+    Case("Timing, 500 ms", case_setup, test_timing<500UL, 130UL>),
+    Case("Timing, 1000 ms", case_setup, test_timing<1000UL, 255UL>),
+    Case("Timing, 3000 ms", case_setup, test_timing<3000UL, 380UL>),
 };
 
 Specification specification((utest::v1::test_setup_handler_t) testsuite_setup, cases);


### PR DESCRIPTION
### Description

Increased time measurement margins in `tests-mbed_hal-watchdog_timing`.

As it turned out during [this CI test run](http://mbed-os-logs.s3-website-us-west-1.amazonaws.com/?prefix=logs/6269/1218) for #6269, the timing margins were too tight for UBLOX_EVK_ODIN_W2 board.

### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [x] Fix (test fix)
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change

CC @bulislaw @0xc0170 @scartmell-arm @jamesbeyond