### PR TITLE
STM32 LPTICKER update for targets supporting LPTIMER

### DIFF
--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -28,7 +28,7 @@ static const ticker_interface_t lp_interface = {
     .read = lp_ticker_read,
     .disable_interrupt = lp_ticker_disable_interrupt,
     .clear_interrupt = lp_ticker_clear_interrupt,
-#if LOWPOWERTIMER_DELAY_TICKS > 0
+#if LPTICKER_DELAY_TICKS > 0
     .set_interrupt = lp_ticker_set_interrupt_wrapper,
 #else
     .set_interrupt = lp_ticker_set_interrupt,

--- a/hal/mbed_lp_ticker_wrapper.cpp
+++ b/hal/mbed_lp_ticker_wrapper.cpp
@@ -15,12 +15,12 @@
  */
 #include "hal/lp_ticker_api.h"
 
-#if DEVICE_LOWPOWERTIMER && (LOWPOWERTIMER_DELAY_TICKS > 0)
+#if DEVICE_LPTICKER && (LPTICKER_DELAY_TICKS > 0)
 
 #include "Timeout.h"
 #include "mbed_critical.h"
 
-static const timestamp_t min_delta = LOWPOWERTIMER_DELAY_TICKS;
+static const timestamp_t min_delta = LPTICKER_DELAY_TICKS;
 
 static bool init = false;
 static bool pending = false;
@@ -108,7 +108,7 @@ static void set_interrupt_later()
  * Wrapper around lp_ticker_set_interrupt to prevent blocking
  *
  * Problems this function is solving:
- * 1. Interrupt may not fire if set earlier than LOWPOWERTIMER_DELAY_TICKS low power clock cycles
+ * 1. Interrupt may not fire if set earlier than LPTICKER_DELAY_TICKS low power clock cycles
  * 2. Setting the interrupt back-to-back will block
  *
  * This wrapper function prevents lp_ticker_set_interrupt from being called

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -179,7 +179,12 @@ static void LPTIM1_IRQHandler(void)
 uint32_t lp_ticker_read(void)
 {
     uint32_t lp_time = LPTIM1->CNT;
-    return lp_time;     
+    /* Reading the LPTIM_CNT register may return unreliable values.
+    It is necessary to perform two consecutive read accesses and verify that the two returned values are identical */
+    while (lp_time != LPTIM1->CNT) {
+        lp_time = LPTIM1->CNT;
+    }
+    return lp_time;
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -36,17 +36,24 @@
 
 LPTIM_HandleTypeDef LptimHandle;
 
-volatile uint32_t lp_SlaveCounter = 0;
-volatile uint32_t lp_oc_int_part = 0;
-volatile uint16_t lp_TickPeriod_us;
+const ticker_info_t* lp_ticker_get_info()
+{
+    static const ticker_info_t info = {
+        RTC_CLOCK,
+        16
+    };
+    return &info;
+}
+
 volatile uint8_t  lp_Fired = 0;
 
 static void LPTIM1_IRQHandler(void);
 static void (*irq_handler)(void);
 
-
 void lp_ticker_init(void)
 {
+    NVIC_DisableIRQ(LPTIM1_IRQn);
+
     /* Check if LPTIM is already configured */
 #if (TARGET_STM32L0)
     if (READ_BIT(RCC->APB1ENR, RCC_APB1ENR_LPTIM1EN) != RESET) {
@@ -111,21 +118,7 @@ void lp_ticker_init(void)
     LptimHandle.Instance = LPTIM1;
     LptimHandle.State = HAL_LPTIM_STATE_RESET;
     LptimHandle.Init.Clock.Source = LPTIM_CLOCKSOURCE_APBCLOCK_LPOSC;
-
-    /*  Prescaler impact:
-            tick period = Prescaler division factor / LPTIM clock
-            Example with LPTIM clock = 32768 Hz LSE
-                Prescaler = LPTIM_PRESCALER_DIV1   => lp_TickPeriod_us = 31us  =>   2s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV2   => lp_TickPeriod_us = 61us  =>   4s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV4   => lp_TickPeriod_us = 122us =>   8s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV8   => lp_TickPeriod_us = 244us =>  16s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV16  => lp_TickPeriod_us = 488us =>  32s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV32  => lp_TickPeriod_us = 976us =>  64s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV64  => lp_TickPeriod_us = 1.9ms => 128s with 16b timer
-                Prescaler = LPTIM_PRESCALER_DIV128 => lp_TickPeriod_us = 3.9ms => 256s with 16b timer
-    */
-    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV2;
-    lp_TickPeriod_us = 2 * 1000000 / RTC_CLOCK;
+    LptimHandle.Init.Clock.Prescaler = LPTIM_PRESCALER_DIV1;
 
     LptimHandle.Init.Trigger.Source = LPTIM_TRIGSOURCE_SOFTWARE;
     LptimHandle.Init.OutputPolarity = LPTIM_OUTPUTPOLARITY_HIGH;
@@ -142,7 +135,6 @@ void lp_ticker_init(void)
     }
 
     NVIC_SetVector(LPTIM1_IRQn, (uint32_t)LPTIM1_IRQHandler);
-    NVIC_EnableIRQ(LPTIM1_IRQn);
 
 #if !(TARGET_STM32L4)
     /* EXTI lines are not configured by default */
@@ -150,10 +142,10 @@ void lp_ticker_init(void)
     __HAL_LPTIM_WAKEUPTIMER_EXTI_ENABLE_RISING_EDGE();
 #endif
 
-    __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_ARRM);
     __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_CMPM);
-    __HAL_LPTIM_ENABLE_IT(&LptimHandle, LPTIM_IT_CMPOK);
     HAL_LPTIM_Counter_Start(&LptimHandle, 0xFFFF);
+
+    __HAL_LPTIM_COMPARE_SET(&LptimHandle, 0);
 }
 
 static void LPTIM1_IRQHandler(void)
