### PR TITLE
Enable tickless mode on Silicon Labs targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2770,7 +2770,7 @@
     "EFM32": {
         "inherits": ["Target"],
         "extra_labels": ["Silicon_Labs", "EFM32"],
-        "macros": ["MBEDTLS_CONFIG_HW_SUPPORT"],
+        "macros": ["MBEDTLS_CONFIG_HW_SUPPORT", "MBED_TICKLESS"],
         "public": false
     },
     "EFM32GG990F1024": {


### PR DESCRIPTION
### Description

This PR activates tickless mode on Silicon Labs targets.

Tests ran:
With lp_ticker backed by RTC: (EFM32LG, EFM32WG, EFM32GG, EFM32HG, EFM32ZG all use the same peripheral so would be covered by this test)
```+-------------------------+-----------------+----------------------------------------------+--------+--------------------+-------------+
| target                  | platform_name   | test suite                                   | result | elapsed_time (sec) | copy_method |
+-------------------------+-----------------+----------------------------------------------+--------+--------------------+-------------+
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-basic              | OK     | 30.57              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-circularbuffer     | OK     | 21.09              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-condition_variable | OK     | 19.46              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-event_flags        | OK     | 19.97              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-heap_and_stack     | OK     | 19.76              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-mail               | OK     | 20.53              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-malloc             | OK     | 39.43              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-memorypool         | OK     | 20.53              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-mutex              | OK     | 21.77              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-queue              | OK     | 20.56              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-rtostimer          | OK     | 20.63              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-semaphore          | OK     | 22.86              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-signals            | OK     | 19.97              | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-systimer           | OK     | 19.7               | default     |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbedmicro-rtos-mbed-threads            | OK     | 22.19              | default     |
+-------------------------+-----------------+----------------------------------------------+--------+--------------------+-------------+
```

With lp_ticker backed by RTCC (EFM32PG, EFR32MG, EFM32PG12, EFR32MG12 all use RTCC to back lp_ticker, so should be covered by the same test):
```+---------------------------+-------------------+----------------------------------------------+--------+--------------------+-------------+
| target                    | platform_name     | test suite                                   | result | elapsed_time (sec) | copy_method |
+---------------------------+-------------------+----------------------------------------------+--------+--------------------+-------------+
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-basic              | OK     | 30.5               | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-circularbuffer     | OK     | 20.67              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-condition_variable | OK     | 20.33              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-event_flags        | OK     | 21.05              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-heap_and_stack     | OK     | 19.97              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-mail               | OK     | 21.06              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-malloc             | OK     | 40.54              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-memorypool         | OK     | 21.35              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-mutex              | OK     | 23.33              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-queue              | OK     | 20.72              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-rtostimer          | OK     | 20.83              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-semaphore          | OK     | 23.12              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-signals            | OK     | 20.57              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-systimer           | OK     | 20.21              | default     |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbedmicro-rtos-mbed-threads            | OK     | 22.68              | default     |
+---------------------------+-------------------+----------------------------------------------+--------+--------------------+-------------+
```