### PR TITLE
Fix deep sleep implementation

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/MKL27Z644_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/MKL27Z644_features.h
@@ -467,6 +467,8 @@
     #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (4)
     /* @brief P-Flash block swap feature. */
     #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (0)
+    /* @brief P-Flash protection region count. */
+    #define FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT (32)
     /* @brief Has FlexNVM memory. */
     #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
     /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,19 +193,75 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
 {
-    kFLASH_accessSegmentBase = 256UL,
-};
-
-/*!
- * @brief Enumeration for acceleration ram property.
- */
-enum _flash_acceleration_ram_property
-{
-    kFLASH_accelerationRamSize = 0x400U
+    kFLASH_AccessSegmentBase = 256UL,
 };
 
 /*!
@@ -212,25 +269,26 @@ enum _flash_acceleration_ram_property
  */
 enum _flash_config_area_range
 {
-    kFLASH_configAreaStart = 0x400U,
-    kFLASH_configAreaEnd = 0x40FU
+    kFLASH_ConfigAreaStart = 0x400U,
+    kFLASH_ConfigAreaEnd = 0x40FU
 };
-
-/*! @brief program Flash block base address*/
-#define PFLASH_BLOCK_BASE 0x00U
-
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
 
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -238,9 +296,9 @@ enum _flash_config_area_range
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief Copy flash_run_command() to RAM*/
-static void copy_flash_run_command(uint8_t *flashRunCommand);
+static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -291,44 +349,111 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
+
+/*!
+ * @brief Position independent code of flash_run_command()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
+ *   {
+ *       // clear CCIF bit
+ *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+ *
+ *       // Check CCIF bit of the flash status register, wait till it is set.
+ *       // IP team indicates that this loop will always complete.
+ *       while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+ *       {
+ *       }
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashRunCommandFunctionCode[] = {
+    0x2180, /* MOVS  R1, #128 ; 0x80 */
+    0x7001, /* STRB  R1, [R0] */
+    /* @4: */
+    0x7802, /* LDRB  R2, [R0] */
+    0x420a, /* TST   R2, R1 */
+    0xd0fc, /* BEQ.N @4 */
+    0x4770  /* BX    LR */
+};
+
+/*!
+ * @brief Position independent code of flash_common_bit_operation()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
+ *   {
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
+ *       __ISB();
+ *       __DSB();
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
+    0xf3bf, 0x8f6f, /* ISB */
+    0xf3bf, 0x8f4f, /* DSB */
+    0xbd10          /* POP   {R4, PC} */
+};
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
-static uint8_t s_flashRunCommand[kFLASH_executeInRamFunctionMaxSize];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint8_t s_flashCacheClearCommand[kFLASH_executeInRamFunctionMaxSize];
+static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -376,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = PFLASH_BLOCK_BASE;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_accessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -418,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -467,8 +639,8 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
-    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_executeInRamFunctionTotalNum;
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
+    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
 }
@@ -513,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -650,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -702,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -755,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -765,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -783,7 +955,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsRamError;
@@ -819,9 +991,9 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             uint32_t programSizeOfCurrentPass;
             uint32_t numberOfPhases;
 
-            if (lengthTobeProgrammedOfCurrentSector > kFLASH_accelerationRamSize)
+            if (lengthTobeProgrammedOfCurrentSector > kFLASH_AccelerationRamSize)
             {
-                programSizeOfCurrentPass = kFLASH_accelerationRamSize;
+                programSizeOfCurrentPass = kFLASH_AccelerationRamSize;
             }
             else
             {
@@ -833,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -867,7 +1039,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     /* Restore function of FlexRAM if needed. */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsEepromError;
@@ -904,7 +1076,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsEepromError;
@@ -950,7 +1122,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     /* Switch function of FlexRAM if needed */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsRamError;
@@ -966,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -986,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1008,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1075,7 +1248,7 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
     if (FLASH_SECURITY_STATE_UNSECURED == (registerValue & FTFx_FSEC_SEC_MASK))
     {
         /* Flash in unsecured state */
-        *state = kFLASH_securityStateNotSecure;
+        *state = kFLASH_SecurityStateNotSecure;
     }
     else
     {
@@ -1084,12 +1257,12 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
         if (FLASH_SECURITY_STATE_KEYEN == (registerValue & FTFx_FSEC_KEYEN_MASK))
         {
             /* Backdoor key security enabled */
-            *state = kFLASH_securityStateBackdoorEnabled;
+            *state = kFLASH_SecurityStateBackdoorEnabled;
         }
         else
         {
             /* Backdoor key security disabled */
-            *state = kFLASH_securityStateBackdoorDisabled;
+            *state = kFLASH_SecurityStateBackdoorDisabled;
         }
     }
 
@@ -1146,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1180,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1210,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1251,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1279,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1306,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1341,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1386,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1394,18 +1621,18 @@ status_t FLASH_IsProtected(flash_config_t *config,
     /* if protectStatusCounter == 0, then no region of the desired flash region is protected */
     if (protectStatusCounter == 0)
     {
-        *protection_state = kFLASH_protectionStateUnprotected;
+        *protection_state = kFLASH_ProtectionStateUnprotected;
     }
     /* if protectStatusCounter == regionCheckedCounter, then each region checked was protected */
     else if (protectStatusCounter == regionCheckedCounter)
     {
-        *protection_state = kFLASH_protectionStateProtected;
+        *protection_state = kFLASH_ProtectionStateProtected;
     }
     /* if protectStatusCounter != regionCheckedCounter, then protection status is mixed
      * In other words, some regions are protected while others are unprotected */
     else
     {
-        *protection_state = kFLASH_protectionStateMixed;
+        *protection_state = kFLASH_ProtectionStateMixed;
     }
 
     return (returnCode);
@@ -1416,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1431,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1438,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1471,24 +1733,24 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
         {
-            *access_state = kFLASH_accessStateUnLimited;
+            *access_state = kFLASH_AccessStateUnLimited;
         }
         else if (executeOnlySegmentCounter < maxSupportedExecuteOnlySegmentCount)
         {
-            *access_state = kFLASH_accessStateMixed;
+            *access_state = kFLASH_AccessStateMixed;
         }
         else
         {
-            *access_state = kFLASH_accessStateExecuteOnly;
+            *access_state = kFLASH_AccessStateExecuteOnly;
         }
     }
 #else
-    *access_state = kFLASH_accessStateUnLimited;
+    *access_state = kFLASH_AccessStateUnLimited;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
 
     return (returnCode);
@@ -1503,27 +1765,27 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     switch (whichProperty)
     {
-        case kFLASH_propertyPflashSectorSize:
+        case kFLASH_PropertyPflashSectorSize:
             *value = config->PFlashSectorSize;
             break;
 
-        case kFLASH_propertyPflashTotalSize:
+        case kFLASH_PropertyPflashTotalSize:
             *value = config->PFlashTotalSize;
             break;
 
-        case kFLASH_propertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockSize:
             *value = config->PFlashTotalSize / FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
             break;
 
-        case kFLASH_propertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockCount:
             *value = config->PFlashBlockCount;
             break;
 
-        case kFLASH_propertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashBlockBaseAddr:
             *value = config->PFlashBlockBase;
             break;
 
-        case kFLASH_propertyPflashFacSupport:
+        case kFLASH_PropertyPflashFacSupport:
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL)
             *value = FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL;
 #else
@@ -1531,31 +1793,39 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
             break;
 
-        case kFLASH_propertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentSize:
             *value = config->PFlashAccessSegmentSize;
             break;
 
-        case kFLASH_propertyPflashAccessSegmentCount:
+        case kFLASH_PropertyPflashAccessSegmentCount:
             *value = config->PFlashAccessSegmentCount;
             break;
 
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+            *value = config->FlexRAMBlockBase;
+            break;
+
+        case kFLASH_PropertyFlexRamTotalSize:
+            *value = config->FlexRAMTotalSize;
+            break;
+
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
-        case kFLASH_propertyDflashSectorSize:
+        case kFLASH_PropertyDflashSectorSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
             break;
-        case kFLASH_propertyDflashTotalSize:
+        case kFLASH_PropertyDflashTotalSize:
             *value = config->DFlashTotalSize;
             break;
-        case kFLASH_propertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE;
             break;
-        case kFLASH_propertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockCount:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
             break;
-        case kFLASH_propertyDflashBlockBaseAddr:
+        case kFLASH_PropertyDflashBlockBaseAddr:
             *value = config->DFlashBlockBase;
             break;
-        case kFLASH_propertyEepromTotalSize:
+        case kFLASH_PropertyEepromTotalSize:
             *value = config->EEpromTotalSize;
             break;
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
@@ -1566,6 +1836,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     return kStatus_FLASH_Success;
 }
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
@@ -1611,7 +1931,7 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     /* Make sure address provided is in the lower half of Program flash but not in the Flash Configuration Field */
     if ((address >= (config->PFlashTotalSize / 2)) ||
-        ((address >= kFLASH_configAreaStart) && (address <= kFLASH_configAreaEnd)))
+        ((address >= kFLASH_ConfigAreaStart) && (address <= kFLASH_ConfigAreaEnd)))
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
     }
@@ -1628,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1646,23 +1966,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
 
     do
     {
-        returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionReportStatus, &returnInfo);
+        returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionReportStatus, &returnInfo);
         if (returnCode != kStatus_FLASH_Success)
         {
             return returnCode;
         }
 
-        if (kFLASH_swapFunctionOptionDisable == option)
+        if (kFLASH_SwapFunctionOptionDisable == option)
         {
-            if (returnInfo.flashSwapState == kFLASH_swapStateDisabled)
+            if (returnInfo.flashSwapState == kFLASH_SwapStateDisabled)
             {
                 return kStatus_FLASH_Success;
             }
-            else if (returnInfo.flashSwapState == kFLASH_swapStateUninitialized)
+            else if (returnInfo.flashSwapState == kFLASH_SwapStateUninitialized)
             {
                 /* The swap system changed to the DISABLED state with Program flash block 0
                  * located at relative flash address 0x0_0000 */
-                returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionDisableSystem, &returnInfo);
+                returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionDisableSystem, &returnInfo);
             }
             else
             {
@@ -1679,12 +1999,12 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
              *    Complete. */
             switch (returnInfo.flashSwapState)
             {
-                case kFLASH_swapStateUninitialized:
+                case kFLASH_SwapStateUninitialized:
                     /* If current swap mode is Uninitialized, Initialize Swap to Initialized/READY state. */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionIntializeSystem, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionIntializeSystem, &returnInfo);
                     break;
-                case kFLASH_swapStateReady:
+                case kFLASH_SwapStateReady:
                     /* Validate whether the address provided to the swap system is matched to
                      * swap indicator address in the IFR */
                     returnCode = flash_validate_swap_indicator_address(config, address);
@@ -1692,23 +2012,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
                     {
                         /* If current swap mode is Initialized/Ready, Initialize Swap to UPDATE state. */
                         returnCode =
-                            FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInUpdateState, &returnInfo);
+                            FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInUpdateState, &returnInfo);
                     }
                     break;
-                case kFLASH_swapStateUpdate:
+                case kFLASH_SwapStateUpdate:
                     /* If current swap mode is Update, Erase indicator sector in non active block
                      * to proceed swap system to update-erased state */
                     returnCode = FLASH_Erase(config, address + (config->PFlashTotalSize >> 1),
-                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_apiEraseKey);
+                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_ApiEraseKey);
                     break;
-                case kFLASH_swapStateUpdateErased:
+                case kFLASH_SwapStateUpdateErased:
                     /* If current swap mode is Update or Update-Erased, progress Swap to COMPLETE State */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInCompleteState, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInCompleteState, &returnInfo);
                     break;
-                case kFLASH_swapStateComplete:
+                case kFLASH_SwapStateComplete:
                     break;
-                case kFLASH_swapStateDisabled:
+                case kFLASH_SwapStateDisabled:
                     /* When swap system is in disabled state, We need to clear swap system back to uninitialized
                      * by issuing EraseAllBlocks command */
                     returnCode = kStatus_FLASH_SwapSystemNotInUninitialized;
@@ -1722,7 +2042,7 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
         {
             break;
         }
-    } while (!((kFLASH_swapStateComplete == returnInfo.flashSwapState) && (kFLASH_swapFunctionOptionEnable == option)));
+    } while (!((kFLASH_SwapStateComplete == returnInfo.flashSwapState) && (kFLASH_SwapFunctionOptionEnable == option)));
 
     return returnCode;
 }
