### PR TITLE
Add overloaded get_erase_size API with address parameter to BlockDevice

### DIFF
--- a/features/TESTS/filesystem/util_block_device/main.cpp
+++ b/features/TESTS/filesystem/util_block_device/main.cpp
@@ -48,6 +48,7 @@ void test_slicing() {
     TEST_ASSERT_EQUAL(0, err);
 
     TEST_ASSERT_EQUAL(BLOCK_SIZE, slice1.get_program_size());
+    TEST_ASSERT_EQUAL(BLOCK_SIZE, slice1.get_erase_size(BLOCK_SIZE));
     TEST_ASSERT_EQUAL((BLOCK_COUNT/2)*BLOCK_SIZE, slice1.size());
 
     // Fill with random sequence
@@ -142,6 +143,7 @@ void test_chaining() {
     TEST_ASSERT_EQUAL(0, err);
 
     TEST_ASSERT_EQUAL(BLOCK_SIZE, chain.get_program_size());
+    TEST_ASSERT_EQUAL(BLOCK_SIZE, chain.get_erase_size((BLOCK_COUNT/2)*BLOCK_SIZE+1));
     TEST_ASSERT_EQUAL(BLOCK_COUNT*BLOCK_SIZE, chain.size());
 
     // Fill with random sequence

--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -135,14 +135,25 @@ public:
      */
     virtual bd_size_t get_program_size() const = 0;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const
     {
         return get_program_size();
+    }
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const
+    {
+        return get_erase_size();
     }
 
     /** Get the value of storage when erased

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -211,6 +211,22 @@ bd_size_t ChainingBlockDevice::get_erase_size() const
     return _erase_size;
 }
 
+bd_size_t ChainingBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    bd_addr_t bd_start_addr = 0;
+    for (size_t i = 0; i < _bd_count; i++) {
+        bd_size_t bdsize = _bds[i]->size();
+        if (addr < (bd_start_addr + bdsize)) {
+            return _bds[i]->get_erase_size(addr - bd_start_addr);
+        }
+        bd_start_addr += bdsize;
+    }
+
+    // Getting here implies an illegal address
+    MBED_ASSERT(0);
+    return 0; // satisfy compiler
+}
+
 int ChainingBlockDevice::get_erase_value() const
 {
     return _erase_value;

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -135,12 +135,20 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an eraseable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/ExhaustibleBlockDevice.cpp
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.cpp
@@ -107,6 +107,11 @@ bd_size_t ExhaustibleBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t ExhaustibleBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(addr);
+}
+
 int ExhaustibleBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/ExhaustibleBlockDevice.h
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.h
@@ -119,11 +119,19 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a erasable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a erasable block in bytes
+     *  @return         Size of an erasable block in bytes
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -81,6 +81,12 @@ bd_size_t HeapBlockDevice::get_erase_size() const
     return _erase_size;
 }
 
+bd_size_t HeapBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    MBED_ASSERT(_blocks != NULL);
+    return _erase_size;
+}
+
 bd_size_t HeapBlockDevice::size() const
 {
     MBED_ASSERT(_blocks != NULL);

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -124,11 +124,19 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the total size of the underlying device
      *

--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -276,6 +276,11 @@ bd_size_t MBRBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t MBRBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(_offset + addr);
+}
+
 int MBRBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/MBRBlockDevice.h
+++ b/features/filesystem/bd/MBRBlockDevice.h
@@ -194,12 +194,20 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/ObservingBlockDevice.cpp
+++ b/features/filesystem/bd/ObservingBlockDevice.cpp
@@ -96,6 +96,11 @@ bd_size_t ObservingBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t ObservingBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(addr);
+}
+
 int ObservingBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/ObservingBlockDevice.h
+++ b/features/filesystem/bd/ObservingBlockDevice.h
@@ -105,11 +105,19 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a erasable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a erasable block in bytes
+     *  @return         Size of an erasable block in bytes
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/ProfilingBlockDevice.cpp
+++ b/features/filesystem/bd/ProfilingBlockDevice.cpp
@@ -82,6 +82,11 @@ bd_size_t ProfilingBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t ProfilingBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(addr);
+}
+
 int ProfilingBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/ProfilingBlockDevice.h
+++ b/features/filesystem/bd/ProfilingBlockDevice.h
@@ -121,12 +121,20 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -82,6 +82,11 @@ bd_size_t ReadOnlyBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t ReadOnlyBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(addr);
+}
+
 int ReadOnlyBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/ReadOnlyBlockDevice.h
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.h
@@ -98,11 +98,19 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a erasable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a erasable block in bytes
+     *  @return         Size of an erasable block in bytes
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -102,6 +102,11 @@ bd_size_t SlicingBlockDevice::get_erase_size() const
     return _bd->get_erase_size();
 }
 
+bd_size_t SlicingBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    return _bd->get_erase_size(_start + addr);
+}
+
 int SlicingBlockDevice::get_erase_value() const
 {
     return _bd->get_erase_value();

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -127,12 +127,20 @@ public:
      */
     virtual bd_size_t get_program_size() const;
 
-    /** Get the size of a eraseable block
+    /** Get the size of an erasable block
      *
-     *  @return         Size of a eraseable block in bytes
+     *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
     virtual bd_size_t get_erase_size() const;
+
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *


### PR DESCRIPTION

### Description
Add an overloaded get_erase_size API with address parameter to BlockDevice and all derived classes.
This is due to the fact that in some flash components, erase size varies depending on address.

### Pull request type
- [ ] Feature
