### PR TITLE
Remove supertarget

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -13,12 +13,6 @@
         "default_lib": "std",
         "bootloader_supported": false
     },
-    "Super_Target": {
-        "inherits": ["Target"],
-        "core": "Cortex-M4",
-        "features_add": ["UVISOR", "BLE", "CLIENT", "IPV4", "IPV6"],
-        "supported_toolchains": ["ARM"]
-    },
     "CM4_UARM": {
         "inherits": ["Target"],
         "core": "Cortex-M4",


### PR DESCRIPTION
### Description

This was used for Doxygen in the past, but now the Doxygen uses a
whitelist of directories to scan. I think it makes sense to remove this
if only to avoid confusion.

### Pull request type

[x] Fix 
[ ] Refactor 
[ ] New target 
[ ] Feature 
[ ] Breaking change 



