### PR TITLE
STM32L4 ADC Internal Channel : correct sampling time

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
@@ -105,9 +105,16 @@ uint16_t adc_read(analogin_t *obj)
     ADC_ChannelConfTypeDef sConfig = {0};
 
     // Configure ADC channel
+    sConfig.Rank         = ADC_REGULAR_RANK_1;
+    sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5; //  default value (1.5 us for 80MHz clock)
+    sConfig.SingleDiff   = ADC_SINGLE_ENDED;
+    sConfig.OffsetNumber = ADC_OFFSET_NONE;
+    sConfig.Offset       = 0;
+
     switch (obj->channel) {
         case 0:
             sConfig.Channel = ADC_CHANNEL_VREFINT;
+            sConfig.SamplingTime = ADC_SAMPLETIME_247CYCLES_5; // Minimum ADC sampling time when reading the internal reference voltage is 4us
             break;
         case 1:
             sConfig.Channel = ADC_CHANNEL_1;
@@ -159,19 +166,15 @@ uint16_t adc_read(analogin_t *obj)
             break;
         case 17:
             sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
+            sConfig.SamplingTime = ADC_SAMPLETIME_247CYCLES_5; // Minimum ADC sampling time when reading the temperature is 5us
             break;
         case 18:
             sConfig.Channel = ADC_CHANNEL_VBAT;
+            sConfig.SamplingTime = ADC_SAMPLETIME_640CYCLES_5; // Minimum ADC sampling time when reading the VBAT is 12us
             break;
         default:
             return 0;
     }
-
-    sConfig.Rank         = ADC_REGULAR_RANK_1;
-    sConfig.SamplingTime = ADC_SAMPLETIME_47CYCLES_5;
-    sConfig.SingleDiff   = ADC_SINGLE_ENDED;
-    sConfig.OffsetNumber = ADC_OFFSET_NONE;
-    sConfig.Offset       = 0;
 
     HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 


### PR DESCRIPTION
### Description

With the current settings, sampling time for ADC internal channels are not sufficiant.

This should fix #6397 

@maskedw


### Pull request type

- [x] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
