### PR TITLE
USB updates and enhancements

### DIFF
--- a/TESTS/usb_device/basic/USBTester.cpp
+++ b/TESTS/usb_device/basic/USBTester.cpp
@@ -145,8 +145,10 @@ void USBTester::callback_set_configuration(uint8_t configuration)
     // Configure endpoints > 0
     endpoint_add(int_in, MAX_EP_SIZE, USB_EP_TYPE_INT);
     endpoint_add(int_out, MAX_EP_SIZE, USB_EP_TYPE_INT, &USBTester::epint_out_callback);
+    read_start(int_out, int_buf, sizeof(int_buf));
     endpoint_add(bulk_in, MAX_EP_SIZE, USB_EP_TYPE_BULK);
     endpoint_add(bulk_out, MAX_EP_SIZE, USB_EP_TYPE_BULK, &USBTester::epbulk_out_callback);
+    read_start(bulk_out, bulk_buf, sizeof(bulk_buf));
 
     complete_set_configuration(true);
 }
@@ -161,8 +163,10 @@ void USBTester::callback_set_interface(uint16_t interface, uint8_t alternate)
 
         endpoint_add(int_in, MAX_EP_SIZE, USB_EP_TYPE_INT);
         endpoint_add(int_out, MAX_EP_SIZE, USB_EP_TYPE_INT, &USBTester::epint_out_callback);
+        read_start(int_out, int_buf, sizeof(int_buf));
         endpoint_add(bulk_in, MAX_EP_SIZE, USB_EP_TYPE_BULK);
         endpoint_add(bulk_out, MAX_EP_SIZE, USB_EP_TYPE_BULK, &USBTester::epbulk_out_callback);
+        read_start(bulk_out, bulk_buf, sizeof(bulk_buf));
 
         complete_set_interface(true);
         return;
@@ -175,8 +179,10 @@ void USBTester::callback_set_interface(uint16_t interface, uint8_t alternate)
 
         endpoint_add(int_in, MIN_EP_SIZE, USB_EP_TYPE_INT);
         endpoint_add(int_out, MIN_EP_SIZE, USB_EP_TYPE_INT, &USBTester::epint_out_callback);
+        read_start(int_out, int_buf, sizeof(int_buf));
         endpoint_add(bulk_in, MIN_EP_SIZE, USB_EP_TYPE_BULK);
         endpoint_add(bulk_out, MIN_EP_SIZE, USB_EP_TYPE_BULK, &USBTester::epbulk_out_callback);
+        read_start(bulk_out, bulk_buf, sizeof(bulk_buf));
 
         complete_set_interface(true);
         return;
@@ -350,20 +356,12 @@ const uint8_t *USBTester::configuration_desc()
 
 void USBTester::epint_out_callback(usb_ep_t endpoint)
 {
-    uint8_t buffer[65];
-    uint32_t size = 0;
-
-    if (!read(endpoint, buffer, sizeof(buffer), &size)) {
-        return;
-    }
+    read_finish(endpoint);
+    read_start(endpoint, int_buf, sizeof(int_buf));
 }
 void USBTester::epbulk_out_callback(usb_ep_t endpoint)
 {
-    uint8_t buffer[65];
-    uint32_t size = 0;
-
-    if (!read(endpoint, buffer, sizeof(buffer), &size)) {
-        return;
-    }
+    read_finish(endpoint);
+    read_start(endpoint, bulk_buf, sizeof(bulk_buf));
 }
 

--- a/TESTS/usb_device/basic/USBTester.h
+++ b/TESTS/usb_device/basic/USBTester.h
@@ -73,8 +73,10 @@ protected:
 protected:
     uint8_t bulk_in;
     uint8_t bulk_out;
+    uint8_t bulk_buf[64];
     uint8_t int_in;
     uint8_t int_out;
+    uint8_t int_buf[64];
     EventQueue *queue;
 
     virtual void callback_state_change(DeviceState new_state);