@@ -1766,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1881,70 +2240,289 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
-/*!
- * @brief Run flash command
- *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- *  flashloader (RAM-resident bootloader).
- */
-void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
-{
-    /* clear CCIF bit */
-    *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 
-    /* Check CCIF bit of the flash status register, wait till it is set.
-     * IP team indicates that this loop will always complete. */
-    while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
     {
-    }
-}
-
-/*!
- * @brief Be used for determining the size of flash_run_command()
- *
- * This function must be defined that lexically follows flash_run_command(),
- * so we can determine the size of flash_run_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_run_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_run_command() to RAM
- *
- * This function copys the memory between flash_run_command() and flash_run_command_end()
- * into the buffer which is also means that copying flash_run_command() to RAM.
- */
-static void copy_flash_run_command(uint8_t *flashRunCommand)
-{
-    /* Calculate the valid length of flash_run_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_run_command_end ahead of flash_run_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_run_command_start_addr = (uint32_t)flash_run_command & (~1U);
-    uint32_t flash_run_command_end_addr = (uint32_t)flash_run_command_end & (~1U);
-    if (flash_run_command_end_addr > flash_run_command_start_addr)
-    {
-        funcLength = flash_run_command_end_addr - flash_run_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_run_command
-         * and flash_run_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
         {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
         }
     }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*!
+ * @brief Copy PIC of flash_run_command() to RAM
+ */
+static void copy_flash_run_command(uint32_t *flashRunCommand)
+{
+    assert(sizeof(s_flashRunCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashRunCommand, (void *)flash_run_command_start_addr, funcLength);
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -1973,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2015,78 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Run flash cache clear command
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- * flashloader (RAM-resident bootloader).
  */
-void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MCM_PLACR_CFCC_MASK;
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-#if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
-#else
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
-#endif
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
-#else
-/*    #error "Unknown flash cache controller"  */
-#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
-       /* Memory barriers for good measure.
-        * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
-    __ISB();
-    __DSB();
-}
-
-/*!
- * @brief Be used for determining the size of flash_cache_clear_command()
- *
- * This function must be defined that lexically follows flash_cache_clear_command(),
- * so we can determine the size of flash_cache_clear_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_cache_clear_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_cache_clear_command() to RAM
- *
- * This function copys the memory between flash_cache_clear_command() and flash_cache_clear_command_end()
- * into the buffer which is also means that copying flash_cache_clear_command() to RAM.
- */
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
-{
-    /* Calculate the valid length of flash_cache_clear_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_cache_clear_command_end ahead of flash_cache_clear_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_cache_clear_command_start_addr = (uint32_t)flash_cache_clear_command & (~1U);
-    uint32_t flash_cache_clear_command_end_addr = (uint32_t)flash_cache_clear_command_end & (~1U);
-    if (flash_cache_clear_command_end_addr > flash_cache_clear_command_start_addr)
-    {
-        funcLength = flash_cache_clear_command_end_addr - flash_cache_clear_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_cache_clear_command
-         * and flash_cache_clear_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
-        {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
-        }
-    }
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)flash_cache_clear_command_start_addr, funcLength);
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2111,39 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
 #else
-    /* #error "Unknown flash cache controller" */
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
+#endif
+/* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2163,18 +2707,39 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
 #else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2191,7 +2756,7 @@ static status_t flash_check_execute_in_ram_function_info(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     if ((config->flashExecuteInRamFunctionInfo) &&
-        (kFLASH_executeInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
+        (kFLASH_ExecuteInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
     {
         return kStatus_FLASH_Success;
     }
@@ -2217,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2250,6 +2813,8 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2263,11 +2828,25 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     else
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
     {
-        info->convertedAddress = address;
+        info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2281,7 +2860,7 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 static status_t flash_check_user_key(uint32_t key)
 {
     /* Validate the user key */
-    if (key != kFLASH_apiEraseKey)
+    if (key != kFLASH_ApiEraseKey)
     {
         return kStatus_FLASH_EraseKeyError;
     }
@@ -2309,7 +2888,7 @@ static status_t flash_update_flexnvm_memory_partition_status(flash_config_t *con
 
     /* Get FlexNVM memory partition info from data flash IFR */
     returnCode = FLASH_ReadResource(config, DFLASH_IFR_READRESOURCE_START_ADDRESS, (uint32_t *)&dataIFRReadOut,
-                                    sizeof(dataIFRReadOut), kFLASH_resourceOptionFlashIfr);
+                                    sizeof(dataIFRReadOut), kFLASH_ResourceOptionFlashIfr);
     if (returnCode != kStatus_FLASH_Success)
     {
         return kStatus_FLASH_PartitionStatusUpdateFailure;
@@ -2515,27 +3094,27 @@ static status_t flash_check_resource_range(uint32_t start,
     status = kStatus_FLASH_Success;
 
     maxReadbleAddress = start + lengthInBytes - 1;
-    if (option == kFLASH_resourceOptionVersionId)
+    if (option == kFLASH_ResourceOptionVersionId)
     {
-        if ((start != kFLASH_resourceRangeVersionIdStart) ||
-            ((start + lengthInBytes - 1) != kFLASH_resourceRangeVersionIdEnd))
+        if ((start != kFLASH_ResourceRangeVersionIdStart) ||
+            ((start + lengthInBytes - 1) != kFLASH_ResourceRangeVersionIdEnd))
         {
             status = kStatus_FLASH_InvalidArgument;
         }
     }
-    else if (option == kFLASH_resourceOptionFlashIfr)
+    else if (option == kFLASH_ResourceOptionFlashIfr)
     {
-        if (maxReadbleAddress < kFLASH_resourceRangePflashIfrSizeInBytes)
+        if (maxReadbleAddress < kFLASH_ResourceRangePflashIfrSizeInBytes)
         {
         }
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
-        else if ((start >= kFLASH_resourceRangePflashSwapIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangePflashSwapIfrEnd))
+        else if ((start >= kFLASH_ResourceRangePflashSwapIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangePflashSwapIfrEnd))
         {
         }
 #endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
-        else if ((start >= kFLASH_resourceRangeDflashIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangeDflashIfrEnd))
+        else if ((start >= kFLASH_ResourceRangeDflashIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangeDflashIfrEnd))
         {
         }
         else
@@ -2556,9 +3135,9 @@ static status_t flash_check_resource_range(uint32_t start,
 /*! @brief Validates the gived swap control option.*/
 static status_t flash_check_swap_control_option(flash_swap_control_option_t option)
 {
-    if ((option == kFLASH_swapControlOptionIntializeSystem) || (option == kFLASH_swapControlOptionSetInUpdateState) ||
-        (option == kFLASH_swapControlOptionSetInCompleteState) || (option == kFLASH_swapControlOptionReportStatus) ||
-        (option == kFLASH_swapControlOptionDisableSystem))
+    if ((option == kFLASH_SwapControlOptionIntializeSystem) || (option == kFLASH_SwapControlOptionSetInUpdateState) ||
+        (option == kFLASH_SwapControlOptionSetInCompleteState) || (option == kFLASH_SwapControlOptionReportStatus) ||
+        (option == kFLASH_SwapControlOptionDisableSystem))
     {
         return kStatus_FLASH_Success;
     }
@@ -2571,21 +3150,23 @@ static status_t flash_check_swap_control_option(flash_swap_control_option_t opti
 /*! @brief Validates the gived address to see if it is equal to swap indicator address in pflash swap IFR.*/
 static status_t flash_validate_swap_indicator_address(flash_config_t *config, uint32_t address)
 {
-    flash_swap_ifr_field_config_t flashSwapIfrField;
+    flash_swap_ifr_field_data_t flashSwapIfrFieldData;
     uint32_t swapIndicatorAddress;
 
     status_t returnCode;
-    returnCode = FLASH_ReadResource(config, kFLASH_resourceRangePflashSwapIfrStart, (uint32_t *)&flashSwapIfrField,
-                                    sizeof(flash_swap_ifr_field_config_t), kFLASH_resourceOptionFlashIfr);
+    returnCode =
+        FLASH_ReadResource(config, kFLASH_ResourceRangePflashSwapIfrStart, flashSwapIfrFieldData.flashSwapIfrData,
+                           sizeof(flashSwapIfrFieldData.flashSwapIfrData), kFLASH_ResourceOptionFlashIfr);
+
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
     }
 
-    /* The high 2 byte value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
-     * the low 4 bit value of Swap Indicator Address is always 4'b0000 */
-    swapIndicatorAddress =
-        (uint32_t)flashSwapIfrField.swapIndicatorAddress * FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
+    /* The high bits value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
+     * the low severval bit value of Swap Indicator Address is always 1'b0 */
+    swapIndicatorAddress = (uint32_t)flashSwapIfrFieldData.flashSwapIfrField.swapIndicatorAddress *
+                           FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
     if (address != swapIndicatorAddress)
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
@@ -2599,8 +3180,8 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 /*! @brief Validates the gived flexram function option.*/
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option)
 {
-    if ((option != kFLASH_flexramFunctionOptionAvailableAsRam) &&
-        (option != kFLASH_flexramFunctionOptionAvailableForEeprom))
+    if ((option != kFLASH_FlexramFunctionOptionAvailableAsRam) &&
+        (option != kFLASH_FlexramFunctionOptionAvailableForEeprom))
     {
         return kStatus_FLASH_InvalidArgument;
     }
@@ -2608,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/drivers/fsl_flash.h
@@ -53,21 +53,21 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
-    kFLASH_driverVersionName = 'F', /*!< Flash driver version name.*/
-    kFLASH_driverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_driverVersionMinor = 1,  /*!< Minor flash driver version.*/
-    kFLASH_driverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
+    kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
+    kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
 
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -128,37 +149,43 @@ enum _flash_driver_version_constants
  */
 enum _flash_status
 {
-    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< Api is executed successfully*/
+    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< API is executed successfully*/
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< Api erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
-        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-ram function is not available.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as ram.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as ram.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
-    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash api is not supported.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
+    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -180,7 +207,7 @@ enum _flash_status
  */
 enum _flash_driver_api_keys
 {
-    kFLASH_apiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
+    kFLASH_ApiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
 };
 /*@}*/
 
@@ -189,10 +216,10 @@ enum _flash_driver_api_keys
  */
 typedef enum _flash_margin_value
 {
-    kFLASH_marginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
-    kFLASH_marginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
-    kFLASH_marginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
-    kFLASH_marginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
+    kFLASH_MarginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
+    kFLASH_MarginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
+    kFLASH_MarginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
+    kFLASH_MarginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
 } flash_margin_value_t;
 
 /*!
@@ -200,9 +227,9 @@ typedef enum _flash_margin_value
  */
 typedef enum _flash_security_state
 {
-    kFLASH_securityStateNotSecure,       /*!< Flash is not secure.*/
-    kFLASH_securityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
-    kFLASH_securityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
+    kFLASH_SecurityStateNotSecure,       /*!< Flash is not secure.*/
+    kFLASH_SecurityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
+    kFLASH_SecurityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
 } flash_security_state_t;
 
 /*!
@@ -210,9 +237,9 @@ typedef enum _flash_security_state
  */
 typedef enum _flash_protection_state
 {
-    kFLASH_protectionStateUnprotected, /*!< Flash region is not protected.*/
-    kFLASH_protectionStateProtected,   /*!< Flash region is protected.*/
-    kFLASH_protectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
+    kFLASH_ProtectionStateUnprotected, /*!< Flash region is not protected.*/
+    kFLASH_ProtectionStateProtected,   /*!< Flash region is protected.*/
+    kFLASH_ProtectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
 } flash_protection_state_t;
 
 /*!
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_accessStateUnLimited,   /*!< Flash region is unLimited.*/
-    kFLASH_accessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_accessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
+    kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -230,41 +257,42 @@ typedef enum _flash_execute_only_access_state
  */
 typedef enum _flash_property_tag
 {
-    kFLASH_propertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
-    kFLASH_propertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
-    kFLASH_propertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
-    kFLASH_propertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
-    kFLASH_propertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
-    kFLASH_propertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
-    kFLASH_propertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
-    kFLASH_propertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
-    kFLASH_propertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
-    kFLASH_propertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
-    kFLASH_propertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
-    kFLASH_propertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_propertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_propertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_propertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_propertyEepromTotalSize = 0x15U
+    kFLASH_PropertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
+    kFLASH_PropertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
+    kFLASH_PropertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
+    kFLASH_PropertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
+    kFLASH_PropertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
+    kFLASH_PropertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
+    kFLASH_PropertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
+    kFLASH_PropertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
+    kFLASH_PropertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
+    kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
+    kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
+    kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
- * @brief Constants for execute-in-ram flash function.
+ * @brief Constants for execute-in-RAM flash function.
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_executeInRamFunctionMaxSize = 64U, /*!< Max size of execute-in-ram function.*/
-    kFLASH_executeInRamFunctionTotalNum = 2U  /*!< Total number of execute-in-ram functions.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
 /*!
- * @brief Flash execute-in-ram function information.
+ * @brief Flash execute-in-RAM function information.
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;    /*!< Number of available execute-in-ram functions.*/
-    uint8_t *flashRunCommand;        /*!< execute-in-ram function: flash_run_command.*/
-    uint8_t *flashCacheClearCommand; /*!< execute-in-ram function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -272,9 +300,9 @@ typedef struct _flash_execute_in_ram_function_config
  */
 typedef enum _flash_read_resource_option
 {
-    kFLASH_resourceOptionFlashIfr =
+    kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_resourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -283,124 +311,234 @@ typedef enum _flash_read_resource_option
 enum _flash_read_resource_range
 {
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    kFLASH_resourceRangePflashIfrSizeInBytes = 1024U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x08U,       /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x0FU,         /*!< Version ID IFR end address.*/
-#else                                                 /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
-    kFLASH_resourceRangePflashIfrSizeInBytes = 256U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,   /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x00U,      /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x07U,        /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 1024U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,     /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x08U,        /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x0FU,          /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0x3FFU), /*!< Pflash swap IFR end address.*/
+#else                                                      /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 256U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x00U,       /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x07U,         /*!< Version ID IFR end address.*/
+#if 0x20000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x8000U, /*!< Pflash swap IFR start address.*/
+#elif 0x40000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x10000U, /*!< Pflash swap IFR start address.*/
+#elif 0x80000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x20000U, /*!< Pflash swap IFR start address.*/
+#else
+    kFLASH_ResourceRangePflashSwapIfrStart = 0,
 #endif
-    kFLASH_resourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
-    kFLASH_resourceRangePflashSwapIfrEnd = 0x403FFU,   /*!< Pflash swap IFR end address.*/
-    kFLASH_resourceRangeDflashIfrStart = 0x800000U,    /*!< Dflash IFR start address.*/
-    kFLASH_resourceRangeDflashIfrEnd = 0x8003FFU,      /*!< Dflash IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0xFFU), /*!< Pflash swap IFR end address.*/
+#endif
+    kFLASH_ResourceRangeDflashIfrStart = 0x800000U, /*!< Dflash IFR start address.*/
+    kFLASH_ResourceRangeDflashIfrEnd = 0x8003FFU,   /*!< Dflash IFR end address.*/
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_flexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_flexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
+
+/*!
+ * @brief Enumeration for acceleration RAM property.
+ */
+enum _flash_acceleration_ram_property
+{
+    kFLASH_AccelerationRamSize = 0x400U
+};
 
 /*!
  * @brief Enumeration for the possible options of Swap function
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_swapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_swapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_swapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_swapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_swapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_swapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_swapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_swapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_swapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_swapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_swapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_swapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_swapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
-    kFLASH_swapBlockStatusLowerHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusLowerHalfProgramBlocksAtZero =
         0x00U, /*!< Swap block status is that lower half program block at zero.*/
-    kFLASH_swapBlockStatusUpperHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusUpperHalfProgramBlocksAtZero =
         0x01U, /*!< Swap block status is that upper half program block at zero.*/
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fileds.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[6];          /*!< Reserved field.*/
-    uint16_t swapDisableWord;      /*!< Swap disable word field.*/
-    uint8_t reserved1[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
+#if (FSL_FEATURE_FLASH_IS_FTFE == 1)
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
+#endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief Flash Swap IFR field data
+ */
+typedef union _flash_swap_ifr_field_data
+{
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
+} flash_swap_ifr_field_data_t;
+
+/*!
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
-    kFLASH_partitionFlexramLoadOptionLoadedWithValidEepromData =
+    kFLASH_PartitionFlexramLoadOptionLoadedWithValidEepromData =
         0x00U, /*!< FlexRAM is loaded with valid EEPROM data during reset sequence.*/
-    kFLASH_partitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
+    kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -410,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-ram function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -445,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-ram functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -491,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -552,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -573,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as ram
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as ram
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -681,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -709,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -737,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -777,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -856,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -879,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -902,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -934,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -953,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -977,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1001,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1036,9 +1196,9 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
  * @param flexnvmPartitionCode Specifies how to split the FlexNVM block between data flash memory and EEPROM backup
  *        memory supporting EEPROM functions.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
  * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
@@ -1058,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1110,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1149,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/MKL43Z4_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/MKL43Z4_features.h
@@ -665,6 +665,8 @@
     #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (4)
     /* @brief P-Flash block swap feature. */
     #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (0)
+    /* @brief P-Flash protection region count. */
+    #define FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT (32)
     /* @brief Has FlexNVM memory. */
     #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
     /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,19 +193,75 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
 {
-    kFLASH_accessSegmentBase = 256UL,
-};
-
-/*!
- * @brief Enumeration for acceleration ram property.
- */
-enum _flash_acceleration_ram_property
-{
-    kFLASH_accelerationRamSize = 0x400U
+    kFLASH_AccessSegmentBase = 256UL,
 };
 
 /*!
@@ -212,25 +269,26 @@ enum _flash_acceleration_ram_property
  */
 enum _flash_config_area_range
 {
-    kFLASH_configAreaStart = 0x400U,
-    kFLASH_configAreaEnd = 0x40FU
+    kFLASH_ConfigAreaStart = 0x400U,
+    kFLASH_ConfigAreaEnd = 0x40FU
 };
-
-/*! @brief program Flash block base address*/
-#define PFLASH_BLOCK_BASE 0x00U
-
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
 
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -238,9 +296,9 @@ enum _flash_config_area_range
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief Copy flash_run_command() to RAM*/
-static void copy_flash_run_command(uint8_t *flashRunCommand);
+static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -291,44 +349,111 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
+
+/*!
+ * @brief Position independent code of flash_run_command()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
+ *   {
+ *       // clear CCIF bit
+ *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+ *
+ *       // Check CCIF bit of the flash status register, wait till it is set.
+ *       // IP team indicates that this loop will always complete.
+ *       while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+ *       {
+ *       }
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashRunCommandFunctionCode[] = {
+    0x2180, /* MOVS  R1, #128 ; 0x80 */
+    0x7001, /* STRB  R1, [R0] */
+    /* @4: */
+    0x7802, /* LDRB  R2, [R0] */
+    0x420a, /* TST   R2, R1 */
+    0xd0fc, /* BEQ.N @4 */
+    0x4770  /* BX    LR */
+};
+
+/*!
+ * @brief Position independent code of flash_common_bit_operation()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
+ *   {
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
+ *       __ISB();
+ *       __DSB();
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
+    0xf3bf, 0x8f6f, /* ISB */
+    0xf3bf, 0x8f4f, /* DSB */
+    0xbd10          /* POP   {R4, PC} */
+};
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
-static uint8_t s_flashRunCommand[kFLASH_executeInRamFunctionMaxSize];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint8_t s_flashCacheClearCommand[kFLASH_executeInRamFunctionMaxSize];
+static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -376,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = PFLASH_BLOCK_BASE;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_accessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -418,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -467,8 +639,8 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
-    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_executeInRamFunctionTotalNum;
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
+    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
 }
@@ -513,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -650,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -702,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -755,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -765,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -783,7 +955,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsRamError;
@@ -819,9 +991,9 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             uint32_t programSizeOfCurrentPass;
             uint32_t numberOfPhases;
 
-            if (lengthTobeProgrammedOfCurrentSector > kFLASH_accelerationRamSize)
+            if (lengthTobeProgrammedOfCurrentSector > kFLASH_AccelerationRamSize)
             {
-                programSizeOfCurrentPass = kFLASH_accelerationRamSize;
+                programSizeOfCurrentPass = kFLASH_AccelerationRamSize;
             }
             else
             {
@@ -833,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -867,7 +1039,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     /* Restore function of FlexRAM if needed. */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsEepromError;
@@ -904,7 +1076,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsEepromError;
@@ -950,7 +1122,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     /* Switch function of FlexRAM if needed */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsRamError;
@@ -966,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -986,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1008,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1075,7 +1248,7 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
     if (FLASH_SECURITY_STATE_UNSECURED == (registerValue & FTFx_FSEC_SEC_MASK))
     {
         /* Flash in unsecured state */
-        *state = kFLASH_securityStateNotSecure;
+        *state = kFLASH_SecurityStateNotSecure;
     }
     else
     {
@@ -1084,12 +1257,12 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
         if (FLASH_SECURITY_STATE_KEYEN == (registerValue & FTFx_FSEC_KEYEN_MASK))
         {
             /* Backdoor key security enabled */
-            *state = kFLASH_securityStateBackdoorEnabled;
+            *state = kFLASH_SecurityStateBackdoorEnabled;
         }
         else
         {
             /* Backdoor key security disabled */
-            *state = kFLASH_securityStateBackdoorDisabled;
+            *state = kFLASH_SecurityStateBackdoorDisabled;
         }
     }
 
@@ -1146,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1180,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1210,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1251,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1279,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1306,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1341,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1386,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1394,18 +1621,18 @@ status_t FLASH_IsProtected(flash_config_t *config,
     /* if protectStatusCounter == 0, then no region of the desired flash region is protected */
     if (protectStatusCounter == 0)
     {
-        *protection_state = kFLASH_protectionStateUnprotected;
+        *protection_state = kFLASH_ProtectionStateUnprotected;
     }
     /* if protectStatusCounter == regionCheckedCounter, then each region checked was protected */
     else if (protectStatusCounter == regionCheckedCounter)
     {
-        *protection_state = kFLASH_protectionStateProtected;
+        *protection_state = kFLASH_ProtectionStateProtected;
     }
     /* if protectStatusCounter != regionCheckedCounter, then protection status is mixed
      * In other words, some regions are protected while others are unprotected */
     else
     {
-        *protection_state = kFLASH_protectionStateMixed;
+        *protection_state = kFLASH_ProtectionStateMixed;
     }
 
     return (returnCode);
@@ -1416,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1431,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1438,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1471,24 +1733,24 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
         {
-            *access_state = kFLASH_accessStateUnLimited;
+            *access_state = kFLASH_AccessStateUnLimited;
         }
         else if (executeOnlySegmentCounter < maxSupportedExecuteOnlySegmentCount)
         {
-            *access_state = kFLASH_accessStateMixed;
+            *access_state = kFLASH_AccessStateMixed;
         }
         else
         {
-            *access_state = kFLASH_accessStateExecuteOnly;
+            *access_state = kFLASH_AccessStateExecuteOnly;
         }
     }
 #else
-    *access_state = kFLASH_accessStateUnLimited;
+    *access_state = kFLASH_AccessStateUnLimited;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
 
     return (returnCode);
@@ -1503,27 +1765,27 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     switch (whichProperty)
     {
-        case kFLASH_propertyPflashSectorSize:
+        case kFLASH_PropertyPflashSectorSize:
             *value = config->PFlashSectorSize;
             break;
 
-        case kFLASH_propertyPflashTotalSize:
+        case kFLASH_PropertyPflashTotalSize:
             *value = config->PFlashTotalSize;
             break;
 
-        case kFLASH_propertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockSize:
             *value = config->PFlashTotalSize / FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
             break;
 
-        case kFLASH_propertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockCount:
             *value = config->PFlashBlockCount;
             break;
 
-        case kFLASH_propertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashBlockBaseAddr:
             *value = config->PFlashBlockBase;
             break;
 
-        case kFLASH_propertyPflashFacSupport:
+        case kFLASH_PropertyPflashFacSupport:
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL)
             *value = FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL;
 #else
@@ -1531,31 +1793,39 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
             break;
 
-        case kFLASH_propertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentSize:
             *value = config->PFlashAccessSegmentSize;
             break;
 
-        case kFLASH_propertyPflashAccessSegmentCount:
+        case kFLASH_PropertyPflashAccessSegmentCount:
             *value = config->PFlashAccessSegmentCount;
             break;
 
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+            *value = config->FlexRAMBlockBase;
+            break;
+
+        case kFLASH_PropertyFlexRamTotalSize:
+            *value = config->FlexRAMTotalSize;
+            break;
+
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
-        case kFLASH_propertyDflashSectorSize:
+        case kFLASH_PropertyDflashSectorSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
             break;
-        case kFLASH_propertyDflashTotalSize:
+        case kFLASH_PropertyDflashTotalSize:
             *value = config->DFlashTotalSize;
             break;
-        case kFLASH_propertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE;
             break;
-        case kFLASH_propertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockCount:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
             break;
-        case kFLASH_propertyDflashBlockBaseAddr:
+        case kFLASH_PropertyDflashBlockBaseAddr:
             *value = config->DFlashBlockBase;
             break;
-        case kFLASH_propertyEepromTotalSize:
+        case kFLASH_PropertyEepromTotalSize:
             *value = config->EEpromTotalSize;
             break;
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
@@ -1566,6 +1836,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     return kStatus_FLASH_Success;
 }
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
@@ -1611,7 +1931,7 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     /* Make sure address provided is in the lower half of Program flash but not in the Flash Configuration Field */
     if ((address >= (config->PFlashTotalSize / 2)) ||
-        ((address >= kFLASH_configAreaStart) && (address <= kFLASH_configAreaEnd)))
+        ((address >= kFLASH_ConfigAreaStart) && (address <= kFLASH_ConfigAreaEnd)))
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
     }
@@ -1628,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1646,23 +1966,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
 
     do
     {
-        returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionReportStatus, &returnInfo);
+        returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionReportStatus, &returnInfo);
         if (returnCode != kStatus_FLASH_Success)
         {
             return returnCode;
         }
 
-        if (kFLASH_swapFunctionOptionDisable == option)
+        if (kFLASH_SwapFunctionOptionDisable == option)
         {
-            if (returnInfo.flashSwapState == kFLASH_swapStateDisabled)
+            if (returnInfo.flashSwapState == kFLASH_SwapStateDisabled)
             {
                 return kStatus_FLASH_Success;
             }
-            else if (returnInfo.flashSwapState == kFLASH_swapStateUninitialized)
+            else if (returnInfo.flashSwapState == kFLASH_SwapStateUninitialized)
             {
                 /* The swap system changed to the DISABLED state with Program flash block 0
                  * located at relative flash address 0x0_0000 */
-                returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionDisableSystem, &returnInfo);
+                returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionDisableSystem, &returnInfo);
             }
             else
             {
@@ -1679,12 +1999,12 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
              *    Complete. */
             switch (returnInfo.flashSwapState)
             {
-                case kFLASH_swapStateUninitialized:
+                case kFLASH_SwapStateUninitialized:
                     /* If current swap mode is Uninitialized, Initialize Swap to Initialized/READY state. */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionIntializeSystem, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionIntializeSystem, &returnInfo);
                     break;
-                case kFLASH_swapStateReady:
+                case kFLASH_SwapStateReady:
                     /* Validate whether the address provided to the swap system is matched to
                      * swap indicator address in the IFR */
                     returnCode = flash_validate_swap_indicator_address(config, address);
@@ -1692,23 +2012,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
                     {
                         /* If current swap mode is Initialized/Ready, Initialize Swap to UPDATE state. */
                         returnCode =
-                            FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInUpdateState, &returnInfo);
+                            FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInUpdateState, &returnInfo);
                     }
                     break;
-                case kFLASH_swapStateUpdate:
+                case kFLASH_SwapStateUpdate:
                     /* If current swap mode is Update, Erase indicator sector in non active block
                      * to proceed swap system to update-erased state */
                     returnCode = FLASH_Erase(config, address + (config->PFlashTotalSize >> 1),
-                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_apiEraseKey);
+                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_ApiEraseKey);
                     break;
-                case kFLASH_swapStateUpdateErased:
+                case kFLASH_SwapStateUpdateErased:
                     /* If current swap mode is Update or Update-Erased, progress Swap to COMPLETE State */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInCompleteState, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInCompleteState, &returnInfo);
                     break;
-                case kFLASH_swapStateComplete:
+                case kFLASH_SwapStateComplete:
                     break;
-                case kFLASH_swapStateDisabled:
+                case kFLASH_SwapStateDisabled:
                     /* When swap system is in disabled state, We need to clear swap system back to uninitialized
                      * by issuing EraseAllBlocks command */
                     returnCode = kStatus_FLASH_SwapSystemNotInUninitialized;
@@ -1722,7 +2042,7 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
         {
             break;
         }
-    } while (!((kFLASH_swapStateComplete == returnInfo.flashSwapState) && (kFLASH_swapFunctionOptionEnable == option)));
+    } while (!((kFLASH_SwapStateComplete == returnInfo.flashSwapState) && (kFLASH_SwapFunctionOptionEnable == option)));
 
     return returnCode;
 }
@@ -1766,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1881,70 +2240,289 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
-/*!
- * @brief Run flash command
- *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- *  flashloader (RAM-resident bootloader).
- */
-void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
-{
-    /* clear CCIF bit */
-    *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 
-    /* Check CCIF bit of the flash status register, wait till it is set.
-     * IP team indicates that this loop will always complete. */
-    while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
     {
-    }
-}
-
-/*!
- * @brief Be used for determining the size of flash_run_command()
- *
- * This function must be defined that lexically follows flash_run_command(),
- * so we can determine the size of flash_run_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_run_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_run_command() to RAM
- *
- * This function copys the memory between flash_run_command() and flash_run_command_end()
- * into the buffer which is also means that copying flash_run_command() to RAM.
- */
-static void copy_flash_run_command(uint8_t *flashRunCommand)
-{
-    /* Calculate the valid length of flash_run_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_run_command_end ahead of flash_run_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_run_command_start_addr = (uint32_t)flash_run_command & (~1U);
-    uint32_t flash_run_command_end_addr = (uint32_t)flash_run_command_end & (~1U);
-    if (flash_run_command_end_addr > flash_run_command_start_addr)
-    {
-        funcLength = flash_run_command_end_addr - flash_run_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_run_command
-         * and flash_run_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
         {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
         }
     }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*!
+ * @brief Copy PIC of flash_run_command() to RAM
+ */
+static void copy_flash_run_command(uint32_t *flashRunCommand)
+{
+    assert(sizeof(s_flashRunCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashRunCommand, (void *)flash_run_command_start_addr, funcLength);
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -1973,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2015,78 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Run flash cache clear command
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- * flashloader (RAM-resident bootloader).
  */
-void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MCM_PLACR_CFCC_MASK;
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-#if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
-#else
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
-#endif
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
-#else
-/*    #error "Unknown flash cache controller"  */
-#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
-       /* Memory barriers for good measure.
-        * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
-    __ISB();
-    __DSB();
-}
-
-/*!
- * @brief Be used for determining the size of flash_cache_clear_command()
- *
- * This function must be defined that lexically follows flash_cache_clear_command(),
- * so we can determine the size of flash_cache_clear_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_cache_clear_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_cache_clear_command() to RAM
- *
- * This function copys the memory between flash_cache_clear_command() and flash_cache_clear_command_end()
- * into the buffer which is also means that copying flash_cache_clear_command() to RAM.
- */
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
-{
-    /* Calculate the valid length of flash_cache_clear_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_cache_clear_command_end ahead of flash_cache_clear_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_cache_clear_command_start_addr = (uint32_t)flash_cache_clear_command & (~1U);
-    uint32_t flash_cache_clear_command_end_addr = (uint32_t)flash_cache_clear_command_end & (~1U);
-    if (flash_cache_clear_command_end_addr > flash_cache_clear_command_start_addr)
-    {
-        funcLength = flash_cache_clear_command_end_addr - flash_cache_clear_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_cache_clear_command
-         * and flash_cache_clear_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
-        {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
-        }
-    }
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)flash_cache_clear_command_start_addr, funcLength);
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2111,39 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
 #else
-    /* #error "Unknown flash cache controller" */
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
+#endif
+/* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2163,18 +2707,39 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
 #else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2191,7 +2756,7 @@ static status_t flash_check_execute_in_ram_function_info(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     if ((config->flashExecuteInRamFunctionInfo) &&
-        (kFLASH_executeInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
+        (kFLASH_ExecuteInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
     {
         return kStatus_FLASH_Success;
     }
@@ -2217,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2250,6 +2813,8 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2263,11 +2828,25 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     else
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
     {
-        info->convertedAddress = address;
+        info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2281,7 +2860,7 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 static status_t flash_check_user_key(uint32_t key)
 {
     /* Validate the user key */
-    if (key != kFLASH_apiEraseKey)
+    if (key != kFLASH_ApiEraseKey)
     {
         return kStatus_FLASH_EraseKeyError;
     }
@@ -2309,7 +2888,7 @@ static status_t flash_update_flexnvm_memory_partition_status(flash_config_t *con
 
     /* Get FlexNVM memory partition info from data flash IFR */
     returnCode = FLASH_ReadResource(config, DFLASH_IFR_READRESOURCE_START_ADDRESS, (uint32_t *)&dataIFRReadOut,
-                                    sizeof(dataIFRReadOut), kFLASH_resourceOptionFlashIfr);
+                                    sizeof(dataIFRReadOut), kFLASH_ResourceOptionFlashIfr);
     if (returnCode != kStatus_FLASH_Success)
     {
         return kStatus_FLASH_PartitionStatusUpdateFailure;
@@ -2515,27 +3094,27 @@ static status_t flash_check_resource_range(uint32_t start,
     status = kStatus_FLASH_Success;
 
     maxReadbleAddress = start + lengthInBytes - 1;
-    if (option == kFLASH_resourceOptionVersionId)
+    if (option == kFLASH_ResourceOptionVersionId)
     {
-        if ((start != kFLASH_resourceRangeVersionIdStart) ||
-            ((start + lengthInBytes - 1) != kFLASH_resourceRangeVersionIdEnd))
+        if ((start != kFLASH_ResourceRangeVersionIdStart) ||
+            ((start + lengthInBytes - 1) != kFLASH_ResourceRangeVersionIdEnd))
         {
             status = kStatus_FLASH_InvalidArgument;
         }
     }
-    else if (option == kFLASH_resourceOptionFlashIfr)
+    else if (option == kFLASH_ResourceOptionFlashIfr)
     {
-        if (maxReadbleAddress < kFLASH_resourceRangePflashIfrSizeInBytes)
+        if (maxReadbleAddress < kFLASH_ResourceRangePflashIfrSizeInBytes)
         {
         }
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
-        else if ((start >= kFLASH_resourceRangePflashSwapIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangePflashSwapIfrEnd))
+        else if ((start >= kFLASH_ResourceRangePflashSwapIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangePflashSwapIfrEnd))
         {
         }
 #endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
-        else if ((start >= kFLASH_resourceRangeDflashIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangeDflashIfrEnd))
+        else if ((start >= kFLASH_ResourceRangeDflashIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangeDflashIfrEnd))
         {
         }
         else
@@ -2556,9 +3135,9 @@ static status_t flash_check_resource_range(uint32_t start,
 /*! @brief Validates the gived swap control option.*/
 static status_t flash_check_swap_control_option(flash_swap_control_option_t option)
 {
-    if ((option == kFLASH_swapControlOptionIntializeSystem) || (option == kFLASH_swapControlOptionSetInUpdateState) ||
-        (option == kFLASH_swapControlOptionSetInCompleteState) || (option == kFLASH_swapControlOptionReportStatus) ||
-        (option == kFLASH_swapControlOptionDisableSystem))
+    if ((option == kFLASH_SwapControlOptionIntializeSystem) || (option == kFLASH_SwapControlOptionSetInUpdateState) ||
+        (option == kFLASH_SwapControlOptionSetInCompleteState) || (option == kFLASH_SwapControlOptionReportStatus) ||
+        (option == kFLASH_SwapControlOptionDisableSystem))
     {
         return kStatus_FLASH_Success;
     }
@@ -2571,21 +3150,23 @@ static status_t flash_check_swap_control_option(flash_swap_control_option_t opti
 /*! @brief Validates the gived address to see if it is equal to swap indicator address in pflash swap IFR.*/
 static status_t flash_validate_swap_indicator_address(flash_config_t *config, uint32_t address)
 {
-    flash_swap_ifr_field_config_t flashSwapIfrField;
+    flash_swap_ifr_field_data_t flashSwapIfrFieldData;
     uint32_t swapIndicatorAddress;
 
     status_t returnCode;
-    returnCode = FLASH_ReadResource(config, kFLASH_resourceRangePflashSwapIfrStart, (uint32_t *)&flashSwapIfrField,
-                                    sizeof(flash_swap_ifr_field_config_t), kFLASH_resourceOptionFlashIfr);
+    returnCode =
+        FLASH_ReadResource(config, kFLASH_ResourceRangePflashSwapIfrStart, flashSwapIfrFieldData.flashSwapIfrData,
+                           sizeof(flashSwapIfrFieldData.flashSwapIfrData), kFLASH_ResourceOptionFlashIfr);
+
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
     }
 
-    /* The high 2 byte value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
-     * the low 4 bit value of Swap Indicator Address is always 4'b0000 */
-    swapIndicatorAddress =
-        (uint32_t)flashSwapIfrField.swapIndicatorAddress * FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
+    /* The high bits value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
+     * the low severval bit value of Swap Indicator Address is always 1'b0 */
+    swapIndicatorAddress = (uint32_t)flashSwapIfrFieldData.flashSwapIfrField.swapIndicatorAddress *
+                           FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
     if (address != swapIndicatorAddress)
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
@@ -2599,8 +3180,8 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 /*! @brief Validates the gived flexram function option.*/
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option)
 {
-    if ((option != kFLASH_flexramFunctionOptionAvailableAsRam) &&
-        (option != kFLASH_flexramFunctionOptionAvailableForEeprom))
+    if ((option != kFLASH_FlexramFunctionOptionAvailableAsRam) &&
+        (option != kFLASH_FlexramFunctionOptionAvailableForEeprom))
     {
         return kStatus_FLASH_InvalidArgument;
     }
@@ -2608,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/drivers/fsl_flash.h
@@ -53,21 +53,21 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
-    kFLASH_driverVersionName = 'F', /*!< Flash driver version name.*/
-    kFLASH_driverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_driverVersionMinor = 1,  /*!< Minor flash driver version.*/
-    kFLASH_driverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
+    kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
+    kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
 
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -128,37 +149,43 @@ enum _flash_driver_version_constants
  */
 enum _flash_status
 {
-    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< Api is executed successfully*/
+    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< API is executed successfully*/
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< Api erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
-        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-ram function is not available.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as ram.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as ram.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
-    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash api is not supported.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
+    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -180,7 +207,7 @@ enum _flash_status
  */
 enum _flash_driver_api_keys
 {
-    kFLASH_apiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
+    kFLASH_ApiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
 };
 /*@}*/
 
@@ -189,10 +216,10 @@ enum _flash_driver_api_keys
  */
 typedef enum _flash_margin_value
 {
-    kFLASH_marginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
-    kFLASH_marginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
-    kFLASH_marginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
-    kFLASH_marginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
+    kFLASH_MarginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
+    kFLASH_MarginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
+    kFLASH_MarginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
+    kFLASH_MarginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
 } flash_margin_value_t;
 
 /*!
@@ -200,9 +227,9 @@ typedef enum _flash_margin_value
  */
 typedef enum _flash_security_state
 {
-    kFLASH_securityStateNotSecure,       /*!< Flash is not secure.*/
-    kFLASH_securityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
-    kFLASH_securityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
+    kFLASH_SecurityStateNotSecure,       /*!< Flash is not secure.*/
+    kFLASH_SecurityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
+    kFLASH_SecurityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
 } flash_security_state_t;
 
 /*!
@@ -210,9 +237,9 @@ typedef enum _flash_security_state
  */
 typedef enum _flash_protection_state
 {
-    kFLASH_protectionStateUnprotected, /*!< Flash region is not protected.*/
-    kFLASH_protectionStateProtected,   /*!< Flash region is protected.*/
-    kFLASH_protectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
+    kFLASH_ProtectionStateUnprotected, /*!< Flash region is not protected.*/
+    kFLASH_ProtectionStateProtected,   /*!< Flash region is protected.*/
+    kFLASH_ProtectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
 } flash_protection_state_t;
 
 /*!
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_accessStateUnLimited,   /*!< Flash region is unLimited.*/
-    kFLASH_accessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_accessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
+    kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -230,41 +257,42 @@ typedef enum _flash_execute_only_access_state
  */
 typedef enum _flash_property_tag
 {
-    kFLASH_propertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
-    kFLASH_propertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
-    kFLASH_propertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
-    kFLASH_propertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
-    kFLASH_propertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
-    kFLASH_propertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
-    kFLASH_propertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
-    kFLASH_propertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
-    kFLASH_propertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
-    kFLASH_propertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
-    kFLASH_propertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
-    kFLASH_propertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_propertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_propertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_propertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_propertyEepromTotalSize = 0x15U
+    kFLASH_PropertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
+    kFLASH_PropertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
+    kFLASH_PropertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
+    kFLASH_PropertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
+    kFLASH_PropertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
+    kFLASH_PropertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
+    kFLASH_PropertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
+    kFLASH_PropertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
+    kFLASH_PropertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
+    kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
+    kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
+    kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
- * @brief Constants for execute-in-ram flash function.
+ * @brief Constants for execute-in-RAM flash function.
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_executeInRamFunctionMaxSize = 64U, /*!< Max size of execute-in-ram function.*/
-    kFLASH_executeInRamFunctionTotalNum = 2U  /*!< Total number of execute-in-ram functions.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
 /*!
- * @brief Flash execute-in-ram function information.
+ * @brief Flash execute-in-RAM function information.
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;    /*!< Number of available execute-in-ram functions.*/
-    uint8_t *flashRunCommand;        /*!< execute-in-ram function: flash_run_command.*/
-    uint8_t *flashCacheClearCommand; /*!< execute-in-ram function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -272,9 +300,9 @@ typedef struct _flash_execute_in_ram_function_config
  */
 typedef enum _flash_read_resource_option
 {
-    kFLASH_resourceOptionFlashIfr =
+    kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_resourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -283,124 +311,234 @@ typedef enum _flash_read_resource_option
 enum _flash_read_resource_range
 {
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    kFLASH_resourceRangePflashIfrSizeInBytes = 1024U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x08U,       /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x0FU,         /*!< Version ID IFR end address.*/
-#else                                                 /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
-    kFLASH_resourceRangePflashIfrSizeInBytes = 256U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,   /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x00U,      /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x07U,        /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 1024U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,     /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x08U,        /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x0FU,          /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0x3FFU), /*!< Pflash swap IFR end address.*/
+#else                                                      /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 256U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x00U,       /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x07U,         /*!< Version ID IFR end address.*/
+#if 0x20000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x8000U, /*!< Pflash swap IFR start address.*/
+#elif 0x40000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x10000U, /*!< Pflash swap IFR start address.*/
+#elif 0x80000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x20000U, /*!< Pflash swap IFR start address.*/
+#else
+    kFLASH_ResourceRangePflashSwapIfrStart = 0,
 #endif
-    kFLASH_resourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
-    kFLASH_resourceRangePflashSwapIfrEnd = 0x403FFU,   /*!< Pflash swap IFR end address.*/
-    kFLASH_resourceRangeDflashIfrStart = 0x800000U,    /*!< Dflash IFR start address.*/
-    kFLASH_resourceRangeDflashIfrEnd = 0x8003FFU,      /*!< Dflash IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0xFFU), /*!< Pflash swap IFR end address.*/
+#endif
+    kFLASH_ResourceRangeDflashIfrStart = 0x800000U, /*!< Dflash IFR start address.*/
+    kFLASH_ResourceRangeDflashIfrEnd = 0x8003FFU,   /*!< Dflash IFR end address.*/
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_flexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_flexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
+
+/*!
+ * @brief Enumeration for acceleration RAM property.
+ */
+enum _flash_acceleration_ram_property
+{
+    kFLASH_AccelerationRamSize = 0x400U
+};
 
 /*!
  * @brief Enumeration for the possible options of Swap function
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_swapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_swapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_swapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_swapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_swapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_swapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_swapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_swapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_swapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_swapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_swapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_swapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_swapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
-    kFLASH_swapBlockStatusLowerHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusLowerHalfProgramBlocksAtZero =
         0x00U, /*!< Swap block status is that lower half program block at zero.*/
-    kFLASH_swapBlockStatusUpperHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusUpperHalfProgramBlocksAtZero =
         0x01U, /*!< Swap block status is that upper half program block at zero.*/
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fileds.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[6];          /*!< Reserved field.*/
-    uint16_t swapDisableWord;      /*!< Swap disable word field.*/
-    uint8_t reserved1[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
+#if (FSL_FEATURE_FLASH_IS_FTFE == 1)
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
+#endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief Flash Swap IFR field data
+ */
+typedef union _flash_swap_ifr_field_data
+{
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
+} flash_swap_ifr_field_data_t;
+
+/*!
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
-    kFLASH_partitionFlexramLoadOptionLoadedWithValidEepromData =
+    kFLASH_PartitionFlexramLoadOptionLoadedWithValidEepromData =
         0x00U, /*!< FlexRAM is loaded with valid EEPROM data during reset sequence.*/
-    kFLASH_partitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
+    kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -410,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-ram function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -445,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-ram functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -491,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -552,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -573,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as ram
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as ram
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -681,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -709,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -737,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -777,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -856,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -879,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -902,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -934,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -953,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -977,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1001,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1036,9 +1196,9 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
  * @param flexnvmPartitionCode Specifies how to split the FlexNVM block between data flash memory and EEPROM backup
  *        memory supporting EEPROM functions.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
  * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
@@ -1058,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1110,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1149,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/MKL82Z7_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/MKL82Z7_features.h
@@ -472,6 +472,8 @@
 #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (8)
 /* @brief P-Flash block swap feature. */
 #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (0)
+/* @brief P-Flash protection region count. */
+#define FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT (32)
 /* @brief Has FlexNVM memory. */
 #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
 /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,6 +193,70 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
@@ -208,18 +273,22 @@ enum _flash_config_area_range
     kFLASH_ConfigAreaEnd = 0x40FU
 };
 
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
-
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -229,7 +298,7 @@ enum _flash_config_area_range
 /*! @brief Copy flash_run_command() to RAM*/
 static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -280,44 +349,46 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
 
 /*!
  * @brief Position independent code of flash_run_command()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
  *   {
  *       // clear CCIF bit
  *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
@@ -329,9 +400,9 @@ static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
  *       }
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-const static uint16_t s_flashRunCommandFunctionCode[] = {
+static const uint16_t s_flashRunCommandFunctionCode[] = {
     0x2180, /* MOVS  R1, #128 ; 0x80 */
     0x7001, /* STRB  R1, [R0] */
     /* @4: */
@@ -342,102 +413,47 @@ const static uint16_t s_flashRunCommandFunctionCode[] = {
 };
 
 /*!
- * @brief Position independent code of flash_cache_clear_command()
+ * @brief Position independent code of flash_common_bit_operation()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
  *   {
- *   #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MCM_PLACR_CFCC_MASK;
- *   #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
- *   #if defined(FMC_PFB01CR_CINV_WAY_MASK)
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
- *   #else
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
- *   #endif
- *   #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
- *   #else
- *   #if defined(FMC_PFB0CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB0CR_S_INV_MASK;
- *   #elif defined(FMC_PFB01CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB01CR_S_INV_MASK;
- *   #endif
- *   //    #error "Unknown flash cache controller"
- *   #endif // FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS
- *       // Memory barriers for good measure.
- *       // All Cache, Branch predictor and TLB maintenance operations before this instruction complete
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
  *       __ISB();
  *       __DSB();
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2280,         /* MOVS R2, #128   ; 0x80 */
-    0x00d2,         /* LSLS R2, R2, #3 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
     0xf3bf, 0x8f6f, /* ISB */
     0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
+    0xbd10          /* POP   {R4, PC} */
 };
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x22f0,         /* MOVS R2, #240    ; 0xf0 */
-    0x0412,         /* LSLS R2, R2, #16 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2220,         /* MOVS R2, #32    ; 0x20 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0x6801,         /* LDR  R1, [R0] */
-    0x2210,         /* MOVS R2, #16    ; 0x10 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-#if defined(FMC_PFB0CR_S_INV_MASK) || defined(FMC_PFB01CR_S_INV_MASK)
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0]  */
-    0x2280,         /* MOVS R2, #128    ; 0x80 */
-    0x0312,         /* LSLS R2, R2, #12 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#endif
-#endif
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
 static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint32_t s_flashCacheClearCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -485,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -527,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -576,7 +639,7 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
     flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
@@ -622,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -759,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -811,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -864,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -874,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -942,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -1075,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -1095,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1117,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1255,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1289,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1319,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1360,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1388,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1415,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1450,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1495,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1525,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1540,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1547,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1580,7 +1733,7 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
@@ -1684,6 +1837,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
     return kStatus_FLASH_Success;
 }
 
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
 {
@@ -1745,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1883,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1998,6 +2240,277 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
  * @brief Copy PIC of flash_run_command() to RAM
@@ -2009,7 +2522,7 @@ static void copy_flash_run_command(uint32_t *flashRunCommand)
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
     memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2038,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2080,18 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Copy PIC of flash_cache_clear_command() to RAM
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
  */
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-    assert(sizeof(s_flashCacheClearCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)s_flashCacheClearCommandFunctionCode,
-           sizeof(s_flashCacheClearCommandFunctionCode));
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2116,45 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
 #elif defined(FMC_PFB01CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
-#else
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
 #endif
 /* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2174,8 +2707,18 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
     FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
@@ -2184,13 +2727,19 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2233,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2263,11 +2810,11 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     /* Clean up info Structure*/
     memset(info, 0, sizeof(flash_operation_config_t));
 
-/* When required by the command, address bit 23 selects between program flash memory
- * (=0) and data flash memory (=1).*/
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2284,8 +2831,22 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
         info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2628,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/drivers/fsl_flash.h
@@ -53,20 +53,20 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
     kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
     kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_DriverVersionMinor = 1,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
     kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -132,33 +153,39 @@ enum _flash_status
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< API erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
         MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as RAM.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as RAM.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
     kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_AccessStateUnLimited,   /*!< Flash region is unLimited.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
     kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_AccessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -242,10 +269,11 @@ typedef enum _flash_property_tag
     kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
     kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
     kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_PropertyEepromTotalSize = 0x15U
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
@@ -253,7 +281,7 @@ typedef enum _flash_property_tag
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< Max size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
     kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
@@ -262,9 +290,9 @@ enum _flash_execute_in_ram_function_constants
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;     /*!< Number of available execute-in-RAM functions.*/
-    uint32_t *flashRunCommand;        /*!< execute-in-RAM function: flash_run_command.*/
-    uint32_t *flashCacheClearCommand; /*!< execute-in-RAM function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -274,7 +302,7 @@ typedef enum _flash_read_resource_option
 {
     kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -312,12 +340,12 @@ enum _flash_read_resource_range
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
 
 /*!
@@ -333,37 +361,37 @@ enum _flash_acceleration_ram_property
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_SwapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
@@ -374,41 +402,72 @@ typedef enum _flash_swap_block_status
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fields.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    uint8_t reserved1[2];     /*!< Reserved field.*/
-    uint16_t swapDisableWord; /*!< Swap disable word field.*/
-    uint8_t reserved2[4];     /*!< Reserved field.*/
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
 #endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Flash Swap IFR field data.
+ * @brief Flash Swap IFR field data
  */
 typedef union _flash_swap_ifr_field_data
 {
-    uint32_t flashSwapIfrData[2];                    /*!< Flash Swap IFR field data .*/
-    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< Flash Swap IFR field struct.*/
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
 } flash_swap_ifr_field_data_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
@@ -417,22 +476,69 @@ typedef enum _flash_partition_flexram_load_option
     kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -442,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-RAM function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -477,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-RAM functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -523,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -584,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -605,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as RAM
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -713,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -741,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -769,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -809,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -888,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -911,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -934,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -966,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -985,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -1009,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1033,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1090,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1142,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1181,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/MKW24D5_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/MKW24D5_features.h
@@ -434,6 +434,8 @@
 #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (8)
 /* @brief P-Flash block swap feature. */
 #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (1)
+/* @brief P-Flash protection region count. */
+#define FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT (32)
 /* @brief Has FlexNVM memory. */
 #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
 /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,6 +193,70 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
@@ -208,18 +273,22 @@ enum _flash_config_area_range
     kFLASH_ConfigAreaEnd = 0x40FU
 };
 
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
-
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -229,7 +298,7 @@ enum _flash_config_area_range
 /*! @brief Copy flash_run_command() to RAM*/
 static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -280,44 +349,46 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
 
 /*!
  * @brief Position independent code of flash_run_command()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
  *   {
  *       // clear CCIF bit
  *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
@@ -329,9 +400,9 @@ static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
  *       }
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-const static uint16_t s_flashRunCommandFunctionCode[] = {
+static const uint16_t s_flashRunCommandFunctionCode[] = {
     0x2180, /* MOVS  R1, #128 ; 0x80 */
     0x7001, /* STRB  R1, [R0] */
     /* @4: */
@@ -342,102 +413,47 @@ const static uint16_t s_flashRunCommandFunctionCode[] = {
 };
 
 /*!
- * @brief Position independent code of flash_cache_clear_command()
+ * @brief Position independent code of flash_common_bit_operation()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
  *   {
- *   #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MCM_PLACR_CFCC_MASK;
- *   #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
- *   #if defined(FMC_PFB01CR_CINV_WAY_MASK)
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
- *   #else
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
- *   #endif
- *   #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
- *   #else
- *   #if defined(FMC_PFB0CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB0CR_S_INV_MASK;
- *   #elif defined(FMC_PFB01CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB01CR_S_INV_MASK;
- *   #endif
- *   //    #error "Unknown flash cache controller"
- *   #endif // FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS
- *       // Memory barriers for good measure.
- *       // All Cache, Branch predictor and TLB maintenance operations before this instruction complete
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
  *       __ISB();
  *       __DSB();
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2280,         /* MOVS R2, #128   ; 0x80 */
-    0x00d2,         /* LSLS R2, R2, #3 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
     0xf3bf, 0x8f6f, /* ISB */
     0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
+    0xbd10          /* POP   {R4, PC} */
 };
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x22f0,         /* MOVS R2, #240    ; 0xf0 */
-    0x0412,         /* LSLS R2, R2, #16 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2220,         /* MOVS R2, #32    ; 0x20 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0x6801,         /* LDR  R1, [R0] */
-    0x2210,         /* MOVS R2, #16    ; 0x10 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-#if defined(FMC_PFB0CR_S_INV_MASK) || defined(FMC_PFB01CR_S_INV_MASK)
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0]  */
-    0x2280,         /* MOVS R2, #128    ; 0x80 */
-    0x0312,         /* LSLS R2, R2, #12 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#endif
-#endif
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
 static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint32_t s_flashCacheClearCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -485,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -527,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -576,7 +639,7 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
     flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
@@ -622,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -759,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -811,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -864,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -874,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -942,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -1075,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -1095,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1117,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1255,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1289,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1319,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1360,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1388,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1415,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1450,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1495,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1525,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1540,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1547,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1580,7 +1733,7 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
@@ -1684,6 +1837,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
     return kStatus_FLASH_Success;
 }
 
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
 {
@@ -1745,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1883,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1998,6 +2240,277 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
  * @brief Copy PIC of flash_run_command() to RAM
@@ -2009,7 +2522,7 @@ static void copy_flash_run_command(uint32_t *flashRunCommand)
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
     memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2038,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2080,18 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Copy PIC of flash_cache_clear_command() to RAM
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
  */
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-    assert(sizeof(s_flashCacheClearCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)s_flashCacheClearCommandFunctionCode,
-           sizeof(s_flashCacheClearCommandFunctionCode));
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2116,45 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
 #elif defined(FMC_PFB01CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
-#else
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
 #endif
 /* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2174,8 +2707,18 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
     FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
@@ -2184,13 +2727,19 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2233,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2263,11 +2810,11 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     /* Clean up info Structure*/
     memset(info, 0, sizeof(flash_operation_config_t));
 
-/* When required by the command, address bit 23 selects between program flash memory
- * (=0) and data flash memory (=1).*/
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2284,8 +2831,22 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
         info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2628,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/drivers/fsl_flash.h
@@ -53,20 +53,20 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
     kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
     kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_DriverVersionMinor = 1,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
     kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -132,33 +153,39 @@ enum _flash_status
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< API erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
         MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as RAM.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as RAM.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
     kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_AccessStateUnLimited,   /*!< Flash region is unLimited.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
     kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_AccessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -242,10 +269,11 @@ typedef enum _flash_property_tag
     kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
     kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
     kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_PropertyEepromTotalSize = 0x15U
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
@@ -253,7 +281,7 @@ typedef enum _flash_property_tag
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< Max size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
     kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
@@ -262,9 +290,9 @@ enum _flash_execute_in_ram_function_constants
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;     /*!< Number of available execute-in-RAM functions.*/
-    uint32_t *flashRunCommand;        /*!< execute-in-RAM function: flash_run_command.*/
-    uint32_t *flashCacheClearCommand; /*!< execute-in-RAM function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -274,7 +302,7 @@ typedef enum _flash_read_resource_option
 {
     kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -312,12 +340,12 @@ enum _flash_read_resource_range
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
 
 /*!
@@ -333,37 +361,37 @@ enum _flash_acceleration_ram_property
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_SwapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
@@ -374,41 +402,72 @@ typedef enum _flash_swap_block_status
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fields.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    uint8_t reserved1[2];     /*!< Reserved field.*/
-    uint16_t swapDisableWord; /*!< Swap disable word field.*/
-    uint8_t reserved2[4];     /*!< Reserved field.*/
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
 #endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Flash Swap IFR field data.
+ * @brief Flash Swap IFR field data
  */
 typedef union _flash_swap_ifr_field_data
 {
-    uint32_t flashSwapIfrData[2];                    /*!< Flash Swap IFR field data .*/
-    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< Flash Swap IFR field struct.*/
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
 } flash_swap_ifr_field_data_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
@@ -417,22 +476,69 @@ typedef enum _flash_partition_flexram_load_option
     kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -442,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-RAM function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -477,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-RAM functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -523,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -584,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -605,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as RAM
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -713,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -741,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -769,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -809,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -888,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -911,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -934,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -966,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -985,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -1009,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1033,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1090,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1142,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1181,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,6 +193,70 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
@@ -208,18 +273,22 @@ enum _flash_config_area_range
     kFLASH_ConfigAreaEnd = 0x40FU
 };
 
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
-
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -229,7 +298,7 @@ enum _flash_config_area_range
 /*! @brief Copy flash_run_command() to RAM*/
 static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -280,44 +349,46 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
 
 /*!
  * @brief Position independent code of flash_run_command()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
  *   {
  *       // clear CCIF bit
  *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
@@ -329,9 +400,9 @@ static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
  *       }
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-const static uint16_t s_flashRunCommandFunctionCode[] = {
+static const uint16_t s_flashRunCommandFunctionCode[] = {
     0x2180, /* MOVS  R1, #128 ; 0x80 */
     0x7001, /* STRB  R1, [R0] */
     /* @4: */
@@ -342,102 +413,47 @@ const static uint16_t s_flashRunCommandFunctionCode[] = {
 };
 
 /*!
- * @brief Position independent code of flash_cache_clear_command()
+ * @brief Position independent code of flash_common_bit_operation()
  *
  * Note1: The prototype of C function is shown as below:
  * @code
- *   void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
  *   {
- *   #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MCM_PLACR_CFCC_MASK;
- *   #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
- *   #if defined(FMC_PFB01CR_CINV_WAY_MASK)
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
- *   #else
- *       *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
- *   #endif
- *   #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
- *       *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
- *   #else
- *   #if defined(FMC_PFB0CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB0CR_S_INV_MASK;
- *   #elif defined(FMC_PFB01CR_S_INV_MASK)
- *       *ftfx_reg |= FMC_PFB01CR_S_INV_MASK;
- *   #endif
- *   //    #error "Unknown flash cache controller"
- *   #endif // FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS
- *       // Memory barriers for good measure.
- *       // All Cache, Branch predictor and TLB maintenance operations before this instruction complete
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
  *       __ISB();
  *       __DSB();
  *   }
  * @endcode
- * Note2: The binary code is generated by IAR 7.50.1
+ * Note2: The binary code is generated by IAR 7.70.1
  */
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2280,         /* MOVS R2, #128   ; 0x80 */
-    0x00d2,         /* LSLS R2, R2, #3 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
     0xf3bf, 0x8f6f, /* ISB */
     0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
+    0xbd10          /* POP   {R4, PC} */
 };
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x22f0,         /* MOVS R2, #240    ; 0xf0 */
-    0x0412,         /* LSLS R2, R2, #16 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0] */
-    0x2220,         /* MOVS R2, #32    ; 0x20 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0x6801,         /* LDR  R1, [R0] */
-    0x2210,         /* MOVS R2, #16    ; 0x10 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-#if defined(FMC_PFB0CR_S_INV_MASK) || defined(FMC_PFB01CR_S_INV_MASK)
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0x6801,         /* LDR  R1, [R0]  */
-    0x2280,         /* MOVS R2, #128    ; 0x80 */
-    0x0312,         /* LSLS R2, R2, #12 */
-    0x430a,         /* ORRS R2, R2, R1 */
-    0x6002,         /* STR  R2, [R0] */
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#else
-const static uint16_t s_flashCacheClearCommandFunctionCode[] = {
-    0xf3bf, 0x8f6f, /* ISB */
-    0xf3bf, 0x8f4f, /* DSB */
-    0x4770          /* BX   LR */
-};
-#endif
-#endif
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
 static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint32_t s_flashCacheClearCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -485,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -527,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -576,7 +639,7 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
     flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
@@ -622,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -759,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -811,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -864,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -874,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -942,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -1075,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -1095,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1117,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1255,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1289,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1319,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1360,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1388,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1415,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1450,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1495,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1525,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1540,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1547,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1580,7 +1733,7 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
@@ -1684,6 +1837,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
     return kStatus_FLASH_Success;
 }
 
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
 {
@@ -1745,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1883,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1998,6 +2240,277 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
  * @brief Copy PIC of flash_run_command() to RAM
@@ -2009,7 +2522,7 @@ static void copy_flash_run_command(uint32_t *flashRunCommand)
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
     memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2038,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2080,18 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Copy PIC of flash_cache_clear_command() to RAM
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
  */
-static void copy_flash_cache_clear_command(uint32_t *flashCacheClearCommand)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-    assert(sizeof(s_flashCacheClearCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
      * of function memory should be even, that's why +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)s_flashCacheClearCommandFunctionCode,
-           sizeof(s_flashCacheClearCommandFunctionCode));
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2116,45 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
 #elif defined(FMC_PFB01CR_S_INV_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
-#else
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
 #endif
 /* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2174,8 +2707,18 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
 #else
 #if defined(FMC_PFB0CR_S_INV_MASK)
     FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
@@ -2184,13 +2727,19 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2233,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2263,11 +2810,11 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     /* Clean up info Structure*/
     memset(info, 0, sizeof(flash_operation_config_t));
 
-/* When required by the command, address bit 23 selects between program flash memory
- * (=0) and data flash memory (=1).*/
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2284,8 +2831,22 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
         info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2628,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_flash.h
@@ -53,20 +53,20 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
     kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
     kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_DriverVersionMinor = 1,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
     kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -132,33 +153,39 @@ enum _flash_status
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< API erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
         MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as RAM.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as RAM.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
     kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_AccessStateUnLimited,   /*!< Flash region is unLimited.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
     kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_AccessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -242,10 +269,11 @@ typedef enum _flash_property_tag
     kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
     kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
     kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_PropertyEepromTotalSize = 0x15U
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
@@ -253,7 +281,7 @@ typedef enum _flash_property_tag
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< Max size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
     kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
@@ -262,9 +290,9 @@ enum _flash_execute_in_ram_function_constants
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;     /*!< Number of available execute-in-RAM functions.*/
-    uint32_t *flashRunCommand;        /*!< execute-in-RAM function: flash_run_command.*/
-    uint32_t *flashCacheClearCommand; /*!< execute-in-RAM function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -274,7 +302,7 @@ typedef enum _flash_read_resource_option
 {
     kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -312,12 +340,12 @@ enum _flash_read_resource_range
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
 
 /*!
@@ -333,37 +361,37 @@ enum _flash_acceleration_ram_property
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_SwapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
@@ -374,41 +402,72 @@ typedef enum _flash_swap_block_status
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fields.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    uint8_t reserved1[2];     /*!< Reserved field.*/
-    uint16_t swapDisableWord; /*!< Swap disable word field.*/
-    uint8_t reserved2[4];     /*!< Reserved field.*/
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
 #endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Flash Swap IFR field data.
+ * @brief Flash Swap IFR field data
  */
 typedef union _flash_swap_ifr_field_data
 {
-    uint32_t flashSwapIfrData[2];                    /*!< Flash Swap IFR field data .*/
-    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< Flash Swap IFR field struct.*/
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
 } flash_swap_ifr_field_data_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
@@ -417,22 +476,69 @@ typedef enum _flash_partition_flexram_load_option
     kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -442,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-RAM function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -477,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-RAM functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -523,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -584,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -605,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as RAM
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -713,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -741,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -769,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -809,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -888,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -911,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -934,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -966,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -985,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -1009,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1033,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
  * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1090,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1142,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1181,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
  * @retval #kStatus_FLASH_Success API was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/MK22F51212_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/MK22F51212_features.h
@@ -477,6 +477,8 @@
 #define FSL_FEATURE_FLASH_PFLASH_BLOCK_DATA_PATH_WIDTH (8)
 /* @brief P-Flash block swap feature. */
 #define FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP (0)
+/* @brief P-Flash protection region count. */
+#define FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT (32)
 /* @brief Has FlexNVM memory. */
 #define FSL_FEATURE_FLASH_HAS_FLEX_NVM (0)
 /* @brief FlexNVM start address. (Valid only if FlexNVM is available.) */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_flash.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_flash.c
@@ -121,6 +121,7 @@
 #define FTFx_ERASE_BLOCK 0x08U                     /*!< ERSBLK*/
 #define FTFx_ERASE_SECTOR 0x09U                    /*!< ERSSCR*/
 #define FTFx_PROGRAM_SECTION 0x0BU                 /*!< PGMSEC*/
+#define FTFx_GENERATE_CRC 0x0CU                    /*!< CRCGEN*/
 #define FTFx_VERIFY_ALL_BLOCK 0x40U                /*!< RD1ALL*/
 #define FTFx_READ_ONCE 0x41U                       /*!< RDONCE or RDINDEX*/
 #define FTFx_PROGRAM_ONCE 0x43U                    /*!< PGMONCE or PGMINDEX*/
@@ -192,19 +193,75 @@
 /*@}*/
 
 /*!
+ * @name Common flash register access info defines
+ * @{
+ */
+#if defined(FTFA_FCCOB_CCOBn_MASK) || defined(FTFE_FCCOB_CCOBn_MASK) || defined(FTFL_FCCOB_CCOBn_MASK)
+#define FTFx_FCCOB3_REG (FTFx->FCCOB[0])
+#define FTFx_FCCOB5_REG (FTFx->FCCOB[6])
+#define FTFx_FCCOB6_REG (FTFx->FCCOB[5])
+#define FTFx_FCCOB7_REG (FTFx->FCCOB[4])
+#else
+#define FTFx_FCCOB3_REG (FTFx->FCCOB3)
+#define FTFx_FCCOB5_REG (FTFx->FCCOB5)
+#define FTFx_FCCOB6_REG (FTFx->FCCOB6)
+#define FTFx_FCCOB7_REG (FTFx->FCCOB7)
+#endif
+
+#if defined(FTFA_FPROT_PROT_MASK) || defined(FTFE_FPROT_PROT_MASK) || defined(FTFL_FPROT_PROT_MASK)
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL3_REG (FTFx->FPROT[4])
+#define FTFx_FPROTL2_REG (FTFx->FPROT[5])
+#define FTFx_FPROTL1_REG (FTFx->FPROT[6])
+#define FTFx_FPROTL0_REG (FTFx->FPROT[7])
+#define FTFx_FPROT_HIGH_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH3_REG (FTFx->FPROT[0])
+#define FTFx_FPROTH2_REG (FTFx->FPROT[1])
+#define FTFx_FPROTH1_REG (FTFx->FPROT[2])
+#define FTFx_FPROTH0_REG (FTFx->FPROT[3])
+#else
+#define FTFx_FPROT_LOW_REG (FTFx->FPROT3)
+#define FTFx_FPROTL3_REG (FTFx->FPROT3)
+#define FTFx_FPROTL2_REG (FTFx->FPROT2)
+#define FTFx_FPROTL1_REG (FTFx->FPROT1)
+#define FTFx_FPROTL0_REG (FTFx->FPROT0)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+#if defined(FTFA_FPROTS_PROTS_MASK) || defined(FTFE_FPROTS_PROTS_MASK) || defined(FTFL_FPROTS_PROTS_MASK)
+#define FTFx_FPROTSH_REG (FTFx->FPROTS[1])
+#define FTFx_FPROTSL_REG (FTFx->FPROTS[0])
+#else
+#define FTFx_FPROTSH_REG (FTFx->FPROTSH)
+#define FTFx_FPROTSL_REG (FTFx->FPROTSL)
+#endif
+#endif
+
+#if defined(FTFA_XACC_XA_MASK) || defined(FTFE_XACC_XA_MASK) || defined(FTFL_XACC_XA_MASK)
+#define FTFx_XACCH3_REG (FTFx->XACC[0])
+#define FTFx_XACCL3_REG (FTFx->XACC[4])
+#else
+#define FTFx_XACCH3_REG (FTFx->XACCH3)
+#define FTFx_XACCL3_REG (FTFx->XACCL3)
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+#if defined(FTFA_XACCS_XA_S_MASK) || defined(FTFE_XACCS_XA_S_MASK) || defined(FTFL_XACCS_XA_S_MASK)
+#define FTFx_XACCSH_REG (FTFx->XACCS[1])
+#define FTFx_XACCSL_REG (FTFx->XACCS[0])
+#else
+#define FTFx_XACCSH_REG (FTFx->XACCSH)
+#define FTFx_XACCSL_REG (FTFx->XACCSL)
+#endif
+#endif
+/*@}*/
+
+/*!
  * @brief Enumeration for access segment property.
  */
 enum _flash_access_segment_property
 {
-    kFLASH_accessSegmentBase = 256UL,
-};
-
-/*!
- * @brief Enumeration for acceleration ram property.
- */
-enum _flash_acceleration_ram_property
-{
-    kFLASH_accelerationRamSize = 0x400U
+    kFLASH_AccessSegmentBase = 256UL,
 };
 
 /*!
@@ -212,25 +269,26 @@ enum _flash_acceleration_ram_property
  */
 enum _flash_config_area_range
 {
-    kFLASH_configAreaStart = 0x400U,
-    kFLASH_configAreaEnd = 0x40FU
+    kFLASH_ConfigAreaStart = 0x400U,
+    kFLASH_ConfigAreaEnd = 0x40FU
 };
-
-/*! @brief program Flash block base address*/
-#define PFLASH_BLOCK_BASE 0x00U
-
-/*! @brief Total flash region count*/
-#define FSL_FEATURE_FTFx_REGION_COUNT (32U)
 
 /*!
  * @name Flash register access type defines
  * @{
  */
-#if FLASH_DRIVER_IS_FLASH_RESIDENT
-#define FTFx_REG_ACCESS_TYPE volatile uint8_t *
+#define FTFx_REG8_ACCESS_TYPE volatile uint8_t *
 #define FTFx_REG32_ACCESS_TYPE volatile uint32_t *
-#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
-       /*@}*/
+/*@}*/
+
+/*!
+ * @brief MSCM prefetch speculation defines.
+ */
+#define MSCM_OCMDR_OCMC1_DFDS_MASK (0x10U)
+#define MSCM_OCMDR_OCMC1_DFCS_MASK (0x20U)
+
+#define MSCM_OCMDR_OCMC1_DFDS_SHIFT (4U)
+#define MSCM_OCMDR_OCMC1_DFCS_SHIFT (5U)
 
 /*******************************************************************************
  * Prototypes
@@ -238,9 +296,9 @@ enum _flash_config_area_range
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief Copy flash_run_command() to RAM*/
-static void copy_flash_run_command(uint8_t *flashRunCommand);
+static void copy_flash_run_command(uint32_t *flashRunCommand);
 /*! @brief Copy flash_cache_clear_command() to RAM*/
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand);
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation);
 /*! @brief Check whether flash execute-in-ram functions are ready*/
 static status_t flash_check_execute_in_ram_function_info(flash_config_t *config);
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
@@ -291,44 +349,111 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option);
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
 
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info);
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info);
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+
 /*******************************************************************************
  * Variables
  ******************************************************************************/
 
 /*! @brief Access to FTFx->FCCOB */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFA->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFE->FCCOB3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFL->FCCOB3;
-#else
-#error "Unknown flash controller"
+volatile uint32_t *const kFCCOBx = (volatile uint32_t *)&FTFx_FCCOB3_REG;
+/*! @brief Access to FTFx->FPROT */
+volatile uint32_t *const kFPROTL = (volatile uint32_t *)&FTFx_FPROT_LOW_REG;
+#if defined(FTFx_FPROT_HIGH_REG)
+volatile uint32_t *const kFPROTH = (volatile uint32_t *)&FTFx_FPROT_HIGH_REG;
 #endif
 
-/*! @brief Access to FTFx->FPROT */
-#if defined(FSL_FEATURE_FLASH_IS_FTFA) && FSL_FEATURE_FLASH_IS_FTFA
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFA->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFE) && FSL_FEATURE_FLASH_IS_FTFE
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFE->FPROT3;
-#elif defined(FSL_FEATURE_FLASH_IS_FTFL) && FSL_FEATURE_FLASH_IS_FTFL
-volatile uint32_t *const kFPROT = (volatile uint32_t *)&FTFL->FPROT3;
-#else
-#error "Unknown flash controller"
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+volatile uint8_t *const kFPROTSL = (volatile uint8_t *)&FTFx_FPROTSL_REG;
+volatile uint8_t *const kFPROTSH = (volatile uint8_t *)&FTFx_FPROTSH_REG;
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*! @brief A function pointer used to point to relocated flash_run_command() */
-static void (*callFlashRunCommand)(FTFx_REG_ACCESS_TYPE ftfx_fstat);
-/*! @brief A function pointer used to point to relocated flash_cache_clear_command() */
-static void (*callFlashCacheClearCommand)(FTFx_REG32_ACCESS_TYPE ftfx_reg);
+static void (*callFlashRunCommand)(FTFx_REG8_ACCESS_TYPE ftfx_fstat);
+/*! @brief A function pointer used to point to relocated flash_common_bit_operation() */
+static void (*callFlashCommonBitOperation)(FTFx_REG32_ACCESS_TYPE base,
+                                           uint32_t bitMask,
+                                           uint32_t bitShift,
+                                           uint32_t bitValue);
+
+/*!
+ * @brief Position independent code of flash_run_command()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_run_command(FTFx_REG8_ACCESS_TYPE ftfx_fstat)
+ *   {
+ *       // clear CCIF bit
+ *       *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+ *
+ *       // Check CCIF bit of the flash status register, wait till it is set.
+ *       // IP team indicates that this loop will always complete.
+ *       while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+ *       {
+ *       }
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashRunCommandFunctionCode[] = {
+    0x2180, /* MOVS  R1, #128 ; 0x80 */
+    0x7001, /* STRB  R1, [R0] */
+    /* @4: */
+    0x7802, /* LDRB  R2, [R0] */
+    0x420a, /* TST   R2, R1 */
+    0xd0fc, /* BEQ.N @4 */
+    0x4770  /* BX    LR */
+};
+
+/*!
+ * @brief Position independent code of flash_common_bit_operation()
+ *
+ * Note1: The prototype of C function is shown as below:
+ * @code
+ *   void flash_common_bit_operation(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift, uint32_t
+ * bitValue)
+ *   {
+ *       if (bitMask)
+ *       {
+ *           uint32_t value = (((uint32_t)(((uint32_t)(bitValue)) << bitShift)) & bitMask);
+ *           *base = (*base & (~bitMask)) | value;
+ *       }
+ *
+ *       __ISB();
+ *       __DSB();
+ *   }
+ * @endcode
+ * Note2: The binary code is generated by IAR 7.70.1
+ */
+static const uint16_t s_flashCommonBitOperationFunctionCode[] = {
+    0xb510, /* PUSH  {R4, LR} */
+    0x2900, /* CMP   R1, #0 */
+    0xd005, /* BEQ.N @12 */
+    0x6804, /* LDR   R4, [R0] */
+    0x438c, /* BICS  R4, R4, R1 */
+    0x4093, /* LSLS  R3, R3, R2 */
+    0x4019, /* ANDS  R1, R1, R3 */
+    0x4321, /* ORRS  R1, R1, R4 */
+    0x6001, /* STR   R1, [R0] */
+    /*  @12: */
+    0xf3bf, 0x8f6f, /* ISB */
+    0xf3bf, 0x8f4f, /* DSB */
+    0xbd10          /* POP   {R4, PC} */
+};
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
 #if (FLASH_DRIVER_IS_FLASH_RESIDENT && !FLASH_DRIVER_IS_EXPORTED)
 /*! @brief A static buffer used to hold flash_run_command() */
-static uint8_t s_flashRunCommand[kFLASH_executeInRamFunctionMaxSize];
-/*! @brief A static buffer used to hold flash_cache_clear_command() */
-static uint8_t s_flashCacheClearCommand[kFLASH_executeInRamFunctionMaxSize];
+static uint32_t s_flashRunCommand[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
+/*! @brief A static buffer used to hold flash_common_bit_operation() */
+static uint32_t s_flashCommonBitOperation[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 /*! @brief Flash execute-in-ram function information */
 static flash_execute_in_ram_function_config_t s_flashExecuteInRamFunctionInfo;
 #endif
@@ -376,39 +501,86 @@ const uint16_t kPFlashDensities[] = {
 
 status_t FLASH_Init(flash_config_t *config)
 {
-    uint32_t flashDensity;
-
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    /* calculate the flash density from SIM_FCFG1.PFSIZE */
-    uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
-    /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
-     * We just use the pre-defined flash size in feature file here to support pre-production parts */
-    if (pfsize == 0xf)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE1_PFSIZE_MASK)
+        uint32_t flashDensity;
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE1_PFSIZE_MASK) >> SIM_FCFG1_CORE1_PFSIZE_SHIFT;
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+        config->PFlashTotalSize = flashDensity;
+#else
+        /* Unused code to solve MISRA-C issue*/
+        config->PFlashBlockBase = kPFlashDensities[0];
+        config->PFlashTotalSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+#endif
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SECTOR_SIZE;
     }
     else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
     {
-        flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        uint32_t flashDensity;
+
+/* calculate the flash density from SIM_FCFG1.PFSIZE */
+#if defined(SIM_FCFG1_CORE0_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_CORE0_PFSIZE_MASK) >> SIM_FCFG1_CORE0_PFSIZE_SHIFT;
+#elif defined(SIM_FCFG1_PFSIZE_MASK)
+        uint8_t pfsize = (SIM->FCFG1 & SIM_FCFG1_PFSIZE_MASK) >> SIM_FCFG1_PFSIZE_SHIFT;
+#else
+#error "Unknown flash size"
+#endif
+        /* PFSIZE=0xf means that on customer parts the IFR was not correctly programmed.
+         * We just use the pre-defined flash size in feature file here to support pre-production parts */
+        if (pfsize == 0xf)
+        {
+            flashDensity = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE;
+        }
+        else
+        {
+            flashDensity = ((uint32_t)kPFlashDensities[pfsize]) << 10;
+        }
+
+        /* fill out a few of the structure members */
+        config->PFlashBlockBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+        config->PFlashTotalSize = flashDensity;
+        config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
+        config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
     }
 
-    /* fill out a few of the structure members */
-    config->PFlashBlockBase = PFLASH_BLOCK_BASE;
-    config->PFlashTotalSize = flashDensity;
-    config->PFlashBlockCount = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
-    config->PFlashSectorSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_SECTOR_SIZE;
-
+    {
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
-    config->PFlashAccessSegmentSize = kFLASH_accessSegmentBase << FTFx->FACSS;
-    config->PFlashAccessSegmentCount = FTFx->FACSN;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSNS;
+        }
+        else
+#endif
+        {
+            config->PFlashAccessSegmentSize = kFLASH_AccessSegmentBase << FTFx->FACSS;
+            config->PFlashAccessSegmentCount = FTFx->FACSN;
+        }
 #else
-    config->PFlashAccessSegmentSize = 0;
-    config->PFlashAccessSegmentCount = 0;
+        config->PFlashAccessSegmentSize = 0;
+        config->PFlashAccessSegmentCount = 0;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
+    }
 
     config->PFlashCallback = NULL;
 
@@ -418,7 +590,7 @@ status_t FLASH_Init(flash_config_t *config)
     {
         s_flashExecuteInRamFunctionInfo.activeFunctionCount = 0;
         s_flashExecuteInRamFunctionInfo.flashRunCommand = s_flashRunCommand;
-        s_flashExecuteInRamFunctionInfo.flashCacheClearCommand = s_flashCacheClearCommand;
+        s_flashExecuteInRamFunctionInfo.flashCommonBitOperation = s_flashCommonBitOperation;
         config->flashExecuteInRamFunctionInfo = &s_flashExecuteInRamFunctionInfo.activeFunctionCount;
         FLASH_PrepareExecuteInRamFunctions(config);
     }
@@ -467,8 +639,8 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     copy_flash_run_command(flashExecuteInRamFunctionInfo->flashRunCommand);
-    copy_flash_cache_clear_command(flashExecuteInRamFunctionInfo->flashCacheClearCommand);
-    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_executeInRamFunctionTotalNum;
+    copy_flash_common_bit_operation(flashExecuteInRamFunctionInfo->flashCommonBitOperation);
+    flashExecuteInRamFunctionInfo->activeFunctionCount = kFLASH_ExecuteInRamFunctionTotalNum;
 
     return kStatus_FLASH_Success;
 }
@@ -513,22 +685,22 @@ status_t FLASH_EraseAll(flash_config_t *config, uint32_t key)
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key)
 {
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t endAddress;      /* storing end address */
     uint32_t numberOfSectors; /* number of sectors calculated by endAddress */
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectorCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectorCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
     /* calculating Flash end address */
     endAddress = start + lengthInBytes - 1;
@@ -650,33 +822,33 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (src == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.blockWriteUnitSize);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.blockWriteUnitSize);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes > 0)
     {
         /* preparing passing parameter to program the flash block */
         kFCCOBx[1] = *src++;
-        if (4 == flashInfo.blockWriteUnitSize)
+        if (4 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_LONGWORD, start);
         }
