### PR TITLE
Added SerialWireOutput to mbed namespace

### DIFF
--- a/drivers/SerialWireOutput.h
+++ b/drivers/SerialWireOutput.h
@@ -19,8 +19,12 @@
 #include "hal/itm_api.h"
 #include "platform/FileHandle.h"
 
+namespace mbed {
+  
 class SerialWireOutput : public FileHandle {
+
 public:
+
     SerialWireOutput(void)
     {
         /* Initialize ITM using internal init function. */
@@ -67,5 +71,7 @@ public:
         return 0;
     }
 };
+ 
+} // namespace mbed
 
 #endif


### PR DESCRIPTION
### Description

Added the SerialWireOutput driver to the mbed namespace

See issue #6421 

See why this is a good idea in #5679

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
