### PR TITLE
Fix initial SP for new Silicon Labs targets on ARMCC

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_ARM_STD/startup_efm32pg12b.S
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/device/TOOLCHAIN_ARM_STD/startup_efm32pg12b.S
@@ -36,7 +36,7 @@ Stack_Size      EQU     0x00001000
 
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
 Stack_Mem       SPACE   Stack_Size
-__initial_sp
+__initial_sp    EQU     0x20040000
 
 
 ; <h> Heap Configuration

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_ARM_STD/startup_efr32mg1p.S
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/device/TOOLCHAIN_ARM_STD/startup_efr32mg1p.S
@@ -33,7 +33,7 @@ Stack_Size      EQU     0x00000400
 
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
 Stack_Mem       SPACE   Stack_Size
-__initial_sp
+__initial_sp    EQU     0x20008000
 
 
 ; <h> Heap Configuration

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_ARM_STD/startup_efr32mg12p.S
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/device/TOOLCHAIN_ARM_STD/startup_efr32mg12p.S
@@ -33,7 +33,7 @@ Stack_Size      EQU     0x00004000
 
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
 Stack_Mem       SPACE   Stack_Size
-__initial_sp
+__initial_sp    EQU     0x20040000
 
 
 ; <h> Heap Configuration


### PR DESCRIPTION
EFR32MG1, EFR32MG12 and EFM32PG12 didn't have a fixed ARMCC linker script yet.