-        else if (8 == flashInfo.blockWriteUnitSize)
+        else if (8 == flashOperationInfo.blockWriteUnitSize)
         {
             kFCCOBx[2] = *src++;
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_PHRASE, start);
@@ -702,10 +874,10 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
         else
         {
             /* update start address for next iteration */
-            start += flashInfo.blockWriteUnitSize;
+            start += flashOperationInfo.blockWriteUnitSize;
 
             /* update lengthInBytes for next iteration */
-            lengthInBytes -= flashInfo.blockWriteUnitSize;
+            lengthInBytes -= flashOperationInfo.blockWriteUnitSize;
         }
     }
 
@@ -755,7 +927,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
 {
     status_t returnCode;
     uint32_t sectorSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     bool needSwitchFlexRamMode = false;
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
@@ -765,17 +937,17 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
-    sectorSize = flashInfo.activeSectorSize;
+    start = flashOperationInfo.convertedAddress;
+    sectorSize = flashOperationInfo.activeSectorSize;
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
     /* Switch function of FlexRAM if needed */
@@ -783,7 +955,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsRamError;
@@ -819,9 +991,9 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             uint32_t programSizeOfCurrentPass;
             uint32_t numberOfPhases;
 
-            if (lengthTobeProgrammedOfCurrentSector > kFLASH_accelerationRamSize)
+            if (lengthTobeProgrammedOfCurrentSector > kFLASH_AccelerationRamSize)
             {
-                programSizeOfCurrentPass = kFLASH_accelerationRamSize;
+                programSizeOfCurrentPass = kFLASH_AccelerationRamSize;
             }
             else
             {
@@ -833,7 +1005,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
             /* Set start address of the data to be programmed */
             kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_PROGRAM_SECTION, start + currentOffset);
             /* Set program size in terms of FEATURE_FLASH_SECTION_CMD_ADDRESS_ALIGMENT */
-            numberOfPhases = programSizeOfCurrentPass / flashInfo.sectionCmdAddressAligment;
+            numberOfPhases = programSizeOfCurrentPass / flashOperationInfo.sectionCmdAddressAligment;
 
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_2_2(numberOfPhases, 0xFFFFU);
 
@@ -867,7 +1039,7 @@ status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *
     /* Restore function of FlexRAM if needed. */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsEepromError;
@@ -904,7 +1076,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     {
         needSwitchFlexRamMode = true;
 
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableForEeprom);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableForEeprom);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_SetFlexramAsEepromError;
@@ -950,7 +1122,7 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
     /* Switch function of FlexRAM if needed */
     if (needSwitchFlexRamMode)
     {
-        returnCode = FLASH_SetFlexramFunction(config, kFLASH_flexramFunctionOptionAvailableAsRam);
+        returnCode = FLASH_SetFlexramFunction(config, kFLASH_FlexramFunctionOptionAvailableAsRam);
         if (returnCode != kStatus_FLASH_Success)
         {
             return kStatus_FLASH_RecoverFlexramAsRamError;
@@ -966,17 +1138,18 @@ status_t FLASH_ReadResource(
     flash_config_t *config, uint32_t start, uint32_t *dst, uint32_t lengthInBytes, flash_read_resource_option_t option)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if ((config == NULL) || (dst == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
     /* Check the supplied address range. */
-    returnCode = flash_check_resource_range(start, lengthInBytes, flashInfo.resourceCmdAddressAligment, option);
+    returnCode =
+        flash_check_resource_range(start, lengthInBytes, flashOperationInfo.resourceCmdAddressAligment, option);
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
@@ -986,11 +1159,11 @@ status_t FLASH_ReadResource(
     {
         /* preparing passing parameter */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_READ_RESOURCE, start);
-        if (flashInfo.resourceCmdAddressAligment == 4)
+        if (flashOperationInfo.resourceCmdAddressAligment == 4)
         {
             kFCCOBx[2] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
-        else if (flashInfo.resourceCmdAddressAligment == 8)
+        else if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             kFCCOBx[1] = BYTES_JOIN_TO_WORD_1_3(option, 0xFFFFFFU);
         }
@@ -1008,14 +1181,14 @@ status_t FLASH_ReadResource(
 
         /* fetch data */
         *dst++ = kFCCOBx[1];
-        if (flashInfo.resourceCmdAddressAligment == 8)
+        if (flashOperationInfo.resourceCmdAddressAligment == 8)
         {
             *dst++ = kFCCOBx[2];
         }
         /* update start address for next iteration */
-        start += flashInfo.resourceCmdAddressAligment;
+        start += flashOperationInfo.resourceCmdAddressAligment;
         /* update lengthInBytes for next iteration */
-        lengthInBytes -= flashInfo.resourceCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.resourceCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1075,7 +1248,7 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
     if (FLASH_SECURITY_STATE_UNSECURED == (registerValue & FTFx_FSEC_SEC_MASK))
     {
         /* Flash in unsecured state */
-        *state = kFLASH_securityStateNotSecure;
+        *state = kFLASH_SecurityStateNotSecure;
     }
     else
     {
@@ -1084,12 +1257,12 @@ status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *
         if (FLASH_SECURITY_STATE_KEYEN == (registerValue & FTFx_FSEC_KEYEN_MASK))
         {
             /* Backdoor key security enabled */
-            *state = kFLASH_securityStateBackdoorEnabled;
+            *state = kFLASH_SecurityStateBackdoorEnabled;
         }
         else
         {
             /* Backdoor key security disabled */
-            *state = kFLASH_securityStateBackdoorDisabled;
+            *state = kFLASH_SecurityStateBackdoorDisabled;
         }
     }
 
@@ -1146,22 +1319,22 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
 {
     /* Check arguments. */
     uint32_t blockSize;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
     uint32_t nextBlockStartAddress;
     uint32_t remainingBytes;
     status_t returnCode;
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.sectionCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.sectionCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
-    start = flashInfo.convertedAddress;
-    blockSize = flashInfo.activeBlockSize;
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
+    start = flashOperationInfo.convertedAddress;
+    blockSize = flashOperationInfo.activeBlockSize;
 
     nextBlockStartAddress = ALIGN_UP(start, blockSize);
     if (nextBlockStartAddress == start)
@@ -1180,7 +1353,7 @@ status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t leng
             verifyLength = remainingBytes;
         }
 
-        numberOfPhrases = verifyLength / flashInfo.sectionCmdAddressAligment;
+        numberOfPhrases = verifyLength / flashOperationInfo.sectionCmdAddressAligment;
 
         /* Fill in verify section command parameters. */
         kFCCOBx[0] = BYTES_JOIN_TO_WORD_1_3(FTFx_VERIFY_SECTION, start);
@@ -1210,22 +1383,22 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData)
 {
     status_t returnCode;
-    flash_operation_config_t flashInfo;
+    flash_operation_config_t flashOperationInfo;
 
     if (expectedData == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    flash_get_matched_operation_info(config, start, &flashInfo);
+    flash_get_matched_operation_info(config, start, &flashOperationInfo);
 
-    returnCode = flash_check_range(config, start, lengthInBytes, flashInfo.checkCmdAddressAligment);
+    returnCode = flash_check_range(config, start, lengthInBytes, flashOperationInfo.checkCmdAddressAligment);
     if (returnCode)
     {
         return returnCode;
     }
 
-    start = flashInfo.convertedAddress;
+    start = flashOperationInfo.convertedAddress;
 
     while (lengthInBytes)
     {
@@ -1251,9 +1424,9 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
             break;
         }
 
-        lengthInBytes -= flashInfo.checkCmdAddressAligment;
-        expectedData += flashInfo.checkCmdAddressAligment / sizeof(*expectedData);
-        start += flashInfo.checkCmdAddressAligment;
+        lengthInBytes -= flashOperationInfo.checkCmdAddressAligment;
+        expectedData += flashOperationInfo.checkCmdAddressAligment / sizeof(*expectedData);
+        start += flashOperationInfo.checkCmdAddressAligment;
     }
 
     return (returnCode);
@@ -1279,19 +1452,21 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state)
 {
     uint32_t endAddress;           /* end address for protection check */
-    uint32_t protectionRegionSize; /* size of flash protection region */
     uint32_t regionCheckedCounter; /* increments each time the flash address was checked for
                                     * protection status */
     uint32_t regionCounter;        /* incrementing variable used to increment through the flash
                                     * protection regions */
     uint32_t protectStatusCounter; /* increments each time a flash region was detected as protected */
 
-    uint8_t flashRegionProtectStatus[FSL_FEATURE_FTFx_REGION_COUNT]; /* array of the protection status for each
+    uint8_t flashRegionProtectStatus[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT]; /* array of the protection
+                                                                      * status for each
                                                                       * protection region */
-    uint32_t flashRegionAddress[FSL_FEATURE_FTFx_REGION_COUNT + 1];  /* array of the start addresses for each flash
-                                                                      * protection region. Note this is REGION_COUNT+1
-                                                                      * due to requiring the next start address after
-                                                                      * the end of flash for loop-check purposes below */
+    uint32_t flashRegionAddress[FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT +
+                                1];                /* array of the start addresses for each flash
+                                 * protection region. Note this is REGION_COUNT+1
+                                 * due to requiring the next start address after
+                                 * the end of flash for loop-check purposes below */
+    flash_protection_config_t flashProtectionInfo; /* flash protection information */
     status_t returnCode;
 
     if (protection_state == NULL)
@@ -1306,28 +1481,24 @@ status_t FLASH_IsProtected(flash_config_t *config,
         return returnCode;
     }
 
+    /* Get necessary flash protection information. */
+    returnCode = flash_get_protection_info(config, &flashProtectionInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     /* calculating Flash end address */
     endAddress = start + lengthInBytes;
-
-    /* Calculate the size of the flash protection region
-     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
-     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
-    if (config->PFlashTotalSize > 32 * 1024)
-    {
-        protectionRegionSize = (config->PFlashTotalSize) / FSL_FEATURE_FTFx_REGION_COUNT;
-    }
-    else
-    {
-        protectionRegionSize = 1024;
-    }
 
     /* populate the flashRegionAddress array with the start address of each flash region */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
 
     /* populate up to 33rd element of array, this is the next address after end of flash array */
-    while (regionCounter <= FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter <= flashProtectionInfo.regionCount)
     {
-        flashRegionAddress[regionCounter] = config->PFlashBlockBase + protectionRegionSize * regionCounter;
+        flashRegionAddress[regionCounter] =
+            flashProtectionInfo.regionBase + flashProtectionInfo.regionSize * regionCounter;
         regionCounter++;
     }
 
@@ -1341,24 +1512,80 @@ status_t FLASH_IsProtected(flash_config_t *config,
      * regionCounter is used to determine which FPROT[3:0] register to check for protection status
      * Note: FPROT=1 means NOT protected, FPROT=0 means protected */
     regionCounter = 0; /* make sure regionCounter is initialized to 0 first */
-    while (regionCounter < FSL_FEATURE_FTFx_REGION_COUNT)
+    while (regionCounter < flashProtectionInfo.regionCount)
     {
-        if (regionCounter < 8)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT3) >> regionCounter) & (0x01u);
-        }
-        else if ((regionCounter >= 8) && (regionCounter < 16))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT2) >> (regionCounter - 8)) & (0x01u);
-        }
-        else if ((regionCounter >= 16) && (regionCounter < 24))
-        {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT1) >> (regionCounter - 16)) & (0x01u);
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSL_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTSH_REG >> (regionCounter - 8)) & (0x01u);
+            }
+            else
+            {
+                break;
+            }
         }
         else