@@ -173,30 +165,9 @@ static void LPTIM1_IRQHandler(void)
             /* Clear Compare match flag */
             __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
 
-            if (lp_oc_int_part > 0) {
-                lp_oc_int_part--;
-            } else {
                 if (irq_handler) {
                     irq_handler();
-                }
             }
-        }
-    }
-
-    /* Compare write interrupt */
-    if (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) != RESET) {
-        if (__HAL_LPTIM_GET_IT_SOURCE(&LptimHandle, LPTIM_IT_CMPOK) != RESET) {
-            /* Clear Compare write flag */
-            __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-        }
-    }
-
-    /* Autoreload match interrupt */
-    if (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_ARRM) != RESET) {
-        if (__HAL_LPTIM_GET_IT_SOURCE(&LptimHandle, LPTIM_IT_ARRM) != RESET) {
-            /* Clear Autoreload match flag */
-            __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_ARRM);
-            lp_SlaveCounter++;
         }
     }
 
@@ -205,82 +176,47 @@ static void LPTIM1_IRQHandler(void)
 #endif
 }
 
-
-uint32_t lp_ticker_read_TickCounter(void)
-{
-    uint16_t cntH_old, cntH, cntL;
-
-    LptimHandle.Instance = LPTIM1;
-
-    /* same algo as us_ticker_read in us_ticker_16b.c */
-    do {
-        cntH_old = lp_SlaveCounter;
-        if (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_ARRM) == SET) {
-            cntH_old += 1;
-        }
-        cntL = LPTIM1->CNT;
-        cntH = lp_SlaveCounter;
-        if (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_ARRM) == SET) {
-            cntH += 1;
-        }
-    } while (cntH_old != cntH);
-    uint32_t lp_time = (uint32_t)(cntH << 16 | cntL);
-    return lp_time;
-}
-
 uint32_t lp_ticker_read(void)
 {
-    lp_ticker_init();
-    return lp_ticker_read_TickCounter() * (uint32_t)lp_TickPeriod_us;
+    uint32_t lp_time = LPTIM1->CNT;
+    return lp_time;     
 }
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
-    // Disable IRQs
-    core_util_critical_section_enter();
-
-    uint32_t timestamp_TickCounter = timestamp / (uint32_t)lp_TickPeriod_us;
-
     LptimHandle.Instance = LPTIM1;
     irq_handler = (void (*)(void))lp_ticker_irq_handler;
 
-    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
-    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
-    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp_TickCounter & 0xFFFF);
-
     /* CMPOK is set by hardware to inform application that the APB bus write operation to the LPTIM_CMP register has been successfully completed */
+    /* Any successive write before respectively the ARROK flag or the CMPOK flag be set, will lead to unpredictable results */
     while (__HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK) == RESET) {
     }
 
-    /* same algo as us_ticker_set_interrupt in us_ticker_16b.c */
-    uint32_t current_time_TickCounter = lp_ticker_read_TickCounter();
-    uint32_t delta = timestamp_TickCounter - current_time_TickCounter;
-    lp_oc_int_part = (delta - 1) >> 16;
-    if ( ((delta - 1) & 0xFFFF) >= 0x8000 &&
-            __HAL_LPTIM_GET_FLAG(&LptimHandle, LPTIM_FLAG_CMPM) == SET ) {
-        ++lp_oc_int_part;
-    }
+    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPOK);
+    __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
+    __HAL_LPTIM_COMPARE_SET(&LptimHandle, timestamp);
 
