### PR TITLE
Implement watchdog and reset reason APIs on Silicon Labs parts

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/resetreason_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/resetreason_api.c
@@ -1,0 +1,132 @@
+/***************************************************************************//**
+ * @file resetreason_api.c
+ *******************************************************************************
+ * @section License
+ * <b>(C) Copyright 2018 Silicon Labs, http://www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "device.h"
+#include "reset_reason_api.h"
+
+#if DEVICE_RESET_REASON
+
+#include "em_rmu.h"
+
+reset_reason_t hal_reset_reason_get(void)
+{
+	uint32_t reasonmask = RMU_ResetCauseGet();
+
+	/* Only care about the upper bit, since that is 'most significant' reset reason */
+	reasonmask = 1 << (31 - __CLZ(reasonmask));
+
+	if (reasonmask & RMU_RSTCAUSE_PORST) {
+		return RESET_REASON_POWER_ON;
+	}
+#if defined(RMU_RSTCAUSE_BODUNREGRST)
+	if (reasonmask & RMU_RSTCAUSE_BODUNREGRST) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_BODREGRST)
+	if (reasonmask & RMU_RSTCAUSE_BODREGRST) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_AVDDBOD)
+	if (reasonmask & RMU_RSTCAUSE_AVDDBOD) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_DVDDBOD)
+	if (reasonmask & RMU_RSTCAUSE_DVDDBOD) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_DECBOD)
+	if (reasonmask & RMU_RSTCAUSE_DECBOD) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+	if (reasonmask & RMU_RSTCAUSE_EXTRST) {
+		return RESET_REASON_PIN_RESET;
+	}
+	if (reasonmask & RMU_RSTCAUSE_WDOGRST) {
+		return RESET_REASON_WATCHDOG;
+	}
+	if (reasonmask & RMU_RSTCAUSE_LOCKUPRST) {
+		return RESET_REASON_LOCKUP;
+	}
+	if (reasonmask & RMU_RSTCAUSE_SYSREQRST) {
+		return RESET_REASON_SOFTWARE;
+	}
+#if defined(RMU_RSTCAUSE_EM4RST)
+	if (reasonmask & RMU_RSTCAUSE_EM4RST) {
+		return RESET_REASON_WAKE_LOW_POWER;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_EM4WURST)
+	if (reasonmask & RMU_RSTCAUSE_EM4WURST) {
+		return RESET_REASON_WAKE_LOW_POWER;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_BODAVDD0)
+	if (reasonmask & RMU_RSTCAUSE_BODAVDD0) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(RMU_RSTCAUSE_BODAVDD1)
+	if (reasonmask & RMU_RSTCAUSE_BODAVDD1) {
+		return RESET_REASON_BROWN_OUT;
+	}
+#endif
+#if defined(BU_PRESENT) && defined(_SILICON_LABS_32B_SERIES_0)
+	if (reasonmask & RMU_RSTCAUSE_BUBODVDDDREG) {
+		return RESET_REASON_BROWN_OUT;
+	}
+	if (reasonmask & RMU_RSTCAUSE_BUBODBUVIN) {
+		return RESET_REASON_BROWN_OUT;
+	}
+	if (reasonmask & RMU_RSTCAUSE_BUBODUNREG) {
+		return RESET_REASON_BROWN_OUT;
+	}
+	if (reasonmask & RMU_RSTCAUSE_BUBODREG) {
+		return RESET_REASON_BROWN_OUT;
+	}
+	if (reasonmask & RMU_RSTCAUSE_BUMODERST) {
+		return RESET_REASON_PLATFORM;
+	}
+#elif defined(RMU_RSTCAUSE_BUMODERST)
+	if (reasonmask & RMU_RSTCAUSE_BUMODERST) {
+		return RESET_REASON_PLATFORM;
+	}
+#endif
+	return RESET_REASON_UNKNOWN;
+}
+
+uint32_t hal_reset_reason_get_raw(void)
+{
+	return RMU->RSTCAUSE;
+}
+
+void hal_reset_reason_clear(void)
+{
+	RMU_ResetCauseClear();
+}
+
+#endif /* DEVICE_RESET_REASON */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/watchdog_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/watchdog_api.c
@@ -1,0 +1,100 @@
+/***************************************************************************//**
+ * @file watchdog_api.c
+ *******************************************************************************
+ * @section License
+ * <b>(C) Copyright 2018 Silicon Labs, http://www.silabs.com</b>
+ *******************************************************************************
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ******************************************************************************/
+
+#include "device.h"
+#include "watchdog_api.h"
+
+#if DEVICE_WATCHDOG
+
+#include "clocking.h"
+#include "em_cmu.h"
+#include "em_wdog.h"
+
+watchdog_status_t hal_watchdog_init(const watchdog_config_t *config)
+{
+    if (config == 0 || config->timeout_ms > 262145 || config->timeout_ms == 0) {
+        return WATCHDOG_STATUS_INVALID_ARGUMENT;
+    }
+
+    uint32_t timeout = config->timeout_ms;
+    if (timeout <= 9) {
+        timeout = 0;
+    } else {
+        timeout -= 2;
+        /* get bit position of highest bit set */
+        timeout = 31 - __CLZ(timeout);
+        /* need to go one over */
+        timeout += 1;
+        /* convert to wdog setting. if bit 4 is the highest, then the
+         * watchdog setting == 1. That means watchdog setting 0xF == 2^18 = 256k */
+        if (timeout > 18) {
+            return WATCHDOG_STATUS_INVALID_ARGUMENT;
+        }
+
+        timeout -= 3;
+    }
+
+    WDOG_Init_TypeDef wdog_init = WDOG_INIT_DEFAULT;
+    wdog_init.clkSel = wdogClkSelULFRCO;
+    wdog_init.em2Run = true;
+    wdog_init.em3Run = true;
+    wdog_init.perSel = timeout;
+
+    WDOGn_Init(DEFAULT_WDOG, &wdog_init);
+
+    return WATCHDOG_STATUS_OK;
+}
+
+void hal_watchdog_kick(void)
+{
+    WDOGn_Feed(DEFAULT_WDOG);
+}
+
+watchdog_status_t hal_watchdog_stop(void)
+{
+    WDOGn_Enable(DEFAULT_WDOG, false);
+    return WATCHDOG_STATUS_OK;
+}
+
+uint32_t hal_watchdog_get_reload_value(void)
+{
+    uint32_t period = (DEFAULT_WDOG->CTRL & _WDOG_CTRL_PERSEL_MASK) >> _WDOG_CTRL_PERSEL_SHIFT;
+    if (period == 0) {
+        return 9;
+    } else {
+        period += 3;
+        return (1U << period) + 1;
+    }
+}
+
+watchdog_features_t hal_watchdog_get_platform_features(void)
+{
+    watchdog_features_t feat = {
+        .max_timeout = 262145,
+        .update_config = true,
+        .disable_watchdog = true
+    };
+    return feat;
+}
+
+#endif /* DEVICE_WATCHDOG */

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2672,7 +2672,7 @@
     "EFM32GG_STK3700": {
         "inherits": ["EFM32GG990F1024"],
         "progen": {"target": "efm32gg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2725,7 +2725,7 @@
     },
     "EFM32LG_STK3600": {
         "inherits": ["EFM32LG990F256"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "device_name": "EFM32LG990F256",
         "config": {
@@ -2780,7 +2780,7 @@
     "EFM32WG_STK3800": {
         "inherits": ["EFM32WG990F256"],
         "progen": {"target": "efm32wg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2834,7 +2834,7 @@
     },
     "EFM32ZG_STK3200": {
         "inherits": ["EFM32ZG222F32"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2888,7 +2888,7 @@
     },
     "EFM32HG_STK3400": {
         "inherits": ["EFM32HG322F64"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2941,7 +2941,7 @@
     },
     "EFM32PG_STK3401": {
         "inherits": ["EFM32PG1B100F256GM32"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3004,7 +3004,7 @@
     },
     "EFR32MG1_BRD4150": {
         "inherits": ["EFR32MG1P132F256GM48"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3047,7 +3047,7 @@
     },
     "TB_SENSE_1": {
         "inherits": ["EFR32MG1P233F256GM48"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {
@@ -3095,7 +3095,7 @@
     },
     "EFM32PG12_STK3402": {
         "inherits": ["EFM32PG12B500F1024GL125"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3149,7 +3149,7 @@
     "TB_SENSE_12": {
         "inherits": ["EFR32MG12P332F1024GL125"],
         "device_name": "EFR32MG12P332F1024GL125",
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RESET_REASON", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2672,7 +2672,7 @@
     "EFM32GG_STK3700": {
         "inherits": ["EFM32GG990F1024"],
         "progen": {"target": "efm32gg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2725,7 +2725,7 @@
     },
     "EFM32LG_STK3600": {
         "inherits": ["EFM32LG990F256"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "device_name": "EFM32LG990F256",
         "config": {
@@ -2780,7 +2780,7 @@
     "EFM32WG_STK3800": {
         "inherits": ["EFM32WG990F256"],
         "progen": {"target": "efm32wg-stk"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2834,7 +2834,7 @@
     },
     "EFM32ZG_STK3200": {
         "inherits": ["EFM32ZG222F32"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2888,7 +2888,7 @@
     },
     "EFM32HG_STK3400": {
         "inherits": ["EFM32HG322F64"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -2941,7 +2941,7 @@
     },
     "EFM32PG_STK3401": {
         "inherits": ["EFM32PG1B100F256GM32"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3004,7 +3004,7 @@
     },
     "EFR32MG1_BRD4150": {
         "inherits": ["EFR32MG1P132F256GM48"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3047,7 +3047,7 @@
     },
     "TB_SENSE_1": {
         "inherits": ["EFR32MG1P233F256GM48"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {
@@ -3095,7 +3095,7 @@
     },
     "EFM32PG12_STK3402": {
         "inherits": ["EFM32PG12B500F1024GL125"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3149,7 +3149,7 @@
     "TB_SENSE_12": {
         "inherits": ["EFR32MG12P332F1024GL125"],
         "device_name": "EFR32MG12P332F1024GL125",
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "FLASH"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "TRNG", "WATCHDOG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {


### PR DESCRIPTION
### Description

Implementation of both watchdog and reset reason APIs for all Silicon Labs parts.

Test results:
```
+---------------------------+-------------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
| target                    | platform_name     | test suite                  | test case                   | passed | failed | result | elapsed_time (sec) |
+---------------------------+-------------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-reset_reason | tests-mbed_hal-reset_reason | 1      | 0      | OK     | 33.53              |
+---------------------------+-------------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
```

```
+-------------------------+-----------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
| target                  | platform_name   | test suite                  | test case                   | passed | failed | result | elapsed_time (sec) |
+-------------------------+-----------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-reset_reason | tests-mbed_hal-reset_reason | 1      | 0      | OK     | 33.56              |
+-------------------------+-----------------+-----------------------------+-----------------------------+--------+--------+--------+--------------------+
```

```
+-------------------------+-----------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
| target                  | platform_name   | test suite              | test case                              | passed | failed | result | elapsed_time (sec) |
+-------------------------+-----------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Init, 500 ms                           | 1      | 0      | OK     | 0.0                |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Init, max_timeout                      | 1      | 0      | OK     | 0.0                |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Platform feature max_timeout is valid  | 1      | 0      | OK     | 0.01               |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Stopped watchdog can be started again  | 1      | 0      | OK     | 0.02               |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Update config with multiple init calls | 1      | 0      | OK     | 0.01               |
| EFM32LG_STK3600-GCC_ARM | EFM32LG_STK3600 | tests-mbed_hal-watchdog | Watchdog can be stopped                | 1      | 0      | OK     | 0.57               |
+-------------------------+-----------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
```

```
+---------------------------+-------------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
| target                    | platform_name     | test suite              | test case                              | passed | failed | result | elapsed_time (sec) |
+---------------------------+-------------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Init, 500 ms                           | 1      | 0      | OK     | 0.0                |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Init, max_timeout                      | 1      | 0      | OK     | 0.0                |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Platform feature max_timeout is valid  | 1      | 0      | OK     | 0.03               |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Stopped watchdog can be started again  | 1      | 0      | OK     | 0.01               |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Update config with multiple init calls | 1      | 0      | OK     | 0.03               |
| EFM32PG12_STK3402-GCC_ARM | EFM32PG12_STK3402 | tests-mbed_hal-watchdog | Watchdog can be stopped                | 1      | 0      | OK     | 0.56               |
+---------------------------+-------------------+-------------------------+----------------------------------------+--------+--------+--------+--------------------+
```