+#endif
         {
-            flashRegionProtectStatus[regionCounter] = ((FTFx->FPROT0) >> (regionCounter - 24)) & (0x01u);
+            /* Note: So far protection region count may be 16/20/24/32/64 */
+            if (regionCounter < 8)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL3_REG >> regionCounter) & (0x01u);
+            }
+            else if ((regionCounter >= 8) && (regionCounter < 16))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL2_REG >> (regionCounter - 8)) & (0x01u);
+            }
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 16)
+#if (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20)
+            else if ((regionCounter >= 16) && (regionCounter < 20))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#else
+            else if ((regionCounter >= 16) && (regionCounter < 24))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL1_REG >> (regionCounter - 16)) & (0x01u);
+            }
+#endif /* (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 20) */
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT > 24)
+            else if ((regionCounter >= 24) && (regionCounter < 32))
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTL0_REG >> (regionCounter - 24)) & (0x01u);
+            }
+#endif
+#if defined(FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT) && \
+    (FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT == 64)
+            else if (regionCounter < 40)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH3_REG >> (regionCounter - 32)) & (0x01u);
+            }
+            else if (regionCounter < 48)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH2_REG >> (regionCounter - 40)) & (0x01u);
+            }
+            else if (regionCounter < 56)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH1_REG >> (regionCounter - 48)) & (0x01u);
+            }
+            else if (regionCounter < 64)
+            {
+                flashRegionProtectStatus[regionCounter] = (FTFx_FPROTH0_REG >> (regionCounter - 56)) & (0x01u);
+            }
+#endif
+            else
+            {
+                break;
+            }
         }