-    // Enable IRQs
-    core_util_critical_section_exit();
+    NVIC_EnableIRQ(LPTIM1_IRQn);
 }
 
 void lp_ticker_fire_interrupt(void)
 {
     lp_Fired = 1;
     NVIC_SetPendingIRQ(LPTIM1_IRQn);
+    NVIC_EnableIRQ(LPTIM1_IRQn);
 }
 
 void lp_ticker_disable_interrupt(void)
 {
     LptimHandle.Instance = LPTIM1;
-    __HAL_LPTIM_DISABLE_IT(&LptimHandle, LPTIM_IT_CMPM);
+    NVIC_DisableIRQ(LPTIM1_IRQn);
 }
 
 void lp_ticker_clear_interrupt(void)
 {
     LptimHandle.Instance = LPTIM1;
     __HAL_LPTIM_CLEAR_FLAG(&LptimHandle, LPTIM_FLAG_CMPM);
+    NVIC_ClearPendingIRQ(LPTIM1_IRQn);
 }
 
 #else /* MBED_CONF_TARGET_LPTICKER_LPTIM */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1071,7 +1071,7 @@
             }
         },
         "detect_code": ["0744"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F410RB"
     },
@@ -1179,7 +1179,7 @@
         },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },
@@ -1193,11 +1193,15 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_lptim": {
+                "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
+                "value": 1
             }
         },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },
@@ -1344,7 +1348,7 @@
         "macros_add": ["USBHOST_OTHER"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0816"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746ZG",
@@ -1373,7 +1377,7 @@
         "macros_add": ["TRANSACTION_QUEUE_SIZE_SPI=2", "USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0819"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F756ZG"
@@ -1401,7 +1405,7 @@
         "supported_form_factors": ["ARDUINO"],
         "macros_add": ["USBHOST_OTHER"],
         "detect_code": ["0818"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F767ZI",
@@ -1426,7 +1430,7 @@
             }
         },
         "detect_code": ["0780"],
-        "device_has_add": ["SERIAL_FC", "FLASH"],
+        "device_has_add": ["LPTICKER", "SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L011K4"
@@ -1449,7 +1453,7 @@
             }
         },
         "detect_code": ["0790"],
-        "device_has_add": ["SERIAL_FC", "FLASH"],
+        "device_has_add": ["LPTICKER", "SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L031K6"
@@ -1471,7 +1475,7 @@
             }
         },
         "detect_code": ["0715"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053R8"
@@ -1493,7 +1497,7 @@
             }
         },
         "detect_code": ["0760"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L073RZ"
     },
@@ -1531,7 +1535,7 @@
             }
         },
         "detect_code": ["0770"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L432KC",
         "bootloader_supported": true
@@ -1553,7 +1557,7 @@
             }
         },
         "detect_code": ["0779"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L433RC",
         "bootloader_supported": true
@@ -1596,7 +1600,7 @@
         },
         "detect_code": ["0765"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476RG",
         "bootloader_supported": true
@@ -1637,7 +1641,7 @@
         },
         "detect_code": ["0827"],
         "macros_add": ["USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L486RG"
     },
@@ -1805,7 +1809,7 @@
             }
         },
         "overrides": {"lse_available": 0},
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053C8"
@@ -1827,7 +1831,7 @@
             }
         },
         "detect_code": ["0833"],
-        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L072CZ"
     },
@@ -1862,7 +1866,7 @@
         },
         "detect_code": ["0815"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746NG"
@@ -1885,7 +1889,7 @@
         },
         "detect_code": ["0817"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F769NI"
@@ -1908,7 +1912,7 @@
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L475VG",
         "bootloader_supported": true
@@ -1930,7 +1934,7 @@
         },
         "detect_code": ["0820"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476VG",
         "bootloader_supported": true
@@ -3918,7 +3922,7 @@
             }
         },
         "detect_code": ["0823"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L496ZG"
     },

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -705,7 +705,7 @@
         "public": false,
         "extra_labels": ["STM"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "LPTICKER_DELAY_TICKS=3"],
         "config": {
             "lse_available": {
                 "help": "Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used",


### PR DESCRIPTION
### Description

STM32 LPTICKER update for targets supporting ST LPTIM

Targets: STM32L0, STM32L4, STM32F7 and few STM32F4

@bulislaw @LMESTM @c1728p9 @screamerbg 

### Pull request type

[ ] Fix  
[x] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