--- a/platform/USBPhy.h
+++ b/platform/USBPhy.h
@@ -23,42 +23,58 @@
 /** Abstract interface to physical USB hardware
  *
  * # Defined behavior
- * * Any endpoint configurations which fit in the parameters of the table returned
- *      by USBPhy::endpoint_table can be used.
- * * All endpoints in any valid endpoint configuration can be used concurrently
- * * Device supports use of at least one control, bulk, interrupt and
+ * * You can use any endpoint configurations that fit in the parameters
+ *      of the table returned by USBPhy::endpoint_table.
+ * * You can use all endpoints in any valid endpoint configuration concurrently.
+ * * The device supports use of at least one control, bulk, interrupt and
  *      isochronous in each direction at the same time - at least 8 endpoints.
- * * Device supports all standard endpoint sizes (wMaxPacketSize)
- * * Device can handle an interrupt latency of at least 100ms if reset is not being performed and address is not being set
- * * USBPhyEvents events are only sent when USBPhy is in the initialized state
- * * When unpowered only the USBPhyEvents::power event can be sent
- * * On USB reset all endpoints are removed except for endpoint 0
- * * USBPhyEvents::out and USBPhyEvents::in events only occur for endpoints which have been added
- * * A call to USBPhy::ep0_write results in USBPhyEvents::in getting called if not
- *      interrupted by a power loss or reset
- * * A call to endpoint_read followed by endpoint_read_result results in USBPhyEvents::out getting called if not
- *      interrupted by a power loss or reset
- * * Endpoint 0 naks all transactions aside from setup packets until one
- *      of ep0_read, ep0_write or ep0_stall has been called
- * * Endpoint 0 stall is automatically cleared on reception of a setup packet
+ * * USBPhy supports all standard endpoint sizes (wMaxPacketSize).
+ * * USBPhy can handle an interrupt latency of at least 100ms if the host PC
+ *      is not performing a reset or setting the device's address.
+ * * USBPhy only sends USBPhyEvents when it is in the initialized state.
+ * * When unpowered, USBPhy only sends the USBPhyEvents::power event.
+ * * On USB reset, all endpoints are removed except for endpoint 0.
+ * * A call to USBPhy::ep0_write results in the call of USBPhyEvents::in when
+ *      the PC reads the data unless a power loss, reset, or a call to
+ *      USBPhy::disconnect occurs first.
+ * * A call to USBPhy::endpoint_write results in the call of USBPhyEvents::in
+ *      when the pc reads the data unless a power loss, reset, or a call to
+ *      USBPhy::endpoint_abort occurs first.
+ * * A call to USBPhy::endpoint_read results in the call of USBPhyEvents::out
+ *      when the pc sends data unless a power loss, reset, or a call to
+ *      USBPhy::endpoint_abort occurs first.
+ * * Endpoint 0 naks all transactions aside from setup packets until
+ *      higher-level code calls one of USBPhy::ep0_read, USBPhy::ep0_write or
+ *      USBPhy::ep0_stall.
+ * * Endpoint 0 stall automatically clears on reception of a setup packet.
  *
  * # Undefined behavior
- * * Calling USBPhy::endpoint_add or USBPhy::endpoint_remove outside of the control requests SetInterface or SetConfiguration
- * * Devices behavior is undefined if latency is greater than 2ms when address is being set - see USB spec 9.2.6.3
- * * Devices behavior is undefined if latency is greater than 10ms when a reset occurs - see USB spec 7.1.7.5
- * * Calling any of the USBPhy::endpoint_* functions on endpoint 0
+ * * Calling USBPhy::endpoint_add or USBPhy::endpoint_remove outside of the
+ *      control requests SetInterface or SetConfiguration.
+ * * Calling USBPhy::endpoint_remove on an endpoint that has an ongoing read
+ *      or write operation. To avoid undefined behavior, you must abort ongoing
+ *      operations with USBPhy::endpoint_abort.
+ * * Devices behavior is undefined if latency is greater than 2ms when address
+ *      is being set - see USB spec 9.2.6.3.
+ * * Devices behavior is undefined if latency is greater than 10ms when a
+ *      reset occurs - see USB spec 7.1.7.5.
+ * * Calling any of the USBPhy::endpoint_* functions on endpoint 0.
  *
  * # Notes
- * * Make sure USB packets are processed in the correct order when multiple packets are present.
- *      Typically IN endpoints should be handled before OUT endpoints if both are pending.
- * * Setup packets may be resent if there is noise on the USB line. The USBPhy should be able
- *      to gracefully handle this scenario and respond to the setup packet with an ACK.
- * * Bi-directional protocols making use of alternating IN and OUT phases should not rely
- *      on the last ACK an IN transfer to indicate that the OUT phase should start. Instead,
- *      the OUT phase should be started at the same time the last IN transfer is started. This
- *      is because the ACK to the last in transfer may be dropped if there is noise on the USB
- *      line. If dropped it will only get re-sent on the next IN phase. More info on this can be
- *      found in section 8.5.3.3 of the USB spec.
+ * * Make sure USBPhy sends USBPhyEvents in the correct order when multiple
+ *      packets are present. USBPhy must send IN endpoint events before OUT
+ *      endpoint events if both are pending.
+ * * A host PC may resend setup packets to a USB device if there is noise on
+ *      the USB line. The USBPhy should be able to handle this scenario and
+ *      respond to the setup packet with an ACK.
+ * * Bidirectional protocols making use of alternating IN and OUT phases
+ *      should not rely on the last ACK an IN transfer to indicate that the
+ *      OUT phase should start. Instead, the OUT phase should be started at
+ *      the same time the last IN transfer is started. This is because the ACK
+ *      to the last in transfer may be dropped if there is noise on the USB
+ *      line. If dropped, it will only be resent on the next IN phase. You can
+ *      find more information on this in section 8.5.3.3 of the USB
+ *      specification.
  *
  * @ingroup usb_device_core
  */