+
         regionCounter++;
     }
 
@@ -1386,7 +1613,7 @@ status_t FLASH_IsProtected(flash_config_t *config,
                 /* increment protectStatusCounter to indicate this region is protected */
                 protectStatusCounter++;
             }
-            start += protectionRegionSize; /* increment to an address within the next region */
+            start += flashProtectionInfo.regionSize; /* increment to an address within the next region */
         }
         regionCounter++; /* increment regionCounter to check for the next flash protection region */
     }
@@ -1394,18 +1621,18 @@ status_t FLASH_IsProtected(flash_config_t *config,
     /* if protectStatusCounter == 0, then no region of the desired flash region is protected */
     if (protectStatusCounter == 0)
     {
-        *protection_state = kFLASH_protectionStateUnprotected;
+        *protection_state = kFLASH_ProtectionStateUnprotected;
     }
     /* if protectStatusCounter == regionCheckedCounter, then each region checked was protected */
     else if (protectStatusCounter == regionCheckedCounter)
     {
-        *protection_state = kFLASH_protectionStateProtected;
+        *protection_state = kFLASH_ProtectionStateProtected;
     }
     /* if protectStatusCounter != regionCheckedCounter, then protection status is mixed
      * In other words, some regions are protected while others are unprotected */
     else
     {
-        *protection_state = kFLASH_protectionStateMixed;
+        *protection_state = kFLASH_ProtectionStateMixed;
     }
 
     return (returnCode);
@@ -1416,6 +1643,9 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t lengthInBytes,
                              flash_execute_only_access_state_t *access_state)
 {
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    flash_access_config_t flashAccessInfo; /* flash Execute-Only information */
+#endif                                     /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
     status_t returnCode;
 
     if (access_state == NULL)
@@ -1431,6 +1661,13 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
     }
 
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+    /* Get necessary flash Execute-Only information. */
+    returnCode = flash_get_access_info(config, &flashAccessInfo);
+    if (returnCode)
+    {
+        return returnCode;
+    }
+
     {
         uint32_t executeOnlySegmentCounter = 0;
 
@@ -1438,31 +1675,56 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
         uint32_t endAddress = start + lengthInBytes;
 
         /* Aligning start address and end address */
-        uint32_t alignedStartAddress = ALIGN_DOWN(start, config->PFlashAccessSegmentSize);
-        uint32_t alignedEndAddress = ALIGN_UP(endAddress, config->PFlashAccessSegmentSize);
+        uint32_t alignedStartAddress = ALIGN_DOWN(start, flashAccessInfo.SegmentSize);
+        uint32_t alignedEndAddress = ALIGN_UP(endAddress, flashAccessInfo.SegmentSize);
 
         uint32_t segmentIndex = 0;
         uint32_t maxSupportedExecuteOnlySegmentCount =
-            (alignedEndAddress - alignedStartAddress) / config->PFlashAccessSegmentSize;
+            (alignedEndAddress - alignedStartAddress) / flashAccessInfo.SegmentSize;
 
         while (start < endAddress)
         {
             uint32_t xacc;
 
-            segmentIndex = start / config->PFlashAccessSegmentSize;
+            segmentIndex = (start - flashAccessInfo.SegmentBase) / flashAccessInfo.SegmentSize;
 
-            if (segmentIndex < 32)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
             {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCL3;
-            }
-            else if (segmentIndex < config->PFlashAccessSegmentCount)
-            {
-                xacc = *(const volatile uint32_t *)&FTFx->XACCH3;
-                segmentIndex -= 32;
+                /* For secondary flash, The two XACCS registers allow up to 16 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 8)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSL_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint8_t *)&FTFx_XACCSH_REG;
+                    segmentIndex -= 8;
+                }
+                else
+                {
+                    break;
+                }
             }
             else
+#endif
             {
-                break;
+                /* For primary flash, The eight XACC registers allow up to 64 restricted segments of equal memory size.
+                 */
+                if (segmentIndex < 32)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCL3_REG;
+                }
+                else if (segmentIndex < flashAccessInfo.SegmentCount)
+                {
+                    xacc = *(const volatile uint32_t *)&FTFx_XACCH3_REG;
+                    segmentIndex -= 32;
+                }
+                else
+                {
+                    break;
+                }
             }
 
             /* Determine if this address range is in a execute-only protection flash segment. */
@@ -1471,24 +1733,24 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
                 executeOnlySegmentCounter++;
             }
 
-            start += config->PFlashAccessSegmentSize;
+            start += flashAccessInfo.SegmentSize;
         }
 
         if (executeOnlySegmentCounter < 1u)
         {
-            *access_state = kFLASH_accessStateUnLimited;
+            *access_state = kFLASH_AccessStateUnLimited;
         }
         else if (executeOnlySegmentCounter < maxSupportedExecuteOnlySegmentCount)
         {
-            *access_state = kFLASH_accessStateMixed;
+            *access_state = kFLASH_AccessStateMixed;
         }
         else
         {
-            *access_state = kFLASH_accessStateExecuteOnly;
+            *access_state = kFLASH_AccessStateExecuteOnly;
         }
     }
 #else
-    *access_state = kFLASH_accessStateUnLimited;
+    *access_state = kFLASH_AccessStateUnLimited;
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
 
     return (returnCode);
@@ -1503,27 +1765,27 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     switch (whichProperty)
     {
-        case kFLASH_propertyPflashSectorSize:
+        case kFLASH_PropertyPflashSectorSize:
             *value = config->PFlashSectorSize;
             break;
 
-        case kFLASH_propertyPflashTotalSize:
+        case kFLASH_PropertyPflashTotalSize:
             *value = config->PFlashTotalSize;
             break;
 
-        case kFLASH_propertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockSize:
             *value = config->PFlashTotalSize / FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT;
             break;
 
-        case kFLASH_propertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockCount:
             *value = config->PFlashBlockCount;
             break;
 
-        case kFLASH_propertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashBlockBaseAddr:
             *value = config->PFlashBlockBase;
             break;
 
-        case kFLASH_propertyPflashFacSupport:
+        case kFLASH_PropertyPflashFacSupport:
 #if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL)
             *value = FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL;
 #else
@@ -1531,31 +1793,39 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 #endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */
             break;
 
-        case kFLASH_propertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentSize:
             *value = config->PFlashAccessSegmentSize;
             break;
 
-        case kFLASH_propertyPflashAccessSegmentCount:
+        case kFLASH_PropertyPflashAccessSegmentCount:
             *value = config->PFlashAccessSegmentCount;
             break;
 
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+            *value = config->FlexRAMBlockBase;
+            break;
+
+        case kFLASH_PropertyFlexRamTotalSize:
+            *value = config->FlexRAMTotalSize;
+            break;
+
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
-        case kFLASH_propertyDflashSectorSize:
+        case kFLASH_PropertyDflashSectorSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
             break;
-        case kFLASH_propertyDflashTotalSize:
+        case kFLASH_PropertyDflashTotalSize:
             *value = config->DFlashTotalSize;
             break;
-        case kFLASH_propertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockSize:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SIZE;
             break;
-        case kFLASH_propertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockCount:
             *value = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
             break;
-        case kFLASH_propertyDflashBlockBaseAddr:
+        case kFLASH_PropertyDflashBlockBaseAddr:
             *value = config->DFlashBlockBase;
             break;
-        case kFLASH_propertyEepromTotalSize:
+        case kFLASH_PropertyEepromTotalSize:
             *value = config->EEpromTotalSize;
             break;
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
@@ -1566,6 +1836,56 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
 
     return kStatus_FLASH_Success;
 }
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value)
+{
+    status_t status = kStatus_FLASH_Success;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    switch (whichProperty)
+    {
+        case kFLASH_PropertyFlashMemoryIndex:
+            if ((value != (uint32_t)kFLASH_MemoryIndexPrimaryFlash) &&
+                (value != (uint32_t)kFLASH_MemoryIndexSecondaryFlash))
+            {
+                return kStatus_FLASH_InvalidPropertyValue;
+            }
+            config->FlashMemoryIndex = value;
+            break;
+
+        case kFLASH_PropertyPflashSectorSize:
+        case kFLASH_PropertyPflashTotalSize:
+        case kFLASH_PropertyPflashBlockSize:
+        case kFLASH_PropertyPflashBlockCount:
+        case kFLASH_PropertyPflashBlockBaseAddr:
+        case kFLASH_PropertyPflashFacSupport:
+        case kFLASH_PropertyPflashAccessSegmentSize:
+        case kFLASH_PropertyPflashAccessSegmentCount:
+        case kFLASH_PropertyFlexRamBlockBaseAddr:
+        case kFLASH_PropertyFlexRamTotalSize:
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        case kFLASH_PropertyDflashSectorSize:
+        case kFLASH_PropertyDflashTotalSize:
+        case kFLASH_PropertyDflashBlockSize:
+        case kFLASH_PropertyDflashBlockCount:
+        case kFLASH_PropertyDflashBlockBaseAddr:
+        case kFLASH_PropertyEepromTotalSize:
+#endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
+            status = kStatus_FLASH_ReadOnlyProperty;
+            break;
+        default: /* catch inputs that are not recognized */
+            status = kStatus_FLASH_UnknownProperty;
+            break;
+    }
+
+    return status;
+}
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
 
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option)
@@ -1611,7 +1931,7 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     /* Make sure address provided is in the lower half of Program flash but not in the Flash Configuration Field */
     if ((address >= (config->PFlashTotalSize / 2)) ||
-        ((address >= kFLASH_configAreaStart) && (address <= kFLASH_configAreaEnd)))
+        ((address >= kFLASH_ConfigAreaStart) && (address <= kFLASH_ConfigAreaEnd)))
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
     }
@@ -1628,9 +1948,9 @@ status_t FLASH_SwapControl(flash_config_t *config,
 
     returnCode = flash_command_sequence(config);
 
-    returnInfo->flashSwapState = (flash_swap_state_t)FTFx->FCCOB5;
-    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB6;
-    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx->FCCOB7;
+    returnInfo->flashSwapState = (flash_swap_state_t)FTFx_FCCOB5_REG;
+    returnInfo->currentSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB6_REG;
+    returnInfo->nextSwapBlockStatus = (flash_swap_block_status_t)FTFx_FCCOB7_REG;
 
     return returnCode;
 }
@@ -1646,23 +1966,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
 
     do
     {
-        returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionReportStatus, &returnInfo);
+        returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionReportStatus, &returnInfo);
         if (returnCode != kStatus_FLASH_Success)
         {
             return returnCode;
         }
 
-        if (kFLASH_swapFunctionOptionDisable == option)
+        if (kFLASH_SwapFunctionOptionDisable == option)
         {
-            if (returnInfo.flashSwapState == kFLASH_swapStateDisabled)
+            if (returnInfo.flashSwapState == kFLASH_SwapStateDisabled)
             {
                 return kStatus_FLASH_Success;
             }
-            else if (returnInfo.flashSwapState == kFLASH_swapStateUninitialized)
+            else if (returnInfo.flashSwapState == kFLASH_SwapStateUninitialized)
             {
                 /* The swap system changed to the DISABLED state with Program flash block 0
                  * located at relative flash address 0x0_0000 */
-                returnCode = FLASH_SwapControl(config, address, kFLASH_swapControlOptionDisableSystem, &returnInfo);
+                returnCode = FLASH_SwapControl(config, address, kFLASH_SwapControlOptionDisableSystem, &returnInfo);
             }
             else
             {
@@ -1679,12 +1999,12 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
              *    Complete. */
             switch (returnInfo.flashSwapState)
             {
-                case kFLASH_swapStateUninitialized:
+                case kFLASH_SwapStateUninitialized:
                     /* If current swap mode is Uninitialized, Initialize Swap to Initialized/READY state. */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionIntializeSystem, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionIntializeSystem, &returnInfo);
                     break;
-                case kFLASH_swapStateReady:
+                case kFLASH_SwapStateReady:
                     /* Validate whether the address provided to the swap system is matched to
                      * swap indicator address in the IFR */
                     returnCode = flash_validate_swap_indicator_address(config, address);
@@ -1692,23 +2012,23 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
                     {
                         /* If current swap mode is Initialized/Ready, Initialize Swap to UPDATE state. */
                         returnCode =
-                            FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInUpdateState, &returnInfo);
+                            FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInUpdateState, &returnInfo);
                     }
                     break;
-                case kFLASH_swapStateUpdate:
+                case kFLASH_SwapStateUpdate:
                     /* If current swap mode is Update, Erase indicator sector in non active block
                      * to proceed swap system to update-erased state */
                     returnCode = FLASH_Erase(config, address + (config->PFlashTotalSize >> 1),
-                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_apiEraseKey);
+                                             FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT, kFLASH_ApiEraseKey);
                     break;
-                case kFLASH_swapStateUpdateErased:
+                case kFLASH_SwapStateUpdateErased:
                     /* If current swap mode is Update or Update-Erased, progress Swap to COMPLETE State */
                     returnCode =
-                        FLASH_SwapControl(config, address, kFLASH_swapControlOptionSetInCompleteState, &returnInfo);
+                        FLASH_SwapControl(config, address, kFLASH_SwapControlOptionSetInCompleteState, &returnInfo);
                     break;
-                case kFLASH_swapStateComplete:
+                case kFLASH_SwapStateComplete:
                     break;
-                case kFLASH_swapStateDisabled:
+                case kFLASH_SwapStateDisabled:
                     /* When swap system is in disabled state, We need to clear swap system back to uninitialized
                      * by issuing EraseAllBlocks command */
                     returnCode = kStatus_FLASH_SwapSystemNotInUninitialized;
@@ -1722,7 +2042,7 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
         {
             break;
         }
-    } while (!((kFLASH_swapStateComplete == returnInfo.flashSwapState) && (kFLASH_swapFunctionOptionEnable == option)));
+    } while (!((kFLASH_SwapStateComplete == returnInfo.flashSwapState) && (kFLASH_SwapFunctionOptionEnable == option)));
 
     return returnCode;
 }
@@ -1766,31 +2086,70 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 }
 #endif /* FSL_FEATURE_FLASH_HAS_PROGRAM_PARTITION_CMD */
 
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus)
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if (config == NULL)
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *kFPROT = protectStatus;
-
-    if (protectStatus != *kFPROT)
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
     {
-        return kStatus_FLASH_CommandFailure;
+        *kFPROTSL = protectStatus->valueLow32b.prots16b.protsl;
+        if (protectStatus->valueLow32b.prots16b.protsl != *kFPROTSL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+        *kFPROTSH = protectStatus->valueLow32b.prots16b.protsh;
+        if (protectStatus->valueLow32b.prots16b.protsh != *kFPROTSH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+    }
+    else
+#endif
+    {
+        *kFPROTL = protectStatus->valueLow32b.protl32b;
+        if (protectStatus->valueLow32b.protl32b != *kFPROTL)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+
+#if defined(FTFx_FPROT_HIGH_REG)
+        *kFPROTH = protectStatus->valueHigh32b.proth32b;
+        if (protectStatus->valueHigh32b.proth32b != *kFPROTH)
+        {
+            return kStatus_FLASH_CommandFailure;
+        }
+#endif
     }
 
     return kStatus_FLASH_Success;
 }
 
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus)
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus)
 {
     if ((config == NULL) || (protectStatus == NULL))
     {
         return kStatus_FLASH_InvalidArgument;
     }
 
-    *protectStatus = *kFPROT;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        protectStatus->valueLow32b.prots16b.protsl = *kFPROTSL;
+        protectStatus->valueLow32b.prots16b.protsh = *kFPROTSH;
+    }
+    else
+#endif
+    {
+        protectStatus->valueLow32b.protl32b = *kFPROTL;
+#if defined(FTFx_FPROT_HIGH_REG)
+        protectStatus->valueHigh32b.proth32b = *kFPROTH;
+#endif
+    }
 
     return kStatus_FLASH_Success;
 }
@@ -1881,70 +2240,289 @@ status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatu
 }
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
 
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
-/*!
- * @brief Run flash command
- *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- *  flashloader (RAM-resident bootloader).
- */
-void flash_run_command(FTFx_REG_ACCESS_TYPE ftfx_fstat)
-{
-    /* clear CCIF bit */
-    *ftfx_fstat = FTFx_FSTAT_CCIF_MASK;
+    void (*flashCommonBitOperationCallback)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue);
+    uint32_t flashCommonBitOperationBuffer[kFLASH_ExecuteInRamFunctionMaxSizeInWords];
 
-    /* Check CCIF bit of the flash status register, wait till it is set.
-     * IP team indicates that this loop will always complete. */
-    while (!((*ftfx_fstat) & FTFx_FSTAT_CCIF_MASK))
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
+
+    memcpy((void *)flashCommonBitOperationBuffer, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    flashCommonBitOperationCallback = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                                uint32_t bitValue))((uint32_t)flashCommonBitOperationBuffer + 1);
+#endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
     {
-    }
-}
-
-/*!
- * @brief Be used for determining the size of flash_run_command()
- *
- * This function must be defined that lexically follows flash_run_command(),
- * so we can determine the size of flash_run_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_run_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_run_command() to RAM
- *
- * This function copys the memory between flash_run_command() and flash_run_command_end()
- * into the buffer which is also means that copying flash_run_command() to RAM.
- */
-static void copy_flash_run_command(uint8_t *flashRunCommand)
-{
-    /* Calculate the valid length of flash_run_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_run_command_end ahead of flash_run_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_run_command_start_addr = (uint32_t)flash_run_command & (~1U);
-    uint32_t flash_run_command_end_addr = (uint32_t)flash_run_command_end & (~1U);
-    if (flash_run_command_end_addr > flash_run_command_start_addr)
-    {
-        funcLength = flash_run_command_end_addr - flash_run_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_run_command
-         * and flash_run_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
+        FTFx_REG32_ACCESS_TYPE regBase;
+#if defined(MCM)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+#elif defined(MCM0)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
         {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_DFCS_MASK;
+#endif
+            }
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, MCM_PLACR_DFCS_MASK, MCM_PLACR_DFCS_SHIFT, 0U);
+#else
+            *regBase &= ~MCM_PLACR_DFCS_MASK;
+#endif
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 1U);
+#else
+                *regBase |= MCM_PLACR_EFDS_MASK;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, MCM_PLACR_EFDS_MASK, MCM_PLACR_EFDS_SHIFT, 0U);
+#else
+                *regBase &= ~MCM_PLACR_EFDS_MASK;
+#endif
+            }
         }
     }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t b0dpeMask, b0ipeMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t b0dpeShift, b0ipeShift;
+#endif
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB01CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB01CR_B0IPE_SHIFT;
+#endif
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        b0dpeShift = FMC_PFB0CR_B0DPE_SHIFT;
+        b0ipeShift = FMC_PFB0CR_B0IPE_SHIFT;
+#endif
+#endif
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 1U);
+#else
+            *regBase |= b0ipeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0ipeMask, b0ipeShift, 0U);
+#else
+            *regBase &= ~b0ipeMask;
+#endif
+        }
+        if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 1U);
+#else
+            *regBase |= b0dpeMask;
+#endif
+        }
+        else
+        {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+            flashCommonBitOperationCallback(regBase, b0dpeMask, b0dpeShift, 0U);
+#else
+            *regBase &= ~b0dpeMask;
+#endif
+        }
+
+/* Invalidate Prefetch Speculation Buffer */
+#if defined(FMC_PFB01CR_S_INV_MASK)
+        FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#elif defined(FMC_PFB0CR_S_INV_MASK)
+        FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#endif
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        FTFx_REG32_ACCESS_TYPE regBase;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+        uint32_t flashSpeculationShift, dataPrefetchShift;
+        flashSpeculationShift = MSCM_OCMDR_OCMC1_DFCS_SHIFT;
+        dataPrefetchShift = MSCM_OCMDR_OCMC1_DFDS_SHIFT;
+#endif
+
+        regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (speculationStatus->instructionOption == kFLASH_prefetchSpeculationOptionDisable)
+        {
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+                return kStatus_FLASH_InvalidSpeculationOption;
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, flashSpeculationMask, flashSpeculationShift, 1U);
+#else
+                *regBase |= flashSpeculationMask;
+#endif
+            }
+        }
+        else
+        {
+            *regBase &= ~flashSpeculationMask;
+            if (speculationStatus->dataOption == kFLASH_prefetchSpeculationOptionEnable)
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 0U);
+#else
+                *regBase &= ~dataPrefetchMask;
+#endif
+            }
+            else
+            {
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+                flashCommonBitOperationCallback(regBase, dataPrefetchMask, dataPrefetchShift, 1U);
+#else
+                *regBase |= dataPrefetchMask;
+#endif
+            }
+        }
+    }
+#else
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+    flashCommonBitOperationCallback((FTFx_REG32_ACCESS_TYPE)0, 0, 0, 0);
+#endif
+#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    return kStatus_FLASH_Success;
+}
+
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus)
+{
+    memset(speculationStatus, 0, sizeof(flash_prefetch_speculation_status_t));
+
+    /* Assuming that all speculation options are enabled. */
+    speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionEnable;
+    speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionEnable;
+
+#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+#if defined(MCM)
+        value = MCM->PLACR;
+#elif defined(MCM0)
+        value = MCM0->PLACR;
+#endif
+        if (value & MCM_PLACR_DFCS_MASK)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (!(value & MCM_PLACR_EFDS_MASK))
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t b0dpeMask, b0ipeMask;
+#if defined(FMC_PFB01CR_B0DPE_MASK)
+        value = FMC->PFB01CR;
+        b0dpeMask = FMC_PFB01CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB01CR_B0IPE_MASK;
+#elif defined(FMC_PFB0CR_B0DPE_MASK)
+        value = FMC->PFB0CR;
+        b0dpeMask = FMC_PFB0CR_B0DPE_MASK;
+        b0ipeMask = FMC_PFB0CR_B0IPE_MASK;
+#endif
+        if (!(value & b0dpeMask))
+        {
+            /* Do not prefetch in response to data references. */
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        if (!(value & b0ipeMask))
+        {
+            /* Do not prefetch in response to instruction fetches. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+    }
+#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
+    {
+        uint32_t value;
+        uint32_t flashSpeculationMask, dataPrefetchMask;
+        value = MSCM->OCMDR[0];
+        flashSpeculationMask = MSCM_OCMDR_OCMC1_DFCS_MASK;
+        dataPrefetchMask = MSCM_OCMDR_OCMC1_DFDS_MASK;
+
+        if (value & flashSpeculationMask)
+        {
+            /* Speculation buffer is off. */
+            speculationStatus->instructionOption = kFLASH_prefetchSpeculationOptionDisable;
+            speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+        }
+        else
+        {
+            /* Speculation buffer is on for instruction. */
+            if (value & dataPrefetchMask)
+            {
+                /* Speculation buffer is off for data. */
+                speculationStatus->dataOption = kFLASH_prefetchSpeculationOptionDisable;
+            }
+        }
+    }
+#endif
+
+    return kStatus_FLASH_Success;
+}
+
+#if FLASH_DRIVER_IS_FLASH_RESIDENT
+/*!
+ * @brief Copy PIC of flash_run_command() to RAM
+ */
+static void copy_flash_run_command(uint32_t *flashRunCommand)
+{
+    assert(sizeof(s_flashRunCommandFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashRunCommand, (void *)flash_run_command_start_addr, funcLength);
-    callFlashRunCommand = (void (*)(FTFx_REG_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashRunCommand, (void *)s_flashRunCommandFunctionCode, sizeof(s_flashRunCommandFunctionCode));
+    callFlashRunCommand = (void (*)(FTFx_REG8_ACCESS_TYPE ftfx_fstat))((uint32_t)flashRunCommand + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -1973,7 +2551,7 @@ static status_t flash_command_sequence(flash_config_t *config)
     /* We pass the ftfx_fstat address as a parameter to flash_run_comamnd() instead of using
      * pre-processed MICRO sentences or operating global variable in flash_run_comamnd()
      * to make sure that flash_run_command() will be compiled into position-independent code (PIC). */
-    callFlashRunCommand((FTFx_REG_ACCESS_TYPE)(&FTFx->FSTAT));
+    callFlashRunCommand((FTFx_REG8_ACCESS_TYPE)(&FTFx->FSTAT));
 #else
     /* clear RDCOLERR & ACCERR & FPVIOL flag in flash status register */
     FTFx->FSTAT = FTFx_FSTAT_RDCOLERR_MASK | FTFx_FSTAT_ACCERR_MASK | FTFx_FSTAT_FPVIOL_MASK;
@@ -2015,78 +2593,19 @@ static status_t flash_command_sequence(flash_config_t *config)
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 /*!
- * @brief Run flash cache clear command
+ * @brief Copy PIC of flash_common_bit_operation() to RAM
  *
- * This function should be copied to RAM for execution to make sure that code works
- * properly even flash cache is disabled.
- * It is for flash-resident bootloader only, not technically required for ROM or
- * flashloader (RAM-resident bootloader).
  */
-void flash_cache_clear_command(FTFx_REG32_ACCESS_TYPE ftfx_reg)
+static void copy_flash_common_bit_operation(uint32_t *flashCommonBitOperation)
 {
-#if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MCM_PLACR_CFCC_MASK;
-#elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
-#if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB01CR_CINV_WAY_MASK) | FMC_PFB01CR_CINV_WAY(~0);
-#else
-    *ftfx_reg = (*ftfx_reg & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
-#endif
-#elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(2);
-    *ftfx_reg |= MSCM_OCMDR_OCMC1(1);
-#else
-/*    #error "Unknown flash cache controller"  */
-#endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
-       /* Memory barriers for good measure.
-        * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
-    __ISB();
-    __DSB();
-}
-
-/*!
- * @brief Be used for determining the size of flash_cache_clear_command()
- *
- * This function must be defined that lexically follows flash_cache_clear_command(),
- * so we can determine the size of flash_cache_clear_command() at runtime and not worry
- * about toolchain or code generation differences.
- */
-void flash_cache_clear_command_end(void)
-{
-}
-
-/*!
- * @brief Copy flash_cache_clear_command() to RAM
- *
- * This function copys the memory between flash_cache_clear_command() and flash_cache_clear_command_end()
- * into the buffer which is also means that copying flash_cache_clear_command() to RAM.
- */
-static void copy_flash_cache_clear_command(uint8_t *flashCacheClearCommand)
-{
-    /* Calculate the valid length of flash_cache_clear_command() memory.
-     * Set max size(64 bytes) as default function size, in case some compiler allocates
-     * flash_cache_clear_command_end ahead of flash_cache_clear_command. */
-    uint32_t funcLength = kFLASH_executeInRamFunctionMaxSize;
-    uint32_t flash_cache_clear_command_start_addr = (uint32_t)flash_cache_clear_command & (~1U);
-    uint32_t flash_cache_clear_command_end_addr = (uint32_t)flash_cache_clear_command_end & (~1U);
-    if (flash_cache_clear_command_end_addr > flash_cache_clear_command_start_addr)
-    {
-        funcLength = flash_cache_clear_command_end_addr - flash_cache_clear_command_start_addr;
-
-        assert(funcLength <= kFLASH_executeInRamFunctionMaxSize);
-
-        /* In case some compiler allocates other function in the middle of flash_cache_clear_command
-         * and flash_cache_clear_command_end. */
-        if (funcLength > kFLASH_executeInRamFunctionMaxSize)
-        {
-            funcLength = kFLASH_executeInRamFunctionMaxSize;
-        }
-    }
+    assert(sizeof(s_flashCommonBitOperationFunctionCode) <= (kFLASH_ExecuteInRamFunctionMaxSizeInWords * 4));
 
     /* Since the value of ARM function pointer is always odd, but the real start address
-     * of function memory should be even, that's why -1 and +1 operation exist. */
-    memcpy((void *)flashCacheClearCommand, (void *)flash_cache_clear_command_start_addr, funcLength);
-    callFlashCacheClearCommand = (void (*)(FTFx_REG32_ACCESS_TYPE ftfx_reg))((uint32_t)flashCacheClearCommand + 1);
+     * of function memory should be even, that's why +1 operation exist. */
+    memcpy((void *)flashCommonBitOperation, (void *)s_flashCommonBitOperationFunctionCode,
+           sizeof(s_flashCommonBitOperationFunctionCode));
+    callFlashCommonBitOperation = (void (*)(FTFx_REG32_ACCESS_TYPE base, uint32_t bitMask, uint32_t bitShift,
+                                            uint32_t bitValue))((uint32_t)flashCommonBitOperation + 1);
 }
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 
@@ -2111,39 +2630,64 @@ void flash_cache_clear(flash_config_t *config)
 #endif
 {
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
+    FTFx_REG32_ACCESS_TYPE regBase = (FTFx_REG32_ACCESS_TYPE)0;
     status_t returnCode = flash_check_execute_in_ram_function_info(config);
     if (kStatus_FLASH_Success != returnCode)
     {
         return;
     }
 
-/* We pass the ftfx register address as a parameter to flash_cache_clear_comamnd() instead of using
- * pre-processed MACROs or a global variable in flash_cache_clear_comamnd()
- * to make sure that flash_cache_clear_command() will be compiled into position-independent code (PIC). */
+/* We pass the ftfx register address as a parameter to flash_common_bit_operation() instead of using
+ * pre-processed MACROs or a global variable in flash_common_bit_operation()
+ * to make sure that flash_common_bit_operation() will be compiled into position-independent code (PIC). */
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
 #if defined(MCM)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM0)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM0->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #if defined(MCM1)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MCM1->PLACR;
+    callFlashCommonBitOperation(regBase, MCM_PLACR_CFCC_MASK, MCM_PLACR_CFCC_SHIFT, 1U);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_FMC_FLASH_CACHE_CONTROLS
 #if defined(FMC_PFB01CR_CINV_WAY_MASK)
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_CINV_WAY_MASK, FMC_PFB01CR_CINV_WAY_SHIFT, 0xFU);
 #else
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_CINV_WAY_MASK, FMC_PFB0CR_CINV_WAY_SHIFT, 0xFU);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0]);
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[0];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
 #else
-    /* #error "Unknown flash cache controller" */
-    /* meaningless code, just a workaround to solve warning*/
-    callFlashCacheClearCommand((FTFx_REG32_ACCESS_TYPE)0);
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+    regBase = (FTFx_REG32_ACCESS_TYPE)&MSCM->OCMDR[1];
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCM1_MASK, MSCM_OCMDR_OCM1_SHIFT, 0x3U);
+#else
+    callFlashCommonBitOperation(regBase, MSCM_OCMDR_OCMC1_MASK, MSCM_OCMDR_OCMC1_SHIFT, 0x3U);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB0CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB0CR_S_INV_MASK, FMC_PFB0CR_S_INV_SHIFT, 1U);
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    regBase = (FTFx_REG32_ACCESS_TYPE)&FMC->PFB01CR;
+    callFlashCommonBitOperation(regBase, FMC_PFB01CR_S_INV_MASK, FMC_PFB01CR_S_INV_SHIFT, 1U);
+#endif
+/* #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
 
+    callFlashCommonBitOperation(regBase, 0, 0, 0);
 #else
 
 #if defined(FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MCM_FLASH_CACHE_CONTROLS
@@ -2163,18 +2707,39 @@ void flash_cache_clear(flash_config_t *config)
     FMC->PFB0CR = (FMC->PFB0CR & ~FMC_PFB0CR_CINV_WAY_MASK) | FMC_PFB0CR_CINV_WAY(~0);
 #endif
 #elif defined(FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS) && FSL_FEATURE_FLASH_HAS_MSCM_FLASH_CACHE_CONTROLS
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(2);
-    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(1);
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCM1(3);
 #else
+    MSCM->OCMDR[0] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+#if defined(MSCM_OCMDR_OCM1_MASK)
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCM1(3);
+#else
+    MSCM->OCMDR[1] |= MSCM_OCMDR_OCMC1(3);
+#endif
+#endif
+#else
+#if defined(FMC_PFB0CR_S_INV_MASK)
+    FMC->PFB0CR |= FMC_PFB0CR_S_INV_MASK;
+#elif defined(FMC_PFB01CR_S_INV_MASK)
+    FMC->PFB01CR |= FMC_PFB01CR_S_INV_MASK;
+#endif
 /*    #error "Unknown flash cache controller" */
 #endif /* FSL_FEATURE_FTFx_MCM_FLASH_CACHE_CONTROLS */
+
+    /* Memory barriers for good measure.
+     * All Cache, Branch predictor and TLB maintenance operations before this instruction complete */
+    __ISB();
+    __DSB();
 #endif /* FLASH_DRIVER_IS_FLASH_RESIDENT */
 }
