### PR TITLE
Add test for consecutive set_interrupt calls for lp ticker

### DIFF
--- a/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
+++ b/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
@@ -51,6 +51,16 @@ void lp_ticker_deepsleep_test(void);
  * Then ticker does not glitch backwards due to an incorrectly implemented ripple counter driver.
  */
 void lp_ticker_glitch_test(void);
+
+/** Test whether two calls to set interrupt can be performed one after another successfully
+ *
+ * Given ticker is available
+ * When ticker is enabled
+ *     and interrupt is set to 0
+ *     and interrupt is set again to some time in the future
+ * Then ticker fires when the counter reaches value set in second call
+ */
+void lp_ticker_consecutive_set_interrupt(void);
 /**@}*/
 
 #ifdef __cplusplus

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -104,6 +104,26 @@ void lp_ticker_glitch_test()
     }
 }
 
+void lp_ticker_consecutive_set_interrupt(void)
+{
+    intFlag = 0;
+
+    const ticker_info_t* p_ticker_info = lp_ticker_get_info();
+
+    set_lp_ticker_irq_handler(ticker_event_handler_stub);
+
+    lp_ticker_init();
+
+    const uint32_t tick_count = lp_ticker_read();
+
+    lp_ticker_set_interrupt(0);
+    lp_ticker_set_interrupt(tick_count + TICKER_INT_VAL);
+
+    wait_ms((TICKER_INT_VAL*1000/p_ticker_info->frequency) + 1); //Ticks to ms + 1
+
+    TEST_ASSERT_EQUAL(1, intFlag);
+}
+
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(20, "default_auto");
@@ -113,7 +133,8 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 Case cases[] = {
     Case("lp ticker info test", lp_ticker_info_test),
     Case("lp ticker sleep test", lp_ticker_deepsleep_test),
-    Case("lp ticker glitch test", lp_ticker_glitch_test)
+    Case("lp ticker glitch test", lp_ticker_glitch_test),
+    Case("lp consecutive set interrupt", lp_ticker_consecutive_set_interrupt)
 };
 
 Specification specification(test_setup, cases);


### PR DESCRIPTION
### Description

* Add test for consecutive set_interrupt calls for lp ticker

### Pull request type

[ ] Fix  
[ ] Refactor  
[ ] New target  
[x] Feature  
[ ] Breaking change

The question is whether we should only keep it for LP or use it for both us and lp.

CC: @mprse @c1728p9 @jeromecoutant @LMESTM 