### PR TITLE
NVStore: key management enhancements

### DIFF
--- a/features/nvstore/README.md
+++ b/features/nvstore/README.md
@@ -22,6 +22,7 @@ Each item is kept in an entry containing a header and data, where the header hol
 - get: Get the value of an item, given key.
 - set: Set the value of an item, given key and value.
 - set_once: Like set, but allows only a one time setting of this item (and disables deleting of this item).
+- set_alloc_key: Like set, but allocates a free key (from the non predefined keys).
 - remove: Remove an item, given key.
 - get_item_size: Get the item value size (in bytes).
 - set_max_keys: Set maximal value of unique keys. Overriding the default of NVSTORE_MAX_KEYS. This affects RAM consumption,

--- a/features/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -70,6 +70,7 @@ static void nvstore_basic_functionality_test()
 
     uint16_t actual_len_bytes = 0;
     NVStore &nvstore = NVStore::get_instance();
+    uint16_t key;
 
     uint8_t *nvstore_testing_buf_set = new uint8_t[basic_func_max_data_size];
     uint8_t *nvstore_testing_buf_get = new uint8_t[basic_func_max_data_size];
@@ -127,6 +128,10 @@ static void nvstore_basic_functionality_test()
     result = nvstore.set(19, 10, &(nvstore_testing_buf_set[3]));
     TEST_ASSERT_EQUAL(NVSTORE_ALREADY_EXISTS, result);
 
+    result = nvstore.set_alloc_key(key, 17, &(nvstore_testing_buf_set[3]));
+    TEST_ASSERT_EQUAL(NVSTORE_NUM_PREDEFINED_KEYS, key);
+    TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);
+
     // Make sure set items are also gotten OK after reset
     result = nvstore.deinit();
     TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);
@@ -152,6 +157,11 @@ static void nvstore_basic_functionality_test()
     TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);
     TEST_ASSERT_EQUAL(64, actual_len_bytes);
     TEST_ASSERT_EQUAL_UINT8_ARRAY(nvstore_testing_buf_set, nvstore_testing_buf_get, 64);
+
+    result = nvstore.get(NVSTORE_NUM_PREDEFINED_KEYS, 64, nvstore_testing_buf_get, actual_len_bytes);
+    TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);
+    TEST_ASSERT_EQUAL(17, actual_len_bytes);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(&nvstore_testing_buf_set[3], nvstore_testing_buf_get, 17);
 
     result = nvstore.get(10, 65, nvstore_testing_buf_get, actual_len_bytes);
     TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, result);

--- a/features/nvstore/source/nvstore.h
+++ b/features/nvstore/source/nvstore.h
@@ -41,10 +41,20 @@ typedef enum {
     NVSTORE_FLASH_AREA_TOO_SMALL   = -7,
     NVSTORE_OS_ERROR               = -8,
     NVSTORE_ALREADY_EXISTS         = -9,
+    NVSTORE_NO_FREE_KEY            = -10,
 } nvstore_status_e;
 
+typedef enum {
+    NVSTORE_FIRST_PREDEFINED_KEY        = 0,
+
+    // All predefined keys used for internal features should be defined here
+
+    NVSTORE_LAST_PREDEFINED_KEY         = 15,
+    NVSTORE_NUM_PREDEFINED_KEYS
+} nvstore_predefined_keys_e;
+
 #ifndef NVSTORE_MAX_KEYS
-#define NVSTORE_MAX_KEYS 16
+#define NVSTORE_MAX_KEYS ((uint16_t)NVSTORE_NUM_PREDEFINED_KEYS)
 #endif
 
 // defines 2 areas - active and nonactive, not configurable
@@ -147,6 +157,24 @@ public:
      *
      */
     int set(uint16_t key, uint16_t buf_size, const void *buf);
+
+    /**
+     * @brief Programs one item of data on Flash, allocating a key.
+     *
+     * @param[out] key                  Returned key of stored item.
+     * @param[in]  buf_size             Item size in bytes.
+     * @param[in]  buf                  Buffer containing data.
+     *
+     * @returns NVSTORE_SUCCESS           Value was successfully written on Flash.
+     *          NVSTORE_WRITE_ERROR       Physical error writing data.
+     *          NVSTORE_BAD_VALUE         Bad value in any of the parameters.
+     *          NVSTORE_FLASH_AREA_TOO_SMALL
+     *                                    Not enough space in Flash area.
+     *          NVSTORE_ALREADY_EXISTS    Item set with write once API already exists.
+     *          NVSTORE_NO_FREE_KEY       Couldn't allocate a key for this call.
+     *
+     */
+    int set_alloc_key(uint16_t &key, uint16_t buf_size, const void *buf);
 
     /**
      * @brief Programs one item of data on Flash, given key, allowing no consequent sets to this key.
@@ -394,14 +422,14 @@ private:
     /**
      * @brief Actual logics of set API (covers also set_once and remove APIs).
      *
-     * @param[in]  key                    key.
+     * @param[out] key                    key (both input and output).
      * @param[in]  buf_size               Buffer size (bytes).
      * @param[in]  buf                    Input Buffer.
      * @param[in]  flags                  Record flags.
      *
      * @returns 0 for success, nonzero for failure.
      */
-    int do_set(uint16_t key, uint16_t buf_size, const void *buf, uint16_t flags);
+    int do_set(uint16_t &key, uint16_t buf_size, const void *buf, uint16_t flags);
 
 };
 /** @}*/


### PR DESCRIPTION
### Description
This PR makes the following changes in NVStore: 
- Define the `nvstore_predefined_keys_e` enum for predefined keys (later filled by internal users of NVStore)
- Add the `set_alloc_key` API, allocating a free key from the non predefined keys

Both changes are required for better handling of the NVStore key management.

### Pull request type
- [x] Feature
