### PR TITLE
QSPI: Dummy cycles count is not an init parameter, but a command parameter

### DIFF
--- a/drivers/QSPI.cpp
+++ b/drivers/QSPI.cpp
@@ -39,7 +39,6 @@ QSPI::QSPI(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, Pin
     _alt_width = QSPI_CFG_BUS_SINGLE;
     _alt_size = QSPI_CFG_ALT_SIZE_8;
     _data_width = QSPI_CFG_BUS_SINGLE;
-    _num_dummy_cycles = 0;
     _mode = 0;
     _hz = ONE_MHZ;
     _initialized = false;
@@ -62,7 +61,6 @@ qspi_status_t QSPI::configure_format(qspi_bus_width_t inst_width, qspi_bus_width
     _alt_width = alt_width;
     _alt_size = alt_size;
     _data_width = data_width;
-    _num_dummy_cycles = dummy_cycles;
     _mode = mode;
 
     //Re-init the device, as the mode might have changed
@@ -107,7 +105,7 @@ qspi_status_t QSPI::read(unsigned int address, char *rx_buffer, size_t *rx_lengt
             if (*rx_length != 0) {
                 lock();
                 if (true == _acquire()) {
-                    _build_qspi_command(-1, address, -1);
+                    _build_qspi_command(-1, address, -1, 0);
                     if (QSPI_STATUS_OK == qspi_read(&_qspi, &_qspi_command, rx_buffer, rx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -131,7 +129,7 @@ qspi_status_t QSPI::write(unsigned int address, const char *tx_buffer, size_t *t
             if (*tx_length != 0) {
                 lock();
                 if (true == _acquire()) {
-                    _build_qspi_command(-1, address, -1);
+                    _build_qspi_command(-1, address, -1, 0);
                     if (QSPI_STATUS_OK == qspi_write(&_qspi, &_qspi_command, tx_buffer, tx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -146,7 +144,7 @@ qspi_status_t QSPI::write(unsigned int address, const char *tx_buffer, size_t *t
     return ret_status;
 }
 
-qspi_status_t QSPI::read(unsigned int instruction, unsigned int alt, unsigned int address, char *rx_buffer, size_t *rx_length) 
+qspi_status_t QSPI::read(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, char *rx_buffer, size_t *rx_length) 
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
 
@@ -155,7 +153,7 @@ qspi_status_t QSPI::read(unsigned int instruction, unsigned int alt, unsigned in
             if (*rx_length != 0) {
                 lock();
                 if ( true == _acquire()) {
-                    _build_qspi_command(instruction, address, alt);
+                    _build_qspi_command(instruction, address, alt, dummy_cnt);
                     if (QSPI_STATUS_OK == qspi_read(&_qspi, &_qspi_command, rx_buffer, rx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -170,7 +168,7 @@ qspi_status_t QSPI::read(unsigned int instruction, unsigned int alt, unsigned in
     return ret_status;
 }
 
-qspi_status_t QSPI::write(unsigned int instruction, unsigned int alt, unsigned int address, const char *tx_buffer, size_t *tx_length) 
+qspi_status_t QSPI::write(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, const char *tx_buffer, size_t *tx_length) 
 {
     qspi_status_t ret_status = QSPI_STATUS_ERROR;
     
@@ -179,7 +177,7 @@ qspi_status_t QSPI::write(unsigned int instruction, unsigned int alt, unsigned i
             if (*tx_length != 0) {
                 lock();
                 if (true == _acquire()) {
-                    _build_qspi_command(instruction, address, alt);
+                    _build_qspi_command(instruction, address, alt, dummy_cnt);
                     if (QSPI_STATUS_OK == qspi_write(&_qspi, &_qspi_command, tx_buffer, tx_length)) {
                         ret_status = QSPI_STATUS_OK;
                     }
@@ -201,7 +199,7 @@ qspi_status_t QSPI::command_transfer(unsigned int instruction, int address, cons
     if (_initialized) {
         lock();
         if (true == _acquire()) {
-            _build_qspi_command(instruction, address, -1); //We just need the command
+            _build_qspi_command(instruction, address, -1, 0); //We just need the command
             if (QSPI_STATUS_OK == qspi_command_transfer(&_qspi, &_qspi_command, (const void *)tx_buffer, tx_length, (void *)rx_buffer, rx_length)) {
                 ret_status = QSPI_STATUS_OK;
             }
@@ -247,7 +245,7 @@ bool QSPI::_acquire()
     return _initialized;
 }
 
-void QSPI::_build_qspi_command(int instruction, int address, int alt) 
+void QSPI::_build_qspi_command(int instruction, int address, int alt, int dummy_cnt) 
 {
     memset( &_qspi_command, 0,  sizeof(qspi_command_t) );
     //Set up instruction phase parameters
@@ -278,8 +276,8 @@ void QSPI::_build_qspi_command(int instruction, int address, int alt)
     } else {
         _qspi_command.alt.disabled = true;
     }
-    
-    _qspi_command.dummy_count = _num_dummy_cycles;
+
+    _qspi_command.dummy_count = dummy_cnt;
 
     //Set up bus width for data phase
     _qspi_command.data.bus_width = _data_width;

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -134,6 +134,7 @@ public:
      *
      *  @param instruction Instruction value to be used in instruction phase
      *  @param alt Alt value to be used in instruction phase
+     *  @param dummy_cnt Amount of dummy cycles to be sent after instruction phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param rx_buffer Buffer for data to be read from the peripheral                          
      *  @param rx_length Pointer to a variable containing the length of rx_buffer, and on return this variable will be updated with the actual number of bytes read
@@ -141,12 +142,13 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t read(unsigned int instruction, unsigned int alt, unsigned int address, char *rx_buffer, size_t *rx_length);
+    qspi_status_t read(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, char *rx_buffer, size_t *rx_length);
 
     /** Write to QSPI peripheral using custom write instruction, alt values
      *
      *  @param instruction Instruction value to be used in instruction phase
      *  @param alt Alt value to be used in instruction phase
+     *  @param dummy_cnt Amount of dummy cycles to be sent after instruction phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param tx_buffer Buffer containing data to be sent to peripheral                          
      *  @param tx_length Pointer to a variable containing the length of data to be transmitted, and on return this variable will be updated with the actual number of bytes written
@@ -154,7 +156,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t write(unsigned int instruction, unsigned int alt, unsigned int address, const char *tx_buffer, size_t *tx_length);
+    qspi_status_t write(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, const char *tx_buffer, size_t *tx_length);
 
     /** Perform a transaction to write to an address(a control register) and get the status results
      *
@@ -195,7 +197,6 @@ protected:
     qspi_alt_size_t _alt_size;
     qspi_bus_width_t _data_width; //Bus width for Data phase
     qspi_command_t _qspi_command; //QSPI Hal command struct
-    unsigned int _num_dummy_cycles; //Number of dummy cycles to be used
     int _hz; //Bus Frequency
     int _mode; //SPI mode
     bool _initialized;
@@ -211,7 +212,7 @@ private:
     /* 
      * This function builds the qspi command struct to be send to Hal
      */
-    inline void _build_qspi_command(int instruction, int address, int alt);
+    inline void _build_qspi_command(int instruction, int address, int alt, int dummy_cnt);
 };
 
 } // namespace mbed


### PR DESCRIPTION
It can change depending on the chosen command, not only at start.
This way we avoid to launch init function and break the internal status variables.

