### PR TITLE
Lora: Fix resetting of max_eirp and antenna_gain values (mbed-os 5.8 branch)

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1332,11 +1332,11 @@ void LoRaMac::reset_mac_parameters(void)
 
     get_phy.attribute = PHY_DEF_MAX_EIRP;
     phy_param = lora_phy->get_phy_params(&get_phy);
-    _params.sys_params.max_eirp = phy_param.value;
+    _params.sys_params.max_eirp = phy_param.f_value;
 
     get_phy.attribute = PHY_DEF_ANTENNA_GAIN;
     phy_param = lora_phy->get_phy_params(&get_phy);
-    _params.sys_params.antenna_gain = phy_param.value;
+    _params.sys_params.antenna_gain = phy_param.f_value;
 
     _params.is_node_ack_requested = false;
     _params.is_srv_ack_requested = false;


### PR DESCRIPTION
### Description

This is a fix for issue #6391.  Please note that this commit is only for mbed-os 5.8 branch. In master this issue no longer occurs due to PR #6279.

max_eirp and antenna_gain are floating point variables. Values of these
were incorrectly read from MIB as integer and therefore incorrect values
were set.

### Pull request type

- [X] Fix
- [ ] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change
