### PR TITLE
KL82Z: Update the clock selection method for LPUART module

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
@@ -39,3 +39,9 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
+
+// Set the UART clock source
+void serial_clock_init(void)
+{
+    CLOCK_SetLpuartClock(2U);
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
@@ -54,3 +54,9 @@ void rtc_setup_oscillator(RTC_Type *base)
     RTC->CR |= RTC_CR_OSCE_MASK;
 }
 #endif
+
+// Set the UART clock source
+void serial_clock_init(void)
+{
+    CLOCK_SetLpuartClock(2U);
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/peripheral_clock_defines.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/peripheral_clock_defines.h
@@ -33,12 +33,6 @@
 
 #include "fsl_clock.h"
 
-/* Array for LPUART module clocks */
-#define LPUART_CLOCK_FREQS                         \
-    {                                              \
-        kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk, kCLOCK_Osc0ErClk   \
-    }
-
 /* Array for I2C module clocks */
 #define I2C_CLOCK_FREQS               \
     {                                 \


### PR DESCRIPTION
Fixes UART issues seen on the KL82Z FRDM board.
