### PR TITLE
QSPI: STM - change default FlashSize to 64Mbit = 8Mbytes = 0x800000

### DIFF
--- a/targets/TARGET_STM/qspi_api.c
+++ b/targets/TARGET_STM/qspi_api.c
@@ -34,7 +34,7 @@
 #include "pinmap.h"
 #include "PeripheralPins.h"
 
-#define QSPI_FLASH_SIZE_DEFAULT 32
+#define QSPI_FLASH_SIZE_DEFAULT 0x800000
 
 void qspi_prepare_command(const qspi_command_t *command, QSPI_CommandTypeDef *st_command) 
 {


### PR DESCRIPTION
With 32 previous value, we cannot write in the memory, it returns an error (invalid address)

Don't you think that this size should become a parameter of the object init function in a later version ?

Kind regards