--- a/platform/USBPhy.h
+++ b/platform/USBPhy.h
@@ -182,16 +182,18 @@ public:
 
     /**
      * Start receiving a packet of up to wMaxPacketSize on endpoint 0
+     *
+     * @param data Buffer to fill with the data read
+     * @param size Size of buffer
      */
-    virtual void ep0_read() = 0;
+    virtual void ep0_read(uint8_t *data, uint32_t size) = 0;
 
     /**
      * Read the contents of a received packet
      *
-     * @param buffer Buffer to fill with the data read
-     * @param size Size of buffer
+     * @return Size of data read
      */
-    virtual uint32_t ep0_read_result(uint8_t *buffer, uint32_t size) = 0;
+    virtual uint32_t ep0_read_result() = 0;
 
     /**
      * Write a packet on endpoint 0
@@ -253,23 +255,20 @@ public:
      * Start a read on the given endpoint
      *
      * @param endpoint Endpoint to start the read on
-     * @param max_packet A hint as to the wMaxPacketSize of this endpoint.
-     *  This must match the size in endpoint_add.
+     * @param data Buffer to fill with data
+     * @param size Size of the read buffer. This must be at least
+     *     the max packet size for this endpoint.
      * @return true if the read was successfully started, false otherwise
      */
-    virtual bool endpoint_read(usb_ep_t endpoint, uint32_t max_packet) = 0;
+    virtual bool endpoint_read(usb_ep_t endpoint, uint8_t *data, uint32_t size) = 0;
 
     /**
      * Finish a read on the given endpoint
      *
-     * @param endpoint Endpoint to read data from
-     * @param data Buffer to fill with data
-     * @param size Size of buffer
-     * @param bytes_read The number of bytes in the current packet. This can be larger than
-     *  the size parameter if the buffer passed in was too small.
+     * @param endpoint Endpoint to check
      * @return true if data was read false otherwise
      */
