### PR TITLE
Add an option to use LowPowerTimer for poll

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -34,6 +34,11 @@
         "force-non-copyable-error": {
             "help": "Force compile time error when a NonCopyable object is copied",
             "value": false
+        },
+
+        "poll-use-lowpower-timer": {
+            "help": "Enable use of low power timer class for poll(). May cause missing events.",
+            "value": false
         }
     },
     "target_overrides": {

--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -34,7 +34,11 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout)
      * interested in. In future, his spinning behaviour will be replaced with
      * condition variables.
      */
+#if MBED_CONF_PLATFORM_POLL_USE_LOWPOWER_TIMER
+    LowPowerTimer timer;
+#else
     Timer timer;
+#endif
     if (timeout > 0) {
         timer.start();
     }

--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -16,6 +16,7 @@
 #include "mbed_poll.h"
 #include "FileHandle.h"
 #include "Timer.h"
+#include "LowPowerTimer.h"
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "rtos/Thread.h"
 #endif


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

Similar to `use-lowpower-timer-ticker` in `events/`

This allows to use LEUART / LPUART with an ability to enter deep sleep.

For example, the cellular modem can stay constantly connected, listening for events, without preventing deep sleep.


### Pull request type

<!-- 
    Required
    Please tick one of the following types 
-->

- [ ] Fix
- [ ] Refactor
- [ ] New target
- [x] Feature
- [ ] Breaking change
