### PR TITLE
[BLE] Fixed inconsistent casing issue for SecurityDb

### DIFF
--- a/features/FEATURE_BLE/ble/pal/MemorySecurityDb.h
+++ b/features/FEATURE_BLE/ble/pal/MemorySecurityDb.h
@@ -17,7 +17,7 @@
 #ifndef PAL_MEMORY_SECURITY_DB_H_
 #define PAL_MEMORY_SECURITY_DB_H_
 
-#include "SecurityDB.h"
+#include "SecurityDb.h"
 
 namespace ble {
 namespace pal {

--- a/features/FEATURE_BLE/ble/pal/SecurityDb.h
+++ b/features/FEATURE_BLE/ble/pal/SecurityDb.h
@@ -84,9 +84,9 @@ struct SecurityEntryIdentity_t {
 };
 
 /**
- * SecurityDB holds the state for active connections and bonded devices.
+ * SecurityDb holds the state for active connections and bonded devices.
  * Keys can be stored in NVM and are returned via callbacks.
- * SecurityDB is responsible for serialising any requests and keeping
+ * SecurityDb is responsible for serialising any requests and keeping
  * the store in a consistent state.
  * Active connections state must be returned immediately.
  */

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioBLE.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioBLE.h
@@ -30,7 +30,7 @@
 #include "CordioPalGenericAccessService.h"
 #include "ble/generic/GenericGap.h"
 #include "ble/generic/GenericSecurityManager.h"
-#include "ble/pal/MemorySecurityDB.h"
+#include "ble/pal/MemorySecurityDb.h"
 #include "ble/pal/SimpleEventQueue.h"
 
 namespace ble {


### PR DESCRIPTION
### Description

Fix for #6476.
The SecurityDb/MemorySecurityDb had some casing inconsistencies across the BLE security manager implementation which created some compilation issues when compiling from a case-sensitive filesystem.
This PR fixes these inconsistencies.

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change