-    virtual bool endpoint_read_result(usb_ep_t endpoint, uint8_t *data, uint32_t size, uint32_t *bytes_read) = 0;
+    virtual uint32_t endpoint_read_result(usb_ep_t endpoint) = 0;
 
     /**
      * Start a write on the given endpoint

--- a/targets/TARGET_Freescale/usb/USBPhyHw.h
+++ b/targets/TARGET_Freescale/usb/USBPhyHw.h
@@ -40,8 +40,8 @@ public:
 
     virtual uint32_t ep0_set_max_packet(uint32_t max_packet);
     virtual void ep0_setup_read_result(uint8_t *buffer, uint32_t size);
-    virtual void ep0_read();
-    virtual uint32_t ep0_read_result(uint8_t *buffer, uint32_t size);
+    virtual void ep0_read(uint8_t *data, uint32_t size);
+    virtual uint32_t ep0_read_result();
     virtual void ep0_write(uint8_t *buffer, uint32_t size);
     virtual void ep0_stall();
 
@@ -50,8 +50,8 @@ public:
     virtual void endpoint_stall(usb_ep_t endpoint);
     virtual void endpoint_unstall(usb_ep_t endpoint);
 
-    virtual bool endpoint_read(usb_ep_t endpoint, uint32_t maximumSize);
-    virtual bool endpoint_read_result(usb_ep_t endpoint, uint8_t *data, uint32_t size, uint32_t *bytesRead);
+    virtual bool endpoint_read(usb_ep_t endpoint, uint8_t *data, uint32_t size);
+    virtual uint32_t endpoint_read_result(usb_ep_t endpoint);
     virtual bool endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size);
     virtual void endpoint_abort(usb_ep_t endpoint);
 
@@ -59,6 +59,12 @@ public:
 
 private:
     USBPhyEvents *events;
+    uint8_t *read_buffers[16];
+    uint16_t read_sizes[16];
+
+    bool endpoint_read_core(usb_ep_t endpoint, uint32_t max_packet);
+    bool endpoint_read_result_core(usb_ep_t endpoint, uint8_t *data, uint32_t size, uint32_t *bytesRead);
+
 
     static void _usbisr(void);
 };

--- a/targets/TARGET_NXP/TARGET_LPC176X/usb/USBPhyHw.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/usb/USBPhyHw.h
@@ -40,18 +40,18 @@ public:
 
     virtual uint32_t ep0_set_max_packet(uint32_t max_packet);
     virtual void ep0_setup_read_result(uint8_t *buffer, uint32_t size);
-    virtual void ep0_read(void);
-    virtual uint32_t ep0_read_result(uint8_t *buffer, uint32_t size);
+    virtual void ep0_read(uint8_t *data, uint32_t size);
+    virtual uint32_t ep0_read_result();
     virtual void ep0_write(uint8_t *buffer, uint32_t size);
-    virtual void ep0_stall(void);
+    virtual void ep0_stall();
 
     virtual bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type);
     virtual void endpoint_remove(usb_ep_t endpoint);
     virtual void endpoint_stall(usb_ep_t endpoint);
     virtual void endpoint_unstall(usb_ep_t endpoint);
 
-    virtual bool endpoint_read(usb_ep_t endpoint, uint32_t maximumSize);
-    virtual bool endpoint_read_result(usb_ep_t endpoint, uint8_t *data, uint32_t size, uint32_t *bytesRead);
+    virtual bool endpoint_read(usb_ep_t endpoint, uint8_t *data, uint32_t size);
+    virtual uint32_t endpoint_read_result(usb_ep_t endpoint);
     virtual bool endpoint_write(usb_ep_t endpoint, uint8_t *data, uint32_t size);
     virtual void endpoint_abort(usb_ep_t endpoint);
 
@@ -59,6 +59,8 @@ public:
 
 private:
     USBPhyEvents *events;
+    uint8_t *read_buffers[16];
+    uint16_t read_sizes[16];
 
     static void _usbisr(void);
 };

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -958,6 +958,7 @@ void USBDevice::deinit()
     lock();
 
     if (_initialized) {
+        disconnect();
         this->_phy->deinit();
         _initialized = false;
     }
@@ -980,7 +981,10 @@ void USBDevice::connect(bool blocking)
 {
     /* Connect device */
     lock();
