### PR TITLE
Enabl-able Python 3 tools testing in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
-python:
-    '2.7'
+python: 2.7
 
 env:
   global:
@@ -30,6 +29,7 @@ before_install:
   - sudo ln -s $HOME/.cache/apt /var/cache/apt/archives
   # Setup ppa to make sure arm-none-eabi-gcc is correct version
   - sudo add-apt-repository -y ppa:team-gcc-arm-embedded/ppa
+  - sudo add-apt-repository -y ppa:deadsnakes/ppa
   # Loop until update succeeds (timeouts can occur)
   - travis_retry $(! sudo apt-get update 2>&1 |grep Failed)
 
@@ -72,14 +72,16 @@ matrix:
           find  -name "*.s" | tee BUILD/badasm |
           sed -e "s/^/Bad Assembler file name found: /" && [ ! -s BUILD/badasm ]
 
-    - env:
-        - NAME=tools
+    - &tools-pytest
+      env: NAME=tools-py2.7
+      python: 2.7
       install:
         # Install dependencies
         - sudo apt-get install gcc-arm-embedded
         - pip install -r requirements.txt
         - pip install pytest pylint hypothesis mock coverage coveralls
         # Print versions we use
+
         - arm-none-eabi-gcc --version
         - python --version
       script:
@@ -93,6 +95,14 @@ matrix:
         - coveralls
         # Report success since we have overridden default behaviour
         - bash -c "$STATUS" success "Local $NAME testing has passed"
+
+#    - <<: *tools-pytest
+#      env: NAME=tools-py3.5
+#      python: 3.5
+#
+#    - <<: *tools-pytest
+#      env: NAME=tools-py3.6
+#      python: 3.6
 
     - env:
         - NAME=astyle


### PR DESCRIPTION
### Description

Updates Travis CI such that once mbed-cli 1.7.0 is released, automatic tools testing against Python 3 can be switched on with a single, small PR.

Tested in personal instance of Travis CI. When enabled, Python 3 fails appropriately. An aborted example can be found here: https://travis-ci.org/cmonr/mbed-os/builds/357062171.

### Pull request type

    [ ] Fix  
    [ ] Refactor  
    [ ] New target  
    [X] Feature  
    [ ] Breaking change
