### PR TITLE
Minimize the size of uvision include paths

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -259,6 +259,20 @@ class Exporter(object):
     def all_supported_targets(cls):
         return [t for t in TARGET_MAP.keys() if cls.is_target_supported(t)]
 
+    @staticmethod
+    def filter_dot(str):
+        """
+        Remove the './' or '.\\' prefix, if present.
+        """
+        if str == None:
+            return None
+        if str[:2] == './':
+            return str[2:]
+        if str[:2] == '.\\':
+            return str[2:]
+        return str
+
+
 
 def apply_supported_whitelist(compiler, whitelist, target):
     """Generate a list of supported targets for a given compiler and post-binary hook

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -417,21 +417,6 @@ class GNUARMEclipse(Exporter):
 
     # -------------------------------------------------------------------------
 
-    @staticmethod
-    def filter_dot(str):
-        """
-        Remove the './' prefix, if present.
-        This function assumes that resources.win_to_unix()
-        replaced all windows backslashes with slashes.
-        """
-        if str == None:
-            return None
-        if str[:2] == './':
-            return str[2:]
-        return str
-
-    # -------------------------------------------------------------------------
-
     def dump_tree(self, nodes, depth=0):
         for k in nodes.keys():
             node = nodes[k]

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -178,7 +178,7 @@ class Uvision(Exporter):
         template = ["--no_vla", "--cpp", "--c99"]
         # Flag is invalid if set in template
         # Optimizations are also set in the template
-        invalid_flag = lambda x: x in template or re.match("-O(\d|time)", x) 
+        invalid_flag = lambda x: x in template or re.match("-O(\d|time)", x)
         flags['c_flags'] = [flag.replace('"','\\"') for flag in c_flags if not invalid_flag(flag)]
         flags['c_flags'] = " ".join(flags['c_flags'])
         flags['ld_flags'] = " ".join(flags['ld_flags'])
@@ -215,7 +215,8 @@ class Uvision(Exporter):
             # UVFile tuples defined above
             'project_files': sorted(list(self.format_src(srcs).items()),
                                     key=lambda tuple: tuple[0].lower()),
-            'include_paths': '; '.join(self.resources.inc_dirs).encode('utf-8'),
+            'include_paths': ';'.join(self.filter_dot(d) for d in
+                                      self.resources.inc_dirs).encode('utf-8'),
             'device': DeviceUvision(self.target),
         }
         sct_file = self.resources.linker_script


### PR DESCRIPTION
### Description

The size of uvision include paths can break the exporter with very large
projects. Some nordic devices are very large projects by themselves.

 ### Pull request type

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change