-    _phy->connect();
+    if (!_connected) {
+        _phy->connect();
+        _connected = true;
+    }
     unlock();
 
     if (blocking) {
@@ -994,7 +998,10 @@ void USBDevice::disconnect()
     lock();
 
     /* Disconnect device */
-    _phy->disconnect();
+    if (_connected) {
+        _phy->disconnect();
+        _connected = false;
+    }
 
     /* Set initial device state */
     if (_device.state > Powered) {
@@ -1199,6 +1206,7 @@ USBDevice::USBDevice(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint1
 
     _phy = phy;
     _initialized = false;
+    _connected = false;
     _current_interface = 0;
     _current_alternate = 0;
     _locked = 0;
@@ -1225,6 +1233,7 @@ USBDevice::USBDevice(uint16_t vendor_id, uint16_t product_id, uint16_t product_r
 
     _phy = get_usb_phy();
     _initialized = false;
+    _connected = false;
     _current_interface = 0;
     _current_alternate = 0;
     _locked = 0;

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -399,6 +399,7 @@ void USBDevice::_complete_set_configuration()
         _control_setup_continue();
     } else {
         _phy->ep0_stall();
+        return;
     }
 
 }
@@ -471,6 +472,7 @@ void USBDevice::_complete_set_interface()
         _control_setup_continue();
     } else {
         _phy->ep0_stall();
+        return;
     }
 }
 
@@ -706,6 +708,7 @@ void USBDevice::_complete_request()
         /* Standard requests */
         if (!_request_setup()) {
             _phy->ep0_stall();
+            return;
         }
 
         /* user_callback may be set by _request_setup() */
@@ -714,6 +717,7 @@ void USBDevice::_complete_request()
         }
     } else if (direction == Failure) {
         _phy->ep0_stall();
+        return;
     } else {
         _transfer.notify = true;
         _transfer.remaining = size;
@@ -872,6 +876,7 @@ void USBDevice::ep0_out()
     if (!_control_out()) {
         /* Protocol stall; this will stall both endpoints */
         _phy->ep0_stall();
+        return;
     }
 }
 
@@ -896,6 +901,7 @@ void USBDevice::ep0_in()
     if (!_control_in()) {
         /* Protocol stall; this will stall both endpoints */
         _phy->ep0_stall();
+        return;
     }
 }
 

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -1256,7 +1256,8 @@ bool USBDevice::read(usb_ep_t endpoint, uint8_t *buffer, uint32_t max_size, uint
         return false;
     }
 
-    if (!configured()) {
+    bool configuring = _transfer.user_callback == SetConfiguration;
+    if (!configured() && !configuring) {
         unlock();
         return false;
     }
@@ -1295,7 +1296,8 @@ bool USBDevice::write(usb_ep_t endpoint, uint8_t *buffer, uint32_t size)
         return false;
     }
 