+#if (defined(__GNUC__))
+/* #pragma GCC pop_options */
+#else
 #if (defined(__CC_ARM))
 #pragma pop
 #endif
-#if (defined(__GNUC__))
-/* #pragma GCC pop_options */
 #endif
 
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
@@ -2191,7 +2756,7 @@ static status_t flash_check_execute_in_ram_function_info(flash_config_t *config)
     flashExecuteInRamFunctionInfo = (flash_execute_in_ram_function_config_t *)config->flashExecuteInRamFunctionInfo;
 
     if ((config->flashExecuteInRamFunctionInfo) &&
-        (kFLASH_executeInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
+        (kFLASH_ExecuteInRamFunctionTotalNum == flashExecuteInRamFunctionInfo->activeFunctionCount))
     {
         return kStatus_FLASH_Success;
     }
@@ -2217,21 +2782,19 @@ static status_t flash_check_range(flash_config_t *config,
         return kStatus_FLASH_AlignmentError;
     }
 
-/* check for valid range of the target addresses */
-#if !FLASH_SSD_IS_FLEXNVM_ENABLED
-    if ((startAddress < config->PFlashBlockBase) ||
-        ((startAddress + lengthInBytes) > (config->PFlashBlockBase + config->PFlashTotalSize)))
-#else
-    if (!(((startAddress >= config->PFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))) ||
-          ((startAddress >= config->DFlashBlockBase) &&
-           ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize)))))
+    /* check for valid range of the target addresses */
+    if (
+#if FLASH_SSD_IS_FLEXNVM_ENABLED
+        ((startAddress >= config->DFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->DFlashBlockBase + config->DFlashTotalSize))) ||
 #endif
+        ((startAddress >= config->PFlashBlockBase) &&
+         ((startAddress + lengthInBytes) <= (config->PFlashBlockBase + config->PFlashTotalSize))))
     {
-        return kStatus_FLASH_AddressError;
+        return kStatus_FLASH_Success;
     }
 
-    return kStatus_FLASH_Success;
+    return kStatus_FLASH_AddressError;
 }
 
 /*! @brief Gets the right address, sector and block size of current flash type which is indicated by address.*/
