### PR TITLE
Skip USB reset tests on OSX

### DIFF
--- a/TESTS/host_tests/pyusb_basic.py
+++ b/TESTS/host_tests/pyusb_basic.py
@@ -217,6 +217,10 @@ class PyusbBasicTest(BaseHostTest):
         except (RuntimeError) as exc:
             self.report_error(exc)
 
+    def _callback_reset_support(self, key, value, timestamp):
+        status = "false" if sys.platform == "darwin" else "true"
+        self.log("Reset supported: %s" % status)
+        self.send_kv("placeholder", status)
 
     def find_device(self, serial_number):
         # to make it more reliable, 20 retries in 2[s]
@@ -263,6 +267,7 @@ class PyusbBasicTest(BaseHostTest):
         self.register_callback('device_suspend_resume_test', self._callback_device_suspend_resume_test)
         self.register_callback('repeated_construction_destruction_test', self._callback_repeated_construction_destruction_test)
 
+        self.register_callback('reset_support', self._callback_reset_support)
 
     def result(self):
         return self.__result

--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -107,7 +107,10 @@ void device_reset_test()
     char _key[11] = {};
     char _value[128] = {};
 
-    {
+    greentea_send_kv("reset_support", 0);
+    greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+    if (strcmp(_value, "false") != 0) {
+
         USBTester serial(vendor_id, product_id, product_release, true);
 
         greentea_send_kv("device_reset_test", serial.get_serial_desc_string());


### PR DESCRIPTION
OSX machines don't allow you to reset USB devices. Skip this test on OSX so testing can still be used.