-    if (!configured()) {
+    bool configuring = _transfer.user_callback == SetConfiguration;
+    if (!configured() && !configuring) {
         unlock();
         return false;
     }

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -509,6 +509,12 @@ private:
     bool _request_get_interface();
     bool _request_set_interface();
     void _change_state(DeviceState state);
+    void _run_later(void (USBDevice::*function)());
+
+    void _complete_request();
+    void _complete_request_xfer_done();
+    void _complete_set_configuration();
+    void _complete_set_interface();
 
     struct endpoint_info_t {
         void (USBDevice::*callback)(usb_ep_t endpoint);
@@ -538,6 +544,17 @@ private:
         SetInterface
     };
 
+    struct complete_request_t {
+        RequestResult result;
+        uint8_t *data;
+        uint32_t size;
+    };
+
+    union complete_args_t {
+        complete_request_t request;
+        bool status;
+    };
+
     struct control_transfer_t {
         setup_packet_t setup;
         uint8_t *ptr;
@@ -547,6 +564,7 @@ private:
         bool notify;
         ControlState stage;
         UserCallback user_callback;
+        complete_args_t args;
     };
 
     endpoint_info_t _endpoint_info[32 - 2];
@@ -556,6 +574,7 @@ private:
     control_transfer_t _transfer;
     usb_device_t _device;
     uint32_t _max_packet_size_ep0;
+    void (USBDevice::*_post_process)();
 
     bool _setup_ready;
     bool _abort_control;

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -571,6 +571,7 @@ private:
 
     USBPhy *_phy;
     bool _initialized;
+    bool _connected;
     control_transfer_t _transfer;
     usb_device_t _device;
     uint32_t _max_packet_size_ep0;

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -202,6 +202,14 @@ public:
     uint32_t endpoint_max_packet_size(usb_ep_t endpoint);
 
     /**
+     * Abort the current transfer on this endpoint
+     *
+     * @param endpoint endpoint with transfer to abort
+     * @note This endpoint must already have been setup with endpoint_add
+     */
+    void endpoint_abort(usb_ep_t endpoint);
+
+    /**
      * start a read on the given endpoint
      *
      * Start a read on the given endpoint. The data buffer must remain

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -202,26 +202,33 @@ public:
     uint32_t endpoint_max_packet_size(usb_ep_t endpoint);
 
     /**
-     * Read a packet on the given endpoint
+     * start a read on the given endpoint
      *
-     * Get the contents of an IN transfer. To ensure all the data from this
-     * endpoint is read make sure the buffer and size passed in is at least
-     * as big as the maximum packet for this endpoint.
+     * Start a read on the given endpoint. The data buffer must remain
+     * unchanged until the transfer either completes or is aborted.
      *
      * @param endpoint endpoint to read data from
      * @param buffer buffer to fill with read data
-     * @param max_size the total size of the data buffer. This must be at least
-     * the max packet size of this endpoint
-     * @param size The size of data that was read
+     * @param size The size of data to read. This must be greater than or equal
+     *        to the max packet size for this endpoint
      * @return true if the read was completed, otherwise false
      * @note This endpoint must already have been setup with endpoint_add
      */
-    bool read(usb_ep_t endpoint, uint8_t *buffer, uint32_t max_size, uint32_t *size);
+    bool read_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t size);
+
+    /**
+     * Get the status of a read
+     *
+     * @param endpoint endpoint to get the status of
+     * @return number of bytes read by this endpoint
+     */
+    uint32_t read_finish(usb_ep_t endpoint);
 
     /**
      * Write a data to the given endpoint
      *
-     * Write data to an endpoint.
+     * Write data to an endpoint. The data sent must remain unchanged until
+     * the transfer either completes or is aborted.
      *
      * @param endpoint endpoint to write data to
      * @param buffer data to write
@@ -229,7 +236,15 @@ public:
      * max packet size of this endpoint
      * @note This endpoint must already have been setup with endpoint_add
      */
-    bool write(usb_ep_t endpoint, uint8_t *buffer, uint32_t size);
+    bool write_start(usb_ep_t endpoint, uint8_t *buffer, uint32_t size);
+
+    /**
+     * Get the status of a write
+     *
+     * @param endpoint endpoint to get the status of
+     * @return number of bytes sent by this endpoint
+     */
+    uint32_t write_finish(usb_ep_t endpoint);
 
     /*
     * Get device descriptor.
@@ -519,6 +534,7 @@ private:
     struct endpoint_info_t {
         void (USBDevice::*callback)(usb_ep_t endpoint);
         uint16_t max_packet_size;
+        uint16_t transfer_size;
         uint8_t flags;
         uint8_t pending;
     };


### PR DESCRIPTION
This PR adds bugfixes/improvements along with an API change to allow for zero copy USB transfers for endpoints. Changes before the commit `Update USBPhy to allow zero copy transfers` are the improvements and bug fixes. Changes after this are to update the code for this API.

Updated docs for this change can be found here:
https://github.com/ARMmbed/Handbook/pull/457

State diagram for previous USB endpoint API:

![usb_endpoint_state_diagram_user](https://user-images.githubusercontent.com/2916772/37574775-48fc1446-2af1-11e8-83b0-a58d6157334a.png)

State diagram for enhanced USB endpoint API:

![usb_endpoint_state_diagram_user_2](https://user-images.githubusercontent.com/2916772/37574788-55d4039a-2af1-11e8-904b-360f853093c0.png)
