### PR TITLE
   tests-mbed_hal-common_tickers / lp ticker speed test : remove set_interrupt call loop

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -408,12 +408,12 @@ void ticker_speed_test(void)
     counter = NUM_OF_CALLS;
     timer.reset();
     timer.start();
-    while (counter--) {
+    // while (counter--) {
         intf->set_interrupt(0);
-    }
+    // }
     timer.stop();
 
-    TEST_ASSERT(timer.read_us() < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
+    TEST_ASSERT(timer.read_us() < (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US));
 
     /* ---- Test fire_interrupt function. ---- */
     counter = NUM_OF_CALLS;


### PR DESCRIPTION
### Description

There is some issue when lp_ticker_set_interrupt function is called into a loop with no delay between.

NB: extract of STM32 reference manual (in chip supporting LPTIM feature):
After a write to the LPTIM_ARR register or the LPTIM_CMP register, a new write operation
to the same register can only be performed when the previous write operation is completed.
Any successive write before respectively the ARROK flag or the CMPOK flag be set, will
lead to unpredictable results.

After dicussion, we decide to remove the loop and check requirement time during an unique call

@LMESTM @c1728p9 @sg- @bulislaw 

Additional question:
is there really a sense to define the same requirement for ticker_set_interrupt time completion  for usticket and lpticker ?

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