@@ -2250,6 +2813,8 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
     if ((address >= config->DFlashBlockBase) && (address <= (config->DFlashBlockBase + config->DFlashTotalSize)))
     {
+        /* When required by the command, address bit 23 selects between program flash memory
+         * (=0) and data flash memory (=1).*/
         info->convertedAddress = address - config->DFlashBlockBase + 0x800000U;
         info->activeSectorSize = FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_SECTOR_SIZE;
         info->activeBlockSize = config->DFlashTotalSize / FSL_FEATURE_FLASH_FLEX_NVM_BLOCK_COUNT;
@@ -2263,11 +2828,25 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
     else
 #endif /* FLASH_SSD_IS_FLEXNVM_ENABLED */
     {
-        info->convertedAddress = address;
+        info->convertedAddress = address - config->PFlashBlockBase;
         info->activeSectorSize = config->PFlashSectorSize;
         info->activeBlockSize = config->PFlashTotalSize / config->PFlashBlockCount;
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+        if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+        {
+#if FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER || FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER
+            /* When required by the command, address bit 23 selects between main flash memory
+             * (=0) and secondary flash memory (=1).*/
+            info->convertedAddress += 0x800000U;
+#endif
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_1_BLOCK_WRITE_UNIT_SIZE;
+        }
+        else
+#endif /* FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED */
+        {
+            info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
+        }
 
-        info->blockWriteUnitSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_WRITE_UNIT_SIZE;
         info->sectorCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTOR_CMD_ADDRESS_ALIGMENT;
         info->sectionCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_SECTION_CMD_ADDRESS_ALIGMENT;
         info->resourceCmdAddressAligment = FSL_FEATURE_FLASH_PFLASH_RESOURCE_CMD_ADDRESS_ALIGMENT;
@@ -2281,7 +2860,7 @@ static status_t flash_get_matched_operation_info(flash_config_t *config,
 static status_t flash_check_user_key(uint32_t key)
 {
     /* Validate the user key */
-    if (key != kFLASH_apiEraseKey)
+    if (key != kFLASH_ApiEraseKey)
     {
         return kStatus_FLASH_EraseKeyError;
     }
@@ -2309,7 +2888,7 @@ static status_t flash_update_flexnvm_memory_partition_status(flash_config_t *con
 
     /* Get FlexNVM memory partition info from data flash IFR */
     returnCode = FLASH_ReadResource(config, DFLASH_IFR_READRESOURCE_START_ADDRESS, (uint32_t *)&dataIFRReadOut,
-                                    sizeof(dataIFRReadOut), kFLASH_resourceOptionFlashIfr);
+                                    sizeof(dataIFRReadOut), kFLASH_ResourceOptionFlashIfr);
     if (returnCode != kStatus_FLASH_Success)
     {
         return kStatus_FLASH_PartitionStatusUpdateFailure;
@@ -2515,27 +3094,27 @@ static status_t flash_check_resource_range(uint32_t start,
     status = kStatus_FLASH_Success;
 
     maxReadbleAddress = start + lengthInBytes - 1;
-    if (option == kFLASH_resourceOptionVersionId)
+    if (option == kFLASH_ResourceOptionVersionId)
     {
-        if ((start != kFLASH_resourceRangeVersionIdStart) ||
-            ((start + lengthInBytes - 1) != kFLASH_resourceRangeVersionIdEnd))
+        if ((start != kFLASH_ResourceRangeVersionIdStart) ||
+            ((start + lengthInBytes - 1) != kFLASH_ResourceRangeVersionIdEnd))
         {
             status = kStatus_FLASH_InvalidArgument;
         }
     }
-    else if (option == kFLASH_resourceOptionFlashIfr)
+    else if (option == kFLASH_ResourceOptionFlashIfr)
     {
-        if (maxReadbleAddress < kFLASH_resourceRangePflashIfrSizeInBytes)
+        if (maxReadbleAddress < kFLASH_ResourceRangePflashIfrSizeInBytes)
         {
         }
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
-        else if ((start >= kFLASH_resourceRangePflashSwapIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangePflashSwapIfrEnd))
+        else if ((start >= kFLASH_ResourceRangePflashSwapIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangePflashSwapIfrEnd))
         {
         }
 #endif /* FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP */
-        else if ((start >= kFLASH_resourceRangeDflashIfrStart) &&
-                 (maxReadbleAddress <= kFLASH_resourceRangeDflashIfrEnd))
+        else if ((start >= kFLASH_ResourceRangeDflashIfrStart) &&
+                 (maxReadbleAddress <= kFLASH_ResourceRangeDflashIfrEnd))
         {
         }
         else
@@ -2556,9 +3135,9 @@ static status_t flash_check_resource_range(uint32_t start,
 /*! @brief Validates the gived swap control option.*/
 static status_t flash_check_swap_control_option(flash_swap_control_option_t option)
 {
-    if ((option == kFLASH_swapControlOptionIntializeSystem) || (option == kFLASH_swapControlOptionSetInUpdateState) ||
-        (option == kFLASH_swapControlOptionSetInCompleteState) || (option == kFLASH_swapControlOptionReportStatus) ||
-        (option == kFLASH_swapControlOptionDisableSystem))
+    if ((option == kFLASH_SwapControlOptionIntializeSystem) || (option == kFLASH_SwapControlOptionSetInUpdateState) ||
+        (option == kFLASH_SwapControlOptionSetInCompleteState) || (option == kFLASH_SwapControlOptionReportStatus) ||
+        (option == kFLASH_SwapControlOptionDisableSystem))
     {
         return kStatus_FLASH_Success;
     }
@@ -2571,21 +3150,23 @@ static status_t flash_check_swap_control_option(flash_swap_control_option_t opti
 /*! @brief Validates the gived address to see if it is equal to swap indicator address in pflash swap IFR.*/
 static status_t flash_validate_swap_indicator_address(flash_config_t *config, uint32_t address)
 {
-    flash_swap_ifr_field_config_t flashSwapIfrField;
+    flash_swap_ifr_field_data_t flashSwapIfrFieldData;
     uint32_t swapIndicatorAddress;
 
     status_t returnCode;
-    returnCode = FLASH_ReadResource(config, kFLASH_resourceRangePflashSwapIfrStart, (uint32_t *)&flashSwapIfrField,
-                                    sizeof(flash_swap_ifr_field_config_t), kFLASH_resourceOptionFlashIfr);
+    returnCode =
+        FLASH_ReadResource(config, kFLASH_ResourceRangePflashSwapIfrStart, flashSwapIfrFieldData.flashSwapIfrData,
+                           sizeof(flashSwapIfrFieldData.flashSwapIfrData), kFLASH_ResourceOptionFlashIfr);
+
     if (returnCode != kStatus_FLASH_Success)
     {
         return returnCode;
     }
 
-    /* The high 2 byte value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
-     * the low 4 bit value of Swap Indicator Address is always 4'b0000 */
-    swapIndicatorAddress =
-        (uint32_t)flashSwapIfrField.swapIndicatorAddress * FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
+    /* The high bits value of Swap Indicator Address is stored in Program Flash Swap IFR Field,
+     * the low severval bit value of Swap Indicator Address is always 1'b0 */
+    swapIndicatorAddress = (uint32_t)flashSwapIfrFieldData.flashSwapIfrField.swapIndicatorAddress *
+                           FSL_FEATURE_FLASH_PFLASH_SWAP_CONTROL_CMD_ADDRESS_ALIGMENT;
     if (address != swapIndicatorAddress)
     {
         return kStatus_FLASH_SwapIndicatorAddressError;
@@ -2599,8 +3180,8 @@ static status_t flash_validate_swap_indicator_address(flash_config_t *config, ui
 /*! @brief Validates the gived flexram function option.*/
 static inline status_t flasn_check_flexram_function_option_range(flash_flexram_function_option_t option)
 {
-    if ((option != kFLASH_flexramFunctionOptionAvailableAsRam) &&
-        (option != kFLASH_flexramFunctionOptionAvailableForEeprom))
+    if ((option != kFLASH_FlexramFunctionOptionAvailableAsRam) &&
+        (option != kFLASH_FlexramFunctionOptionAvailableForEeprom))
     {
         return kStatus_FLASH_InvalidArgument;
     }
@@ -2608,3 +3189,77 @@ static inline status_t flasn_check_flexram_function_option_range(flash_flexram_f
     return kStatus_FLASH_Success;
 }
 #endif /* FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD */
+
+/*! @brief Gets the flash protection information (region size, region count).*/
+static status_t flash_get_protection_info(flash_config_t *config, flash_protection_config_t *info)
+{
+    uint32_t pflashTotalSize;
+
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_protection_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent protection register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER)
+    pflashTotalSize = FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE +
+                      FSL_FEATURE_FLASH_PFLASH_1_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_1_BLOCK_SIZE;
+    info->regionBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    pflashTotalSize = config->PFlashTotalSize;
+    info->regionBase = config->PFlashBlockBase;
+#endif
+
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER
+    if (config->FlashMemoryIndex == (uint32_t)kFLASH_MemoryIndexSecondaryFlash)
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_1_PROTECTION_REGION_COUNT;
+    }
+    else
+#endif
+    {
+        info->regionCount = FSL_FEATURE_FLASH_PFLASH_PROTECTION_REGION_COUNT;
+    }
+
+    /* Calculate the size of the flash protection region
+     * If the flash density is > 32KB, then protection region is 1/32 of total flash density
+     * Else if flash density is < 32KB, then flash protection region is set to 1KB */
+    if (pflashTotalSize > info->regionCount * 1024)
+    {
+        info->regionSize = (pflashTotalSize) / info->regionCount;
+    }
+    else
+    {
+        info->regionSize = 1024;
+    }
+
+    return kStatus_FLASH_Success;
+}
+
+#if defined(FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL) && FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL
+/*! @brief Gets the flash Execute-Only access information (Segment size, Segment count).*/
+static status_t flash_get_access_info(flash_config_t *config, flash_access_config_t *info)
+{
+    if (config == NULL)
+    {
+        return kStatus_FLASH_InvalidArgument;
+    }
+
+    /* Clean up info Structure*/
+    memset(info, 0, sizeof(flash_access_config_t));
+
+/* Note: KW40 has a secondary flash, but it doesn't have independent access register*/
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED && (!FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER)
+    info->SegmentBase = FSL_FEATURE_FLASH_PFLASH_START_ADDRESS;
+#else
+    info->SegmentBase = config->PFlashBlockBase;
+#endif
+    info->SegmentSize = config->PFlashAccessSegmentSize;
+    info->SegmentCount = config->PFlashAccessSegmentCount;
+
+    return kStatus_FLASH_Success;
+}
+#endif /* FSL_FEATURE_FLASH_HAS_ACCESS_CONTROL */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_flash.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/drivers/fsl_flash.h
@@ -53,21 +53,21 @@
  * @name Flash version
  * @{
  */
-/*! @brief Construct the version number for drivers. */
+/*! @brief Constructs the version number for drivers. */
 #if !defined(MAKE_VERSION)
 #define MAKE_VERSION(major, minor, bugfix) (((major) << 16) | ((minor) << 8) | (bugfix))
 #endif
 
-/*! @brief FLASH driver version for SDK*/
-#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 1, 0)) /*!< Version 2.1.0. */
+/*! @brief Flash driver version for SDK*/
+#define FSL_FLASH_DRIVER_VERSION (MAKE_VERSION(2, 2, 0)) /*!< Version 2.2.0. */
 
-/*! @brief FLASH driver version for ROM*/
+/*! @brief Flash driver version for ROM*/
 enum _flash_driver_version_constants
 {
-    kFLASH_driverVersionName = 'F', /*!< Flash driver version name.*/
-    kFLASH_driverVersionMajor = 2,  /*!< Major flash driver version.*/
-    kFLASH_driverVersionMinor = 1,  /*!< Minor flash driver version.*/
-    kFLASH_driverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
+    kFLASH_DriverVersionName = 'F', /*!< Flash driver version name.*/
+    kFLASH_DriverVersionMajor = 2,  /*!< Major flash driver version.*/
+    kFLASH_DriverVersionMinor = 2,  /*!< Minor flash driver version.*/
+    kFLASH_DriverVersionBugfix = 0  /*!< Bugfix for flash driver version.*/
 };
 /*@}*/
 
@@ -75,29 +75,50 @@ enum _flash_driver_version_constants
  * @name Flash configuration
  * @{
  */
-/*! @brief Whether to support FlexNVM in flash driver */
+/*! @brief Indicates whether to support FlexNVM in the Flash driver */
 #if !defined(FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT)
-#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enable FlexNVM support by default. */
+#define FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT 1 /*!< Enables the FlexNVM support by default. */
 #endif
 
-/*! @brief Whether the FlexNVM is enabled in flash driver */
+/*! @brief Indicates whether the FlexNVM is enabled in the Flash driver */
 #define FLASH_SSD_IS_FLEXNVM_ENABLED (FLASH_SSD_CONFIG_ENABLE_FLEXNVM_SUPPORT && FSL_FEATURE_FLASH_HAS_FLEX_NVM)
+
+/*! @brief Indicates whether the secondary flash is supported in the Flash driver */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) || defined(FSL_FEATURE_FLASH_PFLASH_1_START_ADDRESS)
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (1)
+#else
+#define FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own protection register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FPROTS_PROTS_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_PROTECTION_REGISTER (0)
+#endif
+
+/*! @brief Indicates whether the secondary flash has its own Execute-Only access register in flash module */
+#if defined(FSL_FEATURE_FLASH_HAS_MULTIPLE_FLASH) && defined(FTFE_FACSSS_SGSIZE_S_MASK)
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (1)
+#else
+#define FLASH_SSD_SECONDARY_FLASH_HAS_ITS_OWN_ACCESS_REGISTER (0)
+#endif
 
 /*! @brief Flash driver location. */
 #if !defined(FLASH_DRIVER_IS_FLASH_RESIDENT)
 #if (!defined(BL_TARGET_ROM) && !defined(BL_TARGET_RAM))
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 1 /*!< Used for the flash resident application. */
 #else
-#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for non-flash resident application. */
+#define FLASH_DRIVER_IS_FLASH_RESIDENT 0 /*!< Used for the non-flash resident application. */
 #endif
 #endif
 
 /*! @brief Flash Driver Export option */
 #if !defined(FLASH_DRIVER_IS_EXPORTED)
 #if (defined(BL_TARGET_ROM) || defined(BL_TARGET_FLASH))
-#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for ROM bootloader. */
+#define FLASH_DRIVER_IS_EXPORTED 1 /*!< Used for the ROM bootloader. */
 #else
-#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for SDK application. */
+#define FLASH_DRIVER_IS_EXPORTED 0 /*!< Used for the KSDK application. */
 #endif
 #endif
 /*@}*/
@@ -118,7 +139,7 @@ enum _flash_driver_version_constants
 #define kStatusGroupFlashDriver 1
 #endif
 
-/*! @brief Construct a status code value from a group and code number. */
+/*! @brief Constructs a status code value from a group and a code number. */
 #if !defined(MAKE_STATUS)
 #define MAKE_STATUS(group, code) ((((group)*100) + (code)))
 #endif
@@ -128,37 +149,43 @@ enum _flash_driver_version_constants
  */
 enum _flash_status
 {
-    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< Api is executed successfully*/
+    kStatus_FLASH_Success = MAKE_STATUS(kStatusGroupGeneric, 0),         /*!< API is executed successfully*/
     kStatus_FLASH_InvalidArgument = MAKE_STATUS(kStatusGroupGeneric, 4), /*!< Invalid argument*/
     kStatus_FLASH_SizeError = MAKE_STATUS(kStatusGroupFlashDriver, 0),   /*!< Error size*/
     kStatus_FLASH_AlignmentError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with specified baseline*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 1), /*!< Parameter is not aligned with the specified baseline*/
     kStatus_FLASH_AddressError = MAKE_STATUS(kStatusGroupFlashDriver, 2), /*!< Address is out of range */
     kStatus_FLASH_AccessError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bounds addresses */
+        MAKE_STATUS(kStatusGroupFlashDriver, 3), /*!< Invalid instruction codes and out-of bound addresses */
     kStatus_FLASH_ProtectionViolation = MAKE_STATUS(
         kStatusGroupFlashDriver, 4), /*!< The program/erase operation is requested to execute on protected areas */
     kStatus_FLASH_CommandFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 5), /*!< Run-time error during command execution. */
-    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6),   /*!< Unknown property.*/
-    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),     /*!< Api erase key is invalid.*/
-    kStatus_FLASH_RegionExecuteOnly = MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< Current region is execute only.*/
+    kStatus_FLASH_UnknownProperty = MAKE_STATUS(kStatusGroupFlashDriver, 6), /*!< Unknown property.*/
+    kStatus_FLASH_EraseKeyError = MAKE_STATUS(kStatusGroupFlashDriver, 7),   /*!< API erase key is invalid.*/
+    kStatus_FLASH_RegionExecuteOnly =
+        MAKE_STATUS(kStatusGroupFlashDriver, 8), /*!< The current region is execute-only.*/
     kStatus_FLASH_ExecuteInRamFunctionNotReady =
-        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-ram function is not available.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 9), /*!< Execute-in-RAM function is not available.*/
     kStatus_FLASH_PartitionStatusUpdateFailure =
         MAKE_STATUS(kStatusGroupFlashDriver, 10), /*!< Failed to update partition status.*/
     kStatus_FLASH_SetFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set flexram as eeprom.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 11), /*!< Failed to set FlexRAM as EEPROM.*/
     kStatus_FLASH_RecoverFlexramAsRamError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover flexram as ram.*/
-    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set flexram as ram.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 12), /*!< Failed to recover FlexRAM as RAM.*/
+    kStatus_FLASH_SetFlexramAsRamError = MAKE_STATUS(kStatusGroupFlashDriver, 13), /*!< Failed to set FlexRAM as RAM.*/
     kStatus_FLASH_RecoverFlexramAsEepromError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover flexram as eeprom.*/
-    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash api is not supported.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 14), /*!< Failed to recover FlexRAM as EEPROM.*/
+    kStatus_FLASH_CommandNotSupported = MAKE_STATUS(kStatusGroupFlashDriver, 15), /*!< Flash API is not supported.*/
     kStatus_FLASH_SwapSystemNotInUninitialized =
-        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in uninitialzed state.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 16), /*!< Swap system is not in an uninitialzed state.*/
     kStatus_FLASH_SwapIndicatorAddressError =
-        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< Swap indicator address is invalid.*/
+        MAKE_STATUS(kStatusGroupFlashDriver, 17), /*!< The swap indicator address is invalid.*/
+    kStatus_FLASH_ReadOnlyProperty = MAKE_STATUS(kStatusGroupFlashDriver, 18), /*!< The flash property is read-only.*/
+    kStatus_FLASH_InvalidPropertyValue =
+        MAKE_STATUS(kStatusGroupFlashDriver, 19), /*!< The flash property value is out of range.*/
+    kStatus_FLASH_InvalidSpeculationOption =
+        MAKE_STATUS(kStatusGroupFlashDriver, 20), /*!< The option of flash prefetch speculation is invalid.*/
 };
 /*@}*/
 
@@ -166,13 +193,13 @@ enum _flash_status
  * @name Flash API key
  * @{
  */
-/*! @brief Construct the four char code for flash driver API key. */
+/*! @brief Constructs the four character code for the Flash driver API key. */
 #if !defined(FOUR_CHAR_CODE)
 #define FOUR_CHAR_CODE(a, b, c, d) (((d) << 24) | ((c) << 16) | ((b) << 8) | ((a)))
 #endif
 
 /*!
- * @brief Enumeration for flash driver API keys.
+ * @brief Enumeration for Flash driver API keys.
  *
  * @note The resulting value is built with a byte order such that the string
  * being readable in expected order when viewed in a hex editor, if the value
@@ -180,7 +207,7 @@ enum _flash_status
  */
 enum _flash_driver_api_keys
 {
-    kFLASH_apiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
+    kFLASH_ApiEraseKey = FOUR_CHAR_CODE('k', 'f', 'e', 'k') /*!< Key value used to validate all flash erase APIs.*/
 };
 /*@}*/
 
@@ -189,10 +216,10 @@ enum _flash_driver_api_keys
  */
 typedef enum _flash_margin_value
 {
-    kFLASH_marginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
-    kFLASH_marginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
-    kFLASH_marginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
-    kFLASH_marginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
+    kFLASH_MarginValueNormal,  /*!< Use the 'normal' read level for 1s.*/
+    kFLASH_MarginValueUser,    /*!< Apply the 'User' margin to the normal read-1 level.*/
+    kFLASH_MarginValueFactory, /*!< Apply the 'Factory' margin to the normal read-1 level.*/
+    kFLASH_MarginValueInvalid  /*!< Not real margin level, Used to determine the range of valid margin level. */
 } flash_margin_value_t;
 
 /*!
@@ -200,9 +227,9 @@ typedef enum _flash_margin_value
  */
 typedef enum _flash_security_state
 {
-    kFLASH_securityStateNotSecure,       /*!< Flash is not secure.*/
-    kFLASH_securityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
-    kFLASH_securityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
+    kFLASH_SecurityStateNotSecure,       /*!< Flash is not secure.*/
+    kFLASH_SecurityStateBackdoorEnabled, /*!< Flash backdoor is enabled.*/
+    kFLASH_SecurityStateBackdoorDisabled /*!< Flash backdoor is disabled.*/
 } flash_security_state_t;
 
 /*!
@@ -210,9 +237,9 @@ typedef enum _flash_security_state
  */
 typedef enum _flash_protection_state
 {
-    kFLASH_protectionStateUnprotected, /*!< Flash region is not protected.*/
-    kFLASH_protectionStateProtected,   /*!< Flash region is protected.*/
-    kFLASH_protectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
+    kFLASH_ProtectionStateUnprotected, /*!< Flash region is not protected.*/
+    kFLASH_ProtectionStateProtected,   /*!< Flash region is protected.*/
+    kFLASH_ProtectionStateMixed        /*!< Flash is mixed with protected and unprotected region.*/
 } flash_protection_state_t;
 
 /*!
@@ -220,9 +247,9 @@ typedef enum _flash_protection_state
  */
 typedef enum _flash_execute_only_access_state
 {
-    kFLASH_accessStateUnLimited,   /*!< Flash region is unLimited.*/
-    kFLASH_accessStateExecuteOnly, /*!< Flash region is execute only.*/
-    kFLASH_accessStateMixed        /*!< Flash is mixed with unLimited and execute only region.*/
+    kFLASH_AccessStateUnLimited,   /*!< Flash region is unlimited.*/
+    kFLASH_AccessStateExecuteOnly, /*!< Flash region is execute only.*/
+    kFLASH_AccessStateMixed        /*!< Flash is mixed with unlimited and execute only region.*/
 } flash_execute_only_access_state_t;
 
 /*!
@@ -230,41 +257,42 @@ typedef enum _flash_execute_only_access_state
  */
 typedef enum _flash_property_tag
 {
-    kFLASH_propertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
-    kFLASH_propertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
-    kFLASH_propertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
-    kFLASH_propertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
-    kFLASH_propertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
-    kFLASH_propertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
-    kFLASH_propertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
-    kFLASH_propertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
-    kFLASH_propertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
-    kFLASH_propertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
-    kFLASH_propertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
-    kFLASH_propertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
-    kFLASH_propertyDflashBlockSize = 0x12U,          /*!< Dflash block count property.*/
-    kFLASH_propertyDflashBlockCount = 0x13U,         /*!< Dflash block base address property.*/
-    kFLASH_propertyDflashBlockBaseAddr = 0x14U,      /*!< Eeprom total size property.*/
-    kFLASH_propertyEepromTotalSize = 0x15U
+    kFLASH_PropertyPflashSectorSize = 0x00U,         /*!< Pflash sector size property.*/
+    kFLASH_PropertyPflashTotalSize = 0x01U,          /*!< Pflash total size property.*/
+    kFLASH_PropertyPflashBlockSize = 0x02U,          /*!< Pflash block size property.*/
+    kFLASH_PropertyPflashBlockCount = 0x03U,         /*!< Pflash block count property.*/
+    kFLASH_PropertyPflashBlockBaseAddr = 0x04U,      /*!< Pflash block base address property.*/
+    kFLASH_PropertyPflashFacSupport = 0x05U,         /*!< Pflash fac support property.*/
+    kFLASH_PropertyPflashAccessSegmentSize = 0x06U,  /*!< Pflash access segment size property.*/
+    kFLASH_PropertyPflashAccessSegmentCount = 0x07U, /*!< Pflash access segment count property.*/
+    kFLASH_PropertyFlexRamBlockBaseAddr = 0x08U,     /*!< FlexRam block base address property.*/
+    kFLASH_PropertyFlexRamTotalSize = 0x09U,         /*!< FlexRam total size property.*/
+    kFLASH_PropertyDflashSectorSize = 0x10U,         /*!< Dflash sector size property.*/
+    kFLASH_PropertyDflashTotalSize = 0x11U,          /*!< Dflash total size property.*/
+    kFLASH_PropertyDflashBlockSize = 0x12U,          /*!< Dflash block size property.*/
+    kFLASH_PropertyDflashBlockCount = 0x13U,         /*!< Dflash block count property.*/
+    kFLASH_PropertyDflashBlockBaseAddr = 0x14U,      /*!< Dflash block base address property.*/
+    kFLASH_PropertyEepromTotalSize = 0x15U,          /*!< EEPROM total size property.*/
+    kFLASH_PropertyFlashMemoryIndex = 0x20U          /*!< Flash memory index property.*/
 } flash_property_tag_t;
 
 /*!
- * @brief Constants for execute-in-ram flash function.
+ * @brief Constants for execute-in-RAM flash function.
  */
 enum _flash_execute_in_ram_function_constants
 {
-    kFLASH_executeInRamFunctionMaxSize = 64U, /*!< Max size of execute-in-ram function.*/
-    kFLASH_executeInRamFunctionTotalNum = 2U  /*!< Total number of execute-in-ram functions.*/
+    kFLASH_ExecuteInRamFunctionMaxSizeInWords = 16U, /*!< The maximum size of execute-in-RAM function.*/
+    kFLASH_ExecuteInRamFunctionTotalNum = 2U         /*!< Total number of execute-in-RAM functions.*/
 };
 
 /*!
- * @brief Flash execute-in-ram function information.
+ * @brief Flash execute-in-RAM function information.
  */
 typedef struct _flash_execute_in_ram_function_config
 {
-    uint32_t activeFunctionCount;    /*!< Number of available execute-in-ram functions.*/
-    uint8_t *flashRunCommand;        /*!< execute-in-ram function: flash_run_command.*/
-    uint8_t *flashCacheClearCommand; /*!< execute-in-ram function: flash_cache_clear_command.*/
+    uint32_t activeFunctionCount;      /*!< Number of available execute-in-RAM functions.*/
+    uint32_t *flashRunCommand;         /*!< Execute-in-RAM function: flash_run_command.*/
+    uint32_t *flashCommonBitOperation; /*!< Execute-in-RAM function: flash_common_bit_operation.*/
 } flash_execute_in_ram_function_config_t;
 
 /*!
@@ -272,9 +300,9 @@ typedef struct _flash_execute_in_ram_function_config
  */
 typedef enum _flash_read_resource_option
 {
-    kFLASH_resourceOptionFlashIfr =
+    kFLASH_ResourceOptionFlashIfr =
         0x00U, /*!< Select code for Program flash 0 IFR, Program flash swap 0 IFR, Data flash 0 IFR */
-    kFLASH_resourceOptionVersionId = 0x01U /*!< Select code for Version ID*/
+    kFLASH_ResourceOptionVersionId = 0x01U /*!< Select code for the version ID*/
 } flash_read_resource_option_t;
 
 /*!
@@ -283,124 +311,234 @@ typedef enum _flash_read_resource_option
 enum _flash_read_resource_range
 {
 #if (FSL_FEATURE_FLASH_IS_FTFE == 1)
-    kFLASH_resourceRangePflashIfrSizeInBytes = 1024U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x08U,       /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x0FU,         /*!< Version ID IFR end address.*/
-#else                                                 /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
-    kFLASH_resourceRangePflashIfrSizeInBytes = 256U, /*!< Pflash IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdSizeInBytes = 8U,   /*!< Version ID IFR size in byte.*/
-    kFLASH_resourceRangeVersionIdStart = 0x00U,      /*!< Version ID IFR start address.*/
-    kFLASH_resourceRangeVersionIdEnd = 0x07U,        /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 1024U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,     /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x08U,        /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x0FU,          /*!< Version ID IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0x3FFU), /*!< Pflash swap IFR end address.*/
+#else                                                      /* FSL_FEATURE_FLASH_IS_FTFL == 1 or FSL_FEATURE_FLASH_IS_FTFA = =1 */
+    kFLASH_ResourceRangePflashIfrSizeInBytes = 256U,  /*!< Pflash IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdSizeInBytes = 8U,    /*!< Version ID IFR size in byte.*/
+    kFLASH_ResourceRangeVersionIdStart = 0x00U,       /*!< Version ID IFR start address.*/
+    kFLASH_ResourceRangeVersionIdEnd = 0x07U,         /*!< Version ID IFR end address.*/
+#if 0x20000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x8000U, /*!< Pflash swap IFR start address.*/
+#elif 0x40000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x10000U, /*!< Pflash swap IFR start address.*/
+#elif 0x80000U == (FSL_FEATURE_FLASH_PFLASH_BLOCK_COUNT * FSL_FEATURE_FLASH_PFLASH_BLOCK_SIZE)
+    kFLASH_ResourceRangePflashSwapIfrStart = 0x20000U, /*!< Pflash swap IFR start address.*/
+#else
+    kFLASH_ResourceRangePflashSwapIfrStart = 0,
 #endif
-    kFLASH_resourceRangePflashSwapIfrStart = 0x40000U, /*!< Pflash swap IFR start address.*/
-    kFLASH_resourceRangePflashSwapIfrEnd = 0x403FFU,   /*!< Pflash swap IFR end address.*/
-    kFLASH_resourceRangeDflashIfrStart = 0x800000U,    /*!< Dflash IFR start address.*/
-    kFLASH_resourceRangeDflashIfrEnd = 0x8003FFU,      /*!< Dflash IFR end address.*/
+    kFLASH_ResourceRangePflashSwapIfrEnd =
+        (kFLASH_ResourceRangePflashSwapIfrStart + 0xFFU), /*!< Pflash swap IFR end address.*/
+#endif
+    kFLASH_ResourceRangeDflashIfrStart = 0x800000U, /*!< Dflash IFR start address.*/
+    kFLASH_ResourceRangeDflashIfrEnd = 0x8003FFU,   /*!< Dflash IFR end address.*/
 };
 
 /*!
- * @brief Enumeration for the two possilbe options of set flexram function command.
+ * @brief Enumeration for the two possilbe options of set FlexRAM function command.
  */
 typedef enum _flash_flexram_function_option
 {
-    kFLASH_flexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< Option used to make FlexRAM available as RAM */
-    kFLASH_flexramFunctionOptionAvailableForEeprom = 0x00U /*!< Option used to make FlexRAM available for EEPROM */
+    kFLASH_FlexramFunctionOptionAvailableAsRam = 0xFFU,    /*!< An option used to make FlexRAM available as RAM */
+    kFLASH_FlexramFunctionOptionAvailableForEeprom = 0x00U /*!< An option used to make FlexRAM available for EEPROM */
 } flash_flexram_function_option_t;
+
+/*!
+ * @brief Enumeration for acceleration RAM property.
+ */
+enum _flash_acceleration_ram_property
+{
+    kFLASH_AccelerationRamSize = 0x400U
+};
 
 /*!
  * @brief Enumeration for the possible options of Swap function
  */
 typedef enum _flash_swap_function_option
 {
-    kFLASH_swapFunctionOptionEnable = 0x00U, /*!< Option used to enable Swap function */
-    kFLASH_swapFunctionOptionDisable = 0x01U /*!< Option used to Disable Swap function */
+    kFLASH_SwapFunctionOptionEnable = 0x00U, /*!< An option used to enable the Swap function */
+    kFLASH_SwapFunctionOptionDisable = 0x01U /*!< An option used to disable the Swap function */
 } flash_swap_function_option_t;
 
 /*!
- * @brief Enumeration for the possible options of Swap Control commands
+ * @brief Enumeration for the possible options of Swap control commands
  */
 typedef enum _flash_swap_control_option
 {
-    kFLASH_swapControlOptionIntializeSystem = 0x01U,    /*!< Option used to Intialize Swap System */
-    kFLASH_swapControlOptionSetInUpdateState = 0x02U,   /*!< Option used to Set Swap in Update State */
-    kFLASH_swapControlOptionSetInCompleteState = 0x04U, /*!< Option used to Set Swap in Complete State */
-    kFLASH_swapControlOptionReportStatus = 0x08U,       /*!< Option used to Report Swap Status */
-    kFLASH_swapControlOptionDisableSystem = 0x10U       /*!< Option used to Disable Swap Status */
+    kFLASH_SwapControlOptionIntializeSystem = 0x01U,    /*!< An option used to initialize the Swap system */
+    kFLASH_SwapControlOptionSetInUpdateState = 0x02U,   /*!< An option used to set the Swap in an update state */
+    kFLASH_SwapControlOptionSetInCompleteState = 0x04U, /*!< An option used to set the Swap in a complete state */
+    kFLASH_SwapControlOptionReportStatus = 0x08U,       /*!< An option used to report the Swap status */
+    kFLASH_SwapControlOptionDisableSystem = 0x10U       /*!< An option used to disable the Swap status */
 } flash_swap_control_option_t;
 
 /*!
- * @brief Enumeration for the possible flash swap status.
+ * @brief Enumeration for the possible flash Swap status.
  */
 typedef enum _flash_swap_state
 {
-    kFLASH_swapStateUninitialized = 0x00U, /*!< Flash swap system is in uninitialized state.*/
-    kFLASH_swapStateReady = 0x01U,         /*!< Flash swap system is in ready state.*/
-    kFLASH_swapStateUpdate = 0x02U,        /*!< Flash swap system is in update state.*/
-    kFLASH_swapStateUpdateErased = 0x03U,  /*!< Flash swap system is in updateErased state.*/
-    kFLASH_swapStateComplete = 0x04U,      /*!< Flash swap system is in complete state.*/
-    kFLASH_swapStateDisabled = 0x05U       /*!< Flash swap system is in disabled state.*/
+    kFLASH_SwapStateUninitialized = 0x00U, /*!< Flash Swap system is in an uninitialized state.*/
+    kFLASH_SwapStateReady = 0x01U,         /*!< Flash Swap system is in a ready state.*/
+    kFLASH_SwapStateUpdate = 0x02U,        /*!< Flash Swap system is in an update state.*/
+    kFLASH_SwapStateUpdateErased = 0x03U,  /*!< Flash Swap system is in an updateErased state.*/
+    kFLASH_SwapStateComplete = 0x04U,      /*!< Flash Swap system is in a complete state.*/
+    kFLASH_SwapStateDisabled = 0x05U       /*!< Flash Swap system is in a disabled state.*/
 } flash_swap_state_t;
 
 /*!
- * @breif Enumeration for the possible flash swap block status
+ * @breif Enumeration for the possible flash Swap block status
  */
 typedef enum _flash_swap_block_status
 {
-    kFLASH_swapBlockStatusLowerHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusLowerHalfProgramBlocksAtZero =
         0x00U, /*!< Swap block status is that lower half program block at zero.*/
-    kFLASH_swapBlockStatusUpperHalfProgramBlocksAtZero =
+    kFLASH_SwapBlockStatusUpperHalfProgramBlocksAtZero =
         0x01U, /*!< Swap block status is that upper half program block at zero.*/
 } flash_swap_block_status_t;
 
 /*!
- * @brief Flash Swap information.
+ * @brief Flash Swap information
  */
 typedef struct _flash_swap_state_config
 {
-    flash_swap_state_t flashSwapState;                /*!< Current swap system status.*/
-    flash_swap_block_status_t currentSwapBlockStatus; /*!< Current swap block status.*/
-    flash_swap_block_status_t nextSwapBlockStatus;    /*!< Next swap block status.*/
+    flash_swap_state_t flashSwapState;                /*!<The current Swap system status.*/
+    flash_swap_block_status_t currentSwapBlockStatus; /*!< The current Swap block status.*/
+    flash_swap_block_status_t nextSwapBlockStatus;    /*!< The next Swap block status.*/
 } flash_swap_state_config_t;
 
 /*!
- * @brief Flash Swap IFR fileds.
+ * @brief Flash Swap IFR fields
  */
 typedef struct _flash_swap_ifr_field_config
 {
-    uint16_t swapIndicatorAddress; /*!< Swap indicator address field.*/
-    uint16_t swapEnableWord;       /*!< Swap enable word field.*/
-    uint8_t reserved0[6];          /*!< Reserved field.*/
-    uint16_t swapDisableWord;      /*!< Swap disable word field.*/
-    uint8_t reserved1[4];          /*!< Reserved field.*/
+    uint16_t swapIndicatorAddress; /*!< A Swap indicator address field.*/
+    uint16_t swapEnableWord;       /*!< A Swap enable word field.*/
+    uint8_t reserved0[4];          /*!< A reserved field.*/
+#if (FSL_FEATURE_FLASH_IS_FTFE == 1)
+    uint8_t reserved1[2];     /*!< A reserved field.*/
+    uint16_t swapDisableWord; /*!< A Swap disable word field.*/
+    uint8_t reserved2[4];     /*!< A reserved field.*/
+#endif
 } flash_swap_ifr_field_config_t;
 
 /*!
- * @brief Enumeration for FlexRAM load during reset option.
+ * @brief Flash Swap IFR field data
+ */
+typedef union _flash_swap_ifr_field_data
+{
+    uint32_t flashSwapIfrData[2];                    /*!< A flash Swap IFR field data .*/
+    flash_swap_ifr_field_config_t flashSwapIfrField; /*!< A flash Swap IFR field structure.*/
+} flash_swap_ifr_field_data_t;
+
+/*!
+ * @brief PFlash protection status - low 32bit
+ */
+typedef union _pflash_protection_status_low
+{
+    uint32_t protl32b; /*!< PROT[31:0] .*/
+    struct
+    {
+        uint8_t protsl; /*!< PROTS[7:0] .*/
+        uint8_t protsh; /*!< PROTS[15:8] .*/
+        uint8_t reserved[2];
+    } prots16b;
+} pflash_protection_status_low_t;
+
+/*!
+ * @brief PFlash protection status - full
+ */
+typedef struct _pflash_protection_status
+{
+    pflash_protection_status_low_t valueLow32b; /*!< PROT[31:0] or PROTS[15:0].*/
+#if ((FSL_FEATURE_FLASH_IS_FTFA == 1) && (defined(FTFA_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFE == 1) && (defined(FTFE_FPROT_PROT_MASK))) || \
+    ((FSL_FEATURE_FLASH_IS_FTFL == 1) && (defined(FTFL_FPROT_PROT_MASK)))
+    // uint32_t protHigh; /*!< PROT[63:32].*/
+    struct
+    {
+        uint32_t proth32b;
+    } valueHigh32b;
+#endif
+} pflash_protection_status_t;
+
+/*!
+ * @brief Enumeration for the FlexRAM load during reset option.
  */
 typedef enum _flash_partition_flexram_load_option
 {
-    kFLASH_partitionFlexramLoadOptionLoadedWithValidEepromData =
+    kFLASH_PartitionFlexramLoadOptionLoadedWithValidEepromData =
         0x00U, /*!< FlexRAM is loaded with valid EEPROM data during reset sequence.*/
-    kFLASH_partitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
+    kFLASH_PartitionFlexramLoadOptionNotLoaded = 0x01U /*!< FlexRAM is not loaded during reset sequence.*/
 } flash_partition_flexram_load_option_t;
 
-/*! @brief callback type used for pflash block*/
+/*!
+ * @brief Enumeration for the flash memory index.
+ */
+typedef enum _flash_memory_index
+{
+    kFLASH_MemoryIndexPrimaryFlash = 0x00U,   /*!< Current flash memory is primary flash.*/
+    kFLASH_MemoryIndexSecondaryFlash = 0x01U, /*!< Current flash memory is secondary flash.*/
+} flash_memory_index_t;
+
+/*! @brief A callback type used for the Pflash block*/
 typedef void (*flash_callback_t)(void);
 
 /*!
- * @brief Active flash information for current operation.
+ * @brief Enumeration for the two possible options of flash prefetch speculation.
+ */
+typedef enum _flash_prefetch_speculation_option
+{
+    kFLASH_prefetchSpeculationOptionEnable = 0x00000000U,
+    kFLASH_prefetchSpeculationOptionDisable = 0xFFFFFFFFU
+} flash_prefetch_speculation_option_t;
+
+/*!
+ * @brief Flash prefetch speculation status.
+ */
+typedef struct _flash_prefetch_speculation_status
+{
+    flash_prefetch_speculation_option_t instructionOption; /*!< Instruction speculation.*/
+    flash_prefetch_speculation_option_t dataOption;        /*!< Data speculation.*/
+} flash_prefetch_speculation_status_t;
+
+/*!
+ * @brief Active flash protection information for the current operation.
+ */
+typedef struct _flash_protection_config
+{
+    uint32_t regionBase;  /*!< Base address of flash protection region.*/
+    uint32_t regionSize;  /*!< size of flash protection region.*/
+    uint32_t regionCount; /*!< flash protection region count.*/
+} flash_protection_config_t;
+
+/*!
+ * @brief Active flash Execute-Only access information for the current operation.
+ */
+typedef struct _flash_access_config
+{
+    uint32_t SegmentBase;  /*!< Base address of flash Execute-Only segment.*/
+    uint32_t SegmentSize;  /*!< size of flash Execute-Only segment.*/
+    uint32_t SegmentCount; /*!< flash Execute-Only segment count.*/
+} flash_access_config_t;
+
+/*!
+ * @brief Active flash information for the current operation.
  */
 typedef struct _flash_operation_config
 {
-    uint32_t convertedAddress;           /*!< Converted address for current flash type.*/
-    uint32_t activeSectorSize;           /*!< Sector size of current flash type.*/
-    uint32_t activeBlockSize;            /*!< Block size of current flash type.*/
-    uint32_t blockWriteUnitSize;         /*!< write unit size.*/
-    uint32_t sectorCmdAddressAligment;   /*!< Erase sector command address alignment.*/
-    uint32_t sectionCmdAddressAligment;  /*!< Program/Verify section command address alignment.*/
-    uint32_t resourceCmdAddressAligment; /*!< Read resource command address alignment.*/
-    uint32_t checkCmdAddressAligment;    /*!< Program check command address alignment.*/
+    uint32_t convertedAddress;           /*!< A converted address for the current flash type.*/
+    uint32_t activeSectorSize;           /*!< A sector size of the current flash type.*/
+    uint32_t activeBlockSize;            /*!< A block size of the current flash type.*/
+    uint32_t blockWriteUnitSize;         /*!< The write unit size.*/
+    uint32_t sectorCmdAddressAligment;   /*!< An erase sector command address alignment.*/
+    uint32_t sectionCmdAddressAligment;  /*!< A program/verify section command address alignment.*/
+    uint32_t resourceCmdAddressAligment; /*!< A read resource command address alignment.*/
+    uint32_t checkCmdAddressAligment;    /*!< A program check command address alignment.*/
 } flash_operation_config_t;
 
 /*! @brief Flash driver state information.
@@ -410,25 +548,29 @@ typedef struct _flash_operation_config
  */
 typedef struct _flash_config
 {
-    uint32_t PFlashBlockBase;                /*!< Base address of the first PFlash block */
-    uint32_t PFlashTotalSize;                /*!< Size of all combined PFlash block. */
-    uint32_t PFlashBlockCount;               /*!< Number of PFlash blocks. */
-    uint32_t PFlashSectorSize;               /*!< Size in bytes of a sector of PFlash. */
-    flash_callback_t PFlashCallback;         /*!< Callback function for flash API. */
-    uint32_t PFlashAccessSegmentSize;        /*!< Size in bytes of a access segment of PFlash. */
-    uint32_t PFlashAccessSegmentCount;       /*!< Number of PFlash access segments. */
-    uint32_t *flashExecuteInRamFunctionInfo; /*!< Info struct of flash execute-in-ram function. */
-    uint32_t FlexRAMBlockBase;               /*!< For FlexNVM device, this is the base address of FlexRAM
-                                                  For non-FlexNVM device, this is the base address of acceleration RAM memory */
-    uint32_t FlexRAMTotalSize;               /*!< For FlexNVM device, this is the size of FlexRAM
-                                                  For non-FlexNVM device, this is the size of acceleration RAM memory */
-    uint32_t DFlashBlockBase; /*!< For FlexNVM device, this is the base address of D-Flash memory (FlexNVM memory);
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t DFlashTotalSize; /*!< For FlexNVM device, this is total size of the FlexNVM memory;
-                                   For non-FlexNVM device, this field is unused */
-    uint32_t EEpromTotalSize; /*!< For FlexNVM device, this is the size in byte of EEPROM area which was partitioned
-                                 from FlexRAM;
-                                   For non-FlexNVM device, this field is unused */
+    uint32_t PFlashBlockBase;                /*!< A base address of the first PFlash block */
+    uint32_t PFlashTotalSize;                /*!< The size of the combined PFlash block. */
+    uint32_t PFlashBlockCount;               /*!< A number of PFlash blocks. */
+    uint32_t PFlashSectorSize;               /*!< The size in bytes of a sector of PFlash. */
+    flash_callback_t PFlashCallback;         /*!< The callback function for the flash API. */
+    uint32_t PFlashAccessSegmentSize;        /*!< A size in bytes of an access segment of PFlash. */
+    uint32_t PFlashAccessSegmentCount;       /*!< A number of PFlash access segments. */
+    uint32_t *flashExecuteInRamFunctionInfo; /*!< An information structure of the flash execute-in-RAM function. */
+    uint32_t
+        FlexRAMBlockBase;      /*!< For the FlexNVM device, this is the base address of the FlexRAM
+                                    For the non-FlexNVM device, this is the base address of the acceleration RAM memory */
+    uint32_t FlexRAMTotalSize; /*!< For the FlexNVM device, this is the size of the FlexRAM
+                                    For the non-FlexNVM device, this is the size of the acceleration RAM memory */
+    uint32_t
+        DFlashBlockBase; /*!< For the FlexNVM device, this is the base address of the D-Flash memory (FlexNVM memory)
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t DFlashTotalSize; /*!< For the FlexNVM device, this is the total size of the FlexNVM memory;
+                                   For the non-FlexNVM device, this field is unused */
+    uint32_t
+        EEpromTotalSize; /*!< For the FlexNVM device, this is the size in bytes of the EEPROM area which was partitioned
+                            from FlexRAM
+                              For the non-FlexNVM device, this field is unused */
+    uint32_t FlashMemoryIndex; /*!< 0 - primary flash; 1 - secondary flash*/
 } flash_config_t;
 
 /*******************************************************************************
@@ -445,37 +587,37 @@ extern "C" {
  */
 
 /*!
- * @brief Initializes global flash properties structure members
+ * @brief Initializes the global flash properties structure members.
  *
- * This function checks and initializes Flash module for the other Flash APIs.
+ * This function checks and initializes the Flash module for the other Flash APIs.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_Init(flash_config_t *config);
 
 /*!
- * @brief Set the desired flash callback function
+ * @brief Sets the desired flash callback function.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param callback callback function to be stored in driver
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param callback A callback function to be stored in the driver.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_SetCallback(flash_config_t *config, flash_callback_t callback);
 
 /*!
- * @brief Prepare flash execute-in-ram functions
+ * @brief Prepares flash execute-in-RAM functions.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config Pointer to the storage for the driver runtime state.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 #if FLASH_DRIVER_IS_FLASH_RESIDENT
 status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
@@ -491,59 +633,59 @@ status_t FLASH_PrepareExecuteInRamFunctions(flash_config_t *config);
 /*!
  * @brief Erases entire flash
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 status_t FLASH_EraseAll(flash_config_t *config, uint32_t key);
 
 /*!
- * @brief Erases flash sectors encompassed by parameters passed into function
+ * @brief Erases the flash sectors encompassed by parameters passed into function.
  *
  * This function erases the appropriate number of flash sectors based on the
  * desired start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config The pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be erased.
- *              The start address does not need to be sector aligned but must be word-aligned.
+ *              The start address does not need to be sector-aligned but must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
- *                      to be erased. Must be word aligned.
- * @param key value used to validate all flash erase APIs.
+ *                      to be erased. Must be word-aligned.
+ * @param key The value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
+ * @retval #kStatus_FLASH_EraseKeyError The API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, uint32_t key);
 
 /*!
- * @brief Erases entire flash, including protected sectors.
+ * @brief Erases the entire flash, including protected sectors.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update partition status
+ * @retval #kStatus_FLASH_PartitionStatusUpdateFailure Failed to update the partition status.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD) && FSL_FEATURE_FLASH_HAS_ERASE_ALL_BLOCKS_UNSECURE_CMD
 status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
@@ -552,16 +694,16 @@ status_t FLASH_EraseAllUnsecure(flash_config_t *config, uint32_t key);
 /*!
  * @brief Erases all program flash execute-only segments defined by the FXACC registers.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param key value used to validate all flash erase APIs.
+ * @param config Pointer to the storage for the driver runtime state.
+ * @param key A value used to validate all flash erase APIs.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_EraseKeyError Api erase key is invalid.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_EraseKeyError API erase key is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key);
 
@@ -573,101 +715,101 @@ status_t FLASH_EraseAllExecuteOnlySegments(flash_config_t *config, uint32_t key)
  */
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters
+ * @brief Programs flash with data at locations passed in through parameters.
  *
- * This function programs the flash memory with desired data for a given
- * flash area as determined by the start address and length.
+ * This function programs the flash memory with the desired data for a given
+ * flash area as determined by the start address and the length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs Program Once Field through parameters
+ * @brief Programs Program Once Field through parameters.
  *
- * This function programs the Program Once Field with desired data for a given
+ * This function programs the Program Once Field with the desired data for a given
  * flash area as determined by the index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param index The index indicating which area of Program Once Field to be programmed.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param index The index indicating which area of the Program Once Field to be programmed.
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the Program Once Field.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ProgramOnce(flash_config_t *config, uint32_t index, uint32_t *src, uint32_t lengthInBytes);
 
 /*!
- * @brief Programs flash with data at locations passed in through parameters via Program Section command
+ * @brief Programs flash with data at locations passed in through parameters via the Program Section command.
  *
- * This function programs the flash memory with desired data for a given
+ * This function programs the flash memory with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as ram
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SetFlexramAsRamError Failed to set flexram as RAM.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover flexram as eeprom
+ * @retval #kStatus_FLASH_RecoverFlexramAsEepromError Failed to recover FlexRAM as EEPROM.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD) && FSL_FEATURE_FLASH_HAS_PROGRAM_SECTION_CMD
 status_t FLASH_ProgramSection(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes);
 #endif
 
 /*!
- * @brief Programs EEPROM with data at locations passed in through parameters
+ * @brief Programs the EEPROM with data at locations passed in through parameters.
  *
- * This function programs the Emulated EEPROM with desired data for a given
+ * This function programs the emulated EEPROM with the desired data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param src Pointer to the source buffer of data that is to be programmed
+ * @param src A pointer to the source buffer of data that is to be programmed
  *            into the flash.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *                      to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
  * @retval #kStatus_FLASH_SetFlexramAsEepromError Failed to set flexram as eeprom.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover flexram as ram
+ * @retval #kStatus_FLASH_RecoverFlexramAsRamError Failed to recover the FlexRAM as RAM.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src, uint32_t lengthInBytes);
@@ -681,27 +823,27 @@ status_t FLASH_EepromWrite(flash_config_t *config, uint32_t start, uint8_t *src,
  */
 
 /*!
- * @brief Read resource with data at locations passed in through parameters
+ * @brief Reads the resource with data at locations passed in through parameters.
  *
- * This function reads the flash memory with desired location for a given
+ * This function reads the flash memory with the desired location for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be programmed. Must be
  *              word-aligned.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be read. Must be word-aligned.
  * @param option The resource option which indicates which area should be read back.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with the specified baseline.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD) && FSL_FEATURE_FLASH_HAS_READ_RESOURCE_CMD
 status_t FLASH_ReadResource(
@@ -709,23 +851,23 @@ status_t FLASH_ReadResource(
 #endif
 
 /*!
- * @brief Read Program Once Field through parameters
+ * @brief Reads the Program Once Field through parameters.
  *
- * This function reads the read once feild with given index and length
+ * This function reads the read once feild with given index and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param index The index indicating the area of program once field to be read.
- * @param dst Pointer to the destination buffer of data that is used to store
+ * @param dst A pointer to the destination buffer of data that is used to store
  *        data to be read.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be programmed. Must be word-aligned.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, uint32_t lengthInBytes);
 
@@ -737,35 +879,35 @@ status_t FLASH_ReadOnce(flash_config_t *config, uint32_t index, uint32_t *dst, u
  */
 
 /*!
- * @brief Returns the security state via the pointer passed into the function
+ * @brief Returns the security state via the pointer passed into the function.
  *
- * This function retrieves the current Flash security status, including the
+ * This function retrieves the current flash security status, including the
  * security enabling state and the backdoor key enabling state.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param state Pointer to the value returned for the current security status code:
+ * @param config A pointer to storage for the driver runtime state.
+ * @param state A pointer to the value returned for the current security status code:
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
 status_t FLASH_GetSecurityState(flash_config_t *config, flash_security_state_t *state);
 
 /*!
- * @brief Allows user to bypass security with a backdoor key
+ * @brief Allows users to bypass security with a backdoor key.
  *
- * If the MCU is in secured state, this function will unsecure the MCU by
- * comparing the provided backdoor key with ones in the Flash Configuration
- * Field.
+ * If the MCU is in secured state, this function unsecures the MCU by
+ * comparing the provided backdoor key with ones in the flash configuration
+ * field.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param backdoorKey Pointer to the user buffer containing the backdoor key.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param backdoorKey A pointer to the user buffer containing the backdoor key.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey);
 
@@ -777,75 +919,75 @@ status_t FLASH_SecurityBypass(flash_config_t *config, const uint8_t *backdoorKey
  */
 
 /*!
- * @brief Verifies erasure of entire flash at specified margin level
+ * @brief Verifies erasure of the entire flash at a specified margin level.
  *
- * This function will check to see if the flash have been erased to the
+ * This function checks whether the flash is erased to the
  * specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAll(flash_config_t *config, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies erasure of desired flash area at specified margin level
+ * @brief Verifies an erasure of the desired flash area at a specified margin level.
  *
- * This function will check the appropriate number of flash sectors based on
- * the desired start address and length to see if the flash have been erased
+ * This function checks the appropriate number of flash sectors based on
+ * the desired start address and length to check whether the flash is erased
  * to the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified.
- *        The start address does not need to be sector aligned but must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ *        The start address does not need to be sector-aligned but must be word-aligned.
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param margin Read margin choice
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyErase(flash_config_t *config, uint32_t start, uint32_t lengthInBytes, flash_margin_value_t margin);
 
 /*!
- * @brief Verifies programming of desired flash area at specified margin level
+ * @brief Verifies programming of the desired flash area at a specified margin level.
  *
  * This function verifies the data programed in the flash memory using the
- * Flash Program Check Command and compares it with expected data for a given
+ * Flash Program Check Command and compares it to the expected data for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be verified. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be verified. Must be word-aligned.
- * @param expectedData Pointer to the expected data that is to be
+ * @param expectedData A pointer to the expected data that is to be
  *        verified against.
- * @param margin Read margin choice
- * @param failedAddress Pointer to returned failing address.
- * @param failedData Pointer to returned failing data.  Some derivitives do
- *        not included failed data as part of the FCCOBx registers.  In this
+ * @param margin Read margin choice.
+ * @param failedAddress A pointer to the returned failing address.
+ * @param failedData A pointer to the returned failing data.  Some derivatives do
+ *        not include failed data as part of the FCCOBx registers.  In this
  *        case, zeros are returned upon failure.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
  * @retval #kStatus_FLASH_AddressError Address is out of range.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t start,
@@ -856,18 +998,18 @@ status_t FLASH_VerifyProgram(flash_config_t *config,
                              uint32_t *failedData);
 
 /*!
- * @brief Verifies if the program flash executeonly segments have been erased to
- *  the specified read margin level
+ * @brief Verifies whether the program flash execute-only segments have been erased to
+ *  the specified read margin level.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param margin Read margin choice
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param margin Read margin choice.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_margin_value_t margin);
 
@@ -879,22 +1021,22 @@ status_t FLASH_VerifyEraseAllExecuteOnlySegments(flash_config_t *config, flash_m
  */
 
 /*!
- * @brief Returns the protection state of desired flash area via the pointer passed into the function
+ * @brief Returns the protection state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash protect status for a given
+ * This function retrieves the current flash protect status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
  * @param lengthInBytes The length, given in bytes (not words or long-words)
  *        to be checked.  Must be word-aligned.
- * @param protection_state Pointer to the value returned for the current
+ * @param protection_state A pointer to the value returned for the current
  *        protection status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsProtected(flash_config_t *config,
                            uint32_t start,
@@ -902,22 +1044,22 @@ status_t FLASH_IsProtected(flash_config_t *config,
                            flash_protection_state_t *protection_state);
 
 /*!
- * @brief Returns the access state of desired flash area via the pointer passed into the function
+ * @brief Returns the access state of the desired flash area via the pointer passed into the function.
  *
- * This function retrieves the current Flash access status for a given
+ * This function retrieves the current flash access status for a given
  * flash area as determined by the start address and length.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param start The start address of the desired flash memory to be checked. Must be word-aligned.
- * @param lengthInBytes The length, given in bytes (not words or long-words)
+ * @param lengthInBytes The length, given in bytes (not words or long-words),
  *        to be checked.  Must be word-aligned.
- * @param access_state Pointer to the value returned for the current
+ * @param access_state A pointer to the value returned for the current
  *        access status code for the desired flash area.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_AddressError Address is out of range.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_AlignmentError The parameter is not aligned to the specified baseline.
+ * @retval #kStatus_FLASH_AddressError The address is out of range.
  */
 status_t FLASH_IsExecuteOnly(flash_config_t *config,
                              uint32_t start,
@@ -934,16 +1076,34 @@ status_t FLASH_IsExecuteOnly(flash_config_t *config,
 /*!
  * @brief Returns the desired flash property.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param whichProperty The desired property from the list of properties in
  *        enum flash_property_tag_t
- * @param value Pointer to the value returned for the desired flash property
+ * @param value A pointer to the value returned for the desired flash property.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_UnknownProperty unknown property tag
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
  */
 status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t *value);
+
+/*!
+ * @brief Sets the desired flash property.
+ *
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param whichProperty The desired property from the list of properties in
+ *        enum flash_property_tag_t
+ * @param value A to set for the desired flash property.
+ *
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_UnknownProperty An unknown property tag.
+ * @retval #kStatus_FLASH_InvalidPropertyValue An invalid property value.
+ * @retval #kStatus_FLASH_ReadOnlyProperty An read-only property tag.
+ */
+#if FLASH_SSD_IS_SECONDARY_FLASH_SUPPORTED
+status_t FLASH_SetProperty(flash_config_t *config, flash_property_tag_t whichProperty, uint32_t value);
+#endif
 
 /*@}*/
 
@@ -953,17 +1113,17 @@ status_t FLASH_GetProperty(flash_config_t *config, flash_property_tag_t whichPro
  */
 
 /*!
- * @brief Set FlexRAM Function command
+ * @brief Sets the FlexRAM function command.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param option The option used to set work mode of FlexRAM
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param option The option used to set the work mode of FlexRAM.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD) && FSL_FEATURE_FLASH_HAS_SET_FLEXRAM_FUNCTION_CMD
 status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function_option_t option);
@@ -977,21 +1137,21 @@ status_t FLASH_SetFlexramFunction(flash_config_t *config, flash_flexram_function
  */
 
 /*!
- * @brief Configure Swap function or Check the swap state of Flash Module
+ * @brief Configures the Swap function or checks the the swap state of the Flash module.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
- * @param returnInfo Pointer to the data which is used to return the information of flash swap.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param address Address used to configure the flash Swap function.
+ * @param option The possible option used to configure Flash Swap function or check the flash Swap status
+ * @param returnInfo A pointer to the data which is used to return the information of flash Swap.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
- * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
+ * @retval #kStatus_FLASH_CommandFailure Run-time error during the command execution.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD) && FSL_FEATURE_FLASH_HAS_SWAP_CONTROL_CMD
 status_t FLASH_SwapControl(flash_config_t *config,
@@ -1001,21 +1161,21 @@ status_t FLASH_SwapControl(flash_config_t *config,
 #endif
 
 /*!
- * @brief Swap the lower half flash with the higher half flaock
+ * @brief Swaps the lower half flash with the higher half flash.
  *
- * @param config Pointer to storage for the driver runtime state.
+ * @param config A pointer to the storage for the driver runtime state.
  * @param address Address used to configure the flash swap function
- * @param option The possible option used to configure Flash Swap function or check the flash swap status
+ * @param option The possible option used to configure the Flash Swap function or check the flash Swap status.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_AlignmentError Parameter is not aligned with specified baseline.
- * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_SwapIndicatorAddressError Swap indicator address is invalid.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
- * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in uninitialzed state
+ * @retval #kStatus_FLASH_SwapSystemNotInUninitialized Swap system is not in an uninitialzed state.
  */
 #if defined(FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP) && FSL_FEATURE_FLASH_HAS_PFLASH_BLOCK_SWAP
 status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_function_option_t option);
@@ -1036,9 +1196,9 @@ status_t FLASH_Swap(flash_config_t *config, uint32_t address, flash_swap_functio
  * @param flexnvmPartitionCode Specifies how to split the FlexNVM block between data flash memory and EEPROM backup
  *        memory supporting EEPROM functions.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
  * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-ram function is not available.
+ * @retval #kStatus_FLASH_ExecuteInRamFunctionNotReady Execute-in-RAM function is not available.
  * @retval #kStatus_FLASH_AccessError Invalid instruction codes and out-of bounds addresses.
  * @retval #kStatus_FLASH_ProtectionViolation The program/erase operation is requested to execute on protected areas.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
@@ -1058,51 +1218,54 @@ status_t FLASH_ProgramPartition(flash_config_t *config,
 */
 
 /*!
- * @brief Set PFLASH Protection to the intended protection status.
+ * @brief Sets the PFlash Protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to PFlash protection register. Each bit is
- * corresponding to protection of 1/32 of the total PFlash. The least significant bit is corresponding to the lowest
- * address area of P-Flash. The most significant bit is corresponding to the highest address area of PFlash. There are
+ * @param config A pointer to storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * corresponding to protection of 1/32(64) of the total PFlash. The least significant bit is corresponding to the lowest
+ * address area of PFlash. The most significant bit is corresponding to the highest address area of PFlash. There are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
-status_t FLASH_PflashSetProtection(flash_config_t *config, uint32_t protectStatus);
+status_t FLASH_PflashSetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Get PFLASH Protection Status.
+ * @brief Gets the PFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/32 of the
- * total PFlash. The least significant bit is corresponding to the lowest address area of PFlash. The most significant
- * bit is corresponding to the highest address area of PFlash. Thee are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  Protect status returned by the PFlash IP. Each bit is corresponding to the protection of
+ * 1/32(64)
+ * of the
+ * total PFlash. The least significant bit corresponds to the lowest address area of the PFlash. The most significant
+ * bit corresponds to the highest address area of PFlash. There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
  */
-status_t FLASH_PflashGetProtection(flash_config_t *config, uint32_t *protectStatus);
+status_t FLASH_PflashGetProtection(flash_config_t *config, pflash_protection_status_t *protectStatus);
 
 /*!
- * @brief Set DFLASH Protection to the intended protection status.
+ * @brief Sets the DFlash protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to DFlash protection register. Each bit is
- * corresponding to protection of 1/8 of the total DFlash. The least significant bit is corresponding to the lowest
- * address area of DFlash. The most significant bit is corresponding to the highest address area of  DFlash. There are
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the DFlash protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total DFlash. The least significant bit corresponds to the lowest
+ * address area of the DFlash. The most significant bit corresponds to the highest address area of  the DFlash. There
+ * are
  * two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1110,38 +1273,39 @@ status_t FLASH_DflashSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total DFlash. The least significant bit is corresponding to the lowest address area of DFlash. The most
- * significant bit is corresponding to the highest address area of DFlash and so on. There are two possible cases as
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total DFlash. The least significant bit corresponds to the lowest address area of the DFlash. The most
+ * significant bit corresponds to the highest address area of the DFlash, and so on. There are two possible cases as
  * below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_DflashGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
 
 /*!
- * @brief Set EEPROM Protection to the intended protection status.
+ * @brief Sets the EEPROM protection to the intended protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus The expected protect status user wants to set to EEPROM protection register. Each bit is
- * corresponding to protection of 1/8 of the total EEPROM. The least significant bit is corresponding to the lowest
- * address area of EEPROM. The most significant bit is corresponding to the highest address area of EEPROM, and so on.
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus The expected protect status to set to the EEPROM protection register. Each bit
+ * corresponds to the protection of the 1/8 of the total EEPROM. The least significant bit corresponds to the lowest
+ * address area of the EEPROM. The most significant bit corresponds to the highest address area of EEPROM, and so on.
  * There are two possible cases as shown below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  * @retval #kStatus_FLASH_CommandFailure Run-time error during command execution.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
@@ -1149,22 +1313,49 @@ status_t FLASH_EepromSetProtection(flash_config_t *config, uint8_t protectStatus
 #endif
 
 /*!
- * @brief Get DFLASH Protection Status.
+ * @brief Gets the DFlash protection status.
  *
- * @param config Pointer to storage for the driver runtime state.
- * @param protectStatus  DFlash Protect status returned by PFlash IP. Each bit is corresponding to protection of 1/8 of
- * the total EEPROM. The least significant bit is corresponding to the lowest address area of EEPROM. The most
- * significant bit is corresponding to the highest address area of EEPROM. There are two possible cases as below:
+ * @param config A pointer to the storage for the driver runtime state.
+ * @param protectStatus  DFlash Protect status returned by the PFlash IP. Each bit corresponds to the protection of the
+ * 1/8 of
+ * the total EEPROM. The least significant bit corresponds to the lowest address area of the EEPROM. The most
+ * significant bit corresponds to the highest address area of the EEPROM. There are two possible cases as below:
  *       0: this area is protected.
  *       1: this area is unprotected.
  *
- * @retval #kStatus_FLASH_Success Api was executed successfully.
- * @retval #kStatus_FLASH_InvalidArgument Invalid argument is provided.
- * @retval #kStatus_FLASH_CommandNotSupported Flash api is not supported.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidArgument An invalid argument is provided.
+ * @retval #kStatus_FLASH_CommandNotSupported Flash API is not supported.
  */
 #if FLASH_SSD_IS_FLEXNVM_ENABLED
 status_t FLASH_EepromGetProtection(flash_config_t *config, uint8_t *protectStatus);
 #endif
+
+/*@}*/
+
+/*@}*/
+
+/*!
+* @name Flash Speculation Utilities
+* @{
+*/
+
+/*!
+ * @brief Sets the PFlash prefetch speculation to the intended speculation status.
+ *
+ * @param speculationStatus The expected protect status to set to the PFlash protection register. Each bit is
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ * @retval #kStatus_FLASH_InvalidSpeculationOption An invalid speculation option argument is provided.
+ */
+status_t FLASH_PflashSetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
+
+/*!
+ * @brief Gets the PFlash prefetch speculation status.
+ *
+ * @param speculationStatus  Speculation status returned by the PFlash IP.
+ * @retval #kStatus_FLASH_Success API was executed successfully.
+ */
+status_t FLASH_PflashGetPrefetchSpeculation(flash_prefetch_speculation_status_t *speculationStatus);
 
 /*@}*/
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/sleep.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/sleep.c
@@ -26,8 +26,8 @@ void hal_sleep(void)
 
 void hal_deepsleep(void)
 {
-    LPC_CLOCK_INTERNAL_IRC();
+    LPC_CLOCK_INTERNAL_IRC;
     /* Enter Deep Sleep mode */
     POWER_EnterDeepSleep(APP_EXCLUDE_FROM_DEEPSLEEP);
-    LPC_CLOCK_RUN();
+    LPC_CLOCK_RUN;
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/device.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/device.h
@@ -25,8 +25,9 @@
      SYSCON_PDRUNCFG_PDEN_SRAM0_MASK | SYSCON_PDRUNCFG_PDEN_SRAM1_2_3_MASK)
 
 /* Defines used by the sleep code */
-#define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M
-#define LPC_CLOCK_RUN          BOARD_BootClockFROHF48M
+#define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M()
+#define LPC_CLOCK_RUN          ((SYSCON->DEVICE_ID0 == 0xFFF54628) ? \
+                                 BOARD_BootClockPLL220M() : BOARD_BootClockFROHF48M())
 
 #define DEVICE_ID_LENGTH       24
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/device.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/device.h
@@ -25,8 +25,9 @@
      SYSCON_PDRUNCFG_PDEN_SRAM0_MASK | SYSCON_PDRUNCFG_PDEN_SRAM1_2_3_MASK)
 
 /* Defines used by the sleep code */
-#define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M
-#define LPC_CLOCK_RUN          BOARD_BootClockFROHF48M
+#define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M()
+#define LPC_CLOCK_RUN          ((SYSCON->DEVICE_ID0 == 0xFFF54628) ? \
+                                 BOARD_BootClockPLL220M() : BOARD_BootClockFROHF48M())
 
 #define DEVICE_ID_LENGTH       24
 


### PR DESCRIPTION
Fixes the Deep sleep implementation for the MCUXpresso SoC's. This is based on testing using the latest sleep manager that invokes deepsleep mode in the idle loop
