### PR TITLE
STM32L1: Update ST HAL driver to CubeL1 V1.8.1

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/startup_stm32l152xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/startup_stm32l152xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xc.S
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file      startup_stm32l152xc.s
   * @author    MCD Application Team
-  * @version   V2.2.0
-  * @date      01-July-2016
   * @brief     STM32L152XC Devices vector table for 
   *            Atollic toolchain.
   *            This module performs:
@@ -17,7 +15,7 @@
   *            priority is Privileged, and the Stack is set to Main.
   ******************************************************************************
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,8 +1,8 @@
-;/******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XC Devices vector for EWARM toolchain. 
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+;* <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/stm32l152xc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/stm32l152xc.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l152xc.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
   *          This file contains all the peripheral register's definitions, bits 
   *          definitions and memory mapping for STM32L1xx devices.            
@@ -16,7 +14,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -454,21 +452,27 @@ typedef struct
 typedef struct
 {
   __IO uint32_t ICR;        /*!< RI input capture register,                     Address offset: 0x00 */
-  __IO uint32_t ASCR1;      /*!< RI analog switches control register,       Address offset: 0x04 */
-  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,        Address offset: 0x08 */
+  __IO uint32_t ASCR1;      /*!< RI analog switches control register,           Address offset: 0x04 */
+  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,           Address offset: 0x08 */
   __IO uint32_t HYSCR1;     /*!< RI hysteresis control register,                Address offset: 0x0C */
-  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,               Address offset: 0x10 */
-  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,               Address offset: 0x14 */
-  uint32_t RESERVED1;       /*!< Reserved, 0x18                                                                  */
-  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,         Address offset: 0x1C */
-  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                   Address offset: 0x20 */
-  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,  Address offset: 0x24 */
-  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,         Address offset: 0x28 */
-  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                   Address offset: 0x2C */
-  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,  Address offset: 0x30 */
-  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,         Address offset: 0x34 */
-  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                   Address offset: 0x38 */
-  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,  Address offset: 0x3C */
+  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,                Address offset: 0x10 */
+  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,                Address offset: 0x14 */
+  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,                Address offset: 0x18 */
+  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,              Address offset: 0x1C */
+  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                    Address offset: 0x20 */
+  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,        Address offset: 0x24 */
+  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,              Address offset: 0x28 */
+  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                    Address offset: 0x2C */
+  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,        Address offset: 0x30 */
+  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,              Address offset: 0x34 */
+  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                    Address offset: 0x38 */
+  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,        Address offset: 0x3C */
+  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,              Address offset: 0x40 */
+  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                    Address offset: 0x44 */
+  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,        Address offset: 0x48 */
+  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,              Address offset: 0x4C */
+  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                    Address offset: 0x50 */
+  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,        Address offset: 0x54 */
 } RI_TypeDef;
 
 /** 
@@ -3586,56 +3590,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk                
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)                              
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk               
-#define GPIO_AFRL_AFRL1_Pos                  (4U)                              
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk               
-#define GPIO_AFRL_AFRL2_Pos                  (8U)                              
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk               
-#define GPIO_AFRL_AFRL3_Pos                  (12U)                             
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk               
-#define GPIO_AFRL_AFRL4_Pos                  (16U)                             
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk               
-#define GPIO_AFRL_AFRL5_Pos                  (20U)                             
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk               
-#define GPIO_AFRL_AFRL6_Pos                  (24U)                             
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk               
-#define GPIO_AFRL_AFRL7_Pos                  (28U)                             
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk               
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)                              
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk               
-#define GPIO_AFRH_AFRH1_Pos                  (4U)                              
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk               
-#define GPIO_AFRH_AFRH2_Pos                  (8U)                              
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk               
-#define GPIO_AFRH_AFRH3_Pos                  (12U)                             
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk               
-#define GPIO_AFRH_AFRH4_Pos                  (16U)                             
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk               
-#define GPIO_AFRH_AFRH5_Pos                  (20U)                             
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk               
-#define GPIO_AFRH_AFRH6_Pos                  (24U)                             
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk               
-#define GPIO_AFRH_AFRH7_Pos                  (28U)                             
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk               
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /****************** Bit definition for GPIO_BRR register  *********************/
 #define GPIO_BRR_BR_0                        (0x00000001U)                     
@@ -4972,9 +4976,9 @@ typedef struct
 #define RTC_CR_COSEL_Pos                     (19U)                             
 #define RTC_CR_COSEL_Msk                     (0x1U << RTC_CR_COSEL_Pos)        /*!< 0x00080000 */
 #define RTC_CR_COSEL                         RTC_CR_COSEL_Msk                  
-#define RTC_CR_BCK_Pos                       (18U)                             
-#define RTC_CR_BCK_Msk                       (0x1U << RTC_CR_BCK_Pos)          /*!< 0x00040000 */
-#define RTC_CR_BCK                           RTC_CR_BCK_Msk                    
+#define RTC_CR_BKP_Pos                       (18U)                             
+#define RTC_CR_BKP_Msk                       (0x1U << RTC_CR_BKP_Pos)          /*!< 0x00040000 */
+#define RTC_CR_BKP                           RTC_CR_BKP_Msk                    
 #define RTC_CR_SUB1H_Pos                     (17U)                             
 #define RTC_CR_SUB1H_Msk                     (0x1U << RTC_CR_SUB1H_Pos)        /*!< 0x00020000 */
 #define RTC_CR_SUB1H                         RTC_CR_SUB1H_Msk                  
@@ -5026,6 +5030,11 @@ typedef struct
 #define RTC_CR_WUCKSEL_0                     (0x1U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000001 */
 #define RTC_CR_WUCKSEL_1                     (0x2U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000002 */
 #define RTC_CR_WUCKSEL_2                     (0x4U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000004 */
+
+/* Legacy defines */
+#define  RTC_CR_BCK_Pos RTC_CR_BKP_Pos
+#define  RTC_CR_BCK_Msk RTC_CR_BKP_Msk
+#define  RTC_CR_BCK     RTC_CR_BKP
 
 /********************  Bits definition for RTC_ISR register  ******************/
 #define RTC_ISR_RECALPF_Pos                  (16U)                             
@@ -6264,6 +6273,45 @@ typedef struct
 #define RI_HYSCR3_PE_13                 (0x2000U << RI_HYSCR3_PE_Pos)          /*!< 0x00002000 */
 #define RI_HYSCR3_PE_14                 (0x4000U << RI_HYSCR3_PE_Pos)          /*!< 0x00004000 */
 #define RI_HYSCR3_PE_15                 (0x8000U << RI_HYSCR3_PE_Pos)          /*!< 0x00008000 */
+#define RI_HYSCR3_PF_Pos                (16U)                                  
+#define RI_HYSCR3_PF_Msk                (0xFFFFU << RI_HYSCR3_PF_Pos)          /*!< 0xFFFF0000 */
+#define RI_HYSCR3_PF                    RI_HYSCR3_PF_Msk                       /*!< PF[15:0] Port F Hysteresis selection */
+#define RI_HYSCR3_PF_0                  (0x0001U << RI_HYSCR3_PF_Pos)          /*!< 0x00010000 */
+#define RI_HYSCR3_PF_1                  (0x0002U << RI_HYSCR3_PF_Pos)          /*!< 0x00020000 */
+#define RI_HYSCR3_PF_2                  (0x0004U << RI_HYSCR3_PF_Pos)          /*!< 0x00040000 */
+#define RI_HYSCR3_PF_3                  (0x0008U << RI_HYSCR3_PF_Pos)          /*!< 0x00080000 */
+#define RI_HYSCR3_PF_4                  (0x0010U << RI_HYSCR3_PF_Pos)          /*!< 0x00100000 */
+#define RI_HYSCR3_PF_5                  (0x0020U << RI_HYSCR3_PF_Pos)          /*!< 0x00200000 */
+#define RI_HYSCR3_PF_6                  (0x0040U << RI_HYSCR3_PF_Pos)          /*!< 0x00400000 */
+#define RI_HYSCR3_PF_7                  (0x0080U << RI_HYSCR3_PF_Pos)          /*!< 0x00800000 */
+#define RI_HYSCR3_PF_8                  (0x0100U << RI_HYSCR3_PF_Pos)          /*!< 0x01000000 */
+#define RI_HYSCR3_PF_9                  (0x0200U << RI_HYSCR3_PF_Pos)          /*!< 0x02000000 */
+#define RI_HYSCR3_PF_10                 (0x0400U << RI_HYSCR3_PF_Pos)          /*!< 0x04000000 */
+#define RI_HYSCR3_PF_11                 (0x0800U << RI_HYSCR3_PF_Pos)          /*!< 0x08000000 */
+#define RI_HYSCR3_PF_12                 (0x1000U << RI_HYSCR3_PF_Pos)          /*!< 0x10000000 */
+#define RI_HYSCR3_PF_13                 (0x2000U << RI_HYSCR3_PF_Pos)          /*!< 0x20000000 */
+#define RI_HYSCR3_PF_14                 (0x4000U << RI_HYSCR3_PF_Pos)          /*!< 0x40000000 */
+#define RI_HYSCR3_PF_15                 (0x8000U << RI_HYSCR3_PF_Pos)          /*!< 0x80000000 */
+/********************  Bit definition for RI_HYSCR4 register  ********************/
+#define RI_HYSCR4_PG_Pos                (0U)                                   
+#define RI_HYSCR4_PG_Msk                (0xFFFFU << RI_HYSCR4_PG_Pos)          /*!< 0x0000FFFF */
+#define RI_HYSCR4_PG                    RI_HYSCR4_PG_Msk                       /*!< PG[15:0] Port G Hysteresis selection */
+#define RI_HYSCR4_PG_0                  (0x0001U << RI_HYSCR4_PG_Pos)          /*!< 0x00000001 */
+#define RI_HYSCR4_PG_1                  (0x0002U << RI_HYSCR4_PG_Pos)          /*!< 0x00000002 */
+#define RI_HYSCR4_PG_2                  (0x0004U << RI_HYSCR4_PG_Pos)          /*!< 0x00000004 */
+#define RI_HYSCR4_PG_3                  (0x0008U << RI_HYSCR4_PG_Pos)          /*!< 0x00000008 */
+#define RI_HYSCR4_PG_4                  (0x0010U << RI_HYSCR4_PG_Pos)          /*!< 0x00000010 */
+#define RI_HYSCR4_PG_5                  (0x0020U << RI_HYSCR4_PG_Pos)          /*!< 0x00000020 */
+#define RI_HYSCR4_PG_6                  (0x0040U << RI_HYSCR4_PG_Pos)          /*!< 0x00000040 */
+#define RI_HYSCR4_PG_7                  (0x0080U << RI_HYSCR4_PG_Pos)          /*!< 0x00000080 */
+#define RI_HYSCR4_PG_8                  (0x0100U << RI_HYSCR4_PG_Pos)          /*!< 0x00000100 */
+#define RI_HYSCR4_PG_9                  (0x0200U << RI_HYSCR4_PG_Pos)          /*!< 0x00000200 */
+#define RI_HYSCR4_PG_10                 (0x0400U << RI_HYSCR4_PG_Pos)          /*!< 0x00000400 */
+#define RI_HYSCR4_PG_11                 (0x0800U << RI_HYSCR4_PG_Pos)          /*!< 0x00000800 */
+#define RI_HYSCR4_PG_12                 (0x1000U << RI_HYSCR4_PG_Pos)          /*!< 0x00001000 */
+#define RI_HYSCR4_PG_13                 (0x2000U << RI_HYSCR4_PG_Pos)          /*!< 0x00002000 */
+#define RI_HYSCR4_PG_14                 (0x4000U << RI_HYSCR4_PG_Pos)          /*!< 0x00004000 */
+#define RI_HYSCR4_PG_15                 (0x8000U << RI_HYSCR4_PG_Pos)          /*!< 0x00008000 */
 
 /********************  Bit definition for RI_ASMR1 register  ********************/
 #define RI_ASMR1_PA_Pos                 (0U)                                   
@@ -6453,6 +6501,132 @@ typedef struct
 #define RI_CICR3_PC_13                  (0x2000U << RI_CICR3_PC_Pos)           /*!< 0x00002000 */
 #define RI_CICR3_PC_14                  (0x4000U << RI_CICR3_PC_Pos)           /*!< 0x00004000 */
 #define RI_CICR3_PC_15                  (0x8000U << RI_CICR3_PC_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR4 register  ********************/
+#define RI_ASMR4_PF_Pos                 (0U)                                   
+#define RI_ASMR4_PF_Msk                 (0xFFFFU << RI_ASMR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR4_PF                     RI_ASMR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_ASMR4_PF_0                   (0x0001U << RI_ASMR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_ASMR4_PF_1                   (0x0002U << RI_ASMR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_ASMR4_PF_2                   (0x0004U << RI_ASMR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_ASMR4_PF_3                   (0x0008U << RI_ASMR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_ASMR4_PF_4                   (0x0010U << RI_ASMR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_ASMR4_PF_5                   (0x0020U << RI_ASMR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_ASMR4_PF_6                   (0x0040U << RI_ASMR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_ASMR4_PF_7                   (0x0080U << RI_ASMR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_ASMR4_PF_8                   (0x0100U << RI_ASMR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_ASMR4_PF_9                   (0x0200U << RI_ASMR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_ASMR4_PF_10                  (0x0400U << RI_ASMR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_ASMR4_PF_11                  (0x0800U << RI_ASMR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_ASMR4_PF_12                  (0x1000U << RI_ASMR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_ASMR4_PF_13                  (0x2000U << RI_ASMR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_ASMR4_PF_14                  (0x4000U << RI_ASMR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_ASMR4_PF_15                  (0x8000U << RI_ASMR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR4 register  ********************/
+#define RI_CMR4_PF_Pos                  (0U)                                   
+#define RI_CMR4_PF_Msk                  (0xFFFFU << RI_CMR4_PF_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR4_PF                      RI_CMR4_PF_Msk                         /*!< PF[15:0] Port F selection */
+#define RI_CMR4_PF_0                    (0x0001U << RI_CMR4_PF_Pos)            /*!< 0x00000001 */
+#define RI_CMR4_PF_1                    (0x0002U << RI_CMR4_PF_Pos)            /*!< 0x00000002 */
+#define RI_CMR4_PF_2                    (0x0004U << RI_CMR4_PF_Pos)            /*!< 0x00000004 */
+#define RI_CMR4_PF_3                    (0x0008U << RI_CMR4_PF_Pos)            /*!< 0x00000008 */
+#define RI_CMR4_PF_4                    (0x0010U << RI_CMR4_PF_Pos)            /*!< 0x00000010 */
+#define RI_CMR4_PF_5                    (0x0020U << RI_CMR4_PF_Pos)            /*!< 0x00000020 */
+#define RI_CMR4_PF_6                    (0x0040U << RI_CMR4_PF_Pos)            /*!< 0x00000040 */
+#define RI_CMR4_PF_7                    (0x0080U << RI_CMR4_PF_Pos)            /*!< 0x00000080 */
+#define RI_CMR4_PF_8                    (0x0100U << RI_CMR4_PF_Pos)            /*!< 0x00000100 */
+#define RI_CMR4_PF_9                    (0x0200U << RI_CMR4_PF_Pos)            /*!< 0x00000200 */
+#define RI_CMR4_PF_10                   (0x0400U << RI_CMR4_PF_Pos)            /*!< 0x00000400 */
+#define RI_CMR4_PF_11                   (0x0800U << RI_CMR4_PF_Pos)            /*!< 0x00000800 */
+#define RI_CMR4_PF_12                   (0x1000U << RI_CMR4_PF_Pos)            /*!< 0x00001000 */
+#define RI_CMR4_PF_13                   (0x2000U << RI_CMR4_PF_Pos)            /*!< 0x00002000 */
+#define RI_CMR4_PF_14                   (0x4000U << RI_CMR4_PF_Pos)            /*!< 0x00004000 */
+#define RI_CMR4_PF_15                   (0x8000U << RI_CMR4_PF_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR4 register  ********************/
+#define RI_CICR4_PF_Pos                 (0U)                                   
+#define RI_CICR4_PF_Msk                 (0xFFFFU << RI_CICR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR4_PF                     RI_CICR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_CICR4_PF_0                   (0x0001U << RI_CICR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_CICR4_PF_1                   (0x0002U << RI_CICR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_CICR4_PF_2                   (0x0004U << RI_CICR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_CICR4_PF_3                   (0x0008U << RI_CICR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_CICR4_PF_4                   (0x0010U << RI_CICR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_CICR4_PF_5                   (0x0020U << RI_CICR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_CICR4_PF_6                   (0x0040U << RI_CICR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_CICR4_PF_7                   (0x0080U << RI_CICR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_CICR4_PF_8                   (0x0100U << RI_CICR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_CICR4_PF_9                   (0x0200U << RI_CICR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_CICR4_PF_10                  (0x0400U << RI_CICR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_CICR4_PF_11                  (0x0800U << RI_CICR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_CICR4_PF_12                  (0x1000U << RI_CICR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_CICR4_PF_13                  (0x2000U << RI_CICR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_CICR4_PF_14                  (0x4000U << RI_CICR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_CICR4_PF_15                  (0x8000U << RI_CICR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR5 register  ********************/
+#define RI_ASMR5_PG_Pos                 (0U)                                   
+#define RI_ASMR5_PG_Msk                 (0xFFFFU << RI_ASMR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR5_PG                     RI_ASMR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_ASMR5_PG_0                   (0x0001U << RI_ASMR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_ASMR5_PG_1                   (0x0002U << RI_ASMR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_ASMR5_PG_2                   (0x0004U << RI_ASMR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_ASMR5_PG_3                   (0x0008U << RI_ASMR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_ASMR5_PG_4                   (0x0010U << RI_ASMR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_ASMR5_PG_5                   (0x0020U << RI_ASMR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_ASMR5_PG_6                   (0x0040U << RI_ASMR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_ASMR5_PG_7                   (0x0080U << RI_ASMR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_ASMR5_PG_8                   (0x0100U << RI_ASMR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_ASMR5_PG_9                   (0x0200U << RI_ASMR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_ASMR5_PG_10                  (0x0400U << RI_ASMR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_ASMR5_PG_11                  (0x0800U << RI_ASMR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_ASMR5_PG_12                  (0x1000U << RI_ASMR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_ASMR5_PG_13                  (0x2000U << RI_ASMR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_ASMR5_PG_14                  (0x4000U << RI_ASMR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_ASMR5_PG_15                  (0x8000U << RI_ASMR5_PG_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR5 register  ********************/
+#define RI_CMR5_PG_Pos                  (0U)                                   
+#define RI_CMR5_PG_Msk                  (0xFFFFU << RI_CMR5_PG_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR5_PG                      RI_CMR5_PG_Msk                         /*!< PG[15:0] Port G selection */
+#define RI_CMR5_PG_0                    (0x0001U << RI_CMR5_PG_Pos)            /*!< 0x00000001 */
+#define RI_CMR5_PG_1                    (0x0002U << RI_CMR5_PG_Pos)            /*!< 0x00000002 */
+#define RI_CMR5_PG_2                    (0x0004U << RI_CMR5_PG_Pos)            /*!< 0x00000004 */
+#define RI_CMR5_PG_3                    (0x0008U << RI_CMR5_PG_Pos)            /*!< 0x00000008 */
+#define RI_CMR5_PG_4                    (0x0010U << RI_CMR5_PG_Pos)            /*!< 0x00000010 */
+#define RI_CMR5_PG_5                    (0x0020U << RI_CMR5_PG_Pos)            /*!< 0x00000020 */
+#define RI_CMR5_PG_6                    (0x0040U << RI_CMR5_PG_Pos)            /*!< 0x00000040 */
+#define RI_CMR5_PG_7                    (0x0080U << RI_CMR5_PG_Pos)            /*!< 0x00000080 */
+#define RI_CMR5_PG_8                    (0x0100U << RI_CMR5_PG_Pos)            /*!< 0x00000100 */
+#define RI_CMR5_PG_9                    (0x0200U << RI_CMR5_PG_Pos)            /*!< 0x00000200 */
+#define RI_CMR5_PG_10                   (0x0400U << RI_CMR5_PG_Pos)            /*!< 0x00000400 */
+#define RI_CMR5_PG_11                   (0x0800U << RI_CMR5_PG_Pos)            /*!< 0x00000800 */
+#define RI_CMR5_PG_12                   (0x1000U << RI_CMR5_PG_Pos)            /*!< 0x00001000 */
+#define RI_CMR5_PG_13                   (0x2000U << RI_CMR5_PG_Pos)            /*!< 0x00002000 */
+#define RI_CMR5_PG_14                   (0x4000U << RI_CMR5_PG_Pos)            /*!< 0x00004000 */
+#define RI_CMR5_PG_15                   (0x8000U << RI_CMR5_PG_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR5 register  ********************/
+#define RI_CICR5_PG_Pos                 (0U)                                   
+#define RI_CICR5_PG_Msk                 (0xFFFFU << RI_CICR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR5_PG                     RI_CICR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_CICR5_PG_0                   (0x0001U << RI_CICR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_CICR5_PG_1                   (0x0002U << RI_CICR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_CICR5_PG_2                   (0x0004U << RI_CICR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_CICR5_PG_3                   (0x0008U << RI_CICR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_CICR5_PG_4                   (0x0010U << RI_CICR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_CICR5_PG_5                   (0x0020U << RI_CICR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_CICR5_PG_6                   (0x0040U << RI_CICR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_CICR5_PG_7                   (0x0080U << RI_CICR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_CICR5_PG_8                   (0x0100U << RI_CICR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_CICR5_PG_9                   (0x0200U << RI_CICR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_CICR5_PG_10                  (0x0400U << RI_CICR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_CICR5_PG_11                  (0x0800U << RI_CICR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_CICR5_PG_12                  (0x1000U << RI_CICR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_CICR5_PG_13                  (0x2000U << RI_CICR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_CICR5_PG_14                  (0x4000U << RI_CICR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_CICR5_PG_15                  (0x8000U << RI_CICR5_PG_Pos)           /*!< 0x00008000 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -8631,24 +8805,58 @@ typedef struct
 
 /*******************  Bit definition for SCB_CFSR register  *******************/
 /*!< MFSR */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 0U)    /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)  /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 #define SCB_CFSR_IACCVIOL                   SCB_CFSR_IACCVIOL_Msk              /*!< Instruction access violation */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 1U)    /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)      /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 #define SCB_CFSR_DACCVIOL                   SCB_CFSR_DACCVIOL_Msk              /*!< Data access violation */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 3U)    /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)     /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 #define SCB_CFSR_MUNSTKERR                  SCB_CFSR_MUNSTKERR_Msk             /*!< Unstacking error */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_SHCSR_MEMFAULTACT_Pos + 4U)    /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)       /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 #define SCB_CFSR_MSTKERR                    SCB_CFSR_MSTKERR_Msk               /*!< Stacking error */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 7U)    /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)     /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 #define SCB_CFSR_MMARVALID                  SCB_CFSR_MMARVALID_Msk             /*!< Memory Manage Address Register address valid flag */
 /*!< BFSR */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)       /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 #define SCB_CFSR_IBUSERR                    SCB_CFSR_IBUSERR_Msk               /*!< Instruction bus error flag */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)       /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 #define SCB_CFSR_PRECISERR                  SCB_CFSR_PRECISERR_Msk             /*!< Precise data bus error */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 #define SCB_CFSR_IMPRECISERR                SCB_CFSR_IMPRECISERR_Msk           /*!< Imprecise data bus error */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 #define SCB_CFSR_UNSTKERR                   SCB_CFSR_UNSTKERR_Msk              /*!< Unstacking error */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)       /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)         /*!< SCB CFSR (BFSR): STKERR Mask */
 #define SCB_CFSR_STKERR                     SCB_CFSR_STKERR_Msk                /*!< Stacking error */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)       /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 #define SCB_CFSR_BFARVALID                  SCB_CFSR_BFARVALID_Msk             /*!< Bus Fault Address Register address valid flag */
 /*!< UFSR */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 #define SCB_CFSR_UNDEFINSTR                 SCB_CFSR_UNDEFINSTR_Msk            /*!< The processor attempt to excecute an undefined instruction */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)       /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 #define SCB_CFSR_INVSTATE                   SCB_CFSR_INVSTATE_Msk              /*!< Invalid combination of EPSR and instruction */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)       /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)          /*!< SCB CFSR (UFSR): INVPC Mask */
 #define SCB_CFSR_INVPC                      SCB_CFSR_INVPC_Msk                 /*!< Attempt to load EXC_RETURN into pc illegally */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)       /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)           /*!< SCB CFSR (UFSR): NOCP Mask */
 #define SCB_CFSR_NOCP                       SCB_CFSR_NOCP_Msk                  /*!< Attempt to use a coprocessor instruction */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 #define SCB_CFSR_UNALIGNED                  SCB_CFSR_UNALIGNED_Msk             /*!< Fault occurs when there is an attempt to make an unaligned memory access */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 #define SCB_CFSR_DIVBYZERO                  SCB_CFSR_DIVBYZERO_Msk             /*!< Fault occurs when SDIV or DIV instruction is used with a divisor of 0 */
 
 /*******************  Bit definition for SCB_HFSR register  *******************/

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/stm32l1xx.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS STM32L1xx Device Peripheral Access Layer Header File. 
   *
   *          The file is the unique include file that the application programmer
@@ -18,7 +16,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -122,7 +120,7 @@
   */
 #define __STM32L1xx_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32L1xx_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x03) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32L1xx_CMSIS_VERSION        ((__STM32L1xx_CMSIS_VERSION_MAIN << 24)\
                                          |(__STM32L1xx_CMSIS_VERSION_SUB1 << 16)\

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/system_stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/system_stm32l1xx.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    system_stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device System Source File for STM32L1xx devices.  
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file      startup_stm32l151xc.s
   * @author    MCD Application Team
-  * @version   V2.2.0
-  * @date      01-July-2016
   * @brief     STM32L151XC Devices vector table for 
   *            Atollic toolchain.
   *            This module performs:
@@ -17,7 +15,7 @@
   *            priority is Privileged, and the Stack is set to Main.
   ******************************************************************************
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,8 +1,8 @@
-;/******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XC Devices vector for EWARM toolchain. 
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+;* <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/stm32l151xc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/stm32l151xc.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l151xc.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
   *          This file contains all the peripheral register's definitions, bits 
   *          definitions and memory mapping for STM32L1xx devices.            
@@ -16,7 +14,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -439,21 +437,27 @@ typedef struct
 typedef struct
 {
   __IO uint32_t ICR;        /*!< RI input capture register,                     Address offset: 0x00 */
-  __IO uint32_t ASCR1;      /*!< RI analog switches control register,       Address offset: 0x04 */
-  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,        Address offset: 0x08 */
+  __IO uint32_t ASCR1;      /*!< RI analog switches control register,           Address offset: 0x04 */
+  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,           Address offset: 0x08 */
   __IO uint32_t HYSCR1;     /*!< RI hysteresis control register,                Address offset: 0x0C */
-  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,               Address offset: 0x10 */
-  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,               Address offset: 0x14 */
-  uint32_t RESERVED1;       /*!< Reserved, 0x18                                                                  */
-  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,         Address offset: 0x1C */
-  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                   Address offset: 0x20 */
-  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,  Address offset: 0x24 */
-  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,         Address offset: 0x28 */
-  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                   Address offset: 0x2C */
-  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,  Address offset: 0x30 */
-  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,         Address offset: 0x34 */
-  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                   Address offset: 0x38 */
-  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,  Address offset: 0x3C */
+  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,                Address offset: 0x10 */
+  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,                Address offset: 0x14 */
+  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,                Address offset: 0x18 */
+  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,              Address offset: 0x1C */
+  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                    Address offset: 0x20 */
+  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,        Address offset: 0x24 */
+  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,              Address offset: 0x28 */
+  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                    Address offset: 0x2C */
+  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,        Address offset: 0x30 */
+  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,              Address offset: 0x34 */
+  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                    Address offset: 0x38 */
+  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,        Address offset: 0x3C */
+  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,              Address offset: 0x40 */
+  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                    Address offset: 0x44 */
+  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,        Address offset: 0x48 */
+  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,              Address offset: 0x4C */
+  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                    Address offset: 0x50 */
+  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,        Address offset: 0x54 */
 } RI_TypeDef;
 
 /** 
@@ -3569,56 +3573,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk                
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)                              
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk               
-#define GPIO_AFRL_AFRL1_Pos                  (4U)                              
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk               
-#define GPIO_AFRL_AFRL2_Pos                  (8U)                              
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk               
-#define GPIO_AFRL_AFRL3_Pos                  (12U)                             
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk               
-#define GPIO_AFRL_AFRL4_Pos                  (16U)                             
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk               
-#define GPIO_AFRL_AFRL5_Pos                  (20U)                             
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk               
-#define GPIO_AFRL_AFRL6_Pos                  (24U)                             
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk               
-#define GPIO_AFRL_AFRL7_Pos                  (28U)                             
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk               
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)                              
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk               
-#define GPIO_AFRH_AFRH1_Pos                  (4U)                              
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk               
-#define GPIO_AFRH_AFRH2_Pos                  (8U)                              
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk               
-#define GPIO_AFRH_AFRH3_Pos                  (12U)                             
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk               
-#define GPIO_AFRH_AFRH4_Pos                  (16U)                             
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk               
-#define GPIO_AFRH_AFRH5_Pos                  (20U)                             
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk               
-#define GPIO_AFRH_AFRH6_Pos                  (24U)                             
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk               
-#define GPIO_AFRH_AFRH7_Pos                  (28U)                             
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk               
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /****************** Bit definition for GPIO_BRR register  *********************/
 #define GPIO_BRR_BR_0                        (0x00000001U)                     
@@ -4830,9 +4834,9 @@ typedef struct
 #define RTC_CR_COSEL_Pos                     (19U)                             
 #define RTC_CR_COSEL_Msk                     (0x1U << RTC_CR_COSEL_Pos)        /*!< 0x00080000 */
 #define RTC_CR_COSEL                         RTC_CR_COSEL_Msk                  
-#define RTC_CR_BCK_Pos                       (18U)                             
-#define RTC_CR_BCK_Msk                       (0x1U << RTC_CR_BCK_Pos)          /*!< 0x00040000 */
-#define RTC_CR_BCK                           RTC_CR_BCK_Msk                    
+#define RTC_CR_BKP_Pos                       (18U)                             
+#define RTC_CR_BKP_Msk                       (0x1U << RTC_CR_BKP_Pos)          /*!< 0x00040000 */
+#define RTC_CR_BKP                           RTC_CR_BKP_Msk                    
 #define RTC_CR_SUB1H_Pos                     (17U)                             
 #define RTC_CR_SUB1H_Msk                     (0x1U << RTC_CR_SUB1H_Pos)        /*!< 0x00020000 */
 #define RTC_CR_SUB1H                         RTC_CR_SUB1H_Msk                  
@@ -4884,6 +4888,11 @@ typedef struct
 #define RTC_CR_WUCKSEL_0                     (0x1U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000001 */
 #define RTC_CR_WUCKSEL_1                     (0x2U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000002 */
 #define RTC_CR_WUCKSEL_2                     (0x4U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000004 */
+
+/* Legacy defines */
+#define  RTC_CR_BCK_Pos RTC_CR_BKP_Pos
+#define  RTC_CR_BCK_Msk RTC_CR_BKP_Msk
+#define  RTC_CR_BCK     RTC_CR_BKP
 
 /********************  Bits definition for RTC_ISR register  ******************/
 #define RTC_ISR_RECALPF_Pos                  (16U)                             
@@ -6114,6 +6123,45 @@ typedef struct
 #define RI_HYSCR3_PE_13                 (0x2000U << RI_HYSCR3_PE_Pos)          /*!< 0x00002000 */
 #define RI_HYSCR3_PE_14                 (0x4000U << RI_HYSCR3_PE_Pos)          /*!< 0x00004000 */
 #define RI_HYSCR3_PE_15                 (0x8000U << RI_HYSCR3_PE_Pos)          /*!< 0x00008000 */
+#define RI_HYSCR3_PF_Pos                (16U)                                  
+#define RI_HYSCR3_PF_Msk                (0xFFFFU << RI_HYSCR3_PF_Pos)          /*!< 0xFFFF0000 */
+#define RI_HYSCR3_PF                    RI_HYSCR3_PF_Msk                       /*!< PF[15:0] Port F Hysteresis selection */
+#define RI_HYSCR3_PF_0                  (0x0001U << RI_HYSCR3_PF_Pos)          /*!< 0x00010000 */
+#define RI_HYSCR3_PF_1                  (0x0002U << RI_HYSCR3_PF_Pos)          /*!< 0x00020000 */
+#define RI_HYSCR3_PF_2                  (0x0004U << RI_HYSCR3_PF_Pos)          /*!< 0x00040000 */
+#define RI_HYSCR3_PF_3                  (0x0008U << RI_HYSCR3_PF_Pos)          /*!< 0x00080000 */
+#define RI_HYSCR3_PF_4                  (0x0010U << RI_HYSCR3_PF_Pos)          /*!< 0x00100000 */
+#define RI_HYSCR3_PF_5                  (0x0020U << RI_HYSCR3_PF_Pos)          /*!< 0x00200000 */
+#define RI_HYSCR3_PF_6                  (0x0040U << RI_HYSCR3_PF_Pos)          /*!< 0x00400000 */
+#define RI_HYSCR3_PF_7                  (0x0080U << RI_HYSCR3_PF_Pos)          /*!< 0x00800000 */
+#define RI_HYSCR3_PF_8                  (0x0100U << RI_HYSCR3_PF_Pos)          /*!< 0x01000000 */
+#define RI_HYSCR3_PF_9                  (0x0200U << RI_HYSCR3_PF_Pos)          /*!< 0x02000000 */
+#define RI_HYSCR3_PF_10                 (0x0400U << RI_HYSCR3_PF_Pos)          /*!< 0x04000000 */
+#define RI_HYSCR3_PF_11                 (0x0800U << RI_HYSCR3_PF_Pos)          /*!< 0x08000000 */
+#define RI_HYSCR3_PF_12                 (0x1000U << RI_HYSCR3_PF_Pos)          /*!< 0x10000000 */
+#define RI_HYSCR3_PF_13                 (0x2000U << RI_HYSCR3_PF_Pos)          /*!< 0x20000000 */
+#define RI_HYSCR3_PF_14                 (0x4000U << RI_HYSCR3_PF_Pos)          /*!< 0x40000000 */
+#define RI_HYSCR3_PF_15                 (0x8000U << RI_HYSCR3_PF_Pos)          /*!< 0x80000000 */
+/********************  Bit definition for RI_HYSCR4 register  ********************/
+#define RI_HYSCR4_PG_Pos                (0U)                                   
+#define RI_HYSCR4_PG_Msk                (0xFFFFU << RI_HYSCR4_PG_Pos)          /*!< 0x0000FFFF */
+#define RI_HYSCR4_PG                    RI_HYSCR4_PG_Msk                       /*!< PG[15:0] Port G Hysteresis selection */
+#define RI_HYSCR4_PG_0                  (0x0001U << RI_HYSCR4_PG_Pos)          /*!< 0x00000001 */
+#define RI_HYSCR4_PG_1                  (0x0002U << RI_HYSCR4_PG_Pos)          /*!< 0x00000002 */
+#define RI_HYSCR4_PG_2                  (0x0004U << RI_HYSCR4_PG_Pos)          /*!< 0x00000004 */
+#define RI_HYSCR4_PG_3                  (0x0008U << RI_HYSCR4_PG_Pos)          /*!< 0x00000008 */
+#define RI_HYSCR4_PG_4                  (0x0010U << RI_HYSCR4_PG_Pos)          /*!< 0x00000010 */
+#define RI_HYSCR4_PG_5                  (0x0020U << RI_HYSCR4_PG_Pos)          /*!< 0x00000020 */
+#define RI_HYSCR4_PG_6                  (0x0040U << RI_HYSCR4_PG_Pos)          /*!< 0x00000040 */
+#define RI_HYSCR4_PG_7                  (0x0080U << RI_HYSCR4_PG_Pos)          /*!< 0x00000080 */
+#define RI_HYSCR4_PG_8                  (0x0100U << RI_HYSCR4_PG_Pos)          /*!< 0x00000100 */
+#define RI_HYSCR4_PG_9                  (0x0200U << RI_HYSCR4_PG_Pos)          /*!< 0x00000200 */
+#define RI_HYSCR4_PG_10                 (0x0400U << RI_HYSCR4_PG_Pos)          /*!< 0x00000400 */
+#define RI_HYSCR4_PG_11                 (0x0800U << RI_HYSCR4_PG_Pos)          /*!< 0x00000800 */
+#define RI_HYSCR4_PG_12                 (0x1000U << RI_HYSCR4_PG_Pos)          /*!< 0x00001000 */
+#define RI_HYSCR4_PG_13                 (0x2000U << RI_HYSCR4_PG_Pos)          /*!< 0x00002000 */
+#define RI_HYSCR4_PG_14                 (0x4000U << RI_HYSCR4_PG_Pos)          /*!< 0x00004000 */
+#define RI_HYSCR4_PG_15                 (0x8000U << RI_HYSCR4_PG_Pos)          /*!< 0x00008000 */
 
 /********************  Bit definition for RI_ASMR1 register  ********************/
 #define RI_ASMR1_PA_Pos                 (0U)                                   
@@ -6303,6 +6351,132 @@ typedef struct
 #define RI_CICR3_PC_13                  (0x2000U << RI_CICR3_PC_Pos)           /*!< 0x00002000 */
 #define RI_CICR3_PC_14                  (0x4000U << RI_CICR3_PC_Pos)           /*!< 0x00004000 */
 #define RI_CICR3_PC_15                  (0x8000U << RI_CICR3_PC_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR4 register  ********************/
+#define RI_ASMR4_PF_Pos                 (0U)                                   
+#define RI_ASMR4_PF_Msk                 (0xFFFFU << RI_ASMR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR4_PF                     RI_ASMR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_ASMR4_PF_0                   (0x0001U << RI_ASMR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_ASMR4_PF_1                   (0x0002U << RI_ASMR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_ASMR4_PF_2                   (0x0004U << RI_ASMR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_ASMR4_PF_3                   (0x0008U << RI_ASMR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_ASMR4_PF_4                   (0x0010U << RI_ASMR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_ASMR4_PF_5                   (0x0020U << RI_ASMR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_ASMR4_PF_6                   (0x0040U << RI_ASMR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_ASMR4_PF_7                   (0x0080U << RI_ASMR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_ASMR4_PF_8                   (0x0100U << RI_ASMR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_ASMR4_PF_9                   (0x0200U << RI_ASMR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_ASMR4_PF_10                  (0x0400U << RI_ASMR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_ASMR4_PF_11                  (0x0800U << RI_ASMR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_ASMR4_PF_12                  (0x1000U << RI_ASMR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_ASMR4_PF_13                  (0x2000U << RI_ASMR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_ASMR4_PF_14                  (0x4000U << RI_ASMR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_ASMR4_PF_15                  (0x8000U << RI_ASMR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR4 register  ********************/
+#define RI_CMR4_PF_Pos                  (0U)                                   
+#define RI_CMR4_PF_Msk                  (0xFFFFU << RI_CMR4_PF_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR4_PF                      RI_CMR4_PF_Msk                         /*!< PF[15:0] Port F selection */
+#define RI_CMR4_PF_0                    (0x0001U << RI_CMR4_PF_Pos)            /*!< 0x00000001 */
+#define RI_CMR4_PF_1                    (0x0002U << RI_CMR4_PF_Pos)            /*!< 0x00000002 */
+#define RI_CMR4_PF_2                    (0x0004U << RI_CMR4_PF_Pos)            /*!< 0x00000004 */
+#define RI_CMR4_PF_3                    (0x0008U << RI_CMR4_PF_Pos)            /*!< 0x00000008 */
+#define RI_CMR4_PF_4                    (0x0010U << RI_CMR4_PF_Pos)            /*!< 0x00000010 */
+#define RI_CMR4_PF_5                    (0x0020U << RI_CMR4_PF_Pos)            /*!< 0x00000020 */
+#define RI_CMR4_PF_6                    (0x0040U << RI_CMR4_PF_Pos)            /*!< 0x00000040 */
+#define RI_CMR4_PF_7                    (0x0080U << RI_CMR4_PF_Pos)            /*!< 0x00000080 */
+#define RI_CMR4_PF_8                    (0x0100U << RI_CMR4_PF_Pos)            /*!< 0x00000100 */
+#define RI_CMR4_PF_9                    (0x0200U << RI_CMR4_PF_Pos)            /*!< 0x00000200 */
+#define RI_CMR4_PF_10                   (0x0400U << RI_CMR4_PF_Pos)            /*!< 0x00000400 */
+#define RI_CMR4_PF_11                   (0x0800U << RI_CMR4_PF_Pos)            /*!< 0x00000800 */
+#define RI_CMR4_PF_12                   (0x1000U << RI_CMR4_PF_Pos)            /*!< 0x00001000 */
+#define RI_CMR4_PF_13                   (0x2000U << RI_CMR4_PF_Pos)            /*!< 0x00002000 */
+#define RI_CMR4_PF_14                   (0x4000U << RI_CMR4_PF_Pos)            /*!< 0x00004000 */
+#define RI_CMR4_PF_15                   (0x8000U << RI_CMR4_PF_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR4 register  ********************/
+#define RI_CICR4_PF_Pos                 (0U)                                   
+#define RI_CICR4_PF_Msk                 (0xFFFFU << RI_CICR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR4_PF                     RI_CICR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_CICR4_PF_0                   (0x0001U << RI_CICR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_CICR4_PF_1                   (0x0002U << RI_CICR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_CICR4_PF_2                   (0x0004U << RI_CICR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_CICR4_PF_3                   (0x0008U << RI_CICR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_CICR4_PF_4                   (0x0010U << RI_CICR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_CICR4_PF_5                   (0x0020U << RI_CICR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_CICR4_PF_6                   (0x0040U << RI_CICR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_CICR4_PF_7                   (0x0080U << RI_CICR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_CICR4_PF_8                   (0x0100U << RI_CICR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_CICR4_PF_9                   (0x0200U << RI_CICR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_CICR4_PF_10                  (0x0400U << RI_CICR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_CICR4_PF_11                  (0x0800U << RI_CICR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_CICR4_PF_12                  (0x1000U << RI_CICR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_CICR4_PF_13                  (0x2000U << RI_CICR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_CICR4_PF_14                  (0x4000U << RI_CICR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_CICR4_PF_15                  (0x8000U << RI_CICR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR5 register  ********************/
+#define RI_ASMR5_PG_Pos                 (0U)                                   
+#define RI_ASMR5_PG_Msk                 (0xFFFFU << RI_ASMR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR5_PG                     RI_ASMR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_ASMR5_PG_0                   (0x0001U << RI_ASMR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_ASMR5_PG_1                   (0x0002U << RI_ASMR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_ASMR5_PG_2                   (0x0004U << RI_ASMR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_ASMR5_PG_3                   (0x0008U << RI_ASMR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_ASMR5_PG_4                   (0x0010U << RI_ASMR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_ASMR5_PG_5                   (0x0020U << RI_ASMR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_ASMR5_PG_6                   (0x0040U << RI_ASMR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_ASMR5_PG_7                   (0x0080U << RI_ASMR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_ASMR5_PG_8                   (0x0100U << RI_ASMR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_ASMR5_PG_9                   (0x0200U << RI_ASMR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_ASMR5_PG_10                  (0x0400U << RI_ASMR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_ASMR5_PG_11                  (0x0800U << RI_ASMR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_ASMR5_PG_12                  (0x1000U << RI_ASMR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_ASMR5_PG_13                  (0x2000U << RI_ASMR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_ASMR5_PG_14                  (0x4000U << RI_ASMR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_ASMR5_PG_15                  (0x8000U << RI_ASMR5_PG_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR5 register  ********************/
+#define RI_CMR5_PG_Pos                  (0U)                                   
+#define RI_CMR5_PG_Msk                  (0xFFFFU << RI_CMR5_PG_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR5_PG                      RI_CMR5_PG_Msk                         /*!< PG[15:0] Port G selection */
+#define RI_CMR5_PG_0                    (0x0001U << RI_CMR5_PG_Pos)            /*!< 0x00000001 */
+#define RI_CMR5_PG_1                    (0x0002U << RI_CMR5_PG_Pos)            /*!< 0x00000002 */
+#define RI_CMR5_PG_2                    (0x0004U << RI_CMR5_PG_Pos)            /*!< 0x00000004 */
+#define RI_CMR5_PG_3                    (0x0008U << RI_CMR5_PG_Pos)            /*!< 0x00000008 */
+#define RI_CMR5_PG_4                    (0x0010U << RI_CMR5_PG_Pos)            /*!< 0x00000010 */
+#define RI_CMR5_PG_5                    (0x0020U << RI_CMR5_PG_Pos)            /*!< 0x00000020 */
+#define RI_CMR5_PG_6                    (0x0040U << RI_CMR5_PG_Pos)            /*!< 0x00000040 */
+#define RI_CMR5_PG_7                    (0x0080U << RI_CMR5_PG_Pos)            /*!< 0x00000080 */
+#define RI_CMR5_PG_8                    (0x0100U << RI_CMR5_PG_Pos)            /*!< 0x00000100 */
+#define RI_CMR5_PG_9                    (0x0200U << RI_CMR5_PG_Pos)            /*!< 0x00000200 */
+#define RI_CMR5_PG_10                   (0x0400U << RI_CMR5_PG_Pos)            /*!< 0x00000400 */
+#define RI_CMR5_PG_11                   (0x0800U << RI_CMR5_PG_Pos)            /*!< 0x00000800 */
+#define RI_CMR5_PG_12                   (0x1000U << RI_CMR5_PG_Pos)            /*!< 0x00001000 */
+#define RI_CMR5_PG_13                   (0x2000U << RI_CMR5_PG_Pos)            /*!< 0x00002000 */
+#define RI_CMR5_PG_14                   (0x4000U << RI_CMR5_PG_Pos)            /*!< 0x00004000 */
+#define RI_CMR5_PG_15                   (0x8000U << RI_CMR5_PG_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR5 register  ********************/
+#define RI_CICR5_PG_Pos                 (0U)                                   
+#define RI_CICR5_PG_Msk                 (0xFFFFU << RI_CICR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR5_PG                     RI_CICR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_CICR5_PG_0                   (0x0001U << RI_CICR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_CICR5_PG_1                   (0x0002U << RI_CICR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_CICR5_PG_2                   (0x0004U << RI_CICR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_CICR5_PG_3                   (0x0008U << RI_CICR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_CICR5_PG_4                   (0x0010U << RI_CICR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_CICR5_PG_5                   (0x0020U << RI_CICR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_CICR5_PG_6                   (0x0040U << RI_CICR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_CICR5_PG_7                   (0x0080U << RI_CICR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_CICR5_PG_8                   (0x0100U << RI_CICR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_CICR5_PG_9                   (0x0200U << RI_CICR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_CICR5_PG_10                  (0x0400U << RI_CICR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_CICR5_PG_11                  (0x0800U << RI_CICR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_CICR5_PG_12                  (0x1000U << RI_CICR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_CICR5_PG_13                  (0x2000U << RI_CICR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_CICR5_PG_14                  (0x4000U << RI_CICR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_CICR5_PG_15                  (0x8000U << RI_CICR5_PG_Pos)           /*!< 0x00008000 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -8481,24 +8655,58 @@ typedef struct
 
 /*******************  Bit definition for SCB_CFSR register  *******************/
 /*!< MFSR */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 0U)    /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)  /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 #define SCB_CFSR_IACCVIOL                   SCB_CFSR_IACCVIOL_Msk              /*!< Instruction access violation */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 1U)    /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)      /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 #define SCB_CFSR_DACCVIOL                   SCB_CFSR_DACCVIOL_Msk              /*!< Data access violation */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 3U)    /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)     /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 #define SCB_CFSR_MUNSTKERR                  SCB_CFSR_MUNSTKERR_Msk             /*!< Unstacking error */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_SHCSR_MEMFAULTACT_Pos + 4U)    /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)       /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 #define SCB_CFSR_MSTKERR                    SCB_CFSR_MSTKERR_Msk               /*!< Stacking error */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 7U)    /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)     /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 #define SCB_CFSR_MMARVALID                  SCB_CFSR_MMARVALID_Msk             /*!< Memory Manage Address Register address valid flag */
 /*!< BFSR */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)       /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 #define SCB_CFSR_IBUSERR                    SCB_CFSR_IBUSERR_Msk               /*!< Instruction bus error flag */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)       /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 #define SCB_CFSR_PRECISERR                  SCB_CFSR_PRECISERR_Msk             /*!< Precise data bus error */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 #define SCB_CFSR_IMPRECISERR                SCB_CFSR_IMPRECISERR_Msk           /*!< Imprecise data bus error */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 #define SCB_CFSR_UNSTKERR                   SCB_CFSR_UNSTKERR_Msk              /*!< Unstacking error */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)       /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)         /*!< SCB CFSR (BFSR): STKERR Mask */
 #define SCB_CFSR_STKERR                     SCB_CFSR_STKERR_Msk                /*!< Stacking error */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)       /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 #define SCB_CFSR_BFARVALID                  SCB_CFSR_BFARVALID_Msk             /*!< Bus Fault Address Register address valid flag */
 /*!< UFSR */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 #define SCB_CFSR_UNDEFINSTR                 SCB_CFSR_UNDEFINSTR_Msk            /*!< The processor attempt to excecute an undefined instruction */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)       /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 #define SCB_CFSR_INVSTATE                   SCB_CFSR_INVSTATE_Msk              /*!< Invalid combination of EPSR and instruction */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)       /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)          /*!< SCB CFSR (UFSR): INVPC Mask */
 #define SCB_CFSR_INVPC                      SCB_CFSR_INVPC_Msk                 /*!< Attempt to load EXC_RETURN into pc illegally */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)       /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)           /*!< SCB CFSR (UFSR): NOCP Mask */
 #define SCB_CFSR_NOCP                       SCB_CFSR_NOCP_Msk                  /*!< Attempt to use a coprocessor instruction */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 #define SCB_CFSR_UNALIGNED                  SCB_CFSR_UNALIGNED_Msk             /*!< Fault occurs when there is an attempt to make an unaligned memory access */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 #define SCB_CFSR_DIVBYZERO                  SCB_CFSR_DIVBYZERO_Msk             /*!< Fault occurs when SDIV or DIV instruction is used with a divisor of 0 */
 
 /*******************  Bit definition for SCB_HFSR register  *******************/

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/stm32l1xx.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS STM32L1xx Device Peripheral Access Layer Header File. 
   *
   *          The file is the unique include file that the application programmer
@@ -18,7 +16,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -121,7 +119,7 @@
   */
 #define __STM32L1xx_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32L1xx_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x03) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32L1xx_CMSIS_VERSION        ((__STM32L1xx_CMSIS_VERSION_MAIN << 24)\
                                          |(__STM32L1xx_CMSIS_VERSION_SUB1 << 16)\

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/system_stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/system_stm32l1xx.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    system_stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device System Source File for STM32L1xx devices.  
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/stm32l151xba.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/stm32l151xba.h
@@ -3333,56 +3333,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk
-#define GPIO_AFRL_AFRL1_Pos                  (4U)
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk
-#define GPIO_AFRL_AFRL2_Pos                  (8U)
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk
-#define GPIO_AFRL_AFRL3_Pos                  (12U)
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk
-#define GPIO_AFRL_AFRL4_Pos                  (16U)
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk
-#define GPIO_AFRL_AFRL5_Pos                  (20U)
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk
-#define GPIO_AFRL_AFRL6_Pos                  (24U)
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk
-#define GPIO_AFRL_AFRL7_Pos                  (28U)
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk
-#define GPIO_AFRH_AFRH1_Pos                  (4U)
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk
-#define GPIO_AFRH_AFRH2_Pos                  (8U)
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk
-#define GPIO_AFRH_AFRH3_Pos                  (12U)
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk
-#define GPIO_AFRH_AFRH4_Pos                  (16U)
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk
-#define GPIO_AFRH_AFRH5_Pos                  (20U)
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk
-#define GPIO_AFRH_AFRH6_Pos                  (24U)
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk
-#define GPIO_AFRH_AFRH7_Pos                  (28U)
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /******************************************************************************/
 /*                                                                            */

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xe.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/startup_stm32l152xe.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XE Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/startup_stm32l152xe.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/startup_stm32l152xe.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XE Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/startup_stm32l152xe.S
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file      startup_stm32l152xe.s
   * @author    MCD Application Team
-  * @version   V2.2.0
-  * @date      01-July-2016
   * @brief     STM32L152XE Devices vector table for 
   *            Atollic toolchain.
   *            This module performs:
@@ -17,7 +15,7 @@
   *            priority is Privileged, and the Stack is set to Main.
   ******************************************************************************
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/startup_stm32l152xe.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/startup_stm32l152xe.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_IAR/startup_stm32l152xe.S
@@ -1,8 +1,8 @@
-;/******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xe.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XE Devices vector for EWARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+;* <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/stm32l152xe.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/stm32l152xe.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l152xe.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
   *          This file contains all the peripheral register's definitions, bits 
   *          definitions and memory mapping for STM32L1xx devices.            
@@ -16,7 +14,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -463,27 +461,27 @@ typedef struct
 typedef struct
 {
   __IO uint32_t ICR;        /*!< RI input capture register,                     Address offset: 0x00 */
-  __IO uint32_t ASCR1;      /*!< RI analog switches control register,       Address offset: 0x04 */
-  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,        Address offset: 0x08 */
+  __IO uint32_t ASCR1;      /*!< RI analog switches control register,           Address offset: 0x04 */
+  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,           Address offset: 0x08 */
   __IO uint32_t HYSCR1;     /*!< RI hysteresis control register,                Address offset: 0x0C */
-  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,               Address offset: 0x10 */
-  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,               Address offset: 0x14 */
-  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,               Address offset: 0x18 */
-  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,         Address offset: 0x1C */
-  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                   Address offset: 0x20 */
-  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,  Address offset: 0x24 */
-  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,         Address offset: 0x28 */
-  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                   Address offset: 0x2C */
-  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,  Address offset: 0x30 */
-  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,         Address offset: 0x34 */
-  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                   Address offset: 0x38 */
-  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,  Address offset: 0x3C */
-  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,         Address offset: 0x40 */
-  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                   Address offset: 0x44 */
-  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,  Address offset: 0x48 */
-  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,         Address offset: 0x4C */
-  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                   Address offset: 0x50 */
-  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,  Address offset: 0x54 */
+  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,                Address offset: 0x10 */
+  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,                Address offset: 0x14 */
+  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,                Address offset: 0x18 */
+  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,              Address offset: 0x1C */
+  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                    Address offset: 0x20 */
+  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,        Address offset: 0x24 */
+  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,              Address offset: 0x28 */
+  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                    Address offset: 0x2C */
+  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,        Address offset: 0x30 */
+  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,              Address offset: 0x34 */
+  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                    Address offset: 0x38 */
+  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,        Address offset: 0x3C */
+  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,              Address offset: 0x40 */
+  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                    Address offset: 0x44 */
+  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,        Address offset: 0x48 */
+  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,              Address offset: 0x4C */
+  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                    Address offset: 0x50 */
+  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,        Address offset: 0x54 */
 } RI_TypeDef;
 
 /** 
@@ -3656,56 +3654,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk                
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)                              
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk               
-#define GPIO_AFRL_AFRL1_Pos                  (4U)                              
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk               
-#define GPIO_AFRL_AFRL2_Pos                  (8U)                              
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk               
-#define GPIO_AFRL_AFRL3_Pos                  (12U)                             
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk               
-#define GPIO_AFRL_AFRL4_Pos                  (16U)                             
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk               
-#define GPIO_AFRL_AFRL5_Pos                  (20U)                             
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk               
-#define GPIO_AFRL_AFRL6_Pos                  (24U)                             
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk               
-#define GPIO_AFRL_AFRL7_Pos                  (28U)                             
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk               
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)                              
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk               
-#define GPIO_AFRH_AFRH1_Pos                  (4U)                              
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk               
-#define GPIO_AFRH_AFRH2_Pos                  (8U)                              
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk               
-#define GPIO_AFRH_AFRH3_Pos                  (12U)                             
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk               
-#define GPIO_AFRH_AFRH4_Pos                  (16U)                             
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk               
-#define GPIO_AFRH_AFRH5_Pos                  (20U)                             
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk               
-#define GPIO_AFRH_AFRH6_Pos                  (24U)                             
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk               
-#define GPIO_AFRH_AFRH7_Pos                  (28U)                             
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk               
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /****************** Bit definition for GPIO_BRR register  *********************/
 #define GPIO_BRR_BR_0                        (0x00000001U)                     
@@ -5078,9 +5076,9 @@ typedef struct
 #define RTC_CR_COSEL_Pos                     (19U)                             
 #define RTC_CR_COSEL_Msk                     (0x1U << RTC_CR_COSEL_Pos)        /*!< 0x00080000 */
 #define RTC_CR_COSEL                         RTC_CR_COSEL_Msk                  
-#define RTC_CR_BCK_Pos                       (18U)                             
-#define RTC_CR_BCK_Msk                       (0x1U << RTC_CR_BCK_Pos)          /*!< 0x00040000 */
-#define RTC_CR_BCK                           RTC_CR_BCK_Msk                    
+#define RTC_CR_BKP_Pos                       (18U)                             
+#define RTC_CR_BKP_Msk                       (0x1U << RTC_CR_BKP_Pos)          /*!< 0x00040000 */
+#define RTC_CR_BKP                           RTC_CR_BKP_Msk                    
 #define RTC_CR_SUB1H_Pos                     (17U)                             
 #define RTC_CR_SUB1H_Msk                     (0x1U << RTC_CR_SUB1H_Pos)        /*!< 0x00020000 */
 #define RTC_CR_SUB1H                         RTC_CR_SUB1H_Msk                  
@@ -5132,6 +5130,11 @@ typedef struct
 #define RTC_CR_WUCKSEL_0                     (0x1U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000001 */
 #define RTC_CR_WUCKSEL_1                     (0x2U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000002 */
 #define RTC_CR_WUCKSEL_2                     (0x4U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000004 */
+
+/* Legacy defines */
+#define  RTC_CR_BCK_Pos RTC_CR_BKP_Pos
+#define  RTC_CR_BCK_Msk RTC_CR_BKP_Msk
+#define  RTC_CR_BCK     RTC_CR_BKP
 
 /********************  Bits definition for RTC_ISR register  ******************/
 #define RTC_ISR_RECALPF_Pos                  (16U)                             
@@ -6419,7 +6422,6 @@ typedef struct
 #define RI_HYSCR3_PF_13                 (0x2000U << RI_HYSCR3_PF_Pos)          /*!< 0x20000000 */
 #define RI_HYSCR3_PF_14                 (0x4000U << RI_HYSCR3_PF_Pos)          /*!< 0x40000000 */
 #define RI_HYSCR3_PF_15                 (0x8000U << RI_HYSCR3_PF_Pos)          /*!< 0x80000000 */
-
 /********************  Bit definition for RI_HYSCR4 register  ********************/
 #define RI_HYSCR4_PG_Pos                (0U)                                   
 #define RI_HYSCR4_PG_Msk                (0xFFFFU << RI_HYSCR4_PG_Pos)          /*!< 0x0000FFFF */
@@ -8933,24 +8935,58 @@ typedef struct
 
 /*******************  Bit definition for SCB_CFSR register  *******************/
 /*!< MFSR */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 0U)    /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)  /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 #define SCB_CFSR_IACCVIOL                   SCB_CFSR_IACCVIOL_Msk              /*!< Instruction access violation */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 1U)    /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)      /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 #define SCB_CFSR_DACCVIOL                   SCB_CFSR_DACCVIOL_Msk              /*!< Data access violation */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 3U)    /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)     /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 #define SCB_CFSR_MUNSTKERR                  SCB_CFSR_MUNSTKERR_Msk             /*!< Unstacking error */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_SHCSR_MEMFAULTACT_Pos + 4U)    /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)       /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 #define SCB_CFSR_MSTKERR                    SCB_CFSR_MSTKERR_Msk               /*!< Stacking error */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 7U)    /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)     /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 #define SCB_CFSR_MMARVALID                  SCB_CFSR_MMARVALID_Msk             /*!< Memory Manage Address Register address valid flag */
 /*!< BFSR */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)       /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 #define SCB_CFSR_IBUSERR                    SCB_CFSR_IBUSERR_Msk               /*!< Instruction bus error flag */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)       /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 #define SCB_CFSR_PRECISERR                  SCB_CFSR_PRECISERR_Msk             /*!< Precise data bus error */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 #define SCB_CFSR_IMPRECISERR                SCB_CFSR_IMPRECISERR_Msk           /*!< Imprecise data bus error */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 #define SCB_CFSR_UNSTKERR                   SCB_CFSR_UNSTKERR_Msk              /*!< Unstacking error */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)       /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)         /*!< SCB CFSR (BFSR): STKERR Mask */
 #define SCB_CFSR_STKERR                     SCB_CFSR_STKERR_Msk                /*!< Stacking error */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)       /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 #define SCB_CFSR_BFARVALID                  SCB_CFSR_BFARVALID_Msk             /*!< Bus Fault Address Register address valid flag */
 /*!< UFSR */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 #define SCB_CFSR_UNDEFINSTR                 SCB_CFSR_UNDEFINSTR_Msk            /*!< The processor attempt to excecute an undefined instruction */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)       /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 #define SCB_CFSR_INVSTATE                   SCB_CFSR_INVSTATE_Msk              /*!< Invalid combination of EPSR and instruction */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)       /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)          /*!< SCB CFSR (UFSR): INVPC Mask */
 #define SCB_CFSR_INVPC                      SCB_CFSR_INVPC_Msk                 /*!< Attempt to load EXC_RETURN into pc illegally */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)       /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)           /*!< SCB CFSR (UFSR): NOCP Mask */
 #define SCB_CFSR_NOCP                       SCB_CFSR_NOCP_Msk                  /*!< Attempt to use a coprocessor instruction */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 #define SCB_CFSR_UNALIGNED                  SCB_CFSR_UNALIGNED_Msk             /*!< Fault occurs when there is an attempt to make an unaligned memory access */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 #define SCB_CFSR_DIVBYZERO                  SCB_CFSR_DIVBYZERO_Msk             /*!< Fault occurs when SDIV or DIV instruction is used with a divisor of 0 */
 
 /*******************  Bit definition for SCB_HFSR register  *******************/

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/stm32l1xx.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS STM32L1xx Device Peripheral Access Layer Header File. 
   *
   *          The file is the unique include file that the application programmer
@@ -18,7 +16,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -122,7 +120,7 @@
   */
 #define __STM32L1xx_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32L1xx_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x03) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32L1xx_CMSIS_VERSION        ((__STM32L1xx_CMSIS_VERSION_MAIN << 24)\
                                          |(__STM32L1xx_CMSIS_VERSION_SUB1 << 16)\

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_stm32l1xx.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    system_stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device System Source File for STM32L1xx devices.  
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file      startup_stm32l151xc.s
   * @author    MCD Application Team
-  * @version   V2.2.0
-  * @date      01-July-2016
   * @brief     STM32L151XC Devices vector table for 
   *            Atollic toolchain.
   *            This module performs:
@@ -17,7 +15,7 @@
   *            priority is Privileged, and the Stack is set to Main.
   ******************************************************************************
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/stm32l151xc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/stm32l151xc.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l151xc.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
   *          This file contains all the peripheral register's definitions, bits 
   *          definitions and memory mapping for STM32L1xx devices.            
@@ -16,7 +14,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -439,21 +437,27 @@ typedef struct
 typedef struct
 {
   __IO uint32_t ICR;        /*!< RI input capture register,                     Address offset: 0x00 */
-  __IO uint32_t ASCR1;      /*!< RI analog switches control register,       Address offset: 0x04 */
-  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,        Address offset: 0x08 */
+  __IO uint32_t ASCR1;      /*!< RI analog switches control register,           Address offset: 0x04 */
+  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,           Address offset: 0x08 */
   __IO uint32_t HYSCR1;     /*!< RI hysteresis control register,                Address offset: 0x0C */
-  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,               Address offset: 0x10 */
-  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,               Address offset: 0x14 */
-  uint32_t RESERVED1;       /*!< Reserved, 0x18                                                                  */
-  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,         Address offset: 0x1C */
-  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                   Address offset: 0x20 */
-  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,  Address offset: 0x24 */
-  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,         Address offset: 0x28 */
-  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                   Address offset: 0x2C */
-  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,  Address offset: 0x30 */
-  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,         Address offset: 0x34 */
-  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                   Address offset: 0x38 */
-  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,  Address offset: 0x3C */
+  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,                Address offset: 0x10 */
+  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,                Address offset: 0x14 */
+  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,                Address offset: 0x18 */
+  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,              Address offset: 0x1C */
+  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                    Address offset: 0x20 */
+  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,        Address offset: 0x24 */
+  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,              Address offset: 0x28 */
+  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                    Address offset: 0x2C */
+  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,        Address offset: 0x30 */
+  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,              Address offset: 0x34 */
+  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                    Address offset: 0x38 */
+  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,        Address offset: 0x3C */
+  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,              Address offset: 0x40 */
+  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                    Address offset: 0x44 */
+  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,        Address offset: 0x48 */
+  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,              Address offset: 0x4C */
+  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                    Address offset: 0x50 */
+  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,        Address offset: 0x54 */
 } RI_TypeDef;
 
 /** 
@@ -3569,56 +3573,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk                
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)                              
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk               
-#define GPIO_AFRL_AFRL1_Pos                  (4U)                              
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk               
-#define GPIO_AFRL_AFRL2_Pos                  (8U)                              
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk               
-#define GPIO_AFRL_AFRL3_Pos                  (12U)                             
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk               
-#define GPIO_AFRL_AFRL4_Pos                  (16U)                             
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk               
-#define GPIO_AFRL_AFRL5_Pos                  (20U)                             
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk               
-#define GPIO_AFRL_AFRL6_Pos                  (24U)                             
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk               
-#define GPIO_AFRL_AFRL7_Pos                  (28U)                             
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk               
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)                              
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk               
-#define GPIO_AFRH_AFRH1_Pos                  (4U)                              
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk               
-#define GPIO_AFRH_AFRH2_Pos                  (8U)                              
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk               
-#define GPIO_AFRH_AFRH3_Pos                  (12U)                             
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk               
-#define GPIO_AFRH_AFRH4_Pos                  (16U)                             
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk               
-#define GPIO_AFRH_AFRH5_Pos                  (20U)                             
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk               
-#define GPIO_AFRH_AFRH6_Pos                  (24U)                             
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk               
-#define GPIO_AFRH_AFRH7_Pos                  (28U)                             
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk               
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /****************** Bit definition for GPIO_BRR register  *********************/
 #define GPIO_BRR_BR_0                        (0x00000001U)                     
@@ -4830,9 +4834,9 @@ typedef struct
 #define RTC_CR_COSEL_Pos                     (19U)                             
 #define RTC_CR_COSEL_Msk                     (0x1U << RTC_CR_COSEL_Pos)        /*!< 0x00080000 */
 #define RTC_CR_COSEL                         RTC_CR_COSEL_Msk                  
-#define RTC_CR_BCK_Pos                       (18U)                             
-#define RTC_CR_BCK_Msk                       (0x1U << RTC_CR_BCK_Pos)          /*!< 0x00040000 */
-#define RTC_CR_BCK                           RTC_CR_BCK_Msk                    
+#define RTC_CR_BKP_Pos                       (18U)                             
+#define RTC_CR_BKP_Msk                       (0x1U << RTC_CR_BKP_Pos)          /*!< 0x00040000 */
+#define RTC_CR_BKP                           RTC_CR_BKP_Msk                    
 #define RTC_CR_SUB1H_Pos                     (17U)                             
 #define RTC_CR_SUB1H_Msk                     (0x1U << RTC_CR_SUB1H_Pos)        /*!< 0x00020000 */
 #define RTC_CR_SUB1H                         RTC_CR_SUB1H_Msk                  
@@ -4884,6 +4888,11 @@ typedef struct
 #define RTC_CR_WUCKSEL_0                     (0x1U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000001 */
 #define RTC_CR_WUCKSEL_1                     (0x2U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000002 */
 #define RTC_CR_WUCKSEL_2                     (0x4U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000004 */
+
+/* Legacy defines */
+#define  RTC_CR_BCK_Pos RTC_CR_BKP_Pos
+#define  RTC_CR_BCK_Msk RTC_CR_BKP_Msk
+#define  RTC_CR_BCK     RTC_CR_BKP
 
 /********************  Bits definition for RTC_ISR register  ******************/
 #define RTC_ISR_RECALPF_Pos                  (16U)                             
@@ -6114,6 +6123,45 @@ typedef struct
 #define RI_HYSCR3_PE_13                 (0x2000U << RI_HYSCR3_PE_Pos)          /*!< 0x00002000 */
 #define RI_HYSCR3_PE_14                 (0x4000U << RI_HYSCR3_PE_Pos)          /*!< 0x00004000 */
 #define RI_HYSCR3_PE_15                 (0x8000U << RI_HYSCR3_PE_Pos)          /*!< 0x00008000 */
+#define RI_HYSCR3_PF_Pos                (16U)                                  
+#define RI_HYSCR3_PF_Msk                (0xFFFFU << RI_HYSCR3_PF_Pos)          /*!< 0xFFFF0000 */
+#define RI_HYSCR3_PF                    RI_HYSCR3_PF_Msk                       /*!< PF[15:0] Port F Hysteresis selection */
+#define RI_HYSCR3_PF_0                  (0x0001U << RI_HYSCR3_PF_Pos)          /*!< 0x00010000 */
+#define RI_HYSCR3_PF_1                  (0x0002U << RI_HYSCR3_PF_Pos)          /*!< 0x00020000 */
+#define RI_HYSCR3_PF_2                  (0x0004U << RI_HYSCR3_PF_Pos)          /*!< 0x00040000 */
+#define RI_HYSCR3_PF_3                  (0x0008U << RI_HYSCR3_PF_Pos)          /*!< 0x00080000 */
+#define RI_HYSCR3_PF_4                  (0x0010U << RI_HYSCR3_PF_Pos)          /*!< 0x00100000 */
+#define RI_HYSCR3_PF_5                  (0x0020U << RI_HYSCR3_PF_Pos)          /*!< 0x00200000 */
+#define RI_HYSCR3_PF_6                  (0x0040U << RI_HYSCR3_PF_Pos)          /*!< 0x00400000 */
+#define RI_HYSCR3_PF_7                  (0x0080U << RI_HYSCR3_PF_Pos)          /*!< 0x00800000 */
+#define RI_HYSCR3_PF_8                  (0x0100U << RI_HYSCR3_PF_Pos)          /*!< 0x01000000 */
+#define RI_HYSCR3_PF_9                  (0x0200U << RI_HYSCR3_PF_Pos)          /*!< 0x02000000 */
+#define RI_HYSCR3_PF_10                 (0x0400U << RI_HYSCR3_PF_Pos)          /*!< 0x04000000 */
+#define RI_HYSCR3_PF_11                 (0x0800U << RI_HYSCR3_PF_Pos)          /*!< 0x08000000 */
+#define RI_HYSCR3_PF_12                 (0x1000U << RI_HYSCR3_PF_Pos)          /*!< 0x10000000 */
+#define RI_HYSCR3_PF_13                 (0x2000U << RI_HYSCR3_PF_Pos)          /*!< 0x20000000 */
+#define RI_HYSCR3_PF_14                 (0x4000U << RI_HYSCR3_PF_Pos)          /*!< 0x40000000 */
+#define RI_HYSCR3_PF_15                 (0x8000U << RI_HYSCR3_PF_Pos)          /*!< 0x80000000 */
+/********************  Bit definition for RI_HYSCR4 register  ********************/
+#define RI_HYSCR4_PG_Pos                (0U)                                   
+#define RI_HYSCR4_PG_Msk                (0xFFFFU << RI_HYSCR4_PG_Pos)          /*!< 0x0000FFFF */
+#define RI_HYSCR4_PG                    RI_HYSCR4_PG_Msk                       /*!< PG[15:0] Port G Hysteresis selection */
+#define RI_HYSCR4_PG_0                  (0x0001U << RI_HYSCR4_PG_Pos)          /*!< 0x00000001 */
+#define RI_HYSCR4_PG_1                  (0x0002U << RI_HYSCR4_PG_Pos)          /*!< 0x00000002 */
+#define RI_HYSCR4_PG_2                  (0x0004U << RI_HYSCR4_PG_Pos)          /*!< 0x00000004 */
+#define RI_HYSCR4_PG_3                  (0x0008U << RI_HYSCR4_PG_Pos)          /*!< 0x00000008 */
+#define RI_HYSCR4_PG_4                  (0x0010U << RI_HYSCR4_PG_Pos)          /*!< 0x00000010 */
+#define RI_HYSCR4_PG_5                  (0x0020U << RI_HYSCR4_PG_Pos)          /*!< 0x00000020 */
+#define RI_HYSCR4_PG_6                  (0x0040U << RI_HYSCR4_PG_Pos)          /*!< 0x00000040 */
+#define RI_HYSCR4_PG_7                  (0x0080U << RI_HYSCR4_PG_Pos)          /*!< 0x00000080 */
+#define RI_HYSCR4_PG_8                  (0x0100U << RI_HYSCR4_PG_Pos)          /*!< 0x00000100 */
+#define RI_HYSCR4_PG_9                  (0x0200U << RI_HYSCR4_PG_Pos)          /*!< 0x00000200 */
+#define RI_HYSCR4_PG_10                 (0x0400U << RI_HYSCR4_PG_Pos)          /*!< 0x00000400 */
+#define RI_HYSCR4_PG_11                 (0x0800U << RI_HYSCR4_PG_Pos)          /*!< 0x00000800 */
+#define RI_HYSCR4_PG_12                 (0x1000U << RI_HYSCR4_PG_Pos)          /*!< 0x00001000 */
+#define RI_HYSCR4_PG_13                 (0x2000U << RI_HYSCR4_PG_Pos)          /*!< 0x00002000 */
+#define RI_HYSCR4_PG_14                 (0x4000U << RI_HYSCR4_PG_Pos)          /*!< 0x00004000 */
+#define RI_HYSCR4_PG_15                 (0x8000U << RI_HYSCR4_PG_Pos)          /*!< 0x00008000 */
 
 /********************  Bit definition for RI_ASMR1 register  ********************/
 #define RI_ASMR1_PA_Pos                 (0U)                                   
@@ -6303,6 +6351,132 @@ typedef struct
 #define RI_CICR3_PC_13                  (0x2000U << RI_CICR3_PC_Pos)           /*!< 0x00002000 */
 #define RI_CICR3_PC_14                  (0x4000U << RI_CICR3_PC_Pos)           /*!< 0x00004000 */
 #define RI_CICR3_PC_15                  (0x8000U << RI_CICR3_PC_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR4 register  ********************/
+#define RI_ASMR4_PF_Pos                 (0U)                                   
+#define RI_ASMR4_PF_Msk                 (0xFFFFU << RI_ASMR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR4_PF                     RI_ASMR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_ASMR4_PF_0                   (0x0001U << RI_ASMR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_ASMR4_PF_1                   (0x0002U << RI_ASMR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_ASMR4_PF_2                   (0x0004U << RI_ASMR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_ASMR4_PF_3                   (0x0008U << RI_ASMR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_ASMR4_PF_4                   (0x0010U << RI_ASMR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_ASMR4_PF_5                   (0x0020U << RI_ASMR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_ASMR4_PF_6                   (0x0040U << RI_ASMR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_ASMR4_PF_7                   (0x0080U << RI_ASMR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_ASMR4_PF_8                   (0x0100U << RI_ASMR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_ASMR4_PF_9                   (0x0200U << RI_ASMR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_ASMR4_PF_10                  (0x0400U << RI_ASMR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_ASMR4_PF_11                  (0x0800U << RI_ASMR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_ASMR4_PF_12                  (0x1000U << RI_ASMR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_ASMR4_PF_13                  (0x2000U << RI_ASMR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_ASMR4_PF_14                  (0x4000U << RI_ASMR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_ASMR4_PF_15                  (0x8000U << RI_ASMR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR4 register  ********************/
+#define RI_CMR4_PF_Pos                  (0U)                                   
+#define RI_CMR4_PF_Msk                  (0xFFFFU << RI_CMR4_PF_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR4_PF                      RI_CMR4_PF_Msk                         /*!< PF[15:0] Port F selection */
+#define RI_CMR4_PF_0                    (0x0001U << RI_CMR4_PF_Pos)            /*!< 0x00000001 */
+#define RI_CMR4_PF_1                    (0x0002U << RI_CMR4_PF_Pos)            /*!< 0x00000002 */
+#define RI_CMR4_PF_2                    (0x0004U << RI_CMR4_PF_Pos)            /*!< 0x00000004 */
+#define RI_CMR4_PF_3                    (0x0008U << RI_CMR4_PF_Pos)            /*!< 0x00000008 */
+#define RI_CMR4_PF_4                    (0x0010U << RI_CMR4_PF_Pos)            /*!< 0x00000010 */
+#define RI_CMR4_PF_5                    (0x0020U << RI_CMR4_PF_Pos)            /*!< 0x00000020 */
+#define RI_CMR4_PF_6                    (0x0040U << RI_CMR4_PF_Pos)            /*!< 0x00000040 */
+#define RI_CMR4_PF_7                    (0x0080U << RI_CMR4_PF_Pos)            /*!< 0x00000080 */
+#define RI_CMR4_PF_8                    (0x0100U << RI_CMR4_PF_Pos)            /*!< 0x00000100 */
+#define RI_CMR4_PF_9                    (0x0200U << RI_CMR4_PF_Pos)            /*!< 0x00000200 */
+#define RI_CMR4_PF_10                   (0x0400U << RI_CMR4_PF_Pos)            /*!< 0x00000400 */
+#define RI_CMR4_PF_11                   (0x0800U << RI_CMR4_PF_Pos)            /*!< 0x00000800 */
+#define RI_CMR4_PF_12                   (0x1000U << RI_CMR4_PF_Pos)            /*!< 0x00001000 */
+#define RI_CMR4_PF_13                   (0x2000U << RI_CMR4_PF_Pos)            /*!< 0x00002000 */
+#define RI_CMR4_PF_14                   (0x4000U << RI_CMR4_PF_Pos)            /*!< 0x00004000 */
+#define RI_CMR4_PF_15                   (0x8000U << RI_CMR4_PF_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR4 register  ********************/
+#define RI_CICR4_PF_Pos                 (0U)                                   
+#define RI_CICR4_PF_Msk                 (0xFFFFU << RI_CICR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR4_PF                     RI_CICR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_CICR4_PF_0                   (0x0001U << RI_CICR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_CICR4_PF_1                   (0x0002U << RI_CICR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_CICR4_PF_2                   (0x0004U << RI_CICR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_CICR4_PF_3                   (0x0008U << RI_CICR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_CICR4_PF_4                   (0x0010U << RI_CICR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_CICR4_PF_5                   (0x0020U << RI_CICR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_CICR4_PF_6                   (0x0040U << RI_CICR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_CICR4_PF_7                   (0x0080U << RI_CICR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_CICR4_PF_8                   (0x0100U << RI_CICR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_CICR4_PF_9                   (0x0200U << RI_CICR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_CICR4_PF_10                  (0x0400U << RI_CICR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_CICR4_PF_11                  (0x0800U << RI_CICR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_CICR4_PF_12                  (0x1000U << RI_CICR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_CICR4_PF_13                  (0x2000U << RI_CICR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_CICR4_PF_14                  (0x4000U << RI_CICR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_CICR4_PF_15                  (0x8000U << RI_CICR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR5 register  ********************/
+#define RI_ASMR5_PG_Pos                 (0U)                                   
+#define RI_ASMR5_PG_Msk                 (0xFFFFU << RI_ASMR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR5_PG                     RI_ASMR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_ASMR5_PG_0                   (0x0001U << RI_ASMR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_ASMR5_PG_1                   (0x0002U << RI_ASMR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_ASMR5_PG_2                   (0x0004U << RI_ASMR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_ASMR5_PG_3                   (0x0008U << RI_ASMR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_ASMR5_PG_4                   (0x0010U << RI_ASMR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_ASMR5_PG_5                   (0x0020U << RI_ASMR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_ASMR5_PG_6                   (0x0040U << RI_ASMR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_ASMR5_PG_7                   (0x0080U << RI_ASMR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_ASMR5_PG_8                   (0x0100U << RI_ASMR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_ASMR5_PG_9                   (0x0200U << RI_ASMR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_ASMR5_PG_10                  (0x0400U << RI_ASMR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_ASMR5_PG_11                  (0x0800U << RI_ASMR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_ASMR5_PG_12                  (0x1000U << RI_ASMR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_ASMR5_PG_13                  (0x2000U << RI_ASMR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_ASMR5_PG_14                  (0x4000U << RI_ASMR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_ASMR5_PG_15                  (0x8000U << RI_ASMR5_PG_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR5 register  ********************/
+#define RI_CMR5_PG_Pos                  (0U)                                   
+#define RI_CMR5_PG_Msk                  (0xFFFFU << RI_CMR5_PG_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR5_PG                      RI_CMR5_PG_Msk                         /*!< PG[15:0] Port G selection */
+#define RI_CMR5_PG_0                    (0x0001U << RI_CMR5_PG_Pos)            /*!< 0x00000001 */
+#define RI_CMR5_PG_1                    (0x0002U << RI_CMR5_PG_Pos)            /*!< 0x00000002 */
+#define RI_CMR5_PG_2                    (0x0004U << RI_CMR5_PG_Pos)            /*!< 0x00000004 */
+#define RI_CMR5_PG_3                    (0x0008U << RI_CMR5_PG_Pos)            /*!< 0x00000008 */
+#define RI_CMR5_PG_4                    (0x0010U << RI_CMR5_PG_Pos)            /*!< 0x00000010 */
+#define RI_CMR5_PG_5                    (0x0020U << RI_CMR5_PG_Pos)            /*!< 0x00000020 */
+#define RI_CMR5_PG_6                    (0x0040U << RI_CMR5_PG_Pos)            /*!< 0x00000040 */
+#define RI_CMR5_PG_7                    (0x0080U << RI_CMR5_PG_Pos)            /*!< 0x00000080 */
+#define RI_CMR5_PG_8                    (0x0100U << RI_CMR5_PG_Pos)            /*!< 0x00000100 */
+#define RI_CMR5_PG_9                    (0x0200U << RI_CMR5_PG_Pos)            /*!< 0x00000200 */
+#define RI_CMR5_PG_10                   (0x0400U << RI_CMR5_PG_Pos)            /*!< 0x00000400 */
+#define RI_CMR5_PG_11                   (0x0800U << RI_CMR5_PG_Pos)            /*!< 0x00000800 */
+#define RI_CMR5_PG_12                   (0x1000U << RI_CMR5_PG_Pos)            /*!< 0x00001000 */
+#define RI_CMR5_PG_13                   (0x2000U << RI_CMR5_PG_Pos)            /*!< 0x00002000 */
+#define RI_CMR5_PG_14                   (0x4000U << RI_CMR5_PG_Pos)            /*!< 0x00004000 */
+#define RI_CMR5_PG_15                   (0x8000U << RI_CMR5_PG_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR5 register  ********************/
+#define RI_CICR5_PG_Pos                 (0U)                                   
+#define RI_CICR5_PG_Msk                 (0xFFFFU << RI_CICR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR5_PG                     RI_CICR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_CICR5_PG_0                   (0x0001U << RI_CICR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_CICR5_PG_1                   (0x0002U << RI_CICR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_CICR5_PG_2                   (0x0004U << RI_CICR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_CICR5_PG_3                   (0x0008U << RI_CICR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_CICR5_PG_4                   (0x0010U << RI_CICR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_CICR5_PG_5                   (0x0020U << RI_CICR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_CICR5_PG_6                   (0x0040U << RI_CICR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_CICR5_PG_7                   (0x0080U << RI_CICR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_CICR5_PG_8                   (0x0100U << RI_CICR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_CICR5_PG_9                   (0x0200U << RI_CICR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_CICR5_PG_10                  (0x0400U << RI_CICR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_CICR5_PG_11                  (0x0800U << RI_CICR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_CICR5_PG_12                  (0x1000U << RI_CICR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_CICR5_PG_13                  (0x2000U << RI_CICR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_CICR5_PG_14                  (0x4000U << RI_CICR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_CICR5_PG_15                  (0x8000U << RI_CICR5_PG_Pos)           /*!< 0x00008000 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -8481,24 +8655,58 @@ typedef struct
 
 /*******************  Bit definition for SCB_CFSR register  *******************/
 /*!< MFSR */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 0U)    /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)  /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 #define SCB_CFSR_IACCVIOL                   SCB_CFSR_IACCVIOL_Msk              /*!< Instruction access violation */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 1U)    /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)      /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 #define SCB_CFSR_DACCVIOL                   SCB_CFSR_DACCVIOL_Msk              /*!< Data access violation */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 3U)    /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)     /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 #define SCB_CFSR_MUNSTKERR                  SCB_CFSR_MUNSTKERR_Msk             /*!< Unstacking error */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_SHCSR_MEMFAULTACT_Pos + 4U)    /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)       /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 #define SCB_CFSR_MSTKERR                    SCB_CFSR_MSTKERR_Msk               /*!< Stacking error */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 7U)    /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)     /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 #define SCB_CFSR_MMARVALID                  SCB_CFSR_MMARVALID_Msk             /*!< Memory Manage Address Register address valid flag */
 /*!< BFSR */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)       /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 #define SCB_CFSR_IBUSERR                    SCB_CFSR_IBUSERR_Msk               /*!< Instruction bus error flag */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)       /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 #define SCB_CFSR_PRECISERR                  SCB_CFSR_PRECISERR_Msk             /*!< Precise data bus error */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 #define SCB_CFSR_IMPRECISERR                SCB_CFSR_IMPRECISERR_Msk           /*!< Imprecise data bus error */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 #define SCB_CFSR_UNSTKERR                   SCB_CFSR_UNSTKERR_Msk              /*!< Unstacking error */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)       /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)         /*!< SCB CFSR (BFSR): STKERR Mask */
 #define SCB_CFSR_STKERR                     SCB_CFSR_STKERR_Msk                /*!< Stacking error */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)       /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 #define SCB_CFSR_BFARVALID                  SCB_CFSR_BFARVALID_Msk             /*!< Bus Fault Address Register address valid flag */
 /*!< UFSR */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 #define SCB_CFSR_UNDEFINSTR                 SCB_CFSR_UNDEFINSTR_Msk            /*!< The processor attempt to excecute an undefined instruction */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)       /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 #define SCB_CFSR_INVSTATE                   SCB_CFSR_INVSTATE_Msk              /*!< Invalid combination of EPSR and instruction */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)       /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)          /*!< SCB CFSR (UFSR): INVPC Mask */
 #define SCB_CFSR_INVPC                      SCB_CFSR_INVPC_Msk                 /*!< Attempt to load EXC_RETURN into pc illegally */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)       /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)           /*!< SCB CFSR (UFSR): NOCP Mask */
 #define SCB_CFSR_NOCP                       SCB_CFSR_NOCP_Msk                  /*!< Attempt to use a coprocessor instruction */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 #define SCB_CFSR_UNALIGNED                  SCB_CFSR_UNALIGNED_Msk             /*!< Fault occurs when there is an attempt to make an unaligned memory access */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 #define SCB_CFSR_DIVBYZERO                  SCB_CFSR_DIVBYZERO_Msk             /*!< Fault occurs when SDIV or DIV instruction is used with a divisor of 0 */
 
 /*******************  Bit definition for SCB_HFSR register  *******************/

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/stm32l1xx.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS STM32L1xx Device Peripheral Access Layer Header File. 
   *
   *          The file is the unique include file that the application programmer
@@ -18,7 +16,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -134,7 +132,7 @@
   */
 #define __STM32L1xx_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32L1xx_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x03) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32L1xx_CMSIS_VERSION        ((__STM32L1xx_CMSIS_VERSION_MAIN << 24)\
                                          |(__STM32L1xx_CMSIS_VERSION_SUB1 << 16)\

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/system_stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/system_stm32l1xx.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    system_stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device System Source File for STM32L1xx devices.  
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,8 +1,8 @@
-;******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L151XC Devices vector for MDK-ARM toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* COPYRIGHT(c) 2016 STMicroelectronics
+;* COPYRIGHT(c) 2017 STMicroelectronics
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/startup_stm32l151xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l151xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/startup_stm32l151xc.S
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file      startup_stm32l151xc.s
   * @author    MCD Application Team
-  * @version   V2.2.0
-  * @date      01-July-2016
   * @brief     STM32L151XC Devices vector table for 
   *            Atollic toolchain.
   *            This module performs:
@@ -17,7 +15,7 @@
   *            priority is Privileged, and the Stack is set to Main.
   ******************************************************************************
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,8 +1,8 @@
-;/******************** (C) COPYRIGHT 2016 STMicroelectronics ********************
+;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
-;* Version            : V2.2.0
-;* Date               : 01-July-2016
+;* Version            : 21-April-2017
+;* Date               : V2.2.1
 ;* Description        : STM32L152XC Devices vector for EWARM toolchain. 
 ;*                      This module performs:
 ;*                      - Set the initial SP
@@ -16,7 +16,7 @@
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;********************************************************************************
 ;*
-;* <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+;* <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
 ;*
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_IAR/startup_stm32l152xc.S
@@ -1,4 +1,4 @@
-;/******************** (C) COPYRIGHT 2017 STMicroelectronics ********************
+;********************* (C) COPYRIGHT 2017 STMicroelectronics ********************
 ;* File Name          : startup_stm32l152xc.s
 ;* Author             : MCD Application Team
 ;* Version            : 21-April-2017

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/stm32l151xc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/stm32l151xc.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l151xc.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer Header File. 
   *          This file contains all the peripheral register's definitions, bits 
   *          definitions and memory mapping for STM32L1xx devices.            
@@ -16,7 +14,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -439,21 +437,27 @@ typedef struct
 typedef struct
 {
   __IO uint32_t ICR;        /*!< RI input capture register,                     Address offset: 0x00 */
-  __IO uint32_t ASCR1;      /*!< RI analog switches control register,       Address offset: 0x04 */
-  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,        Address offset: 0x08 */
+  __IO uint32_t ASCR1;      /*!< RI analog switches control register,           Address offset: 0x04 */
+  __IO uint32_t ASCR2;      /*!< RI analog switch control register 2,           Address offset: 0x08 */
   __IO uint32_t HYSCR1;     /*!< RI hysteresis control register,                Address offset: 0x0C */
-  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,               Address offset: 0x10 */
-  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,               Address offset: 0x14 */
-  uint32_t RESERVED1;       /*!< Reserved, 0x18                                                                  */
-  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,         Address offset: 0x1C */
-  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                   Address offset: 0x20 */
-  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,  Address offset: 0x24 */
-  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,         Address offset: 0x28 */
-  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                   Address offset: 0x2C */
-  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,  Address offset: 0x30 */
-  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,         Address offset: 0x34 */
-  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                   Address offset: 0x38 */
-  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,  Address offset: 0x3C */
+  __IO uint32_t HYSCR2;     /*!< RI Hysteresis control register,                Address offset: 0x10 */
+  __IO uint32_t HYSCR3;     /*!< RI Hysteresis control register,                Address offset: 0x14 */
+  __IO uint32_t HYSCR4;     /*!< RI Hysteresis control register,                Address offset: 0x18 */
+  __IO uint32_t ASMR1;      /*!< RI Analog switch mode register 1,              Address offset: 0x1C */
+  __IO uint32_t CMR1;       /*!< RI Channel mask register 1,                    Address offset: 0x20 */
+  __IO uint32_t CICR1;      /*!< RI Channel Iden for capture register 1,        Address offset: 0x24 */
+  __IO uint32_t ASMR2;      /*!< RI Analog switch mode register 2,              Address offset: 0x28 */
+  __IO uint32_t CMR2;       /*!< RI Channel mask register 2,                    Address offset: 0x2C */
+  __IO uint32_t CICR2;      /*!< RI Channel Iden for capture register 2,        Address offset: 0x30 */
+  __IO uint32_t ASMR3;      /*!< RI Analog switch mode register 3,              Address offset: 0x34 */
+  __IO uint32_t CMR3;       /*!< RI Channel mask register 3,                    Address offset: 0x38 */
+  __IO uint32_t CICR3;      /*!< RI Channel Iden for capture register 3,        Address offset: 0x3C */
+  __IO uint32_t ASMR4;      /*!< RI Analog switch mode register 4,              Address offset: 0x40 */
+  __IO uint32_t CMR4;       /*!< RI Channel mask register 4,                    Address offset: 0x44 */
+  __IO uint32_t CICR4;      /*!< RI Channel Iden for capture register 4,        Address offset: 0x48 */
+  __IO uint32_t ASMR5;      /*!< RI Analog switch mode register 5,              Address offset: 0x4C */
+  __IO uint32_t CMR5;       /*!< RI Channel mask register 5,                    Address offset: 0x50 */
+  __IO uint32_t CICR5;      /*!< RI Channel Iden for capture register 5,        Address offset: 0x54 */
 } RI_TypeDef;
 
 /** 
@@ -3569,56 +3573,56 @@ typedef struct
 #define GPIO_LCKR_LCKK                       GPIO_LCKR_LCKK_Msk                
 
 /****************** Bit definition for GPIO_AFRL register  ********************/
-#define GPIO_AFRL_AFRL0_Pos                  (0U)                              
-#define GPIO_AFRL_AFRL0_Msk                  (0xFU << GPIO_AFRL_AFRL0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRL_AFRL0                      GPIO_AFRL_AFRL0_Msk               
-#define GPIO_AFRL_AFRL1_Pos                  (4U)                              
-#define GPIO_AFRL_AFRL1_Msk                  (0xFU << GPIO_AFRL_AFRL1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRL_AFRL1                      GPIO_AFRL_AFRL1_Msk               
-#define GPIO_AFRL_AFRL2_Pos                  (8U)                              
-#define GPIO_AFRL_AFRL2_Msk                  (0xFU << GPIO_AFRL_AFRL2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRL_AFRL2                      GPIO_AFRL_AFRL2_Msk               
-#define GPIO_AFRL_AFRL3_Pos                  (12U)                             
-#define GPIO_AFRL_AFRL3_Msk                  (0xFU << GPIO_AFRL_AFRL3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRL_AFRL3                      GPIO_AFRL_AFRL3_Msk               
-#define GPIO_AFRL_AFRL4_Pos                  (16U)                             
-#define GPIO_AFRL_AFRL4_Msk                  (0xFU << GPIO_AFRL_AFRL4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRL_AFRL4                      GPIO_AFRL_AFRL4_Msk               
-#define GPIO_AFRL_AFRL5_Pos                  (20U)                             
-#define GPIO_AFRL_AFRL5_Msk                  (0xFU << GPIO_AFRL_AFRL5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRL_AFRL5                      GPIO_AFRL_AFRL5_Msk               
-#define GPIO_AFRL_AFRL6_Pos                  (24U)                             
-#define GPIO_AFRL_AFRL6_Msk                  (0xFU << GPIO_AFRL_AFRL6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRL_AFRL6                      GPIO_AFRL_AFRL6_Msk               
-#define GPIO_AFRL_AFRL7_Pos                  (28U)                             
-#define GPIO_AFRL_AFRL7_Msk                  (0xFU << GPIO_AFRL_AFRL7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRL_AFRL7                      GPIO_AFRL_AFRL7_Msk               
+#define GPIO_AFRL_AFSEL0_Pos                  (0U)                              
+#define GPIO_AFRL_AFSEL0_Msk                  (0xFU << GPIO_AFRL_AFSEL0_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRL_AFSEL0                      GPIO_AFRL_AFSEL0_Msk               
+#define GPIO_AFRL_AFSEL1_Pos                  (4U)                              
+#define GPIO_AFRL_AFSEL1_Msk                  (0xFU << GPIO_AFRL_AFSEL1_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRL_AFSEL1                      GPIO_AFRL_AFSEL1_Msk               
+#define GPIO_AFRL_AFSEL2_Pos                  (8U)                              
+#define GPIO_AFRL_AFSEL2_Msk                  (0xFU << GPIO_AFRL_AFSEL2_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRL_AFSEL2                      GPIO_AFRL_AFSEL2_Msk               
+#define GPIO_AFRL_AFSEL3_Pos                  (12U)                             
+#define GPIO_AFRL_AFSEL3_Msk                  (0xFU << GPIO_AFRL_AFSEL3_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRL_AFSEL3                      GPIO_AFRL_AFSEL3_Msk               
+#define GPIO_AFRL_AFSEL4_Pos                  (16U)                             
+#define GPIO_AFRL_AFSEL4_Msk                  (0xFU << GPIO_AFRL_AFSEL4_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRL_AFSEL4                      GPIO_AFRL_AFSEL4_Msk               
+#define GPIO_AFRL_AFSEL5_Pos                  (20U)                             
+#define GPIO_AFRL_AFSEL5_Msk                  (0xFU << GPIO_AFRL_AFSEL5_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRL_AFSEL5                      GPIO_AFRL_AFSEL5_Msk               
+#define GPIO_AFRL_AFSEL6_Pos                  (24U)                             
+#define GPIO_AFRL_AFSEL6_Msk                  (0xFU << GPIO_AFRL_AFSEL6_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRL_AFSEL6                      GPIO_AFRL_AFSEL6_Msk               
+#define GPIO_AFRL_AFSEL7_Pos                  (28U)                             
+#define GPIO_AFRL_AFSEL7_Msk                  (0xFU << GPIO_AFRL_AFSEL7_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRL_AFSEL7                      GPIO_AFRL_AFSEL7_Msk               
 
 /****************** Bit definition for GPIO_AFRH register  ********************/
-#define GPIO_AFRH_AFRH0_Pos                  (0U)                              
-#define GPIO_AFRH_AFRH0_Msk                  (0xFU << GPIO_AFRH_AFRH0_Pos)     /*!< 0x0000000F */
-#define GPIO_AFRH_AFRH0                      GPIO_AFRH_AFRH0_Msk               
-#define GPIO_AFRH_AFRH1_Pos                  (4U)                              
-#define GPIO_AFRH_AFRH1_Msk                  (0xFU << GPIO_AFRH_AFRH1_Pos)     /*!< 0x000000F0 */
-#define GPIO_AFRH_AFRH1                      GPIO_AFRH_AFRH1_Msk               
-#define GPIO_AFRH_AFRH2_Pos                  (8U)                              
-#define GPIO_AFRH_AFRH2_Msk                  (0xFU << GPIO_AFRH_AFRH2_Pos)     /*!< 0x00000F00 */
-#define GPIO_AFRH_AFRH2                      GPIO_AFRH_AFRH2_Msk               
-#define GPIO_AFRH_AFRH3_Pos                  (12U)                             
-#define GPIO_AFRH_AFRH3_Msk                  (0xFU << GPIO_AFRH_AFRH3_Pos)     /*!< 0x0000F000 */
-#define GPIO_AFRH_AFRH3                      GPIO_AFRH_AFRH3_Msk               
-#define GPIO_AFRH_AFRH4_Pos                  (16U)                             
-#define GPIO_AFRH_AFRH4_Msk                  (0xFU << GPIO_AFRH_AFRH4_Pos)     /*!< 0x000F0000 */
-#define GPIO_AFRH_AFRH4                      GPIO_AFRH_AFRH4_Msk               
-#define GPIO_AFRH_AFRH5_Pos                  (20U)                             
-#define GPIO_AFRH_AFRH5_Msk                  (0xFU << GPIO_AFRH_AFRH5_Pos)     /*!< 0x00F00000 */
-#define GPIO_AFRH_AFRH5                      GPIO_AFRH_AFRH5_Msk               
-#define GPIO_AFRH_AFRH6_Pos                  (24U)                             
-#define GPIO_AFRH_AFRH6_Msk                  (0xFU << GPIO_AFRH_AFRH6_Pos)     /*!< 0x0F000000 */
-#define GPIO_AFRH_AFRH6                      GPIO_AFRH_AFRH6_Msk               
-#define GPIO_AFRH_AFRH7_Pos                  (28U)                             
-#define GPIO_AFRH_AFRH7_Msk                  (0xFU << GPIO_AFRH_AFRH7_Pos)     /*!< 0xF0000000 */
-#define GPIO_AFRH_AFRH7                      GPIO_AFRH_AFRH7_Msk               
+#define GPIO_AFRH_AFSEL8_Pos                  (0U)                              
+#define GPIO_AFRH_AFSEL8_Msk                  (0xFU << GPIO_AFRH_AFSEL8_Pos)     /*!< 0x0000000F */
+#define GPIO_AFRH_AFSEL8                      GPIO_AFRH_AFSEL8_Msk               
+#define GPIO_AFRH_AFSEL9_Pos                  (4U)                              
+#define GPIO_AFRH_AFSEL9_Msk                  (0xFU << GPIO_AFRH_AFSEL9_Pos)     /*!< 0x000000F0 */
+#define GPIO_AFRH_AFSEL9                      GPIO_AFRH_AFSEL9_Msk               
+#define GPIO_AFRH_AFSEL10_Pos                  (8U)                              
+#define GPIO_AFRH_AFSEL10_Msk                  (0xFU << GPIO_AFRH_AFSEL10_Pos)     /*!< 0x00000F00 */
+#define GPIO_AFRH_AFSEL10                      GPIO_AFRH_AFSEL10_Msk               
+#define GPIO_AFRH_AFSEL11_Pos                  (12U)                             
+#define GPIO_AFRH_AFSEL11_Msk                  (0xFU << GPIO_AFRH_AFSEL11_Pos)     /*!< 0x0000F000 */
+#define GPIO_AFRH_AFSEL11                      GPIO_AFRH_AFSEL11_Msk               
+#define GPIO_AFRH_AFSEL12_Pos                  (16U)                             
+#define GPIO_AFRH_AFSEL12_Msk                  (0xFU << GPIO_AFRH_AFSEL12_Pos)     /*!< 0x000F0000 */
+#define GPIO_AFRH_AFSEL12                      GPIO_AFRH_AFSEL12_Msk               
+#define GPIO_AFRH_AFSEL13_Pos                  (20U)                             
+#define GPIO_AFRH_AFSEL13_Msk                  (0xFU << GPIO_AFRH_AFSEL13_Pos)     /*!< 0x00F00000 */
+#define GPIO_AFRH_AFSEL13                      GPIO_AFRH_AFSEL13_Msk               
+#define GPIO_AFRH_AFSEL14_Pos                  (24U)                             
+#define GPIO_AFRH_AFSEL14_Msk                  (0xFU << GPIO_AFRH_AFSEL14_Pos)     /*!< 0x0F000000 */
+#define GPIO_AFRH_AFSEL14                      GPIO_AFRH_AFSEL14_Msk               
+#define GPIO_AFRH_AFSEL15_Pos                  (28U)                             
+#define GPIO_AFRH_AFSEL15_Msk                  (0xFU << GPIO_AFRH_AFSEL15_Pos)     /*!< 0xF0000000 */
+#define GPIO_AFRH_AFSEL15                      GPIO_AFRH_AFSEL15_Msk               
 
 /****************** Bit definition for GPIO_BRR register  *********************/
 #define GPIO_BRR_BR_0                        (0x00000001U)                     
@@ -4830,9 +4834,9 @@ typedef struct
 #define RTC_CR_COSEL_Pos                     (19U)                             
 #define RTC_CR_COSEL_Msk                     (0x1U << RTC_CR_COSEL_Pos)        /*!< 0x00080000 */
 #define RTC_CR_COSEL                         RTC_CR_COSEL_Msk                  
-#define RTC_CR_BCK_Pos                       (18U)                             
-#define RTC_CR_BCK_Msk                       (0x1U << RTC_CR_BCK_Pos)          /*!< 0x00040000 */
-#define RTC_CR_BCK                           RTC_CR_BCK_Msk                    
+#define RTC_CR_BKP_Pos                       (18U)                             
+#define RTC_CR_BKP_Msk                       (0x1U << RTC_CR_BKP_Pos)          /*!< 0x00040000 */
+#define RTC_CR_BKP                           RTC_CR_BKP_Msk                    
 #define RTC_CR_SUB1H_Pos                     (17U)                             
 #define RTC_CR_SUB1H_Msk                     (0x1U << RTC_CR_SUB1H_Pos)        /*!< 0x00020000 */
 #define RTC_CR_SUB1H                         RTC_CR_SUB1H_Msk                  
@@ -4884,6 +4888,11 @@ typedef struct
 #define RTC_CR_WUCKSEL_0                     (0x1U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000001 */
 #define RTC_CR_WUCKSEL_1                     (0x2U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000002 */
 #define RTC_CR_WUCKSEL_2                     (0x4U << RTC_CR_WUCKSEL_Pos)      /*!< 0x00000004 */
+
+/* Legacy defines */
+#define  RTC_CR_BCK_Pos RTC_CR_BKP_Pos
+#define  RTC_CR_BCK_Msk RTC_CR_BKP_Msk
+#define  RTC_CR_BCK     RTC_CR_BKP
 
 /********************  Bits definition for RTC_ISR register  ******************/
 #define RTC_ISR_RECALPF_Pos                  (16U)                             
@@ -6114,6 +6123,45 @@ typedef struct
 #define RI_HYSCR3_PE_13                 (0x2000U << RI_HYSCR3_PE_Pos)          /*!< 0x00002000 */
 #define RI_HYSCR3_PE_14                 (0x4000U << RI_HYSCR3_PE_Pos)          /*!< 0x00004000 */
 #define RI_HYSCR3_PE_15                 (0x8000U << RI_HYSCR3_PE_Pos)          /*!< 0x00008000 */
+#define RI_HYSCR3_PF_Pos                (16U)                                  
+#define RI_HYSCR3_PF_Msk                (0xFFFFU << RI_HYSCR3_PF_Pos)          /*!< 0xFFFF0000 */
+#define RI_HYSCR3_PF                    RI_HYSCR3_PF_Msk                       /*!< PF[15:0] Port F Hysteresis selection */
+#define RI_HYSCR3_PF_0                  (0x0001U << RI_HYSCR3_PF_Pos)          /*!< 0x00010000 */
+#define RI_HYSCR3_PF_1                  (0x0002U << RI_HYSCR3_PF_Pos)          /*!< 0x00020000 */
+#define RI_HYSCR3_PF_2                  (0x0004U << RI_HYSCR3_PF_Pos)          /*!< 0x00040000 */
+#define RI_HYSCR3_PF_3                  (0x0008U << RI_HYSCR3_PF_Pos)          /*!< 0x00080000 */
+#define RI_HYSCR3_PF_4                  (0x0010U << RI_HYSCR3_PF_Pos)          /*!< 0x00100000 */
+#define RI_HYSCR3_PF_5                  (0x0020U << RI_HYSCR3_PF_Pos)          /*!< 0x00200000 */
+#define RI_HYSCR3_PF_6                  (0x0040U << RI_HYSCR3_PF_Pos)          /*!< 0x00400000 */
+#define RI_HYSCR3_PF_7                  (0x0080U << RI_HYSCR3_PF_Pos)          /*!< 0x00800000 */
+#define RI_HYSCR3_PF_8                  (0x0100U << RI_HYSCR3_PF_Pos)          /*!< 0x01000000 */
+#define RI_HYSCR3_PF_9                  (0x0200U << RI_HYSCR3_PF_Pos)          /*!< 0x02000000 */
+#define RI_HYSCR3_PF_10                 (0x0400U << RI_HYSCR3_PF_Pos)          /*!< 0x04000000 */
+#define RI_HYSCR3_PF_11                 (0x0800U << RI_HYSCR3_PF_Pos)          /*!< 0x08000000 */
+#define RI_HYSCR3_PF_12                 (0x1000U << RI_HYSCR3_PF_Pos)          /*!< 0x10000000 */
+#define RI_HYSCR3_PF_13                 (0x2000U << RI_HYSCR3_PF_Pos)          /*!< 0x20000000 */
+#define RI_HYSCR3_PF_14                 (0x4000U << RI_HYSCR3_PF_Pos)          /*!< 0x40000000 */
+#define RI_HYSCR3_PF_15                 (0x8000U << RI_HYSCR3_PF_Pos)          /*!< 0x80000000 */
+/********************  Bit definition for RI_HYSCR4 register  ********************/
+#define RI_HYSCR4_PG_Pos                (0U)                                   
+#define RI_HYSCR4_PG_Msk                (0xFFFFU << RI_HYSCR4_PG_Pos)          /*!< 0x0000FFFF */
+#define RI_HYSCR4_PG                    RI_HYSCR4_PG_Msk                       /*!< PG[15:0] Port G Hysteresis selection */
+#define RI_HYSCR4_PG_0                  (0x0001U << RI_HYSCR4_PG_Pos)          /*!< 0x00000001 */
+#define RI_HYSCR4_PG_1                  (0x0002U << RI_HYSCR4_PG_Pos)          /*!< 0x00000002 */
+#define RI_HYSCR4_PG_2                  (0x0004U << RI_HYSCR4_PG_Pos)          /*!< 0x00000004 */
+#define RI_HYSCR4_PG_3                  (0x0008U << RI_HYSCR4_PG_Pos)          /*!< 0x00000008 */
+#define RI_HYSCR4_PG_4                  (0x0010U << RI_HYSCR4_PG_Pos)          /*!< 0x00000010 */
+#define RI_HYSCR4_PG_5                  (0x0020U << RI_HYSCR4_PG_Pos)          /*!< 0x00000020 */
+#define RI_HYSCR4_PG_6                  (0x0040U << RI_HYSCR4_PG_Pos)          /*!< 0x00000040 */
+#define RI_HYSCR4_PG_7                  (0x0080U << RI_HYSCR4_PG_Pos)          /*!< 0x00000080 */
+#define RI_HYSCR4_PG_8                  (0x0100U << RI_HYSCR4_PG_Pos)          /*!< 0x00000100 */
+#define RI_HYSCR4_PG_9                  (0x0200U << RI_HYSCR4_PG_Pos)          /*!< 0x00000200 */
+#define RI_HYSCR4_PG_10                 (0x0400U << RI_HYSCR4_PG_Pos)          /*!< 0x00000400 */
+#define RI_HYSCR4_PG_11                 (0x0800U << RI_HYSCR4_PG_Pos)          /*!< 0x00000800 */
+#define RI_HYSCR4_PG_12                 (0x1000U << RI_HYSCR4_PG_Pos)          /*!< 0x00001000 */
+#define RI_HYSCR4_PG_13                 (0x2000U << RI_HYSCR4_PG_Pos)          /*!< 0x00002000 */
+#define RI_HYSCR4_PG_14                 (0x4000U << RI_HYSCR4_PG_Pos)          /*!< 0x00004000 */
+#define RI_HYSCR4_PG_15                 (0x8000U << RI_HYSCR4_PG_Pos)          /*!< 0x00008000 */
 
 /********************  Bit definition for RI_ASMR1 register  ********************/
 #define RI_ASMR1_PA_Pos                 (0U)                                   
@@ -6303,6 +6351,132 @@ typedef struct
 #define RI_CICR3_PC_13                  (0x2000U << RI_CICR3_PC_Pos)           /*!< 0x00002000 */
 #define RI_CICR3_PC_14                  (0x4000U << RI_CICR3_PC_Pos)           /*!< 0x00004000 */
 #define RI_CICR3_PC_15                  (0x8000U << RI_CICR3_PC_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR4 register  ********************/
+#define RI_ASMR4_PF_Pos                 (0U)                                   
+#define RI_ASMR4_PF_Msk                 (0xFFFFU << RI_ASMR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR4_PF                     RI_ASMR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_ASMR4_PF_0                   (0x0001U << RI_ASMR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_ASMR4_PF_1                   (0x0002U << RI_ASMR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_ASMR4_PF_2                   (0x0004U << RI_ASMR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_ASMR4_PF_3                   (0x0008U << RI_ASMR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_ASMR4_PF_4                   (0x0010U << RI_ASMR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_ASMR4_PF_5                   (0x0020U << RI_ASMR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_ASMR4_PF_6                   (0x0040U << RI_ASMR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_ASMR4_PF_7                   (0x0080U << RI_ASMR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_ASMR4_PF_8                   (0x0100U << RI_ASMR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_ASMR4_PF_9                   (0x0200U << RI_ASMR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_ASMR4_PF_10                  (0x0400U << RI_ASMR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_ASMR4_PF_11                  (0x0800U << RI_ASMR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_ASMR4_PF_12                  (0x1000U << RI_ASMR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_ASMR4_PF_13                  (0x2000U << RI_ASMR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_ASMR4_PF_14                  (0x4000U << RI_ASMR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_ASMR4_PF_15                  (0x8000U << RI_ASMR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR4 register  ********************/
+#define RI_CMR4_PF_Pos                  (0U)                                   
+#define RI_CMR4_PF_Msk                  (0xFFFFU << RI_CMR4_PF_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR4_PF                      RI_CMR4_PF_Msk                         /*!< PF[15:0] Port F selection */
+#define RI_CMR4_PF_0                    (0x0001U << RI_CMR4_PF_Pos)            /*!< 0x00000001 */
+#define RI_CMR4_PF_1                    (0x0002U << RI_CMR4_PF_Pos)            /*!< 0x00000002 */
+#define RI_CMR4_PF_2                    (0x0004U << RI_CMR4_PF_Pos)            /*!< 0x00000004 */
+#define RI_CMR4_PF_3                    (0x0008U << RI_CMR4_PF_Pos)            /*!< 0x00000008 */
+#define RI_CMR4_PF_4                    (0x0010U << RI_CMR4_PF_Pos)            /*!< 0x00000010 */
+#define RI_CMR4_PF_5                    (0x0020U << RI_CMR4_PF_Pos)            /*!< 0x00000020 */
+#define RI_CMR4_PF_6                    (0x0040U << RI_CMR4_PF_Pos)            /*!< 0x00000040 */
+#define RI_CMR4_PF_7                    (0x0080U << RI_CMR4_PF_Pos)            /*!< 0x00000080 */
+#define RI_CMR4_PF_8                    (0x0100U << RI_CMR4_PF_Pos)            /*!< 0x00000100 */
+#define RI_CMR4_PF_9                    (0x0200U << RI_CMR4_PF_Pos)            /*!< 0x00000200 */
+#define RI_CMR4_PF_10                   (0x0400U << RI_CMR4_PF_Pos)            /*!< 0x00000400 */
+#define RI_CMR4_PF_11                   (0x0800U << RI_CMR4_PF_Pos)            /*!< 0x00000800 */
+#define RI_CMR4_PF_12                   (0x1000U << RI_CMR4_PF_Pos)            /*!< 0x00001000 */
+#define RI_CMR4_PF_13                   (0x2000U << RI_CMR4_PF_Pos)            /*!< 0x00002000 */
+#define RI_CMR4_PF_14                   (0x4000U << RI_CMR4_PF_Pos)            /*!< 0x00004000 */
+#define RI_CMR4_PF_15                   (0x8000U << RI_CMR4_PF_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR4 register  ********************/
+#define RI_CICR4_PF_Pos                 (0U)                                   
+#define RI_CICR4_PF_Msk                 (0xFFFFU << RI_CICR4_PF_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR4_PF                     RI_CICR4_PF_Msk                        /*!< PF[15:0] Port F selection */
+#define RI_CICR4_PF_0                   (0x0001U << RI_CICR4_PF_Pos)           /*!< 0x00000001 */
+#define RI_CICR4_PF_1                   (0x0002U << RI_CICR4_PF_Pos)           /*!< 0x00000002 */
+#define RI_CICR4_PF_2                   (0x0004U << RI_CICR4_PF_Pos)           /*!< 0x00000004 */
+#define RI_CICR4_PF_3                   (0x0008U << RI_CICR4_PF_Pos)           /*!< 0x00000008 */
+#define RI_CICR4_PF_4                   (0x0010U << RI_CICR4_PF_Pos)           /*!< 0x00000010 */
+#define RI_CICR4_PF_5                   (0x0020U << RI_CICR4_PF_Pos)           /*!< 0x00000020 */
+#define RI_CICR4_PF_6                   (0x0040U << RI_CICR4_PF_Pos)           /*!< 0x00000040 */
+#define RI_CICR4_PF_7                   (0x0080U << RI_CICR4_PF_Pos)           /*!< 0x00000080 */
+#define RI_CICR4_PF_8                   (0x0100U << RI_CICR4_PF_Pos)           /*!< 0x00000100 */
+#define RI_CICR4_PF_9                   (0x0200U << RI_CICR4_PF_Pos)           /*!< 0x00000200 */
+#define RI_CICR4_PF_10                  (0x0400U << RI_CICR4_PF_Pos)           /*!< 0x00000400 */
+#define RI_CICR4_PF_11                  (0x0800U << RI_CICR4_PF_Pos)           /*!< 0x00000800 */
+#define RI_CICR4_PF_12                  (0x1000U << RI_CICR4_PF_Pos)           /*!< 0x00001000 */
+#define RI_CICR4_PF_13                  (0x2000U << RI_CICR4_PF_Pos)           /*!< 0x00002000 */
+#define RI_CICR4_PF_14                  (0x4000U << RI_CICR4_PF_Pos)           /*!< 0x00004000 */
+#define RI_CICR4_PF_15                  (0x8000U << RI_CICR4_PF_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_ASMR5 register  ********************/
+#define RI_ASMR5_PG_Pos                 (0U)                                   
+#define RI_ASMR5_PG_Msk                 (0xFFFFU << RI_ASMR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_ASMR5_PG                     RI_ASMR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_ASMR5_PG_0                   (0x0001U << RI_ASMR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_ASMR5_PG_1                   (0x0002U << RI_ASMR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_ASMR5_PG_2                   (0x0004U << RI_ASMR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_ASMR5_PG_3                   (0x0008U << RI_ASMR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_ASMR5_PG_4                   (0x0010U << RI_ASMR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_ASMR5_PG_5                   (0x0020U << RI_ASMR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_ASMR5_PG_6                   (0x0040U << RI_ASMR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_ASMR5_PG_7                   (0x0080U << RI_ASMR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_ASMR5_PG_8                   (0x0100U << RI_ASMR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_ASMR5_PG_9                   (0x0200U << RI_ASMR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_ASMR5_PG_10                  (0x0400U << RI_ASMR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_ASMR5_PG_11                  (0x0800U << RI_ASMR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_ASMR5_PG_12                  (0x1000U << RI_ASMR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_ASMR5_PG_13                  (0x2000U << RI_ASMR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_ASMR5_PG_14                  (0x4000U << RI_ASMR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_ASMR5_PG_15                  (0x8000U << RI_ASMR5_PG_Pos)           /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CMR5 register  ********************/
+#define RI_CMR5_PG_Pos                  (0U)                                   
+#define RI_CMR5_PG_Msk                  (0xFFFFU << RI_CMR5_PG_Pos)            /*!< 0x0000FFFF */
+#define RI_CMR5_PG                      RI_CMR5_PG_Msk                         /*!< PG[15:0] Port G selection */
+#define RI_CMR5_PG_0                    (0x0001U << RI_CMR5_PG_Pos)            /*!< 0x00000001 */
+#define RI_CMR5_PG_1                    (0x0002U << RI_CMR5_PG_Pos)            /*!< 0x00000002 */
+#define RI_CMR5_PG_2                    (0x0004U << RI_CMR5_PG_Pos)            /*!< 0x00000004 */
+#define RI_CMR5_PG_3                    (0x0008U << RI_CMR5_PG_Pos)            /*!< 0x00000008 */
+#define RI_CMR5_PG_4                    (0x0010U << RI_CMR5_PG_Pos)            /*!< 0x00000010 */
+#define RI_CMR5_PG_5                    (0x0020U << RI_CMR5_PG_Pos)            /*!< 0x00000020 */
+#define RI_CMR5_PG_6                    (0x0040U << RI_CMR5_PG_Pos)            /*!< 0x00000040 */
+#define RI_CMR5_PG_7                    (0x0080U << RI_CMR5_PG_Pos)            /*!< 0x00000080 */
+#define RI_CMR5_PG_8                    (0x0100U << RI_CMR5_PG_Pos)            /*!< 0x00000100 */
+#define RI_CMR5_PG_9                    (0x0200U << RI_CMR5_PG_Pos)            /*!< 0x00000200 */
+#define RI_CMR5_PG_10                   (0x0400U << RI_CMR5_PG_Pos)            /*!< 0x00000400 */
+#define RI_CMR5_PG_11                   (0x0800U << RI_CMR5_PG_Pos)            /*!< 0x00000800 */
+#define RI_CMR5_PG_12                   (0x1000U << RI_CMR5_PG_Pos)            /*!< 0x00001000 */
+#define RI_CMR5_PG_13                   (0x2000U << RI_CMR5_PG_Pos)            /*!< 0x00002000 */
+#define RI_CMR5_PG_14                   (0x4000U << RI_CMR5_PG_Pos)            /*!< 0x00004000 */
+#define RI_CMR5_PG_15                   (0x8000U << RI_CMR5_PG_Pos)            /*!< 0x00008000 */
+
+/********************  Bit definition for RI_CICR5 register  ********************/
+#define RI_CICR5_PG_Pos                 (0U)                                   
+#define RI_CICR5_PG_Msk                 (0xFFFFU << RI_CICR5_PG_Pos)           /*!< 0x0000FFFF */
+#define RI_CICR5_PG                     RI_CICR5_PG_Msk                        /*!< PG[15:0] Port G selection */
+#define RI_CICR5_PG_0                   (0x0001U << RI_CICR5_PG_Pos)           /*!< 0x00000001 */
+#define RI_CICR5_PG_1                   (0x0002U << RI_CICR5_PG_Pos)           /*!< 0x00000002 */
+#define RI_CICR5_PG_2                   (0x0004U << RI_CICR5_PG_Pos)           /*!< 0x00000004 */
+#define RI_CICR5_PG_3                   (0x0008U << RI_CICR5_PG_Pos)           /*!< 0x00000008 */
+#define RI_CICR5_PG_4                   (0x0010U << RI_CICR5_PG_Pos)           /*!< 0x00000010 */
+#define RI_CICR5_PG_5                   (0x0020U << RI_CICR5_PG_Pos)           /*!< 0x00000020 */
+#define RI_CICR5_PG_6                   (0x0040U << RI_CICR5_PG_Pos)           /*!< 0x00000040 */
+#define RI_CICR5_PG_7                   (0x0080U << RI_CICR5_PG_Pos)           /*!< 0x00000080 */
+#define RI_CICR5_PG_8                   (0x0100U << RI_CICR5_PG_Pos)           /*!< 0x00000100 */
+#define RI_CICR5_PG_9                   (0x0200U << RI_CICR5_PG_Pos)           /*!< 0x00000200 */
+#define RI_CICR5_PG_10                  (0x0400U << RI_CICR5_PG_Pos)           /*!< 0x00000400 */
+#define RI_CICR5_PG_11                  (0x0800U << RI_CICR5_PG_Pos)           /*!< 0x00000800 */
+#define RI_CICR5_PG_12                  (0x1000U << RI_CICR5_PG_Pos)           /*!< 0x00001000 */
+#define RI_CICR5_PG_13                  (0x2000U << RI_CICR5_PG_Pos)           /*!< 0x00002000 */
+#define RI_CICR5_PG_14                  (0x4000U << RI_CICR5_PG_Pos)           /*!< 0x00004000 */
+#define RI_CICR5_PG_15                  (0x8000U << RI_CICR5_PG_Pos)           /*!< 0x00008000 */
 
 /******************************************************************************/
 /*                                                                            */
@@ -8481,24 +8655,58 @@ typedef struct
 
 /*******************  Bit definition for SCB_CFSR register  *******************/
 /*!< MFSR */
+#define SCB_CFSR_IACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 0U)    /*!< SCB CFSR (MMFSR): IACCVIOL Position */
+#define SCB_CFSR_IACCVIOL_Msk              (1UL /*<< SCB_CFSR_IACCVIOL_Pos*/)  /*!< SCB CFSR (MMFSR): IACCVIOL Mask */
 #define SCB_CFSR_IACCVIOL                   SCB_CFSR_IACCVIOL_Msk              /*!< Instruction access violation */
+#define SCB_CFSR_DACCVIOL_Pos              (SCB_SHCSR_MEMFAULTACT_Pos + 1U)    /*!< SCB CFSR (MMFSR): DACCVIOL Position */
+#define SCB_CFSR_DACCVIOL_Msk              (1UL << SCB_CFSR_DACCVIOL_Pos)      /*!< SCB CFSR (MMFSR): DACCVIOL Mask */
 #define SCB_CFSR_DACCVIOL                   SCB_CFSR_DACCVIOL_Msk              /*!< Data access violation */
+#define SCB_CFSR_MUNSTKERR_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 3U)    /*!< SCB CFSR (MMFSR): MUNSTKERR Position */
+#define SCB_CFSR_MUNSTKERR_Msk             (1UL << SCB_CFSR_MUNSTKERR_Pos)     /*!< SCB CFSR (MMFSR): MUNSTKERR Mask */
 #define SCB_CFSR_MUNSTKERR                  SCB_CFSR_MUNSTKERR_Msk             /*!< Unstacking error */
+#define SCB_CFSR_MSTKERR_Pos               (SCB_SHCSR_MEMFAULTACT_Pos + 4U)    /*!< SCB CFSR (MMFSR): MSTKERR Position */
+#define SCB_CFSR_MSTKERR_Msk               (1UL << SCB_CFSR_MSTKERR_Pos)       /*!< SCB CFSR (MMFSR): MSTKERR Mask */
 #define SCB_CFSR_MSTKERR                    SCB_CFSR_MSTKERR_Msk               /*!< Stacking error */
+#define SCB_CFSR_MMARVALID_Pos             (SCB_SHCSR_MEMFAULTACT_Pos + 7U)    /*!< SCB CFSR (MMFSR): MMARVALID Position */
+#define SCB_CFSR_MMARVALID_Msk             (1UL << SCB_CFSR_MMARVALID_Pos)     /*!< SCB CFSR (MMFSR): MMARVALID Mask */
 #define SCB_CFSR_MMARVALID                  SCB_CFSR_MMARVALID_Msk             /*!< Memory Manage Address Register address valid flag */
 /*!< BFSR */
+#define SCB_CFSR_IBUSERR_Pos              (SCB_CFSR_BUSFAULTSR_Pos + 0U)       /*!< SCB CFSR (BFSR): IBUSERR Position */
+#define SCB_CFSR_IBUSERR_Msk              (1UL << SCB_CFSR_IBUSERR_Pos)        /*!< SCB CFSR (BFSR): IBUSERR Mask */
 #define SCB_CFSR_IBUSERR                    SCB_CFSR_IBUSERR_Msk               /*!< Instruction bus error flag */
+#define SCB_CFSR_PRECISERR_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 1U)       /*!< SCB CFSR (BFSR): PRECISERR Position */
+#define SCB_CFSR_PRECISERR_Msk            (1UL << SCB_CFSR_PRECISERR_Pos)      /*!< SCB CFSR (BFSR): PRECISERR Mask */
 #define SCB_CFSR_PRECISERR                  SCB_CFSR_PRECISERR_Msk             /*!< Precise data bus error */
+#define SCB_CFSR_IMPRECISERR_Pos          (SCB_CFSR_BUSFAULTSR_Pos + 2U)       /*!< SCB CFSR (BFSR): IMPRECISERR Position */
+#define SCB_CFSR_IMPRECISERR_Msk          (1UL << SCB_CFSR_IMPRECISERR_Pos)    /*!< SCB CFSR (BFSR): IMPRECISERR Mask */
 #define SCB_CFSR_IMPRECISERR                SCB_CFSR_IMPRECISERR_Msk           /*!< Imprecise data bus error */
+#define SCB_CFSR_UNSTKERR_Pos             (SCB_CFSR_BUSFAULTSR_Pos + 3U)       /*!< SCB CFSR (BFSR): UNSTKERR Position */
+#define SCB_CFSR_UNSTKERR_Msk             (1UL << SCB_CFSR_UNSTKERR_Pos)       /*!< SCB CFSR (BFSR): UNSTKERR Mask */
 #define SCB_CFSR_UNSTKERR                   SCB_CFSR_UNSTKERR_Msk              /*!< Unstacking error */
+#define SCB_CFSR_STKERR_Pos               (SCB_CFSR_BUSFAULTSR_Pos + 4U)       /*!< SCB CFSR (BFSR): STKERR Position */
+#define SCB_CFSR_STKERR_Msk               (1UL << SCB_CFSR_STKERR_Pos)         /*!< SCB CFSR (BFSR): STKERR Mask */
 #define SCB_CFSR_STKERR                     SCB_CFSR_STKERR_Msk                /*!< Stacking error */
+#define SCB_CFSR_BFARVALID_Pos            (SCB_CFSR_BUSFAULTSR_Pos + 7U)       /*!< SCB CFSR (BFSR): BFARVALID Position */
+#define SCB_CFSR_BFARVALID_Msk            (1UL << SCB_CFSR_BFARVALID_Pos)      /*!< SCB CFSR (BFSR): BFARVALID Mask */
 #define SCB_CFSR_BFARVALID                  SCB_CFSR_BFARVALID_Msk             /*!< Bus Fault Address Register address valid flag */
 /*!< UFSR */
+#define SCB_CFSR_UNDEFINSTR_Pos           (SCB_CFSR_USGFAULTSR_Pos + 0U)       /*!< SCB CFSR (UFSR): UNDEFINSTR Position */
+#define SCB_CFSR_UNDEFINSTR_Msk           (1UL << SCB_CFSR_UNDEFINSTR_Pos)     /*!< SCB CFSR (UFSR): UNDEFINSTR Mask */
 #define SCB_CFSR_UNDEFINSTR                 SCB_CFSR_UNDEFINSTR_Msk            /*!< The processor attempt to excecute an undefined instruction */
+#define SCB_CFSR_INVSTATE_Pos             (SCB_CFSR_USGFAULTSR_Pos + 1U)       /*!< SCB CFSR (UFSR): INVSTATE Position */
+#define SCB_CFSR_INVSTATE_Msk             (1UL << SCB_CFSR_INVSTATE_Pos)       /*!< SCB CFSR (UFSR): INVSTATE Mask */
 #define SCB_CFSR_INVSTATE                   SCB_CFSR_INVSTATE_Msk              /*!< Invalid combination of EPSR and instruction */
+#define SCB_CFSR_INVPC_Pos                (SCB_CFSR_USGFAULTSR_Pos + 2U)       /*!< SCB CFSR (UFSR): INVPC Position */
+#define SCB_CFSR_INVPC_Msk                (1UL << SCB_CFSR_INVPC_Pos)          /*!< SCB CFSR (UFSR): INVPC Mask */
 #define SCB_CFSR_INVPC                      SCB_CFSR_INVPC_Msk                 /*!< Attempt to load EXC_RETURN into pc illegally */
+#define SCB_CFSR_NOCP_Pos                 (SCB_CFSR_USGFAULTSR_Pos + 3U)       /*!< SCB CFSR (UFSR): NOCP Position */
+#define SCB_CFSR_NOCP_Msk                 (1UL << SCB_CFSR_NOCP_Pos)           /*!< SCB CFSR (UFSR): NOCP Mask */
 #define SCB_CFSR_NOCP                       SCB_CFSR_NOCP_Msk                  /*!< Attempt to use a coprocessor instruction */
+#define SCB_CFSR_UNALIGNED_Pos            (SCB_CFSR_USGFAULTSR_Pos + 8U)       /*!< SCB CFSR (UFSR): UNALIGNED Position */
+#define SCB_CFSR_UNALIGNED_Msk            (1UL << SCB_CFSR_UNALIGNED_Pos)      /*!< SCB CFSR (UFSR): UNALIGNED Mask */
 #define SCB_CFSR_UNALIGNED                  SCB_CFSR_UNALIGNED_Msk             /*!< Fault occurs when there is an attempt to make an unaligned memory access */
+#define SCB_CFSR_DIVBYZERO_Pos            (SCB_CFSR_USGFAULTSR_Pos + 9U)       /*!< SCB CFSR (UFSR): DIVBYZERO Position */
+#define SCB_CFSR_DIVBYZERO_Msk            (1UL << SCB_CFSR_DIVBYZERO_Pos)      /*!< SCB CFSR (UFSR): DIVBYZERO Mask */
 #define SCB_CFSR_DIVBYZERO                  SCB_CFSR_DIVBYZERO_Msk             /*!< Fault occurs when SDIV or DIV instruction is used with a divisor of 0 */
 
 /*******************  Bit definition for SCB_HFSR register  *******************/

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/stm32l1xx.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS STM32L1xx Device Peripheral Access Layer Header File. 
   *
   *          The file is the unique include file that the application programmer
@@ -18,7 +16,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -121,7 +119,7 @@
   */
 #define __STM32L1xx_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */                                  
 #define __STM32L1xx_CMSIS_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_CMSIS_VERSION_SUB2   (0x03) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
 #define __STM32L1xx_CMSIS_VERSION        ((__STM32L1xx_CMSIS_VERSION_MAIN << 24)\
                                          |(__STM32L1xx_CMSIS_VERSION_SUB1 << 16)\

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_stm32l1xx.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/system_stm32l1xx.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    system_stm32l1xx.h
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device System Source File for STM32L1xx devices.  
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32_hal_legacy.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32_hal_legacy.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32_hal_legacy.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains aliases definition for the STM32Cube HAL constants 
   *          macros and functions maintained for legacy purpose.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -138,6 +136,9 @@
 #define COMP_EXTI_LINE_COMP5_EVENT     COMP_EXTI_LINE_COMP5
 #define COMP_EXTI_LINE_COMP6_EVENT     COMP_EXTI_LINE_COMP6
 #define COMP_EXTI_LINE_COMP7_EVENT     COMP_EXTI_LINE_COMP7
+#if defined(STM32L0)
+#define COMP_LPTIMCONNECTION_ENABLED   ((uint32_t)0x00000003U)    /*!< COMPX output generic naming: connected to LPTIM input 1 for COMP1, LPTIM input 2 for COMP2 */
+#endif
 #define COMP_OUTPUT_COMP6TIM2OCREFCLR  COMP_OUTPUT_COMP6_TIM2OCREFCLR
 #if defined(STM32F373xC) || defined(STM32F378xx)
 #define COMP_OUTPUT_TIM3IC1            COMP_OUTPUT_COMP1_TIM3IC1
@@ -240,9 +241,9 @@
 #define DAC1_CHANNEL_1                                  DAC_CHANNEL_1
 #define DAC1_CHANNEL_2                                  DAC_CHANNEL_2
 #define DAC2_CHANNEL_1                                  DAC_CHANNEL_1
-#define DAC_WAVE_NONE                                   ((uint32_t)0x00000000U)
-#define DAC_WAVE_NOISE                                  ((uint32_t)DAC_CR_WAVE1_0)
-#define DAC_WAVE_TRIANGLE                               ((uint32_t)DAC_CR_WAVE1_1)                           
+#define DAC_WAVE_NONE                                   0x00000000U
+#define DAC_WAVE_NOISE                                  DAC_CR_WAVE1_0
+#define DAC_WAVE_TRIANGLE                               DAC_CR_WAVE1_1
 #define DAC_WAVEGENERATION_NONE                         DAC_WAVE_NONE
 #define DAC_WAVEGENERATION_NOISE                        DAC_WAVE_NOISE
 #define DAC_WAVEGENERATION_TRIANGLE                     DAC_WAVE_TRIANGLE
@@ -264,7 +265,6 @@
 #define HAL_REMAPDMA_TIM17_DMA_CH7              DMA_REMAP_TIM17_DMA_CH7      
 #define HAL_REMAPDMA_SPI2_DMA_CH67              DMA_REMAP_SPI2_DMA_CH67  
 #define HAL_REMAPDMA_USART2_DMA_CH67            DMA_REMAP_USART2_DMA_CH67 
-#define HAL_REMAPDMA_USART3_DMA_CH32            DMA_REMAP_USART3_DMA_CH32  
 #define HAL_REMAPDMA_I2C1_DMA_CH76              DMA_REMAP_I2C1_DMA_CH76   
 #define HAL_REMAPDMA_TIM1_DMA_CH6               DMA_REMAP_TIM1_DMA_CH6     
 #define HAL_REMAPDMA_TIM2_DMA_CH7               DMA_REMAP_TIM2_DMA_CH7      
@@ -355,6 +355,7 @@
 #define OB_RDP_LEVEL0                 OB_RDP_LEVEL_0
 #define OB_RDP_LEVEL1                 OB_RDP_LEVEL_1
 #define OB_RDP_LEVEL2                 OB_RDP_LEVEL_2
+
 /**
   * @}
   */
@@ -380,7 +381,7 @@
 /** @defgroup LL_FMC_Aliased_Defines LL FMC Aliased Defines maintained for compatibility purpose
   * @{
   */
-#if defined(STM32L4) || defined(STM32F7)
+#if defined(STM32L4) || defined(STM32F7) || defined(STM32H7)
 #define FMC_NAND_PCC_WAIT_FEATURE_DISABLE       FMC_NAND_WAIT_FEATURE_DISABLE
 #define FMC_NAND_PCC_WAIT_FEATURE_ENABLE        FMC_NAND_WAIT_FEATURE_ENABLE
 #define FMC_NAND_PCC_MEM_BUS_WIDTH_8            FMC_NAND_MEM_BUS_WIDTH_8
@@ -455,6 +456,78 @@
   * @}
   */
 
+/** @defgroup HAL_JPEG_Aliased_Macros HAL JPEG Aliased Macros maintained for legacy purpose
+  * @{
+  */
+  
+#if defined(STM32H7)
+ #define __HAL_RCC_JPEG_CLK_ENABLE               __HAL_RCC_JPGDECEN_CLK_ENABLE
+ #define __HAL_RCC_JPEG_CLK_DISABLE              __HAL_RCC_JPGDECEN_CLK_DISABLE
+ #define __HAL_RCC_JPEG_FORCE_RESET              __HAL_RCC_JPGDECRST_FORCE_RESET
+ #define __HAL_RCC_JPEG_RELEASE_RESET            __HAL_RCC_JPGDECRST_RELEASE_RESET
+ #define __HAL_RCC_JPEG_CLK_SLEEP_ENABLE         __HAL_RCC_JPGDEC_CLK_SLEEP_ENABLE
+ #define __HAL_RCC_JPEG_CLK_SLEEP_DISABLE        __HAL_RCC_JPGDEC_CLK_SLEEP_DISABLE
+
+  #define DMA_REQUEST_DAC1 DMA_REQUEST_DAC1_CH1 
+  #define DMA_REQUEST_DAC2 DMA_REQUEST_DAC1_CH2 
+
+ #define BDMA_REQUEST_LP_UART1_RX BDMA_REQUEST_LPUART1_RX
+ #define BDMA_REQUEST_LP_UART1_TX BDMA_REQUEST_LPUART1_TX
+
+ #define HAL_DMAMUX1_REQUEST_GEN_DMAMUX1_CH0_EVT    HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH0_EVT
+ #define HAL_DMAMUX1_REQUEST_GEN_DMAMUX1_CH1_EVT    HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH1_EVT
+ #define HAL_DMAMUX1_REQUEST_GEN_DMAMUX1_CH2_EVT    HAL_DMAMUX1_REQ_GEN_DMAMUX1_CH2_EVT
+ #define HAL_DMAMUX1_REQUEST_GEN_LPTIM1_OUT         HAL_DMAMUX1_REQ_GEN_LPTIM1_OUT
+ #define HAL_DMAMUX1_REQUEST_GEN_LPTIM2_OUT         HAL_DMAMUX1_REQ_GEN_LPTIM2_OUT
+ #define HAL_DMAMUX1_REQUEST_GEN_LPTIM3_OUT         HAL_DMAMUX1_REQ_GEN_LPTIM3_OUT
+ #define HAL_DMAMUX1_REQUEST_GEN_EXTI0              HAL_DMAMUX1_REQ_GEN_EXTI0
+ #define HAL_DMAMUX1_REQUEST_GEN_TIM12_TRGO         HAL_DMAMUX1_REQ_GEN_TIM12_TRGO
+
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH0_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH0_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH1_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH1_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH2_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH2_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH3_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH3_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH4_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH4_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH5_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH5_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_DMAMUX2_CH6_EVT    HAL_DMAMUX2_REQ_GEN_DMAMUX2_CH6_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_LPUART1_RX_WKUP    HAL_DMAMUX2_REQ_GEN_LPUART1_RX_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_LPUART1_TX_WKUP    HAL_DMAMUX2_REQ_GEN_LPUART1_TX_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM2_WKUP        HAL_DMAMUX2_REQ_GEN_LPTIM2_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM2_OUT         HAL_DMAMUX2_REQ_GEN_LPTIM2_OUT
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM3_WKUP        HAL_DMAMUX2_REQ_GEN_LPTIM3_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM3_OUT         HAL_DMAMUX2_REQ_GEN_LPTIM3_OUT
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM4_WKUP        HAL_DMAMUX2_REQ_GEN_LPTIM4_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_LPTIM5_WKUP        HAL_DMAMUX2_REQ_GEN_LPTIM5_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_I2C4_WKUP          HAL_DMAMUX2_REQ_GEN_I2C4_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_SPI6_WKUP          HAL_DMAMUX2_REQ_GEN_SPI6_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_COMP1_OUT          HAL_DMAMUX2_REQ_GEN_COMP1_OUT
+ #define HAL_DMAMUX2_REQUEST_GEN_COMP2_OUT          HAL_DMAMUX2_REQ_GEN_COMP2_OUT
+ #define HAL_DMAMUX2_REQUEST_GEN_RTC_WKUP           HAL_DMAMUX2_REQ_GEN_RTC_WKUP
+ #define HAL_DMAMUX2_REQUEST_GEN_EXTI0              HAL_DMAMUX2_REQ_GEN_EXTI0
+ #define HAL_DMAMUX2_REQUEST_GEN_EXTI2              HAL_DMAMUX2_REQ_GEN_EXTI2
+ #define HAL_DMAMUX2_REQUEST_GEN_I2C4_IT_EVT        HAL_DMAMUX2_REQ_GEN_I2C4_IT_EVT
+ #define HAL_DMAMUX2_REQUEST_GEN_SPI6_IT            HAL_DMAMUX2_REQ_GEN_SPI6_IT
+ #define HAL_DMAMUX2_REQUEST_GEN_LPUART1_TX_IT      HAL_DMAMUX2_REQ_GEN_LPUART1_TX_IT
+ #define HAL_DMAMUX2_REQUEST_GEN_LPUART1_RX_IT      HAL_DMAMUX2_REQ_GEN_LPUART1_RX_IT
+ #define HAL_DMAMUX2_REQUEST_GEN_ADC3_IT            HAL_DMAMUX2_REQ_GEN_ADC3_IT
+ #define HAL_DMAMUX2_REQUEST_GEN_ADC3_AWD1_OUT      HAL_DMAMUX2_REQ_GEN_ADC3_AWD1_OUT
+ #define HAL_DMAMUX2_REQUEST_GEN_BDMA_CH0_IT        HAL_DMAMUX2_REQ_GEN_BDMA_CH0_IT
+ #define HAL_DMAMUX2_REQUEST_GEN_BDMA_CH1_IT        HAL_DMAMUX2_REQ_GEN_BDMA_CH1_IT
+
+ #define HAL_DMAMUX_REQUEST_GEN_NO_EVENT            HAL_DMAMUX_REQ_GEN_NO_EVENT
+ #define HAL_DMAMUX_REQUEST_GEN_RISING              HAL_DMAMUX_REQ_GEN_RISING
+ #define HAL_DMAMUX_REQUEST_GEN_FALLING             HAL_DMAMUX_REQ_GEN_FALLING
+ #define HAL_DMAMUX_REQUEST_GEN_RISING_FALLING      HAL_DMAMUX_REQ_GEN_RISING_FALLING
+
+
+#endif /* STM32H7  */
+  
+  
+/**
+  * @}
+  */ 
+  
+  
 /** @defgroup HAL_HRTIM_Aliased_Macros HAL HRTIM Aliased Macros maintained for legacy purpose
   * @{
   */
@@ -668,7 +741,6 @@
 #define FORMAT_BCD                  RTC_FORMAT_BCD
 
 #define RTC_ALARMSUBSECONDMASK_None     RTC_ALARMSUBSECONDMASK_NONE
-#define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
 #define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE
 #define RTC_TAMPERMASK_FLAG_DISABLED    RTC_TAMPERMASK_FLAG_DISABLE
 #define RTC_TAMPERMASK_FLAG_ENABLED     RTC_TAMPERMASK_FLAG_ENABLE
@@ -676,9 +748,6 @@
 #define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
 #define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE 
 #define RTC_TAMPERERASEBACKUP_ENABLED   RTC_TAMPER_ERASE_BACKUP_ENABLE
-#define RTC_TAMPERERASEBACKUP_DISABLED  RTC_TAMPER_ERASE_BACKUP_DISABLE 
-#define RTC_MASKTAMPERFLAG_DISABLED     RTC_TAMPERMASK_FLAG_DISABLE 
-#define RTC_MASKTAMPERFLAG_ENABLED      RTC_TAMPERMASK_FLAG_ENABLE
 #define RTC_TAMPER1_2_INTERRUPT         RTC_ALL_TAMPER_INTERRUPT 
 #define RTC_TAMPER1_2_3_INTERRUPT       RTC_ALL_TAMPER_INTERRUPT 
 
@@ -852,6 +921,8 @@
 #define __DIVFRAQ_SAMPLING8             UART_DIVFRAQ_SAMPLING8
 #define __UART_BRR_SAMPLING8            UART_BRR_SAMPLING8
 
+#define __DIV_LPUART                    UART_DIV_LPUART
+
 #define UART_WAKEUPMETHODE_IDLELINE     UART_WAKEUPMETHOD_IDLELINE
 #define UART_WAKEUPMETHODE_ADDRESSMARK  UART_WAKEUPMETHOD_ADDRESSMARK
 
@@ -913,48 +984,48 @@
 #define MACFCR_CLEAR_MASK       ETH_MACFCR_CLEAR_MASK
 #define DMAOMR_CLEAR_MASK       ETH_DMAOMR_CLEAR_MASK
 
-#define ETH_MMCCR              ((uint32_t)0x00000100U)  
-#define ETH_MMCRIR             ((uint32_t)0x00000104U)  
-#define ETH_MMCTIR             ((uint32_t)0x00000108U)  
-#define ETH_MMCRIMR            ((uint32_t)0x0000010CU)  
-#define ETH_MMCTIMR            ((uint32_t)0x00000110U)  
-#define ETH_MMCTGFSCCR         ((uint32_t)0x0000014CU)  
-#define ETH_MMCTGFMSCCR        ((uint32_t)0x00000150U)  
-#define ETH_MMCTGFCR           ((uint32_t)0x00000168U)  
-#define ETH_MMCRFCECR          ((uint32_t)0x00000194U)  
-#define ETH_MMCRFAECR          ((uint32_t)0x00000198U)  
-#define ETH_MMCRGUFCR          ((uint32_t)0x000001C4U)
+#define ETH_MMCCR              0x00000100U
+#define ETH_MMCRIR             0x00000104U
+#define ETH_MMCTIR             0x00000108U
+#define ETH_MMCRIMR            0x0000010CU
+#define ETH_MMCTIMR            0x00000110U
+#define ETH_MMCTGFSCCR         0x0000014CU
+#define ETH_MMCTGFMSCCR        0x00000150U
+#define ETH_MMCTGFCR           0x00000168U
+#define ETH_MMCRFCECR          0x00000194U
+#define ETH_MMCRFAECR          0x00000198U
+#define ETH_MMCRGUFCR          0x000001C4U
  
-#define ETH_MAC_TXFIFO_FULL          ((uint32_t)0x02000000)  /* Tx FIFO full */
-#define ETH_MAC_TXFIFONOT_EMPTY      ((uint32_t)0x01000000)  /* Tx FIFO not empty */
-#define ETH_MAC_TXFIFO_WRITE_ACTIVE  ((uint32_t)0x00400000)  /* Tx FIFO write active */
-#define ETH_MAC_TXFIFO_IDLE     ((uint32_t)0x00000000)  /* Tx FIFO read status: Idle */
-#define ETH_MAC_TXFIFO_READ     ((uint32_t)0x00100000)  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
-#define ETH_MAC_TXFIFO_WAITING  ((uint32_t)0x00200000)  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
-#define ETH_MAC_TXFIFO_WRITING  ((uint32_t)0x00300000)  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
-#define ETH_MAC_TRANSMISSION_PAUSE     ((uint32_t)0x00080000)  /* MAC transmitter in pause */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            ((uint32_t)0x00000000)  /* MAC transmit frame controller: Idle */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         ((uint32_t)0x00020000)  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   ((uint32_t)0x00040000)  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
-#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    ((uint32_t)0x00060000)  /* MAC transmit frame controller: Transferring input frame for transmission */
-#define ETH_MAC_MII_TRANSMIT_ACTIVE      ((uint32_t)0x00010000)  /* MAC MII transmit engine active */
-#define ETH_MAC_RXFIFO_EMPTY             ((uint32_t)0x00000000)  /* Rx FIFO fill level: empty */
-#define ETH_MAC_RXFIFO_BELOW_THRESHOLD   ((uint32_t)0x00000100)  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
-#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD   ((uint32_t)0x00000200)  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
-#define ETH_MAC_RXFIFO_FULL              ((uint32_t)0x00000300)  /* Rx FIFO fill level: full */
+#define ETH_MAC_TXFIFO_FULL                             0x02000000U  /* Tx FIFO full */
+#define ETH_MAC_TXFIFONOT_EMPTY                         0x01000000U  /* Tx FIFO not empty */
+#define ETH_MAC_TXFIFO_WRITE_ACTIVE                     0x00400000U  /* Tx FIFO write active */
+#define ETH_MAC_TXFIFO_IDLE                             0x00000000U  /* Tx FIFO read status: Idle */
+#define ETH_MAC_TXFIFO_READ                             0x00100000U  /* Tx FIFO read status: Read (transferring data to the MAC transmitter) */
+#define ETH_MAC_TXFIFO_WAITING                          0x00200000U  /* Tx FIFO read status: Waiting for TxStatus from MAC transmitter */
+#define ETH_MAC_TXFIFO_WRITING                          0x00300000U  /* Tx FIFO read status: Writing the received TxStatus or flushing the TxFIFO */
+#define ETH_MAC_TRANSMISSION_PAUSE                      0x00080000U  /* MAC transmitter in pause */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_IDLE            0x00000000U  /* MAC transmit frame controller: Idle */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_WAITING         0x00020000U  /* MAC transmit frame controller: Waiting for Status of previous frame or IFG/backoff period to be over */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_GENRATING_PCF   0x00040000U  /* MAC transmit frame controller: Generating and transmitting a Pause control frame (in full duplex mode) */
+#define ETH_MAC_TRANSMITFRAMECONTROLLER_TRANSFERRING    0x00060000U  /* MAC transmit frame controller: Transferring input frame for transmission */
+#define ETH_MAC_MII_TRANSMIT_ACTIVE           0x00010000U  /* MAC MII transmit engine active */
+#define ETH_MAC_RXFIFO_EMPTY                  0x00000000U  /* Rx FIFO fill level: empty */
+#define ETH_MAC_RXFIFO_BELOW_THRESHOLD        0x00000100U  /* Rx FIFO fill level: fill-level below flow-control de-activate threshold */
+#define ETH_MAC_RXFIFO_ABOVE_THRESHOLD        0x00000200U  /* Rx FIFO fill level: fill-level above flow-control activate threshold */
+#define ETH_MAC_RXFIFO_FULL                   0x00000300U  /* Rx FIFO fill level: full */
 #if defined(STM32F1)
 #else
-#define ETH_MAC_READCONTROLLER_IDLE               ((uint32_t)0x00000000)  /* Rx FIFO read controller IDLE state */
-#define ETH_MAC_READCONTROLLER_READING_DATA       ((uint32_t)0x00000020)  /* Rx FIFO read controller Reading frame data */
-#define ETH_MAC_READCONTROLLER_READING_STATUS     ((uint32_t)0x00000040)  /* Rx FIFO read controller Reading frame status (or time-stamp) */
+#define ETH_MAC_READCONTROLLER_IDLE           0x00000000U  /* Rx FIFO read controller IDLE state */
+#define ETH_MAC_READCONTROLLER_READING_DATA   0x00000020U  /* Rx FIFO read controller Reading frame data */
+#define ETH_MAC_READCONTROLLER_READING_STATUS 0x00000040U  /* Rx FIFO read controller Reading frame status (or time-stamp) */
 #endif
-#define ETH_MAC_READCONTROLLER_FLUSHING           ((uint32_t)0x00000060)  /* Rx FIFO read controller Flushing the frame data and status */
-#define ETH_MAC_RXFIFO_WRITE_ACTIVE     ((uint32_t)0x00000010)  /* Rx FIFO write controller active */
-#define ETH_MAC_SMALL_FIFO_NOTACTIVE    ((uint32_t)0x00000000)  /* MAC small FIFO read / write controllers not active */
-#define ETH_MAC_SMALL_FIFO_READ_ACTIVE  ((uint32_t)0x00000002)  /* MAC small FIFO read controller active */
-#define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE ((uint32_t)0x00000004)  /* MAC small FIFO write controller active */
-#define ETH_MAC_SMALL_FIFO_RW_ACTIVE    ((uint32_t)0x00000006)  /* MAC small FIFO read / write controllers active */
-#define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   ((uint32_t)0x00000001)  /* MAC MII receive protocol engine active */
+#define ETH_MAC_READCONTROLLER_FLUSHING       0x00000060U  /* Rx FIFO read controller Flushing the frame data and status */
+#define ETH_MAC_RXFIFO_WRITE_ACTIVE           0x00000010U  /* Rx FIFO write controller active */
+#define ETH_MAC_SMALL_FIFO_NOTACTIVE          0x00000000U  /* MAC small FIFO read / write controllers not active */
+#define ETH_MAC_SMALL_FIFO_READ_ACTIVE        0x00000002U  /* MAC small FIFO read controller active */
+#define ETH_MAC_SMALL_FIFO_WRITE_ACTIVE       0x00000004U  /* MAC small FIFO write controller active */
+#define ETH_MAC_SMALL_FIFO_RW_ACTIVE          0x00000006U  /* MAC small FIFO read / write controllers active */
+#define ETH_MAC_MII_RECEIVE_PROTOCOL_ACTIVE   0x00000001U  /* MAC MII receive protocol engine active */
 
 /**
   * @}
@@ -976,7 +1047,7 @@
   * @}
   */  
   
-#if defined(STM32L4xx) || defined(STM32F7) || defined(STM32F427xx) || defined(STM32F437xx) ||\
+#if defined(STM32L4) || defined(STM32F7) || defined(STM32F427xx) || defined(STM32F437xx) ||\
     defined(STM32F429xx) || defined(STM32F439xx) || defined(STM32F469xx) || defined(STM32F479xx)
 /** @defgroup HAL_DMA2D_Aliased_Defines HAL DMA2D Aliased Defines maintained for legacy purpose
   * @{
@@ -1001,7 +1072,7 @@
 /**
   * @}
   */    
-#endif  /* STM32L4xx ||  STM32F7*/
+#endif  /* STM32L4 ||  STM32F7*/
 
 /** @defgroup HAL_PPP_Aliased_Defines HAL PPP Aliased Defines maintained for legacy purpose
   * @{
@@ -1186,6 +1257,9 @@
   * @{
   */ 
 #define HAL_LTDC_LineEvenCallback HAL_LTDC_LineEventCallback
+#define HAL_LTDC_Relaod           HAL_LTDC_Reload
+#define HAL_LTDC_StructInitFromVideoConfig  HAL_LTDCEx_StructInitFromVideoConfig
+#define HAL_LTDC_StructInitFromAdaptedCommandConfig  HAL_LTDCEx_StructInitFromAdaptedCommandConfig
 /**
   * @}
   */  
@@ -1227,6 +1301,7 @@
 #define __HAL_CLEAR_FLAG                      __HAL_SYSCFG_CLEAR_FLAG
 #define __HAL_VREFINT_OUT_ENABLE              __HAL_SYSCFG_VREFINT_OUT_ENABLE
 #define __HAL_VREFINT_OUT_DISABLE             __HAL_SYSCFG_VREFINT_OUT_DISABLE
+#define __HAL_SYSCFG_SRAM2_WRP_ENABLE         __HAL_SYSCFG_SRAM2_WRP_0_31_ENABLE
 
 #define SYSCFG_FLAG_VREF_READY                SYSCFG_FLAG_VREFINT_READY
 #define SYSCFG_FLAG_RC48                      RCC_FLAG_HSI48
@@ -1308,7 +1383,6 @@
 #define __HAL_ADC_CR1_SCANCONV                           ADC_CR1_SCANCONV
 #define __HAL_ADC_CR2_EOCSelection                       ADC_CR2_EOCSelection
 #define __HAL_ADC_CR2_DMAContReq                         ADC_CR2_DMAContReq
-#define __HAL_ADC_GET_RESOLUTION                         ADC_GET_RESOLUTION
 #define __HAL_ADC_JSQR                                   ADC_JSQR
 
 #define __HAL_ADC_CHSELR_CHANNEL                         ADC_CHSELR_CHANNEL
@@ -1621,7 +1695,11 @@
   
 #define __HAL_I2C_RESET_CR2             I2C_RESET_CR2
 #define __HAL_I2C_GENERATE_START        I2C_GENERATE_START
+#if defined(STM32F1)
+#define __HAL_I2C_FREQ_RANGE            I2C_FREQRANGE
+#else
 #define __HAL_I2C_FREQ_RANGE            I2C_FREQ_RANGE
+#endif /* STM32F1 */
 #define __HAL_I2C_RISE_TIME             I2C_RISE_TIME
 #define __HAL_I2C_SPEED_STANDARD        I2C_SPEED_STANDARD
 #define __HAL_I2C_SPEED_FAST            I2C_SPEED_FAST
@@ -1781,20 +1859,20 @@
 #define HAL_RCC_CCSCallback HAL_RCC_CSSCallback
 #define HAL_RC48_EnableBuffer_Cmd(cmd) (((cmd)==ENABLE) ? HAL_RCCEx_EnableHSI48_VREFINT() : HAL_RCCEx_DisableHSI48_VREFINT())
 
-#define __ADC_CLK_DISABLE __HAL_RCC_ADC_CLK_DISABLE
-#define __ADC_CLK_ENABLE __HAL_RCC_ADC_CLK_ENABLE
-#define __ADC_CLK_SLEEP_DISABLE __HAL_RCC_ADC_CLK_SLEEP_DISABLE
-#define __ADC_CLK_SLEEP_ENABLE __HAL_RCC_ADC_CLK_SLEEP_ENABLE
-#define __ADC_FORCE_RESET __HAL_RCC_ADC_FORCE_RESET
-#define __ADC_RELEASE_RESET __HAL_RCC_ADC_RELEASE_RESET
-#define __ADC1_CLK_DISABLE        __HAL_RCC_ADC1_CLK_DISABLE
-#define __ADC1_CLK_ENABLE         __HAL_RCC_ADC1_CLK_ENABLE
-#define __ADC1_FORCE_RESET        __HAL_RCC_ADC1_FORCE_RESET
-#define __ADC1_RELEASE_RESET      __HAL_RCC_ADC1_RELEASE_RESET
-#define __ADC1_CLK_SLEEP_ENABLE   __HAL_RCC_ADC1_CLK_SLEEP_ENABLE  
-#define __ADC1_CLK_SLEEP_DISABLE  __HAL_RCC_ADC1_CLK_SLEEP_DISABLE  
-#define __ADC2_CLK_DISABLE __HAL_RCC_ADC2_CLK_DISABLE
-#define __ADC2_CLK_ENABLE __HAL_RCC_ADC2_CLK_ENABLE
+#define __ADC_CLK_DISABLE          __HAL_RCC_ADC_CLK_DISABLE
+#define __ADC_CLK_ENABLE           __HAL_RCC_ADC_CLK_ENABLE
+#define __ADC_CLK_SLEEP_DISABLE    __HAL_RCC_ADC_CLK_SLEEP_DISABLE
+#define __ADC_CLK_SLEEP_ENABLE     __HAL_RCC_ADC_CLK_SLEEP_ENABLE
+#define __ADC_FORCE_RESET          __HAL_RCC_ADC_FORCE_RESET
+#define __ADC_RELEASE_RESET        __HAL_RCC_ADC_RELEASE_RESET
+#define __ADC1_CLK_DISABLE         __HAL_RCC_ADC1_CLK_DISABLE
+#define __ADC1_CLK_ENABLE          __HAL_RCC_ADC1_CLK_ENABLE
+#define __ADC1_FORCE_RESET         __HAL_RCC_ADC1_FORCE_RESET
+#define __ADC1_RELEASE_RESET       __HAL_RCC_ADC1_RELEASE_RESET
+#define __ADC1_CLK_SLEEP_ENABLE    __HAL_RCC_ADC1_CLK_SLEEP_ENABLE  
+#define __ADC1_CLK_SLEEP_DISABLE   __HAL_RCC_ADC1_CLK_SLEEP_DISABLE  
+#define __ADC2_CLK_DISABLE         __HAL_RCC_ADC2_CLK_DISABLE
+#define __ADC2_CLK_ENABLE          __HAL_RCC_ADC2_CLK_ENABLE
 #define __ADC2_FORCE_RESET __HAL_RCC_ADC2_FORCE_RESET
 #define __ADC2_RELEASE_RESET __HAL_RCC_ADC2_RELEASE_RESET
 #define __ADC3_CLK_DISABLE __HAL_RCC_ADC3_CLK_DISABLE
@@ -1811,7 +1889,7 @@
 #define __CRYP_CLK_SLEEP_DISABLE  __HAL_RCC_CRYP_CLK_SLEEP_DISABLE
 #define __CRYP_CLK_ENABLE  __HAL_RCC_CRYP_CLK_ENABLE
 #define __CRYP_CLK_DISABLE  __HAL_RCC_CRYP_CLK_DISABLE
-#define __CRYP_FORCE_RESET  __HAL_RCC_CRYP_FORCE_RESET
+#define __CRYP_FORCE_RESET       __HAL_RCC_CRYP_FORCE_RESET
 #define __CRYP_RELEASE_RESET  __HAL_RCC_CRYP_RELEASE_RESET
 #define __AFIO_CLK_DISABLE __HAL_RCC_AFIO_CLK_DISABLE
 #define __AFIO_CLK_ENABLE __HAL_RCC_AFIO_CLK_ENABLE
@@ -2227,26 +2305,26 @@
 #define __USART3_CLK_SLEEP_ENABLE __HAL_RCC_USART3_CLK_SLEEP_ENABLE
 #define __USART3_FORCE_RESET __HAL_RCC_USART3_FORCE_RESET
 #define __USART3_RELEASE_RESET __HAL_RCC_USART3_RELEASE_RESET
-#define __USART4_CLK_DISABLE        __HAL_RCC_USART4_CLK_DISABLE
-#define __USART4_CLK_ENABLE         __HAL_RCC_USART4_CLK_ENABLE
-#define __USART4_CLK_SLEEP_ENABLE   __HAL_RCC_USART4_CLK_SLEEP_ENABLE
-#define __USART4_CLK_SLEEP_DISABLE  __HAL_RCC_USART4_CLK_SLEEP_DISABLE 
-#define __USART4_FORCE_RESET        __HAL_RCC_USART4_FORCE_RESET
-#define __USART4_RELEASE_RESET      __HAL_RCC_USART4_RELEASE_RESET
-#define __USART5_CLK_DISABLE        __HAL_RCC_USART5_CLK_DISABLE
-#define __USART5_CLK_ENABLE         __HAL_RCC_USART5_CLK_ENABLE
-#define __USART5_CLK_SLEEP_ENABLE   __HAL_RCC_USART5_CLK_SLEEP_ENABLE
-#define __USART5_CLK_SLEEP_DISABLE  __HAL_RCC_USART5_CLK_SLEEP_DISABLE 
-#define __USART5_FORCE_RESET        __HAL_RCC_USART5_FORCE_RESET
-#define __USART5_RELEASE_RESET      __HAL_RCC_USART5_RELEASE_RESET
-#define __USART7_CLK_DISABLE        __HAL_RCC_USART7_CLK_DISABLE
-#define __USART7_CLK_ENABLE         __HAL_RCC_USART7_CLK_ENABLE
-#define __USART7_FORCE_RESET        __HAL_RCC_USART7_FORCE_RESET
-#define __USART7_RELEASE_RESET      __HAL_RCC_USART7_RELEASE_RESET
-#define __USART8_CLK_DISABLE        __HAL_RCC_USART8_CLK_DISABLE
-#define __USART8_CLK_ENABLE         __HAL_RCC_USART8_CLK_ENABLE
-#define __USART8_FORCE_RESET        __HAL_RCC_USART8_FORCE_RESET
-#define __USART8_RELEASE_RESET      __HAL_RCC_USART8_RELEASE_RESET
+#define __USART4_CLK_DISABLE        __HAL_RCC_UART4_CLK_DISABLE
+#define __USART4_CLK_ENABLE         __HAL_RCC_UART4_CLK_ENABLE
+#define __USART4_CLK_SLEEP_ENABLE   __HAL_RCC_UART4_CLK_SLEEP_ENABLE
+#define __USART4_CLK_SLEEP_DISABLE  __HAL_RCC_UART4_CLK_SLEEP_DISABLE 
+#define __USART4_FORCE_RESET        __HAL_RCC_UART4_FORCE_RESET
+#define __USART4_RELEASE_RESET      __HAL_RCC_UART4_RELEASE_RESET
+#define __USART5_CLK_DISABLE        __HAL_RCC_UART5_CLK_DISABLE
+#define __USART5_CLK_ENABLE         __HAL_RCC_UART5_CLK_ENABLE
+#define __USART5_CLK_SLEEP_ENABLE   __HAL_RCC_UART5_CLK_SLEEP_ENABLE
+#define __USART5_CLK_SLEEP_DISABLE  __HAL_RCC_UART5_CLK_SLEEP_DISABLE 
+#define __USART5_FORCE_RESET        __HAL_RCC_UART5_FORCE_RESET
+#define __USART5_RELEASE_RESET      __HAL_RCC_UART5_RELEASE_RESET
+#define __USART7_CLK_DISABLE        __HAL_RCC_UART7_CLK_DISABLE
+#define __USART7_CLK_ENABLE         __HAL_RCC_UART7_CLK_ENABLE
+#define __USART7_FORCE_RESET        __HAL_RCC_UART7_FORCE_RESET
+#define __USART7_RELEASE_RESET      __HAL_RCC_UART7_RELEASE_RESET
+#define __USART8_CLK_DISABLE        __HAL_RCC_UART8_CLK_DISABLE
+#define __USART8_CLK_ENABLE         __HAL_RCC_UART8_CLK_ENABLE
+#define __USART8_FORCE_RESET        __HAL_RCC_UART8_FORCE_RESET
+#define __USART8_RELEASE_RESET      __HAL_RCC_UART8_RELEASE_RESET
 #define __USB_CLK_DISABLE         __HAL_RCC_USB_CLK_DISABLE
 #define __USB_CLK_ENABLE          __HAL_RCC_USB_CLK_ENABLE
 #define __USB_FORCE_RESET         __HAL_RCC_USB_FORCE_RESET
@@ -2406,7 +2484,6 @@
 #define __HAL_RCC_OTGHSULPI_CLK_SLEEP_DISABLE     __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE 
 #define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_ENABLED  __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_ENABLED
 #define __HAL_RCC_OTGHSULPI_IS_CLK_SLEEP_DISABLED __HAL_RCC_USB_OTG_HS_ULPI_IS_CLK_SLEEP_DISABLED   
-#define __CRYP_FORCE_RESET             __HAL_RCC_CRYP_FORCE_RESET  
 #define __SRAM3_CLK_SLEEP_ENABLE       __HAL_RCC_SRAM3_CLK_SLEEP_ENABLE  
 #define __CAN2_CLK_SLEEP_ENABLE        __HAL_RCC_CAN2_CLK_SLEEP_ENABLE
 #define __CAN2_CLK_SLEEP_DISABLE       __HAL_RCC_CAN2_CLK_SLEEP_DISABLE  
@@ -2439,8 +2516,6 @@
 #define __ADC12_CLK_DISABLE         __HAL_RCC_ADC12_CLK_DISABLE
 #define __ADC34_CLK_ENABLE          __HAL_RCC_ADC34_CLK_ENABLE
 #define __ADC34_CLK_DISABLE         __HAL_RCC_ADC34_CLK_DISABLE
-#define __ADC12_CLK_ENABLE          __HAL_RCC_ADC12_CLK_ENABLE
-#define __ADC12_CLK_DISABLE         __HAL_RCC_ADC12_CLK_DISABLE
 #define __DAC2_CLK_ENABLE           __HAL_RCC_DAC2_CLK_ENABLE
 #define __DAC2_CLK_DISABLE          __HAL_RCC_DAC2_CLK_DISABLE
 #define __TIM18_CLK_ENABLE          __HAL_RCC_TIM18_CLK_ENABLE
@@ -2462,8 +2537,6 @@
 #define __ADC12_RELEASE_RESET       __HAL_RCC_ADC12_RELEASE_RESET
 #define __ADC34_FORCE_RESET         __HAL_RCC_ADC34_FORCE_RESET
 #define __ADC34_RELEASE_RESET       __HAL_RCC_ADC34_RELEASE_RESET
-#define __ADC12_FORCE_RESET         __HAL_RCC_ADC12_FORCE_RESET
-#define __ADC12_RELEASE_RESET       __HAL_RCC_ADC12_RELEASE_RESET
 #define __DAC2_FORCE_RESET          __HAL_RCC_DAC2_FORCE_RESET
 #define __DAC2_RELEASE_RESET        __HAL_RCC_DAC2_RELEASE_RESET
 #define __TIM18_FORCE_RESET         __HAL_RCC_TIM18_FORCE_RESET
@@ -2635,6 +2708,30 @@
 #define RCC_SDIOCLKSOURCE_SYSCLK           RCC_SDMMC1CLKSOURCE_SYSCLK
 #endif
 
+#if defined(STM32H7)
+#define __HAL_RCC_USB_OTG_HS_CLK_ENABLE()              __HAL_RCC_USB1_OTG_HS_CLK_ENABLE()
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_ENABLE()         __HAL_RCC_USB1_OTG_HS_ULPI_CLK_ENABLE()
+#define __HAL_RCC_USB_OTG_HS_CLK_DISABLE()             __HAL_RCC_USB1_OTG_HS_CLK_DISABLE()
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_DISABLE()        __HAL_RCC_USB1_OTG_HS_ULPI_CLK_DISABLE()
+#define __HAL_RCC_USB_OTG_HS_FORCE_RESET()             __HAL_RCC_USB1_OTG_HS_FORCE_RESET()
+#define __HAL_RCC_USB_OTG_HS_RELEASE_RESET()           __HAL_RCC_USB1_OTG_HS_RELEASE_RESET()
+#define __HAL_RCC_USB_OTG_HS_CLK_SLEEP_ENABLE()        __HAL_RCC_USB1_OTG_HS_CLK_SLEEP_ENABLE()
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_ENABLE()   __HAL_RCC_USB1_OTG_HS_ULPI_CLK_SLEEP_ENABLE()
+#define __HAL_RCC_USB_OTG_HS_CLK_SLEEP_DISABLE()       __HAL_RCC_USB1_OTG_HS_CLK_SLEEP_DISABLE()
+#define __HAL_RCC_USB_OTG_HS_ULPI_CLK_SLEEP_DISABLE()  __HAL_RCC_USB1_OTG_HS_ULPI_CLK_SLEEP_DISABLE()
+
+#define __HAL_RCC_USB_OTG_FS_CLK_ENABLE()             __HAL_RCC_USB2_OTG_FS_CLK_ENABLE()
+#define __HAL_RCC_USB_OTG_FS_ULPI_CLK_ENABLE()        __HAL_RCC_USB2_OTG_FS_ULPI_CLK_ENABLE()
+#define __HAL_RCC_USB_OTG_FS_CLK_DISABLE()            __HAL_RCC_USB2_OTG_FS_CLK_DISABLE()
+#define __HAL_RCC_USB_OTG_FS_ULPI_CLK_DISABLE()       __HAL_RCC_USB2_OTG_FS_ULPI_CLK_DISABLE()
+#define __HAL_RCC_USB_OTG_FS_FORCE_RESET()            __HAL_RCC_USB2_OTG_FS_FORCE_RESET()
+#define __HAL_RCC_USB_OTG_FS_RELEASE_RESET()          __HAL_RCC_USB2_OTG_FS_RELEASE_RESET()
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_ENABLE()       __HAL_RCC_USB2_OTG_FS_CLK_SLEEP_ENABLE()
+#define __HAL_RCC_USB_OTG_FS_ULPI_CLK_SLEEP_ENABLE()  __HAL_RCC_USB2_OTG_FS_ULPI_CLK_SLEEP_ENABLE()
+#define __HAL_RCC_USB_OTG_FS_CLK_SLEEP_DISABLE()      __HAL_RCC_USB2_OTG_FS_CLK_SLEEP_DISABLE()
+#define __HAL_RCC_USB_OTG_FS_ULPI_CLK_SLEEP_DISABLE() __HAL_RCC_USB2_OTG_FS_ULPI_CLK_SLEEP_DISABLE()
+#endif
+
 #define __HAL_RCC_I2SCLK            __HAL_RCC_I2S_CONFIG
 #define __HAL_RCC_I2SCLK_CONFIG     __HAL_RCC_I2S_CONFIG
 
@@ -2648,10 +2745,22 @@
 
 #define RCC_IT_HSI14                RCC_IT_HSI14RDY
 
-#if defined(STM32L0)
-#define RCC_IT_LSECSS              RCC_IT_CSSLSE 
-#define RCC_IT_CSS                 RCC_IT_CSSHSE
-#endif
+#define RCC_IT_CSSLSE               RCC_IT_LSECSS
+#define RCC_IT_CSSHSE               RCC_IT_CSS
+
+#define RCC_PLLMUL_3                RCC_PLL_MUL3
+#define RCC_PLLMUL_4                RCC_PLL_MUL4
+#define RCC_PLLMUL_6                RCC_PLL_MUL6
+#define RCC_PLLMUL_8                RCC_PLL_MUL8
+#define RCC_PLLMUL_12               RCC_PLL_MUL12
+#define RCC_PLLMUL_16               RCC_PLL_MUL16
+#define RCC_PLLMUL_24               RCC_PLL_MUL24
+#define RCC_PLLMUL_32               RCC_PLL_MUL32
+#define RCC_PLLMUL_48               RCC_PLL_MUL48
+
+#define RCC_PLLDIV_2                RCC_PLL_DIV2
+#define RCC_PLLDIV_3                RCC_PLL_DIV3
+#define RCC_PLLDIV_4                RCC_PLL_DIV4
 
 #define IS_RCC_MCOSOURCE            IS_RCC_MCO1SOURCE
 #define __HAL_RCC_MCO_CONFIG        __HAL_RCC_MCO1_CONFIG
@@ -2676,7 +2785,10 @@
 #define RCC_MCOSOURCE_PLLCLK_NODIV  RCC_MCO1SOURCE_PLLCLK
 #define RCC_MCOSOURCE_PLLCLK_DIV2   RCC_MCO1SOURCE_PLLCLK_DIV2
 
+#if defined(STM32WB) || defined(STM32G0)
+#else
 #define RCC_RTCCLKSOURCE_NONE       RCC_RTCCLKSOURCE_NO_CLK
+#endif
 
 #define RCC_USBCLK_PLLSAI1          RCC_USBCLKSOURCE_PLLSAI1
 #define RCC_USBCLK_PLL              RCC_USBCLKSOURCE_PLL
@@ -2768,10 +2880,22 @@
 #define __HAL_RCC_DFSDM_IS_CLK_SLEEP_DISABLED  __HAL_RCC_DFSDM1_IS_CLK_SLEEP_DISABLED
 #define DfsdmClockSelection         Dfsdm1ClockSelection
 #define RCC_PERIPHCLK_DFSDM         RCC_PERIPHCLK_DFSDM1
-#define RCC_DFSDMCLKSOURCE_PCLK     RCC_DFSDM1CLKSOURCE_PCLK
+#define RCC_DFSDMCLKSOURCE_PCLK     RCC_DFSDM1CLKSOURCE_PCLK2
 #define RCC_DFSDMCLKSOURCE_SYSCLK   RCC_DFSDM1CLKSOURCE_SYSCLK
 #define __HAL_RCC_DFSDM_CONFIG      __HAL_RCC_DFSDM1_CONFIG
 #define __HAL_RCC_GET_DFSDM_SOURCE  __HAL_RCC_GET_DFSDM1_SOURCE
+#define RCC_DFSDM1CLKSOURCE_PCLK    RCC_DFSDM1CLKSOURCE_PCLK2
+#define RCC_SWPMI1CLKSOURCE_PCLK    RCC_SWPMI1CLKSOURCE_PCLK1
+#define RCC_LPTIM1CLKSOURCE_PCLK    RCC_LPTIM1CLKSOURCE_PCLK1
+#define RCC_LPTIM2CLKSOURCE_PCLK    RCC_LPTIM2CLKSOURCE_PCLK1
+
+#define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB1    RCC_DFSDM1AUDIOCLKSOURCE_I2S1
+#define RCC_DFSDM1AUDIOCLKSOURCE_I2SAPB2    RCC_DFSDM1AUDIOCLKSOURCE_I2S2
+#define RCC_DFSDM2AUDIOCLKSOURCE_I2SAPB1    RCC_DFSDM2AUDIOCLKSOURCE_I2S1
+#define RCC_DFSDM2AUDIOCLKSOURCE_I2SAPB2    RCC_DFSDM2AUDIOCLKSOURCE_I2S2
+#define RCC_DFSDM1CLKSOURCE_APB2            RCC_DFSDM1CLKSOURCE_PCLK2
+#define RCC_DFSDM2CLKSOURCE_APB2            RCC_DFSDM2CLKSOURCE_PCLK2
+#define RCC_FMPI2C1CLKSOURCE_APB            RCC_FMPI2C1CLKSOURCE_PCLK1
 
 /**
   * @}
@@ -2789,8 +2913,10 @@
 /** @defgroup HAL_RTC_Aliased_Macros HAL RTC Aliased Macros maintained for legacy purpose
   * @{
   */
-  
+#if defined (STM32G0)
+#else
 #define __HAL_RTC_CLEAR_FLAG                      __HAL_RTC_EXTI_CLEAR_FLAG
+#endif
 #define __HAL_RTC_DISABLE_IT                      __HAL_RTC_EXTI_DISABLE_IT
 #define __HAL_RTC_ENABLE_IT                       __HAL_RTC_EXTI_ENABLE_IT
 
@@ -2851,7 +2977,7 @@
 #define SD_OCR_CID_CSD_OVERWRIETE   SD_OCR_CID_CSD_OVERWRITE
 #define SD_CMD_SD_APP_STAUS         SD_CMD_SD_APP_STATUS
 
-#if defined(STM32F4)
+#if defined(STM32F4) || defined(STM32F2)
 #define  SD_SDMMC_DISABLED          SD_SDIO_DISABLED
 #define  SD_SDMMC_FUNCTION_BUSY     SD_SDIO_FUNCTION_BUSY     
 #define  SD_SDMMC_FUNCTION_FAILED   SD_SDIO_FUNCTION_FAILED   
@@ -2902,6 +3028,14 @@
 #define  SDIO_IRQn                  SDMMC1_IRQn
 #define  SDIO_IRQHandler            SDMMC1_IRQHandler
 #endif
+
+#if defined(STM32F7) || defined(STM32F4) || defined(STM32F2)
+#define  HAL_SD_CardCIDTypedef       HAL_SD_CardCIDTypeDef
+#define  HAL_SD_CardCSDTypedef       HAL_SD_CardCSDTypeDef
+#define  HAL_SD_CardStatusTypedef    HAL_SD_CardStatusTypeDef
+#define  HAL_SD_CardStateTypedef     HAL_SD_CardStateTypeDef
+#endif
+
 /**
   * @}
   */
@@ -3090,6 +3224,7 @@
   * @{
   */
 #define __HAL_LTDC_LAYER LTDC_LAYER
+#define __HAL_LTDC_RELOAD_CONFIG  __HAL_LTDC_RELOAD_IMMEDIATE_CONFIG
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   HAL module driver.
   *          This is the common part of the HAL initialization
   *
@@ -23,7 +21,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -75,15 +73,15 @@
  * @brief STM32L1xx HAL Driver version number
    */
 #define __STM32L1xx_HAL_VERSION_MAIN   (0x01) /*!< [31:24] main version */
-#define __STM32L1xx_HAL_VERSION_SUB1   (0x02) /*!< [23:16] sub1 version */
-#define __STM32L1xx_HAL_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version */
+#define __STM32L1xx_HAL_VERSION_SUB1   (0x03) /*!< [23:16] sub1 version */
+#define __STM32L1xx_HAL_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
 #define __STM32L1xx_HAL_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
 #define __STM32L1xx_HAL_VERSION         ((__STM32L1xx_HAL_VERSION_MAIN << 24)\
                                         |(__STM32L1xx_HAL_VERSION_SUB1 << 16)\
                                         |(__STM32L1xx_HAL_VERSION_SUB2 << 8 )\
                                         |(__STM32L1xx_HAL_VERSION_RC))
 
-#define IDCODE_DEVID_MASK    ((uint32_t)0x00000FFF)
+#define IDCODE_DEVID_MASK    (0x00000FFFU)
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains all the functions prototypes for the HAL 
   *          module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_adc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Analog to Digital Convertor (ADC)
   *          peripheral:
@@ -256,7 +254,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -309,18 +307,18 @@
   /* Ex of profile low frequency : Clock source at 0.1 MHz, ADC clock         */
   /* prescaler 4, sampling time 7.5 ADC clock cycles, resolution 12 bits.     */
   /* Unit: ms                                                                 */
-  #define ADC_ENABLE_TIMEOUT              ((uint32_t) 2)
-  #define ADC_DISABLE_TIMEOUT             ((uint32_t) 2)
+  #define ADC_ENABLE_TIMEOUT              (2U)
+  #define ADC_DISABLE_TIMEOUT             (2U)
 
   /* Delay for ADC stabilization time.                                        */
   /* Maximum delay is 1us (refer to device datasheet, parameter tSTAB).       */
   /* Unit: us                                                                 */
-  #define ADC_STAB_DELAY_US               ((uint32_t) 3)
+  #define ADC_STAB_DELAY_US               (3U)
 
   /* Delay for temperature sensor stabilization time.                         */
   /* Maximum delay is 10us (refer to device datasheet, parameter tSTART).     */
   /* Unit: us                                                                 */
-  #define ADC_TEMPSENSOR_DELAY_US         ((uint32_t) 10)
+  #define ADC_TEMPSENSOR_DELAY_US         (10U)
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_adc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file containing functions prototypes of ADC HAL library.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -201,36 +199,36 @@ typedef struct
   * @brief  HAL ADC state machine: ADC states definition (bitfields)
   */ 
 /* States of ADC global scope */
-#define HAL_ADC_STATE_RESET             ((uint32_t)0x00000000)    /*!< ADC not yet initialized or disabled */
-#define HAL_ADC_STATE_READY             ((uint32_t)0x00000001)    /*!< ADC peripheral ready for use */
-#define HAL_ADC_STATE_BUSY_INTERNAL     ((uint32_t)0x00000002)    /*!< ADC is busy to internal process (initialization, calibration) */
-#define HAL_ADC_STATE_TIMEOUT           ((uint32_t)0x00000004)    /*!< TimeOut occurrence */
+#define HAL_ADC_STATE_RESET             (0x00000000U)    /*!< ADC not yet initialized or disabled */
+#define HAL_ADC_STATE_READY             (0x00000001U)    /*!< ADC peripheral ready for use */
+#define HAL_ADC_STATE_BUSY_INTERNAL     (0x00000002U)    /*!< ADC is busy to internal process (initialization, calibration) */
+#define HAL_ADC_STATE_TIMEOUT           (0x00000004U)    /*!< TimeOut occurrence */
 
 /* States of ADC errors */
-#define HAL_ADC_STATE_ERROR_INTERNAL    ((uint32_t)0x00000010)    /*!< Internal error occurrence */
-#define HAL_ADC_STATE_ERROR_CONFIG      ((uint32_t)0x00000020)    /*!< Configuration error occurrence */
-#define HAL_ADC_STATE_ERROR_DMA         ((uint32_t)0x00000040)    /*!< DMA error occurrence */
+#define HAL_ADC_STATE_ERROR_INTERNAL    (0x00000010U)    /*!< Internal error occurrence */
+#define HAL_ADC_STATE_ERROR_CONFIG      (0x00000020U)    /*!< Configuration error occurrence */
+#define HAL_ADC_STATE_ERROR_DMA         (0x00000040U)    /*!< DMA error occurrence */
 
 /* States of ADC group regular */
-#define HAL_ADC_STATE_REG_BUSY          ((uint32_t)0x00000100)    /*!< A conversion on group regular is ongoing or can occur (either by continuous mode,
+#define HAL_ADC_STATE_REG_BUSY          (0x00000100U)    /*!< A conversion on group regular is ongoing or can occur (either by continuous mode,
                                                                        external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
-#define HAL_ADC_STATE_REG_EOC           ((uint32_t)0x00000200)    /*!< Conversion data available on group regular */
-#define HAL_ADC_STATE_REG_OVR           ((uint32_t)0x00000400)    /*!< Overrun occurrence */
-#define HAL_ADC_STATE_REG_EOSMP         ((uint32_t)0x00000800)    /*!< Not available on STM32L1 device: End Of Sampling flag raised  */
+#define HAL_ADC_STATE_REG_EOC           (0x00000200U)    /*!< Conversion data available on group regular */
+#define HAL_ADC_STATE_REG_OVR           (0x00000400U)    /*!< Overrun occurrence */
+#define HAL_ADC_STATE_REG_EOSMP         (0x00000800U)    /*!< Not available on STM32L1 device: End Of Sampling flag raised  */
 
 /* States of ADC group injected */
-#define HAL_ADC_STATE_INJ_BUSY          ((uint32_t)0x00001000)    /*!< A conversion on group injected is ongoing or can occur (either by auto-injection mode,
+#define HAL_ADC_STATE_INJ_BUSY          (0x00001000U)    /*!< A conversion on group injected is ongoing or can occur (either by auto-injection mode,
                                                                        external trigger, low power auto power-on (if feature available), multimode ADC master control (if feature available)) */
-#define HAL_ADC_STATE_INJ_EOC           ((uint32_t)0x00002000)    /*!< Conversion data available on group injected */
-#define HAL_ADC_STATE_INJ_JQOVF         ((uint32_t)0x00004000)    /*!< Not available on STM32L1 device: Injected queue overflow occurrence */
+#define HAL_ADC_STATE_INJ_EOC           (0x00002000U)    /*!< Conversion data available on group injected */
+#define HAL_ADC_STATE_INJ_JQOVF         (0x00004000U)    /*!< Not available on STM32L1 device: Injected queue overflow occurrence */
 
 /* States of ADC analog watchdogs */
-#define HAL_ADC_STATE_AWD1              ((uint32_t)0x00010000)    /*!< Out-of-window occurrence of analog watchdog 1 */
-#define HAL_ADC_STATE_AWD2              ((uint32_t)0x00020000)    /*!< Not available on STM32L1 device: Out-of-window occurrence of analog watchdog 2 */
-#define HAL_ADC_STATE_AWD3              ((uint32_t)0x00040000)    /*!< Not available on STM32L1 device: Out-of-window occurrence of analog watchdog 3 */
+#define HAL_ADC_STATE_AWD1              (0x00010000U)    /*!< Out-of-window occurrence of analog watchdog 1 */
+#define HAL_ADC_STATE_AWD2              (0x00020000U)    /*!< Not available on STM32L1 device: Out-of-window occurrence of analog watchdog 2 */
+#define HAL_ADC_STATE_AWD3              (0x00040000U)    /*!< Not available on STM32L1 device: Out-of-window occurrence of analog watchdog 3 */
 
 /* States of ADC multi-mode */
-#define HAL_ADC_STATE_MULTIMODE_SLAVE   ((uint32_t)0x00100000)    /*!< Not available on STM32L1 device: ADC in multimode slave state, controlled by another ADC master ( */
+#define HAL_ADC_STATE_MULTIMODE_SLAVE   (0x00100000U)    /*!< Not available on STM32L1 device: ADC in multimode slave state, controlled by another ADC master ( */
 
 
 /** 
@@ -267,11 +265,11 @@ typedef struct
 /** @defgroup ADC_Error_Code ADC Error Code
   * @{
   */
-#define HAL_ADC_ERROR_NONE        ((uint32_t)0x00)   /*!< No error                                              */
-#define HAL_ADC_ERROR_INTERNAL    ((uint32_t)0x01)   /*!< ADC IP internal error: if problem of clocking, 
+#define HAL_ADC_ERROR_NONE        (0x00U)   /*!< No error                                              */
+#define HAL_ADC_ERROR_INTERNAL    (0x01U)   /*!< ADC IP internal error: if problem of clocking, 
                                                           enable/disable, erroneous state                       */
-#define HAL_ADC_ERROR_OVR         ((uint32_t)0x02)   /*!< Overrun error                                         */
-#define HAL_ADC_ERROR_DMA         ((uint32_t)0x04)   /*!< DMA transfer error                                    */
+#define HAL_ADC_ERROR_OVR         (0x02U)   /*!< Overrun error                                         */
+#define HAL_ADC_ERROR_DMA         (0x04U)   /*!< DMA transfer error                                    */
 /**
   * @}
   */
@@ -279,7 +277,7 @@ typedef struct
 /** @defgroup ADC_ClockPrescaler ADC ClockPrescaler
   * @{
   */
-#define ADC_CLOCK_ASYNC_DIV1          ((uint32_t)0x00000000)          /*!< ADC asynchronous clock derived from ADC dedicated HSI without prescaler */
+#define ADC_CLOCK_ASYNC_DIV1          (0x00000000U)                   /*!< ADC asynchronous clock derived from ADC dedicated HSI without prescaler */
 #define ADC_CLOCK_ASYNC_DIV2          ((uint32_t)ADC_CCR_ADCPRE_0)    /*!< ADC asynchronous clock derived from ADC dedicated HSI divided by a prescaler of 2 */
 #define ADC_CLOCK_ASYNC_DIV4          ((uint32_t)ADC_CCR_ADCPRE_1)    /*!< ADC asynchronous clock derived from ADC dedicated HSI divided by a prescaler of 4 */
 /**
@@ -289,7 +287,7 @@ typedef struct
 /** @defgroup ADC_Resolution ADC Resolution
   * @{
   */
-#define ADC_RESOLUTION_12B      ((uint32_t)0x00000000)          /*!<  ADC 12-bit resolution */
+#define ADC_RESOLUTION_12B      (0x00000000U)                   /*!<  ADC 12-bit resolution */
 #define ADC_RESOLUTION_10B      ((uint32_t)ADC_CR1_RES_0)       /*!<  ADC 10-bit resolution */
 #define ADC_RESOLUTION_8B       ((uint32_t)ADC_CR1_RES_1)       /*!<  ADC 8-bit resolution */
 #define ADC_RESOLUTION_6B       ((uint32_t)ADC_CR1_RES)         /*!<  ADC 6-bit resolution */
@@ -300,7 +298,7 @@ typedef struct
 /** @defgroup ADC_Data_align ADC Data_align
   * @{
   */
-#define ADC_DATAALIGN_RIGHT      ((uint32_t)0x00000000)
+#define ADC_DATAALIGN_RIGHT      (0x00000000U)
 #define ADC_DATAALIGN_LEFT       ((uint32_t)ADC_CR2_ALIGN)
 /**
   * @}
@@ -309,7 +307,7 @@ typedef struct
 /** @defgroup ADC_Scan_mode ADC Scan mode
   * @{
   */
-#define ADC_SCAN_DISABLE         ((uint32_t)0x00000000)
+#define ADC_SCAN_DISABLE         (0x00000000U)
 #define ADC_SCAN_ENABLE          ((uint32_t)ADC_CR1_SCAN)
 /**
   * @}
@@ -318,7 +316,7 @@ typedef struct
 /** @defgroup ADC_External_trigger_edge_Regular ADC external trigger enable for regular group
   * @{
   */
-#define ADC_EXTERNALTRIGCONVEDGE_NONE           ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGCONVEDGE_NONE           (0x00000000U)
 #define ADC_EXTERNALTRIGCONVEDGE_RISING         ((uint32_t)ADC_CR2_EXTEN_0)
 #define ADC_EXTERNALTRIGCONVEDGE_FALLING        ((uint32_t)ADC_CR2_EXTEN_1)
 #define ADC_EXTERNALTRIGCONVEDGE_RISINGFALLING  ((uint32_t)ADC_CR2_EXTEN)
@@ -345,7 +343,7 @@ typedef struct
 #define ADC_EXTERNALTRIGCONV_T9_CC2      ADC_EXTERNALTRIG_T9_CC2
 #define ADC_EXTERNALTRIGCONV_T9_TRGO     ADC_EXTERNALTRIG_T9_TRGO
 #define ADC_EXTERNALTRIGCONV_EXT_IT11    ADC_EXTERNALTRIG_EXT_IT11
-#define ADC_SOFTWARE_START               ((uint32_t)0x00000010)
+#define ADC_SOFTWARE_START               (0x00000010U)
 /**
   * @}
   */
@@ -353,7 +351,7 @@ typedef struct
 /** @defgroup ADC_EOCSelection ADC EOCSelection
   * @{
   */
-#define ADC_EOC_SEQ_CONV            ((uint32_t)0x00000000)
+#define ADC_EOC_SEQ_CONV            (0x00000000U)
 #define ADC_EOC_SINGLE_CONV         ((uint32_t)ADC_CR2_EOCS)
 /**
   * @}
@@ -366,7 +364,7 @@ typedef struct
 /* feature limited to enable or disable settings:                             */
 /* Setting "ADC_AUTOWAIT_UNTIL_DATA_READ" is equivalent to "ENABLE".          */
 
-#define ADC_AUTOWAIT_DISABLE                ((uint32_t)0x00000000)
+#define ADC_AUTOWAIT_DISABLE                (0x00000000U)
 #define ADC_AUTOWAIT_UNTIL_DATA_READ        ((uint32_t)(                                  ADC_CR2_DELS_0)) /*!< Insert a delay between ADC conversions: infinite delay, until the result of previous conversion is read */
 #define ADC_AUTOWAIT_7_APBCLOCKCYCLES       ((uint32_t)(                 ADC_CR2_DELS_1                 )) /*!< Insert a delay between ADC conversions: 7 APB clock cycles */
 #define ADC_AUTOWAIT_15_APBCLOCKCYCLES      ((uint32_t)(                 ADC_CR2_DELS_1 | ADC_CR2_DELS_0)) /*!< Insert a delay between ADC conversions: 15 APB clock cycles */
@@ -382,7 +380,7 @@ typedef struct
 /** @defgroup ADC_LowPowerAutoPowerOff ADC LowPowerAutoPowerOff
   * @{
   */
-#define ADC_AUTOPOWEROFF_DISABLE            ((uint32_t)0x00000000)
+#define ADC_AUTOPOWEROFF_DISABLE            (0x00000000U)
 #define ADC_AUTOPOWEROFF_IDLE_PHASE         ((uint32_t)ADC_CR1_PDI)                     /*!< ADC power off when ADC is not converting (idle phase) */
 #define ADC_AUTOPOWEROFF_DELAY_PHASE        ((uint32_t)ADC_CR1_PDD)                     /*!< ADC power off when a delay is inserted between conversions (see parameter ADC_LowPowerAutoWait) */
 #define ADC_AUTOPOWEROFF_IDLE_DELAY_PHASES  ((uint32_t)(ADC_CR1_PDI | ADC_CR1_PDD))     /*!< ADC power off when ADC is not converting (idle phase) and when a delay is inserted between conversions */
@@ -395,13 +393,13 @@ typedef struct
   * @{
   */
 #if defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)
-#define ADC_CHANNELS_BANK_A                 ((uint32_t)0x00000000)
+#define ADC_CHANNELS_BANK_A                 (0x00000000U)
 #define ADC_CHANNELS_BANK_B                 ((uint32_t)ADC_CR2_CFG)
 
 #define IS_ADC_CHANNELSBANK(BANK) (((BANK) == ADC_CHANNELS_BANK_A) || \
                                    ((BANK) == ADC_CHANNELS_BANK_B)   )
 #else
-#define ADC_CHANNELS_BANK_A                 ((uint32_t)0x00000000)
+#define ADC_CHANNELS_BANK_A                 (0x00000000U)
 
 #define IS_ADC_CHANNELSBANK(BANK) (((BANK) == ADC_CHANNELS_BANK_A))
 #endif /* STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
@@ -414,7 +412,7 @@ typedef struct
   */
 /* Note: Depending on devices, some channels may not be available on package  */
 /*       pins. Refer to device datasheet for channels availability.           */
-#define ADC_CHANNEL_0           ((uint32_t)0x00000000)                                                                            /* Channel different in bank A and bank B */
+#define ADC_CHANNEL_0           (0x00000000U)                                                                                     /* Channel different in bank A and bank B */
 #define ADC_CHANNEL_1           ((uint32_t)(                                                                    ADC_SQR5_SQ1_0))  /* Channel different in bank A and bank B */
 #define ADC_CHANNEL_2           ((uint32_t)(                                                   ADC_SQR5_SQ1_1                 ))  /* Channel different in bank A and bank B */
 #define ADC_CHANNEL_3           ((uint32_t)(                                                   ADC_SQR5_SQ1_1 | ADC_SQR5_SQ1_0))  /* Channel different in bank A and bank B */
@@ -467,7 +465,7 @@ typedef struct
 /** @defgroup ADC_sampling_times ADC sampling times
   * @{
   */
-#define ADC_SAMPLETIME_4CYCLES      ((uint32_t)0x00000000)                            /*!< Sampling time 4 ADC clock cycles */
+#define ADC_SAMPLETIME_4CYCLES      (0x00000000U)                                     /*!< Sampling time 4 ADC clock cycles */
 #define ADC_SAMPLETIME_9CYCLES      ((uint32_t) ADC_SMPR3_SMP0_0)                     /*!< Sampling time 9 ADC clock cycles */
 #define ADC_SAMPLETIME_16CYCLES     ((uint32_t) ADC_SMPR3_SMP0_1)                     /*!< Sampling time 16 ADC clock cycles */
 #define ADC_SAMPLETIME_24CYCLES     ((uint32_t)(ADC_SMPR3_SMP0_1 | ADC_SMPR3_SMP0_0)) /*!< Sampling time 24 ADC clock cycles */
@@ -554,35 +552,35 @@ typedef struct
 /** @defgroup ADC_regular_rank ADC rank into regular group
   * @{
   */
-#define ADC_REGULAR_RANK_1    ((uint32_t)0x00000001)
-#define ADC_REGULAR_RANK_2    ((uint32_t)0x00000002)
-#define ADC_REGULAR_RANK_3    ((uint32_t)0x00000003)
-#define ADC_REGULAR_RANK_4    ((uint32_t)0x00000004)
-#define ADC_REGULAR_RANK_5    ((uint32_t)0x00000005)
-#define ADC_REGULAR_RANK_6    ((uint32_t)0x00000006)
-#define ADC_REGULAR_RANK_7    ((uint32_t)0x00000007)
-#define ADC_REGULAR_RANK_8    ((uint32_t)0x00000008)
-#define ADC_REGULAR_RANK_9    ((uint32_t)0x00000009)
-#define ADC_REGULAR_RANK_10   ((uint32_t)0x0000000A)
-#define ADC_REGULAR_RANK_11   ((uint32_t)0x0000000B)
-#define ADC_REGULAR_RANK_12   ((uint32_t)0x0000000C)
-#define ADC_REGULAR_RANK_13   ((uint32_t)0x0000000D)
-#define ADC_REGULAR_RANK_14   ((uint32_t)0x0000000E)
-#define ADC_REGULAR_RANK_15   ((uint32_t)0x0000000F)
-#define ADC_REGULAR_RANK_16   ((uint32_t)0x00000010)
-#define ADC_REGULAR_RANK_17   ((uint32_t)0x00000011)
-#define ADC_REGULAR_RANK_18   ((uint32_t)0x00000012)
-#define ADC_REGULAR_RANK_19   ((uint32_t)0x00000013)
-#define ADC_REGULAR_RANK_20   ((uint32_t)0x00000014)
-#define ADC_REGULAR_RANK_21   ((uint32_t)0x00000015)
-#define ADC_REGULAR_RANK_22   ((uint32_t)0x00000016)
-#define ADC_REGULAR_RANK_23   ((uint32_t)0x00000017)
-#define ADC_REGULAR_RANK_24   ((uint32_t)0x00000018)
-#define ADC_REGULAR_RANK_25   ((uint32_t)0x00000019)
-#define ADC_REGULAR_RANK_26   ((uint32_t)0x0000001A)
-#define ADC_REGULAR_RANK_27   ((uint32_t)0x0000001B)
+#define ADC_REGULAR_RANK_1    (0x00000001U)
+#define ADC_REGULAR_RANK_2    (0x00000002U)
+#define ADC_REGULAR_RANK_3    (0x00000003U)
+#define ADC_REGULAR_RANK_4    (0x00000004U)
+#define ADC_REGULAR_RANK_5    (0x00000005U)
+#define ADC_REGULAR_RANK_6    (0x00000006U)
+#define ADC_REGULAR_RANK_7    (0x00000007U)
+#define ADC_REGULAR_RANK_8    (0x00000008U)
+#define ADC_REGULAR_RANK_9    (0x00000009U)
+#define ADC_REGULAR_RANK_10   (0x0000000AU)
+#define ADC_REGULAR_RANK_11   (0x0000000BU)
+#define ADC_REGULAR_RANK_12   (0x0000000CU)
+#define ADC_REGULAR_RANK_13   (0x0000000DU)
+#define ADC_REGULAR_RANK_14   (0x0000000EU)
+#define ADC_REGULAR_RANK_15   (0x0000000FU)
+#define ADC_REGULAR_RANK_16   (0x00000010U)
+#define ADC_REGULAR_RANK_17   (0x00000011U)
+#define ADC_REGULAR_RANK_18   (0x00000012U)
+#define ADC_REGULAR_RANK_19   (0x00000013U)
+#define ADC_REGULAR_RANK_20   (0x00000014U)
+#define ADC_REGULAR_RANK_21   (0x00000015U)
+#define ADC_REGULAR_RANK_22   (0x00000016U)
+#define ADC_REGULAR_RANK_23   (0x00000017U)
+#define ADC_REGULAR_RANK_24   (0x00000018U)
+#define ADC_REGULAR_RANK_25   (0x00000019U)
+#define ADC_REGULAR_RANK_26   (0x0000001AU)
+#define ADC_REGULAR_RANK_27   (0x0000001BU)
 #if defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)
-#define ADC_REGULAR_RANK_28   ((uint32_t)0x0000001C)
+#define ADC_REGULAR_RANK_28   (0x0000001CU)
 #endif /* STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
 /**
   * @}
@@ -591,7 +589,7 @@ typedef struct
 /** @defgroup ADC_analog_watchdog_mode ADC analog watchdog mode
   * @{
   */
-#define ADC_ANALOGWATCHDOG_NONE                 ((uint32_t)0x00000000)
+#define ADC_ANALOGWATCHDOG_NONE                 (0x00000000U)
 #define ADC_ANALOGWATCHDOG_SINGLE_REG           ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN))
 #define ADC_ANALOGWATCHDOG_SINGLE_INJEC         ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_JAWDEN))
 #define ADC_ANALOGWATCHDOG_SINGLE_REGINJEC      ((uint32_t)(ADC_CR1_AWDSGL | ADC_CR1_AWDEN | ADC_CR1_JAWDEN))
@@ -663,7 +661,7 @@ typedef struct
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
 
 /* External triggers of regular group for ADC1 */
-#define ADC_EXTERNALTRIG_T9_CC2         ((uint32_t) 0x00000000)
+#define ADC_EXTERNALTRIG_T9_CC2         (0x00000000U)
 #define ADC_EXTERNALTRIG_T9_TRGO        ((uint32_t)(                                                         ADC_CR2_EXTSEL_0))
 #define ADC_EXTERNALTRIG_T2_CC3         ((uint32_t)(                                      ADC_CR2_EXTSEL_1                   ))
 #define ADC_EXTERNALTRIG_T2_CC2         ((uint32_t)(                                      ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0))
@@ -1200,19 +1198,19 @@ typedef struct
   *
   */  
 #define IS_ADC_RANGE(__RESOLUTION__, __ADC_DATA__)                                          \
-   ((((__RESOLUTION__) == ADC_RESOLUTION_12B) && ((__ADC_DATA__) <= ((uint32_t)0x0FFF))) || \
-    (((__RESOLUTION__) == ADC_RESOLUTION_10B) && ((__ADC_DATA__) <= ((uint32_t)0x03FF))) || \
-    (((__RESOLUTION__) == ADC_RESOLUTION_8B)  && ((__ADC_DATA__) <= ((uint32_t)0x00FF))) || \
-    (((__RESOLUTION__) == ADC_RESOLUTION_6B)  && ((__ADC_DATA__) <= ((uint32_t)0x003F)))   )
+   ((((__RESOLUTION__) == ADC_RESOLUTION_12B) && ((__ADC_DATA__) <= (0x0FFFU))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_10B) && ((__ADC_DATA__) <= (0x03FFU))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_8B)  && ((__ADC_DATA__) <= (0x00FFU))) || \
+    (((__RESOLUTION__) == ADC_RESOLUTION_6B)  && ((__ADC_DATA__) <= (0x003FU)))   )
 
 
 #if defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)
-#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)28)))
+#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (28U)))
 #else
-#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)27)))
+#define IS_ADC_REGULAR_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (27U)))
 #endif
 
-#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= ((uint32_t)1)) && ((NUMBER) <= ((uint32_t)8)))
+#define IS_ADC_REGULAR_DISCONT_NUMBER(NUMBER) (((NUMBER) >= (1U)) && ((NUMBER) <= (8U)))
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_adc_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file provides firmware functions to manage the following 
   *          functionalities of the Analog to Digital Convertor (ADC)
   *          peripheral:
@@ -25,7 +23,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -75,19 +73,19 @@
   /* ADC conversion cycles (unit: ADC clock cycles)                           */
   /* (selected sampling time + conversion time of 12 ADC clock cycles, with   */
   /* resolution 12 bits)                                                      */
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_4CYCLE5   ((uint32_t) 16)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_9CYCLES   ((uint32_t) 21)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_16CYCLES  ((uint32_t) 28)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_24CYCLES  ((uint32_t) 36)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_48CYCLES  ((uint32_t) 60)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_96CYCLES  ((uint32_t)108)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_192CYCLES ((uint32_t)204)
-  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_384CYCLES ((uint32_t)396)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_4CYCLE5   ( 16U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_9CYCLES   ( 21U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_16CYCLES  ( 28U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_24CYCLES  ( 36U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_48CYCLES  ( 60U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_96CYCLES  (108U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_192CYCLES (204U)
+  #define ADC_CONVERSIONCLOCKCYCLES_SAMPLETIME_384CYCLES (396U)
 
   /* Delay for temperature sensor stabilization time.                         */
   /* Maximum delay is 10us (refer to device datasheet, parameter tSTART).     */
   /* Unit: us                                                                 */
-  #define ADC_TEMPSENSOR_DELAY_US         ((uint32_t) 10)
+  #define ADC_TEMPSENSOR_DELAY_US         (10U)
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_adc_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_adc_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of ADC HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -140,10 +138,10 @@ typedef struct
 /** @defgroup ADCEx_injected_rank ADCEx rank into injected group
   * @{
   */
-#define ADC_INJECTED_RANK_1    ((uint32_t)0x00000001)
-#define ADC_INJECTED_RANK_2    ((uint32_t)0x00000002)
-#define ADC_INJECTED_RANK_3    ((uint32_t)0x00000003)
-#define ADC_INJECTED_RANK_4    ((uint32_t)0x00000004)
+#define ADC_INJECTED_RANK_1    (0x00000001U)
+#define ADC_INJECTED_RANK_2    (0x00000002U)
+#define ADC_INJECTED_RANK_3    (0x00000003U)
+#define ADC_INJECTED_RANK_4    (0x00000004U)
 /**
   * @}
   */
@@ -151,7 +149,7 @@ typedef struct
 /** @defgroup ADCEx_External_trigger_edge_Injected ADCEx external trigger enable for injected group
   * @{
   */
-#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           ((uint32_t)0x00000000)
+#define ADC_EXTERNALTRIGINJECCONV_EDGE_NONE           (0x00000000U)
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_RISING         ((uint32_t)ADC_CR2_JEXTEN_0)
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_FALLING        ((uint32_t)ADC_CR2_JEXTEN_1)
 #define ADC_EXTERNALTRIGINJECCONV_EDGE_RISINGFALLING  ((uint32_t)ADC_CR2_JEXTEN)
@@ -175,7 +173,7 @@ typedef struct
 #define ADC_EXTERNALTRIGINJECCONV_T9_TRGO     ADC_EXTERNALTRIGINJEC_T9_TRGO
 #define ADC_EXTERNALTRIGINJECCONV_T10_CC1     ADC_EXTERNALTRIGINJEC_T10_CC1
 #define ADC_EXTERNALTRIGINJECCONV_EXT_IT15    ADC_EXTERNALTRIGINJEC_EXT_IT15
-#define ADC_INJECTED_SOFTWARE_START      ((uint32_t)0x00000010)
+#define ADC_INJECTED_SOFTWARE_START      (0x00000010U)
 /**
   * @}
   */
@@ -197,7 +195,7 @@ typedef struct
 
 /* List of external triggers of injected group for ADC1:                      */
 /* (used internally by HAL driver. To not use into HAL structure parameters)  */
-#define ADC_EXTERNALTRIGINJEC_T9_CC1         ((uint32_t) 0x00000000)
+#define ADC_EXTERNALTRIGINJEC_T9_CC1         (0x00000000U)
 #define ADC_EXTERNALTRIGINJEC_T9_TRGO        ((uint32_t)(                                                         ADC_CR2_JEXTSEL_0))
 #define ADC_EXTERNALTRIGINJEC_T2_TRGO        ((uint32_t)(                                      ADC_CR2_JEXTSEL_1                   ))
 #define ADC_EXTERNALTRIGINJEC_T2_CC1         ((uint32_t)(                                      ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0))
@@ -333,7 +331,7 @@ typedef struct
   ((_SAMPLETIME_) << (3 * ((_CHANNELNB_) - 30)))
 #else
 #define ADC_SMPR0(_SAMPLETIME_, _CHANNELNB_)                                   \
-  ((uint32_t)0x00000000)
+  (0x00000000U)
 #endif /* STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
 
 #if defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)
@@ -517,7 +515,7 @@ typedef struct
 /** @defgroup ADCEx_injected_nb_conv_verification ADCEx injected nb conv verification
   * @{
   */
-#define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= ((uint32_t)1)) && ((LENGTH) <= ((uint32_t)4)))
+#define IS_ADC_INJECTED_NB_CONV(LENGTH) (((LENGTH) >= (1U)) && ((LENGTH) <= (4U)))
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_comp.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   COMP HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the COMP peripheral:
@@ -92,7 +90,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -192,13 +190,13 @@
   /*  - Comparator 2: delay minimum of 800 CPU cycles. Wait loop takes 3 CPU  */
   /*                 cycles per iteration, therefore total wait iterations    */
   /*                 number must be initialized at 266 iterations.            */
-#define COMP1_START_DELAY_CPU_CYCLES       ((uint32_t)106)
-#define COMP2_START_DELAY_CPU_CYCLES       ((uint32_t)266)
+#define COMP1_START_DELAY_CPU_CYCLES       (106U)
+#define COMP2_START_DELAY_CPU_CYCLES       (266U)
 
   /* Comparator status "locked": to update COMP handle state (software lock   */
   /* only on COMP of STM32L1xx devices) by bitfield:                          */
   /* states HAL_COMP_STATE_READY_LOCKED, HAL_COMP_STATE_BUSY_LOCKED.          */
-#define COMP_STATE_BIT_LOCK     ((uint32_t) 0x00000010)  
+#define COMP_STATE_BIT_LOCK     (0x00000010U)  
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_comp.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of COMP HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_comp_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_comp_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of COMP HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_conf.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_conf.h
@@ -2,13 +2,13 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_conf.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
-  * @brief   HAL configuration file.
+  * @brief   HAL configuration template file. 
+  *          This file should be copied to the application folder and renamed
+  *          to stm32l1xx_hal_conf.h.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -33,14 +33,14 @@
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
   ******************************************************************************
-  */
+  */ 
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32L1xx_HAL_CONF_H
 #define __STM32L1xx_HAL_CONF_H
 
 #ifdef __cplusplus
-extern "C" {
+ extern "C" {
 #endif
 
 /* Exported types ------------------------------------------------------------*/
@@ -48,9 +48,9 @@ extern "C" {
 
 /* ########################## Module Selection ############################## */
 /**
-  * @brief This is the list of modules to be used in the HAL driver
+  * @brief This is the list of modules to be used in the HAL driver 
   */
-#define HAL_MODULE_ENABLED
+#define HAL_MODULE_ENABLED  
 #define HAL_ADC_MODULE_ENABLED
 #define HAL_COMP_MODULE_ENABLED
 #define HAL_CORTEX_MODULE_ENABLED
@@ -84,14 +84,14 @@ extern "C" {
 /**
   * @brief Adjust the value of External High Speed oscillator (HSE) used in your application.
   *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSE is used as system clock source, directly or through the PLL).
+  *        (when HSE is used as system clock source, directly or through the PLL).  
   */
-#if !defined  (HSE_VALUE)
-  #define HSE_VALUE    ((uint32_t)8000000) /*!< Value of the External oscillator in Hz */
+#if !defined  (HSE_VALUE) 
+  #define HSE_VALUE    (8000000U) /*!< Value of the External oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-#define HSE_STARTUP_TIMEOUT    ((uint32_t)200)   /*!< Time out for HSE start up, in ms */
+  #define HSE_STARTUP_TIMEOUT    (200U)   /*!< Time out for HSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**
@@ -99,177 +99,189 @@ extern "C" {
   *        This value is the default MSI range value after Reset.
   */
 #if !defined  (MSI_VALUE)
-#define MSI_VALUE    ((uint32_t)2097000) /*!< Value of the Internal oscillator in Hz*/
+  #define MSI_VALUE    (2097000U) /*!< Value of the Internal oscillator in Hz*/
 #endif /* MSI_VALUE */
 /**
   * @brief Internal High Speed oscillator (HSI) value.
   *        This value is used by the RCC HAL module to compute the system frequency
-  *        (when HSI is used as system clock source, directly or through the PLL).
+  *        (when HSI is used as system clock source, directly or through the PLL). 
   */
 #if !defined  (HSI_VALUE)
-#define HSI_VALUE    ((uint32_t)16000000) /*!< Value of the Internal oscillator in Hz*/
+  #define HSI_VALUE    (16000000U) /*!< Value of the Internal oscillator in Hz*/
 #endif /* HSI_VALUE */
 
 /**
   * @brief External Low Speed oscillator (LSE) value.
-  *        This value is used by the UART, RTC HAL module to compute the system frequency
   */
 #if !defined  (LSE_VALUE)
-#define LSE_VALUE    ((uint32_t)32768) /*!< Value of the External oscillator in Hz*/
+  #define LSE_VALUE    (32768U) /*!< Value of the External Low Speed oscillator in Hz*/
 #endif /* LSE_VALUE */
 
-
+/**
+  * @brief Time out for LSE start up value in ms.
+  */
 #if !defined  (LSE_STARTUP_TIMEOUT)
-#define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
-#endif /* HSE_STARTUP_TIMEOUT */
+  #define LSE_STARTUP_TIMEOUT    (5000U)   /*!< Time out for LSE start up, in ms */
+#endif /* LSE_STARTUP_TIMEOUT */
 
-
+   
 /* Tip: To avoid modifying this file each time you need to use different HSE,
    ===  you can define the HSE value in your toolchain compiler preprocessor. */
 
 /* ########################### System Configuration ######################### */
 /**
   * @brief This is the HAL system configuration section
-  */
-#define  VDD_VALUE                    ((uint32_t)3300) /*!< Value of VDD in mv */
-#define  TICK_INT_PRIORITY            ((uint32_t)0x000F)    /*!< tick interrupt priority */
-#define  USE_RTOS                     0
-#define  PREFETCH_ENABLE              1
-#define  INSTRUCTION_CACHE_ENABLE     0
-#define  DATA_CACHE_ENABLE            0
+  */     
+#define  VDD_VALUE                    (3300U) /*!< Value of VDD in mv */          
+#define  TICK_INT_PRIORITY            (0x000FU)    /*!< tick interrupt priority */            
+#define  USE_RTOS                     0U
+#define  PREFETCH_ENABLE              1U
+#define  INSTRUCTION_CACHE_ENABLE     0U
+#define  DATA_CACHE_ENABLE            0U
 
 /* ########################## Assert Selection ############################## */
 /**
-  * @brief Uncomment the line below to expanse the "assert_param" macro in the
+  * @brief Uncomment the line below to expanse the "assert_param" macro in the 
   *        HAL drivers code
   */
-/*#define USE_FULL_ASSERT    1*/
+/*#define USE_FULL_ASSERT    1U*/ 
 
 /* Includes ------------------------------------------------------------------*/
 /**
-  * @brief Include module's header file
+  * @brief Include module's header file 
   */
 
 #ifdef HAL_RCC_MODULE_ENABLED
-#include "stm32l1xx_hal_rcc.h"
+ #include "stm32l1xx_hal_rcc.h"
 #endif /* HAL_RCC_MODULE_ENABLED */
-
+  
 #ifdef HAL_GPIO_MODULE_ENABLED
-#include "stm32l1xx_hal_gpio.h"
+ #include "stm32l1xx_hal_gpio.h"
 #endif /* HAL_GPIO_MODULE_ENABLED */
 
 #ifdef HAL_DMA_MODULE_ENABLED
-#include "stm32l1xx_hal_dma.h"
+  #include "stm32l1xx_hal_dma.h"
 #endif /* HAL_DMA_MODULE_ENABLED */
 
 #ifdef HAL_CORTEX_MODULE_ENABLED
-#include "stm32l1xx_hal_cortex.h"
+ #include "stm32l1xx_hal_cortex.h"
 #endif /* HAL_CORTEX_MODULE_ENABLED */
 
 #ifdef HAL_ADC_MODULE_ENABLED
-#include "stm32l1xx_hal_adc.h"
+ #include "stm32l1xx_hal_adc.h"
 #endif /* HAL_ADC_MODULE_ENABLED */
 
 #ifdef HAL_COMP_MODULE_ENABLED
-#include "stm32l1xx_hal_comp.h"
+  #include "stm32l1xx_hal_comp.h"
 #endif /* HAL_COMP_MODULE_ENABLED */
 
 #ifdef HAL_CRC_MODULE_ENABLED
-#include "stm32l1xx_hal_crc.h"
+ #include "stm32l1xx_hal_crc.h"
 #endif /* HAL_CRC_MODULE_ENABLED */
 
 #ifdef HAL_CRYP_MODULE_ENABLED
-#include "stm32l1xx_hal_cryp.h"
+ #include "stm32l1xx_hal_cryp.h"
 #endif /* HAL_CRYP_MODULE_ENABLED */
 
 #ifdef HAL_DAC_MODULE_ENABLED
-#include "stm32l1xx_hal_dac.h"
+ #include "stm32l1xx_hal_dac.h"
 #endif /* HAL_DAC_MODULE_ENABLED */
 
 #ifdef HAL_FLASH_MODULE_ENABLED
-#include "stm32l1xx_hal_flash.h"
+ #include "stm32l1xx_hal_flash.h"
 #endif /* HAL_FLASH_MODULE_ENABLED */
 
 #ifdef HAL_SRAM_MODULE_ENABLED
-#include "stm32l1xx_hal_sram.h"
+ #include "stm32l1xx_hal_sram.h"
 #endif /* HAL_SRAM_MODULE_ENABLED */
 
 #ifdef HAL_NOR_MODULE_ENABLED
-#include "stm32l1xx_hal_nor.h"
-#endif /* HAL_NOR_MODULE_ENABLED */
+ #include "stm32l1xx_hal_nor.h"
+#endif /* HAL_NOR_MODULE_ENABLED */ 
 
 #ifdef HAL_I2C_MODULE_ENABLED
-#include "stm32l1xx_hal_i2c.h"
+ #include "stm32l1xx_hal_i2c.h"
 #endif /* HAL_I2C_MODULE_ENABLED */
 
 #ifdef HAL_I2S_MODULE_ENABLED
-#include "stm32l1xx_hal_i2s.h"
+ #include "stm32l1xx_hal_i2s.h"
 #endif /* HAL_I2S_MODULE_ENABLED */
 
 #ifdef HAL_IWDG_MODULE_ENABLED
-#include "stm32l1xx_hal_iwdg.h"
+ #include "stm32l1xx_hal_iwdg.h"
 #endif /* HAL_IWDG_MODULE_ENABLED */
 
 #ifdef HAL_LCD_MODULE_ENABLED
-#include "stm32l1xx_hal_lcd.h"
+ #include "stm32l1xx_hal_lcd.h"
 #endif /* HAL_LCD_MODULE_ENABLED */
-
+   
 #ifdef HAL_OPAMP_MODULE_ENABLED
-#include "stm32l1xx_hal_opamp.h"
+ #include "stm32l1xx_hal_opamp.h"
 #endif /* HAL_OPAMP_MODULE_ENABLED */
 
 #ifdef HAL_PWR_MODULE_ENABLED
-#include "stm32l1xx_hal_pwr.h"
+ #include "stm32l1xx_hal_pwr.h"
 #endif /* HAL_PWR_MODULE_ENABLED */
 
 #ifdef HAL_RTC_MODULE_ENABLED
-#include "stm32l1xx_hal_rtc.h"
+ #include "stm32l1xx_hal_rtc.h"
 #endif /* HAL_RTC_MODULE_ENABLED */
 
 #ifdef HAL_SD_MODULE_ENABLED
-#include "stm32l1xx_hal_sd.h"
-#endif /* HAL_SD_MODULE_ENABLED */
+ #include "stm32l1xx_hal_sd.h"
+#endif /* HAL_SD_MODULE_ENABLED */     
 
 #ifdef HAL_SPI_MODULE_ENABLED
-#include "stm32l1xx_hal_spi.h"
+ #include "stm32l1xx_hal_spi.h"
 #endif /* HAL_SPI_MODULE_ENABLED */
 
 #ifdef HAL_TIM_MODULE_ENABLED
-#include "stm32l1xx_hal_tim.h"
+ #include "stm32l1xx_hal_tim.h"
 #endif /* HAL_TIM_MODULE_ENABLED */
 
 #ifdef HAL_UART_MODULE_ENABLED
-#include "stm32l1xx_hal_uart.h"
+ #include "stm32l1xx_hal_uart.h"
 #endif /* HAL_UART_MODULE_ENABLED */
 
 #ifdef HAL_USART_MODULE_ENABLED
-#include "stm32l1xx_hal_usart.h"
+ #include "stm32l1xx_hal_usart.h"
 #endif /* HAL_USART_MODULE_ENABLED */
 
 #ifdef HAL_IRDA_MODULE_ENABLED
-#include "stm32l1xx_hal_irda.h"
+ #include "stm32l1xx_hal_irda.h"
 #endif /* HAL_IRDA_MODULE_ENABLED */
 
 #ifdef HAL_SMARTCARD_MODULE_ENABLED
-#include "stm32l1xx_hal_smartcard.h"
+ #include "stm32l1xx_hal_smartcard.h"
 #endif /* HAL_SMARTCARD_MODULE_ENABLED */
 
 #ifdef HAL_WWDG_MODULE_ENABLED
-#include "stm32l1xx_hal_wwdg.h"
+ #include "stm32l1xx_hal_wwdg.h"
 #endif /* HAL_WWDG_MODULE_ENABLED */
 
 #ifdef HAL_PCD_MODULE_ENABLED
-#include "stm32l1xx_hal_pcd.h"
+ #include "stm32l1xx_hal_pcd.h"
 #endif /* HAL_PCD_MODULE_ENABLED */
-
+   
 /* Exported macro ------------------------------------------------------------*/
 #ifdef  USE_FULL_ASSERT
-/* ALL MBED targets use same stm32_assert.h */
+// ALL MBED targets use same stm32_assert.h
+/**
+  * @brief  The assert_param macro is used for function's parameters check.
+  * @param  expr: If expr is false, it calls assert_failed function
+  *         which reports the name of the source file and the source
+  *         line number of the call that failed. 
+  *         If expr is true, it returns no value.
+  * @retval None
+  */
+  //#define assert_param(expr) ((expr) ? (void)0U : assert_failed((uint8_t *)__FILE__, __LINE__))
+/* Exported functions ------------------------------------------------------- */
+  //void assert_failed(uint8_t* file, uint32_t line);
 #include "stm32_assert.h"
 #else
-#define assert_param(expr) ((void)0U)
-#endif /* USE_FULL_ASSERT */
-
+  #define assert_param(expr) ((void)0U)
+#endif /* USE_FULL_ASSERT */   
+   
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cortex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cortex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cortex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   CORTEX HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -23,29 +21,8 @@
     This section provide functions allowing to configure the NVIC interrupts (IRQ).
     The Cortex-M3 exceptions are managed by CMSIS functions.
    
-    (#) Configure the NVIC Priority Grouping using HAL_NVIC_SetPriorityGrouping()
-        function according to the following table.
+    (#) Configure the NVIC Priority Grouping using HAL_NVIC_SetPriorityGrouping() function
 
-     The table below gives the allowed values of the pre-emption priority and subpriority according
-     to the Priority Grouping configuration performed by HAL_NVIC_SetPriorityGrouping() function.
-       ==========================================================================================================================
-         NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  |       Description
-       ==========================================================================================================================
-        NVIC_PRIORITYGROUP_0  |                0                  |            0-15             | 0 bits for pre-emption priority
-                              |                                   |                             | 4 bits for subpriority
-       --------------------------------------------------------------------------------------------------------------------------
-        NVIC_PRIORITYGROUP_1  |                0-1                |            0-7              | 1 bits for pre-emption priority
-                              |                                   |                             | 3 bits for subpriority
-       --------------------------------------------------------------------------------------------------------------------------    
-        NVIC_PRIORITYGROUP_2  |                0-3                |            0-3              | 2 bits for pre-emption priority
-                              |                                   |                             | 2 bits for subpriority
-       --------------------------------------------------------------------------------------------------------------------------    
-        NVIC_PRIORITYGROUP_3  |                0-7                |            0-1              | 3 bits for pre-emption priority
-                              |                                   |                             | 1 bits for subpriority
-       --------------------------------------------------------------------------------------------------------------------------    
-        NVIC_PRIORITYGROUP_4  |                0-15               |            0                | 4 bits for pre-emption priority
-                              |                                   |                             | 0 bits for subpriority                       
-       ==========================================================================================================================
      (#)  Configure the priority of the selected IRQ Channels using HAL_NVIC_SetPriority() 
 
      (#)  Enable the selected IRQ Channels using HAL_NVIC_EnableIRQ() 
@@ -93,7 +70,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -119,6 +96,30 @@
   *
   ******************************************************************************
   */
+
+/*
+  Additional Tables: CORTEX_NVIC_Priority_Table
+     The table below gives the allowed values of the pre-emption priority and subpriority according
+     to the Priority Grouping configuration performed by HAL_NVIC_SetPriorityGrouping() function.
+       ==========================================================================================================================
+         NVIC_PriorityGroup   | NVIC_IRQChannelPreemptionPriority | NVIC_IRQChannelSubPriority  |       Description
+       ==========================================================================================================================
+        NVIC_PRIORITYGROUP_0  |                0                  |            0-15             | 0 bits for pre-emption priority
+                              |                                   |                             | 4 bits for subpriority
+       --------------------------------------------------------------------------------------------------------------------------
+        NVIC_PRIORITYGROUP_1  |                0-1                |            0-7              | 1 bits for pre-emption priority
+                              |                                   |                             | 3 bits for subpriority
+       --------------------------------------------------------------------------------------------------------------------------    
+        NVIC_PRIORITYGROUP_2  |                0-3                |            0-3              | 2 bits for pre-emption priority
+                              |                                   |                             | 2 bits for subpriority
+       --------------------------------------------------------------------------------------------------------------------------    
+        NVIC_PRIORITYGROUP_3  |                0-7                |            0-1              | 3 bits for pre-emption priority
+                              |                                   |                             | 1 bits for subpriority
+       --------------------------------------------------------------------------------------------------------------------------    
+        NVIC_PRIORITYGROUP_4  |                0-15               |            0                | 4 bits for pre-emption priority
+                              |                                   |                             | 0 bits for subpriority                       
+       ==========================================================================================================================
+*/
 
 /* Includes ------------------------------------------------------------------*/
 #include "stm32l1xx_hal.h"
@@ -292,6 +293,40 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb)
   */
 
 #if (__MPU_PRESENT == 1)
+/**
+  * @brief  Enable the MPU.
+  * @param  MPU_Control: Specifies the control mode of the MPU during hard fault, 
+  *          NMI, FAULTMASK and privileged accessto the default memory 
+  *          This parameter can be one of the following values:
+  *            @arg MPU_HFNMI_PRIVDEF_NONE
+  *            @arg MPU_HARDFAULT_NMI
+  *            @arg MPU_PRIVILEGED_DEFAULT
+  *            @arg MPU_HFNMI_PRIVDEF
+  * @retval None
+  */
+void HAL_MPU_Enable(uint32_t MPU_Control)
+{
+  /* Enable the MPU */
+  MPU->CTRL = (MPU_Control | MPU_CTRL_ENABLE_Msk);
+
+  /* Ensure MPU setting take effects */
+  __DSB();
+  __ISB();
+}
+
+/**
+  * @brief  Disable the MPU.
+  * @retval None
+  */
+void HAL_MPU_Disable(void)
+{
+  /* Make sure outstanding transfers are done */
+  __DMB();
+
+  /* Disable the MPU and clear the control register*/
+  MPU->CTRL  = 0;
+}
+
 /**
   * @brief  Initializes and configures the Region and the memory to be protected.
   * @param  MPU_Init: Pointer to a MPU_Region_InitTypeDef structure that contains

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cortex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cortex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cortex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CORTEX HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -108,16 +106,16 @@ typedef struct
   * @{
   */
 
-#define NVIC_PRIORITYGROUP_0         ((uint32_t)0x00000007) /*!< 0 bits for pre-emption priority
-                                                                 4 bits for subpriority */
-#define NVIC_PRIORITYGROUP_1         ((uint32_t)0x00000006) /*!< 1 bits for pre-emption priority
-                                                                 3 bits for subpriority */
-#define NVIC_PRIORITYGROUP_2         ((uint32_t)0x00000005) /*!< 2 bits for pre-emption priority
-                                                                 2 bits for subpriority */
-#define NVIC_PRIORITYGROUP_3         ((uint32_t)0x00000004) /*!< 3 bits for pre-emption priority
-                                                                 1 bits for subpriority */
-#define NVIC_PRIORITYGROUP_4         ((uint32_t)0x00000003) /*!< 4 bits for pre-emption priority
-                                                                 0 bits for subpriority */
+#define NVIC_PRIORITYGROUP_0         (0x00000007U) /*!< 0 bits for pre-emption priority
+                                                        4 bits for subpriority */
+#define NVIC_PRIORITYGROUP_1         (0x00000006U) /*!< 1 bits for pre-emption priority
+                                                        3 bits for subpriority */
+#define NVIC_PRIORITYGROUP_2         (0x00000005U) /*!< 2 bits for pre-emption priority
+                                                        2 bits for subpriority */
+#define NVIC_PRIORITYGROUP_3         (0x00000004U) /*!< 3 bits for pre-emption priority
+                                                        1 bits for subpriority */
+#define NVIC_PRIORITYGROUP_4         (0x00000003U) /*!< 4 bits for pre-emption priority
+                                                        0 bits for subpriority */
 /**
   * @}
   */
@@ -125,8 +123,8 @@ typedef struct
 /** @defgroup CORTEX_SysTick_clock_source CORTEX SysTick clock source
   * @{
   */
-#define SYSTICK_CLKSOURCE_HCLK_DIV8    ((uint32_t)0x00000000)
-#define SYSTICK_CLKSOURCE_HCLK         ((uint32_t)0x00000004)
+#define SYSTICK_CLKSOURCE_HCLK_DIV8    (0x00000000U)
+#define SYSTICK_CLKSOURCE_HCLK         (0x00000004U)
 
 /**
   * @}
@@ -136,10 +134,11 @@ typedef struct
 /** @defgroup CORTEX_MPU_HFNMI_PRIVDEF_Control MPU HFNMI and PRIVILEGED Access control
   * @{
   */
-#define  MPU_HFNMI_PRIVDEF_NONE      ((uint32_t)0x00000000)  
-#define  MPU_HARDFAULT_NMI           ((uint32_t)0x00000002)
-#define  MPU_PRIVILEGED_DEFAULT      ((uint32_t)0x00000004)
-#define  MPU_HFNMI_PRIVDEF           ((uint32_t)0x00000006)
+#define  MPU_HFNMI_PRIVDEF_NONE      (0x00000000U)  
+#define  MPU_HARDFAULT_NMI           (MPU_CTRL_HFNMIENA_Msk)
+#define  MPU_PRIVILEGED_DEFAULT      (MPU_CTRL_PRIVDEFENA_Msk)
+#define  MPU_HFNMI_PRIVDEF           (MPU_CTRL_HFNMIENA_Msk | MPU_CTRL_PRIVDEFENA_Msk)
+
 /**
   * @}
   */
@@ -386,40 +385,6 @@ typedef struct
   * @{
   */
 
-#if (__MPU_PRESENT == 1)
-/**
-  * @brief  Disables the MPU
-  * @retval None
-  */
-__STATIC_INLINE void HAL_MPU_Disable(void)
-{
-  /* Disable fault exceptions */
-  SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTENA_Msk;
-  
-  /* Disable the MPU */
-  MPU->CTRL  &= ~MPU_CTRL_ENABLE_Msk;
-}
-
-/**
-  * @brief  Enables the MPU
-  * @param  MPU_Control: Specifies the control mode of the MPU during hard fault, 
-  *          NMI, FAULTMASK and privileged accessto the default memory 
-  *          This parameter can be one of the following values:
-  *            @arg MPU_HFNMI_PRIVDEF_NONE
-  *            @arg MPU_HARDFAULT_NMI
-  *            @arg MPU_PRIVILEGED_DEFAULT
-  *            @arg MPU_HFNMI_PRIVDEF
-  * @retval None
-  */
-__STATIC_INLINE void HAL_MPU_Enable(uint32_t MPU_Control)
-{
-  /* Enable the MPU */
-  MPU->CTRL   = MPU_Control | MPU_CTRL_ENABLE_Msk;
-  
-  /* Enable fault exceptions */
-  SCB->SHCSR |= SCB_SHCSR_MEMFAULTENA_Msk;
-}
-#endif /* __MPU_PRESENT */
 
 /**
   * @}
@@ -449,6 +414,8 @@ uint32_t HAL_SYSTICK_Config(uint32_t TicksNumb);
   */ 
 /* Peripheral Control functions ***********************************************/
 #if (__MPU_PRESENT == 1)
+void HAL_MPU_Enable(uint32_t MPU_Control);
+void HAL_MPU_Disable(void);
 void HAL_MPU_ConfigRegion(MPU_Region_InitTypeDef *MPU_Init);
 #endif /* __MPU_PRESENT */
 uint32_t HAL_NVIC_GetPriorityGrouping(void);

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_crc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_crc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_crc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   CRC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Cyclic Redundancy Check (CRC) peripheral:
@@ -32,7 +30,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_crc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_crc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_crc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CRC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cryp.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   CRYP HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -70,7 +68,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cryp.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CRYP HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -143,7 +141,7 @@ typedef struct
 /** @defgroup CRYP_Data_Type CRYP Data Type
   * @{
   */
-#define CRYP_DATATYPE_32B         ((uint32_t)0x00000000)
+#define CRYP_DATATYPE_32B         (0x00000000U)
 #define CRYP_DATATYPE_16B         AES_CR_DATATYPE_0
 #define CRYP_DATATYPE_8B          AES_CR_DATATYPE_1
 #define CRYP_DATATYPE_1B          AES_CR_DATATYPE
@@ -161,7 +159,7 @@ typedef struct
   */ 
 #define CRYP_CR_ALGOMODE_DIRECTION              (uint32_t)(AES_CR_MODE|AES_CR_CHMOD)
 
-#define CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT        ((uint32_t)0x00000000)
+#define CRYP_CR_ALGOMODE_AES_ECB_ENCRYPT        (0x00000000U)
 #define CRYP_CR_ALGOMODE_AES_ECB_KEYDERDECRYPT  (AES_CR_MODE)
 #define CRYP_CR_ALGOMODE_AES_CBC_ENCRYPT        (AES_CR_CHMOD_0)
 #define CRYP_CR_ALGOMODE_AES_CBC_KEYDERDECRYPT  ((uint32_t)(AES_CR_CHMOD_0|AES_CR_MODE))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cryp_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   CRYPEx HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -13,7 +11,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_cryp_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_cryp_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CRYPEx HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dac.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   DAC HAL module driver.
   *         This file provides firmware functions to manage the following 
   *         functionalities of the Digital to Analog Converter (DAC) peripheral:
@@ -173,7 +171,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dac.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of DAC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -129,7 +127,7 @@ typedef struct
 /** @defgroup DAC_trigger_selection DAC trigger selection
   * @{
   */
-#define DAC_TRIGGER_NONE                   ((uint32_t)0x00000000) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
+#define DAC_TRIGGER_NONE                   (0x00000000U) /*!< Conversion is automatic once the DAC1_DHRxxxx register 
                                                                        has been loaded, and not by external trigger */
 #define DAC_TRIGGER_T6_TRGO                ((uint32_t)                                                    DAC_CR_TEN1)  /*!< TIM6 TRGO selected as external conversion trigger for DAC channel */
 #define DAC_TRIGGER_T7_TRGO                ((uint32_t)(                 DAC_CR_TSEL1_1                  | DAC_CR_TEN1)) /*!< TIM7 TRGO selected as external conversion trigger for DAC channel */
@@ -146,7 +144,7 @@ typedef struct
 /** @defgroup DAC_output_buffer DAC output buffer
   * @{
   */
-#define DAC_OUTPUTBUFFER_ENABLE            ((uint32_t)0x00000000)
+#define DAC_OUTPUTBUFFER_ENABLE            (0x00000000U)
 #define DAC_OUTPUTBUFFER_DISABLE           ((uint32_t)DAC_CR_BOFF1)
 
 /**
@@ -156,8 +154,8 @@ typedef struct
 /** @defgroup DAC_Channel_selection DAC Channel selection
   * @{
   */
-#define DAC_CHANNEL_1                      ((uint32_t)0x00000000)
-#define DAC_CHANNEL_2                      ((uint32_t)0x00000010)
+#define DAC_CHANNEL_1                      (0x00000000U)
+#define DAC_CHANNEL_2                      (0x00000010U)
 
 /**
   * @}
@@ -166,9 +164,9 @@ typedef struct
 /** @defgroup DAC_data_alignement DAC data alignement
   * @{
   */
-#define DAC_ALIGN_12B_R                    ((uint32_t)0x00000000)
-#define DAC_ALIGN_12B_L                    ((uint32_t)0x00000004)
-#define DAC_ALIGN_8B_R                     ((uint32_t)0x00000008)
+#define DAC_ALIGN_12B_R                    (0x00000000U)
+#define DAC_ALIGN_12B_L                    (0x00000004U)
+#define DAC_ALIGN_8B_R                     (0x00000008U)
 
 /**
   * @}
@@ -307,11 +305,11 @@ typedef struct
 
 #define IS_DAC_DATA(DATA) ((DATA) <= 0xFFF0)
 
-#define DAC_DHR12R1_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000008) + (__ALIGNMENT__))
+#define DAC_DHR12R1_ALIGNMENT(__ALIGNMENT__) ((0x00000008U) + (__ALIGNMENT__))
 
-#define DAC_DHR12R2_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000014) + (__ALIGNMENT__))
+#define DAC_DHR12R2_ALIGNMENT(__ALIGNMENT__) ((0x00000014U) + (__ALIGNMENT__))
 
-#define DAC_DHR12RD_ALIGNMENT(__ALIGNMENT__) (((uint32_t)0x00000020) + (__ALIGNMENT__))
+#define DAC_DHR12RD_ALIGNMENT(__ALIGNMENT__) ((0x00000020U) + (__ALIGNMENT__))
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dac_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   DAC HAL module driver.
   *         This file provides firmware functions to manage the following 
   *         functionalities of DAC extension peripheral:
@@ -25,7 +23,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dac_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dac_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of DAC HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -65,7 +63,7 @@
 /** @defgroup DACEx_lfsrunmask_triangleamplitude DACEx lfsrunmask triangleamplitude
   * @{
   */
-#define DAC_LFSRUNMASK_BIT0                ((uint32_t)0x00000000) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
+#define DAC_LFSRUNMASK_BIT0                (0x00000000U) /*!< Unmask DAC channel LFSR bit0 for noise wave generation */
 #define DAC_LFSRUNMASK_BITS1_0             ((uint32_t)DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[1:0] for noise wave generation */
 #define DAC_LFSRUNMASK_BITS2_0             ((uint32_t)DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[2:0] for noise wave generation */
 #define DAC_LFSRUNMASK_BITS3_0             ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0)/*!< Unmask DAC channel LFSR bit[3:0] for noise wave generation */
@@ -77,7 +75,7 @@
 #define DAC_LFSRUNMASK_BITS9_0             ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[9:0] for noise wave generation */
 #define DAC_LFSRUNMASK_BITS10_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1) /*!< Unmask DAC channel LFSR bit[10:0] for noise wave generation */
 #define DAC_LFSRUNMASK_BITS11_0            ((uint32_t)DAC_CR_MAMP1_3 | DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Unmask DAC channel LFSR bit[11:0] for noise wave generation */
-#define DAC_TRIANGLEAMPLITUDE_1            ((uint32_t)0x00000000) /*!< Select max triangle amplitude of 1 */
+#define DAC_TRIANGLEAMPLITUDE_1            (0x00000000U) /*!< Select max triangle amplitude of 1 */
 #define DAC_TRIANGLEAMPLITUDE_3            ((uint32_t)DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 3 */
 #define DAC_TRIANGLEAMPLITUDE_7            ((uint32_t)DAC_CR_MAMP1_1) /*!< Select max triangle amplitude of 7 */
 #define DAC_TRIANGLEAMPLITUDE_15           ((uint32_t)DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Select max triangle amplitude of 15 */
@@ -121,8 +119,8 @@
 /** @defgroup DACEx_wave_generation DACEx wave generation
   * @{
   */
-#define DAC_WAVE_NOISE                     ((uint32_t)DAC_CR_WAVE1_0)
-#define DAC_WAVE_TRIANGLE                  ((uint32_t)DAC_CR_WAVE1_1)
+#define DAC_WAVE_NOISE                     DAC_CR_WAVE1_0
+#define DAC_WAVE_TRIANGLE                  DAC_CR_WAVE1_1
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_def.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_def.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_def.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains HAL common defines, enumeration, macros and 
   *          structures definitions. 
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dma.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dma.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   DMA HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Direct Memory Access (DMA) peripheral:
@@ -72,7 +70,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_dma.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_dma.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of DMA HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -167,11 +165,11 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Error_Code DMA Error Code
   * @{
   */
-#define HAL_DMA_ERROR_NONE          ((uint32_t)0x00000000)    /*!< No error */
-#define HAL_DMA_ERROR_TE            ((uint32_t)0x00000001)    /*!< Transfer error */
-#define HAL_DMA_ERROR_NO_XFER       ((uint32_t)0x00000004)    /*!< no ongoing transfer */
-#define HAL_DMA_ERROR_TIMEOUT       ((uint32_t)0x00000020)    /*!< Timeout error */
-#define HAL_DMA_ERROR_NOT_SUPPORTED ((uint32_t)0x00000100)    /*!< Not supported mode */     
+#define HAL_DMA_ERROR_NONE          (0x00000000U)    /*!< No error */
+#define HAL_DMA_ERROR_TE            (0x00000001U)    /*!< Transfer error */
+#define HAL_DMA_ERROR_NO_XFER       (0x00000004U)    /*!< no ongoing transfer */
+#define HAL_DMA_ERROR_TIMEOUT       (0x00000020U)    /*!< Timeout error */
+#define HAL_DMA_ERROR_NOT_SUPPORTED (0x00000100U)    /*!< Not supported mode */     
 /**
   * @}
   */
@@ -179,14 +177,14 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_request DMA request
   * @{
   */
-#define DMA_REQUEST_0                     ((uint32_t)0x00000000)
-#define DMA_REQUEST_1                     ((uint32_t)0x00000001)
-#define DMA_REQUEST_2                     ((uint32_t)0x00000002)
-#define DMA_REQUEST_3                     ((uint32_t)0x00000003)
-#define DMA_REQUEST_4                     ((uint32_t)0x00000004)
-#define DMA_REQUEST_5                     ((uint32_t)0x00000005)
-#define DMA_REQUEST_6                     ((uint32_t)0x00000006)
-#define DMA_REQUEST_7                     ((uint32_t)0x00000007)
+#define DMA_REQUEST_0                     (0x00000000U)
+#define DMA_REQUEST_1                     (0x00000001U)
+#define DMA_REQUEST_2                     (0x00000002U)
+#define DMA_REQUEST_3                     (0x00000003U)
+#define DMA_REQUEST_4                     (0x00000004U)
+#define DMA_REQUEST_5                     (0x00000005U)
+#define DMA_REQUEST_6                     (0x00000006U)
+#define DMA_REQUEST_7                     (0x00000007U)
 
 /**
   * @}
@@ -195,7 +193,7 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Data_transfer_direction DMA Data transfer direction
   * @{
   */ 
-#define DMA_PERIPH_TO_MEMORY         ((uint32_t)0x00000000)      /*!< Peripheral to memory direction */
+#define DMA_PERIPH_TO_MEMORY         (0x00000000U)               /*!< Peripheral to memory direction */
 #define DMA_MEMORY_TO_PERIPH         ((uint32_t)DMA_CCR_DIR)     /*!< Memory to peripheral direction */
 #define DMA_MEMORY_TO_MEMORY         ((uint32_t)DMA_CCR_MEM2MEM) /*!< Memory to memory direction     */
 
@@ -207,7 +205,7 @@ typedef struct __DMA_HandleTypeDef
   * @{
   */ 
 #define DMA_PINC_ENABLE        ((uint32_t)DMA_CCR_PINC)   /*!< Peripheral increment mode Enable */
-#define DMA_PINC_DISABLE       ((uint32_t)0x00000000)     /*!< Peripheral increment mode Disable */
+#define DMA_PINC_DISABLE       (0x00000000U)              /*!< Peripheral increment mode Disable */
 /**
   * @}
   */ 
@@ -216,7 +214,7 @@ typedef struct __DMA_HandleTypeDef
   * @{
   */ 
 #define DMA_MINC_ENABLE         ((uint32_t)DMA_CCR_MINC)   /*!< Memory increment mode Enable  */
-#define DMA_MINC_DISABLE        ((uint32_t)0x00000000)     /*!< Memory increment mode Disable */
+#define DMA_MINC_DISABLE        (0x00000000U)              /*!< Memory increment mode Disable */
 /**
   * @}
   */
@@ -224,7 +222,7 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Peripheral_data_size DMA Peripheral data size
   * @{
   */ 
-#define DMA_PDATAALIGN_BYTE          ((uint32_t)0x00000000)        /*!< Peripheral data alignment: Byte     */
+#define DMA_PDATAALIGN_BYTE          (0x00000000U)                 /*!< Peripheral data alignment: Byte     */
 #define DMA_PDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_PSIZE_0)   /*!< Peripheral data alignment: HalfWord */
 #define DMA_PDATAALIGN_WORD          ((uint32_t)DMA_CCR_PSIZE_1)   /*!< Peripheral data alignment: Word     */
 /**
@@ -234,7 +232,7 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Memory_data_size DMA Memory data size
   * @{ 
   */
-#define DMA_MDATAALIGN_BYTE          ((uint32_t)0x00000000)        /*!< Memory data alignment: Byte     */
+#define DMA_MDATAALIGN_BYTE          (0x00000000U)                 /*!< Memory data alignment: Byte     */
 #define DMA_MDATAALIGN_HALFWORD      ((uint32_t)DMA_CCR_MSIZE_0)   /*!< Memory data alignment: HalfWord */
 #define DMA_MDATAALIGN_WORD          ((uint32_t)DMA_CCR_MSIZE_1)   /*!< Memory data alignment: Word     */
 /**
@@ -244,7 +242,7 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_mode DMA mode
   * @{
   */ 
-#define DMA_NORMAL         ((uint32_t)0x00000000)       /*!< Normal mode                  */
+#define DMA_NORMAL         (0x00000000U)                /*!< Normal mode                  */
 #define DMA_CIRCULAR       ((uint32_t)DMA_CCR_CIRC)     /*!< Circular mode                */
 /**
   * @}
@@ -253,7 +251,7 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_Priority_level DMA Priority level
   * @{
   */
-#define DMA_PRIORITY_LOW             ((uint32_t)0x00000000)     /*!< Priority level : Low       */
+#define DMA_PRIORITY_LOW             (0x00000000U)              /*!< Priority level : Low       */
 #define DMA_PRIORITY_MEDIUM          ((uint32_t)DMA_CCR_PL_0)   /*!< Priority level : Medium    */
 #define DMA_PRIORITY_HIGH            ((uint32_t)DMA_CCR_PL_1)   /*!< Priority level : High      */
 #define DMA_PRIORITY_VERY_HIGH       ((uint32_t)DMA_CCR_PL)     /*!< Priority level : Very_High */
@@ -275,34 +273,34 @@ typedef struct __DMA_HandleTypeDef
 /** @defgroup DMA_flag_definitions DMA flag definitions
   * @{
   */ 
-#define DMA_FLAG_GL1                      ((uint32_t)0x00000001)
-#define DMA_FLAG_TC1                      ((uint32_t)0x00000002)
-#define DMA_FLAG_HT1                      ((uint32_t)0x00000004)
-#define DMA_FLAG_TE1                      ((uint32_t)0x00000008)
-#define DMA_FLAG_GL2                      ((uint32_t)0x00000010)
-#define DMA_FLAG_TC2                      ((uint32_t)0x00000020)
-#define DMA_FLAG_HT2                      ((uint32_t)0x00000040)
-#define DMA_FLAG_TE2                      ((uint32_t)0x00000080)
-#define DMA_FLAG_GL3                      ((uint32_t)0x00000100)
-#define DMA_FLAG_TC3                      ((uint32_t)0x00000200)
-#define DMA_FLAG_HT3                      ((uint32_t)0x00000400)
-#define DMA_FLAG_TE3                      ((uint32_t)0x00000800)
-#define DMA_FLAG_GL4                      ((uint32_t)0x00001000)
-#define DMA_FLAG_TC4                      ((uint32_t)0x00002000)
-#define DMA_FLAG_HT4                      ((uint32_t)0x00004000)
-#define DMA_FLAG_TE4                      ((uint32_t)0x00008000)
-#define DMA_FLAG_GL5                      ((uint32_t)0x00010000)
-#define DMA_FLAG_TC5                      ((uint32_t)0x00020000)
-#define DMA_FLAG_HT5                      ((uint32_t)0x00040000)
-#define DMA_FLAG_TE5                      ((uint32_t)0x00080000)
-#define DMA_FLAG_GL6                      ((uint32_t)0x00100000)
-#define DMA_FLAG_TC6                      ((uint32_t)0x00200000)
-#define DMA_FLAG_HT6                      ((uint32_t)0x00400000)
-#define DMA_FLAG_TE6                      ((uint32_t)0x00800000)
-#define DMA_FLAG_GL7                      ((uint32_t)0x01000000)
-#define DMA_FLAG_TC7                      ((uint32_t)0x02000000)
-#define DMA_FLAG_HT7                      ((uint32_t)0x04000000)
-#define DMA_FLAG_TE7                      ((uint32_t)0x08000000)
+#define DMA_FLAG_GL1                      (0x00000001U)
+#define DMA_FLAG_TC1                      (0x00000002U)
+#define DMA_FLAG_HT1                      (0x00000004U)
+#define DMA_FLAG_TE1                      (0x00000008U)
+#define DMA_FLAG_GL2                      (0x00000010U)
+#define DMA_FLAG_TC2                      (0x00000020U)
+#define DMA_FLAG_HT2                      (0x00000040U)
+#define DMA_FLAG_TE2                      (0x00000080U)
+#define DMA_FLAG_GL3                      (0x00000100U)
+#define DMA_FLAG_TC3                      (0x00000200U)
+#define DMA_FLAG_HT3                      (0x00000400U)
+#define DMA_FLAG_TE3                      (0x00000800U)
+#define DMA_FLAG_GL4                      (0x00001000U)
+#define DMA_FLAG_TC4                      (0x00002000U)
+#define DMA_FLAG_HT4                      (0x00004000U)
+#define DMA_FLAG_TE4                      (0x00008000U)
+#define DMA_FLAG_GL5                      (0x00010000U)
+#define DMA_FLAG_TC5                      (0x00020000U)
+#define DMA_FLAG_HT5                      (0x00040000U)
+#define DMA_FLAG_TE5                      (0x00080000U)
+#define DMA_FLAG_GL6                      (0x00100000U)
+#define DMA_FLAG_TC6                      (0x00200000U)
+#define DMA_FLAG_HT6                      (0x00400000U)
+#define DMA_FLAG_TE6                      (0x00800000U)
+#define DMA_FLAG_GL7                      (0x01000000U)
+#define DMA_FLAG_TC7                      (0x02000000U)
+#define DMA_FLAG_HT7                      (0x04000000U)
+#define DMA_FLAG_TE7                      (0x08000000U)
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_flash.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   FLASH HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the internal FLASH memory:
@@ -140,7 +138,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -239,10 +237,10 @@ extern void    FLASH_PageErase(uint32_t PageAddress);
   *         Call the HAL_FLASH_Lock() to disable the flash memory access
   *         (recommended to protect the FLASH memory against possible unwanted operation).
   *
-  * @param  TypeProgram:  Indicate the way to program at a specified address.
+  * @param  TypeProgram   Indicate the way to program at a specified address.
   *                       This parameter can be a value of @ref FLASH_Type_Program
-  * @param  Address:      Specifies the address to be programmed.
-  * @param  Data:         Specifies the data to be programmed
+  * @param  Address       Specifie the address to be programmed.
+  * @param  Data          Specifie the data to be programmed
   * 
   * @retval HAL_StatusTypeDef HAL Status
   */
@@ -281,10 +279,10 @@ HAL_StatusTypeDef HAL_FLASH_Program(uint32_t TypeProgram, uint32_t Address, uint
 /**
   * @brief   Program word at a specified address  with interrupt enabled.
   *
-  * @param  TypeProgram: Indicate the way to program at a specified address.
+  * @param  TypeProgram  Indicate the way to program at a specified address.
   *                      This parameter can be a value of @ref FLASH_Type_Program
-  * @param  Address:     Specifies the address to be programmed.
-  * @param  Data:        Specifies the data to be programmed
+  * @param  Address      Specifie the address to be programmed.
+  * @param  Data         Specifie the data to be programmed
   * 
   * @retval HAL_StatusTypeDef HAL Status
   */
@@ -321,7 +319,7 @@ HAL_StatusTypeDef HAL_FLASH_Program_IT(uint32_t TypeProgram, uint32_t Address, u
   */
 void HAL_FLASH_IRQHandler(void)
 {
-  uint32_t addresstmp = 0;
+  uint32_t addresstmp = 0U;
   
   /* Check FLASH operation error flags */
   if( __HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR)     || 
@@ -371,7 +369,7 @@ void HAL_FLASH_IRQHandler(void)
         pFlash.NbPagesToErase--;
 
         /* Check if there are still pages to erase */
-        if(pFlash.NbPagesToErase != 0)
+        if(pFlash.NbPagesToErase != 0U)
         {
           addresstmp = pFlash.Page;
           /*Indicate user which sector has been erased */
@@ -630,7 +628,7 @@ HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
   { 
     if (Timeout != HAL_MAX_DELAY)
     {
-      if((Timeout == 0) || ((HAL_GetTick()-tickstart) > Timeout))
+      if((Timeout == 0U) || ((HAL_GetTick()-tickstart) > Timeout))
       {
         return HAL_TIMEOUT;
       }
@@ -670,7 +668,7 @@ HAL_StatusTypeDef FLASH_WaitForLastOperation(uint32_t Timeout)
   */
 static void FLASH_SetErrorCode(void)
 {
-  uint32_t flags = 0;
+  uint32_t flags = 0U;
   
   if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR))
   {

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.h
@@ -137,9 +137,10 @@ typedef struct
   * @{
   */ 
 
+#ifndef FLASH_SIZE // MBED
 #define FLASH_SIZE                (uint32_t)((*((uint32_t *)FLASHSIZE_BASE)&0xFFFFU) * 1024U)
+#endif // MBED
 #define FLASH_PAGE_SIZE           (256U)  /*!< FLASH Page Size in bytes */
-#endif
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_flash.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of Flash HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -57,7 +55,7 @@
 /** @addtogroup FLASH_Private_Constants
   * @{
   */
-#define FLASH_TIMEOUT_VALUE   ((uint32_t)50000U) /* 50 s */
+#define FLASH_TIMEOUT_VALUE      (50000U) /* 50 s */
 /**
   * @}
   */
@@ -66,7 +64,7 @@
   * @{
   */
 
-#define IS_FLASH_TYPEPROGRAM(_VALUE_)   (((_VALUE_) == FLASH_TYPEPROGRAM_WORD))
+#define IS_FLASH_TYPEPROGRAM(_VALUE_)   ((_VALUE_) == FLASH_TYPEPROGRAM_WORD)
 
 #define IS_FLASH_LATENCY(__LATENCY__) (((__LATENCY__) == FLASH_LATENCY_0) || \
                                        ((__LATENCY__) == FLASH_LATENCY_1))
@@ -85,9 +83,9 @@
   */
 typedef enum 
 {
-  FLASH_PROC_NONE              = 0, 
-  FLASH_PROC_PAGEERASE         = 1,
-  FLASH_PROC_PROGRAM           = 2,
+  FLASH_PROC_NONE              = 0U, 
+  FLASH_PROC_PAGEERASE         = 1U,
+  FLASH_PROC_PROGRAM           = 2U,
 } FLASH_ProcedureTypeDef;
 
 /** 
@@ -139,10 +137,9 @@ typedef struct
   * @{
   */ 
 
-#ifndef FLASH_SIZE
-#define FLASH_SIZE                (uint32_t)(*((uint16_t *)FLASHSIZE_BASE) * 1024U)
+#define FLASH_SIZE                (uint32_t)((*((uint32_t *)FLASHSIZE_BASE)&0xFFFFU) * 1024U)
+#define FLASH_PAGE_SIZE           (256U)  /*!< FLASH Page Size in bytes */
 #endif
-#define FLASH_PAGE_SIZE           ((uint32_t)256U)  /*!< FLASH Page Size in bytes */
 
 /**
   * @}
@@ -151,7 +148,7 @@ typedef struct
 /** @defgroup FLASH_Type_Program FLASH Type Program
   * @{
   */ 
-#define FLASH_TYPEPROGRAM_WORD       ((uint32_t)0x02U)  /*!<Program a word (32-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAM_WORD       (0x02U)  /*!<Program a word (32-bit) at a specified address.*/
 
 /**
   * @}
@@ -160,7 +157,7 @@ typedef struct
 /** @defgroup FLASH_Latency FLASH Latency
   * @{
   */ 
-#define FLASH_LATENCY_0            ((uint32_t)0x00000000U)    /*!< FLASH Zero Latency cycle */
+#define FLASH_LATENCY_0            (0x00000000U)    /*!< FLASH Zero Latency cycle */
 #define FLASH_LATENCY_1            FLASH_ACR_LATENCY         /*!< FLASH One Latency cycle */
 
 /**
@@ -170,7 +167,7 @@ typedef struct
 /** @defgroup FLASH_Interrupts FLASH Interrupts 
   * @{
   */
-   
+
 #define FLASH_IT_EOP               FLASH_PECR_EOPIE  /*!< End of programming interrupt source */
 #define FLASH_IT_ERR               FLASH_PECR_ERRIE  /*!< Error interrupt source */
 /**
@@ -206,21 +203,21 @@ typedef struct
   * @{
   */ 
 
-#define FLASH_PDKEY1               ((uint32_t)0x04152637U) /*!< Flash power down key1 */
-#define FLASH_PDKEY2               ((uint32_t)0xFAFBFCFDU) /*!< Flash power down key2: used with FLASH_PDKEY1 
+#define FLASH_PDKEY1               (0x04152637U) /*!< Flash power down key1 */
+#define FLASH_PDKEY2               (0xFAFBFCFDU) /*!< Flash power down key2: used with FLASH_PDKEY1 
                                                               to unlock the RUN_PD bit in FLASH_ACR */
 
-#define FLASH_PEKEY1               ((uint32_t)0x89ABCDEFU) /*!< Flash program erase key1 */
-#define FLASH_PEKEY2               ((uint32_t)0x02030405U) /*!< Flash program erase key: used with FLASH_PEKEY2
+#define FLASH_PEKEY1               (0x89ABCDEFU) /*!< Flash program erase key1 */
+#define FLASH_PEKEY2               (0x02030405U) /*!< Flash program erase key: used with FLASH_PEKEY2
                                                                to unlock the write access to the FLASH_PECR register and
                                                                data EEPROM */
 
-#define FLASH_PRGKEY1              ((uint32_t)0x8C9DAEBFU) /*!< Flash program memory key1 */
-#define FLASH_PRGKEY2              ((uint32_t)0x13141516U) /*!< Flash program memory key2: used with FLASH_PRGKEY2
+#define FLASH_PRGKEY1              (0x8C9DAEBFU) /*!< Flash program memory key1 */
+#define FLASH_PRGKEY2              (0x13141516U) /*!< Flash program memory key2: used with FLASH_PRGKEY2
                                                                to unlock the program memory */
 
-#define FLASH_OPTKEY1              ((uint32_t)0xFBEAD9C8U) /*!< Flash option key1 */
-#define FLASH_OPTKEY2              ((uint32_t)0x24252627U) /*!< Flash option key2: used with FLASH_OPTKEY1 to
+#define FLASH_OPTKEY1              (0xFBEAD9C8U) /*!< Flash option key1 */
+#define FLASH_OPTKEY2              (0x24252627U) /*!< Flash option key2: used with FLASH_OPTKEY1 to
                                                               unlock the write access to the option byte block */
 /**
   * @}
@@ -307,8 +304,6 @@ typedef struct
   * @param  __FLAG__ specifies the FLASH flags to clear.
   *          This parameter can be any combination of the following values:
   *            @arg @ref FLASH_FLAG_EOP         FLASH End of Operation flag 
-  *            @arg @ref FLASH_FLAG_ENDHV       FLASH End of High Voltage flag
-  *            @arg @ref FLASH_FLAG_READY       FLASH Ready flag after low power mode
   *            @arg @ref FLASH_FLAG_PGAERR      FLASH Programming Alignment error flag
   *            @arg @ref FLASH_FLAG_SIZERR      FLASH Size error flag
   *            @arg @ref FLASH_FLAG_OPTVERR     FLASH Option validity error error flag

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_flash_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended FLASH HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -38,7 +36,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -205,7 +203,7 @@ static HAL_StatusTypeDef  FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t
 HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t *PageError)
 {
   HAL_StatusTypeDef status = HAL_ERROR;
-  uint32_t address = 0;
+  uint32_t address = 0U;
   
   /* Process Locked */
   __HAL_LOCK(&pFlash);
@@ -222,7 +220,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
     assert_param(IS_NBPAGES(pEraseInit->NbPages));
     assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
     assert_param(IS_FLASH_PROGRAM_ADDRESS(pEraseInit->PageAddress));
-    assert_param(IS_FLASH_PROGRAM_ADDRESS((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1));
+    assert_param(IS_FLASH_PROGRAM_ADDRESS((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U));
 
 #if defined(STM32L151xDX) || defined(STM32L152xDX) || defined(STM32L162xDX)
     /* Check on which bank belongs the 1st address to erase */
@@ -230,7 +228,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
     {
       /* BANK1 */
       /* Check that last page to erase still belongs to BANK1 */
-      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1) > FLASH_BANK1_END)
+      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U) > FLASH_BANK1_END)
       {
         /*  Last page does not belong to BANK1, erase procedure cannot be performed because memory is not
             continuous */
@@ -243,7 +241,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
     {
       /* BANK2 */
       /* Check that last page to erase still belongs to BANK2 */
-      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1) > FLASH_BANK2_END)
+      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U) > FLASH_BANK2_END)
       {
         /*  Last page does not belong to BANK2, erase procedure cannot be performed because memory is not
             continuous */
@@ -300,7 +298,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase(FLASH_EraseInitTypeDef *pEraseInit, uint32_t
   */
 HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
 {
-  HAL_StatusTypeDef status = HAL_OK;
+  HAL_StatusTypeDef status = HAL_ERROR;
 
   /* If procedure already ongoing, reject the next one */
   if (pFlash.ProcedureOnGoing != FLASH_PROC_NONE)
@@ -312,7 +310,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
   assert_param(IS_NBPAGES(pEraseInit->NbPages));
   assert_param(IS_FLASH_TYPEERASE(pEraseInit->TypeErase));
   assert_param(IS_FLASH_PROGRAM_ADDRESS(pEraseInit->PageAddress));
-  assert_param(IS_FLASH_PROGRAM_ADDRESS((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1));
+  assert_param(IS_FLASH_PROGRAM_ADDRESS((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U));
 
   /* Process Locked */
   __HAL_LOCK(&pFlash);
@@ -323,7 +321,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
     {
       /* BANK1 */
       /* Check that last page to erase still belongs to BANK1 */
-      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1) > FLASH_BANK1_END)
+      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U) > FLASH_BANK1_END)
       {
         /*  Last page does not belong to BANK1, erase procedure cannot be performed because memory is not
             continuous */
@@ -336,7 +334,7 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
     {
       /* BANK2 */
       /* Check that last page to erase still belongs to BANK2 */
-      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1) > FLASH_BANK2_END)
+      if (((pEraseInit->PageAddress & ~(FLASH_PAGE_SIZE - 1U)) + pEraseInit->NbPages * FLASH_PAGE_SIZE - 1U) > FLASH_BANK2_END)
       {
         /*  Last page does not belong to BANK2, erase procedure cannot be performed because memory is not
             continuous */
@@ -347,15 +345,26 @@ HAL_StatusTypeDef HAL_FLASHEx_Erase_IT(FLASH_EraseInitTypeDef *pEraseInit)
     }
 #endif /* STM32L151xDX || STM32L152xDX || STM32L162xDX */
 
-  /* Enable End of FLASH Operation and Error source interrupts */
-  __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP | FLASH_IT_ERR);
+  /* Wait for last operation to be completed */
+  status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
   
-  pFlash.ProcedureOnGoing = FLASH_PROC_PAGEERASE;
-  pFlash.NbPagesToErase = pEraseInit->NbPages;
-  pFlash.Page = pEraseInit->PageAddress;
+  if (status == HAL_OK)
+  {
+    /* Enable End of FLASH Operation and Error source interrupts */
+    __HAL_FLASH_ENABLE_IT(FLASH_IT_EOP | FLASH_IT_ERR);
+    
+    pFlash.ProcedureOnGoing = FLASH_PROC_PAGEERASE;
+    pFlash.NbPagesToErase = pEraseInit->NbPages;
+    pFlash.Page = pEraseInit->PageAddress;
 
-  /*Erase 1st page and wait for IT*/
-  FLASH_PageErase(pEraseInit->PageAddress);
+    /*Erase 1st page and wait for IT*/
+    FLASH_PageErase(pEraseInit->PageAddress);
+  }
+  else
+  {
+    /* Process Unlocked */
+    __HAL_UNLOCK(&pFlash);
+  }
 
   return status;
 }
@@ -605,7 +614,7 @@ HAL_StatusTypeDef HAL_FLASHEx_AdvOBProgram (FLASH_AdvOBProgramInitTypeDef *pAdvO
   */
 void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
 {
-  pAdvOBInit->OptionType = 0;
+  pAdvOBInit->OptionType = 0U;
   
 #if defined(FLASH_OBR_SPRMOD)
       
@@ -630,7 +639,7 @@ void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
   pAdvOBInit->OptionType |= OPTIONBYTE_BOOTCONFIG;
 
   /* Get Boot config OB */
-  pAdvOBInit->BootConfig = (FLASH->OBR & FLASH_OBR_nRST_BFB2) >> 16;
+  pAdvOBInit->BootConfig = (FLASH->OBR & FLASH_OBR_nRST_BFB2) >> 16U;
 
 #endif /* FLASH_OBR_nRST_BFB2 */
 }
@@ -649,10 +658,10 @@ void HAL_FLASHEx_AdvOBGetConfig(FLASH_AdvOBProgramInitTypeDef *pAdvOBInit)
 HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  uint16_t tmp1 = 0;
-  uint32_t tmp2 = 0;
-  uint8_t optiontmp = 0;
-  uint16_t optiontmp2 = 0;
+  uint16_t tmp1 = 0U;
+  uint32_t tmp2 = 0U;
+  uint8_t optiontmp = 0U;
+  uint16_t optiontmp2 = 0U;
   
   status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
   
@@ -664,7 +673,7 @@ HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void)
   
   /* calculate the option byte to write */
   tmp1 = (uint16_t)(~(optiontmp2 ));
-  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)optiontmp2));
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16U)) | ((uint32_t)optiontmp2));
   
   if(status == HAL_OK)
   {         
@@ -692,10 +701,10 @@ HAL_StatusTypeDef HAL_FLASHEx_OB_SelectPCROP(void)
 HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  uint16_t tmp1 = 0;
-  uint32_t tmp2 = 0;
-  uint8_t optiontmp = 0;
-  uint16_t optiontmp2 = 0;
+  uint16_t tmp1 = 0U;
+  uint32_t tmp2 = 0U;
+  uint8_t optiontmp = 0U;
+  uint16_t optiontmp2 = 0U;
   
   status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
   
@@ -707,7 +716,7 @@ HAL_StatusTypeDef HAL_FLASHEx_OB_DeSelectPCROP(void)
   
   /* calculate the option byte to write */
   tmp1 = (uint16_t)(~(optiontmp2 ));
-  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)optiontmp2));
+  tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16U)) | ((uint32_t)optiontmp2));
   
   if(status == HAL_OK)
   {         
@@ -813,7 +822,7 @@ HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Erase(uint32_t TypeErase, uint32_t Addr
     if(TypeErase == FLASH_TYPEERASEDATA_WORD)
     {
       /* Write 00000000h to valid address in the data memory */
-      *(__IO uint32_t *) Address = 0x00000000;
+      *(__IO uint32_t *) Address = 0x00000000U;
     }
 
     if(TypeErase == FLASH_TYPEERASEDATA_HALFWORD)
@@ -846,8 +855,8 @@ HAL_StatusTypeDef HAL_FLASHEx_DATAEEPROM_Erase(uint32_t TypeErase, uint32_t Addr
   *         this function to configure the Fixed Time Programming.
   * @param  TypeProgram  Indicate the way to program at a specified address.
   *         This parameter can be a value of @ref FLASHEx_Type_Program_Data
-  * @param  Address  specifies the address to be programmed.
-  * @param  Data specifies the data to be programmed
+  * @param  Address  specifie the address to be programmed.
+  * @param  Data     specifie the data to be programmed
   * 
   * @retval HAL_StatusTypeDef HAL Status
   */
@@ -870,43 +879,43 @@ HAL_StatusTypeDef   HAL_FLASHEx_DATAEEPROM_Program(uint32_t TypeProgram, uint32_
     /* Clean the error context */
     pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
 
-    if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTBYTE)
-    {
-      /*Program word (8-bit) at a specified address.*/
-      status = FLASH_DATAEEPROM_FastProgramByte(Address, (uint8_t) Data);
-    }
-    
-    if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTHALFWORD)
-    {
-      /* Program halfword (16-bit) at a specified address.*/
-      status = FLASH_DATAEEPROM_FastProgramHalfWord(Address, (uint16_t) Data);
-    }    
-    
-    if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTWORD)
-    {
-      /* Program word (32-bit) at a specified address.*/
-      status = FLASH_DATAEEPROM_FastProgramWord(Address, (uint32_t) Data);
-    }
-    
     if(TypeProgram == FLASH_TYPEPROGRAMDATA_WORD)
     {
       /* Program word (32-bit) at a specified address.*/
       status = FLASH_DATAEEPROM_ProgramWord(Address, (uint32_t) Data);
     }
-       
-    if(TypeProgram == FLASH_TYPEPROGRAMDATA_HALFWORD)
+    else if(TypeProgram == FLASH_TYPEPROGRAMDATA_HALFWORD)
     {
       /* Program halfword (16-bit) at a specified address.*/
       status = FLASH_DATAEEPROM_ProgramHalfWord(Address, (uint16_t) Data);
     }
-        
-    if(TypeProgram == FLASH_TYPEPROGRAMDATA_BYTE)
+    else if(TypeProgram == FLASH_TYPEPROGRAMDATA_BYTE)
     {
       /* Program byte (8-bit) at a specified address.*/
       status = FLASH_DATAEEPROM_ProgramByte(Address, (uint8_t) Data);
     }
+    else if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTBYTE)
+    {
+      /*Program word (8-bit) at a specified address.*/
+      status = FLASH_DATAEEPROM_FastProgramByte(Address, (uint8_t) Data);
+    }
+    else if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTHALFWORD)
+    {
+      /* Program halfword (16-bit) at a specified address.*/
+      status = FLASH_DATAEEPROM_FastProgramHalfWord(Address, (uint16_t) Data);
+    }    
+    else if(TypeProgram == FLASH_TYPEPROGRAMDATA_FASTWORD)
+    {
+      /* Program word (32-bit) at a specified address.*/
+      status = FLASH_DATAEEPROM_FastProgramWord(Address, (uint32_t) Data);
+    }
+    else
+    {
+      status = HAL_ERROR;
+    }
+
   }
-  
+
   /* Process Unlocked */
   __HAL_UNLOCK(&pFlash);
 
@@ -965,7 +974,7 @@ void HAL_FLASHEx_DATAEEPROM_DisableFixedTimeProgram(void)
 static HAL_StatusTypeDef FLASH_OB_RDPConfig(uint8_t OB_RDP)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  uint32_t tmp1 = 0, tmp2 = 0, tmp3 = 0;
+  uint32_t tmp1 = 0U, tmp2 = 0U, tmp3 = 0U;
   
   /* Check the parameters */
   assert_param(IS_OB_RDP(OB_RDP));
@@ -991,7 +1000,7 @@ static HAL_StatusTypeDef FLASH_OB_RDPConfig(uint8_t OB_RDP)
 
     /* calculate the option byte to write */
     tmp1 = (~((uint32_t)(OB_RDP | tmp3)));
-    tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16)) | ((uint32_t)(OB_RDP | tmp3)));
+    tmp2 = (uint32_t)(((uint32_t)((uint32_t)(tmp1) << 16U)) | ((uint32_t)(OB_RDP | tmp3)));
 
     /* Wait for last operation to be completed */
     status = FLASH_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
@@ -1029,16 +1038,16 @@ static HAL_StatusTypeDef FLASH_OB_RDPConfig(uint8_t OB_RDP)
 static HAL_StatusTypeDef FLASH_OB_BORConfig(uint8_t OB_BOR)
 {
   HAL_StatusTypeDef status = HAL_OK;
-  uint32_t tmp = 0, tmp1 = 0;
+  uint32_t tmp = 0U, tmp1 = 0U;
 
   /* Check the parameters */
   assert_param(IS_OB_BOR_LEVEL(OB_BOR));
 
   /* Get the User Option byte register */
-  tmp1 = OB->USER & ((~FLASH_OBR_BOR_LEV) >> 16);
+  tmp1 = OB->USER & ((~FLASH_OBR_BOR_LEV) >> 16U);
 
-  /* Calculate the option byte to write - [0xFF | nUSER | 0x00 | USER]*/
-  tmp = (uint32_t)~((OB_BOR | tmp1)) << 16;
+  /* Calculate the option byte to write - [0xFFU | nUSER | 0x00U | USER]*/
+  tmp = (uint32_t)~((OB_BOR | tmp1)) << 16U;
   tmp |= (OB_BOR | tmp1);
     
   /* Wait for last operation to be completed */
@@ -1067,7 +1076,7 @@ static HAL_StatusTypeDef FLASH_OB_BORConfig(uint8_t OB_BOR)
 static uint8_t FLASH_OB_GetUser(void)
 {
   /* Return the User Option Byte */
-  return (uint8_t)((FLASH->OBR & FLASH_OBR_USER) >> 16);
+  return (uint8_t)((FLASH->OBR & FLASH_OBR_USER) >> 16U);
 }
 
 /**
@@ -1090,7 +1099,7 @@ static uint8_t FLASH_OB_GetRDP(void)
 static uint8_t FLASH_OB_GetBOR(void)
 {
   /* Return the BOR level */
-  return (uint8_t)((FLASH->OBR & (uint32_t)FLASH_OBR_BOR_LEV) >> 16);
+  return (uint8_t)((FLASH->OBR & (uint32_t)FLASH_OBR_BOR_LEV) >> 16U);
 }
 
 /**
@@ -1114,7 +1123,7 @@ static HAL_StatusTypeDef FLASH_OB_WRPConfig(FLASH_OBProgramInitTypeDef *pOBInit,
     pFlash.ErrorCode = HAL_FLASH_ERROR_NONE;
 
     /* WRP for sector between 0 to 31 */
-    if (pOBInit->WRPSector0To31 != 0)
+    if (pOBInit->WRPSector0To31 != 0U)
     {
       FLASH_OB_WRPConfigWRP1OrPCROP1(pOBInit->WRPSector0To31, NewState);
     }
@@ -1126,7 +1135,7 @@ static HAL_StatusTypeDef FLASH_OB_WRPConfig(FLASH_OBProgramInitTypeDef *pOBInit,
       
     /* Pages for Cat3, Cat4 & Cat5 devices*/
     /* WRP for sector between 32 to 63 */
-    if (pOBInit->WRPSector32To63 != 0)
+    if (pOBInit->WRPSector32To63 != 0U)
     {
       FLASH_OB_WRPConfigWRP2OrPCROP2(pOBInit->WRPSector32To63, NewState);
     }
@@ -1139,7 +1148,7 @@ static HAL_StatusTypeDef FLASH_OB_WRPConfig(FLASH_OBProgramInitTypeDef *pOBInit,
       
     /* Pages for devices with FLASH >= 256KB*/
     /* WRP for sector between 64 to 95 */
-    if (pOBInit->WRPSector64To95 != 0)
+    if (pOBInit->WRPSector64To95 != 0U)
     {
       FLASH_OB_WRPConfigWRP3(pOBInit->WRPSector64To95, NewState);
     }
@@ -1151,7 +1160,7 @@ static HAL_StatusTypeDef FLASH_OB_WRPConfig(FLASH_OBProgramInitTypeDef *pOBInit,
 
     /* Pages for Cat5 devices*/
     /* WRP for sector between 96 to 127 */
-    if (pOBInit->WRPSector96To127 != 0)
+    if (pOBInit->WRPSector96To127 != 0U)
     {
       FLASH_OB_WRPConfigWRP4(pOBInit->WRPSector96To127, NewState);
     }
@@ -1199,7 +1208,7 @@ static HAL_StatusTypeDef FLASH_OB_PCROPConfig(FLASH_AdvOBProgramInitTypeDef *pAd
 
     /* Pages for Cat2 devices*/
     /* PCROP for sector between 0 to 31 */
-    if (pAdvOBInit->PCROPSector0To31 != 0)
+    if (pAdvOBInit->PCROPSector0To31 != 0U)
     {
       FLASH_OB_WRPConfigWRP1OrPCROP1(pAdvOBInit->PCROPSector0To31, pcropstate);
     }
@@ -1208,7 +1217,7 @@ static HAL_StatusTypeDef FLASH_OB_PCROPConfig(FLASH_AdvOBProgramInitTypeDef *pAd
 
     /* Pages for Cat3 devices*/
     /* WRP for sector between 32 to 63 */
-    if (pAdvOBInit->PCROPSector32To63 != 0)
+    if (pAdvOBInit->PCROPSector32To63 != 0U)
     {
       FLASH_OB_WRPConfigWRP2OrPCROP2(pAdvOBInit->PCROPSector32To63, pcropstate);
     }
@@ -1234,9 +1243,9 @@ static HAL_StatusTypeDef FLASH_OB_PCROPConfig(FLASH_AdvOBProgramInitTypeDef *pAd
   */
 static void FLASH_OB_WRPConfigWRP1OrPCROP1(uint32_t WRP1OrPCROP1, FunctionalState NewState)
 {
-  uint32_t wrp01data = 0, wrp23data = 0;
+  uint32_t wrp01data = 0U, wrp23data = 0U;
   
-  uint32_t tmp1 = 0, tmp2 = 0;
+  uint32_t tmp1 = 0U, tmp2 = 0U;
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WRP1OrPCROP1));
@@ -1245,22 +1254,22 @@ static void FLASH_OB_WRPConfigWRP1OrPCROP1(uint32_t WRP1OrPCROP1, FunctionalStat
   if (NewState != DISABLE)
   {
     wrp01data = (uint16_t)(((WRP1OrPCROP1 & WRP_MASK_LOW) | OB->WRP01));
-    wrp23data = (uint16_t)((((WRP1OrPCROP1 & WRP_MASK_HIGH)>>16 | OB->WRP23))); 
-    tmp1 = (uint32_t)(~(wrp01data) << 16)|(wrp01data);
+    wrp23data = (uint16_t)((((WRP1OrPCROP1 & WRP_MASK_HIGH)>>16U | OB->WRP23))); 
+    tmp1 = (uint32_t)(~(wrp01data) << 16U)|(wrp01data);
     OB->WRP01 = tmp1;
 
-    tmp2 = (uint32_t)(~(wrp23data) << 16)|(wrp23data);
+    tmp2 = (uint32_t)(~(wrp23data) << 16U)|(wrp23data);
     OB->WRP23 = tmp2;      
   }
   else
   {
     wrp01data = (uint16_t)(~WRP1OrPCROP1 & (WRP_MASK_LOW & OB->WRP01));
-    wrp23data = (uint16_t)((((~WRP1OrPCROP1 & WRP_MASK_HIGH)>>16 & OB->WRP23))); 
+    wrp23data = (uint16_t)((((~WRP1OrPCROP1 & WRP_MASK_HIGH)>>16U & OB->WRP23))); 
 
-    tmp1 = (uint32_t)((~wrp01data) << 16)|(wrp01data);
+    tmp1 = (uint32_t)((~wrp01data) << 16U)|(wrp01data);
     OB->WRP01 = tmp1;
     
-    tmp2 = (uint32_t)((~wrp23data) << 16)|(wrp23data);
+    tmp2 = (uint32_t)((~wrp23data) << 16U)|(wrp23data);
     OB->WRP23 = tmp2;
   }
 }
@@ -1280,9 +1289,9 @@ static void FLASH_OB_WRPConfigWRP1OrPCROP1(uint32_t WRP1OrPCROP1, FunctionalStat
   */
 static void FLASH_OB_WRPConfigWRP2OrPCROP2(uint32_t WRP2OrPCROP2, FunctionalState NewState)
 {
-  uint32_t wrp45data = 0, wrp67data = 0;
+  uint32_t wrp45data = 0U, wrp67data = 0U;
   
-  uint32_t tmp1 = 0, tmp2 = 0;
+  uint32_t tmp1 = 0U, tmp2 = 0U;
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WRP2OrPCROP2));
@@ -1291,22 +1300,22 @@ static void FLASH_OB_WRPConfigWRP2OrPCROP2(uint32_t WRP2OrPCROP2, FunctionalStat
   if (NewState != DISABLE)
   {
     wrp45data = (uint16_t)(((WRP2OrPCROP2 & WRP_MASK_LOW) | OB->WRP45));
-    wrp67data = (uint16_t)((((WRP2OrPCROP2 & WRP_MASK_HIGH)>>16 | OB->WRP67))); 
-    tmp1 = (uint32_t)(~(wrp45data) << 16)|(wrp45data);
+    wrp67data = (uint16_t)((((WRP2OrPCROP2 & WRP_MASK_HIGH)>>16U | OB->WRP67))); 
+    tmp1 = (uint32_t)(~(wrp45data) << 16U)|(wrp45data);
     OB->WRP45 = tmp1;
     
-    tmp2 = (uint32_t)(~(wrp67data) << 16)|(wrp67data);
+    tmp2 = (uint32_t)(~(wrp67data) << 16U)|(wrp67data);
     OB->WRP67 = tmp2;
   }
   else
   {
     wrp45data = (uint16_t)(~WRP2OrPCROP2 & (WRP_MASK_LOW & OB->WRP45));
-    wrp67data = (uint16_t)((((~WRP2OrPCROP2 & WRP_MASK_HIGH)>>16 & OB->WRP67))); 
+    wrp67data = (uint16_t)((((~WRP2OrPCROP2 & WRP_MASK_HIGH)>>16U & OB->WRP67))); 
     
-    tmp1 = (uint32_t)((~wrp45data) << 16)|(wrp45data);
+    tmp1 = (uint32_t)((~wrp45data) << 16U)|(wrp45data);
     OB->WRP45 = tmp1;
     
-    tmp2 = (uint32_t)((~wrp67data) << 16)|(wrp67data);
+    tmp2 = (uint32_t)((~wrp67data) << 16U)|(wrp67data);
     OB->WRP67 = tmp2;
   }
 }
@@ -1326,9 +1335,9 @@ static void FLASH_OB_WRPConfigWRP2OrPCROP2(uint32_t WRP2OrPCROP2, FunctionalStat
   */
 static void FLASH_OB_WRPConfigWRP3(uint32_t WRP3, FunctionalState NewState)
 {
-  uint32_t wrp89data = 0, wrp1011data = 0;
+  uint32_t wrp89data = 0U, wrp1011data = 0U;
   
-  uint32_t tmp1 = 0, tmp2 = 0;
+  uint32_t tmp1 = 0U, tmp2 = 0U;
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WRP3));
@@ -1337,22 +1346,22 @@ static void FLASH_OB_WRPConfigWRP3(uint32_t WRP3, FunctionalState NewState)
   if (NewState != DISABLE)
   {
     wrp89data = (uint16_t)(((WRP3 & WRP_MASK_LOW) | OB->WRP89));
-    wrp1011data = (uint16_t)((((WRP3 & WRP_MASK_HIGH)>>16 | OB->WRP1011))); 
-    tmp1 = (uint32_t)(~(wrp89data) << 16)|(wrp89data);
+    wrp1011data = (uint16_t)((((WRP3 & WRP_MASK_HIGH)>>16U | OB->WRP1011))); 
+    tmp1 = (uint32_t)(~(wrp89data) << 16U)|(wrp89data);
     OB->WRP89 = tmp1;
 
-    tmp2 = (uint32_t)(~(wrp1011data) << 16)|(wrp1011data);
+    tmp2 = (uint32_t)(~(wrp1011data) << 16U)|(wrp1011data);
     OB->WRP1011 = tmp2;      
   }
   else
   {
     wrp89data = (uint16_t)(~WRP3 & (WRP_MASK_LOW & OB->WRP89));
-    wrp1011data = (uint16_t)((((~WRP3 & WRP_MASK_HIGH)>>16 & OB->WRP1011))); 
+    wrp1011data = (uint16_t)((((~WRP3 & WRP_MASK_HIGH)>>16U & OB->WRP1011))); 
 
-    tmp1 = (uint32_t)((~wrp89data) << 16)|(wrp89data);
+    tmp1 = (uint32_t)((~wrp89data) << 16U)|(wrp89data);
     OB->WRP89 = tmp1;
 
-    tmp2 = (uint32_t)((~wrp1011data) << 16)|(wrp1011data);
+    tmp2 = (uint32_t)((~wrp1011data) << 16U)|(wrp1011data);
     OB->WRP1011 = tmp2;
   }
 }
@@ -1371,9 +1380,9 @@ static void FLASH_OB_WRPConfigWRP3(uint32_t WRP3, FunctionalState NewState)
   */
 static void FLASH_OB_WRPConfigWRP4(uint32_t WRP4, FunctionalState NewState)
 {
-  uint32_t wrp1213data = 0, wrp1415data = 0;
+  uint32_t wrp1213data = 0U, wrp1415data = 0U;
   
-  uint32_t tmp1 = 0, tmp2 = 0;
+  uint32_t tmp1 = 0U, tmp2 = 0U;
   
   /* Check the parameters */
   assert_param(IS_OB_WRP(WRP4));
@@ -1382,22 +1391,22 @@ static void FLASH_OB_WRPConfigWRP4(uint32_t WRP4, FunctionalState NewState)
   if (NewState != DISABLE)
   {
     wrp1213data = (uint16_t)(((WRP4 & WRP_MASK_LOW) | OB->WRP1213));
-    wrp1415data = (uint16_t)((((WRP4 & WRP_MASK_HIGH)>>16 | OB->WRP1415))); 
-    tmp1 = (uint32_t)(~(wrp1213data) << 16)|(wrp1213data);
+    wrp1415data = (uint16_t)((((WRP4 & WRP_MASK_HIGH)>>16U | OB->WRP1415))); 
+    tmp1 = (uint32_t)(~(wrp1213data) << 16U)|(wrp1213data);
     OB->WRP1213 = tmp1;
 
-    tmp2 = (uint32_t)(~(wrp1415data) << 16)|(wrp1415data);
+    tmp2 = (uint32_t)(~(wrp1415data) << 16U)|(wrp1415data);
     OB->WRP1415 = tmp2;      
   }
   else
   {
     wrp1213data = (uint16_t)(~WRP4 & (WRP_MASK_LOW & OB->WRP1213));
-    wrp1415data = (uint16_t)((((~WRP4 & WRP_MASK_HIGH)>>16 & OB->WRP1415))); 
+    wrp1415data = (uint16_t)((((~WRP4 & WRP_MASK_HIGH)>>16U & OB->WRP1415))); 
 
-    tmp1 = (uint32_t)((~wrp1213data) << 16)|(wrp1213data);
+    tmp1 = (uint32_t)((~wrp1213data) << 16U)|(wrp1213data);
     OB->WRP1213 = tmp1;
 
-    tmp2 = (uint32_t)((~wrp1415data) << 16)|(wrp1415data);
+    tmp2 = (uint32_t)((~wrp1415data) << 16U)|(wrp1415data);
     OB->WRP1415 = tmp2;
   }
 }
@@ -1422,7 +1431,7 @@ static void FLASH_OB_WRPConfigWRP4(uint32_t WRP4, FunctionalState NewState)
 static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t OB_IWDG, uint8_t OB_STOP, uint8_t OB_STDBY)
 {
   HAL_StatusTypeDef status = HAL_OK; 
-  uint32_t tmp = 0, tmp1 = 0;
+  uint32_t tmp = 0U, tmp1 = 0U;
 
   /* Check the parameters */
   assert_param(IS_OB_IWDG_SOURCE(OB_IWDG));
@@ -1430,10 +1439,10 @@ static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t OB_IWDG, uint8_t OB_STOP, u
   assert_param(IS_OB_STDBY_SOURCE(OB_STDBY));
 
   /* Get the User Option byte register */
-  tmp1 = OB->USER & ((~FLASH_OBR_USER) >> 16);
+  tmp1 = OB->USER & ((~FLASH_OBR_USER) >> 16U);
 
   /* Calculate the user option byte to write */ 
-  tmp = (uint32_t)(((uint32_t)~((uint32_t)((uint32_t)(OB_IWDG) | (uint32_t)(OB_STOP) | (uint32_t)(OB_STDBY) | tmp1))) << 16);
+  tmp = (uint32_t)(((uint32_t)~((uint32_t)((uint32_t)(OB_IWDG) | (uint32_t)(OB_STOP) | (uint32_t)(OB_STDBY) | tmp1))) << 16U);
   tmp |= ((uint32_t)(OB_IWDG) | ((uint32_t)OB_STOP) | (uint32_t)(OB_STDBY) | tmp1);
   
   /* Wait for last operation to be completed */
@@ -1475,16 +1484,16 @@ static HAL_StatusTypeDef FLASH_OB_UserConfig(uint8_t OB_IWDG, uint8_t OB_STOP, u
 static HAL_StatusTypeDef FLASH_OB_BootConfig(uint8_t OB_BOOT)
 {
   HAL_StatusTypeDef status = HAL_OK; 
-  uint32_t tmp = 0, tmp1 = 0;
+  uint32_t tmp = 0U, tmp1 = 0U;
 
   /* Check the parameters */
   assert_param(IS_OB_BOOT_BANK(OB_BOOT));
 
   /* Get the User Option byte register  and BOR Level*/
-  tmp1 = OB->USER & ((~FLASH_OBR_nRST_BFB2) >> 16);
+  tmp1 = OB->USER & ((~FLASH_OBR_nRST_BFB2) >> 16U);
 
   /* Calculate the option byte to write */
-  tmp = (uint32_t)~(OB_BOOT | tmp1) << 16;
+  tmp = (uint32_t)~(OB_BOOT | tmp1) << 16U;
   tmp |= (OB_BOOT | tmp1);
 
   /* Wait for last operation to be completed */
@@ -1525,7 +1534,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramByte(uint32_t Address, uint
 {
   HAL_StatusTypeDef status = HAL_OK;
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-  uint32_t tmp = 0, tmpaddr = 0;
+  uint32_t tmp = 0U, tmpaddr = 0U;
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB  */
   
   /* Check the parameters */
@@ -1541,7 +1550,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramByte(uint32_t Address, uint
 
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
     /* Possible only on Cat1 devices */
-    if(Data != (uint8_t)0x00) 
+    if(Data != (uint8_t)0x00U) 
     {
       /* If the previous operation is completed, proceed to write the new Data */
       *(__IO uint8_t *)Address = Data;
@@ -1551,14 +1560,14 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramByte(uint32_t Address, uint
     }
     else
     {
-      tmpaddr = Address & 0xFFFFFFFC;
+      tmpaddr = Address & 0xFFFFFFFCU;
       tmp = * (__IO uint32_t *) tmpaddr;
-      tmpaddr = 0xFF << ((uint32_t) (0x8 * (Address & 0x3)));
+      tmpaddr = 0xFFU << ((uint32_t) (0x8U * (Address & 0x3U)));
       tmp &= ~tmpaddr;
-      status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFC);
+      status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFCU);
       /* Process Unlocked */
       __HAL_UNLOCK(&pFlash);
-      status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFC), tmp);
+      status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFCU), tmp);
       /* Process Locked */
       __HAL_LOCK(&pFlash);
     }
@@ -1585,7 +1594,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramHalfWord(uint32_t Address, 
 {
   HAL_StatusTypeDef status = HAL_OK;
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-  uint32_t tmp = 0, tmpaddr = 0;
+  uint32_t tmp = 0U, tmpaddr = 0U;
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB  */
   
   /* Check the parameters */
@@ -1601,7 +1610,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramHalfWord(uint32_t Address, 
 
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
     /* Possible only on Cat1 devices */
-    if(Data != (uint16_t)0x0000) 
+    if(Data != (uint16_t)0x0000U) 
     {
       /* If the previous operation is completed, proceed to write the new data */
       *(__IO uint16_t *)Address = Data;
@@ -1613,19 +1622,19 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_FastProgramHalfWord(uint32_t Address, 
     {
       /* Process Unlocked */
       __HAL_UNLOCK(&pFlash);
-      if((Address & 0x3) != 0x3)
+      if((Address & 0x3U) != 0x3U)
       {
-        tmpaddr = Address & 0xFFFFFFFC;
+        tmpaddr = Address & 0xFFFFFFFCU;
         tmp = * (__IO uint32_t *) tmpaddr;
-        tmpaddr = 0xFFFF << ((uint32_t) (0x8 * (Address & 0x3)));
+        tmpaddr = 0xFFFFU << ((uint32_t) (0x8U * (Address & 0x3U)));
         tmp &= ~tmpaddr;        
-        status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFC);
-        status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFC), tmp);
+        status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFCU);
+        status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFCU), tmp);
       }
       else
       {
-        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address, 0x00);
-        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address + 1, 0x00);
+        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address, 0x00U);
+        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address + 1U, 0x00U);
       }
       /* Process Locked */
       __HAL_LOCK(&pFlash);
@@ -1684,7 +1693,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t 
 {
   HAL_StatusTypeDef status = HAL_OK;
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-  uint32_t tmp = 0, tmpaddr = 0;
+  uint32_t tmp = 0U, tmpaddr = 0U;
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB  */
   
   /* Check the parameters */
@@ -1696,7 +1705,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t 
   if(status == HAL_OK)
   {
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-    if(Data != (uint8_t) 0x00)
+    if(Data != (uint8_t) 0x00U)
     {  
       *(__IO uint8_t *)Address = Data;
     
@@ -1706,14 +1715,14 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramByte(uint32_t Address, uint8_t 
     }
     else
     {
-      tmpaddr = Address & 0xFFFFFFFC;
+      tmpaddr = Address & 0xFFFFFFFCU;
       tmp = * (__IO uint32_t *) tmpaddr;
-      tmpaddr = 0xFF << ((uint32_t) (0x8 * (Address & 0x3)));
+      tmpaddr = 0xFFU << ((uint32_t) (0x8U * (Address & 0x3U)));
       tmp &= ~tmpaddr;        
-      status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFC);
+      status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFCU);
       /* Process Unlocked */
       __HAL_UNLOCK(&pFlash);
-      status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFC), tmp);
+      status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFCU), tmp);
       /* Process Locked */
       __HAL_LOCK(&pFlash);
     }
@@ -1738,7 +1747,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramHalfWord(uint32_t Address, uint
 {
   HAL_StatusTypeDef status = HAL_OK;
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-  uint32_t tmp = 0, tmpaddr = 0;
+  uint32_t tmp = 0U, tmpaddr = 0U;
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB  */
   
   /* Check the parameters */
@@ -1750,7 +1759,7 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramHalfWord(uint32_t Address, uint
   if(status == HAL_OK)
   {
 #if defined(STM32L100xB) || defined(STM32L151xB) || defined(STM32L152xB)
-    if(Data != (uint16_t)0x0000)
+    if(Data != (uint16_t)0x0000U)
     {
       *(__IO uint16_t *)Address = Data;
    
@@ -1761,19 +1770,19 @@ static HAL_StatusTypeDef FLASH_DATAEEPROM_ProgramHalfWord(uint32_t Address, uint
     {
       /* Process Unlocked */
       __HAL_UNLOCK(&pFlash);
-      if((Address & 0x3) != 0x3)
+      if((Address & 0x3U) != 0x3U)
       {
-        tmpaddr = Address & 0xFFFFFFFC;
+        tmpaddr = Address & 0xFFFFFFFCU;
         tmp = * (__IO uint32_t *) tmpaddr;
-        tmpaddr = 0xFFFF << ((uint32_t) (0x8 * (Address & 0x3)));
+        tmpaddr = 0xFFFFU << ((uint32_t) (0x8U * (Address & 0x3U)));
         tmp &= ~tmpaddr;          
-        status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFC);
-        status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFC), tmp);
+        status = HAL_FLASHEx_DATAEEPROM_Erase(FLASH_TYPEERASEDATA_WORD, Address & 0xFFFFFFFCU);
+        status = HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTWORD, (Address & 0xFFFFFFFCU), tmp);
       }
       else
       {
-        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address, 0x00);
-        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address + 1, 0x00);
+        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address, 0x00U);
+        HAL_FLASHEx_DATAEEPROM_Program(FLASH_TYPEPROGRAMDATA_FASTBYTE, Address + 1U, 0x00U);
       }
       /* Process Locked */
       __HAL_LOCK(&pFlash);

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ex.h
@@ -1,14 +1,12 @@
 /**
   ******************************************************************************
-  * @file    stm32l1xx_hal_flash.h
+  * @file    stm32l1xx_hal_flash_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
-  * @brief   Header file of Flash HAL module.
+  * @brief   Header file of Flash HAL Extended module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -86,29 +84,29 @@
  || defined(STM32L151xBA) || defined(STM32L152xBA)
      
 /******* Devices with FLASH 128K *******/
-#define FLASH_NBPAGES_MAX       512 /* 512 pages from page 0 to page 511 */
+#define FLASH_NBPAGES_MAX       512U /* 512 pages from page 0 to page 511U */
 
 #elif defined(STM32L100xC) || defined(STM32L151xC) || defined(STM32L152xC) || defined(STM32L162xC) \
    || defined(STM32L151xCA) || defined(STM32L152xCA) || defined(STM32L162xCA)
 
 /******* Devices with FLASH 256K *******/
-#define FLASH_NBPAGES_MAX       1025 /* 1025 pages from page 0 to page 1024 */
+#define FLASH_NBPAGES_MAX       1025U /* 1025 pages from page 0 to page 1024U */
 
 #elif defined(STM32L151xD) || defined(STM32L151xDX) || defined(STM32L152xD) || defined(STM32L152xDX) \
    || defined(STM32L162xD) || defined(STM32L162xDX)
 
 /******* Devices with FLASH 384K *******/
-#define FLASH_NBPAGES_MAX       1536 /* 1536 pages from page 0 to page 1535 */
+#define FLASH_NBPAGES_MAX       1536U /* 1536 pages from page 0 to page 1535U */
 
 #elif defined(STM32L151xE) || defined(STM32L152xE) || defined(STM32L162xE)
 
 /******* Devices with FLASH 512K *******/
-#define FLASH_NBPAGES_MAX       2048 /* 2048 pages from page 0 to page 2047 */
+#define FLASH_NBPAGES_MAX       2048U /* 2048 pages from page 0 to page 2047U */
 
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB || STM32L100xBA || STM32L151xBA || STM32L152xBA */
 
-#define WRP_MASK_LOW                 ((uint32_t)0x0000FFFFU)
-#define WRP_MASK_HIGH                 ((uint32_t)0xFFFF0000U)
+#define WRP_MASK_LOW                 (0x0000FFFFU)
+#define WRP_MASK_HIGH                (0xFFFF0000U)
 
 /**
   * @}
@@ -175,13 +173,13 @@
 #define IS_TYPEERASEDATA(__VALUE__)     (((__VALUE__) == FLASH_TYPEERASEDATA_BYTE) || \
                                          ((__VALUE__) == FLASH_TYPEERASEDATA_HALFWORD) || \
                                          ((__VALUE__) == FLASH_TYPEERASEDATA_WORD))
-
 #define IS_TYPEPROGRAMDATA(__VALUE__)   (((__VALUE__) == FLASH_TYPEPROGRAMDATA_BYTE) || \
                                          ((__VALUE__) == FLASH_TYPEPROGRAMDATA_HALFWORD) || \
                                          ((__VALUE__) == FLASH_TYPEPROGRAMDATA_WORD) || \
                                          ((__VALUE__) == FLASH_TYPEPROGRAMDATA_FASTBYTE) || \
                                          ((__VALUE__) == FLASH_TYPEPROGRAMDATA_FASTHALFWORD) || \
                                          ((__VALUE__) == FLASH_TYPEPROGRAMDATA_FASTWORD))
+
 
 /** @defgroup FLASHEx_Address FLASHEx Address
   * @{
@@ -204,7 +202,7 @@
 
 #endif /* STM32L100xB || STM32L151xB || STM32L152xB || (...) || STM32L151xCA || STM32L152xCA || STM32L162xCA */
 
-#define IS_NBPAGES(__PAGES__) (((__PAGES__) >= 1) && ((__PAGES__) <= FLASH_NBPAGES_MAX)) 
+#define IS_NBPAGES(__PAGES__) (((__PAGES__) >= 1U) && ((__PAGES__) <= FLASH_NBPAGES_MAX)) 
 
 /**
   * @}
@@ -325,8 +323,8 @@ typedef struct
 /** @defgroup FLASHEx_Type_Erase FLASHEx_Type_Erase
   * @{
   */
-#define FLASH_TYPEERASE_PAGES           ((uint32_t)0x00U)  /*!<Page erase only*/
- 
+#define FLASH_TYPEERASE_PAGES           (0x00U)  /*!<Page erase only*/
+
 /**
   * @}
   */
@@ -334,10 +332,10 @@ typedef struct
 /** @defgroup FLASHEx_Option_Type FLASHEx Option Type
   * @{
   */
-#define OPTIONBYTE_WRP            ((uint32_t)0x01U)  /*!<WRP option byte configuration*/
-#define OPTIONBYTE_RDP            ((uint32_t)0x02U)  /*!<RDP option byte configuration*/
-#define OPTIONBYTE_USER           ((uint32_t)0x04U)  /*!<USER option byte configuration*/
-#define OPTIONBYTE_BOR            ((uint32_t)0x08U)  /*!<BOR option byte configuration*/
+#define OPTIONBYTE_WRP            (0x01U)  /*!<WRP option byte configuration*/
+#define OPTIONBYTE_RDP            (0x02U)  /*!<RDP option byte configuration*/
+#define OPTIONBYTE_USER           (0x04U)  /*!<USER option byte configuration*/
+#define OPTIONBYTE_BOR            (0x08U)  /*!<BOR option byte configuration*/
 
 /**
   * @}
@@ -346,8 +344,8 @@ typedef struct
 /** @defgroup FLASHEx_WRP_State FLASHEx WRP State
   * @{
   */
-#define OB_WRPSTATE_DISABLE        ((uint32_t)0x00U)  /*!<Disable the write protection of the desired sectors*/
-#define OB_WRPSTATE_ENABLE         ((uint32_t)0x01U)  /*!<Enable the write protection of the desired sectors*/
+#define OB_WRPSTATE_DISABLE        (0x00U)  /*!<Disable the write protection of the desired sectors*/
+#define OB_WRPSTATE_ENABLE         (0x01U)  /*!<Enable the write protection of the desired sectors*/
 
 /**
   * @}
@@ -358,38 +356,38 @@ typedef struct
   */
   
 /* Common pages for Cat1, Cat2, Cat3, Cat4 & Cat5 devices */
-#define OB_WRP1_PAGES0TO15    ((uint32_t)0x00000001) /* Write protection of Sector0 */  
-#define OB_WRP1_PAGES16TO31   ((uint32_t)0x00000002) /* Write protection of Sector1 */  
-#define OB_WRP1_PAGES32TO47   ((uint32_t)0x00000004) /* Write protection of Sector2 */  
-#define OB_WRP1_PAGES48TO63   ((uint32_t)0x00000008) /* Write protection of Sector3 */  
-#define OB_WRP1_PAGES64TO79   ((uint32_t)0x00000010) /* Write protection of Sector4 */  
-#define OB_WRP1_PAGES80TO95   ((uint32_t)0x00000020) /* Write protection of Sector5 */  
-#define OB_WRP1_PAGES96TO111  ((uint32_t)0x00000040) /* Write protection of Sector6 */  
-#define OB_WRP1_PAGES112TO127 ((uint32_t)0x00000080) /* Write protection of Sector7 */  
-#define OB_WRP1_PAGES128TO143 ((uint32_t)0x00000100) /* Write protection of Sector8 */  
-#define OB_WRP1_PAGES144TO159 ((uint32_t)0x00000200) /* Write protection of Sector9 */  
-#define OB_WRP1_PAGES160TO175 ((uint32_t)0x00000400) /* Write protection of Sector10 */ 
-#define OB_WRP1_PAGES176TO191 ((uint32_t)0x00000800) /* Write protection of Sector11 */ 
-#define OB_WRP1_PAGES192TO207 ((uint32_t)0x00001000) /* Write protection of Sector12 */ 
-#define OB_WRP1_PAGES208TO223 ((uint32_t)0x00002000) /* Write protection of Sector13 */ 
-#define OB_WRP1_PAGES224TO239 ((uint32_t)0x00004000) /* Write protection of Sector14 */ 
-#define OB_WRP1_PAGES240TO255 ((uint32_t)0x00008000) /* Write protection of Sector15 */ 
-#define OB_WRP1_PAGES256TO271 ((uint32_t)0x00010000) /* Write protection of Sector16 */ 
-#define OB_WRP1_PAGES272TO287 ((uint32_t)0x00020000) /* Write protection of Sector17 */ 
-#define OB_WRP1_PAGES288TO303 ((uint32_t)0x00040000) /* Write protection of Sector18 */ 
-#define OB_WRP1_PAGES304TO319 ((uint32_t)0x00080000) /* Write protection of Sector19 */ 
-#define OB_WRP1_PAGES320TO335 ((uint32_t)0x00100000) /* Write protection of Sector20 */ 
-#define OB_WRP1_PAGES336TO351 ((uint32_t)0x00200000) /* Write protection of Sector21 */ 
-#define OB_WRP1_PAGES352TO367 ((uint32_t)0x00400000) /* Write protection of Sector22 */ 
-#define OB_WRP1_PAGES368TO383 ((uint32_t)0x00800000) /* Write protection of Sector23 */ 
-#define OB_WRP1_PAGES384TO399 ((uint32_t)0x01000000) /* Write protection of Sector24 */ 
-#define OB_WRP1_PAGES400TO415 ((uint32_t)0x02000000) /* Write protection of Sector25 */ 
-#define OB_WRP1_PAGES416TO431 ((uint32_t)0x04000000) /* Write protection of Sector26 */ 
-#define OB_WRP1_PAGES432TO447 ((uint32_t)0x08000000) /* Write protection of Sector27 */ 
-#define OB_WRP1_PAGES448TO463 ((uint32_t)0x10000000) /* Write protection of Sector28 */ 
-#define OB_WRP1_PAGES464TO479 ((uint32_t)0x20000000) /* Write protection of Sector29 */ 
-#define OB_WRP1_PAGES480TO495 ((uint32_t)0x40000000) /* Write protection of Sector30 */ 
-#define OB_WRP1_PAGES496TO511 ((uint32_t)0x80000000U) /* Write protection of Sector31 */ 
+#define OB_WRP1_PAGES0TO15    (0x00000001U) /* Write protection of Sector0 */  
+#define OB_WRP1_PAGES16TO31   (0x00000002U) /* Write protection of Sector1 */  
+#define OB_WRP1_PAGES32TO47   (0x00000004U) /* Write protection of Sector2 */  
+#define OB_WRP1_PAGES48TO63   (0x00000008U) /* Write protection of Sector3 */  
+#define OB_WRP1_PAGES64TO79   (0x00000010U) /* Write protection of Sector4 */  
+#define OB_WRP1_PAGES80TO95   (0x00000020U) /* Write protection of Sector5 */  
+#define OB_WRP1_PAGES96TO111  (0x00000040U) /* Write protection of Sector6 */  
+#define OB_WRP1_PAGES112TO127 (0x00000080U) /* Write protection of Sector7 */  
+#define OB_WRP1_PAGES128TO143 (0x00000100U) /* Write protection of Sector8 */  
+#define OB_WRP1_PAGES144TO159 (0x00000200U) /* Write protection of Sector9 */  
+#define OB_WRP1_PAGES160TO175 (0x00000400U) /* Write protection of Sector10 */ 
+#define OB_WRP1_PAGES176TO191 (0x00000800U) /* Write protection of Sector11 */ 
+#define OB_WRP1_PAGES192TO207 (0x00001000U) /* Write protection of Sector12 */ 
+#define OB_WRP1_PAGES208TO223 (0x00002000U) /* Write protection of Sector13 */ 
+#define OB_WRP1_PAGES224TO239 (0x00004000U) /* Write protection of Sector14 */ 
+#define OB_WRP1_PAGES240TO255 (0x00008000U) /* Write protection of Sector15 */ 
+#define OB_WRP1_PAGES256TO271 (0x00010000U) /* Write protection of Sector16 */ 
+#define OB_WRP1_PAGES272TO287 (0x00020000U) /* Write protection of Sector17 */ 
+#define OB_WRP1_PAGES288TO303 (0x00040000U) /* Write protection of Sector18 */ 
+#define OB_WRP1_PAGES304TO319 (0x00080000U) /* Write protection of Sector19 */ 
+#define OB_WRP1_PAGES320TO335 (0x00100000U) /* Write protection of Sector20 */ 
+#define OB_WRP1_PAGES336TO351 (0x00200000U) /* Write protection of Sector21 */ 
+#define OB_WRP1_PAGES352TO367 (0x00400000U) /* Write protection of Sector22 */ 
+#define OB_WRP1_PAGES368TO383 (0x00800000U) /* Write protection of Sector23 */ 
+#define OB_WRP1_PAGES384TO399 (0x01000000U) /* Write protection of Sector24 */ 
+#define OB_WRP1_PAGES400TO415 (0x02000000U) /* Write protection of Sector25 */ 
+#define OB_WRP1_PAGES416TO431 (0x04000000U) /* Write protection of Sector26 */ 
+#define OB_WRP1_PAGES432TO447 (0x08000000U) /* Write protection of Sector27 */ 
+#define OB_WRP1_PAGES448TO463 (0x10000000U) /* Write protection of Sector28 */ 
+#define OB_WRP1_PAGES464TO479 (0x20000000U) /* Write protection of Sector29 */ 
+#define OB_WRP1_PAGES480TO495 (0x40000000U) /* Write protection of Sector30 */ 
+#define OB_WRP1_PAGES496TO511 (0x80000000U) /* Write protection of Sector31 */ 
   
 #define OB_WRP1_ALLPAGES      ((uint32_t)FLASH_WRPR1_WRP) /*!< Write protection of all Sectors */
   
@@ -407,44 +405,44 @@ typedef struct
   */
   
 /* Pages for Cat3, Cat4 & Cat5 devices*/
-#define OB_WRP2_PAGES512TO527   ((uint32_t)0x00000001) /* Write protection of Sector32 */  
-#define OB_WRP2_PAGES528TO543   ((uint32_t)0x00000002) /* Write protection of Sector33 */  
-#define OB_WRP2_PAGES544TO559   ((uint32_t)0x00000004) /* Write protection of Sector34 */  
-#define OB_WRP2_PAGES560TO575   ((uint32_t)0x00000008) /* Write protection of Sector35 */  
-#define OB_WRP2_PAGES576TO591   ((uint32_t)0x00000010) /* Write protection of Sector36 */  
-#define OB_WRP2_PAGES592TO607   ((uint32_t)0x00000020) /* Write protection of Sector37 */  
-#define OB_WRP2_PAGES608TO623   ((uint32_t)0x00000040) /* Write protection of Sector38 */  
-#define OB_WRP2_PAGES624TO639   ((uint32_t)0x00000080) /* Write protection of Sector39 */  
-#define OB_WRP2_PAGES640TO655   ((uint32_t)0x00000100) /* Write protection of Sector40 */  
-#define OB_WRP2_PAGES656TO671   ((uint32_t)0x00000200) /* Write protection of Sector41 */  
-#define OB_WRP2_PAGES672TO687   ((uint32_t)0x00000400) /* Write protection of Sector42 */  
-#define OB_WRP2_PAGES688TO703   ((uint32_t)0x00000800) /* Write protection of Sector43 */  
-#define OB_WRP2_PAGES704TO719   ((uint32_t)0x00001000) /* Write protection of Sector44 */  
-#define OB_WRP2_PAGES720TO735   ((uint32_t)0x00002000) /* Write protection of Sector45 */  
-#define OB_WRP2_PAGES736TO751   ((uint32_t)0x00004000) /* Write protection of Sector46 */  
-#define OB_WRP2_PAGES752TO767   ((uint32_t)0x00008000) /* Write protection of Sector47 */  
+#define OB_WRP2_PAGES512TO527   (0x00000001U) /* Write protection of Sector32 */  
+#define OB_WRP2_PAGES528TO543   (0x00000002U) /* Write protection of Sector33 */  
+#define OB_WRP2_PAGES544TO559   (0x00000004U) /* Write protection of Sector34 */  
+#define OB_WRP2_PAGES560TO575   (0x00000008U) /* Write protection of Sector35 */  
+#define OB_WRP2_PAGES576TO591   (0x00000010U) /* Write protection of Sector36 */  
+#define OB_WRP2_PAGES592TO607   (0x00000020U) /* Write protection of Sector37 */  
+#define OB_WRP2_PAGES608TO623   (0x00000040U) /* Write protection of Sector38 */  
+#define OB_WRP2_PAGES624TO639   (0x00000080U) /* Write protection of Sector39 */  
+#define OB_WRP2_PAGES640TO655   (0x00000100U) /* Write protection of Sector40 */  
+#define OB_WRP2_PAGES656TO671   (0x00000200U) /* Write protection of Sector41 */  
+#define OB_WRP2_PAGES672TO687   (0x00000400U) /* Write protection of Sector42 */  
+#define OB_WRP2_PAGES688TO703   (0x00000800U) /* Write protection of Sector43 */  
+#define OB_WRP2_PAGES704TO719   (0x00001000U) /* Write protection of Sector44 */  
+#define OB_WRP2_PAGES720TO735   (0x00002000U) /* Write protection of Sector45 */  
+#define OB_WRP2_PAGES736TO751   (0x00004000U) /* Write protection of Sector46 */  
+#define OB_WRP2_PAGES752TO767   (0x00008000U) /* Write protection of Sector47 */  
 
 #if defined(STM32L100xC) || defined(STM32L151xC) || defined(STM32L152xC) || defined(STM32L162xC)   \
  || defined(STM32L151xCA) || defined(STM32L151xD) || defined(STM32L152xCA) || defined(STM32L152xD) \
  || defined(STM32L162xCA) || defined(STM32L162xD) || defined(STM32L151xE) || defined(STM32L152xE)  \
  || defined(STM32L162xE)
 
-#define OB_WRP2_PAGES768TO783   ((uint32_t)0x00010000) /* Write protection of Sector48 */  
-#define OB_WRP2_PAGES784TO799   ((uint32_t)0x00020000) /* Write protection of Sector49 */  
-#define OB_WRP2_PAGES800TO815   ((uint32_t)0x00040000) /* Write protection of Sector50 */  
-#define OB_WRP2_PAGES816TO831   ((uint32_t)0x00080000) /* Write protection of Sector51 */  
-#define OB_WRP2_PAGES832TO847   ((uint32_t)0x00100000) /* Write protection of Sector52 */  
-#define OB_WRP2_PAGES848TO863   ((uint32_t)0x00200000) /* Write protection of Sector53 */  
-#define OB_WRP2_PAGES864TO879   ((uint32_t)0x00400000) /* Write protection of Sector54 */  
-#define OB_WRP2_PAGES880TO895   ((uint32_t)0x00800000) /* Write protection of Sector55 */  
-#define OB_WRP2_PAGES896TO911   ((uint32_t)0x01000000) /* Write protection of Sector56 */  
-#define OB_WRP2_PAGES912TO927   ((uint32_t)0x02000000) /* Write protection of Sector57 */  
-#define OB_WRP2_PAGES928TO943   ((uint32_t)0x04000000) /* Write protection of Sector58 */  
-#define OB_WRP2_PAGES944TO959   ((uint32_t)0x08000000) /* Write protection of Sector59 */  
-#define OB_WRP2_PAGES960TO975   ((uint32_t)0x10000000) /* Write protection of Sector60 */  
-#define OB_WRP2_PAGES976TO991   ((uint32_t)0x20000000) /* Write protection of Sector61 */  
-#define OB_WRP2_PAGES992TO1007  ((uint32_t)0x40000000) /* Write protection of Sector62 */
-#define OB_WRP2_PAGES1008TO1023 ((uint32_t)0x80000000U) /* Write protection of Sector63 */
+#define OB_WRP2_PAGES768TO783   (0x00010000U) /* Write protection of Sector48 */  
+#define OB_WRP2_PAGES784TO799   (0x00020000U) /* Write protection of Sector49 */  
+#define OB_WRP2_PAGES800TO815   (0x00040000U) /* Write protection of Sector50 */  
+#define OB_WRP2_PAGES816TO831   (0x00080000U) /* Write protection of Sector51 */  
+#define OB_WRP2_PAGES832TO847   (0x00100000U) /* Write protection of Sector52 */  
+#define OB_WRP2_PAGES848TO863   (0x00200000U) /* Write protection of Sector53 */  
+#define OB_WRP2_PAGES864TO879   (0x00400000U) /* Write protection of Sector54 */  
+#define OB_WRP2_PAGES880TO895   (0x00800000U) /* Write protection of Sector55 */  
+#define OB_WRP2_PAGES896TO911   (0x01000000U) /* Write protection of Sector56 */  
+#define OB_WRP2_PAGES912TO927   (0x02000000U) /* Write protection of Sector57 */  
+#define OB_WRP2_PAGES928TO943   (0x04000000U) /* Write protection of Sector58 */  
+#define OB_WRP2_PAGES944TO959   (0x08000000U) /* Write protection of Sector59 */  
+#define OB_WRP2_PAGES960TO975   (0x10000000U) /* Write protection of Sector60 */  
+#define OB_WRP2_PAGES976TO991   (0x20000000U) /* Write protection of Sector61 */  
+#define OB_WRP2_PAGES992TO1007  (0x40000000U) /* Write protection of Sector62 */
+#define OB_WRP2_PAGES1008TO1023 (0x80000000U) /* Write protection of Sector63 */
 
 #endif /* STM32L100xC || STM32L151xC || STM32L152xC || (...) || STM32L162xD || STM32L151xE || STM32L152xE || STM32L162xE */
       
@@ -465,38 +463,38 @@ typedef struct
   */
   
 /* Pages for devices with FLASH >= 256KB*/
-#define OB_WRP3_PAGES1024TO1039 ((uint32_t)0x00000001) /* Write protection of Sector64 */
-#define OB_WRP3_PAGES1040TO1055 ((uint32_t)0x00000002) /* Write protection of Sector65 */
-#define OB_WRP3_PAGES1056TO1071 ((uint32_t)0x00000004) /* Write protection of Sector66 */
-#define OB_WRP3_PAGES1072TO1087 ((uint32_t)0x00000008) /* Write protection of Sector67 */
-#define OB_WRP3_PAGES1088TO1103 ((uint32_t)0x00000010) /* Write protection of Sector68 */
-#define OB_WRP3_PAGES1104TO1119 ((uint32_t)0x00000020) /* Write protection of Sector69 */
-#define OB_WRP3_PAGES1120TO1135 ((uint32_t)0x00000040) /* Write protection of Sector70 */
-#define OB_WRP3_PAGES1136TO1151 ((uint32_t)0x00000080) /* Write protection of Sector71 */
-#define OB_WRP3_PAGES1152TO1167 ((uint32_t)0x00000100) /* Write protection of Sector72 */
-#define OB_WRP3_PAGES1168TO1183 ((uint32_t)0x00000200) /* Write protection of Sector73 */
-#define OB_WRP3_PAGES1184TO1199 ((uint32_t)0x00000400) /* Write protection of Sector74 */
-#define OB_WRP3_PAGES1200TO1215 ((uint32_t)0x00000800) /* Write protection of Sector75 */
-#define OB_WRP3_PAGES1216TO1231 ((uint32_t)0x00001000) /* Write protection of Sector76 */
-#define OB_WRP3_PAGES1232TO1247 ((uint32_t)0x00002000) /* Write protection of Sector77 */
-#define OB_WRP3_PAGES1248TO1263 ((uint32_t)0x00004000) /* Write protection of Sector78 */
-#define OB_WRP3_PAGES1264TO1279 ((uint32_t)0x00008000) /* Write protection of Sector79 */
-#define OB_WRP3_PAGES1280TO1295 ((uint32_t)0x00010000) /* Write protection of Sector80 */
-#define OB_WRP3_PAGES1296TO1311 ((uint32_t)0x00020000) /* Write protection of Sector81 */
-#define OB_WRP3_PAGES1312TO1327 ((uint32_t)0x00040000) /* Write protection of Sector82 */
-#define OB_WRP3_PAGES1328TO1343 ((uint32_t)0x00080000) /* Write protection of Sector83 */
-#define OB_WRP3_PAGES1344TO1359 ((uint32_t)0x00100000) /* Write protection of Sector84 */
-#define OB_WRP3_PAGES1360TO1375 ((uint32_t)0x00200000) /* Write protection of Sector85 */
-#define OB_WRP3_PAGES1376TO1391 ((uint32_t)0x00400000) /* Write protection of Sector86 */
-#define OB_WRP3_PAGES1392TO1407 ((uint32_t)0x00800000) /* Write protection of Sector87 */
-#define OB_WRP3_PAGES1408TO1423 ((uint32_t)0x01000000) /* Write protection of Sector88 */
-#define OB_WRP3_PAGES1424TO1439 ((uint32_t)0x02000000) /* Write protection of Sector89 */
-#define OB_WRP3_PAGES1440TO1455 ((uint32_t)0x04000000) /* Write protection of Sector90 */
-#define OB_WRP3_PAGES1456TO1471 ((uint32_t)0x08000000) /* Write protection of Sector91 */
-#define OB_WRP3_PAGES1472TO1487 ((uint32_t)0x10000000) /* Write protection of Sector92 */
-#define OB_WRP3_PAGES1488TO1503 ((uint32_t)0x20000000) /* Write protection of Sector93 */
-#define OB_WRP3_PAGES1504TO1519 ((uint32_t)0x40000000) /* Write protection of Sector94 */
-#define OB_WRP3_PAGES1520TO1535 ((uint32_t)0x80000000U) /* Write protection of Sector95 */
+#define OB_WRP3_PAGES1024TO1039 (0x00000001U) /* Write protection of Sector64 */
+#define OB_WRP3_PAGES1040TO1055 (0x00000002U) /* Write protection of Sector65 */
+#define OB_WRP3_PAGES1056TO1071 (0x00000004U) /* Write protection of Sector66 */
+#define OB_WRP3_PAGES1072TO1087 (0x00000008U) /* Write protection of Sector67 */
+#define OB_WRP3_PAGES1088TO1103 (0x00000010U) /* Write protection of Sector68 */
+#define OB_WRP3_PAGES1104TO1119 (0x00000020U) /* Write protection of Sector69 */
+#define OB_WRP3_PAGES1120TO1135 (0x00000040U) /* Write protection of Sector70 */
+#define OB_WRP3_PAGES1136TO1151 (0x00000080U) /* Write protection of Sector71 */
+#define OB_WRP3_PAGES1152TO1167 (0x00000100U) /* Write protection of Sector72 */
+#define OB_WRP3_PAGES1168TO1183 (0x00000200U) /* Write protection of Sector73 */
+#define OB_WRP3_PAGES1184TO1199 (0x00000400U) /* Write protection of Sector74 */
+#define OB_WRP3_PAGES1200TO1215 (0x00000800U) /* Write protection of Sector75 */
+#define OB_WRP3_PAGES1216TO1231 (0x00001000U) /* Write protection of Sector76 */
+#define OB_WRP3_PAGES1232TO1247 (0x00002000U) /* Write protection of Sector77 */
+#define OB_WRP3_PAGES1248TO1263 (0x00004000U) /* Write protection of Sector78 */
+#define OB_WRP3_PAGES1264TO1279 (0x00008000U) /* Write protection of Sector79 */
+#define OB_WRP3_PAGES1280TO1295 (0x00010000U) /* Write protection of Sector80 */
+#define OB_WRP3_PAGES1296TO1311 (0x00020000U) /* Write protection of Sector81 */
+#define OB_WRP3_PAGES1312TO1327 (0x00040000U) /* Write protection of Sector82 */
+#define OB_WRP3_PAGES1328TO1343 (0x00080000U) /* Write protection of Sector83 */
+#define OB_WRP3_PAGES1344TO1359 (0x00100000U) /* Write protection of Sector84 */
+#define OB_WRP3_PAGES1360TO1375 (0x00200000U) /* Write protection of Sector85 */
+#define OB_WRP3_PAGES1376TO1391 (0x00400000U) /* Write protection of Sector86 */
+#define OB_WRP3_PAGES1392TO1407 (0x00800000U) /* Write protection of Sector87 */
+#define OB_WRP3_PAGES1408TO1423 (0x01000000U) /* Write protection of Sector88 */
+#define OB_WRP3_PAGES1424TO1439 (0x02000000U) /* Write protection of Sector89 */
+#define OB_WRP3_PAGES1440TO1455 (0x04000000U) /* Write protection of Sector90 */
+#define OB_WRP3_PAGES1456TO1471 (0x08000000U) /* Write protection of Sector91 */
+#define OB_WRP3_PAGES1472TO1487 (0x10000000U) /* Write protection of Sector92 */
+#define OB_WRP3_PAGES1488TO1503 (0x20000000U) /* Write protection of Sector93 */
+#define OB_WRP3_PAGES1504TO1519 (0x40000000U) /* Write protection of Sector94 */
+#define OB_WRP3_PAGES1520TO1535 (0x80000000U) /* Write protection of Sector95 */
 
 #define OB_WRP3_ALLPAGES        ((uint32_t)FLASH_WRPR3_WRP) /*!< Write protection of all Sectors */
 
@@ -514,41 +512,41 @@ typedef struct
   */
   
 /* Pages for Cat5 devices*/
-#define OB_WRP4_PAGES1536TO1551 ((uint32_t)0x00000001)/* Write protection of Sector96*/   
-#define OB_WRP4_PAGES1552TO1567 ((uint32_t)0x00000002)/* Write protection of Sector97*/   
-#define OB_WRP4_PAGES1568TO1583 ((uint32_t)0x00000004)/* Write protection of Sector98*/   
-#define OB_WRP4_PAGES1584TO1599 ((uint32_t)0x00000008)/* Write protection of Sector99*/   
-#define OB_WRP4_PAGES1600TO1615 ((uint32_t)0x00000010) /* Write protection of Sector100*/ 
-#define OB_WRP4_PAGES1616TO1631 ((uint32_t)0x00000020) /* Write protection of Sector101*/ 
-#define OB_WRP4_PAGES1632TO1647 ((uint32_t)0x00000040) /* Write protection of Sector102*/ 
-#define OB_WRP4_PAGES1648TO1663 ((uint32_t)0x00000080) /* Write protection of Sector103*/ 
-#define OB_WRP4_PAGES1664TO1679 ((uint32_t)0x00000100) /* Write protection of Sector104*/ 
-#define OB_WRP4_PAGES1680TO1695 ((uint32_t)0x00000200) /* Write protection of Sector105*/ 
-#define OB_WRP4_PAGES1696TO1711 ((uint32_t)0x00000400) /* Write protection of Sector106*/ 
-#define OB_WRP4_PAGES1712TO1727 ((uint32_t)0x00000800) /* Write protection of Sector107*/ 
-#define OB_WRP4_PAGES1728TO1743 ((uint32_t)0x00001000) /* Write protection of Sector108*/ 
-#define OB_WRP4_PAGES1744TO1759 ((uint32_t)0x00002000) /* Write protection of Sector109*/ 
-#define OB_WRP4_PAGES1760TO1775 ((uint32_t)0x00004000) /* Write protection of Sector110*/ 
-#define OB_WRP4_PAGES1776TO1791 ((uint32_t)0x00008000) /* Write protection of Sector111*/ 
+#define OB_WRP4_PAGES1536TO1551 (0x00000001U)/* Write protection of Sector96*/   
+#define OB_WRP4_PAGES1552TO1567 (0x00000002U)/* Write protection of Sector97*/   
+#define OB_WRP4_PAGES1568TO1583 (0x00000004U)/* Write protection of Sector98*/   
+#define OB_WRP4_PAGES1584TO1599 (0x00000008U)/* Write protection of Sector99*/   
+#define OB_WRP4_PAGES1600TO1615 (0x00000010U) /* Write protection of Sector100*/ 
+#define OB_WRP4_PAGES1616TO1631 (0x00000020U) /* Write protection of Sector101*/ 
+#define OB_WRP4_PAGES1632TO1647 (0x00000040U) /* Write protection of Sector102*/ 
+#define OB_WRP4_PAGES1648TO1663 (0x00000080U) /* Write protection of Sector103*/ 
+#define OB_WRP4_PAGES1664TO1679 (0x00000100U) /* Write protection of Sector104*/ 
+#define OB_WRP4_PAGES1680TO1695 (0x00000200U) /* Write protection of Sector105*/ 
+#define OB_WRP4_PAGES1696TO1711 (0x00000400U) /* Write protection of Sector106*/ 
+#define OB_WRP4_PAGES1712TO1727 (0x00000800U) /* Write protection of Sector107*/ 
+#define OB_WRP4_PAGES1728TO1743 (0x00001000U) /* Write protection of Sector108*/ 
+#define OB_WRP4_PAGES1744TO1759 (0x00002000U) /* Write protection of Sector109*/ 
+#define OB_WRP4_PAGES1760TO1775 (0x00004000U) /* Write protection of Sector110*/ 
+#define OB_WRP4_PAGES1776TO1791 (0x00008000U) /* Write protection of Sector111*/ 
 
 #if defined(STM32L151xE) || defined(STM32L152xE) || defined(STM32L162xE)
 
-#define OB_WRP4_PAGES1792TO1807 ((uint32_t)0x00010000) /* Write protection of Sector112*/ 
-#define OB_WRP4_PAGES1808TO1823 ((uint32_t)0x00020000) /* Write protection of Sector113*/ 
-#define OB_WRP4_PAGES1824TO1839 ((uint32_t)0x00040000) /* Write protection of Sector114*/ 
-#define OB_WRP4_PAGES1840TO1855 ((uint32_t)0x00080000) /* Write protection of Sector115*/ 
-#define OB_WRP4_PAGES1856TO1871 ((uint32_t)0x00100000) /* Write protection of Sector116*/ 
-#define OB_WRP4_PAGES1872TO1887 ((uint32_t)0x00200000) /* Write protection of Sector117*/ 
-#define OB_WRP4_PAGES1888TO1903 ((uint32_t)0x00400000) /* Write protection of Sector118*/ 
-#define OB_WRP4_PAGES1904TO1919 ((uint32_t)0x00800000) /* Write protection of Sector119*/ 
-#define OB_WRP4_PAGES1920TO1935 ((uint32_t)0x01000000) /* Write protection of Sector120*/ 
-#define OB_WRP4_PAGES1936TO1951 ((uint32_t)0x02000000) /* Write protection of Sector121*/ 
-#define OB_WRP4_PAGES1952TO1967 ((uint32_t)0x04000000) /* Write protection of Sector122*/ 
-#define OB_WRP4_PAGES1968TO1983 ((uint32_t)0x08000000) /* Write protection of Sector123*/ 
-#define OB_WRP4_PAGES1984TO1999 ((uint32_t)0x10000000) /* Write protection of Sector124*/ 
-#define OB_WRP4_PAGES2000TO2015 ((uint32_t)0x20000000) /* Write protection of Sector125*/ 
-#define OB_WRP4_PAGES2016TO2031 ((uint32_t)0x40000000) /* Write protection of Sector126*/ 
-#define OB_WRP4_PAGES2032TO2047 ((uint32_t)0x80000000U) /* Write protection of Sector127*/ 
+#define OB_WRP4_PAGES1792TO1807 (0x00010000U) /* Write protection of Sector112*/ 
+#define OB_WRP4_PAGES1808TO1823 (0x00020000U) /* Write protection of Sector113*/ 
+#define OB_WRP4_PAGES1824TO1839 (0x00040000U) /* Write protection of Sector114*/ 
+#define OB_WRP4_PAGES1840TO1855 (0x00080000U) /* Write protection of Sector115*/ 
+#define OB_WRP4_PAGES1856TO1871 (0x00100000U) /* Write protection of Sector116*/ 
+#define OB_WRP4_PAGES1872TO1887 (0x00200000U) /* Write protection of Sector117*/ 
+#define OB_WRP4_PAGES1888TO1903 (0x00400000U) /* Write protection of Sector118*/ 
+#define OB_WRP4_PAGES1904TO1919 (0x00800000U) /* Write protection of Sector119*/ 
+#define OB_WRP4_PAGES1920TO1935 (0x01000000U) /* Write protection of Sector120*/ 
+#define OB_WRP4_PAGES1936TO1951 (0x02000000U) /* Write protection of Sector121*/ 
+#define OB_WRP4_PAGES1952TO1967 (0x04000000U) /* Write protection of Sector122*/ 
+#define OB_WRP4_PAGES1968TO1983 (0x08000000U) /* Write protection of Sector123*/ 
+#define OB_WRP4_PAGES1984TO1999 (0x10000000U) /* Write protection of Sector124*/ 
+#define OB_WRP4_PAGES2000TO2015 (0x20000000U) /* Write protection of Sector125*/ 
+#define OB_WRP4_PAGES2016TO2031 (0x40000000U) /* Write protection of Sector126*/ 
+#define OB_WRP4_PAGES2032TO2047 (0x80000000U) /* Write protection of Sector127*/ 
 
 #endif /* STM32L151xE || STM32L152xE || STM32L162xE */
 
@@ -626,7 +624,7 @@ typedef struct
   * @{
   */ 
   
-#define OPTIONBYTE_PCROP        ((uint32_t)0x01U)  /*!<PCROP option byte configuration*/
+#define OPTIONBYTE_PCROP        (0x01U)  /*!<PCROP option byte configuration*/
 
 /**
   * @}
@@ -640,7 +638,7 @@ typedef struct
   * @{
   */ 
   
-#define OPTIONBYTE_BOOTCONFIG   ((uint32_t)0x02U)  /*!<BOOTConfig option byte configuration*/
+#define OPTIONBYTE_BOOTCONFIG   (0x02U)  /*!<BOOTConfig option byte configuration*/
 
 /**
   * @}
@@ -653,8 +651,8 @@ typedef struct
 /** @defgroup  FLASHEx_PCROP_State FLASHEx PCROP State
   * @{
   */
-#define OB_PCROP_STATE_DISABLE        ((uint32_t)0x00U)  /*!<Disable PCROP for selected sectors */
-#define OB_PCROP_STATE_ENABLE         ((uint32_t)0x01U)  /*!<Enable PCROP for selected sectors */
+#define OB_PCROP_STATE_DISABLE        (0x00U)  /*!<Disable PCROP for selected sectors */
+#define OB_PCROP_STATE_ENABLE         (0x01U)  /*!<Enable PCROP for selected sectors */
     
 /**
   * @}
@@ -678,40 +676,40 @@ typedef struct
   */
   
 /* Common pages for Cat1, Cat2, Cat3, Cat4 & Cat5 devices */
-#define OB_PCROP1_PAGES0TO15    ((uint32_t)0x00000001U) /* PC Read/Write  protection of Sector0 */  
-#define OB_PCROP1_PAGES16TO31   ((uint32_t)0x00000002U) /* PC Read/Write  protection of Sector1 */  
-#define OB_PCROP1_PAGES32TO47   ((uint32_t)0x00000004U) /* PC Read/Write  protection of Sector2 */  
-#define OB_PCROP1_PAGES48TO63   ((uint32_t)0x00000008U) /* PC Read/Write  protection of Sector3 */  
-#define OB_PCROP1_PAGES64TO79   ((uint32_t)0x00000010U) /* PC Read/Write  protection of Sector4 */  
-#define OB_PCROP1_PAGES80TO95   ((uint32_t)0x00000020U) /* PC Read/Write  protection of Sector5 */  
-#define OB_PCROP1_PAGES96TO111  ((uint32_t)0x00000040U) /* PC Read/Write  protection of Sector6 */  
-#define OB_PCROP1_PAGES112TO127 ((uint32_t)0x00000080U) /* PC Read/Write  protection of Sector7 */  
-#define OB_PCROP1_PAGES128TO143 ((uint32_t)0x00000100U) /* PC Read/Write  protection of Sector8 */  
-#define OB_PCROP1_PAGES144TO159 ((uint32_t)0x00000200U) /* PC Read/Write  protection of Sector9 */  
-#define OB_PCROP1_PAGES160TO175 ((uint32_t)0x00000400U) /* PC Read/Write  protection of Sector10 */ 
-#define OB_PCROP1_PAGES176TO191 ((uint32_t)0x00000800U) /* PC Read/Write  protection of Sector11 */ 
-#define OB_PCROP1_PAGES192TO207 ((uint32_t)0x00001000U) /* PC Read/Write  protection of Sector12 */ 
-#define OB_PCROP1_PAGES208TO223 ((uint32_t)0x00002000U) /* PC Read/Write  protection of Sector13 */ 
-#define OB_PCROP1_PAGES224TO239 ((uint32_t)0x00004000U) /* PC Read/Write  protection of Sector14 */ 
-#define OB_PCROP1_PAGES240TO255 ((uint32_t)0x00008000U) /* PC Read/Write  protection of Sector15 */ 
-#define OB_PCROP1_PAGES256TO271 ((uint32_t)0x00010000U) /* PC Read/Write  protection of Sector16 */ 
-#define OB_PCROP1_PAGES272TO287 ((uint32_t)0x00020000U) /* PC Read/Write  protection of Sector17 */ 
-#define OB_PCROP1_PAGES288TO303 ((uint32_t)0x00040000U) /* PC Read/Write  protection of Sector18 */ 
-#define OB_PCROP1_PAGES304TO319 ((uint32_t)0x00080000U) /* PC Read/Write  protection of Sector19 */ 
-#define OB_PCROP1_PAGES320TO335 ((uint32_t)0x00100000U) /* PC Read/Write  protection of Sector20 */ 
-#define OB_PCROP1_PAGES336TO351 ((uint32_t)0x00200000U) /* PC Read/Write  protection of Sector21 */ 
-#define OB_PCROP1_PAGES352TO367 ((uint32_t)0x00400000U) /* PC Read/Write  protection of Sector22 */ 
-#define OB_PCROP1_PAGES368TO383 ((uint32_t)0x00800000U) /* PC Read/Write  protection of Sector23 */ 
-#define OB_PCROP1_PAGES384TO399 ((uint32_t)0x01000000U) /* PC Read/Write  protection of Sector24 */ 
-#define OB_PCROP1_PAGES400TO415 ((uint32_t)0x02000000U) /* PC Read/Write  protection of Sector25 */ 
-#define OB_PCROP1_PAGES416TO431 ((uint32_t)0x04000000U) /* PC Read/Write  protection of Sector26 */ 
-#define OB_PCROP1_PAGES432TO447 ((uint32_t)0x08000000U) /* PC Read/Write  protection of Sector27 */ 
-#define OB_PCROP1_PAGES448TO463 ((uint32_t)0x10000000U) /* PC Read/Write  protection of Sector28 */ 
-#define OB_PCROP1_PAGES464TO479 ((uint32_t)0x20000000U) /* PC Read/Write  protection of Sector29 */ 
-#define OB_PCROP1_PAGES480TO495 ((uint32_t)0x40000000U) /* PC Read/Write  protection of Sector30 */ 
-#define OB_PCROP1_PAGES496TO511 ((uint32_t)0x80000000U) /* PC Read/Write  protection of Sector31 */ 
+#define OB_PCROP1_PAGES0TO15    (0x00000001U) /* PC Read/Write  protection of Sector0 */  
+#define OB_PCROP1_PAGES16TO31   (0x00000002U) /* PC Read/Write  protection of Sector1 */  
+#define OB_PCROP1_PAGES32TO47   (0x00000004U) /* PC Read/Write  protection of Sector2 */  
+#define OB_PCROP1_PAGES48TO63   (0x00000008U) /* PC Read/Write  protection of Sector3 */  
+#define OB_PCROP1_PAGES64TO79   (0x00000010U) /* PC Read/Write  protection of Sector4 */  
+#define OB_PCROP1_PAGES80TO95   (0x00000020U) /* PC Read/Write  protection of Sector5 */  
+#define OB_PCROP1_PAGES96TO111  (0x00000040U) /* PC Read/Write  protection of Sector6 */  
+#define OB_PCROP1_PAGES112TO127 (0x00000080U) /* PC Read/Write  protection of Sector7 */  
+#define OB_PCROP1_PAGES128TO143 (0x00000100U) /* PC Read/Write  protection of Sector8 */  
+#define OB_PCROP1_PAGES144TO159 (0x00000200U) /* PC Read/Write  protection of Sector9 */  
+#define OB_PCROP1_PAGES160TO175 (0x00000400U) /* PC Read/Write  protection of Sector10 */ 
+#define OB_PCROP1_PAGES176TO191 (0x00000800U) /* PC Read/Write  protection of Sector11 */ 
+#define OB_PCROP1_PAGES192TO207 (0x00001000U) /* PC Read/Write  protection of Sector12 */ 
+#define OB_PCROP1_PAGES208TO223 (0x00002000U) /* PC Read/Write  protection of Sector13 */ 
+#define OB_PCROP1_PAGES224TO239 (0x00004000U) /* PC Read/Write  protection of Sector14 */ 
+#define OB_PCROP1_PAGES240TO255 (0x00008000U) /* PC Read/Write  protection of Sector15 */ 
+#define OB_PCROP1_PAGES256TO271 (0x00010000U) /* PC Read/Write  protection of Sector16 */ 
+#define OB_PCROP1_PAGES272TO287 (0x00020000U) /* PC Read/Write  protection of Sector17 */ 
+#define OB_PCROP1_PAGES288TO303 (0x00040000U) /* PC Read/Write  protection of Sector18 */ 
+#define OB_PCROP1_PAGES304TO319 (0x00080000U) /* PC Read/Write  protection of Sector19 */ 
+#define OB_PCROP1_PAGES320TO335 (0x00100000U) /* PC Read/Write  protection of Sector20 */ 
+#define OB_PCROP1_PAGES336TO351 (0x00200000U) /* PC Read/Write  protection of Sector21 */ 
+#define OB_PCROP1_PAGES352TO367 (0x00400000U) /* PC Read/Write  protection of Sector22 */ 
+#define OB_PCROP1_PAGES368TO383 (0x00800000U) /* PC Read/Write  protection of Sector23 */ 
+#define OB_PCROP1_PAGES384TO399 (0x01000000U) /* PC Read/Write  protection of Sector24 */ 
+#define OB_PCROP1_PAGES400TO415 (0x02000000U) /* PC Read/Write  protection of Sector25 */ 
+#define OB_PCROP1_PAGES416TO431 (0x04000000U) /* PC Read/Write  protection of Sector26 */ 
+#define OB_PCROP1_PAGES432TO447 (0x08000000U) /* PC Read/Write  protection of Sector27 */ 
+#define OB_PCROP1_PAGES448TO463 (0x10000000U) /* PC Read/Write  protection of Sector28 */ 
+#define OB_PCROP1_PAGES464TO479 (0x20000000U) /* PC Read/Write  protection of Sector29 */ 
+#define OB_PCROP1_PAGES480TO495 (0x40000000U) /* PC Read/Write  protection of Sector30 */ 
+#define OB_PCROP1_PAGES496TO511 (0x80000000U) /* PC Read/Write  protection of Sector31 */ 
   
-#define OB_PCROP1_ALLPAGES      ((uint32_t)0xFFFFFFFFU) /*!< PC Read/Write  protection of all Sectors */
+#define OB_PCROP1_ALLPAGES      (0xFFFFFFFFU) /*!< PC Read/Write  protection of all Sectors */
   
 /**
   * @}
@@ -725,40 +723,40 @@ typedef struct
   */
   
 /* Pages for Cat3, Cat4 & Cat5 devices*/
-#define OB_PCROP2_PAGES512TO527   ((uint32_t)0x00000001U) /* PC Read/Write  protection of Sector32 */  
-#define OB_PCROP2_PAGES528TO543   ((uint32_t)0x00000002U) /* PC Read/Write  protection of Sector33 */  
-#define OB_PCROP2_PAGES544TO559   ((uint32_t)0x00000004U) /* PC Read/Write  protection of Sector34 */  
-#define OB_PCROP2_PAGES560TO575   ((uint32_t)0x00000008U) /* PC Read/Write  protection of Sector35 */  
-#define OB_PCROP2_PAGES576TO591   ((uint32_t)0x00000010U) /* PC Read/Write  protection of Sector36 */  
-#define OB_PCROP2_PAGES592TO607   ((uint32_t)0x00000020U) /* PC Read/Write  protection of Sector37 */  
-#define OB_PCROP2_PAGES608TO623   ((uint32_t)0x00000040U) /* PC Read/Write  protection of Sector38 */  
-#define OB_PCROP2_PAGES624TO639   ((uint32_t)0x00000080U) /* PC Read/Write  protection of Sector39 */  
-#define OB_PCROP2_PAGES640TO655   ((uint32_t)0x00000100U) /* PC Read/Write  protection of Sector40 */  
-#define OB_PCROP2_PAGES656TO671   ((uint32_t)0x00000200U) /* PC Read/Write  protection of Sector41 */  
-#define OB_PCROP2_PAGES672TO687   ((uint32_t)0x00000400U) /* PC Read/Write  protection of Sector42 */  
-#define OB_PCROP2_PAGES688TO703   ((uint32_t)0x00000800U) /* PC Read/Write  protection of Sector43 */  
-#define OB_PCROP2_PAGES704TO719   ((uint32_t)0x00001000U) /* PC Read/Write  protection of Sector44 */  
-#define OB_PCROP2_PAGES720TO735   ((uint32_t)0x00002000U) /* PC Read/Write  protection of Sector45 */  
-#define OB_PCROP2_PAGES736TO751   ((uint32_t)0x00004000U) /* PC Read/Write  protection of Sector46 */  
-#define OB_PCROP2_PAGES752TO767   ((uint32_t)0x00008000U) /* PC Read/Write  protection of Sector47 */  
-#define OB_PCROP2_PAGES768TO783   ((uint32_t)0x00010000U) /* PC Read/Write  protection of Sector48 */  
-#define OB_PCROP2_PAGES784TO799   ((uint32_t)0x00020000U) /* PC Read/Write  protection of Sector49 */  
-#define OB_PCROP2_PAGES800TO815   ((uint32_t)0x00040000U) /* PC Read/Write  protection of Sector50 */  
-#define OB_PCROP2_PAGES816TO831   ((uint32_t)0x00080000U) /* PC Read/Write  protection of Sector51 */  
-#define OB_PCROP2_PAGES832TO847   ((uint32_t)0x00100000U) /* PC Read/Write  protection of Sector52 */  
-#define OB_PCROP2_PAGES848TO863   ((uint32_t)0x00200000U) /* PC Read/Write  protection of Sector53 */  
-#define OB_PCROP2_PAGES864TO879   ((uint32_t)0x00400000U) /* PC Read/Write  protection of Sector54 */  
-#define OB_PCROP2_PAGES880TO895   ((uint32_t)0x00800000U) /* PC Read/Write  protection of Sector55 */  
-#define OB_PCROP2_PAGES896TO911   ((uint32_t)0x01000000U) /* PC Read/Write  protection of Sector56 */  
-#define OB_PCROP2_PAGES912TO927   ((uint32_t)0x02000000U) /* PC Read/Write  protection of Sector57 */  
-#define OB_PCROP2_PAGES928TO943   ((uint32_t)0x04000000U) /* PC Read/Write  protection of Sector58 */  
-#define OB_PCROP2_PAGES944TO959   ((uint32_t)0x08000000U) /* PC Read/Write  protection of Sector59 */  
-#define OB_PCROP2_PAGES960TO975   ((uint32_t)0x10000000U) /* PC Read/Write  protection of Sector60 */  
-#define OB_PCROP2_PAGES976TO991   ((uint32_t)0x20000000U) /* PC Read/Write  protection of Sector61 */  
-#define OB_PCROP2_PAGES992TO1007  ((uint32_t)0x40000000U) /* PC Read/Write  protection of Sector62 */
-#define OB_PCROP2_PAGES1008TO1023 ((uint32_t)0x80000000U) /* PC Read/Write  protection of Sector63 */
+#define OB_PCROP2_PAGES512TO527   (0x00000001U) /* PC Read/Write  protection of Sector32 */  
+#define OB_PCROP2_PAGES528TO543   (0x00000002U) /* PC Read/Write  protection of Sector33 */  
+#define OB_PCROP2_PAGES544TO559   (0x00000004U) /* PC Read/Write  protection of Sector34 */  
+#define OB_PCROP2_PAGES560TO575   (0x00000008U) /* PC Read/Write  protection of Sector35 */  
+#define OB_PCROP2_PAGES576TO591   (0x00000010U) /* PC Read/Write  protection of Sector36 */  
+#define OB_PCROP2_PAGES592TO607   (0x00000020U) /* PC Read/Write  protection of Sector37 */  
+#define OB_PCROP2_PAGES608TO623   (0x00000040U) /* PC Read/Write  protection of Sector38 */  
+#define OB_PCROP2_PAGES624TO639   (0x00000080U) /* PC Read/Write  protection of Sector39 */  
+#define OB_PCROP2_PAGES640TO655   (0x00000100U) /* PC Read/Write  protection of Sector40 */  
+#define OB_PCROP2_PAGES656TO671   (0x00000200U) /* PC Read/Write  protection of Sector41 */  
+#define OB_PCROP2_PAGES672TO687   (0x00000400U) /* PC Read/Write  protection of Sector42 */  
+#define OB_PCROP2_PAGES688TO703   (0x00000800U) /* PC Read/Write  protection of Sector43 */  
+#define OB_PCROP2_PAGES704TO719   (0x00001000U) /* PC Read/Write  protection of Sector44 */  
+#define OB_PCROP2_PAGES720TO735   (0x00002000U) /* PC Read/Write  protection of Sector45 */  
+#define OB_PCROP2_PAGES736TO751   (0x00004000U) /* PC Read/Write  protection of Sector46 */  
+#define OB_PCROP2_PAGES752TO767   (0x00008000U) /* PC Read/Write  protection of Sector47 */  
+#define OB_PCROP2_PAGES768TO783   (0x00010000U) /* PC Read/Write  protection of Sector48 */  
+#define OB_PCROP2_PAGES784TO799   (0x00020000U) /* PC Read/Write  protection of Sector49 */  
+#define OB_PCROP2_PAGES800TO815   (0x00040000U) /* PC Read/Write  protection of Sector50 */  
+#define OB_PCROP2_PAGES816TO831   (0x00080000U) /* PC Read/Write  protection of Sector51 */  
+#define OB_PCROP2_PAGES832TO847   (0x00100000U) /* PC Read/Write  protection of Sector52 */  
+#define OB_PCROP2_PAGES848TO863   (0x00200000U) /* PC Read/Write  protection of Sector53 */  
+#define OB_PCROP2_PAGES864TO879   (0x00400000U) /* PC Read/Write  protection of Sector54 */  
+#define OB_PCROP2_PAGES880TO895   (0x00800000U) /* PC Read/Write  protection of Sector55 */  
+#define OB_PCROP2_PAGES896TO911   (0x01000000U) /* PC Read/Write  protection of Sector56 */  
+#define OB_PCROP2_PAGES912TO927   (0x02000000U) /* PC Read/Write  protection of Sector57 */  
+#define OB_PCROP2_PAGES928TO943   (0x04000000U) /* PC Read/Write  protection of Sector58 */  
+#define OB_PCROP2_PAGES944TO959   (0x08000000U) /* PC Read/Write  protection of Sector59 */  
+#define OB_PCROP2_PAGES960TO975   (0x10000000U) /* PC Read/Write  protection of Sector60 */  
+#define OB_PCROP2_PAGES976TO991   (0x20000000U) /* PC Read/Write  protection of Sector61 */  
+#define OB_PCROP2_PAGES992TO1007  (0x40000000U) /* PC Read/Write  protection of Sector62 */
+#define OB_PCROP2_PAGES1008TO1023 (0x80000000U) /* PC Read/Write  protection of Sector63 */
 
-#define OB_PCROP2_ALLPAGES        ((uint32_t)0xFFFFFFFFU) /*!< PC Read/Write  protection of all Sectors */
+#define OB_PCROP2_ALLPAGES        (0xFFFFFFFFU) /*!< PC Read/Write  protection of all Sectors */
 
 /**
   * @}
@@ -768,9 +766,9 @@ typedef struct
 /** @defgroup FLASHEx_Type_Erase_Data FLASHEx Type Erase Data
   * @{
   */
-#define FLASH_TYPEERASEDATA_BYTE            ((uint32_t)0x00U)  /*!<Erase byte (8-bit) at a specified address.*/
-#define FLASH_TYPEERASEDATA_HALFWORD        ((uint32_t)0x01U)  /*!<Erase a half-word (16-bit) at a specified address.*/
-#define FLASH_TYPEERASEDATA_WORD            ((uint32_t)0x02U)  /*!<Erase a word (32-bit) at a specified address.*/
+#define FLASH_TYPEERASEDATA_BYTE            (0x00U)  /*!<Erase byte (8-bit) at a specified address.*/
+#define FLASH_TYPEERASEDATA_HALFWORD        (0x01U)  /*!<Erase a half-word (16-bit) at a specified address.*/
+#define FLASH_TYPEERASEDATA_WORD            (0x02U)  /*!<Erase a word (32-bit) at a specified address.*/
 
 /**
   * @}
@@ -779,12 +777,12 @@ typedef struct
 /** @defgroup FLASHEx_Type_Program_Data FLASHEx Type Program Data
   * @{
   */
-#define FLASH_TYPEPROGRAMDATA_BYTE            ((uint32_t)0x00U)  /*!<Program byte (8-bit) at a specified address.*/
-#define FLASH_TYPEPROGRAMDATA_HALFWORD        ((uint32_t)0x01U)  /*!<Program a half-word (16-bit) at a specified address.*/
-#define FLASH_TYPEPROGRAMDATA_WORD            ((uint32_t)0x02U)  /*!<Program a word (32-bit) at a specified address.*/
-#define FLASH_TYPEPROGRAMDATA_FASTBYTE        ((uint32_t)0x04U)  /*!<Fast Program byte (8-bit) at a specified address.*/
-#define FLASH_TYPEPROGRAMDATA_FASTHALFWORD    ((uint32_t)0x08U)  /*!<Fast Program a half-word (16-bit) at a specified address.*/
-#define FLASH_TYPEPROGRAMDATA_FASTWORD        ((uint32_t)0x10U)  /*!<Fast Program a word (32-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_BYTE            (0x00U)  /*!<Program byte (8-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_HALFWORD        (0x01U)  /*!<Program a half-word (16-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_WORD            (0x02U)  /*!<Program a word (32-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_FASTBYTE        (0x04U)  /*!<Fast Program byte (8-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_FASTHALFWORD    (0x08U)  /*!<Fast Program a half-word (16-bit) at a specified address.*/
+#define FLASH_TYPEPROGRAMDATA_FASTWORD        (0x10U)  /*!<Fast Program a word (32-bit) at a specified address.*/
 
 /**
   * @}
@@ -799,7 +797,7 @@ typedef struct
 #define OB_BOOT_BANK2                 ((uint8_t)0x00U) /*!< At startup, if boot pins are set in boot from user Flash position
                                                             and this parameter is selected the device will boot from Bank 2 
                                                             or Bank 1, depending on the activation of the bank */
-#define OB_BOOT_BANK1                 ((uint8_t)(FLASH_OBR_nRST_BFB2 >> 16)) /*!< At startup, if boot pins are set in boot from user Flash position
+#define OB_BOOT_BANK1                 ((uint8_t)(FLASH_OBR_nRST_BFB2 >> 16U)) /*!< At startup, if boot pins are set in boot from user Flash position
                                                             and this parameter is selected the device will boot from Bank1(Default) */
 
 /**
@@ -828,7 +826,7 @@ typedef struct
 #define __HAL_FLASH_SET_LATENCY(__LATENCY__)  do  { \
                                                   if ((__LATENCY__) == FLASH_LATENCY_1) {__HAL_FLASH_ACC64_ENABLE();} \
                                                   MODIFY_REG((FLASH->ACR), FLASH_ACR_LATENCY, (__LATENCY__)); \
-                                              } while(0)
+                                              } while(0U)
 
 /**
   * @brief  Get the FLASH Latency.
@@ -863,7 +861,7 @@ typedef struct
   */ 
 #define __HAL_FLASH_PREFETCH_BUFFER_ENABLE()    do  { __HAL_FLASH_ACC64_ENABLE(); \
                                                   SET_BIT((FLASH->ACR), FLASH_ACR_PRFTEN); \
-                                                } while(0)
+                                                } while(0U)
 
 /**
   * @brief  Disable the FLASH prefetch buffer.
@@ -891,7 +889,7 @@ typedef struct
 #define __HAL_FLASH_POWER_DOWN_ENABLE() do { FLASH->PDKEYR = FLASH_PDKEY1;    \
                                              FLASH->PDKEYR = FLASH_PDKEY2;    \
                                              SET_BIT((FLASH->ACR), FLASH_ACR_RUN_PD);  \
-                                           } while (0)
+                                           } while (0U)
 
 /**
   * @brief  Disable the Flash Run power down mode.
@@ -901,7 +899,7 @@ typedef struct
 #define __HAL_FLASH_POWER_DOWN_DISABLE() do { FLASH->PDKEYR = FLASH_PDKEY1;    \
                                               FLASH->PDKEYR = FLASH_PDKEY2;    \
                                              CLEAR_BIT((FLASH->ACR), FLASH_ACR_RUN_PD);  \
-                                            } while (0)
+                                            } while (0U)
                                             
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ramfunc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ramfunc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_flash_ramfunc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   FLASH RAMFUNC driver.
   *          This file provides a Flash firmware functions which should be 
   *          executed from internal SRAM
@@ -32,7 +30,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -195,9 +193,9 @@ __RAM_FUNC HAL_FLASHEx_EraseParallelPage(uint32_t Page_Address1, uint32_t Page_A
     SET_BIT(FLASH->PECR, FLASH_PECR_PROG);
   
     /* Write 00000000h to the first word of the first program page to erase */
-    *(__IO uint32_t *)Page_Address1 = 0x00000000;
+    *(__IO uint32_t *)Page_Address1 = 0x00000000U;
     /* Write 00000000h to the first word of the second program page to erase */    
-    *(__IO uint32_t *)Page_Address2 = 0x00000000;    
+    *(__IO uint32_t *)Page_Address2 = 0x00000000U;
  
     /* Wait for last operation to be completed */
     status = FLASHRAM_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
@@ -243,10 +241,10 @@ __RAM_FUNC HAL_FLASHEx_EraseParallelPage(uint32_t Page_Address1, uint32_t Page_A
   */
 __RAM_FUNC HAL_FLASHEx_ProgramParallelHalfPage(uint32_t Address1, uint32_t* pBuffer1, uint32_t Address2, uint32_t* pBuffer2)
 {
-  uint32_t count = 0; 
+  uint32_t count = 0U; 
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008) 
+  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008U) 
      This bit prevents the interruption of multicycle instructions and therefore 
      will increase the interrupt latency. of Cortex-M3. */
   SET_BIT(SCnSCB->ACTLR, SCnSCB_ACTLR_DISMCYCINT_Msk);
@@ -269,7 +267,7 @@ __RAM_FUNC HAL_FLASHEx_ProgramParallelHalfPage(uint32_t Address1, uint32_t* pBuf
       __disable_irq();
 
       /* Write the first half page directly with 32 different words */
-      while(count < 32)
+      while(count < 32U)
       {
         *(__IO uint32_t*) ((uint32_t)(Address1 + (4 * count))) = *pBuffer1;
         pBuffer1++;
@@ -277,8 +275,8 @@ __RAM_FUNC HAL_FLASHEx_ProgramParallelHalfPage(uint32_t Address1, uint32_t* pBuf
       }
 
       /* Write the second half page directly with 32 different words */
-      count = 0;
-      while(count < 32)
+      count = 0U;
+      while(count < 32U)
       {
         *(__IO uint32_t*) ((uint32_t)(Address2 + (4 * count))) = *pBuffer2;
         pBuffer2++;
@@ -331,10 +329,10 @@ __RAM_FUNC HAL_FLASHEx_ProgramParallelHalfPage(uint32_t Address1, uint32_t* pBuf
   */
 __RAM_FUNC HAL_FLASHEx_HalfPageProgram(uint32_t Address, uint32_t* pBuffer)
 {
-  uint32_t count = 0; 
+  uint32_t count = 0U; 
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008) 
+  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008U) 
      This bit prevents the interruption of multicycle instructions and therefore 
      will increase the interrupt latency. of Cortex-M3. */
   SET_BIT(SCnSCB->ACTLR, SCnSCB_ACTLR_DISMCYCINT_Msk);
@@ -352,18 +350,18 @@ __RAM_FUNC HAL_FLASHEx_HalfPageProgram(uint32_t Address, uint32_t* pBuffer)
     __disable_irq();
 
     /* Write one half page directly with 32 different words */
-    while(count < 32)
+    while(count < 32U)
     {
       *(__IO uint32_t*) ((uint32_t)(Address + (4 * count))) = *pBuffer;
       pBuffer++;
       count ++;  
     }
 
-    /* Enable IRQs */
-    __enable_irq();
-
     /* Wait for last operation to be completed */
     status = FLASHRAM_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
+
+    /* Enable IRQs */
+    __enable_irq();
  
     /* If the write operation is completed, disable the PROG and FPRG bits */
     CLEAR_BIT(FLASH->PECR, FLASH_PECR_PROG);
@@ -462,7 +460,7 @@ __RAM_FUNC HAL_FLASHEx_DATAEEPROM_EraseDoubleWord(uint32_t Address)
 {
   HAL_StatusTypeDef status = HAL_OK;
   
-  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008) 
+  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008U) 
      This bit prevents the interruption of multicycle instructions and therefore 
      will increase the interrupt latency. of Cortex-M3. */
   SET_BIT(SCnSCB->ACTLR, SCnSCB_ACTLR_DISMCYCINT_Msk);
@@ -480,9 +478,9 @@ __RAM_FUNC HAL_FLASHEx_DATAEEPROM_EraseDoubleWord(uint32_t Address)
     SET_BIT(FLASH->PECR, FLASH_PECR_DATA);
    
     /* Write 00000000h to the 2 words to erase */
-    *(__IO uint32_t *)Address = 0x00000000;
-    Address += 4;
-    *(__IO uint32_t *)Address = 0x00000000;
+    *(__IO uint32_t *)Address = 0x00000000U;
+    Address += 4U;
+    *(__IO uint32_t *)Address = 0x00000000U;
    
     /* Wait for last operation to be completed */
     status = FLASHRAM_WaitForLastOperation(FLASH_TIMEOUT_VALUE);
@@ -520,7 +518,7 @@ __RAM_FUNC HAL_FLASHEx_DATAEEPROM_ProgramDoubleWord(uint32_t Address, uint64_t D
 {
   HAL_StatusTypeDef status = HAL_OK;
 
-  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008) 
+  /* Set the DISMCYCINT[0] bit in the Auxillary Control Register (0xE000E008U) 
      This bit prevents the interruption of multicycle instructions and therefore 
      will increase the interrupt latency. of Cortex-M3. */
   SET_BIT(SCnSCB->ACTLR, SCnSCB_ACTLR_DISMCYCINT_Msk);
@@ -536,7 +534,7 @@ __RAM_FUNC HAL_FLASHEx_DATAEEPROM_ProgramDoubleWord(uint32_t Address, uint64_t D
     
     /* Write the 2 words */  
      *(__IO uint32_t *)Address = (uint32_t) Data;
-     Address += 4;
+     Address += 4U;
      *(__IO uint32_t *)Address = (uint32_t) (Data >> 32);
     
     /* Wait for last operation to be completed */
@@ -571,7 +569,7 @@ __RAM_FUNC HAL_FLASHEx_DATAEEPROM_ProgramDoubleWord(uint32_t Address, uint64_t D
   */
 static __RAM_FUNC FLASHRAM_SetErrorCode(void)
 {
-  uint32_t flags = 0;
+  uint32_t flags = 0U;
   
   if(__HAL_FLASH_GET_FLAG(FLASH_FLAG_WRPERR))
   {
@@ -621,12 +619,12 @@ static __RAM_FUNC  FLASHRAM_WaitForLastOperation(uint32_t Timeout)
        Even if the FLASH operation fails, the BUSY flag will be reset and an error
        flag will be set */
        
-    while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) && (Timeout != 0x00)) 
+    while(__HAL_FLASH_GET_FLAG(FLASH_FLAG_BSY) && (Timeout != 0x00U)) 
     { 
       Timeout--;
     }
     
-    if(Timeout == 0x00 )
+    if(Timeout == 0x00U)
     {
       return HAL_TIMEOUT;
     }

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ramfunc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_flash_ramfunc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_flash_ramfunc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of FLASH RAMFUNC driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_gpio.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   GPIO HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the General Purpose Input/Output (GPIO) peripheral:
@@ -105,7 +103,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -151,15 +149,15 @@
 /** @addtogroup GPIO_Private_Constants
   * @{
   */
-#define GPIO_MODE             ((uint32_t)0x00000003)
-#define EXTI_MODE             ((uint32_t)0x10000000)
-#define GPIO_MODE_IT          ((uint32_t)0x00010000)
-#define GPIO_MODE_EVT         ((uint32_t)0x00020000)
-#define RISING_EDGE           ((uint32_t)0x00100000)
-#define FALLING_EDGE          ((uint32_t)0x00200000)
-#define GPIO_OUTPUT_TYPE      ((uint32_t)0x00000010)
+#define GPIO_MODE             (0x00000003U)
+#define EXTI_MODE             (0x10000000U)
+#define GPIO_MODE_IT          (0x00010000U)
+#define GPIO_MODE_EVT         (0x00020000U)
+#define RISING_EDGE           (0x00100000U)
+#define FALLING_EDGE          (0x00200000U)
+#define GPIO_OUTPUT_TYPE      (0x00000010U)
 
-#define GPIO_NUMBER           ((uint32_t)16)
+#define GPIO_NUMBER           (16U)
  
 /**
   * @}
@@ -209,7 +207,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
   while (((GPIO_Init->Pin) >> position) != 0)
   {
     /* Get current io position */
-    iocurrent = (GPIO_Init->Pin) & ((uint32_t)1 << position);
+    iocurrent = (GPIO_Init->Pin) & (1U << position);
     
     if(iocurrent)
     {
@@ -224,8 +222,8 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         /* Configure Alternate function mapped with the current IO */ 
         /* Identify AFRL or AFRH register based on IO position*/
         temp = GPIOx->AFR[position >> 3];
-        CLEAR_BIT(temp, (uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;      
-        SET_BIT(temp, (uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & (uint32_t)0x07) * 4));       
+        CLEAR_BIT(temp, 0xFU << ((uint32_t)(position & 0x07U) * 4)) ;      
+        SET_BIT(temp, (uint32_t)(GPIO_Init->Alternate) << (((uint32_t)position & 0x07U) * 4));       
         GPIOx->AFR[position >> 3] = temp;
       }
 
@@ -268,7 +266,7 @@ void HAL_GPIO_Init(GPIO_TypeDef  *GPIOx, GPIO_InitTypeDef *GPIO_Init)
         __HAL_RCC_SYSCFG_CLK_ENABLE();
         
         temp = SYSCFG->EXTICR[position >> 2];
-        CLEAR_BIT(temp, ((uint32_t)0x0F) << (4 * (position & 0x03)));
+        CLEAR_BIT(temp, (0x0FU) << (4 * (position & 0x03)));
         SET_BIT(temp, (GPIO_GET_INDEX(GPIOx)) << (4 * (position & 0x03)));
         SYSCFG->EXTICR[position >> 2] = temp;
                   
@@ -333,7 +331,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
   while ((GPIO_Pin >> position) != 0)
   {
     /* Get current io position */
-    iocurrent = (GPIO_Pin) & ((uint32_t)1 << position);
+    iocurrent = (GPIO_Pin) & (1U << position);
 
     if (iocurrent)
     {
@@ -342,7 +340,7 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
       CLEAR_BIT(GPIOx->MODER, GPIO_MODER_MODER0 << (position * 2)); 
   
       /* Configure the default Alternate Function in current IO */ 
-      CLEAR_BIT(GPIOx->AFR[position >> 3], (uint32_t)0xF << ((uint32_t)(position & (uint32_t)0x07) * 4)) ;
+      CLEAR_BIT(GPIOx->AFR[position >> 3], 0xFU << ((uint32_t)(position & 0x07U) * 4)) ;
   
       /* Configure the default value for IO Speed */
       CLEAR_BIT(GPIOx->OSPEEDR, GPIO_OSPEEDER_OSPEEDR0 << (position * 2));
@@ -357,10 +355,10 @@ void HAL_GPIO_DeInit(GPIO_TypeDef  *GPIOx, uint32_t GPIO_Pin)
       /* Clear the External Interrupt or Event for the current IO */
       
       tmp = SYSCFG->EXTICR[position >> 2];
-      tmp &= (((uint32_t)0x0F) << (4 * (position & 0x03)));
+      tmp &= ((0x0FU) << (4 * (position & 0x03)));
       if(tmp == (GPIO_GET_INDEX(GPIOx) << (4 * (position & 0x03))))
       {
-        tmp = ((uint32_t)0x0F) << (4 * (position & 0x03));
+        tmp = (0x0FU) << (4 * (position & 0x03));
         CLEAR_BIT(SYSCFG->EXTICR[position >> 2], tmp);
         
         /* Clear EXTI line configuration */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_gpio.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of GPIO HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -103,25 +101,25 @@ typedef enum
 /** @defgroup GPIO_pins GPIO pins
   * @{
   */
-#define GPIO_PIN_0                 ((uint16_t)0x0001)  /* Pin 0 selected    */
-#define GPIO_PIN_1                 ((uint16_t)0x0002)  /* Pin 1 selected    */
-#define GPIO_PIN_2                 ((uint16_t)0x0004)  /* Pin 2 selected    */
-#define GPIO_PIN_3                 ((uint16_t)0x0008)  /* Pin 3 selected    */
-#define GPIO_PIN_4                 ((uint16_t)0x0010)  /* Pin 4 selected    */
-#define GPIO_PIN_5                 ((uint16_t)0x0020)  /* Pin 5 selected    */
-#define GPIO_PIN_6                 ((uint16_t)0x0040)  /* Pin 6 selected    */
-#define GPIO_PIN_7                 ((uint16_t)0x0080)  /* Pin 7 selected    */
-#define GPIO_PIN_8                 ((uint16_t)0x0100)  /* Pin 8 selected    */
-#define GPIO_PIN_9                 ((uint16_t)0x0200)  /* Pin 9 selected    */
-#define GPIO_PIN_10                ((uint16_t)0x0400)  /* Pin 10 selected   */
-#define GPIO_PIN_11                ((uint16_t)0x0800)  /* Pin 11 selected   */
-#define GPIO_PIN_12                ((uint16_t)0x1000)  /* Pin 12 selected   */
-#define GPIO_PIN_13                ((uint16_t)0x2000)  /* Pin 13 selected   */
-#define GPIO_PIN_14                ((uint16_t)0x4000)  /* Pin 14 selected   */
-#define GPIO_PIN_15                ((uint16_t)0x8000)  /* Pin 15 selected   */
-#define GPIO_PIN_All               ((uint16_t)0xFFFF)  /* All pins selected */
+#define GPIO_PIN_0                 ((uint16_t)0x0001U)  /* Pin 0 selected    */
+#define GPIO_PIN_1                 ((uint16_t)0x0002U)  /* Pin 1 selected    */
+#define GPIO_PIN_2                 ((uint16_t)0x0004U)  /* Pin 2 selected    */
+#define GPIO_PIN_3                 ((uint16_t)0x0008U)  /* Pin 3 selected    */
+#define GPIO_PIN_4                 ((uint16_t)0x0010U)  /* Pin 4 selected    */
+#define GPIO_PIN_5                 ((uint16_t)0x0020U)  /* Pin 5 selected    */
+#define GPIO_PIN_6                 ((uint16_t)0x0040U)  /* Pin 6 selected    */
+#define GPIO_PIN_7                 ((uint16_t)0x0080U)  /* Pin 7 selected    */
+#define GPIO_PIN_8                 ((uint16_t)0x0100U)  /* Pin 8 selected    */
+#define GPIO_PIN_9                 ((uint16_t)0x0200U)  /* Pin 9 selected    */
+#define GPIO_PIN_10                ((uint16_t)0x0400U)  /* Pin 10 selected   */
+#define GPIO_PIN_11                ((uint16_t)0x0800U)  /* Pin 11 selected   */
+#define GPIO_PIN_12                ((uint16_t)0x1000U)  /* Pin 12 selected   */
+#define GPIO_PIN_13                ((uint16_t)0x2000U)  /* Pin 13 selected   */
+#define GPIO_PIN_14                ((uint16_t)0x4000U)  /* Pin 14 selected   */
+#define GPIO_PIN_15                ((uint16_t)0x8000U)  /* Pin 15 selected   */
+#define GPIO_PIN_All               ((uint16_t)0xFFFFU)  /* All pins selected */
 
-#define GPIO_PIN_MASK              ((uint32_t)0x0000FFFF) /* PIN mask for assert test */
+#define GPIO_PIN_MASK              (0x0000FFFFU) /* PIN mask for assert test */
 /**
   * @}
   */
@@ -136,21 +134,21 @@ typedef enum
   *           - Z  : IO Direction mode (Input, Output, Alternate or Analog)
   * @{
   */ 
-#define  GPIO_MODE_INPUT                        ((uint32_t)0x00000000)   /*!< Input Floating Mode                   */
-#define  GPIO_MODE_OUTPUT_PP                    ((uint32_t)0x00000001)   /*!< Output Push Pull Mode                 */
-#define  GPIO_MODE_OUTPUT_OD                    ((uint32_t)0x00000011)   /*!< Output Open Drain Mode                */
-#define  GPIO_MODE_AF_PP                        ((uint32_t)0x00000002)   /*!< Alternate Function Push Pull Mode     */
-#define  GPIO_MODE_AF_OD                        ((uint32_t)0x00000012)   /*!< Alternate Function Open Drain Mode    */
+#define  GPIO_MODE_INPUT                        (0x00000000U)   /*!< Input Floating Mode                   */
+#define  GPIO_MODE_OUTPUT_PP                    (0x00000001U)   /*!< Output Push Pull Mode                 */
+#define  GPIO_MODE_OUTPUT_OD                    (0x00000011U)   /*!< Output Open Drain Mode                */
+#define  GPIO_MODE_AF_PP                        (0x00000002U)   /*!< Alternate Function Push Pull Mode     */
+#define  GPIO_MODE_AF_OD                        (0x00000012U)   /*!< Alternate Function Open Drain Mode    */
 
-#define  GPIO_MODE_ANALOG                       ((uint32_t)0x00000003)   /*!< Analog Mode  */
+#define  GPIO_MODE_ANALOG                       (0x00000003U)   /*!< Analog Mode  */
     
-#define  GPIO_MODE_IT_RISING                    ((uint32_t)0x10110000)   /*!< External Interrupt Mode with Rising edge trigger detection          */
-#define  GPIO_MODE_IT_FALLING                   ((uint32_t)0x10210000)   /*!< External Interrupt Mode with Falling edge trigger detection         */
-#define  GPIO_MODE_IT_RISING_FALLING            ((uint32_t)0x10310000)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
+#define  GPIO_MODE_IT_RISING                    (0x10110000U)   /*!< External Interrupt Mode with Rising edge trigger detection          */
+#define  GPIO_MODE_IT_FALLING                   (0x10210000U)   /*!< External Interrupt Mode with Falling edge trigger detection         */
+#define  GPIO_MODE_IT_RISING_FALLING            (0x10310000U)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection  */
 
-#define  GPIO_MODE_EVT_RISING                   ((uint32_t)0x10120000)   /*!< External Event Mode with Rising edge trigger detection               */
-#define  GPIO_MODE_EVT_FALLING                  ((uint32_t)0x10220000)   /*!< External Event Mode with Falling edge trigger detection              */
-#define  GPIO_MODE_EVT_RISING_FALLING           ((uint32_t)0x10320000)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
+#define  GPIO_MODE_EVT_RISING                   (0x10120000U)   /*!< External Event Mode with Rising edge trigger detection               */
+#define  GPIO_MODE_EVT_FALLING                  (0x10220000U)   /*!< External Event Mode with Falling edge trigger detection              */
+#define  GPIO_MODE_EVT_RISING_FALLING           (0x10320000U)   /*!< External Event Mode with Rising/Falling edge trigger detection       */
 
 /**
   * @}
@@ -160,10 +158,10 @@ typedef enum
   * @brief GPIO Output Maximum frequency
   * @{
   */  
-#define  GPIO_SPEED_FREQ_LOW       ((uint32_t)0x00000000) /*!< max: 400 KHz, please refer to the product datasheet */
-#define  GPIO_SPEED_FREQ_MEDIUM    ((uint32_t)0x00000001) /*!< max: 1 MHz to 2 MHz, please refer to the product datasheet */
-#define  GPIO_SPEED_FREQ_HIGH      ((uint32_t)0x00000002) /*!< max: 2 MHz to 10 MHz, please refer to the product datasheet */
-#define  GPIO_SPEED_FREQ_VERY_HIGH ((uint32_t)0x00000003) /*!< max: 8 MHz to 50 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_LOW       (0x00000000U) /*!< max: 400 KHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_MEDIUM    (0x00000001U) /*!< max: 1 MHz to 2 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_HIGH      (0x00000002U) /*!< max: 2 MHz to 10 MHz, please refer to the product datasheet */
+#define  GPIO_SPEED_FREQ_VERY_HIGH (0x00000003U) /*!< max: 8 MHz to 50 MHz, please refer to the product datasheet */
 
 /**
   * @}
@@ -173,9 +171,9 @@ typedef enum
    * @brief GPIO Pull-Up or Pull-Down Activation
    * @{
    */  
-#define  GPIO_NOPULL        ((uint32_t)0x00000000)   /*!< No Pull-up or Pull-down activation  */
-#define  GPIO_PULLUP        ((uint32_t)0x00000001)   /*!< Pull-up activation                  */
-#define  GPIO_PULLDOWN      ((uint32_t)0x00000002)   /*!< Pull-down activation                */
+#define  GPIO_NOPULL        (0x00000000U)   /*!< No Pull-up or Pull-down activation  */
+#define  GPIO_PULLUP        (0x00000001U)   /*!< Pull-up activation                  */
+#define  GPIO_PULLDOWN      (0x00000002U)   /*!< Pull-down activation                */
 
 /**
   * @}
@@ -201,8 +199,8 @@ typedef enum
 
 #define IS_GPIO_PIN_ACTION(ACTION) (((ACTION) == GPIO_PIN_RESET) || ((ACTION) == GPIO_PIN_SET))
 
-#define IS_GPIO_PIN(__PIN__)        ((((__PIN__) & GPIO_PIN_MASK) != (uint32_t)0x00) &&\
-                                     (((__PIN__) & ~GPIO_PIN_MASK) == (uint32_t)0x00))
+#define IS_GPIO_PIN(__PIN__)        ((((__PIN__) & GPIO_PIN_MASK) != 0x00U) &&\
+                                     (((__PIN__) & ~GPIO_PIN_MASK) == 0x00U))
 
 #define IS_GPIO_PULL(PULL) (((PULL) == GPIO_NOPULL) || ((PULL) == GPIO_PULLUP) || \
                             ((PULL) == GPIO_PULLDOWN))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_gpio_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_gpio_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of GPIO HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_i2c.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   I2C HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Inter Integrated Circuit (I2C) peripheral:
@@ -211,7 +209,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -257,12 +255,12 @@
 /** @defgroup I2C_Private_Define I2C Private Define
   * @{
   */
-#define I2C_TIMEOUT_FLAG          ((uint32_t)35U)         /*!< Timeout 35 ms             */
-#define I2C_TIMEOUT_ADDR_SLAVE    ((uint32_t)10000U)      /*!< Timeout 10 s              */
-#define I2C_TIMEOUT_BUSY_FLAG     ((uint32_t)25U)         /*!< Timeout 25 ms             */
-#define I2C_NO_OPTION_FRAME       ((uint32_t)0xFFFF0000U) /*!< XferOptions default value */
+#define I2C_TIMEOUT_FLAG          (35U)         /*!< Timeout 35 ms             */
+#define I2C_TIMEOUT_ADDR_SLAVE    (10000U)      /*!< Timeout 10 s              */
+#define I2C_TIMEOUT_BUSY_FLAG     (25U)         /*!< Timeout 25 ms             */
+#define I2C_NO_OPTION_FRAME       (0xFFFF0000U) /*!< XferOptions default value */
 
-#define I2C_MIN_PCLK_FREQ         ((uint32_t)2000000U)    /*!< 2 MHz                     */
+#define I2C_MIN_PCLK_FREQ         (2000000U)    /*!< 2 MHz                     */
 
 /* Private define for @ref PreviousState usage */
 #define I2C_STATE_MSK             ((uint32_t)((HAL_I2C_STATE_BUSY_TX | HAL_I2C_STATE_BUSY_RX) & (~(uint32_t)HAL_I2C_STATE_READY))) /*!< Mask State define, keep only RX and TX bits            */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2c.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_i2c.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of I2C HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -179,13 +177,13 @@ typedef enum
   * @brief  I2C Error Code definition  
   * @{
   */ 
-#define HAL_I2C_ERROR_NONE       ((uint32_t)0x00000000U)    /*!< No error           */
-#define HAL_I2C_ERROR_BERR       ((uint32_t)0x00000001U)    /*!< BERR error         */
-#define HAL_I2C_ERROR_ARLO       ((uint32_t)0x00000002U)    /*!< ARLO error         */
-#define HAL_I2C_ERROR_AF         ((uint32_t)0x00000004U)    /*!< AF error           */
-#define HAL_I2C_ERROR_OVR        ((uint32_t)0x00000008U)    /*!< OVR error          */
-#define HAL_I2C_ERROR_DMA        ((uint32_t)0x00000010U)    /*!< DMA transfer error */
-#define HAL_I2C_ERROR_TIMEOUT    ((uint32_t)0x00000020U)    /*!< Timeout Error      */
+#define HAL_I2C_ERROR_NONE       (0x00000000U)    /*!< No error           */
+#define HAL_I2C_ERROR_BERR       (0x00000001U)    /*!< BERR error         */
+#define HAL_I2C_ERROR_ARLO       (0x00000002U)    /*!< ARLO error         */
+#define HAL_I2C_ERROR_AF         (0x00000004U)    /*!< AF error           */
+#define HAL_I2C_ERROR_OVR        (0x00000008U)    /*!< OVR error          */
+#define HAL_I2C_ERROR_DMA        (0x00000010U)    /*!< DMA transfer error */
+#define HAL_I2C_ERROR_TIMEOUT    (0x00000020U)    /*!< Timeout Error      */
 /**
   * @}
   */
@@ -248,7 +246,7 @@ typedef struct
 /** @defgroup I2C_duty_cycle_in_fast_mode I2C duty cycle in fast mode
   * @{
   */
-#define I2C_DUTYCYCLE_2                 ((uint32_t)0x00000000U)
+#define I2C_DUTYCYCLE_2                 (0x00000000U)
 #define I2C_DUTYCYCLE_16_9              I2C_CCR_DUTY
 /**
   * @}
@@ -257,8 +255,8 @@ typedef struct
 /** @defgroup I2C_addressing_mode I2C addressing mode
   * @{
   */
-#define I2C_ADDRESSINGMODE_7BIT         ((uint32_t)0x00004000U)
-#define I2C_ADDRESSINGMODE_10BIT        (I2C_OAR1_ADDMODE | ((uint32_t)0x00004000U))
+#define I2C_ADDRESSINGMODE_7BIT         (0x00004000U)
+#define I2C_ADDRESSINGMODE_10BIT        (I2C_OAR1_ADDMODE | (0x00004000U))
 /**
   * @}
   */
@@ -266,7 +264,7 @@ typedef struct
 /** @defgroup I2C_dual_addressing_mode  I2C dual addressing mode
   * @{
   */
-#define I2C_DUALADDRESS_DISABLE         ((uint32_t)0x00000000U)
+#define I2C_DUALADDRESS_DISABLE         (0x00000000U)
 #define I2C_DUALADDRESS_ENABLE          I2C_OAR2_ENDUAL
 /**
   * @}
@@ -275,7 +273,7 @@ typedef struct
 /** @defgroup I2C_general_call_addressing_mode I2C general call addressing mode
   * @{
   */
-#define I2C_GENERALCALL_DISABLE         ((uint32_t)0x00000000U)
+#define I2C_GENERALCALL_DISABLE         (0x00000000U)
 #define I2C_GENERALCALL_ENABLE          I2C_CR1_ENGC
 /**
   * @}
@@ -284,7 +282,7 @@ typedef struct
 /** @defgroup I2C_nostretch_mode I2C nostretch mode
   * @{
   */
-#define I2C_NOSTRETCH_DISABLE           ((uint32_t)0x00000000U)
+#define I2C_NOSTRETCH_DISABLE           (0x00000000U)
 #define I2C_NOSTRETCH_ENABLE            I2C_CR1_NOSTRETCH
 /**
   * @}
@@ -293,8 +291,8 @@ typedef struct
 /** @defgroup I2C_Memory_Address_Size I2C Memory Address Size
   * @{
   */
-#define I2C_MEMADD_SIZE_8BIT            ((uint32_t)0x00000001U)
-#define I2C_MEMADD_SIZE_16BIT           ((uint32_t)0x00000010U)
+#define I2C_MEMADD_SIZE_8BIT            (0x00000001U)
+#define I2C_MEMADD_SIZE_16BIT           (0x00000010U)
 /**
   * @}
   */
@@ -302,8 +300,8 @@ typedef struct
 /** @defgroup I2C_XferDirection_definition I2C XferDirection definition Master Point of View
   * @{
   */
-#define I2C_DIRECTION_RECEIVE           ((uint32_t)0x00000000U) 
-#define I2C_DIRECTION_TRANSMIT          ((uint32_t)0x00000001U)
+#define I2C_DIRECTION_RECEIVE           (0x00000000U) 
+#define I2C_DIRECTION_TRANSMIT          (0x00000001U)
 /**
   * @}
   */
@@ -311,10 +309,10 @@ typedef struct
 /** @defgroup I2C_XferOptions_definition I2C XferOptions definition
   * @{
   */
-#define  I2C_FIRST_FRAME                ((uint32_t)0x00000001U)
-#define  I2C_NEXT_FRAME                 ((uint32_t)0x00000002U)
-#define  I2C_FIRST_AND_LAST_FRAME       ((uint32_t)0x00000004U)
-#define  I2C_LAST_FRAME                 ((uint32_t)0x00000008U)
+#define  I2C_FIRST_FRAME                (0x00000001U)
+#define  I2C_NEXT_FRAME                 (0x00000002U)
+#define  I2C_FIRST_AND_LAST_FRAME       (0x00000004U)
+#define  I2C_LAST_FRAME                 (0x00000008U)
 /**
   * @}
   */
@@ -581,7 +579,7 @@ uint32_t             HAL_I2C_GetError(I2C_HandleTypeDef *hi2c);
 /** @defgroup I2C_Private_Constants I2C Private Constants
   * @{
   */
-#define I2C_FLAG_MASK  ((uint32_t)0x0000FFFFU)
+#define I2C_FLAG_MASK  (0x0000FFFFU)
 /**
   * @}
   */ 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2s.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2s.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_i2s.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   I2S HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Integrated Interchip Sound (I2S) peripheral:
@@ -108,7 +106,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -279,7 +277,7 @@ HAL_StatusTypeDef HAL_I2S_Init(I2S_HandleTypeDef *hi2s)
     tmp = tmp / 10;  
 
     /* Check the parity of the divider */
-    i2sodd = (uint32_t)(tmp & (uint32_t)1);
+    i2sodd = (uint32_t)(tmp & 1U);
 
     /* Compute the i2sdiv prescaler */
     i2sdiv = (uint32_t)((tmp - i2sodd) / 2);

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2s.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_i2s.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_i2s.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of I2S HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -153,11 +151,11 @@ typedef struct
   * @{
   */
 
-#define HAL_I2S_ERROR_NONE      ((uint32_t)0x00)    /*!< No error                    */
-#define HAL_I2S_ERROR_UDR       ((uint32_t)0x01)    /*!< I2S Underrun error          */
-#define HAL_I2S_ERROR_OVR       ((uint32_t)0x02)    /*!< I2S Overrun error           */
-#define HAL_I2S_ERROR_FRE       ((uint32_t)0x04)    /*!< I2S Frame format error      */
-#define HAL_I2S_ERROR_DMA       ((uint32_t)0x08)    /*!< DMA transfer error          */
+#define HAL_I2S_ERROR_NONE      (0x00U)    /*!< No error                    */
+#define HAL_I2S_ERROR_UDR       (0x01U)    /*!< I2S Underrun error          */
+#define HAL_I2S_ERROR_OVR       (0x02U)    /*!< I2S Overrun error           */
+#define HAL_I2S_ERROR_FRE       (0x04U)    /*!< I2S Frame format error      */
+#define HAL_I2S_ERROR_DMA       (0x08U)    /*!< DMA transfer error          */
 
 /**
   * @}
@@ -166,10 +164,10 @@ typedef struct
 /** @defgroup I2S_Mode I2S Mode
   * @{
   */
-#define I2S_MODE_SLAVE_TX                ((uint32_t)0x00000000)
-#define I2S_MODE_SLAVE_RX                ((uint32_t)0x00000100)
-#define I2S_MODE_MASTER_TX               ((uint32_t)0x00000200)
-#define I2S_MODE_MASTER_RX               ((uint32_t)0x00000300)
+#define I2S_MODE_SLAVE_TX                (0x00000000U)
+#define I2S_MODE_SLAVE_RX                (0x00000100U)
+#define I2S_MODE_MASTER_TX               (0x00000200U)
+#define I2S_MODE_MASTER_RX               (0x00000300U)
 
 #define IS_I2S_MODE(MODE) (((MODE) == I2S_MODE_SLAVE_TX)  || \
                            ((MODE) == I2S_MODE_SLAVE_RX)  || \
@@ -182,7 +180,7 @@ typedef struct
 /** @defgroup I2S_Standard I2S Standard
   * @{
   */
-#define I2S_STANDARD_PHILIPS             ((uint32_t)0x00000000)
+#define I2S_STANDARD_PHILIPS             (0x00000000U)
 #define I2S_STANDARD_MSB                 ((uint32_t) SPI_I2SCFGR_I2SSTD_0)
 #define I2S_STANDARD_LSB                 ((uint32_t) SPI_I2SCFGR_I2SSTD_1)
 #define I2S_STANDARD_PCM_SHORT           ((uint32_t)(SPI_I2SCFGR_I2SSTD_0 |\
@@ -204,7 +202,7 @@ typedef struct
 /** @defgroup I2S_Data_Format I2S Data Format
   * @{
   */
-#define I2S_DATAFORMAT_16B               ((uint32_t)0x00000000)
+#define I2S_DATAFORMAT_16B               (0x00000000U)
 #define I2S_DATAFORMAT_16B_EXTENDED      ((uint32_t) SPI_I2SCFGR_CHLEN)
 #define I2S_DATAFORMAT_24B               ((uint32_t)(SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_0))
 #define I2S_DATAFORMAT_32B               ((uint32_t)(SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_1))
@@ -221,7 +219,7 @@ typedef struct
   * @{
   */
 #define I2S_MCLKOUTPUT_ENABLE           ((uint32_t)SPI_I2SPR_MCKOE)
-#define I2S_MCLKOUTPUT_DISABLE          ((uint32_t)0x00000000)
+#define I2S_MCLKOUTPUT_DISABLE          (0x00000000U)
 
 #define IS_I2S_MCLK_OUTPUT(OUTPUT) (((OUTPUT) == I2S_MCLKOUTPUT_ENABLE) || \
                                     ((OUTPUT) == I2S_MCLKOUTPUT_DISABLE))
@@ -232,16 +230,16 @@ typedef struct
 /** @defgroup I2S_Audio_Frequency I2S Audio Frequency
   * @{
   */
-#define I2S_AUDIOFREQ_192K               ((uint32_t)192000)
-#define I2S_AUDIOFREQ_96K                ((uint32_t)96000)
-#define I2S_AUDIOFREQ_48K                ((uint32_t)48000)
-#define I2S_AUDIOFREQ_44K                ((uint32_t)44100)
-#define I2S_AUDIOFREQ_32K                ((uint32_t)32000)
-#define I2S_AUDIOFREQ_22K                ((uint32_t)22050)
-#define I2S_AUDIOFREQ_16K                ((uint32_t)16000)
-#define I2S_AUDIOFREQ_11K                ((uint32_t)11025)
-#define I2S_AUDIOFREQ_8K                 ((uint32_t)8000)
-#define I2S_AUDIOFREQ_DEFAULT            ((uint32_t)2)
+#define I2S_AUDIOFREQ_192K               (192000U)
+#define I2S_AUDIOFREQ_96K                (96000U)
+#define I2S_AUDIOFREQ_48K                (48000U)
+#define I2S_AUDIOFREQ_44K                (44100U)
+#define I2S_AUDIOFREQ_32K                (32000U)
+#define I2S_AUDIOFREQ_22K                (22050U)
+#define I2S_AUDIOFREQ_16K                (16000U)
+#define I2S_AUDIOFREQ_11K                (11025U)
+#define I2S_AUDIOFREQ_8K                 (8000U)
+#define I2S_AUDIOFREQ_DEFAULT            (2U)
 
 #define IS_I2S_AUDIO_FREQ(FREQ) ((((FREQ) >= I2S_AUDIOFREQ_8K)    && \
                                   ((FREQ) <= I2S_AUDIOFREQ_192K)) || \
@@ -253,7 +251,7 @@ typedef struct
 /** @defgroup I2S_Clock_Polarity I2S Clock Polarity
   * @{
   */
-#define I2S_CPOL_LOW                    ((uint32_t)0x00000000)
+#define I2S_CPOL_LOW                    (0x00000000U)
 #define I2S_CPOL_HIGH                   ((uint32_t)SPI_I2SCFGR_CKPOL)
 
 #define IS_I2S_CPOL(CPOL) (((CPOL) == I2S_CPOL_LOW) || \

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_irda.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_irda.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_irda.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   IRDA HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the IrDA SIR ENDEC block (IrDA):
@@ -103,7 +101,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_irda.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_irda.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_irda.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains all the functions prototypes for the IRDA 
   *          firmware library.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -154,12 +152,12 @@ typedef struct
 /** @defgroup IRDA_Error_Codes IRDA Error Codes
   * @{
   */
-#define HAL_IRDA_ERROR_NONE      ((uint32_t)0x00)    /*!< No error            */
-#define HAL_IRDA_ERROR_PE        ((uint32_t)0x01)    /*!< Parity error        */
-#define HAL_IRDA_ERROR_NE        ((uint32_t)0x02)    /*!< Noise error         */
-#define HAL_IRDA_ERROR_FE        ((uint32_t)0x04)    /*!< frame error         */
-#define HAL_IRDA_ERROR_ORE       ((uint32_t)0x08)    /*!< Overrun error       */
-#define HAL_IRDA_ERROR_DMA       ((uint32_t)0x10)    /*!< DMA transfer error  */
+#define HAL_IRDA_ERROR_NONE      (0x00U)    /*!< No error            */
+#define HAL_IRDA_ERROR_PE        (0x01U)    /*!< Parity error        */
+#define HAL_IRDA_ERROR_NE        (0x02U)    /*!< Noise error         */
+#define HAL_IRDA_ERROR_FE        (0x04U)    /*!< frame error         */
+#define HAL_IRDA_ERROR_ORE       (0x08U)    /*!< Overrun error       */
+#define HAL_IRDA_ERROR_DMA       (0x10U)    /*!< DMA transfer error  */
 
 /**
   * @}
@@ -169,7 +167,7 @@ typedef struct
 /** @defgroup IRDA_Word_Length IRDA Word Length
   * @{
   */
-#define IRDA_WORDLENGTH_8B                  ((uint32_t)0x00000000)
+#define IRDA_WORDLENGTH_8B                  (0x00000000U)
 #define IRDA_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M)
 /**
   * @}
@@ -178,7 +176,7 @@ typedef struct
 /** @defgroup IRDA_Parity IRDA Parity
   * @{
   */
-#define IRDA_PARITY_NONE                    ((uint32_t)0x00000000)
+#define IRDA_PARITY_NONE                    (0x00000000U)
 #define IRDA_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
 #define IRDA_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
 /**
@@ -199,7 +197,7 @@ typedef struct
   * @{
   */
 #define IRDA_POWERMODE_LOWPOWER             ((uint32_t)USART_CR3_IRLP)
-#define IRDA_POWERMODE_NORMAL               ((uint32_t)0x00000000)
+#define IRDA_POWERMODE_NORMAL               (0x00000000U)
 /**
   * @}
   */
@@ -207,7 +205,7 @@ typedef struct
 /** @defgroup IRDA_One_Bit  IRDA One Bit Sampling
   * @{
   */
-#define IRDA_ONE_BIT_SAMPLE_DISABLE         ((uint32_t)0x00000000)
+#define IRDA_ONE_BIT_SAMPLE_DISABLE         (0x00000000U)
 #define IRDA_ONE_BIT_SAMPLE_ENABLE          ((uint32_t)USART_CR3_ONEBIT)
 /**
   * @}
@@ -485,7 +483,7 @@ do{                                         \
                                         ((PARITY) == IRDA_PARITY_ODD))
 
 #define IS_IRDA_MODE(MODE)             ((((MODE) & (~((uint32_t)IRDA_MODE_TX_RX))) == 0x00) && \
-                                        ((MODE) != (uint32_t)0x00000000))
+                                        ((MODE) != 0x00000000U))
 
 #define IS_IRDA_POWERMODE(MODE)        (((MODE) == IRDA_POWERMODE_LOWPOWER) || \
                                         ((MODE) == IRDA_POWERMODE_NORMAL))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_iwdg.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_iwdg.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_iwdg.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   IWDG HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Independent Watchdog (IWDG) peripheral:
@@ -75,7 +73,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_iwdg.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_iwdg.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_iwdg.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of IWDG HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_lcd.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_lcd.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_lcd.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   LCD Controller HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the LCD Controller (LCD) peripheral:
@@ -63,7 +61,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_lcd.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_lcd.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_lcd.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of LCD Controller HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -139,12 +137,12 @@ typedef struct
   * @{
   */
 
-#define HAL_LCD_ERROR_NONE      ((uint32_t)0x00)    /*!< No error */
-#define HAL_LCD_ERROR_FCRSF     ((uint32_t)0x01)    /*!< Synchro flag timeout error */
-#define HAL_LCD_ERROR_UDR       ((uint32_t)0x02)    /*!< Update display request flag timeout error */
-#define HAL_LCD_ERROR_UDD       ((uint32_t)0x04)    /*!< Update display done flag timeout error */
-#define HAL_LCD_ERROR_ENS       ((uint32_t)0x08)    /*!< LCD enabled status flag timeout error */
-#define HAL_LCD_ERROR_RDY       ((uint32_t)0x10)    /*!< LCD Booster ready timeout error */
+#define HAL_LCD_ERROR_NONE      (0x00U)    /*!< No error */
+#define HAL_LCD_ERROR_FCRSF     (0x01U)    /*!< Synchro flag timeout error */
+#define HAL_LCD_ERROR_UDR       (0x02U)    /*!< Update display request flag timeout error */
+#define HAL_LCD_ERROR_UDD       (0x04U)    /*!< Update display done flag timeout error */
+#define HAL_LCD_ERROR_ENS       (0x08U)    /*!< LCD enabled status flag timeout error */
+#define HAL_LCD_ERROR_RDY       (0x10U)    /*!< LCD Booster ready timeout error */
 
 /**
   * @}
@@ -154,21 +152,21 @@ typedef struct
   * @{
   */
 
-#define LCD_PRESCALER_1        ((uint32_t)0x00000000)  /*!< CLKPS = LCDCLK        */
-#define LCD_PRESCALER_2        ((uint32_t)0x00400000)  /*!< CLKPS = LCDCLK/2      */
-#define LCD_PRESCALER_4        ((uint32_t)0x00800000)  /*!< CLKPS = LCDCLK/4      */
-#define LCD_PRESCALER_8        ((uint32_t)0x00C00000)  /*!< CLKPS = LCDCLK/8      */
-#define LCD_PRESCALER_16       ((uint32_t)0x01000000)  /*!< CLKPS = LCDCLK/16     */
-#define LCD_PRESCALER_32       ((uint32_t)0x01400000)  /*!< CLKPS = LCDCLK/32     */
-#define LCD_PRESCALER_64       ((uint32_t)0x01800000)  /*!< CLKPS = LCDCLK/64     */
-#define LCD_PRESCALER_128      ((uint32_t)0x01C00000)  /*!< CLKPS = LCDCLK/128    */
-#define LCD_PRESCALER_256      ((uint32_t)0x02000000)  /*!< CLKPS = LCDCLK/256    */
-#define LCD_PRESCALER_512      ((uint32_t)0x02400000)  /*!< CLKPS = LCDCLK/512    */
-#define LCD_PRESCALER_1024     ((uint32_t)0x02800000)  /*!< CLKPS = LCDCLK/1024   */
-#define LCD_PRESCALER_2048     ((uint32_t)0x02C00000)  /*!< CLKPS = LCDCLK/2048   */
-#define LCD_PRESCALER_4096     ((uint32_t)0x03000000)  /*!< CLKPS = LCDCLK/4096   */
-#define LCD_PRESCALER_8192     ((uint32_t)0x03400000)  /*!< CLKPS = LCDCLK/8192   */
-#define LCD_PRESCALER_16384    ((uint32_t)0x03800000)  /*!< CLKPS = LCDCLK/16384  */
+#define LCD_PRESCALER_1        (0x00000000U)           /*!< CLKPS = LCDCLK        */
+#define LCD_PRESCALER_2        (0x00400000U)           /*!< CLKPS = LCDCLK/2      */
+#define LCD_PRESCALER_4        (0x00800000U)           /*!< CLKPS = LCDCLK/4      */
+#define LCD_PRESCALER_8        (0x00C00000U)           /*!< CLKPS = LCDCLK/8      */
+#define LCD_PRESCALER_16       (0x01000000U)           /*!< CLKPS = LCDCLK/16     */
+#define LCD_PRESCALER_32       (0x01400000U)           /*!< CLKPS = LCDCLK/32     */
+#define LCD_PRESCALER_64       (0x01800000U)           /*!< CLKPS = LCDCLK/64     */
+#define LCD_PRESCALER_128      (0x01C00000U)           /*!< CLKPS = LCDCLK/128    */
+#define LCD_PRESCALER_256      (0x02000000U)           /*!< CLKPS = LCDCLK/256    */
+#define LCD_PRESCALER_512      (0x02400000U)           /*!< CLKPS = LCDCLK/512    */
+#define LCD_PRESCALER_1024     (0x02800000U)           /*!< CLKPS = LCDCLK/1024   */
+#define LCD_PRESCALER_2048     (0x02C00000U)           /*!< CLKPS = LCDCLK/2048   */
+#define LCD_PRESCALER_4096     (0x03000000U)           /*!< CLKPS = LCDCLK/4096   */
+#define LCD_PRESCALER_8192     (0x03400000U)           /*!< CLKPS = LCDCLK/8192   */
+#define LCD_PRESCALER_16384    (0x03800000U)           /*!< CLKPS = LCDCLK/16384  */
 #define LCD_PRESCALER_32768    ((uint32_t)LCD_FCR_PS)  /*!< CLKPS = LCDCLK/32768  */
 
 #define IS_LCD_PRESCALER(__PRESCALER__) (((__PRESCALER__) == LCD_PRESCALER_1)     || \
@@ -196,21 +194,21 @@ typedef struct
   * @{
   */
 
-#define LCD_DIVIDER_16    ((uint32_t)0x00000000)  /*!< LCD frequency = CLKPS/16 */
-#define LCD_DIVIDER_17    ((uint32_t)0x00040000)  /*!< LCD frequency = CLKPS/17 */
-#define LCD_DIVIDER_18    ((uint32_t)0x00080000)  /*!< LCD frequency = CLKPS/18 */
-#define LCD_DIVIDER_19    ((uint32_t)0x000C0000)  /*!< LCD frequency = CLKPS/19 */
-#define LCD_DIVIDER_20    ((uint32_t)0x00100000)  /*!< LCD frequency = CLKPS/20 */
-#define LCD_DIVIDER_21    ((uint32_t)0x00140000)  /*!< LCD frequency = CLKPS/21 */
-#define LCD_DIVIDER_22    ((uint32_t)0x00180000)  /*!< LCD frequency = CLKPS/22 */
-#define LCD_DIVIDER_23    ((uint32_t)0x001C0000)  /*!< LCD frequency = CLKPS/23 */
-#define LCD_DIVIDER_24    ((uint32_t)0x00200000)  /*!< LCD frequency = CLKPS/24 */
-#define LCD_DIVIDER_25    ((uint32_t)0x00240000)  /*!< LCD frequency = CLKPS/25 */
-#define LCD_DIVIDER_26    ((uint32_t)0x00280000)  /*!< LCD frequency = CLKPS/26 */
-#define LCD_DIVIDER_27    ((uint32_t)0x002C0000)  /*!< LCD frequency = CLKPS/27 */
-#define LCD_DIVIDER_28    ((uint32_t)0x00300000)  /*!< LCD frequency = CLKPS/28 */
-#define LCD_DIVIDER_29    ((uint32_t)0x00340000)  /*!< LCD frequency = CLKPS/29 */
-#define LCD_DIVIDER_30    ((uint32_t)0x00380000)  /*!< LCD frequency = CLKPS/30 */
+#define LCD_DIVIDER_16    (0x00000000U)           /*!< LCD frequency = CLKPS/16 */
+#define LCD_DIVIDER_17    (0x00040000U)           /*!< LCD frequency = CLKPS/17 */
+#define LCD_DIVIDER_18    (0x00080000U)           /*!< LCD frequency = CLKPS/18 */
+#define LCD_DIVIDER_19    (0x000C0000U)           /*!< LCD frequency = CLKPS/19 */
+#define LCD_DIVIDER_20    (0x00100000U)           /*!< LCD frequency = CLKPS/20 */
+#define LCD_DIVIDER_21    (0x00140000U)           /*!< LCD frequency = CLKPS/21 */
+#define LCD_DIVIDER_22    (0x00180000U)           /*!< LCD frequency = CLKPS/22 */
+#define LCD_DIVIDER_23    (0x001C0000U)           /*!< LCD frequency = CLKPS/23 */
+#define LCD_DIVIDER_24    (0x00200000U)           /*!< LCD frequency = CLKPS/24 */
+#define LCD_DIVIDER_25    (0x00240000U)           /*!< LCD frequency = CLKPS/25 */
+#define LCD_DIVIDER_26    (0x00280000U)           /*!< LCD frequency = CLKPS/26 */
+#define LCD_DIVIDER_27    (0x002C0000U)           /*!< LCD frequency = CLKPS/27 */
+#define LCD_DIVIDER_28    (0x00300000U)           /*!< LCD frequency = CLKPS/28 */
+#define LCD_DIVIDER_29    (0x00340000U)           /*!< LCD frequency = CLKPS/29 */
+#define LCD_DIVIDER_30    (0x00380000U)           /*!< LCD frequency = CLKPS/30 */
 #define LCD_DIVIDER_31    ((uint32_t)LCD_FCR_DIV) /*!< LCD frequency = CLKPS/31 */
 
 #define IS_LCD_DIVIDER(__DIVIDER__) (((__DIVIDER__) == LCD_DIVIDER_16) || \
@@ -239,7 +237,7 @@ typedef struct
   * @{
   */
   
-#define LCD_DUTY_STATIC                 ((uint32_t)0x00000000)            /*!< Static duty */
+#define LCD_DUTY_STATIC                 (0x00000000U)                     /*!< Static duty */
 #define LCD_DUTY_1_2                    (LCD_CR_DUTY_0)                   /*!< 1/2 duty    */
 #define LCD_DUTY_1_3                    (LCD_CR_DUTY_1)                   /*!< 1/3 duty    */
 #define LCD_DUTY_1_4                    ((LCD_CR_DUTY_1 | LCD_CR_DUTY_0)) /*!< 1/4 duty    */
@@ -260,7 +258,7 @@ typedef struct
   * @{
   */
   
-#define LCD_BIAS_1_4                    ((uint32_t)0x00000000)  /*!< 1/4 Bias */
+#define LCD_BIAS_1_4                    (0x00000000U)           /*!< 1/4 Bias */
 #define LCD_BIAS_1_2                    LCD_CR_BIAS_0           /*!< 1/2 Bias */
 #define LCD_BIAS_1_3                    LCD_CR_BIAS_1           /*!< 1/3 Bias */
 
@@ -275,7 +273,7 @@ typedef struct
   * @{
   */
   
-#define LCD_VOLTAGESOURCE_INTERNAL      ((uint32_t)0x00000000)  /*!< Internal voltage source for the LCD */
+#define LCD_VOLTAGESOURCE_INTERNAL      (0x00000000U)           /*!< Internal voltage source for the LCD */
 #define LCD_VOLTAGESOURCE_EXTERNAL      LCD_CR_VSEL             /*!< External voltage source for the LCD */
 
 #define IS_LCD_VOLTAGE_SOURCE(SOURCE) (((SOURCE) == LCD_VOLTAGESOURCE_INTERNAL) || \
@@ -299,7 +297,7 @@ typedef struct
   * @{
   */
 
-#define LCD_PULSEONDURATION_0           ((uint32_t)0x00000000)          /*!< Pulse ON duration = 0 pulse   */
+#define LCD_PULSEONDURATION_0           (0x00000000U)                   /*!< Pulse ON duration = 0 pulse   */
 #define LCD_PULSEONDURATION_1           (LCD_FCR_PON_0)                 /*!< Pulse ON duration = 1/CK_PS  */
 #define LCD_PULSEONDURATION_2           (LCD_FCR_PON_1)                 /*!< Pulse ON duration = 2/CK_PS  */
 #define LCD_PULSEONDURATION_3           (LCD_FCR_PON_1 | LCD_FCR_PON_0) /*!< Pulse ON duration = 3/CK_PS  */
@@ -324,7 +322,7 @@ typedef struct
   * @{
   */
 
-#define LCD_HIGHDRIVE_0           ((uint32_t)0x00000000)          /*!< Low resistance Drive   */
+#define LCD_HIGHDRIVE_0           (0x00000000U)                   /*!< Low resistance Drive   */
 #define LCD_HIGHDRIVE_1           (LCD_FCR_HD)                    /*!< High resistance Drive  */
 
 #define IS_LCD_HIGHDRIVE(__HIGHDRIVE__) (((__HIGHDRIVE__) == LCD_HIGHDRIVE_0) || \
@@ -337,7 +335,7 @@ typedef struct
   * @{
   */
 
-#define LCD_DEADTIME_0                  ((uint32_t)0x00000000)            /*!< No dead Time  */
+#define LCD_DEADTIME_0                  (0x00000000U)                     /*!< No dead Time  */
 #define LCD_DEADTIME_1                  (LCD_FCR_DEAD_0)                  /*!< One Phase between different couple of Frame   */
 #define LCD_DEADTIME_2                  (LCD_FCR_DEAD_1)                  /*!< Two Phase between different couple of Frame   */
 #define LCD_DEADTIME_3                  (LCD_FCR_DEAD_1 | LCD_FCR_DEAD_0) /*!< Three Phase between different couple of Frame */
@@ -362,7 +360,7 @@ typedef struct
   * @{
   */
 
-#define LCD_BLINKMODE_OFF               ((uint32_t)0x00000000)  /*!< Blink disabled            */
+#define LCD_BLINKMODE_OFF               (0x00000000U)           /*!< Blink disabled            */
 #define LCD_BLINKMODE_SEG0_COM0         (LCD_FCR_BLINK_0)       /*!< Blink enabled on SEG[0], COM[0] (1 pixel)   */
 #define LCD_BLINKMODE_SEG0_ALLCOM       (LCD_FCR_BLINK_1)       /*!< Blink enabled on SEG[0], all COM (up to 
                                                                     8 pixels according to the programmed duty)  */
@@ -380,7 +378,7 @@ typedef struct
   * @{
   */
 
-#define LCD_BLINKFREQUENCY_DIV8         ((uint32_t)0x00000000)                /*!< The Blink frequency = fLCD/8    */
+#define LCD_BLINKFREQUENCY_DIV8         (0x00000000U)                         /*!< The Blink frequency = fLCD/8    */
 #define LCD_BLINKFREQUENCY_DIV16        (LCD_FCR_BLINKF_0)                    /*!< The Blink frequency = fLCD/16   */
 #define LCD_BLINKFREQUENCY_DIV32        (LCD_FCR_BLINKF_1)                    /*!< The Blink frequency = fLCD/32   */
 #define LCD_BLINKFREQUENCY_DIV64        (LCD_FCR_BLINKF_1 | LCD_FCR_BLINKF_0) /*!< The Blink frequency = fLCD/64   */
@@ -405,7 +403,7 @@ typedef struct
   * @{
   */
 
-#define LCD_CONTRASTLEVEL_0               ((uint32_t)0x00000000)        /*!< Maximum Voltage = 2.60V    */
+#define LCD_CONTRASTLEVEL_0               (0x00000000U)                 /*!< Maximum Voltage = 2.60V    */
 #define LCD_CONTRASTLEVEL_1               (LCD_FCR_CC_0)                /*!< Maximum Voltage = 2.73V    */
 #define LCD_CONTRASTLEVEL_2               (LCD_FCR_CC_1)                /*!< Maximum Voltage = 2.86V    */
 #define LCD_CONTRASTLEVEL_3               (LCD_FCR_CC_1 | LCD_FCR_CC_0) /*!< Maximum Voltage = 2.99V    */
@@ -430,7 +428,7 @@ typedef struct
   * @{
   */
 
-#define LCD_MUXSEGMENT_DISABLE            ((uint32_t)0x00000000)        /*!< SEG pin multiplexing disabled */
+#define LCD_MUXSEGMENT_DISABLE            (0x00000000U)                 /*!< SEG pin multiplexing disabled */
 #define LCD_MUXSEGMENT_ENABLE             (LCD_CR_MUX_SEG)              /*!< SEG[31:28] are multiplexed with SEG[43:40]    */
 
 #define IS_LCD_MUXSEGMENT(__VALUE__) (((__VALUE__) == LCD_MUXSEGMENT_ENABLE) || \
@@ -458,22 +456,22 @@ typedef struct
   * @{
   */
 
-#define LCD_RAM_REGISTER0               ((uint32_t)0x00000000) /*!< LCD RAM Register 0  */
-#define LCD_RAM_REGISTER1               ((uint32_t)0x00000001) /*!< LCD RAM Register 1  */
-#define LCD_RAM_REGISTER2               ((uint32_t)0x00000002) /*!< LCD RAM Register 2  */
-#define LCD_RAM_REGISTER3               ((uint32_t)0x00000003) /*!< LCD RAM Register 3  */
-#define LCD_RAM_REGISTER4               ((uint32_t)0x00000004) /*!< LCD RAM Register 4  */
-#define LCD_RAM_REGISTER5               ((uint32_t)0x00000005) /*!< LCD RAM Register 5  */
-#define LCD_RAM_REGISTER6               ((uint32_t)0x00000006) /*!< LCD RAM Register 6  */
-#define LCD_RAM_REGISTER7               ((uint32_t)0x00000007) /*!< LCD RAM Register 7  */
-#define LCD_RAM_REGISTER8               ((uint32_t)0x00000008) /*!< LCD RAM Register 8  */
-#define LCD_RAM_REGISTER9               ((uint32_t)0x00000009) /*!< LCD RAM Register 9  */
-#define LCD_RAM_REGISTER10              ((uint32_t)0x0000000A) /*!< LCD RAM Register 10 */
-#define LCD_RAM_REGISTER11              ((uint32_t)0x0000000B) /*!< LCD RAM Register 11 */
-#define LCD_RAM_REGISTER12              ((uint32_t)0x0000000C) /*!< LCD RAM Register 12 */
-#define LCD_RAM_REGISTER13              ((uint32_t)0x0000000D) /*!< LCD RAM Register 13 */
-#define LCD_RAM_REGISTER14              ((uint32_t)0x0000000E) /*!< LCD RAM Register 14 */
-#define LCD_RAM_REGISTER15              ((uint32_t)0x0000000F) /*!< LCD RAM Register 15 */
+#define LCD_RAM_REGISTER0               (0x00000000U) /*!< LCD RAM Register 0  */
+#define LCD_RAM_REGISTER1               (0x00000001U) /*!< LCD RAM Register 1  */
+#define LCD_RAM_REGISTER2               (0x00000002U) /*!< LCD RAM Register 2  */
+#define LCD_RAM_REGISTER3               (0x00000003U) /*!< LCD RAM Register 3  */
+#define LCD_RAM_REGISTER4               (0x00000004U) /*!< LCD RAM Register 4  */
+#define LCD_RAM_REGISTER5               (0x00000005U) /*!< LCD RAM Register 5  */
+#define LCD_RAM_REGISTER6               (0x00000006U) /*!< LCD RAM Register 6  */
+#define LCD_RAM_REGISTER7               (0x00000007U) /*!< LCD RAM Register 7  */
+#define LCD_RAM_REGISTER8               (0x00000008U) /*!< LCD RAM Register 8  */
+#define LCD_RAM_REGISTER9               (0x00000009U) /*!< LCD RAM Register 9  */
+#define LCD_RAM_REGISTER10              (0x0000000AU) /*!< LCD RAM Register 10 */
+#define LCD_RAM_REGISTER11              (0x0000000BU) /*!< LCD RAM Register 11 */
+#define LCD_RAM_REGISTER12              (0x0000000CU) /*!< LCD RAM Register 12 */
+#define LCD_RAM_REGISTER13              (0x0000000DU) /*!< LCD RAM Register 13 */
+#define LCD_RAM_REGISTER14              (0x0000000EU) /*!< LCD RAM Register 14 */
+#define LCD_RAM_REGISTER15              (0x0000000FU) /*!< LCD RAM Register 15 */
 
 #define IS_LCD_RAM_REGISTER(__REGISTER__) (((__REGISTER__) == LCD_RAM_REGISTER0)  || \
                                            ((__REGISTER__) == LCD_RAM_REGISTER1)  || \

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_nor.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_nor.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_nor.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   NOR HAL module driver.
   *          This file provides a generic firmware to drive NOR memories mounted 
   *          as external device.
@@ -55,7 +53,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_nor.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_nor.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_nor.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of NOR HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_opamp.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   OPAMP HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the operational amplifier(s)(OPAMP1, OPAMP2 etc) 
@@ -138,7 +136,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_opamp.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of OPAMP HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -174,15 +172,15 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /**
   * CSR register Mask 
   */
-#define OPAMP_CSR_INSTANCE_OFFSET   ((uint32_t)  8) /* Offset of each OPAMP instance into register CSR */
-#define OPAMP_OTR_INSTANCE_OFFSET   ((uint32_t) 10) /* Offset of each OPAMP instance into register OTR */
+#define OPAMP_CSR_INSTANCE_OFFSET   ( 8U) /* Offset of each OPAMP instance into register CSR */
+#define OPAMP_OTR_INSTANCE_OFFSET   (10U) /* Offset of each OPAMP instance into register OTR */
     
         
 /** @defgroup OPAMP_Mode OPAMP Mode
   * @{
   */
-#define OPAMP_STANDALONE_MODE            ((uint32_t)0x00000000) /*!< OPAMP standalone mode */
-#define OPAMP_FOLLOWER_MODE              ((uint32_t)0x00000001) /*!< OPAMP follower mode */
+#define OPAMP_STANDALONE_MODE            (0x00000000U) /*!< OPAMP standalone mode */
+#define OPAMP_FOLLOWER_MODE              (0x00000001U) /*!< OPAMP follower mode */
 
 /**
   * @}
@@ -191,9 +189,9 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /** @defgroup OPAMP_NonInvertingInput OPAMP NonInvertingInput
   * @{
   */
-#define OPAMP_NONINVERTINGINPUT_IO0      ((uint32_t)0x00000000)  /*!< Comparator non-inverting input connected to dedicated IO pin low-leakage */
-#define OPAMP_NONINVERTINGINPUT_DAC_CH1  ((uint32_t)0x00000001)  /*!< Comparator non-inverting input connected internally to DAC channel 1. Available only on OPAMP1 and OPAMP2. */
-#define OPAMP_NONINVERTINGINPUT_DAC_CH2  ((uint32_t)0x00000002)  /*!< Comparator non-inverting input connected internally to DAC channel 2. Available only on OPAMP2 and OPAMP3 (OPAMP3 availability depends on STM32L1 devices). */
+#define OPAMP_NONINVERTINGINPUT_IO0      (0x00000000U)  /*!< Comparator non-inverting input connected to dedicated IO pin low-leakage */
+#define OPAMP_NONINVERTINGINPUT_DAC_CH1  (0x00000001U)  /*!< Comparator non-inverting input connected internally to DAC channel 1. Available only on OPAMP1 and OPAMP2. */
+#define OPAMP_NONINVERTINGINPUT_DAC_CH2  (0x00000002U)  /*!< Comparator non-inverting input connected internally to DAC channel 2. Available only on OPAMP2 and OPAMP3 (OPAMP3 availability depends on STM32L1 devices). */
 
 /**
   * @}
@@ -203,8 +201,8 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
   * @{
   */
 /* Note: Literal "OPAMP_SEC_INVERTINGINPUT_IO1" is a legacy naming of "OPAMP_INVERTINGINPUT_IO1". It is equivalent and must be replaced by "OPAMP_INVERTINGINPUT_IO1". */
-#define OPAMP_INVERTINGINPUT_IO0         ((uint32_t)0x00000000)  /*!< Comparator inverting input connected to dedicated IO pin low-leakage */
-#define OPAMP_INVERTINGINPUT_IO1         ((uint32_t)0x00000001)  /*!< Comparator inverting input connected to alternative IO pin available on some device packages */
+#define OPAMP_INVERTINGINPUT_IO0         (0x00000000U)  /*!< Comparator inverting input connected to dedicated IO pin low-leakage */
+#define OPAMP_INVERTINGINPUT_IO1         (0x00000001U)  /*!< Comparator inverting input connected to alternative IO pin available on some device packages */
 
 /**
   * @}
@@ -213,8 +211,8 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /** @defgroup OPAMP_PowerMode OPAMP PowerMode
   * @{
   */
-#define OPAMP_POWERMODE_NORMAL        ((uint32_t)0x00000000)
-#define OPAMP_POWERMODE_LOWPOWER      ((uint32_t)0x00000001)
+#define OPAMP_POWERMODE_NORMAL        (0x00000000U)
+#define OPAMP_POWERMODE_LOWPOWER      (0x00000001U)
 
 /**
   * @}
@@ -223,7 +221,7 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /** @defgroup OPAMP_PowerSupplyRange OPAMP PowerSupplyRange
   * @{
   */
-#define OPAMP_POWERSUPPLY_LOW          ((uint32_t)0x00000000)  /*!< Power supply range low (VDDA lower than 2.4V) */
+#define OPAMP_POWERSUPPLY_LOW          (0x00000000U)           /*!< Power supply range low (VDDA lower than 2.4V) */
 #define OPAMP_POWERSUPPLY_HIGH         OPAMP_CSR_AOP_RANGE     /*!< Power supply range high (VDDA higher than 2.4V) */
 
 /**
@@ -233,8 +231,8 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /** @defgroup OPAMP_UserTrimming OPAMP User Trimming
   * @{
   */
-#define OPAMP_TRIMMING_FACTORY        ((uint32_t)0x00000000)                          /*!< Factory trimming */
-#define OPAMP_TRIMMING_USER           OPAMP_OTR_OT_USER                               /*!< User trimming */
+#define OPAMP_TRIMMING_FACTORY        (0x00000000U)                          /*!< Factory trimming */
+#define OPAMP_TRIMMING_USER           OPAMP_OTR_OT_USER                      /*!< User trimming */
 
 /**
   * @}
@@ -243,9 +241,9 @@ typedef  uint32_t HAL_OPAMP_TrimmingValueTypeDef;
 /** @defgroup OPAMP_FactoryTrimming OPAMP FactoryTrimming
   * @{
   */
-#define OPAMP_FACTORYTRIMMING_DUMMY    ((uint32_t)0xFFFFFFFF)                           /*!< Dummy value if trimming value could not be retrieved */
+#define OPAMP_FACTORYTRIMMING_DUMMY    (0xFFFFFFFFU)                                    /*!< Dummy value if trimming value could not be retrieved */
 
-#define OPAMP_FACTORYTRIMMING_P        ((uint32_t)0x00000000)                           /*!< Offset trimming P */
+#define OPAMP_FACTORYTRIMMING_P        (0x00000000U)                                    /*!< Offset trimming P */
 #define OPAMP_FACTORYTRIMMING_N        POSITION_VAL(OPAMP_OTR_AO1_OPT_OFFSET_TRIM_HIGH) /*!< Offset trimming N */
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_opamp_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended OPAMP HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -15,7 +13,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_opamp_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_opamp_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of OPAMP HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pcd.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   PCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
@@ -44,7 +42,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -195,19 +193,19 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
  /*Clear pending interrupts*/
  hpcd->Instance->ISTR = 0;
  
-  /*Set Btable Adress*/
+ /*Set Btable Adress*/
  hpcd->Instance->BTABLE = BTABLE_ADDRESS;
-  
-  /*set wInterrupt_Mask global variable*/
-  wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
-    | USB_CNTR_ESOFM | USB_CNTR_RESETM;
-  
-  /*Set interrupt mask*/
-  hpcd->Instance->CNTR = wInterrupt_Mask;
-  
-  hpcd->USB_Address = 0;
-  hpcd->State= HAL_PCD_STATE_READY;
-
+ 
+ /*set wInterrupt_Mask global variable*/
+ wInterrupt_Mask = USB_CNTR_CTRM  | USB_CNTR_WKUPM | USB_CNTR_SUSPM | USB_CNTR_ERRM \
+   | USB_CNTR_SOFM | USB_CNTR_ESOFM | USB_CNTR_RESETM;
+ 
+ /*Set interrupt mask*/
+ hpcd->Instance->CNTR = wInterrupt_Mask;
+ 
+ hpcd->USB_Address = 0;
+ hpcd->State= HAL_PCD_STATE_READY;
+ 
  return HAL_OK;
 }
 
@@ -413,8 +411,8 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
           /* Process Control Data OUT Packet*/
            HAL_PCD_DataOutStageCallback(hpcd, 0);
           
-          PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket);
-          PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID);
+          PCD_SET_EP_RX_CNT(hpcd->Instance, PCD_ENDP0, ep->maxpacket)
+          PCD_SET_EP_RX_STATUS(hpcd->Instance, PCD_ENDP0, USB_EP_RX_VALID)
         }
       }
     }
@@ -442,7 +440,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         }
         else
         {
-          if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_RX)
+          if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num)& USB_EP_DTOG_RX) == USB_EP_DTOG_RX)
           {
             /*read from endpoint BUF0Addr buffer*/
             count = PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
@@ -460,7 +458,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
               PCD_ReadPMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, count);
             }
           }
-          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_OUT);  
+          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_OUT)  
         }
         /*multi-packet on the NON control OUT endpoint*/
         ep->xfer_count+=count;
@@ -496,7 +494,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
         }
         else
         {
-          if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num) & USB_EP_DTOG_TX)
+          if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num)& USB_EP_DTOG_TX) == USB_EP_DTOG_TX)
           {
             /*read from endpoint BUF0Addr buffer*/
             ep->xfer_count = PCD_GET_EP_DBUF0_CNT(hpcd->Instance, ep->num);
@@ -514,7 +512,7 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
               PCD_WritePMA(hpcd->Instance, ep->xfer_buff, ep->pmaaddr1, ep->xfer_count);
             }
           }
-          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_IN);  
+          PCD_FreeUserBuffer(hpcd->Instance, ep->num, PCD_EP_DBUF_IN)  
         }
         /*multi-packet on the NON control IN endpoint*/
         ep->xfer_count = PCD_GET_EP_TX_CNT(hpcd->Instance, ep->num);
@@ -546,15 +544,17 @@ static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd)
   */
 static void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
 {
-  uint32_t n = (wNBytes + 1) >> 1;   /* n = (wNBytes + 1) / 2 */
+  uint32_t n =  ((uint32_t)((uint32_t)wNBytes + 1U)) >> 1U;
+  
   uint32_t i, temp1, temp2;
   uint16_t *pdwVal;
-  pdwVal = (uint16_t *)(wPMABufAddr * 2 + (uint32_t)USBx + 0x400);
+  pdwVal = (uint16_t *)((uint32_t)(wPMABufAddr * 2 + (uint32_t)USBx + 0x400U));
+  
   for (i = n; i != 0; i--)
   {
     temp1 = (uint16_t) * pbUsrBuf;
     pbUsrBuf++;
-    temp2 = temp1 | (uint16_t) * pbUsrBuf << 8;
+    temp2 = temp1 | ((uint16_t)((uint16_t)  * pbUsrBuf << 8U)) ;
     *pdwVal++ = temp2;
     pdwVal++;
     pbUsrBuf++;
@@ -571,13 +571,19 @@ static void PCD_WritePMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABuf
   */
 static void PCD_ReadPMA(USB_TypeDef  *USBx, uint8_t *pbUsrBuf, uint16_t wPMABufAddr, uint16_t wNBytes)
 {
-  uint32_t n = (wNBytes + 1) >> 1;/* /2*/
+  uint32_t n =  ((uint32_t)((uint32_t)wNBytes + 1U)) >> 1U;
   uint32_t i;
   uint32_t *pdwVal;
-  pdwVal = (uint32_t *)(wPMABufAddr * 2 + (uint32_t)USBx + 0x400);
+
+  pdwVal = (uint32_t *)((uint32_t)(wPMABufAddr * 2 + (uint32_t)USBx + 0x400U));
+  uint32_t tmp = *pdwVal++;
+  *pbUsrBuf++ = (uint16_t)((tmp >> 0) & 0xFF);
+  *pbUsrBuf++ = (uint16_t)((tmp >> 8) & 0xFF);
+  
+  
   for (i = n; i != 0; i--)
   {
-    *(uint16_t*)pbUsrBuf++ = *pdwVal++;
+    *(uint16_t*)((uint32_t)pbUsrBuf++) = *pdwVal++;
     pbUsrBuf++;
   }
 }
@@ -971,19 +977,19 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
     {
       /*Set the endpoint Transmit buffer address */
       PCD_SET_EP_TX_ADDRESS(hpcd->Instance, ep->num, ep->pmaadress);
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       /* Configure NAK status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_NAK); 
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_NAK) 
     }
     else
     {
       /*Set the endpoint Receive buffer address */
       PCD_SET_EP_RX_ADDRESS(hpcd->Instance, ep->num, ep->pmaadress);
       /*Set the endpoint Receive buffer counter*/
-      PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, ep->maxpacket);
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, ep->maxpacket)
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
       /* Configure VALID status for the Endpoint*/
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID)
     }
   }
   /*Double Buffer*/
@@ -992,29 +998,29 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
     /*Set the endpoint as double buffered*/
     PCD_SET_EP_DBUF(hpcd->Instance, ep->num);
     /*Set buffer address for double buffered mode*/
-    PCD_SET_EP_DBUF_ADDR(hpcd->Instance, ep->num,ep->pmaaddr0, ep->pmaaddr1);
+    PCD_SET_EP_DBUF_ADDR(hpcd->Instance, ep->num,ep->pmaaddr0, ep->pmaaddr1)
     
     if (ep->is_in==0)
     {
       /* Clear the data toggle bits for the endpoint IN/OUT*/
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       
       /* Reset value of the data toggle bits for the endpoint out*/
       PCD_TX_DTOG(hpcd->Instance, ep->num);
       
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID)
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS)
     }
     else
     {
       /* Clear the data toggle bits for the endpoint IN/OUT*/
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       PCD_RX_DTOG(hpcd->Instance, ep->num);
       /* Configure DISABLE status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS)
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS)
     }
   } 
   
@@ -1051,15 +1057,15 @@ HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   {
     if (ep->is_in)
     {
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       /* Configure DISABLE status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS); 
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS) 
     }
     else
     {
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
       /* Configure DISABLE status for the Endpoint*/
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS)
     }
   }
   /*Double Buffer*/
@@ -1068,24 +1074,24 @@ HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
     if (ep->is_in==0)
     {
       /* Clear the data toggle bits for the endpoint IN/OUT*/
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       
       /* Reset value of the data toggle bits for the endpoint out*/
       PCD_TX_DTOG(hpcd->Instance, ep->num);
       
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS)
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS)
     }
     else
     {
       /* Clear the data toggle bits for the endpoint IN/OUT*/
-      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
-      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
+      PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
+      PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
       PCD_RX_DTOG(hpcd->Instance, ep->num);
       /* Configure DISABLE status for the Endpoint*/
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS);
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS);
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_DIS)
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_DIS)
     }
   } 
   
@@ -1116,8 +1122,6 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   ep->is_in = 0;
   ep->num = ep_addr & 0x7F;
    
-  __HAL_LOCK(hpcd); 
-   
   /* Multi packet transfer*/
   if (ep->xfer_len > ep->maxpacket)
   {
@@ -1134,18 +1138,16 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   if (ep->doublebuffer == 0) 
   {
     /*Set RX buffer count*/
-    PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, len);
+    PCD_SET_EP_RX_CNT(hpcd->Instance, ep->num, len)
   }
   else
   {
     /*Set the Double buffer counter*/
-    PCD_SET_EP_DBUF_CNT(hpcd->Instance, ep->num, ep->is_in, len);
+    PCD_SET_EP_DBUF_CNT(hpcd->Instance, ep->num, ep->is_in, len)
   } 
   
-  PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
-  
-  __HAL_UNLOCK(hpcd); 
-  
+  PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID)
+
   return HAL_OK;
 }
 
@@ -1180,9 +1182,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   ep->xfer_count = 0;
   ep->is_in = 1;
   ep->num = ep_addr & 0x7F;
-  
-  __HAL_LOCK(hpcd); 
-  
+
   /*Multi packet transfer*/
   if (ep->xfer_len > ep->maxpacket)
   {
@@ -1203,27 +1203,26 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   }
   else
   {
-    /*Set the Double buffer counter */
-    PCD_SET_EP_DBUF_CNT(hpcd->Instance, ep->num, ep->is_in, len);
-    
     /*Write the data to the USB endpoint*/
-    if (PCD_GET_ENDPOINT(hpcd->Instance, ep->num)& USB_EP_DTOG_TX)
+    if ((PCD_GET_ENDPOINT(hpcd->Instance, ep->num)& USB_EP_DTOG_TX) == USB_EP_DTOG_TX)
     {
+      /*Set the Double buffer counter for pmabuffer1*/
+      PCD_SET_EP_DBUF1_CNT(hpcd->Instance, ep->num, ep->is_in, len)
       pmabuffer = ep->pmaaddr1;
     }
     else
     {
+      /*Set the Double buffer counter for pmabuffer0*/
+      PCD_SET_EP_DBUF0_CNT(hpcd->Instance, ep->num, ep->is_in, len)
       pmabuffer = ep->pmaaddr0;
     }
 
     PCD_WritePMA(hpcd->Instance, ep->xfer_buff, pmabuffer, len);
-    PCD_FreeUserBuffer(hpcd->Instance, ep->num, ep->is_in);
+    PCD_FreeUserBuffer(hpcd->Instance, ep->num, ep->is_in)
   }
 
-  PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
-  
-  __HAL_UNLOCK(hpcd);
-     
+  PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID)
+
   return HAL_OK;
 }
 
@@ -1255,17 +1254,17 @@ HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   if (ep->num == 0)
   {
     /* This macro sets STALL status for RX & TX*/ 
-    PCD_SET_EP_TXRX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_STALL, USB_EP_TX_STALL); 
+    PCD_SET_EP_TXRX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_STALL, USB_EP_TX_STALL) 
   }
   else
   {
     if (ep->is_in)
     {
-      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num , USB_EP_TX_STALL); 
+      PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num , USB_EP_TX_STALL)
     }
     else
     {
-      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num , USB_EP_RX_STALL);
+      PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num , USB_EP_RX_STALL)
     }
   }
   __HAL_UNLOCK(hpcd); 
@@ -1300,13 +1299,13 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   
   if (ep->is_in)
   {
-    PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num);
-    PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID);
+    PCD_CLEAR_TX_DTOG(hpcd->Instance, ep->num)
+    PCD_SET_EP_TX_STATUS(hpcd->Instance, ep->num, USB_EP_TX_VALID)
   }
   else
   {
-    PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num);
-    PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID);
+    PCD_CLEAR_RX_DTOG(hpcd->Instance, ep->num)
+    PCD_SET_EP_RX_STATUS(hpcd->Instance, ep->num, USB_EP_RX_VALID)
   }
   __HAL_UNLOCK(hpcd); 
     

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pcd.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of PCD HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -198,7 +196,7 @@ typedef struct
   * @{
   */
 
-#define  USB_WAKEUP_EXTI_LINE              ((uint32_t)0x00040000)  /*!< External interrupt line 18 Connected to the USB FS EXTI Line */
+#define  USB_WAKEUP_EXTI_LINE              (0x00040000U)  /*!< External interrupt line 18 Connected to the USB FS EXTI Line */
 /**
   * @}
   */
@@ -328,10 +326,11 @@ typedef struct
  */
 
 /* SetENDPOINT */
-#define PCD_SET_ENDPOINT(USBx, bEpNum,wRegValue)  (*(&(USBx)->EP0R + (bEpNum) * 2)= (uint16_t)(wRegValue))
+/* SetENDPOINT */
+#define PCD_SET_ENDPOINT(USBx, bEpNum,wRegValue)  (*((uint16_t *)(((uint32_t)(&(USBx)->EP0R + (bEpNum) * 2U))))= (uint16_t)(wRegValue))
 
 /* GetENDPOINT */
-#define PCD_GET_ENDPOINT(USBx, bEpNum)        (*(&(USBx)->EP0R + (bEpNum) * 2))
+#define PCD_GET_ENDPOINT(USBx, bEpNum)            (*((uint16_t *)(((uint32_t)(&(USBx)->EP0R + (bEpNum) * 2U)))))
 
 
 
@@ -343,7 +342,7 @@ typedef struct
   * @retval None
   */
 #define PCD_SET_EPTYPE(USBx, bEpNum,wType) (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                  ((PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_T_MASK) | (wType) )))
+                                  ((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & ((uint32_t)(USB_EP_T_MASK))) | ((uint32_t)(wType)) )))
 
 /**
   * @brief  gets the type in the endpoint register(bits EP_TYPE[1:0])
@@ -351,7 +350,7 @@ typedef struct
   * @param  bEpNum: Endpoint Number.
   * @retval Endpoint Type
   */
-#define PCD_GET_EPTYPE(USBx, bEpNum) (PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_T_FIELD)
+#define PCD_GET_EPTYPE(USBx, bEpNum) (((uint16_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_T_FIELD)
 
 
 /**
@@ -400,18 +399,18 @@ typedef struct
   */
 #define PCD_SET_EP_TX_STATUS(USBx, bEpNum, wState) { register uint16_t _wRegVal;\
    \
-    _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPTX_DTOGMASK;\
+    _wRegVal = (uint32_t) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPTX_DTOGMASK);\
    /* toggle first bit ? */     \
    if((USB_EPTX_DTOG1 & (wState))!= 0)      \
    {                                                                            \
-     _wRegVal ^= USB_EPTX_DTOG1;        \
+     _wRegVal ^=(uint16_t) USB_EPTX_DTOG1;        \
    }                                                                            \
    /* toggle second bit ?  */         \
-   if((USB_EPTX_DTOG2 & (wState))!= 0)      \
+   if((USB_EPTX_DTOG2 & ((uint32_t)(wState)))!= 0U)      \
    {                                                                            \
-     _wRegVal ^= USB_EPTX_DTOG2;        \
+     _wRegVal ^=(uint16_t) USB_EPTX_DTOG2;        \
    }                                                                            \
-   PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX|USB_EP_CTR_TX));    \
+   PCD_SET_ENDPOINT((USBx), (bEpNum), (((uint32_t)(_wRegVal)) | USB_EP_CTR_RX|USB_EP_CTR_TX));\
   } /* PCD_SET_EP_TX_STATUS */
 
 /**
@@ -424,18 +423,18 @@ typedef struct
 #define PCD_SET_EP_RX_STATUS(USBx, bEpNum,wState) {\
     register uint16_t _wRegVal;   \
     \
-    _wRegVal = PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPRX_DTOGMASK;\
+    _wRegVal = (uint32_t) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPRX_DTOGMASK);\
     /* toggle first bit ? */  \
     if((USB_EPRX_DTOG1 & (wState))!= 0) \
     {                                                                             \
-      _wRegVal ^= USB_EPRX_DTOG1;  \
+      _wRegVal ^= (uint16_t) USB_EPRX_DTOG1;  \
     }                                                                             \
     /* toggle second bit ? */  \
-    if((USB_EPRX_DTOG2 & (wState))!= 0) \
+    if((USB_EPRX_DTOG2 & ((uint32_t)(wState)))!= 0U) \
     {                                                                             \
-      _wRegVal ^= USB_EPRX_DTOG2;  \
+      _wRegVal ^= (uint16_t) USB_EPRX_DTOG2;  \
     }                                                                             \
-    PCD_SET_ENDPOINT((USBx), (bEpNum), (_wRegVal | USB_EP_CTR_RX|USB_EP_CTR_TX)); \
+    PCD_SET_ENDPOINT((USBx), (bEpNum), (((uint32_t)(_wRegVal)) | USB_EP_CTR_RX|USB_EP_CTR_TX)); \
   } /* PCD_SET_EP_RX_STATUS */
 
 /**
@@ -480,9 +479,8 @@ typedef struct
   * @param  bEpNum: Endpoint Number.
   * @retval status
   */
-#define PCD_GET_EP_TX_STATUS(USBx, bEpNum) ((uint16_t)PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPTX_STAT)
-
-#define PCD_GET_EP_RX_STATUS(USBx, bEpNum) ((uint16_t)PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPRX_STAT)
+#define PCD_GET_EP_TX_STATUS(USBx, bEpNum) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPTX_STAT)
+#define PCD_GET_EP_RX_STATUS(USBx, bEpNum) (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPRX_STAT)
 
 /**
   * @brief  sets directly the VALID tx/rx-status into the endpoint register
@@ -512,9 +510,9 @@ typedef struct
   * @retval None
   */
 #define PCD_SET_EP_KIND(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((PCD_GET_ENDPOINT((USBx), (bEpNum)) | USB_EP_KIND) & USB_EPREG_MASK))))
+                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) | USB_EP_KIND) & USB_EPREG_MASK))))
 #define PCD_CLEAR_EP_KIND(USBx, bEpNum)  (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                (USB_EP_CTR_RX|USB_EP_CTR_TX|(PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPKIND_MASK))))
+                                (USB_EP_CTR_RX|USB_EP_CTR_TX|((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPKIND_MASK))))
 
 /**
   * @brief  Sets/clears directly STATUS_OUT bit in the endpoint register.
@@ -541,9 +539,9 @@ typedef struct
   * @retval None
   */
 #define PCD_CLEAR_RX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0x7FFF & USB_EPREG_MASK))
+                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0x7FFFU & USB_EPREG_MASK))
 #define PCD_CLEAR_TX_EP_CTR(USBx, bEpNum)   (PCD_SET_ENDPOINT((USBx), (bEpNum),\
-                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0xFF7F & USB_EPREG_MASK))
+                                   PCD_GET_ENDPOINT((USBx), (bEpNum)) & 0xFF7FU & USB_EPREG_MASK))
 
 /**
   * @brief  Toggles DTOG_RX / DTOG_TX bit in the endpoint register.
@@ -552,9 +550,9 @@ typedef struct
   * @retval None
   */
 #define PCD_RX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX | (PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK)))
+                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_RX | (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK)))
 #define PCD_TX_DTOG(USBx, bEpNum)    (PCD_SET_ENDPOINT((USBx), (bEpNum), \
-                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX | (PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK)))
+                                   USB_EP_CTR_RX|USB_EP_CTR_TX|USB_EP_DTOG_TX | (((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK)))
 
 /**
   * @brief  Clears DTOG_RX / DTOG_TX bit in the endpoint register.
@@ -562,13 +560,13 @@ typedef struct
   * @param  bEpNum: Endpoint Number.
   * @retval None
   */
-#define PCD_CLEAR_RX_DTOG(USBx, bEpNum)  if((PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_DTOG_RX) != 0)\
+#define PCD_CLEAR_RX_DTOG(USBx, bEpNum)  if((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_DTOG_RX) != 0)\
                                          {                                                              \
-                                           PCD_RX_DTOG((USBx), (bEpNum));                               \
+                                           PCD_RX_DTOG((USBx),(bEpNum));\
                                          }
-#define PCD_CLEAR_TX_DTOG(USBx, bEpNum)  if((PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EP_DTOG_TX) != 0)\
-                                         {                                                              \
-                                            PCD_TX_DTOG((USBx), (bEpNum));                              \
+#define PCD_CLEAR_TX_DTOG(USBx, bEpNum)  if((((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EP_DTOG_TX) != 0)\
+                                         {\
+                                           PCD_TX_DTOG((USBx),(bEpNum));\
                                          }
       
 /**
@@ -579,18 +577,18 @@ typedef struct
   * @retval None
   */
 #define PCD_SET_EP_ADDRESS(USBx, bEpNum,bAddr) PCD_SET_ENDPOINT((USBx), (bEpNum),\
-    USB_EP_CTR_RX|USB_EP_CTR_TX|(PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPREG_MASK) | (bAddr))
+    USB_EP_CTR_RX|USB_EP_CTR_TX|(((uint32_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)))) & USB_EPREG_MASK) | (bAddr))
 
 #define PCD_GET_EP_ADDRESS(USBx, bEpNum) ((uint8_t)(PCD_GET_ENDPOINT((USBx), (bEpNum)) & USB_EPADDR_FIELD))
 
-#define PCD_EP_TX_ADDRESS(USBx, bEpNum) ((uint32_t *)(((USBx)->BTABLE+(bEpNum)*8)*2+     ((uint32_t)(USBx) + 0x400)))
-#define PCD_EP_TX_CNT(USBx, bEpNum) ((uint32_t *)(((USBx)->BTABLE+(bEpNum)*8+2)*2+  ((uint32_t)(USBx) + 0x400)))
-#define PCD_EP_RX_ADDRESS(USBx, bEpNum) ((uint32_t *)(((USBx)->BTABLE+(bEpNum)*8+4)*2+  ((uint32_t)(USBx) + 0x400)))
-#define PCD_EP_RX_CNT(USBx, bEpNum) ((uint32_t *)(((USBx)->BTABLE+(bEpNum)*8+6)*2+  ((uint32_t)(USBx) + 0x400)))
+#define PCD_EP_TX_ADDRESS(USBx, bEpNum) ((uint16_t *)((uint32_t)((((USBx)->BTABLE+(bEpNum)*8)*2+     ((uint32_t)(USBx) + 0x400U)))))
+#define PCD_EP_TX_CNT(USBx, bEpNum) ((uint16_t *)((uint32_t)((((USBx)->BTABLE+(bEpNum)*8+2)*2+  ((uint32_t)(USBx) + 0x400U)))))
+#define PCD_EP_RX_ADDRESS(USBx, bEpNum) ((uint16_t *)((uint32_t)((((USBx)->BTABLE+(bEpNum)*8+4)*2+ ((uint32_t)(USBx) + 0x400U)))))
+#define PCD_EP_RX_CNT(USBx, bEpNum) ((uint16_t *)((uint32_t)((((USBx)->BTABLE+(bEpNum)*8+6)*2+  ((uint32_t)(USBx) + 0x400U)))))
       
 #define PCD_SET_EP_RX_CNT(USBx, bEpNum,wCount) {\
-    uint32_t *pdwReg = PCD_EP_RX_CNT((USBx), (bEpNum)); \
-    PCD_SET_EP_CNT_RX_REG(pdwReg, (wCount));\
+    uint16_t *pdwReg =PCD_EP_RX_CNT((USBx),(bEpNum)); \
+    PCD_SET_EP_CNT_RX_REG((pdwReg), (wCount))\
   }
 
 /**
@@ -625,7 +623,7 @@ typedef struct
     {                                                  \
       (wNBlocks)--;\
     }                                                  \
-    *pdwReg = (uint16_t)((uint16_t)((wNBlocks) << 10) | 0x8000); \
+    *pdwReg = (uint16_t)((uint16_t)((wNBlocks) << 10U) | (uint16_t)0x8000U); \
   }/* PCD_CALC_BLK32 */
 
 #define PCD_CALC_BLK2(dwReg,wCount,wNBlocks) {\
@@ -641,17 +639,17 @@ typedef struct
     uint16_t wNBlocks;\
     if((wCount) > 62)                                \
     {                                                \
-      PCD_CALC_BLK32((dwReg),(wCount),wNBlocks);     \
+      PCD_CALC_BLK32((dwReg),(wCount),wNBlocks)     \
     }                                                \
     else                                             \
     {                                                \
-      PCD_CALC_BLK2((dwReg),(wCount),wNBlocks);      \
+      PCD_CALC_BLK2((dwReg),(wCount),wNBlocks)     \
     }                                                \
   }/* PCD_SET_EP_CNT_RX_REG */
 
 #define PCD_SET_EP_RX_DBUF0_CNT(USBx, bEpNum,wCount) {\
-    uint32_t *pdwReg = PCD_EP_TX_CNT((USBx), (bEpNum)); \
-    PCD_SET_EP_CNT_RX_REG(pdwReg, (wCount));\
+    uint16_t *pdwReg = PCD_EP_TX_CNT((USBx), (bEpNum)); \
+    PCD_SET_EP_CNT_RX_REG(pdwReg, (wCount))\
   }
 /**
   * @brief  sets counter for the tx/rx buffer.
@@ -679,8 +677,8 @@ typedef struct
   * @param  wBuf0Addr: buffer 0 address.
   * @retval Counter value
   */
-#define PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum,wBuf0Addr) {PCD_SET_EP_TX_ADDRESS((USBx), (bEpNum), (wBuf0Addr));}
-#define PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum,wBuf1Addr) {PCD_SET_EP_RX_ADDRESS((USBx), (bEpNum), (wBuf1Addr));}
+#define PCD_SET_EP_DBUF0_ADDR(USBx, bEpNum,wBuf0Addr) (PCD_SET_EP_TX_ADDRESS((USBx), (bEpNum), (wBuf0Addr)))
+#define PCD_SET_EP_DBUF1_ADDR(USBx, bEpNum,wBuf1Addr) (PCD_SET_EP_RX_ADDRESS((USBx), (bEpNum), (wBuf1Addr)))
 
 /**
   * @brief  Sets addresses in a double buffer endpoint.
@@ -716,7 +714,7 @@ typedef struct
 #define PCD_SET_EP_DBUF0_CNT(USBx, bEpNum, bDir, wCount)  { \
     if((bDir) == PCD_EP_DBUF_OUT)\
       /* OUT endpoint */ \
-    {PCD_SET_EP_RX_DBUF0_CNT((USBx), (bEpNum),(wCount));} \
+    {PCD_SET_EP_RX_DBUF0_CNT((USBx), (bEpNum),(wCount))} \
     else if((bDir) == PCD_EP_DBUF_IN)\
       /* IN endpoint */ \
       *PCD_EP_TX_CNT((USBx), (bEpNum)) = (uint32_t)(wCount);  \
@@ -725,17 +723,17 @@ typedef struct
 #define PCD_SET_EP_DBUF1_CNT(USBx, bEpNum, bDir, wCount)  { \
     if((bDir) == PCD_EP_DBUF_OUT)\
     {/* OUT endpoint */                                       \
-      PCD_SET_EP_RX_CNT((USBx), (bEpNum),(wCount));           \
+      PCD_SET_EP_RX_CNT((USBx), (bEpNum),(wCount))           \
     }                                                         \
     else if((bDir) == PCD_EP_DBUF_IN)\
     {/* IN endpoint */                                        \
-      *PCD_EP_TX_CNT((USBx), (bEpNum)) = (uint32_t)(wCount); \
+      *PCD_EP_RX_CNT((USBx), (bEpNum)) = (uint32_t)(wCount); \
     }                                                         \
   } /* SetEPDblBuf1Count */
 
 #define PCD_SET_EP_DBUF_CNT(USBx, bEpNum, bDir, wCount) {\
-    PCD_SET_EP_DBUF0_CNT((USBx), (bEpNum), (bDir), (wCount)); \
-    PCD_SET_EP_DBUF1_CNT((USBx), (bEpNum), (bDir), (wCount)); \
+    PCD_SET_EP_DBUF0_CNT((USBx), (bEpNum), (bDir), (wCount)) \
+    PCD_SET_EP_DBUF1_CNT((USBx), (bEpNum), (bDir), (wCount)) \
   } /* PCD_SET_EP_DBUF_CNT  */
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pcd_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended PCD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the USB Peripheral Controller:
@@ -12,7 +10,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pcd_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pcd_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of PCD HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pwr.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   PWR HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -14,7 +12,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -57,10 +55,10 @@
 
 /* Private typedef -----------------------------------------------------------*/
 /* Private define ------------------------------------------------------------*/
-#define PVD_MODE_IT               ((uint32_t)0x00010000)
-#define PVD_MODE_EVT              ((uint32_t)0x00020000)
-#define PVD_RISING_EDGE           ((uint32_t)0x00000001)
-#define PVD_FALLING_EDGE          ((uint32_t)0x00000002)
+#define PVD_MODE_IT               (0x00010000U)
+#define PVD_MODE_EVT              (0x00020000U)
+#define PVD_RISING_EDGE           (0x00000001U)
+#define PVD_FALLING_EDGE          (0x00000002U)
 
 /* Private macro -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pwr.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of PWR HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -81,7 +79,7 @@ typedef struct
 /** @addtogroup PWR_Private_Constants
   * @{
   */ 
-#define PWR_EXTI_LINE_PVD  ((uint32_t)0x00010000)  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
+#define PWR_EXTI_LINE_PVD  (0x00010000U)  /*!< External interrupt line 16 Connected to the PVD EXTI Line */
 
 /**
   * @}
@@ -170,13 +168,13 @@ typedef struct
 /** @defgroup PWR_PVD_Mode PWR PVD Mode
   * @{
   */
-#define PWR_PVD_MODE_NORMAL                 ((uint32_t)0x00000000)   /*!< basic mode is used */
-#define PWR_PVD_MODE_IT_RISING              ((uint32_t)0x00010001)   /*!< External Interrupt Mode with Rising edge trigger detection */
-#define PWR_PVD_MODE_IT_FALLING             ((uint32_t)0x00010002)   /*!< External Interrupt Mode with Falling edge trigger detection */
-#define PWR_PVD_MODE_IT_RISING_FALLING      ((uint32_t)0x00010003)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
-#define PWR_PVD_MODE_EVENT_RISING           ((uint32_t)0x00020001)   /*!< Event Mode with Rising edge trigger detection */
-#define PWR_PVD_MODE_EVENT_FALLING          ((uint32_t)0x00020002)   /*!< Event Mode with Falling edge trigger detection */
-#define PWR_PVD_MODE_EVENT_RISING_FALLING   ((uint32_t)0x00020003)   /*!< Event Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_NORMAL                 (0x00000000U)   /*!< basic mode is used */
+#define PWR_PVD_MODE_IT_RISING              (0x00010001U)   /*!< External Interrupt Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_IT_FALLING             (0x00010002U)   /*!< External Interrupt Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_IT_RISING_FALLING      (0x00010003U)   /*!< External Interrupt Mode with Rising/Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING           (0x00020001U)   /*!< Event Mode with Rising edge trigger detection */
+#define PWR_PVD_MODE_EVENT_FALLING          (0x00020002U)   /*!< Event Mode with Falling edge trigger detection */
+#define PWR_PVD_MODE_EVENT_RISING_FALLING   (0x00020003U)   /*!< Event Mode with Rising/Falling edge trigger detection */
 
  /**
  * @}
@@ -185,7 +183,7 @@ typedef struct
 /** @defgroup PWR_Regulator_state_in_SLEEP_STOP_mode PWR Regulator state in SLEEP/STOP mode
   * @{
   */
-#define PWR_MAINREGULATOR_ON           ((uint32_t)0x00000000)
+#define PWR_MAINREGULATOR_ON           (0x00000000U)
 #define PWR_LOWPOWERREGULATOR_ON       PWR_CR_LPSDSR
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pwr_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended PWR HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of the Power Controller (PWR) peripheral:
@@ -13,7 +11,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_pwr_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_pwr_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of PWR HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rcc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   RCC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Reset and Clock Control (RCC) peripheral:
@@ -51,7 +49,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -272,10 +270,10 @@ void HAL_RCC_DeInit(void)
   CLEAR_REG(RCC->CFGR);
   
   /* Set MSIClockRange & MSITRIM[4:0] bits to the reset value */
-  MODIFY_REG(RCC->ICSCR, (RCC_ICSCR_MSIRANGE | RCC_ICSCR_MSITRIM), (((uint32_t)0 << RCC_ICSCR_MSITRIM_BITNUMBER) | RCC_ICSCR_MSIRANGE_5));
+  MODIFY_REG(RCC->ICSCR, (RCC_ICSCR_MSIRANGE | RCC_ICSCR_MSITRIM), ((0U << RCC_ICSCR_MSITRIM_BITNUMBER) | RCC_ICSCR_MSIRANGE_5));
   
   /* Set HSITRIM bits to the reset value */
-  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, ((uint32_t)0x10 << POSITION_VAL(RCC_ICSCR_HSITRIM)));
+  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, (0x10U << POSITION_VAL(RCC_ICSCR_HSITRIM)));
   
   /* Disable all interrupts */
   CLEAR_REG(RCC->CIR);
@@ -903,7 +901,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   if(((RCC_ClkInitStruct->ClockType) & RCC_CLOCKTYPE_PCLK2) == RCC_CLOCKTYPE_PCLK2)
   {
     assert_param(IS_RCC_PCLK(RCC_ClkInitStruct->APB2CLKDivider));
-    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, ((RCC_ClkInitStruct->APB2CLKDivider) << 3));
+    MODIFY_REG(RCC->CFGR, RCC_CFGR_PPRE2, ((RCC_ClkInitStruct->APB2CLKDivider) << 3U));
   }
  
   /* Update the SystemCoreClock global variable */
@@ -961,7 +959,7 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
   */
 void HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv)
 {
-  GPIO_InitTypeDef gpio = {0};
+  GPIO_InitTypeDef gpio;
 
   /* Check the parameters */
   assert_param(IS_RCC_MCO(RCC_MCOx));
@@ -1039,8 +1037,8 @@ void HAL_RCC_DisableCSS(void)
   */
 uint32_t HAL_RCC_GetSysClockFreq(void)
 {
-  uint32_t tmpreg = 0, pllm = 0, plld = 0, pllvco = 0, msiclkrange = 0;
-  uint32_t sysclockfreq = 0;
+  uint32_t tmpreg = 0U, pllm = 0U, plld = 0U, pllvco = 0U, msiclkrange = 0U;
+  uint32_t sysclockfreq = 0U;
   
   tmpreg = RCC->CFGR;
   
@@ -1060,7 +1058,7 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
     case RCC_SYSCLKSOURCE_STATUS_PLLCLK:  /* PLL used as system clock */
     {
       pllm = PLLMulTable[(uint32_t)(tmpreg & RCC_CFGR_PLLMUL) >> RCC_CFGR_PLLMUL_BITNUMBER];
-      plld = ((uint32_t)(tmpreg & RCC_CFGR_PLLDIV) >> RCC_CFGR_PLLDIV_BITNUMBER) + 1;
+      plld = ((uint32_t)(tmpreg & RCC_CFGR_PLLDIV) >> RCC_CFGR_PLLDIV_BITNUMBER) + 1U;
       if (__HAL_RCC_GET_PLL_OSCSOURCE() != RCC_PLLSOURCE_HSI)
       {
         /* HSE used as PLL clock source */
@@ -1078,7 +1076,7 @@ uint32_t HAL_RCC_GetSysClockFreq(void)
     default: /* MSI used as system clock */
     {
       msiclkrange = (RCC->ICSCR & RCC_ICSCR_MSIRANGE ) >> RCC_ICSCR_MSIRANGE_BITNUMBER;
-      sysclockfreq = (32768 * (1 << (msiclkrange + 1)));
+      sysclockfreq = (32768U * (1U << (msiclkrange + 1U)));
       break;
     }
   }
@@ -1245,7 +1243,7 @@ void HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pF
   RCC_ClkInitStruct->APB1CLKDivider = (uint32_t)(RCC->CFGR & RCC_CFGR_PPRE1);   
   
   /* Get the APB2 configuration ----------------------------------------------*/ 
-  RCC_ClkInitStruct->APB2CLKDivider = (uint32_t)((RCC->CFGR & RCC_CFGR_PPRE2) >> 3);
+  RCC_ClkInitStruct->APB2CLKDivider = (uint32_t)((RCC->CFGR & RCC_CFGR_PPRE2) >> 3U);
   
   /* Get the Flash Wait State (Latency) configuration ------------------------*/   
   *pFLatency = (uint32_t)(FLASH->ACR & FLASH_ACR_LATENCY); 
@@ -1300,7 +1298,7 @@ __weak void HAL_RCC_CSSCallback(void)
   */
 static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t MSIrange)
 {
-  uint32_t vos = 0;
+  uint32_t vos = 0U;
   uint32_t latency = FLASH_LATENCY_0;  /* default value 0WS */
 
   /* HCLK can reach 4 MHz only if AHB prescaler = 1 */
@@ -1308,12 +1306,12 @@ static HAL_StatusTypeDef RCC_SetFlashLatencyFromMSIRange(uint32_t MSIrange)
   {
     if(__HAL_RCC_PWR_IS_CLK_ENABLED())
     {
-      vos = HAL_PWREx_GetVoltageRange();
+      vos = READ_BIT(PWR->CR, PWR_CR_VOS);
     }
     else
     {
       __HAL_RCC_PWR_CLK_ENABLE();
-      vos = HAL_PWREx_GetVoltageRange();
+      vos = READ_BIT(PWR->CR, PWR_CR_VOS);
       __HAL_RCC_PWR_CLK_DISABLE();
     }
     

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rcc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RCC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -68,10 +66,10 @@
 #define RCC_LSE_TIMEOUT_VALUE      LSE_STARTUP_TIMEOUT
 #define CLOCKSWITCH_TIMEOUT_VALUE  (5000U)  /* 5 s    */
 #define HSE_TIMEOUT_VALUE          HSE_STARTUP_TIMEOUT
-#define MSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1) */
-#define HSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1) */
-#define LSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1) */
-#define PLL_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1) */
+#define MSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1U) */
+#define HSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1U) */
+#define LSI_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1U) */
+#define PLL_TIMEOUT_VALUE          (2U)      /* 2 ms (minimum Tick + 1U) */
 /**
   * @}
   */
@@ -100,63 +98,63 @@
 /* --- CR Register ---*/
 /* Alias word address of HSION bit */
 #define RCC_HSION_BIT_NUMBER      POSITION_VAL(RCC_CR_HSION)
-#define RCC_CR_HSION_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32) + (RCC_HSION_BIT_NUMBER * 4)))
+#define RCC_CR_HSION_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32U) + (RCC_HSION_BIT_NUMBER * 4U)))
 /* Alias word address of MSION bit */
 #define RCC_MSION_BIT_NUMBER      POSITION_VAL(RCC_CR_MSION)
-#define RCC_CR_MSION_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32) + (RCC_MSION_BIT_NUMBER * 4)))
+#define RCC_CR_MSION_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32U) + (RCC_MSION_BIT_NUMBER * 4U)))
 /* Alias word address of HSEON bit */
 #define RCC_HSEON_BIT_NUMBER      POSITION_VAL(RCC_CR_HSEON)
-#define RCC_CR_HSEON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32) + (RCC_HSEON_BIT_NUMBER * 4)))
+#define RCC_CR_HSEON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32U) + (RCC_HSEON_BIT_NUMBER * 4U)))
 /* Alias word address of CSSON bit */
 #define RCC_CSSON_BIT_NUMBER      POSITION_VAL(RCC_CR_CSSON)
-#define RCC_CR_CSSON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32) + (RCC_CSSON_BIT_NUMBER * 4)))
+#define RCC_CR_CSSON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32U) + (RCC_CSSON_BIT_NUMBER * 4U)))
 /* Alias word address of PLLON bit */
 #define RCC_PLLON_BIT_NUMBER      POSITION_VAL(RCC_CR_PLLON)
-#define RCC_CR_PLLON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32) + (RCC_PLLON_BIT_NUMBER * 4)))
+#define RCC_CR_PLLON_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CR_OFFSET_BB * 32U) + (RCC_PLLON_BIT_NUMBER * 4U)))
 
 /* --- CSR Register ---*/
 /* Alias word address of LSION bit */
 #define RCC_LSION_BIT_NUMBER      POSITION_VAL(RCC_CSR_LSION)
-#define RCC_CSR_LSION_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_LSION_BIT_NUMBER * 4)))
+#define RCC_CSR_LSION_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_LSION_BIT_NUMBER * 4U)))
 
 /* Alias word address of RMVF bit */
 #define RCC_RMVF_BIT_NUMBER       POSITION_VAL(RCC_CSR_RMVF)
-#define RCC_CSR_RMVF_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_RMVF_BIT_NUMBER * 4)))
+#define RCC_CSR_RMVF_BB           ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_RMVF_BIT_NUMBER * 4U)))
 
 /* Alias word address of LSEON bit */
 #define RCC_LSEON_BIT_NUMBER      POSITION_VAL(RCC_CSR_LSEON)
-#define RCC_CSR_LSEON_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_LSEON_BIT_NUMBER * 4)))
+#define RCC_CSR_LSEON_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_LSEON_BIT_NUMBER * 4U)))
 
 /* Alias word address of LSEON bit */
 #define RCC_LSEBYP_BIT_NUMBER     POSITION_VAL(RCC_CSR_LSEBYP)
-#define RCC_CSR_LSEBYP_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_LSEBYP_BIT_NUMBER * 4)))
+#define RCC_CSR_LSEBYP_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_LSEBYP_BIT_NUMBER * 4U)))
 
 /* Alias word address of RTCEN bit */
 #define RCC_RTCEN_BIT_NUMBER      POSITION_VAL(RCC_CSR_RTCEN)
-#define RCC_CSR_RTCEN_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_RTCEN_BIT_NUMBER * 4)))
+#define RCC_CSR_RTCEN_BB          ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_RTCEN_BIT_NUMBER * 4U)))
 
 /* Alias word address of RTCRST bit */
 #define RCC_RTCRST_BIT_NUMBER     POSITION_VAL(RCC_CSR_RTCRST)
-#define RCC_CSR_RTCRST_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (RCC_RTCRST_BIT_NUMBER * 4)))
+#define RCC_CSR_RTCRST_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (RCC_RTCRST_BIT_NUMBER * 4U)))
 
 /**
   * @}
   */
   
 /* CR register byte 2 (Bits[23:16]) base address */
-#define RCC_CR_BYTE2_ADDRESS          ((uint32_t)(RCC_BASE + RCC_CR_OFFSET + 0x02))
+#define RCC_CR_BYTE2_ADDRESS          ((uint32_t)(RCC_BASE + RCC_CR_OFFSET + 0x02U))
 
 /* CIR register byte 1 (Bits[15:8]) base address */
-#define RCC_CIR_BYTE1_ADDRESS     ((uint32_t)(RCC_BASE + RCC_CIR_OFFSET + 0x01))
+#define RCC_CIR_BYTE1_ADDRESS     ((uint32_t)(RCC_BASE + RCC_CIR_OFFSET + 0x01U))
 
 /* CIR register byte 2 (Bits[23:16]) base address */
-#define RCC_CIR_BYTE2_ADDRESS     ((uint32_t)(RCC_BASE + RCC_CIR_OFFSET + 0x02))
+#define RCC_CIR_BYTE2_ADDRESS     ((uint32_t)(RCC_BASE + RCC_CIR_OFFSET + 0x02U))
 
 /* Defines used for Flags */
-#define CR_REG_INDEX                     ((uint8_t)1)
-#define CSR_REG_INDEX                    ((uint8_t)2)
+#define CR_REG_INDEX                     ((uint8_t)1U)
+#define CSR_REG_INDEX                    ((uint8_t)2U)
 
-#define RCC_FLAG_MASK                    ((uint8_t)0x1F)
+#define RCC_FLAG_MASK                    ((uint8_t)0x1FU)
 
 /**
   * @}
@@ -178,8 +176,8 @@
 #define IS_RCC_LSE(__LSE__) (((__LSE__) == RCC_LSE_OFF) || ((__LSE__) == RCC_LSE_ON) || \
                              ((__LSE__) == RCC_LSE_BYPASS))
 #define IS_RCC_HSI(__HSI__) (((__HSI__) == RCC_HSI_OFF) || ((__HSI__) == RCC_HSI_ON))
-#define IS_RCC_CALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= 0x1F)
-#define IS_RCC_MSICALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= 0xFF)
+#define IS_RCC_CALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= 0x1FU)
+#define IS_RCC_MSICALIBRATION_VALUE(__VALUE__) ((__VALUE__) <= 0xFFU)
 #define IS_RCC_MSI_CLOCK_RANGE(__RANGE__)  (((__RANGE__) == RCC_MSIRANGE_0) || \
                                             ((__RANGE__) == RCC_MSIRANGE_1) || \
                                             ((__RANGE__) == RCC_MSIRANGE_2) || \
@@ -282,7 +280,7 @@ typedef struct
                                        This parameter can be a value of @ref RCC_HSI_Config */
 
   uint32_t HSICalibrationValue;   /*!< The HSI calibration trimming value (default is RCC_HSICALIBRATION_DEFAULT).
-                                       This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1F */
+                                       This parameter must be a number between Min_Data = 0x00 and Max_Data = 0x1FU */
 
   uint32_t LSIState;              /*!< The new state of the LSI.
                                        This parameter can be a value of @ref RCC_LSI_Config */
@@ -291,7 +289,7 @@ typedef struct
                                        This parameter can be a value of @ref RCC_MSI_Config */
 
   uint32_t MSICalibrationValue;   /*!< The MSI calibration trimming value. (default is RCC_MSICALIBRATION_DEFAULT).
-                                       This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFF */
+                                       This parameter must be a number between Min_Data = 0x00 and Max_Data = 0xFFU */
 
   uint32_t MSIClockRange;         /*!< The MSI  frequency  range.
                                         This parameter can be a value of @ref RCC_MSI_Clock_Range */
@@ -344,12 +342,12 @@ typedef struct
 /** @defgroup RCC_Oscillator_Type Oscillator Type
   * @{
   */
-#define RCC_OSCILLATORTYPE_NONE            ((uint32_t)0x00000000)
-#define RCC_OSCILLATORTYPE_HSE             ((uint32_t)0x00000001)
-#define RCC_OSCILLATORTYPE_HSI             ((uint32_t)0x00000002)
-#define RCC_OSCILLATORTYPE_LSE             ((uint32_t)0x00000004)
-#define RCC_OSCILLATORTYPE_LSI             ((uint32_t)0x00000008)
-#define RCC_OSCILLATORTYPE_MSI             ((uint32_t)0x00000010)
+#define RCC_OSCILLATORTYPE_NONE            (0x00000000U)
+#define RCC_OSCILLATORTYPE_HSE             (0x00000001U)
+#define RCC_OSCILLATORTYPE_HSI             (0x00000002U)
+#define RCC_OSCILLATORTYPE_LSE             (0x00000004U)
+#define RCC_OSCILLATORTYPE_LSI             (0x00000008U)
+#define RCC_OSCILLATORTYPE_MSI             (0x00000010U)
 /**
   * @}
   */
@@ -357,9 +355,9 @@ typedef struct
 /** @defgroup RCC_HSE_Config HSE Config
   * @{
   */
-#define RCC_HSE_OFF                      ((uint32_t)0x00000000)                     /*!< HSE clock deactivation */
-#define RCC_HSE_ON                       ((uint32_t)0x00000001)                     /*!< HSE clock activation */
-#define RCC_HSE_BYPASS                   ((uint32_t)0x00000005)                     /*!< External clock source for HSE clock */
+#define RCC_HSE_OFF                      (0x00000000U)                     /*!< HSE clock deactivation */
+#define RCC_HSE_ON                       (0x00000001U)                     /*!< HSE clock activation */
+#define RCC_HSE_BYPASS                   (0x00000005U)                     /*!< External clock source for HSE clock */
 /**
   * @}
   */
@@ -367,9 +365,9 @@ typedef struct
 /** @defgroup RCC_LSE_Config LSE Config
   * @{
   */
-#define RCC_LSE_OFF                      ((uint32_t)0x00000000)                       /*!< LSE clock deactivation */
-#define RCC_LSE_ON                       ((uint32_t)0x00000001)                       /*!< LSE clock activation */
-#define RCC_LSE_BYPASS                   ((uint32_t)0x00000005)                       /*!< External clock source for LSE clock */
+#define RCC_LSE_OFF                      (0x00000000U)                       /*!< LSE clock deactivation */
+#define RCC_LSE_ON                       (0x00000001U)                       /*!< LSE clock activation */
+#define RCC_LSE_BYPASS                   (0x00000005U)                       /*!< External clock source for LSE clock */
 
 /**
   * @}
@@ -378,10 +376,10 @@ typedef struct
 /** @defgroup RCC_HSI_Config HSI Config
   * @{
   */
-#define RCC_HSI_OFF                      ((uint32_t)0x00000000)           /*!< HSI clock deactivation */
+#define RCC_HSI_OFF                      (0x00000000U)           /*!< HSI clock deactivation */
 #define RCC_HSI_ON                       RCC_CR_HSION                     /*!< HSI clock activation */
 
-#define RCC_HSICALIBRATION_DEFAULT       ((uint32_t)0x10)         /* Default HSI calibration trimming value */
+#define RCC_HSICALIBRATION_DEFAULT       (0x10U)         /* Default HSI calibration trimming value */
 
 /**
   * @}
@@ -406,7 +404,7 @@ typedef struct
 /** @defgroup RCC_LSI_Config LSI Config
   * @{
   */
-#define RCC_LSI_OFF                      ((uint32_t)0x00000000)   /*!< LSI clock deactivation */
+#define RCC_LSI_OFF                      (0x00000000U)   /*!< LSI clock deactivation */
 #define RCC_LSI_ON                       RCC_CSR_LSION            /*!< LSI clock activation */
 
 /**
@@ -416,10 +414,10 @@ typedef struct
 /** @defgroup RCC_MSI_Config MSI Config
   * @{
   */
-#define RCC_MSI_OFF                      ((uint32_t)0x00000000)
-#define RCC_MSI_ON                       ((uint32_t)0x00000001)
+#define RCC_MSI_OFF                      (0x00000000U)
+#define RCC_MSI_ON                       (0x00000001U)
 
-#define RCC_MSICALIBRATION_DEFAULT       ((uint32_t)0x00000000U)   /* Default MSI calibration trimming value */
+#define RCC_MSICALIBRATION_DEFAULT       (0x00000000U)   /* Default MSI calibration trimming value */
 
 /**
   * @}
@@ -428,9 +426,9 @@ typedef struct
 /** @defgroup RCC_PLL_Config PLL Config
   * @{
   */
-#define RCC_PLL_NONE                      ((uint32_t)0x00000000)  /*!< PLL is not configured */
-#define RCC_PLL_OFF                       ((uint32_t)0x00000001)  /*!< PLL deactivation */
-#define RCC_PLL_ON                        ((uint32_t)0x00000002)  /*!< PLL activation */
+#define RCC_PLL_NONE                      (0x00000000U)  /*!< PLL is not configured */
+#define RCC_PLL_OFF                       (0x00000001U)  /*!< PLL deactivation */
+#define RCC_PLL_ON                        (0x00000002U)  /*!< PLL activation */
 
 /**
   * @}
@@ -439,10 +437,10 @@ typedef struct
 /** @defgroup RCC_System_Clock_Type System Clock Type
   * @{
   */
-#define RCC_CLOCKTYPE_SYSCLK             ((uint32_t)0x00000001) /*!< SYSCLK to configure */
-#define RCC_CLOCKTYPE_HCLK               ((uint32_t)0x00000002) /*!< HCLK to configure */
-#define RCC_CLOCKTYPE_PCLK1              ((uint32_t)0x00000004) /*!< PCLK1 to configure */
-#define RCC_CLOCKTYPE_PCLK2              ((uint32_t)0x00000008) /*!< PCLK2 to configure */
+#define RCC_CLOCKTYPE_SYSCLK             (0x00000001U) /*!< SYSCLK to configure */
+#define RCC_CLOCKTYPE_HCLK               (0x00000002U) /*!< HCLK to configure */
+#define RCC_CLOCKTYPE_PCLK1              (0x00000004U) /*!< PCLK1 to configure */
+#define RCC_CLOCKTYPE_PCLK2              (0x00000008U) /*!< PCLK2 to configure */
 
 /**
   * @}
@@ -505,7 +503,7 @@ typedef struct
 /** @defgroup RCC_HAL_EC_RTC_HSE_DIV RTC HSE Prescaler
   * @{
   */
-#define RCC_RTC_HSE_DIV_2               (uint32_t)0x00000000U /*!< HSE is divided by 2 for RTC clock  */
+#define RCC_RTC_HSE_DIV_2               0x00000000U /*!< HSE is divided by 2 for RTC clock  */
 #define RCC_RTC_HSE_DIV_4               RCC_CR_RTCPRE_0       /*!< HSE is divided by 4 for RTC clock  */
 #define RCC_RTC_HSE_DIV_8               RCC_CR_RTCPRE_1       /*!< HSE is divided by 8 for RTC clock  */
 #define RCC_RTC_HSE_DIV_16              RCC_CR_RTCPRE         /*!< HSE is divided by 16 for RTC clock */
@@ -516,7 +514,7 @@ typedef struct
 /** @defgroup RCC_RTC_LCD_Clock_Source RTC LCD Clock Source
   * @{
   */
-#define RCC_RTCCLKSOURCE_NO_CLK          ((uint32_t)0x00000000)                 /*!< No clock */
+#define RCC_RTCCLKSOURCE_NO_CLK          (0x00000000U)                 /*!< No clock */
 #define RCC_RTCCLKSOURCE_LSE             RCC_CSR_RTCSEL_LSE                  /*!< LSE oscillator clock used as RTC clock */
 #define RCC_RTCCLKSOURCE_LSI             RCC_CSR_RTCSEL_LSI                  /*!< LSI oscillator clock used as RTC clock */
 #define RCC_RTCCLKSOURCE_HSE_DIVX        RCC_CSR_RTCSEL_HSE                         /*!< HSE oscillator clock divided by X used as RTC clock */
@@ -561,7 +559,7 @@ typedef struct
 /** @defgroup RCC_MCO_Index MCO Index
   * @{
   */
-#define RCC_MCO1                         ((uint32_t)0x00000000)
+#define RCC_MCO1                         (0x00000000U)
 #define RCC_MCO                          RCC_MCO1               /*!< MCO1 to be compliant with other families with 2 MCOs*/
 
 /**
@@ -620,22 +618,22 @@ typedef struct
   * @{
   */
 /* Flags in the CR register */
-#define RCC_FLAG_HSIRDY                  ((uint8_t)((CR_REG_INDEX << 5) | POSITION_VAL(RCC_CR_HSIRDY))) /*!< Internal High Speed clock ready flag */
-#define RCC_FLAG_MSIRDY                  ((uint8_t)((CR_REG_INDEX << 5) | POSITION_VAL(RCC_CR_MSIRDY))) /*!< MSI clock ready flag */
-#define RCC_FLAG_HSERDY                  ((uint8_t)((CR_REG_INDEX << 5) | POSITION_VAL(RCC_CR_HSERDY))) /*!< External High Speed clock ready flag */
-#define RCC_FLAG_PLLRDY                  ((uint8_t)((CR_REG_INDEX << 5) | POSITION_VAL(RCC_CR_PLLRDY))) /*!< PLL clock ready flag */
+#define RCC_FLAG_HSIRDY                  ((uint8_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_HSIRDY))) /*!< Internal High Speed clock ready flag */
+#define RCC_FLAG_MSIRDY                  ((uint8_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_MSIRDY))) /*!< MSI clock ready flag */
+#define RCC_FLAG_HSERDY                  ((uint8_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_HSERDY))) /*!< External High Speed clock ready flag */
+#define RCC_FLAG_PLLRDY                  ((uint8_t)((CR_REG_INDEX << 5U) | POSITION_VAL(RCC_CR_PLLRDY))) /*!< PLL clock ready flag */
 
 /* Flags in the CSR register */
-#define RCC_FLAG_LSIRDY                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_LSIRDY)))   /*!< Internal Low Speed oscillator Ready */
-#define RCC_FLAG_LSECSS                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_LSECSSD)))  /*!< CSS on LSE failure Detection */
-#define RCC_FLAG_OBLRST                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_OBLRSTF)))  /*!< Options bytes loading reset flag */
-#define RCC_FLAG_PINRST                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_PINRSTF)))  /*!< PIN reset flag */
-#define RCC_FLAG_PORRST                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_PORRSTF)))  /*!< POR/PDR reset flag */
-#define RCC_FLAG_SFTRST                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_SFTRSTF)))  /*!< Software Reset flag */
-#define RCC_FLAG_IWDGRST                 ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_IWDGRSTF))) /*!< Independent Watchdog reset flag */
-#define RCC_FLAG_WWDGRST                 ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_WWDGRSTF))) /*!< Window watchdog reset flag */
-#define RCC_FLAG_LPWRRST                 ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_LPWRRSTF))) /*!< Low-Power reset flag */
-#define RCC_FLAG_LSERDY                  ((uint8_t)((CSR_REG_INDEX << 5) | POSITION_VAL(RCC_CSR_LSERDY))) /*!< External Low Speed oscillator Ready */
+#define RCC_FLAG_LSIRDY                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LSIRDY)))   /*!< Internal Low Speed oscillator Ready */
+#define RCC_FLAG_LSECSS                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LSECSSD)))  /*!< CSS on LSE failure Detection */
+#define RCC_FLAG_OBLRST                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_OBLRSTF)))  /*!< Options bytes loading reset flag */
+#define RCC_FLAG_PINRST                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_PINRSTF)))  /*!< PIN reset flag */
+#define RCC_FLAG_PORRST                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_PORRSTF)))  /*!< POR/PDR reset flag */
+#define RCC_FLAG_SFTRST                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_SFTRSTF)))  /*!< Software Reset flag */
+#define RCC_FLAG_IWDGRST                 ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_IWDGRSTF))) /*!< Independent Watchdog reset flag */
+#define RCC_FLAG_WWDGRST                 ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_WWDGRSTF))) /*!< Window watchdog reset flag */
+#define RCC_FLAG_LPWRRST                 ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LPWRRSTF))) /*!< Low-Power reset flag */
+#define RCC_FLAG_LSERDY                  ((uint8_t)((CSR_REG_INDEX << 5U) | POSITION_VAL(RCC_CSR_LSERDY))) /*!< External Low Speed oscillator Ready */
 
 /**
   * @}
@@ -664,56 +662,56 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOAEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOB_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_GPIOBEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOBEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOC_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_GPIOCEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOCEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOD_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIODEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOH_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_GPIOHEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOHEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_CRC_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_CRCEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_CRCEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_FLITF_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_FLITFEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FLITFEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_DMA1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_DMA1EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA1EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 #define __HAL_RCC_GPIOA_CLK_DISABLE()     (RCC->AHBENR &= ~(RCC_AHBENR_GPIOAEN))
 #define __HAL_RCC_GPIOB_CLK_DISABLE()     (RCC->AHBENR &= ~(RCC_AHBENR_GPIOBEN))
@@ -742,105 +740,105 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM2EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM3_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM3EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM3EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM4_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM4EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM4EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM6_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM6EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM6EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM7_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM7EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM7EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_WWDG_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_WWDGEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_WWDGEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_SPI2_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI2EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI2EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_USART2_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USART2EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USART2EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_USART3_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USART3EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_I2C1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C1EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_I2C2_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C2EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_I2C2EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_USB_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_USBEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_USBEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_PWR_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_PWREN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_DAC_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_DACEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_DACEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_COMP_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_COMPEN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_COMPEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 
 #define __HAL_RCC_TIM2_CLK_DISABLE()      (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM2EN))
@@ -876,49 +874,49 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SYSCFGEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM9_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM9EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM9EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM10_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM10EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM10EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM11_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM11EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_TIM11EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_ADC1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC1EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_ADC1EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_SPI1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SPI1EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_USART1_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN);\
                                         /* Delay after an RCC peripheral clock enabling */\
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_USART1EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 #define __HAL_RCC_SYSCFG_CLK_DISABLE()    (RCC->APB2ENR &= ~(RCC_APB2ENR_SYSCFGEN))
 #define __HAL_RCC_TIM9_CLK_DISABLE()      (RCC->APB2ENR &= ~(RCC_APB2ENR_TIM9EN))
@@ -1422,7 +1420,7 @@ typedef struct
                         CLEAR_BIT(RCC->CR, RCC_CR_HSEON);                   \
                         CLEAR_BIT(RCC->CR, RCC_CR_HSEBYP);                  \
                       }                                                     \
-                    }while(0)
+                    }while(0U)
 
 /**
   * @}
@@ -1470,7 +1468,7 @@ typedef struct
                         CLEAR_BIT(RCC->CSR, RCC_CSR_LSEON);                 \
                         CLEAR_BIT(RCC->CSR, RCC_CSR_LSEBYP);                \
                       }                                                     \
-                    }while(0)
+                    }while(0U)
 
 /**
   * @}
@@ -1701,12 +1699,12 @@ typedef struct
             {                                                                             \
               MODIFY_REG(RCC->CR, RCC_CR_RTCPRE, ((__RTC_CLKSOURCE__) & RCC_CR_RTCPRE));  \
             }                                                                             \
-          } while (0)
+          } while (0U)
 
 #define __HAL_RCC_RTC_CONFIG(__RTC_CLKSOURCE__) do { \
                                       __HAL_RCC_RTC_CLKPRESCALER(__RTC_CLKSOURCE__);      \
                                       RCC->CSR |= ((__RTC_CLKSOURCE__) & RCC_CSR_RTCSEL); \
-                                    } while (0)
+                                    } while (0U)
                                                    
 /** @brief Macro to get the RTC clock source.
   * @retval The clock source can be one of the following values:
@@ -1840,7 +1838,7 @@ typedef struct
   * @note (*) This bit is available in high and medium+ density devices only.
   * @retval The new state of __FLAG__ (TRUE or FALSE).
   */
-#define __HAL_RCC_GET_FLAG(__FLAG__) (((((__FLAG__) >> 5) == CR_REG_INDEX)? RCC->CR :RCC->CSR) & ((uint32_t)1 << ((__FLAG__) & RCC_FLAG_MASK)))   
+#define __HAL_RCC_GET_FLAG(__FLAG__) (((((__FLAG__) >> 5U) == CR_REG_INDEX)? RCC->CR :RCC->CSR) & (1U << ((__FLAG__) & RCC_FLAG_MASK)))   
 
 /**
   * @}
@@ -1878,6 +1876,10 @@ HAL_StatusTypeDef HAL_RCC_ClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, ui
 /* Peripheral Control functions  ************************************************/
 void              HAL_RCC_MCOConfig(uint32_t RCC_MCOx, uint32_t RCC_MCOSource, uint32_t RCC_MCODiv);
 void              HAL_RCC_EnableCSS(void);
+/* CSS NMI IRQ handler */
+void              HAL_RCC_NMI_IRQHandler(void);
+/* User Callbacks in non blocking mode (IT mode) */
+void              HAL_RCC_CSSCallback(void);
 void              HAL_RCC_DisableCSS(void);
 uint32_t          HAL_RCC_GetSysClockFreq(void);
 uint32_t          HAL_RCC_GetHCLKFreq(void);
@@ -1885,12 +1887,6 @@ uint32_t          HAL_RCC_GetPCLK1Freq(void);
 uint32_t          HAL_RCC_GetPCLK2Freq(void);
 void              HAL_RCC_GetOscConfig(RCC_OscInitTypeDef  *RCC_OscInitStruct);
 void              HAL_RCC_GetClockConfig(RCC_ClkInitTypeDef  *RCC_ClkInitStruct, uint32_t *pFLatency);
-
-/* CSS NMI IRQ handler */
-void              HAL_RCC_NMI_IRQHandler(void);
-
-/* User Callbacks in non blocking mode (IT mode) */
-void              HAL_RCC_CSSCallback(void);
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rcc_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended RCC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities RCC extension peripheral:
@@ -12,7 +10,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -235,7 +233,7 @@ HAL_StatusTypeDef HAL_RCCEx_PeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClk
   */
 void HAL_RCCEx_GetPeriphCLKConfig(RCC_PeriphCLKInitTypeDef  *PeriphClkInit)
 {
-  uint32_t srcclk = 0;
+  uint32_t srcclk = 0U;
   
   /* Set all possible values for the extended clock type parameter------------*/
   PeriphClkInit->PeriphClockSelection = RCC_PERIPHCLK_RTC;

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rcc_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rcc_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RCC HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -58,7 +56,7 @@
  * @{
  */
 
-#define LSI_VALUE                  ((uint32_t)37000)  /* ~37kHz */
+#define LSI_VALUE                  (37000U)  /* ~37kHz */
 
 #if defined(STM32L100xBA) || defined(STM32L151xBA) || defined(STM32L152xBA)\
  || defined(STM32L100xC) || defined(STM32L151xC) || defined(STM32L152xC)\
@@ -69,7 +67,7 @@
 
 /* Alias word address of LSECSSON bit */
 #define LSECSSON_BITNUMBER      POSITION_VAL(RCC_CSR_LSECSSON)
-#define CSR_LSECSSON_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32) + (LSECSSON_BITNUMBER * 4)))
+#define CSR_LSECSSON_BB         ((uint32_t)(PERIPH_BB_BASE + (RCC_CSR_OFFSET_BB * 32U) + (LSECSSON_BITNUMBER * 4U)))
 
 #endif /* STM32L100xBA || STM32L151xBA || STM32L152xBA || STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX*/
 
@@ -132,11 +130,11 @@ typedef struct
 /** @defgroup RCCEx_Periph_Clock_Selection RCCEx Periph Clock Selection
   * @{
   */
-#define RCC_PERIPHCLK_RTC           ((uint32_t)0x00000001)
+#define RCC_PERIPHCLK_RTC           (0x00000001U)
 
 #if defined(LCD)
 
-#define RCC_PERIPHCLK_LCD           ((uint32_t)0x00000002)
+#define RCC_PERIPHCLK_LCD           (0x00000002U)
 
 #endif /* LCD */
 
@@ -183,7 +181,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOEEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOE_CLK_DISABLE()   (RCC->AHBENR &= ~(RCC_AHBENR_GPIOEEN))
 
 #endif /* STM32L151xB || STM32L152xB || ... || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
@@ -198,14 +196,14 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOFEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_GPIOG_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->AHBENR, RCC_AHBENR_GPIOGEN);\
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_GPIOGEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 #define __HAL_RCC_GPIOF_CLK_DISABLE()   (RCC->AHBENR &= ~(RCC_AHBENR_GPIOFEN))
 #define __HAL_RCC_GPIOG_CLK_DISABLE()   (RCC->AHBENR &= ~(RCC_AHBENR_GPIOGEN))
@@ -224,7 +222,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_DMA2EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 #define __HAL_RCC_DMA2_CLK_DISABLE()    (RCC->AHBENR &= ~(RCC_AHBENR_DMA2EN))
 
@@ -239,7 +237,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_AESEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_CRYP_CLK_DISABLE()    (RCC->AHBENR &= ~(RCC_AHBENR_AESEN))
 
 #endif /* STM32L162xC || STM32L162xCA || STM32L162xD || STM32L162xE || STM32L162xDX */
@@ -252,7 +250,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->AHBENR, RCC_AHBENR_FSMCEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_FSMC_CLK_DISABLE()    (RCC->AHBENR &= ~(RCC_AHBENR_FSMCEN))
 
 #endif /* STM32L151xD || STM32L152xD || STM32L162xD */
@@ -269,7 +267,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_LCDEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_LCD_CLK_DISABLE()       (RCC->APB1ENR &= ~(RCC_APB1ENR_LCDEN))
 
 #endif /* STM32L100xB || STM32L152xBA || ... || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
@@ -290,7 +288,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_TIM5EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_TIM5_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_TIM5EN))
 
 #endif /* STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
@@ -307,7 +305,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_SPI3EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_SPI3_CLK_DISABLE()    (RCC->APB1ENR &= ~(RCC_APB1ENR_SPI3EN))
 
 #endif /* STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
@@ -321,14 +319,14 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART4EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_UART5_CLK_ENABLE()   do { \
                                         __IO uint32_t tmpreg; \
                                         SET_BIT(RCC->APB1ENR, RCC_APB1ENR_UART5EN);\
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB1ENR, RCC_APB1ENR_UART5EN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 
 #define __HAL_RCC_UART4_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_UART4EN))
 #define __HAL_RCC_UART5_CLK_DISABLE()   (RCC->APB1ENR &= ~(RCC_APB1ENR_UART5EN))
@@ -359,7 +357,7 @@ typedef struct
                                         /* Delay after an RCC peripheral clock enabling */ \
                                         tmpreg = READ_BIT(RCC->APB2ENR, RCC_APB2ENR_SDIOEN);\
                                         UNUSED(tmpreg); \
-                                      } while(0)
+                                      } while(0U)
 #define __HAL_RCC_SDIO_CLK_DISABLE()    (RCC->APB2ENR &= ~(RCC_APB2ENR_SDIOEN))
 
 #endif /* STM32L151xD || STM32L152xD || STM32L162xD */
@@ -927,7 +925,7 @@ typedef struct
   do {                                                      \
     __HAL_RCC_LSECSS_EXTI_ENABLE_RISING_EDGE();             \
     __HAL_RCC_LSECSS_EXTI_ENABLE_FALLING_EDGE();            \
-  } while(0)  
+  } while(0U)  
   
 /**
   * @brief Disable the RCC LSE CSS Extended Interrupt Rising & Falling Trigger.
@@ -937,7 +935,7 @@ typedef struct
   do {                                                       \
     __HAL_RCC_LSECSS_EXTI_DISABLE_RISING_EDGE();             \
     __HAL_RCC_LSECSS_EXTI_DISABLE_FALLING_EDGE();            \
-  } while(0)  
+  } while(0U)  
 
 /**
   * @brief Check whether the specified RCC LSE CSS EXTI interrupt flag is set or not.
@@ -1035,7 +1033,7 @@ void              HAL_RCCEx_LSECSS_Callback(void);
 /**
   * @}
   */
-
+  
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rtc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   RTC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Real Time Clock (RTC) peripheral:
@@ -102,7 +100,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -421,7 +419,7 @@ HAL_StatusTypeDef HAL_RTC_SetTime(RTC_HandleTypeDef *hrtc, RTC_TimeTypeDef *sTim
     hrtc->Instance->TR = (uint32_t)(tmpreg & RTC_TR_RESERVED_MASK);
      
     /* Clear the bits to be configured */
-    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BCK;
+    hrtc->Instance->CR &= (uint32_t)~RTC_CR_BKP;
     
     /* Configure the RTC_CR register */
     hrtc->Instance->CR |= (uint32_t)(sTime->DayLightSaving | sTime->StoreOperation);

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rtc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RTC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -187,7 +185,7 @@ typedef struct
 /** @defgroup RTC_Asynchronous_Predivider Asynchronous Predivider 
   * @{
   */ 
-#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= (uint32_t)0x7F)
+#define IS_RTC_ASYNCH_PREDIV(PREDIV)   ((PREDIV) <= 0x7FU)
 /**
   * @}
   */ 
@@ -195,10 +193,10 @@ typedef struct
 /** @defgroup RTC_Time_Definitions Time Definitions 
   * @{
   */ 
-#define IS_RTC_HOUR12(HOUR)            (((HOUR) > (uint32_t)0) && ((HOUR) <= (uint32_t)12))
-#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= (uint32_t)23)
-#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= (uint32_t)59)
-#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= (uint32_t)59)
+#define IS_RTC_HOUR12(HOUR)            (((HOUR) > 0U) && ((HOUR) <= 12U))
+#define IS_RTC_HOUR24(HOUR)            ((HOUR) <= 23U)
+#define IS_RTC_MINUTES(MINUTES)        ((MINUTES) <= 59U)
+#define IS_RTC_SECONDS(SECONDS)        ((SECONDS) <= 59U)
 /**
   * @}
   */ 
@@ -254,7 +252,7 @@ typedef struct
 /** @defgroup RTC_Year_Date_Definitions Year Definitions
   * @{
   */ 
-#define IS_RTC_YEAR(YEAR)              ((YEAR) <= (uint32_t)99)
+#define IS_RTC_YEAR(YEAR)              ((YEAR) <= 99U)
 /**
   * @}
   */ 
@@ -277,8 +275,8 @@ typedef struct
 #define RTC_MONTH_NOVEMBER             ((uint8_t)0x11)
 #define RTC_MONTH_DECEMBER             ((uint8_t)0x12)
 
-#define IS_RTC_MONTH(MONTH)            (((MONTH) >= (uint32_t)1) && ((MONTH) <= (uint32_t)12))
-#define IS_RTC_DATE(DATE)              (((DATE) >= (uint32_t)1) && ((DATE) <= (uint32_t)31))
+#define IS_RTC_MONTH(MONTH)            (((MONTH) >= 1U) && ((MONTH) <= 12U))
+#define IS_RTC_DATE(DATE)              (((DATE) >= 1U) && ((DATE) <= 31U))
 /**
   * @}
   */ 
@@ -308,7 +306,7 @@ typedef struct
 /** @defgroup RTC_Alarm_Definitions Alarm Definitions
   * @{
   */ 
-#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) >(uint32_t) 0) && ((DATE) <= (uint32_t)31))
+#define IS_RTC_ALARM_DATE_WEEKDAY_DATE(DATE) (((DATE) > 0U) && ((DATE) <= 31U))
 #define IS_RTC_ALARM_DATE_WEEKDAY_WEEKDAY(WEEKDAY) (((WEEKDAY) == RTC_WEEKDAY_MONDAY)    || \
                                                     ((WEEKDAY) == RTC_WEEKDAY_TUESDAY)   || \
                                                     ((WEEKDAY) == RTC_WEEKDAY_WEDNESDAY) || \

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rtc_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended RTC HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Real Time Clock (RTC) Extension peripheral:
@@ -63,7 +61,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -153,10 +151,10 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
   else
   {
     /* Reset TR, DR and CR registers */
-    hrtc->Instance->TR = (uint32_t)0x00000000;
-    hrtc->Instance->DR = (uint32_t)0x00002101;
+    hrtc->Instance->TR = 0x00000000U;
+    hrtc->Instance->DR = 0x00002101U;
     /* Reset All CR bits except CR[2:0] */
-    hrtc->Instance->CR &= (uint32_t)0x00000007;
+    hrtc->Instance->CR &= 0x00000007U;
     
     tickstart = HAL_GetTick();
     
@@ -176,23 +174,23 @@ HAL_StatusTypeDef HAL_RTC_DeInit(RTC_HandleTypeDef *hrtc)
     }
     
     /* Reset all RTC CR register bits */
-    hrtc->Instance->CR &= (uint32_t)0x00000000;
-    hrtc->Instance->WUTR = (uint32_t)0x0000FFFF;
-    hrtc->Instance->PRER = (uint32_t)0x007F00FF;
-    hrtc->Instance->CALIBR = (uint32_t)0x00000000;
-    hrtc->Instance->ALRMAR = (uint32_t)0x00000000;
-    hrtc->Instance->ALRMBR = (uint32_t)0x00000000;
+    hrtc->Instance->CR &= 0x00000000U;
+    hrtc->Instance->WUTR = 0x0000FFFFU;
+    hrtc->Instance->PRER = 0x007F00FFU;
+    hrtc->Instance->CALIBR = 0x00000000U;
+    hrtc->Instance->ALRMAR = 0x00000000U;
+    hrtc->Instance->ALRMBR = 0x00000000U;
 #if defined(STM32L100xBA) || defined (STM32L151xBA) || defined (STM32L152xBA) || defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX) 
-    hrtc->Instance->SHIFTR = (uint32_t)0x00000000;
-    hrtc->Instance->CALR = (uint32_t)0x00000000;
-    hrtc->Instance->ALRMASSR = (uint32_t)0x00000000;
-    hrtc->Instance->ALRMBSSR = (uint32_t)0x00000000;
+    hrtc->Instance->SHIFTR = 0x00000000U;
+    hrtc->Instance->CALR = 0x00000000U;
+    hrtc->Instance->ALRMASSR = 0x00000000U;
+    hrtc->Instance->ALRMBSSR = 0x00000000U;
 #endif /* STM32L100xBA || STM32L151xBA || STM32L152xBA || STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
     /* Reset ISR register and exit initialization mode */
-    hrtc->Instance->ISR = (uint32_t)0x00000000;
+    hrtc->Instance->ISR = 0x00000000U;
     
     /* Reset Tamper and alternate functions configuration register */
-    hrtc->Instance->TAFCR = 0x00000000;
+    hrtc->Instance->TAFCR = 0x00000000U;
     
     /* Wait for synchro */
     if(HAL_RTC_WaitForSynchro(hrtc) != HAL_OK)

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_rtc_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_rtc_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RTC HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -121,7 +119,7 @@ typedef struct
   uint32_t DayLightSaving;  /*!< Specifies RTC_DayLightSaveOperation: the value of hour adjustment. 
                                  This parameter can be a value of @ref RTC_DayLightSaving_Definitions */
   
-  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BCK bit 
+  uint32_t StoreOperation;  /*!< Specifies RTC_StoreOperation value to be written in the BKP bit 
                                  in CR register to store the operation.
                                  This parameter can be a value of @ref RTC_StoreOperation_Definitions */
 }RTC_TimeTypeDef; 
@@ -165,8 +163,8 @@ typedef struct
   */  
 #define RTC_TR_RESERVED_MASK    (0x007F7F7FU)
 #define RTC_DR_RESERVED_MASK    (0x00FFFF3FU) 
-#define RTC_INIT_MASK           ((uint32_t)0xFFFFFFFFU)  
-#define RTC_RSF_MASK            ((uint32_t)0xFFFFFF5FU)
+#define RTC_INIT_MASK           (0xFFFFFFFFU)  
+#define RTC_RSF_MASK            (0xFFFFFF5FU)
 
 #if defined(STM32L100xBA) || defined (STM32L151xBA) || defined (STM32L152xBA) || defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)   
 #define RTC_FLAGS_MASK          ((uint32_t)(RTC_FLAG_ALRAWF | RTC_FLAG_ALRBWF | RTC_FLAG_WUTWF | \
@@ -192,9 +190,9 @@ typedef struct
   * @{
   */ 
 #if defined(STM32L100xBA) || defined (STM32L151xBA) || defined (STM32L152xBA) || defined(STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined(STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined(STM32L151xE) || defined(STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)   
-#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x7FFF)
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= 0x7FFFU)
 #elif defined(STM32L100xB) || defined (STM32L151xB) || defined (STM32L152xB)
-#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= (uint32_t)0x1FFF)
+#define IS_RTC_SYNCH_PREDIV(PREDIV)    ((PREDIV) <= 0x1FFFU)
 #endif /* STM32L100xBA || STM32L151xBA || STM32L152xBA || STM32L100xC || STM32L151xC || STM32L152xC || STM32L162xC || STM32L151xCA || STM32L151xD || STM32L152xCA || STM32L152xD || STM32L162xCA || STM32L162xD || STM32L151xE || STM32L151xDX || STM32L152xE || STM32L152xDX || STM32L162xE || STM32L162xDX */
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sd.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sd.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_sd.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SD card HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Secure Digital (SD) peripheral:
@@ -153,7 +151,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -1853,7 +1851,7 @@ HAL_SD_ErrorTypedef HAL_SD_HighSpeed (SD_HandleTypeDef *hsd)
   if (SD_SPEC != SD_ALLZERO)
   {
     /* Set Block Size for Card */
-    sdio_cmdinitstructure.Argument         = (uint32_t)64;
+    sdio_cmdinitstructure.Argument         = 64U;
     sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
     sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
     sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;
@@ -3183,7 +3181,7 @@ static HAL_SD_ErrorTypedef SD_FindSCR(SD_HandleTypeDef *hsd, uint32_t *pSCR)
   
   /* Set Block Size To 8 Bytes */
   /* Send CMD55 APP_CMD with argument as card's RCA */
-  sdio_cmdinitstructure.Argument         = (uint32_t)8;
+  sdio_cmdinitstructure.Argument         = 8U;
   sdio_cmdinitstructure.CmdIndex         = SD_CMD_SET_BLOCKLEN;
   sdio_cmdinitstructure.Response         = SDIO_RESPONSE_SHORT;
   sdio_cmdinitstructure.WaitForInterrupt = SDIO_WAIT_NO;

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sd.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sd.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_sd.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SD HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -290,15 +288,15 @@ typedef enum
   */  
 typedef enum
 {
-  SD_CARD_READY                  = ((uint32_t)0x00000001),  /*!< Card state is ready                     */
-  SD_CARD_IDENTIFICATION         = ((uint32_t)0x00000002),  /*!< Card is in identification state         */
-  SD_CARD_STANDBY                = ((uint32_t)0x00000003),  /*!< Card is in standby state                */
-  SD_CARD_TRANSFER               = ((uint32_t)0x00000004),  /*!< Card is in transfer state               */  
-  SD_CARD_SENDING                = ((uint32_t)0x00000005),  /*!< Card is sending an operation            */
-  SD_CARD_RECEIVING              = ((uint32_t)0x00000006),  /*!< Card is receiving operation information */
-  SD_CARD_PROGRAMMING            = ((uint32_t)0x00000007),  /*!< Card is in programming state            */
-  SD_CARD_DISCONNECTED           = ((uint32_t)0x00000008),  /*!< Card is disconnected                    */
-  SD_CARD_ERROR                  = ((uint32_t)0x000000FF)   /*!< Card is in error state                  */
+  SD_CARD_READY                  = (0x00000001U),  /*!< Card state is ready                     */
+  SD_CARD_IDENTIFICATION         = (0x00000002U),  /*!< Card is in identification state         */
+  SD_CARD_STANDBY                = (0x00000003U),  /*!< Card is in standby state                */
+  SD_CARD_TRANSFER               = (0x00000004U),  /*!< Card is in transfer state               */  
+  SD_CARD_SENDING                = (0x00000005U),  /*!< Card is sending an operation            */
+  SD_CARD_RECEIVING              = (0x00000006U),  /*!< Card is receiving operation information */
+  SD_CARD_PROGRAMMING            = (0x00000007U),  /*!< Card is in programming state            */
+  SD_CARD_DISCONNECTED           = (0x00000008U),  /*!< Card is disconnected                    */
+  SD_CARD_ERROR                  = (0x000000FFU)   /*!< Card is in error state                  */
 
 }HAL_SD_CardStateTypedef;
 /** 
@@ -420,14 +418,14 @@ typedef enum
 /** 
   * @brief Supported SD Memory Cards 
   */
-#define STD_CAPACITY_SD_CARD_V1_1             ((uint32_t)0x00000000)
-#define STD_CAPACITY_SD_CARD_V2_0             ((uint32_t)0x00000001)
-#define HIGH_CAPACITY_SD_CARD                 ((uint32_t)0x00000002)
-#define MULTIMEDIA_CARD                       ((uint32_t)0x00000003)
-#define SECURE_DIGITAL_IO_CARD                ((uint32_t)0x00000004)
-#define HIGH_SPEED_MULTIMEDIA_CARD            ((uint32_t)0x00000005)
-#define SECURE_DIGITAL_IO_COMBO_CARD          ((uint32_t)0x00000006)
-#define HIGH_CAPACITY_MMC_CARD                ((uint32_t)0x00000007)
+#define STD_CAPACITY_SD_CARD_V1_1             (0x00000000U)
+#define STD_CAPACITY_SD_CARD_V2_0             (0x00000001U)
+#define HIGH_CAPACITY_SD_CARD                 (0x00000002U)
+#define MULTIMEDIA_CARD                       (0x00000003U)
+#define SECURE_DIGITAL_IO_CARD                (0x00000004U)
+#define HIGH_SPEED_MULTIMEDIA_CARD            (0x00000005U)
+#define SECURE_DIGITAL_IO_COMBO_CARD          (0x00000006U)
+#define HIGH_CAPACITY_MMC_CARD                (0x00000007U)
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_smartcard.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_smartcard.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_smartcard.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SMARTCARD HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the SMARTCARD peripheral:
@@ -103,7 +101,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_smartcard.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_smartcard.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_smartcard.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains all the functions prototypes for the SMARTCARD 
   *          firmware library.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -170,12 +168,12 @@ typedef struct
 /** @defgroup SMARTCARD_Error_Codes SMARTCARD Error Codes
   * @{
   */
-#define HAL_SMARTCARD_ERROR_NONE      ((uint32_t)0x00)    /*!< No error            */
-#define HAL_SMARTCARD_ERROR_PE        ((uint32_t)0x01)    /*!< Parity error        */
-#define HAL_SMARTCARD_ERROR_NE        ((uint32_t)0x02)    /*!< Noise error         */
-#define HAL_SMARTCARD_ERROR_FE        ((uint32_t)0x04)    /*!< frame error         */
-#define HAL_SMARTCARD_ERROR_ORE       ((uint32_t)0x08)    /*!< Overrun error       */
-#define HAL_SMARTCARD_ERROR_DMA       ((uint32_t)0x10)    /*!< DMA transfer error  */
+#define HAL_SMARTCARD_ERROR_NONE      (0x00U)    /*!< No error            */
+#define HAL_SMARTCARD_ERROR_PE        (0x01U)    /*!< Parity error        */
+#define HAL_SMARTCARD_ERROR_NE        (0x02U)    /*!< Noise error         */
+#define HAL_SMARTCARD_ERROR_FE        (0x04U)    /*!< frame error         */
+#define HAL_SMARTCARD_ERROR_ORE       (0x08U)    /*!< Overrun error       */
+#define HAL_SMARTCARD_ERROR_DMA       (0x10U)    /*!< DMA transfer error  */
 
 /**
   * @}
@@ -222,7 +220,7 @@ typedef struct
 /** @defgroup SMARTCARD_Clock_Polarity  SMARTCARD Clock Polarity
   * @{
   */
-#define SMARTCARD_POLARITY_LOW                   ((uint32_t)0x00000000)
+#define SMARTCARD_POLARITY_LOW                   (0x00000000U)
 #define SMARTCARD_POLARITY_HIGH                  ((uint32_t)USART_CR2_CPOL)
 /**
   * @}
@@ -231,7 +229,7 @@ typedef struct
 /** @defgroup SMARTCARD_Clock_Phase SMARTCARD Clock Phase
   * @{
   */
-#define SMARTCARD_PHASE_1EDGE                    ((uint32_t)0x00000000)
+#define SMARTCARD_PHASE_1EDGE                    (0x00000000U)
 #define SMARTCARD_PHASE_2EDGE                    ((uint32_t)USART_CR2_CPHA)
 /**
   * @}
@@ -240,7 +238,7 @@ typedef struct
 /** @defgroup SMARTCARD_Last_Bit  SMARTCARD Last Bit
   * @{
   */
-#define SMARTCARD_LASTBIT_DISABLE                ((uint32_t)0x00000000)
+#define SMARTCARD_LASTBIT_DISABLE                (0x00000000U)
 #define SMARTCARD_LASTBIT_ENABLE                 ((uint32_t)USART_CR2_LBCL)
 /**
   * @}
@@ -249,7 +247,7 @@ typedef struct
 /** @defgroup SMARTCARD_OneBit_Sampling SMARTCARD One Bit Sampling Method
   * @{
   */
-#define SMARTCARD_ONE_BIT_SAMPLE_DISABLE    ((uint32_t)0x00000000)
+#define SMARTCARD_ONE_BIT_SAMPLE_DISABLE    (0x00000000U)
 #define SMARTCARD_ONE_BIT_SAMPLE_ENABLE     ((uint32_t)USART_CR3_ONEBIT)
 /**
   * @}
@@ -259,7 +257,7 @@ typedef struct
   * @{
   */
 #define SMARTCARD_NACK_ENABLE                     ((uint32_t)USART_CR3_NACK)
-#define SMARTCARD_NACK_DISABLE                    ((uint32_t)0x00000000)
+#define SMARTCARD_NACK_DISABLE                    (0x00000000U)
 /**
   * @}
   */
@@ -278,37 +276,37 @@ typedef struct
 /** @defgroup SMARTCARD_Prescaler SMARTCARD Prescaler
   * @{
   */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV2         ((uint32_t)0x00000001)          /*!< SYSCLK divided by 2 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV4         ((uint32_t)0x00000002)          /*!< SYSCLK divided by 4 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV6         ((uint32_t)0x00000003)          /*!< SYSCLK divided by 6 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV8         ((uint32_t)0x00000004)          /*!< SYSCLK divided by 8 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV10        ((uint32_t)0x00000005)          /*!< SYSCLK divided by 10 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV12        ((uint32_t)0x00000006)          /*!< SYSCLK divided by 12 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV14        ((uint32_t)0x00000007)          /*!< SYSCLK divided by 14 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV16        ((uint32_t)0x00000008)          /*!< SYSCLK divided by 16 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV18        ((uint32_t)0x00000009)          /*!< SYSCLK divided by 18 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV20        ((uint32_t)0x0000000A)          /*!< SYSCLK divided by 20 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV22        ((uint32_t)0x0000000B)          /*!< SYSCLK divided by 22 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV24        ((uint32_t)0x0000000C)          /*!< SYSCLK divided by 24 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV26        ((uint32_t)0x0000000D)          /*!< SYSCLK divided by 26 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV28        ((uint32_t)0x0000000E)          /*!< SYSCLK divided by 28 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV30        ((uint32_t)0x0000000F)          /*!< SYSCLK divided by 30 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV32        ((uint32_t)0x00000010)          /*!< SYSCLK divided by 32 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV34        ((uint32_t)0x00000011)          /*!< SYSCLK divided by 34 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV36        ((uint32_t)0x00000012)          /*!< SYSCLK divided by 36 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV38        ((uint32_t)0x00000013)          /*!< SYSCLK divided by 38 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV40        ((uint32_t)0x00000014)          /*!< SYSCLK divided by 40 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV42        ((uint32_t)0x00000015)          /*!< SYSCLK divided by 42 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV44        ((uint32_t)0x00000016)          /*!< SYSCLK divided by 44 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV46        ((uint32_t)0x00000017)          /*!< SYSCLK divided by 46 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV48        ((uint32_t)0x00000018)          /*!< SYSCLK divided by 48 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV50        ((uint32_t)0x00000019)          /*!< SYSCLK divided by 50 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV52        ((uint32_t)0x0000001A)          /*!< SYSCLK divided by 52 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV54        ((uint32_t)0x0000001B)          /*!< SYSCLK divided by 54 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV56        ((uint32_t)0x0000001C)          /*!< SYSCLK divided by 56 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV58        ((uint32_t)0x0000001D)          /*!< SYSCLK divided by 58 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV60        ((uint32_t)0x0000001E)          /*!< SYSCLK divided by 60 */
-#define SMARTCARD_PRESCALER_SYSCLK_DIV62        ((uint32_t)0x0000001F)          /*!< SYSCLK divided by 62 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV2         (0x00000001U)          /*!< SYSCLK divided by 2 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV4         (0x00000002U)          /*!< SYSCLK divided by 4 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV6         (0x00000003U)          /*!< SYSCLK divided by 6 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV8         (0x00000004U)          /*!< SYSCLK divided by 8 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV10        (0x00000005U)          /*!< SYSCLK divided by 10 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV12        (0x00000006U)          /*!< SYSCLK divided by 12 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV14        (0x00000007U)          /*!< SYSCLK divided by 14 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV16        (0x00000008U)          /*!< SYSCLK divided by 16 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV18        (0x00000009U)          /*!< SYSCLK divided by 18 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV20        (0x0000000AU)          /*!< SYSCLK divided by 20 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV22        (0x0000000BU)          /*!< SYSCLK divided by 22 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV24        (0x0000000CU)          /*!< SYSCLK divided by 24 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV26        (0x0000000DU)          /*!< SYSCLK divided by 26 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV28        (0x0000000EU)          /*!< SYSCLK divided by 28 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV30        (0x0000000FU)          /*!< SYSCLK divided by 30 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV32        (0x00000010U)          /*!< SYSCLK divided by 32 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV34        (0x00000011U)          /*!< SYSCLK divided by 34 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV36        (0x00000012U)          /*!< SYSCLK divided by 36 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV38        (0x00000013U)          /*!< SYSCLK divided by 38 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV40        (0x00000014U)          /*!< SYSCLK divided by 40 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV42        (0x00000015U)          /*!< SYSCLK divided by 42 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV44        (0x00000016U)          /*!< SYSCLK divided by 44 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV46        (0x00000017U)          /*!< SYSCLK divided by 46 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV48        (0x00000018U)          /*!< SYSCLK divided by 48 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV50        (0x00000019U)          /*!< SYSCLK divided by 50 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV52        (0x0000001AU)          /*!< SYSCLK divided by 52 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV54        (0x0000001BU)          /*!< SYSCLK divided by 54 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV56        (0x0000001CU)          /*!< SYSCLK divided by 56 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV58        (0x0000001DU)          /*!< SYSCLK divided by 58 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV60        (0x0000001EU)          /*!< SYSCLK divided by 60 */
+#define SMARTCARD_PRESCALER_SYSCLK_DIV62        (0x0000001FU)          /*!< SYSCLK divided by 62 */
 /**
   * @}
   */
@@ -594,8 +592,8 @@ do{                                                        \
 #define IS_SMARTCARD_PARITY(PARITY)         (((PARITY) == SMARTCARD_PARITY_EVEN) || \
                                              ((PARITY) == SMARTCARD_PARITY_ODD))
 
-#define IS_SMARTCARD_MODE(MODE)             ((((MODE) & (~((uint32_t)SMARTCARD_MODE_TX_RX))) == 0x00) && \
-                                             ((MODE) != (uint32_t)0x00000000))
+#define IS_SMARTCARD_MODE(MODE)             ((((MODE) & (~((uint32_t)SMARTCARD_MODE_TX_RX))) == 0x00U) && \
+                                             ((MODE) != 0x00000000U))
 
 #define IS_SMARTCARD_POLARITY(CPOL)         (((CPOL) == SMARTCARD_POLARITY_LOW) || ((CPOL) == SMARTCARD_POLARITY_HIGH))
 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_spi.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SPI HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -59,7 +57,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_spi.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SPI HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -168,13 +166,13 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_Error_Codes SPI Error Codes
   * @{
   */ 
-#define HAL_SPI_ERROR_NONE      ((uint32_t)0x00)    /*!< No error             */
-#define HAL_SPI_ERROR_MODF      ((uint32_t)0x01)    /*!< MODF error           */
-#define HAL_SPI_ERROR_CRC       ((uint32_t)0x02)    /*!< CRC error            */
-#define HAL_SPI_ERROR_OVR       ((uint32_t)0x04)    /*!< OVR error            */
-#define HAL_SPI_ERROR_FRE       ((uint32_t)0x08)    /*!< FRE error            */
-#define HAL_SPI_ERROR_DMA       ((uint32_t)0x10)    /*!< DMA transfer error   */
-#define HAL_SPI_ERROR_FLAG      ((uint32_t)0x20)    /*!< Flag: RXNE,TXE, BSY  */
+#define HAL_SPI_ERROR_NONE      (0x00U)    /*!< No error             */
+#define HAL_SPI_ERROR_MODF      (0x01U)    /*!< MODF error           */
+#define HAL_SPI_ERROR_CRC       (0x02U)    /*!< CRC error            */
+#define HAL_SPI_ERROR_OVR       (0x04U)    /*!< OVR error            */
+#define HAL_SPI_ERROR_FRE       (0x08U)    /*!< FRE error            */
+#define HAL_SPI_ERROR_DMA       (0x10U)    /*!< DMA transfer error   */
+#define HAL_SPI_ERROR_FLAG      (0x20U)    /*!< Flag: RXNE,TXE, BSY  */
 
 /**
   * @}
@@ -183,7 +181,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_mode SPI mode
   * @{
   */
-#define SPI_MODE_SLAVE                  ((uint32_t)0x00000000)
+#define SPI_MODE_SLAVE                  (0x00000000U)
 #define SPI_MODE_MASTER                 (SPI_CR1_MSTR | SPI_CR1_SSI)
 
 #define IS_SPI_MODE(MODE) (((MODE) == SPI_MODE_SLAVE) || \
@@ -195,7 +193,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_Direction_mode SPI Direction mode
   * @{
   */
-#define SPI_DIRECTION_2LINES             ((uint32_t)0x00000000)
+#define SPI_DIRECTION_2LINES             (0x00000000U)
 #define SPI_DIRECTION_2LINES_RXONLY      SPI_CR1_RXONLY
 #define SPI_DIRECTION_1LINE              SPI_CR1_BIDIMODE
 
@@ -215,7 +213,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_data_size SPI data size
   * @{
   */
-#define SPI_DATASIZE_8BIT               ((uint32_t)0x00000000)
+#define SPI_DATASIZE_8BIT               (0x00000000U)
 #define SPI_DATASIZE_16BIT              SPI_CR1_DFF
 
 #define IS_SPI_DATASIZE(DATASIZE) (((DATASIZE) == SPI_DATASIZE_16BIT) || \
@@ -227,7 +225,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_Clock_Polarity SPI Clock Polarity
   * @{
   */
-#define SPI_POLARITY_LOW                ((uint32_t)0x00000000)
+#define SPI_POLARITY_LOW                (0x00000000U)
 #define SPI_POLARITY_HIGH               SPI_CR1_CPOL
 
 #define IS_SPI_CPOL(CPOL) (((CPOL) == SPI_POLARITY_LOW) || \
@@ -239,7 +237,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_Clock_Phase SPI Clock Phase
   * @{
   */
-#define SPI_PHASE_1EDGE                 ((uint32_t)0x00000000)
+#define SPI_PHASE_1EDGE                 (0x00000000U)
 #define SPI_PHASE_2EDGE                 SPI_CR1_CPHA
 
 #define IS_SPI_CPHA(CPHA) (((CPHA) == SPI_PHASE_1EDGE) || \
@@ -252,7 +250,7 @@ typedef struct __SPI_HandleTypeDef
   * @{
   */
 #define SPI_NSS_SOFT                    SPI_CR1_SSM
-#define SPI_NSS_HARD_INPUT              ((uint32_t)0x00000000)
+#define SPI_NSS_HARD_INPUT              (0x00000000U)
 #define SPI_NSS_HARD_OUTPUT             ((uint32_t)(SPI_CR2_SSOE << 16))
 
 #define IS_SPI_NSS(NSS) (((NSS) == SPI_NSS_SOFT)       || \
@@ -265,7 +263,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_BaudRate_Prescaler SPI BaudRate Prescaler
   * @{
   */
-#define SPI_BAUDRATEPRESCALER_2         ((uint32_t)0x00000000)
+#define SPI_BAUDRATEPRESCALER_2         (0x00000000U)
 #define SPI_BAUDRATEPRESCALER_4         ((uint32_t)SPI_CR1_BR_0)
 #define SPI_BAUDRATEPRESCALER_8         ((uint32_t)SPI_CR1_BR_1)
 #define SPI_BAUDRATEPRESCALER_16        ((uint32_t)SPI_CR1_BR_1 | SPI_CR1_BR_0)
@@ -289,7 +287,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_MSB_LSB_transmission SPI MSB LSB transmission
   * @{
   */
-#define SPI_FIRSTBIT_MSB                ((uint32_t)0x00000000)
+#define SPI_FIRSTBIT_MSB                (0x00000000U)
 #define SPI_FIRSTBIT_LSB                SPI_CR1_LSBFIRST
 
 #define IS_SPI_FIRST_BIT(BIT) (((BIT) == SPI_FIRSTBIT_MSB) || \
@@ -301,7 +299,7 @@ typedef struct __SPI_HandleTypeDef
 /** @defgroup SPI_CRC_Calculation SPI CRC Calculation
   * @{
   */
-#define SPI_CRCCALCULATION_DISABLE     ((uint32_t)0x00000000)
+#define SPI_CRCCALCULATION_DISABLE     (0x00000000U)
 #define SPI_CRCCALCULATION_ENABLE      SPI_CR1_CRCEN
 
 #define IS_SPI_CRC_CALCULATION(CALCULATION) (((CALCULATION) == SPI_CRCCALCULATION_DISABLE) || \

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi_ex.c
@@ -2,18 +2,15 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_spi_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Extended SPI HAL module driver.
-  *    
-  *          This file provides firmware functions to manage the following 
-  *          functionalities SPI extension peripheral:
-  *           + Extended Peripheral Control functions
-  *  
+  *          This file provides firmware functions to manage the following
+  *          SPI peripheral extended functionalities :
+  *           + IO operation functions
+  *
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -53,11 +50,11 @@
 #ifdef HAL_SPI_MODULE_ENABLED
 
 /* Private typedef -----------------------------------------------------------*/
-/* Private define ------------------------------------------------------------*/
-/* Private macro -------------------------------------------------------------*/
+/* Private defines -----------------------------------------------------------*/
+/* Private macros ------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
 /* Private function prototypes -----------------------------------------------*/
-/* Private functions ---------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 
 /** @addtogroup SPI_Exported_Functions
   * @{
@@ -69,16 +66,16 @@
   */
 
 /**
-  * @brief  Initializes the SPI according to the specified parameters 
+  * @brief  Initializes the SPI according to the specified parameters
   *         in the SPI_InitTypeDef and create the associated handle.
   * @param  hspi: pointer to a SPI_HandleTypeDef structure that contains
-  *                the configuration information for SPI module.
+  *               the configuration information for SPI module.
   * @retval HAL status
   */
 HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
 {
   /* Check the SPI handle allocation */
-  if(hspi == NULL)
+  if (hspi == NULL)
   {
     return HAL_ERROR;
   }
@@ -97,7 +94,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
   assert_param(IS_SPI_CRC_CALCULATION(hspi->Init.CRCCalculation));
   assert_param(IS_SPI_CRC_POLYNOMIAL(hspi->Init.CRCPolynomial));
 
-  if(hspi->State == HAL_SPI_STATE_RESET)
+  if (hspi->State == HAL_SPI_STATE_RESET)
   {
     /* Allocate lock resource and initialize it */
     hspi->Lock = HAL_UNLOCKED;
@@ -105,7 +102,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
     /* Init the low level hardware : GPIO, CLOCK, NVIC... */
     HAL_SPI_MspInit(hspi);
   }
-  
+
   hspi->State = HAL_SPI_STATE_BUSY;
 
   /* Disble the selected SPI peripheral */
@@ -119,7 +116,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
                          hspi->Init.BaudRatePrescaler | hspi->Init.FirstBit  | hspi->Init.CRCCalculation);
 
   /* Configure : NSS management */
-  hspi->Instance->CR2 = (((hspi->Init.NSS >> 16) & SPI_CR2_SSOE) | hspi->Init.TIMode);
+  hspi->Instance->CR2 = (((hspi->Init.NSS >> 16U) & SPI_CR2_SSOE) | hspi->Init.TIMode);
 
   /*---------------------------- SPIx CRCPOLY Configuration ------------------*/
   /* Configure : CRC Polynomial */
@@ -132,7 +129,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
 
   hspi->ErrorCode = HAL_SPI_ERROR_NONE;
   hspi->State = HAL_SPI_STATE_READY;
-  
+
   return HAL_OK;
 }
 
@@ -145,6 +142,7 @@ HAL_StatusTypeDef HAL_SPI_Init(SPI_HandleTypeDef *hspi)
   */
 
 #endif /* HAL_SPI_MODULE_ENABLED */
+
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_spi_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_spi_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
-  * @brief   Header file of SPI HAL module.
+  * @brief   Header file of SPI HAL Extended module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -33,74 +31,78 @@
   * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
   *
   ******************************************************************************
-  */ 
+  */
 
 /* Define to prevent recursive inclusion -------------------------------------*/
 #ifndef __STM32L1xx_HAL_SPI_EX_H
 #define __STM32L1xx_HAL_SPI_EX_H
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /* Includes ------------------------------------------------------------------*/
-#include "stm32l1xx_hal_def.h"  
+#include "stm32l1xx_hal_def.h"
 
 /** @addtogroup STM32L1xx_HAL_Driver
   * @{
   */
 
-/** @addtogroup SPI
+/** @addtogroup SPIEx
   * @{
-  */ 
+  */
 
 /* Exported types ------------------------------------------------------------*/
-
 /* Exported constants --------------------------------------------------------*/
-
-/** @defgroup SPI_Exported_Constants SPI Exported Constants
+/** @defgroup SPIEx_Exported_Constants SPIEx Exported Constants
   * @{
-  */ 
+  */
 #if defined (STM32L100xC) || defined (STM32L151xC) || defined (STM32L152xC) || defined (STM32L162xC) || defined (STM32L151xCA) || defined (STM32L151xD) || defined (STM32L152xCA) || defined (STM32L152xD) || defined (STM32L162xCA) || defined (STM32L162xD) || defined (STM32L151xE) || defined (STM32L151xDX) || defined (STM32L152xE) || defined (STM32L152xDX) || defined (STM32L162xE) || defined (STM32L162xDX)
 /** @defgroup SPI_TI_mode SPI TI mode
   * @{
   */
-#define SPI_TIMODE_DISABLE             ((uint32_t)0x00000000)
+#define SPI_TIMODE_DISABLE             (0x00000000U)
 #define SPI_TIMODE_ENABLE              SPI_CR2_FRF
 
 #define IS_SPI_TIMODE(MODE) (((MODE) == SPI_TIMODE_DISABLE) || \
                              ((MODE) == SPI_TIMODE_ENABLE))
+/**
+  * @}
+  */
 #else
 /** @defgroup SPI_TI_mode SPI TI mode disable
-  * @brief  SPI TI Mode not supported for Category 1 and 2 
+  * @brief  SPI TI Mode not supported for Category 1 and 2
   * @{
   */
-#define SPI_TIMODE_DISABLE             ((uint32_t)0x00000000)
+#define SPI_TIMODE_DISABLE             (0x00000000U)
 
 #define IS_SPI_TIMODE(MODE) ((MODE) == SPI_TIMODE_DISABLE)
-
+/**
+  * @}
+  */
 #endif
-/**
-  * @}
-  */
-  
+/* Exported macros -----------------------------------------------------------*/
+/* Exported functions --------------------------------------------------------*/
 /**
   * @}
   */
 
-
 /**
   * @}
-  */ 
+  */
 
 /**
   * @}
   */
-  
+
+/**
+  * @}
+  */
+
 #ifdef __cplusplus
 }
 #endif
 
-#endif /* __STM32L1xx_HAL_SPI_H */
+#endif /* __STM32L1xx_HAL_SPI_EX_H */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sram.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sram.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_sram.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SRAM HAL module driver.
   *          This file provides a generic firmware to drive SRAM memories  
   *          mounted as external device.
@@ -64,7 +62,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sram.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_sram.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_sram.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SRAM HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_tim.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   TIM HAL module driver
   *          This file provides firmware functions to manage the following
   *          functionalities of the Timer (TIM) peripheral:
@@ -102,7 +100,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_tim.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of TIM HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -279,7 +277,7 @@ typedef struct
 /** @defgroup TIM_Input_Channel_Polarity TIM Input Channel Polarity
   * @{
   */
-#define  TIM_INPUTCHANNELPOLARITY_RISING      ((uint32_t)0x00000000)            /*!< Polarity for TIx source */
+#define  TIM_INPUTCHANNELPOLARITY_RISING      (0x00000000U)                     /*!< Polarity for TIx source */
 #define  TIM_INPUTCHANNELPOLARITY_FALLING     (TIM_CCER_CC1P)                   /*!< Polarity for TIx source */
 #define  TIM_INPUTCHANNELPOLARITY_BOTHEDGE    (TIM_CCER_CC1P | TIM_CCER_CC1NP)  /*!< Polarity for TIx source */
 /**
@@ -290,7 +288,7 @@ typedef struct
   * @{
   */
 #define TIM_ETRPOLARITY_INVERTED              (TIM_SMCR_ETP)                    /*!< Polarity for ETR source */
-#define TIM_ETRPOLARITY_NONINVERTED           ((uint32_t)0x0000)                /*!< Polarity for ETR source */
+#define TIM_ETRPOLARITY_NONINVERTED           (0x0000U)                         /*!< Polarity for ETR source */
 /**
   * @}
   */
@@ -298,7 +296,7 @@ typedef struct
 /** @defgroup TIM_ETR_Prescaler TIM ETR Prescaler
   * @{
   */
-#define TIM_ETRPRESCALER_DIV1                 ((uint32_t)0x0000)                /*!< No prescaler is used */
+#define TIM_ETRPRESCALER_DIV1                 (0x0000U)                         /*!< No prescaler is used */
 #define TIM_ETRPRESCALER_DIV2                 (TIM_SMCR_ETPS_0)                 /*!< ETR input source is divided by 2 */
 #define TIM_ETRPRESCALER_DIV4                 (TIM_SMCR_ETPS_1)                 /*!< ETR input source is divided by 4 */
 #define TIM_ETRPRESCALER_DIV8                 (TIM_SMCR_ETPS)                   /*!< ETR input source is divided by 8 */
@@ -309,7 +307,7 @@ typedef struct
 /** @defgroup TIM_Counter_Mode TIM Counter Mode
   * @{
   */
-#define TIM_COUNTERMODE_UP                 ((uint32_t)0x0000)
+#define TIM_COUNTERMODE_UP                 (0x0000U)
 #define TIM_COUNTERMODE_DOWN               TIM_CR1_DIR
 #define TIM_COUNTERMODE_CENTERALIGNED1     TIM_CR1_CMS_0
 #define TIM_COUNTERMODE_CENTERALIGNED2     TIM_CR1_CMS_1
@@ -321,7 +319,7 @@ typedef struct
 /** @defgroup TIM_ClockDivision TIM ClockDivision
   * @{
   */
-#define TIM_CLOCKDIVISION_DIV1                       ((uint32_t)0x0000)
+#define TIM_CLOCKDIVISION_DIV1                       (0x0000U)
 #define TIM_CLOCKDIVISION_DIV2                       (TIM_CR1_CKD_0)
 #define TIM_CLOCKDIVISION_DIV4                       (TIM_CR1_CKD_1)
 /**
@@ -331,7 +329,7 @@ typedef struct
 /** @defgroup TIM_Output_Compare_and_PWM_modes TIM Output Compare and PWM modes
   * @{
   */
-#define TIM_OCMODE_TIMING                   ((uint32_t)0x0000)
+#define TIM_OCMODE_TIMING                   (0x0000U)
 #define TIM_OCMODE_ACTIVE                   (TIM_CCMR1_OC1M_0)
 #define TIM_OCMODE_INACTIVE                 (TIM_CCMR1_OC1M_1)
 #define TIM_OCMODE_TOGGLE                   (TIM_CCMR1_OC1M_0 | TIM_CCMR1_OC1M_1)
@@ -346,7 +344,7 @@ typedef struct
 /** @defgroup TIM_Output_Fast_State TIM Output Fast State
   * @{
   */
-#define TIM_OCFAST_DISABLE                ((uint32_t)0x0000)
+#define TIM_OCFAST_DISABLE                (0x0000U)
 #define TIM_OCFAST_ENABLE                 (TIM_CCMR1_OC1FE)
 /**
   * @}
@@ -355,7 +353,7 @@ typedef struct
 /** @defgroup TIM_Output_Compare_Polarity TIM Output Compare Polarity
   * @{
   */
-#define TIM_OCPOLARITY_HIGH                ((uint32_t)0x0000)
+#define TIM_OCPOLARITY_HIGH                (0x0000U)
 #define TIM_OCPOLARITY_LOW                 (TIM_CCER_CC1P)
 /**
   * @}
@@ -365,7 +363,7 @@ typedef struct
   * @{
   */
 #define TIM_OCIDLESTATE_SET                (TIM_CR2_OIS1)
-#define TIM_OCIDLESTATE_RESET              ((uint32_t)0x0000)
+#define TIM_OCIDLESTATE_RESET              (0x0000U)
 /**
   * @}
   */
@@ -373,11 +371,11 @@ typedef struct
 /** @defgroup TIM_Channel TIM Channel
   * @{
   */
-#define TIM_CHANNEL_1                      ((uint32_t)0x0000)
-#define TIM_CHANNEL_2                      ((uint32_t)0x0004)
-#define TIM_CHANNEL_3                      ((uint32_t)0x0008)
-#define TIM_CHANNEL_4                      ((uint32_t)0x000C)
-#define TIM_CHANNEL_ALL                    ((uint32_t)0x0018)
+#define TIM_CHANNEL_1                      (0x0000U)
+#define TIM_CHANNEL_2                      (0x0004U)
+#define TIM_CHANNEL_3                      (0x0008U)
+#define TIM_CHANNEL_4                      (0x000CU)
+#define TIM_CHANNEL_ALL                    (0x0018U)
 /**
   * @}
   */
@@ -407,7 +405,7 @@ typedef struct
 /** @defgroup TIM_Input_Capture_Prescaler TIM Input Capture Prescaler
   * @{
   */
-#define TIM_ICPSC_DIV1                     ((uint32_t)0x0000)       /*!< Capture performed each time an edge is detected on the capture input */
+#define TIM_ICPSC_DIV1                     (0x0000U)                /*!< Capture performed each time an edge is detected on the capture input */
 #define TIM_ICPSC_DIV2                     (TIM_CCMR1_IC1PSC_0)     /*!< Capture performed once every 2 events */
 #define TIM_ICPSC_DIV4                     (TIM_CCMR1_IC1PSC_1)     /*!< Capture performed once every 4 events */
 #define TIM_ICPSC_DIV8                     (TIM_CCMR1_IC1PSC)       /*!< Capture performed once every 8 events */
@@ -419,7 +417,7 @@ typedef struct
   * @{
   */
 #define TIM_OPMODE_SINGLE                  (TIM_CR1_OPM)
-#define TIM_OPMODE_REPETITIVE              ((uint32_t)0x0000)
+#define TIM_OPMODE_REPETITIVE              (0x0000U)
 /**
   * @}
   */
@@ -495,7 +493,7 @@ typedef struct
   */
 #define  TIM_CLOCKSOURCE_ETRMODE2    (TIM_SMCR_ETPS_1)
 #define  TIM_CLOCKSOURCE_INTERNAL    (TIM_SMCR_ETPS_0)
-#define  TIM_CLOCKSOURCE_ITR0        ((uint32_t)0x0000)
+#define  TIM_CLOCKSOURCE_ITR0        (0x0000U)
 #define  TIM_CLOCKSOURCE_ITR1        (TIM_SMCR_TS_0)
 #define  TIM_CLOCKSOURCE_ITR2        (TIM_SMCR_TS_1)
 #define  TIM_CLOCKSOURCE_ITR3        (TIM_SMCR_TS_0 | TIM_SMCR_TS_1)
@@ -533,9 +531,9 @@ typedef struct
 /** @defgroup TIM_ClearInput_Source TIM ClearInput Source
   * @{
   */
-#define TIM_CLEARINPUTSOURCE_ETR            ((uint32_t)0x0001) 
-#define TIM_CLEARINPUTSOURCE_OCREFCLR       ((uint32_t)0x0002) 
-#define TIM_CLEARINPUTSOURCE_NONE           ((uint32_t)0x0000)
+#define TIM_CLEARINPUTSOURCE_ETR            (0x0001U) 
+#define TIM_CLEARINPUTSOURCE_OCREFCLR       (0x0002U) 
+#define TIM_CLEARINPUTSOURCE_NONE           (0x0000U)
 /**
   * @}
   */
@@ -564,7 +562,7 @@ typedef struct
   * @{
   */
 #define TIM_OSSR_ENABLE         (TIM_BDTR_OSSR)
-#define TIM_OSSR_DISABLE              ((uint32_t)0x0000)
+#define TIM_OSSR_DISABLE        (0x0000U)
 /**
   * @}
   */
@@ -573,7 +571,7 @@ typedef struct
   * @{
   */
 #define TIM_OSSI_ENABLE         (TIM_BDTR_OSSI)
-#define TIM_OSSI_DISABLE            ((uint32_t)0x0000)
+#define TIM_OSSI_DISABLE        (0x0000U)
 /**
   * @}
   */
@@ -581,10 +579,10 @@ typedef struct
 /** @defgroup TIM_Lock_level TIM Lock level
   * @{
   */
-#define TIM_LOCKLEVEL_OFF     ((uint32_t)0x0000)
-#define TIM_LOCKLEVEL_1            (TIM_BDTR_LOCK_0)
-#define TIM_LOCKLEVEL_2            (TIM_BDTR_LOCK_1)
-#define TIM_LOCKLEVEL_3            (TIM_BDTR_LOCK)
+#define TIM_LOCKLEVEL_OFF       (0x0000U)
+#define TIM_LOCKLEVEL_1         (TIM_BDTR_LOCK_0)
+#define TIM_LOCKLEVEL_2         (TIM_BDTR_LOCK_1)
+#define TIM_LOCKLEVEL_3         (TIM_BDTR_LOCK)
 /**
   * @}
   */
@@ -593,7 +591,7 @@ typedef struct
   * @{
   */
 #define TIM_AUTOMATICOUTPUT_ENABLE           (TIM_BDTR_AOE)
-#define  TIM_AUTOMATICOUTPUT_DISABLE          ((uint32_t)0x0000)
+#define TIM_AUTOMATICOUTPUT_DISABLE          (0x0000U)
 /**
   * @}
   */
@@ -601,7 +599,7 @@ typedef struct
 /** @defgroup TIM_Master_Mode_Selection TIM Master Mode Selection
   * @{
   */
-#define  TIM_TRGO_RESET            ((uint32_t)0x0000)
+#define  TIM_TRGO_RESET            (0x0000U)
 #define  TIM_TRGO_ENABLE           (TIM_CR2_MMS_0)
 #define  TIM_TRGO_UPDATE           (TIM_CR2_MMS_1)
 #define  TIM_TRGO_OC1              ((TIM_CR2_MMS_1 | TIM_CR2_MMS_0))
@@ -616,11 +614,11 @@ typedef struct
 /** @defgroup TIM_Slave_Mode TIM Slave Mode
   * @{
   */
-#define TIM_SLAVEMODE_DISABLE              ((uint32_t)0x0000)
-#define TIM_SLAVEMODE_RESET                ((uint32_t)0x0004)
-#define TIM_SLAVEMODE_GATED                ((uint32_t)0x0005)
-#define TIM_SLAVEMODE_TRIGGER              ((uint32_t)0x0006)
-#define TIM_SLAVEMODE_EXTERNAL1            ((uint32_t)0x0007)
+#define TIM_SLAVEMODE_DISABLE              (0x0000U)
+#define TIM_SLAVEMODE_RESET                (0x0004U)
+#define TIM_SLAVEMODE_GATED                (0x0005U)
+#define TIM_SLAVEMODE_TRIGGER              (0x0006U)
+#define TIM_SLAVEMODE_EXTERNAL1            (0x0007U)
 /**
   * @}
   */
@@ -628,8 +626,8 @@ typedef struct
 /** @defgroup TIM_Master_Slave_Mode TIM Master Slave Mode
   * @{
   */
-#define TIM_MASTERSLAVEMODE_ENABLE          ((uint32_t)0x0080)
-#define TIM_MASTERSLAVEMODE_DISABLE         ((uint32_t)0x0000)
+#define TIM_MASTERSLAVEMODE_ENABLE          (0x0080U)
+#define TIM_MASTERSLAVEMODE_DISABLE         (0x0000U)
 /**
   * @}
   */
@@ -637,15 +635,15 @@ typedef struct
 /** @defgroup TIM_Trigger_Selection TIM Trigger Selection
   * @{
   */
-#define TIM_TS_ITR0                        ((uint32_t)0x0000)
-#define TIM_TS_ITR1                        ((uint32_t)0x0010)
-#define TIM_TS_ITR2                        ((uint32_t)0x0020)
-#define TIM_TS_ITR3                        ((uint32_t)0x0030)
-#define TIM_TS_TI1F_ED                     ((uint32_t)0x0040)
-#define TIM_TS_TI1FP1                      ((uint32_t)0x0050)
-#define TIM_TS_TI2FP2                      ((uint32_t)0x0060)
-#define TIM_TS_ETRF                        ((uint32_t)0x0070)
-#define TIM_TS_NONE                        ((uint32_t)0xFFFF)
+#define TIM_TS_ITR0                        (0x0000U)
+#define TIM_TS_ITR1                        (0x0010U)
+#define TIM_TS_ITR2                        (0x0020U)
+#define TIM_TS_ITR3                        (0x0030U)
+#define TIM_TS_TI1F_ED                     (0x0040U)
+#define TIM_TS_TI1FP1                      (0x0050U)
+#define TIM_TS_TI2FP2                      (0x0060U)
+#define TIM_TS_ETRF                        (0x0070U)
+#define TIM_TS_NONE                        (0xFFFFU)
 /**
   * @}
   */
@@ -676,7 +674,7 @@ typedef struct
 /** @defgroup TIM_TI1_Selection TIM TI1 Input Selection
   * @{
   */
-#define TIM_TI1SELECTION_CH1                ((uint32_t)0x0000)
+#define TIM_TI1SELECTION_CH1                (0x0000U)
 #define TIM_TI1SELECTION_XORCOMBINATION     (TIM_CR2_TI1S)
 /**
   * @}
@@ -685,24 +683,24 @@ typedef struct
 /** @defgroup TIM_DMA_Base_address TIM DMA Base Address
   * @{
   */
-#define TIM_DMABASE_CR1                    (0x00000000)
-#define TIM_DMABASE_CR2                    (0x00000001)
-#define TIM_DMABASE_SMCR                   (0x00000002)
-#define TIM_DMABASE_DIER                   (0x00000003)
-#define TIM_DMABASE_SR                     (0x00000004)
-#define TIM_DMABASE_EGR                    (0x00000005)
-#define TIM_DMABASE_CCMR1                  (0x00000006)
-#define TIM_DMABASE_CCMR2                  (0x00000007)
-#define TIM_DMABASE_CCER                   (0x00000008)
-#define TIM_DMABASE_CNT                    (0x00000009)
-#define TIM_DMABASE_PSC                    (0x0000000A)
-#define TIM_DMABASE_ARR                    (0x0000000B)
-#define TIM_DMABASE_CCR1                   (0x0000000D)
-#define TIM_DMABASE_CCR2                   (0x0000000E)
-#define TIM_DMABASE_CCR3                   (0x0000000F)
-#define TIM_DMABASE_CCR4                   (0x00000010)
-#define TIM_DMABASE_DCR                    (0x00000012)
-#define TIM_DMABASE_OR                     (0x00000013)
+#define TIM_DMABASE_CR1                    (0x00000000U)
+#define TIM_DMABASE_CR2                    (0x00000001U)
+#define TIM_DMABASE_SMCR                   (0x00000002U)
+#define TIM_DMABASE_DIER                   (0x00000003U)
+#define TIM_DMABASE_SR                     (0x00000004U)
+#define TIM_DMABASE_EGR                    (0x00000005U)
+#define TIM_DMABASE_CCMR1                  (0x00000006U)
+#define TIM_DMABASE_CCMR2                  (0x00000007U)
+#define TIM_DMABASE_CCER                   (0x00000008U)
+#define TIM_DMABASE_CNT                    (0x00000009U)
+#define TIM_DMABASE_PSC                    (0x0000000AU)
+#define TIM_DMABASE_ARR                    (0x0000000BU)
+#define TIM_DMABASE_CCR1                   (0x0000000DU)
+#define TIM_DMABASE_CCR2                   (0x0000000EU)
+#define TIM_DMABASE_CCR3                   (0x0000000FU)
+#define TIM_DMABASE_CCR4                   (0x00000010U)
+#define TIM_DMABASE_DCR                    (0x00000012U)
+#define TIM_DMABASE_OR                     (0x00000013U)
 /**
   * @}
   */
@@ -748,8 +746,8 @@ typedef struct
 /** @defgroup TIM_Channel_CC_State TIM Capture/Compare Channel State
   * @{
   */
-#define TIM_CCx_ENABLE                   ((uint32_t)0x0001)
-#define TIM_CCx_DISABLE                  ((uint32_t)0x0000)
+#define TIM_CCx_ENABLE                   (0x0001U)
+#define TIM_CCx_DISABLE                  (0x0000U)
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim_ex.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim_ex.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_tim_ex.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   TIM HAL module driver.
   *          This file provides firmware functions to manage the following
   *          functionalities of the Timer extension peripheral:
@@ -23,7 +21,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim_ex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_tim_ex.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_tim_ex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of TIM HAL Extension module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_uart.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_uart.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_uart.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   UART HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Universal Asynchronous Receiver Transmitter (UART) peripheral:
@@ -127,7 +125,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_uart.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_uart.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_uart.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains all the functions prototypes for the UART 
   *          firmware library.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -157,12 +155,12 @@ typedef struct
   * @{
   */
 
-#define HAL_UART_ERROR_NONE      ((uint32_t)0x00)    /*!< No error            */
-#define HAL_UART_ERROR_PE        ((uint32_t)0x01)    /*!< Parity error        */
-#define HAL_UART_ERROR_NE        ((uint32_t)0x02)    /*!< Noise error         */
-#define HAL_UART_ERROR_FE        ((uint32_t)0x04)    /*!< frame error         */
-#define HAL_UART_ERROR_ORE       ((uint32_t)0x08)    /*!< Overrun error       */
-#define HAL_UART_ERROR_DMA       ((uint32_t)0x10)    /*!< DMA transfer error  */
+#define HAL_UART_ERROR_NONE      (0x00U)    /*!< No error            */
+#define HAL_UART_ERROR_PE        (0x01U)    /*!< Parity error        */
+#define HAL_UART_ERROR_NE        (0x02U)    /*!< Noise error         */
+#define HAL_UART_ERROR_FE        (0x04U)    /*!< frame error         */
+#define HAL_UART_ERROR_ORE       (0x08U)    /*!< Overrun error       */
+#define HAL_UART_ERROR_DMA       (0x10U)    /*!< DMA transfer error  */
 
 /**
   * @}
@@ -171,7 +169,7 @@ typedef struct
 /** @defgroup UART_Word_Length   UART Word Length
   * @{
   */
-#define UART_WORDLENGTH_8B                  ((uint32_t)0x00000000)
+#define UART_WORDLENGTH_8B                  (0x00000000U)
 #define UART_WORDLENGTH_9B                  ((uint32_t)USART_CR1_M)
 /**
   * @}
@@ -180,7 +178,7 @@ typedef struct
 /** @defgroup UART_Stop_Bits   UART Number of Stop Bits
   * @{
   */
-#define UART_STOPBITS_1                     ((uint32_t)0x00000000)
+#define UART_STOPBITS_1                     (0x00000000U)
 #define UART_STOPBITS_2                     ((uint32_t)USART_CR2_STOP_1)
 /**
   * @}
@@ -189,7 +187,7 @@ typedef struct
 /** @defgroup UART_Parity  UART Parity
   * @{
   */ 
-#define UART_PARITY_NONE                    ((uint32_t)0x00000000)
+#define UART_PARITY_NONE                    (0x00000000U)
 #define UART_PARITY_EVEN                    ((uint32_t)USART_CR1_PCE)
 #define UART_PARITY_ODD                     ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
 /**
@@ -199,7 +197,7 @@ typedef struct
 /** @defgroup UART_Hardware_Flow_Control UART Hardware Flow Control
   * @{
   */ 
-#define UART_HWCONTROL_NONE                  ((uint32_t)0x00000000)
+#define UART_HWCONTROL_NONE                  (0x00000000U)
 #define UART_HWCONTROL_RTS                   ((uint32_t)USART_CR3_RTSE)
 #define UART_HWCONTROL_CTS                   ((uint32_t)USART_CR3_CTSE)
 #define UART_HWCONTROL_RTS_CTS               ((uint32_t)(USART_CR3_RTSE | USART_CR3_CTSE))
@@ -221,7 +219,7 @@ typedef struct
  /** @defgroup UART_State  UART State
   * @{
   */ 
-#define UART_STATE_DISABLE                  ((uint32_t)0x00000000)
+#define UART_STATE_DISABLE                  (0x00000000U)
 #define UART_STATE_ENABLE                   ((uint32_t)USART_CR1_UE)
 /**
   * @}
@@ -230,7 +228,7 @@ typedef struct
 /** @defgroup UART_Over_Sampling UART Over Sampling
   * @{
   */
-#define UART_OVERSAMPLING_16                    ((uint32_t)0x00000000)
+#define UART_OVERSAMPLING_16                    (0x00000000U)
 #define UART_OVERSAMPLING_8                     ((uint32_t)USART_CR1_OVER8)
 /**
   * @}
@@ -239,7 +237,7 @@ typedef struct
 /** @defgroup UART_LIN_Break_Detection_Length  UART LIN Break Detection Length
   * @{
   */  
-#define UART_LINBREAKDETECTLENGTH_10B      ((uint32_t)0x00000000)
+#define UART_LINBREAKDETECTLENGTH_10B      (0x00000000U)
 #define UART_LINBREAKDETECTLENGTH_11B      ((uint32_t)USART_CR2_LBDL)
 /**
   * @}
@@ -248,7 +246,7 @@ typedef struct
 /** @defgroup UART_WakeUp_functions UART Wakeup Functions
   * @{
   */
-#define UART_WAKEUPMETHOD_IDLELINE                ((uint32_t)0x00000000)
+#define UART_WAKEUPMETHOD_IDLELINE                (0x00000000U)
 #define UART_WAKEUPMETHOD_ADDRESSMARK             ((uint32_t)USART_CR1_WAKE)
 /**
   * @}
@@ -628,8 +626,8 @@ do{                                         \
                                         ((CONTROL) == UART_HWCONTROL_CTS) || \
                                         ((CONTROL) == UART_HWCONTROL_RTS_CTS))
 
-#define IS_UART_MODE(MODE)             ((((MODE) & (~((uint32_t)UART_MODE_TX_RX))) == 0x00) && \
-                                        ((MODE) != (uint32_t)0x00000000))
+#define IS_UART_MODE(MODE)             ((((MODE) & (~((uint32_t)UART_MODE_TX_RX))) == 0x00U) && \
+                                        ((MODE) != 0x00000000U))
 
 #define IS_UART_STATE(STATE)           (((STATE) == UART_STATE_DISABLE) || \
                                         ((STATE) == UART_STATE_ENABLE))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_usart.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_usart.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_usart.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   USART HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Universal Synchronous Asynchronous Receiver Transmitter (USART) peripheral:
@@ -109,7 +107,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_usart.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_usart.h
@@ -2,14 +2,12 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_usart.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   This file contains all the functions prototypes for the USART 
   *          firmware library.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -159,12 +157,12 @@ typedef struct
 /** @defgroup USART_Error_Codes USART Error Codes
   * @{
   */
-#define HAL_USART_ERROR_NONE      ((uint32_t)0x00)    /*!< No error            */
-#define HAL_USART_ERROR_PE        ((uint32_t)0x01)    /*!< Parity error        */
-#define HAL_USART_ERROR_NE        ((uint32_t)0x02)    /*!< Noise error         */
-#define HAL_USART_ERROR_FE        ((uint32_t)0x04)    /*!< frame error         */
-#define HAL_USART_ERROR_ORE       ((uint32_t)0x08)    /*!< Overrun error       */
-#define HAL_USART_ERROR_DMA       ((uint32_t)0x10)     /*!< DMA transfer error  */
+#define HAL_USART_ERROR_NONE      (0x00U)    /*!< No error            */
+#define HAL_USART_ERROR_PE        (0x01U)    /*!< Parity error        */
+#define HAL_USART_ERROR_NE        (0x02U)    /*!< Noise error         */
+#define HAL_USART_ERROR_FE        (0x04U)    /*!< frame error         */
+#define HAL_USART_ERROR_ORE       (0x08U)    /*!< Overrun error       */
+#define HAL_USART_ERROR_DMA       (0x10U)     /*!< DMA transfer error  */
 /**
   * @}
   */
@@ -172,7 +170,7 @@ typedef struct
 /** @defgroup USART_Word_Length USART Word Length
   * @{
   */
-#define USART_WORDLENGTH_8B             ((uint32_t)0x00000000)
+#define USART_WORDLENGTH_8B             (0x00000000U)
 #define USART_WORDLENGTH_9B             ((uint32_t)USART_CR1_M)
 /**
   * @}
@@ -181,7 +179,7 @@ typedef struct
 /** @defgroup USART_Stop_Bits USART Number of Stop Bits
   * @{
   */
-#define USART_STOPBITS_1                ((uint32_t)0x00000000)
+#define USART_STOPBITS_1                (0x00000000U)
 #define USART_STOPBITS_0_5              ((uint32_t)USART_CR2_STOP_0)
 #define USART_STOPBITS_2                ((uint32_t)USART_CR2_STOP_1)
 #define USART_STOPBITS_1_5              ((uint32_t)(USART_CR2_STOP_0 | USART_CR2_STOP_1))
@@ -192,7 +190,7 @@ typedef struct
 /** @defgroup USART_Parity USART Parity
   * @{
   */ 
-#define USART_PARITY_NONE               ((uint32_t)0x00000000)
+#define USART_PARITY_NONE               (0x00000000U)
 #define USART_PARITY_EVEN               ((uint32_t)USART_CR1_PCE)
 #define USART_PARITY_ODD                ((uint32_t)(USART_CR1_PCE | USART_CR1_PS)) 
 /**
@@ -213,7 +211,7 @@ typedef struct
 /** @defgroup USART_Clock USART Clock
   * @{
   */ 
-#define USART_CLOCK_DISABLE             ((uint32_t)0x00000000)
+#define USART_CLOCK_DISABLE             (0x00000000U)
 #define USART_CLOCK_ENABLE              ((uint32_t)USART_CR2_CLKEN)
 /**
   * @}
@@ -222,7 +220,7 @@ typedef struct
 /** @defgroup USART_Clock_Polarity USART Clock Polarity
   * @{
   */
-#define USART_POLARITY_LOW              ((uint32_t)0x00000000)
+#define USART_POLARITY_LOW              (0x00000000U)
 #define USART_POLARITY_HIGH             ((uint32_t)USART_CR2_CPOL)
 /**
   * @}
@@ -231,7 +229,7 @@ typedef struct
 /** @defgroup USART_Clock_Phase USART Clock Phase
   * @{
   */
-#define USART_PHASE_1EDGE               ((uint32_t)0x00000000)
+#define USART_PHASE_1EDGE               (0x00000000U)
 #define USART_PHASE_2EDGE               ((uint32_t)USART_CR2_CPHA)
 /**
   * @}
@@ -240,7 +238,7 @@ typedef struct
 /** @defgroup USART_Last_Bit USART Last Bit
   * @{
   */
-#define USART_LASTBIT_DISABLE           ((uint32_t)0x00000000)
+#define USART_LASTBIT_DISABLE           (0x00000000U)
 #define USART_LASTBIT_ENABLE            ((uint32_t)USART_CR2_LBCL)
 /**
   * @}
@@ -250,7 +248,7 @@ typedef struct
   * @{
   */
 #define USART_NACK_ENABLE               ((uint32_t)USART_CR3_NACK)
-#define USART_NACK_DISABLE              ((uint32_t)0x00000000)
+#define USART_NACK_DISABLE              (0x00000000U)
 /**
   * @}
   */
@@ -520,7 +518,7 @@ do{                                          \
                                          ((PARITY) == USART_PARITY_EVEN) || \
                                          ((PARITY) == USART_PARITY_ODD))
 
-#define IS_USART_MODE(MODE)             ((((MODE) & (~((uint32_t)USART_MODE_TX_RX))) == 0x00) && ((MODE) != (uint32_t)0x00000000))
+#define IS_USART_MODE(MODE)             ((((MODE) & (~((uint32_t)USART_MODE_TX_RX))) == 0x00U) && ((MODE) != 0x00000000U))
 
 #define IS_USART_CLOCK(CLOCK)           (((CLOCK) == USART_CLOCK_DISABLE) || \
                                          ((CLOCK) == USART_CLOCK_ENABLE))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_wwdg.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_wwdg.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_wwdg.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   WWDG HAL module driver.
   *          This file provides firmware functions to manage the following 
   *          functionalities of the Window Watchdog (WWDG) peripheral:
@@ -96,7 +94,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_wwdg.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_hal_wwdg.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_hal_wwdg.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of WWDG HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_adc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_adc.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_adc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   ADC LL module driver
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_adc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_adc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_adc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of ADC LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -71,46 +69,46 @@ extern "C" {
 
 /* Internal register offset for ADC group regular sequencer configuration */
 /* (offset placed into a spare area of literal definition) */
-#define ADC_SQR1_REGOFFSET                 ((uint32_t)0x00000000U)
-#define ADC_SQR2_REGOFFSET                 ((uint32_t)0x00000100U)
-#define ADC_SQR3_REGOFFSET                 ((uint32_t)0x00000200U)
-#define ADC_SQR4_REGOFFSET                 ((uint32_t)0x00000300U)
-#define ADC_SQR5_REGOFFSET                 ((uint32_t)0x00000400U)
+#define ADC_SQR1_REGOFFSET                 0x00000000U
+#define ADC_SQR2_REGOFFSET                 0x00000100U
+#define ADC_SQR3_REGOFFSET                 0x00000200U
+#define ADC_SQR4_REGOFFSET                 0x00000300U
+#define ADC_SQR5_REGOFFSET                 0x00000400U
 
 #define ADC_REG_SQRX_REGOFFSET_MASK        (ADC_SQR1_REGOFFSET | ADC_SQR2_REGOFFSET | ADC_SQR3_REGOFFSET | ADC_SQR4_REGOFFSET | ADC_SQR5_REGOFFSET)
 #define ADC_REG_RANK_ID_SQRX_MASK          (ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0)
 
 /* Definition of ADC group regular sequencer bits information to be inserted  */
 /* into ADC group regular sequencer ranks literals definition.                */
-#define ADC_REG_RANK_1_SQRX_BITOFFSET_POS  ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ1) */
-#define ADC_REG_RANK_2_SQRX_BITOFFSET_POS  ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ2) */
-#define ADC_REG_RANK_3_SQRX_BITOFFSET_POS  ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ3) */
-#define ADC_REG_RANK_4_SQRX_BITOFFSET_POS  ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ4) */
-#define ADC_REG_RANK_5_SQRX_BITOFFSET_POS  ((uint32_t)20U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ5) */
-#define ADC_REG_RANK_6_SQRX_BITOFFSET_POS  ((uint32_t)25U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ6) */
-#define ADC_REG_RANK_7_SQRX_BITOFFSET_POS  ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ7) */
-#define ADC_REG_RANK_8_SQRX_BITOFFSET_POS  ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ8) */
-#define ADC_REG_RANK_9_SQRX_BITOFFSET_POS  ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ9) */
-#define ADC_REG_RANK_10_SQRX_BITOFFSET_POS ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ10) */
-#define ADC_REG_RANK_11_SQRX_BITOFFSET_POS ((uint32_t)20U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ11) */
-#define ADC_REG_RANK_12_SQRX_BITOFFSET_POS ((uint32_t)25U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ12) */
-#define ADC_REG_RANK_13_SQRX_BITOFFSET_POS ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ13) */
-#define ADC_REG_RANK_14_SQRX_BITOFFSET_POS ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ14) */
-#define ADC_REG_RANK_15_SQRX_BITOFFSET_POS ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ15) */
-#define ADC_REG_RANK_16_SQRX_BITOFFSET_POS ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ16) */
-#define ADC_REG_RANK_17_SQRX_BITOFFSET_POS ((uint32_t)20U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ17) */
-#define ADC_REG_RANK_18_SQRX_BITOFFSET_POS ((uint32_t)25U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ18) */
-#define ADC_REG_RANK_19_SQRX_BITOFFSET_POS ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ29) */
-#define ADC_REG_RANK_20_SQRX_BITOFFSET_POS ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ20) */
-#define ADC_REG_RANK_21_SQRX_BITOFFSET_POS ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ21) */
-#define ADC_REG_RANK_22_SQRX_BITOFFSET_POS ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ22) */
-#define ADC_REG_RANK_23_SQRX_BITOFFSET_POS ((uint32_t)20U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ23) */
-#define ADC_REG_RANK_24_SQRX_BITOFFSET_POS ((uint32_t)25U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ24) */
-#define ADC_REG_RANK_25_SQRX_BITOFFSET_POS ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ25) */
-#define ADC_REG_RANK_26_SQRX_BITOFFSET_POS ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ26) */
-#define ADC_REG_RANK_27_SQRX_BITOFFSET_POS ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ27) */
+#define ADC_REG_RANK_1_SQRX_BITOFFSET_POS  ( 0U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ1) */
+#define ADC_REG_RANK_2_SQRX_BITOFFSET_POS  ( 5U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ2) */
+#define ADC_REG_RANK_3_SQRX_BITOFFSET_POS  (10U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ3) */
+#define ADC_REG_RANK_4_SQRX_BITOFFSET_POS  (15U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ4) */
+#define ADC_REG_RANK_5_SQRX_BITOFFSET_POS  (20U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ5) */
+#define ADC_REG_RANK_6_SQRX_BITOFFSET_POS  (25U) /* Value equivalent to POSITION_VAL(ADC_SQR5_SQ6) */
+#define ADC_REG_RANK_7_SQRX_BITOFFSET_POS  ( 0U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ7) */
+#define ADC_REG_RANK_8_SQRX_BITOFFSET_POS  ( 5U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ8) */
+#define ADC_REG_RANK_9_SQRX_BITOFFSET_POS  (10U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ9) */
+#define ADC_REG_RANK_10_SQRX_BITOFFSET_POS (15U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ10) */
+#define ADC_REG_RANK_11_SQRX_BITOFFSET_POS (20U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ11) */
+#define ADC_REG_RANK_12_SQRX_BITOFFSET_POS (25U) /* Value equivalent to POSITION_VAL(ADC_SQR4_SQ12) */
+#define ADC_REG_RANK_13_SQRX_BITOFFSET_POS ( 0U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ13) */
+#define ADC_REG_RANK_14_SQRX_BITOFFSET_POS ( 5U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ14) */
+#define ADC_REG_RANK_15_SQRX_BITOFFSET_POS (10U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ15) */
+#define ADC_REG_RANK_16_SQRX_BITOFFSET_POS (15U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ16) */
+#define ADC_REG_RANK_17_SQRX_BITOFFSET_POS (20U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ17) */
+#define ADC_REG_RANK_18_SQRX_BITOFFSET_POS (25U) /* Value equivalent to POSITION_VAL(ADC_SQR3_SQ18) */
+#define ADC_REG_RANK_19_SQRX_BITOFFSET_POS ( 0U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ29) */
+#define ADC_REG_RANK_20_SQRX_BITOFFSET_POS ( 5U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ20) */
+#define ADC_REG_RANK_21_SQRX_BITOFFSET_POS (10U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ21) */
+#define ADC_REG_RANK_22_SQRX_BITOFFSET_POS (15U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ22) */
+#define ADC_REG_RANK_23_SQRX_BITOFFSET_POS (20U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ23) */
+#define ADC_REG_RANK_24_SQRX_BITOFFSET_POS (25U) /* Value equivalent to POSITION_VAL(ADC_SQR2_SQ24) */
+#define ADC_REG_RANK_25_SQRX_BITOFFSET_POS ( 0U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ25) */
+#define ADC_REG_RANK_26_SQRX_BITOFFSET_POS ( 5U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ26) */
+#define ADC_REG_RANK_27_SQRX_BITOFFSET_POS (10U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ27) */
 #if defined(ADC_SQR1_SQ28)
-#define ADC_REG_RANK_28_SQRX_BITOFFSET_POS ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ28) */
+#define ADC_REG_RANK_28_SQRX_BITOFFSET_POS (15U) /* Value equivalent to POSITION_VAL(ADC_SQR1_SQ28) */
 #endif
 
 
@@ -123,17 +121,17 @@ extern "C" {
 
 /* Internal register offset for ADC group injected data register */
 /* (offset placed into a spare area of literal definition) */
-#define ADC_JDR1_REGOFFSET                 ((uint32_t)0x00000000U)
-#define ADC_JDR2_REGOFFSET                 ((uint32_t)0x00000100U)
-#define ADC_JDR3_REGOFFSET                 ((uint32_t)0x00000200U)
-#define ADC_JDR4_REGOFFSET                 ((uint32_t)0x00000300U)
+#define ADC_JDR1_REGOFFSET                 0x00000000U
+#define ADC_JDR2_REGOFFSET                 0x00000100U
+#define ADC_JDR3_REGOFFSET                 0x00000200U
+#define ADC_JDR4_REGOFFSET                 0x00000300U
 
 /* Internal register offset for ADC group injected offset configuration */
 /* (offset placed into a spare area of literal definition) */
-#define ADC_JOFR1_REGOFFSET                ((uint32_t)0x00000000U)
-#define ADC_JOFR2_REGOFFSET                ((uint32_t)0x00001000U)
-#define ADC_JOFR3_REGOFFSET                ((uint32_t)0x00002000U)
-#define ADC_JOFR4_REGOFFSET                ((uint32_t)0x00003000U)
+#define ADC_JOFR1_REGOFFSET                0x00000000U
+#define ADC_JOFR2_REGOFFSET                0x00001000U
+#define ADC_JOFR3_REGOFFSET                0x00002000U
+#define ADC_JOFR4_REGOFFSET                0x00003000U
 
 #define ADC_INJ_JDRX_REGOFFSET_MASK        (ADC_JDR1_REGOFFSET | ADC_JDR2_REGOFFSET | ADC_JDR3_REGOFFSET | ADC_JDR4_REGOFFSET)
 #define ADC_INJ_JOFRX_REGOFFSET_MASK       (ADC_JOFR1_REGOFFSET | ADC_JOFR2_REGOFFSET | ADC_JOFR3_REGOFFSET | ADC_JOFR4_REGOFFSET)
@@ -141,10 +139,10 @@ extern "C" {
 
 /* Definition of ADC group injected sequencer bits information to be inserted */
 /* into ADC group injected sequencer ranks literals definition.               */
-#define ADC_INJ_RANK_1_JSQR_BITOFFSET_POS  ((uint32_t) 0U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ1) */
-#define ADC_INJ_RANK_2_JSQR_BITOFFSET_POS  ((uint32_t) 5U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ2) */
-#define ADC_INJ_RANK_3_JSQR_BITOFFSET_POS  ((uint32_t)10U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ3) */
-#define ADC_INJ_RANK_4_JSQR_BITOFFSET_POS  ((uint32_t)15U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ4) */
+#define ADC_INJ_RANK_1_JSQR_BITOFFSET_POS  ( 0U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ1) */
+#define ADC_INJ_RANK_2_JSQR_BITOFFSET_POS  ( 5U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ2) */
+#define ADC_INJ_RANK_3_JSQR_BITOFFSET_POS  (10U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ3) */
+#define ADC_INJ_RANK_4_JSQR_BITOFFSET_POS  (15U) /* Value equivalent to POSITION_VAL(ADC_JSQR_JSQ4) */
 
 
 
@@ -160,7 +158,7 @@ extern "C" {
 #define ADC_REG_TRIG_SOURCE_MASK            (((LL_ADC_REG_TRIG_SOFTWARE & ADC_CR2_EXTSEL) >> (4U * 0U)) | \
                                              ((ADC_CR2_EXTSEL)                            >> (4U * 1U)) | \
                                              ((ADC_CR2_EXTSEL)                            >> (4U * 2U)) | \
-                                             ((ADC_CR2_EXTSEL)                            >> (4U * 3U))  )
+                                             ((ADC_CR2_EXTSEL)                            >> (4U * 3U)))
 
 /* Mask containing trigger edge masks for each of possible                    */
 /* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
@@ -168,11 +166,11 @@ extern "C" {
 #define ADC_REG_TRIG_EDGE_MASK              (((LL_ADC_REG_TRIG_SOFTWARE & ADC_CR2_EXTEN) >> (4U * 0U)) | \
                                              ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)            >> (4U * 1U)) | \
                                              ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)            >> (4U * 2U)) | \
-                                             ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)            >> (4U * 3U))  )
+                                             ((ADC_REG_TRIG_EXT_EDGE_DEFAULT)            >> (4U * 3U)))
 
 /* Definition of ADC group regular trigger bits information.                  */
-#define ADC_REG_TRIG_EXTSEL_BITOFFSET_POS  ((uint32_t)24U) /* Value equivalent to POSITION_VAL(ADC_CR2_EXTSEL) */
-#define ADC_REG_TRIG_EXTEN_BITOFFSET_POS   ((uint32_t)28U) /* Value equivalent to POSITION_VAL(ADC_CR2_EXTEN) */
+#define ADC_REG_TRIG_EXTSEL_BITOFFSET_POS  (24U) /* Value equivalent to POSITION_VAL(ADC_CR2_EXTSEL) */
+#define ADC_REG_TRIG_EXTEN_BITOFFSET_POS   (28U) /* Value equivalent to POSITION_VAL(ADC_CR2_EXTEN) */
 
 
 
@@ -188,7 +186,7 @@ extern "C" {
 #define ADC_INJ_TRIG_SOURCE_MASK            (((LL_ADC_REG_TRIG_SOFTWARE & ADC_CR2_JEXTSEL) >> (4U * 0U)) | \
                                              ((ADC_CR2_JEXTSEL)                            >> (4U * 1U)) | \
                                              ((ADC_CR2_JEXTSEL)                            >> (4U * 2U)) | \
-                                             ((ADC_CR2_JEXTSEL)                            >> (4U * 3U))  )
+                                             ((ADC_CR2_JEXTSEL)                            >> (4U * 3U)))
 
 /* Mask containing trigger edge masks for each of possible                    */
 /* trigger edge selection duplicated with shifts [0; 4; 8; 12]                */
@@ -196,11 +194,11 @@ extern "C" {
 #define ADC_INJ_TRIG_EDGE_MASK              (((LL_ADC_INJ_TRIG_SOFTWARE & ADC_CR2_JEXTEN) >> (4U * 0U)) | \
                                              ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)             >> (4U * 1U)) | \
                                              ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)             >> (4U * 2U)) | \
-                                             ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)             >> (4U * 3U))  )
+                                             ((ADC_INJ_TRIG_EXT_EDGE_DEFAULT)             >> (4U * 3U)))
 
 /* Definition of ADC group injected trigger bits information.                 */
-#define ADC_INJ_TRIG_EXTSEL_BITOFFSET_POS  ((uint32_t)16U) /* Value equivalent to POSITION_VAL(ADC_CR2_JEXTSEL) */
-#define ADC_INJ_TRIG_EXTEN_BITOFFSET_POS   ((uint32_t)20U) /* Value equivalent to POSITION_VAL(ADC_CR2_JEXTEN) */
+#define ADC_INJ_TRIG_EXTSEL_BITOFFSET_POS  (16U) /* Value equivalent to POSITION_VAL(ADC_CR2_JEXTSEL) */
+#define ADC_INJ_TRIG_EXTEN_BITOFFSET_POS   (20U) /* Value equivalent to POSITION_VAL(ADC_CR2_JEXTEN) */
 
 
 
@@ -215,33 +213,33 @@ extern "C" {
 /* - channel sampling time defined by SMPRx register offset                   */
 /*   and SMPx bits positions into SMPRx register                              */
 #define ADC_CHANNEL_ID_NUMBER_MASK         (ADC_CR1_AWDCH)
-#define ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS ((uint32_t) 0U)/* Value equivalent to POSITION_VAL(ADC_CHANNEL_ID_NUMBER_MASK) */
+#define ADC_CHANNEL_ID_NUMBER_BITOFFSET_POS ( 0U)/* Value equivalent to POSITION_VAL(ADC_CHANNEL_ID_NUMBER_MASK) */
 #define ADC_CHANNEL_ID_MASK                (ADC_CHANNEL_ID_NUMBER_MASK | ADC_CHANNEL_ID_INTERNAL_CH_MASK)
 /* Equivalent mask of ADC_CHANNEL_NUMBER_MASK aligned on register LSB (bit 0) */
-#define ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 ((uint32_t)0x0000001FU) /* Equivalent to shift: (ADC_CHANNEL_NUMBER_MASK >> POSITION_VAL(ADC_CHANNEL_NUMBER_MASK)) */
+#define ADC_CHANNEL_ID_NUMBER_MASK_POSBIT0 0x0000001FU /* Equivalent to shift: (ADC_CHANNEL_NUMBER_MASK >> POSITION_VAL(ADC_CHANNEL_NUMBER_MASK)) */
 
 /* Channel differentiation between external and internal channels */
-#define ADC_CHANNEL_ID_INTERNAL_CH         ((uint32_t)0x80000000U) /* Marker of internal channel */
+#define ADC_CHANNEL_ID_INTERNAL_CH         0x80000000U   /* Marker of internal channel */
 #define ADC_CHANNEL_ID_INTERNAL_CH_MASK    (ADC_CHANNEL_ID_INTERNAL_CH)
 
 /* Internal register offset for ADC channel sampling time configuration */
 /* (offset placed into a spare area of literal definition) */
-#define ADC_SMPR1_REGOFFSET                ((uint32_t)0x00000000U)
-#define ADC_SMPR2_REGOFFSET                ((uint32_t)0x02000000U)
-#define ADC_SMPR3_REGOFFSET                ((uint32_t)0x04000000U)
+#define ADC_SMPR1_REGOFFSET                0x00000000U
+#define ADC_SMPR2_REGOFFSET                0x02000000U
+#define ADC_SMPR3_REGOFFSET                0x04000000U
 #if defined(ADC_SMPR0_SMP31)
-#define ADC_SMPR0_REGOFFSET                ((uint32_t)0x28000000U) /* SMPR0 register offset from SMPR1 is 20 registers. On STM32L1, parameter not available on all devices: only on STM32L1 Cat.4 and Cat.5. */
+#define ADC_SMPR0_REGOFFSET                0x28000000U   /* SMPR0 register offset from SMPR1 is 20 registers. On STM32L1, parameter not available on all devices: only on STM32L1 Cat.4 and Cat.5. */
 #define ADC_CHANNEL_SMPRX_REGOFFSET_MASK   (ADC_SMPR1_REGOFFSET | ADC_SMPR2_REGOFFSET | ADC_SMPR3_REGOFFSET | ADC_SMPR0_REGOFFSET)
 #else
 #define ADC_CHANNEL_SMPRX_REGOFFSET_MASK   (ADC_SMPR1_REGOFFSET | ADC_SMPR2_REGOFFSET | ADC_SMPR3_REGOFFSET)
 #endif /* ADC_SMPR0_SMP31 */
 
-#define ADC_CHANNEL_SMPx_BITOFFSET_MASK    ((uint32_t)0x01F00000U)
-#define ADC_CHANNEL_SMPx_BITOFFSET_POS     ((uint32_t)20U)           /* Value equivalent to POSITION_VAL(ADC_CHANNEL_SMPx_BITOFFSET_MASK) */
+#define ADC_CHANNEL_SMPx_BITOFFSET_MASK    0x01F00000U
+#define ADC_CHANNEL_SMPx_BITOFFSET_POS     (20U)           /* Value equivalent to POSITION_VAL(ADC_CHANNEL_SMPx_BITOFFSET_MASK) */
 
 /* Definition of channels ID number information to be inserted into           */
 /* channels literals definition.                                              */
-#define ADC_CHANNEL_0_NUMBER               ((uint32_t)0x00000000U)
+#define ADC_CHANNEL_0_NUMBER               0x00000000U
 #define ADC_CHANNEL_1_NUMBER               (                                                                        ADC_CR1_AWDCH_0)
 #define ADC_CHANNEL_2_NUMBER               (                                                      ADC_CR1_AWDCH_1                  )
 #define ADC_CHANNEL_3_NUMBER               (                                                      ADC_CR1_AWDCH_1 | ADC_CR1_AWDCH_0)
@@ -278,39 +276,39 @@ extern "C" {
 
 /* Definition of channels sampling time information to be inserted into       */
 /* channels literals definition.                                              */
-#define ADC_CHANNEL_0_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t) 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP0) */
-#define ADC_CHANNEL_1_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t) 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP1) */
-#define ADC_CHANNEL_2_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t) 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP2) */
-#define ADC_CHANNEL_3_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t) 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP3) */
-#define ADC_CHANNEL_4_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP4) */
-#define ADC_CHANNEL_5_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP5) */
-#define ADC_CHANNEL_6_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP6) */
-#define ADC_CHANNEL_7_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP7) */
-#define ADC_CHANNEL_8_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP8) */
-#define ADC_CHANNEL_9_SMP                  (ADC_SMPR3_REGOFFSET | (((uint32_t)27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP9) */
-#define ADC_CHANNEL_10_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t) 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP10) */
-#define ADC_CHANNEL_11_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t) 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP11) */
-#define ADC_CHANNEL_12_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t) 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP12) */
-#define ADC_CHANNEL_13_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t) 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP13) */
-#define ADC_CHANNEL_14_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP14) */
-#define ADC_CHANNEL_15_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP15) */
-#define ADC_CHANNEL_16_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP16) */
-#define ADC_CHANNEL_17_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP17) */
-#define ADC_CHANNEL_18_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP18) */
-#define ADC_CHANNEL_19_SMP                 (ADC_SMPR2_REGOFFSET | (((uint32_t)27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP19) */
-#define ADC_CHANNEL_20_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t) 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP20) */
-#define ADC_CHANNEL_21_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t) 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP21) */
-#define ADC_CHANNEL_22_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t) 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP22) */
-#define ADC_CHANNEL_23_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t) 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP23) */
-#define ADC_CHANNEL_24_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP24) */
-#define ADC_CHANNEL_25_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP25) */
-#define ADC_CHANNEL_26_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP26) */
+#define ADC_CHANNEL_0_SMP                  (ADC_SMPR3_REGOFFSET | (( 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP0) */
+#define ADC_CHANNEL_1_SMP                  (ADC_SMPR3_REGOFFSET | (( 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP1) */
+#define ADC_CHANNEL_2_SMP                  (ADC_SMPR3_REGOFFSET | (( 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP2) */
+#define ADC_CHANNEL_3_SMP                  (ADC_SMPR3_REGOFFSET | (( 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP3) */
+#define ADC_CHANNEL_4_SMP                  (ADC_SMPR3_REGOFFSET | ((12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP4) */
+#define ADC_CHANNEL_5_SMP                  (ADC_SMPR3_REGOFFSET | ((15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP5) */
+#define ADC_CHANNEL_6_SMP                  (ADC_SMPR3_REGOFFSET | ((18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP6) */
+#define ADC_CHANNEL_7_SMP                  (ADC_SMPR3_REGOFFSET | ((21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP7) */
+#define ADC_CHANNEL_8_SMP                  (ADC_SMPR3_REGOFFSET | ((24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP8) */
+#define ADC_CHANNEL_9_SMP                  (ADC_SMPR3_REGOFFSET | ((27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR3_SMP9) */
+#define ADC_CHANNEL_10_SMP                 (ADC_SMPR2_REGOFFSET | (( 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP10) */
+#define ADC_CHANNEL_11_SMP                 (ADC_SMPR2_REGOFFSET | (( 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP11) */
+#define ADC_CHANNEL_12_SMP                 (ADC_SMPR2_REGOFFSET | (( 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP12) */
+#define ADC_CHANNEL_13_SMP                 (ADC_SMPR2_REGOFFSET | (( 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP13) */
+#define ADC_CHANNEL_14_SMP                 (ADC_SMPR2_REGOFFSET | ((12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP14) */
+#define ADC_CHANNEL_15_SMP                 (ADC_SMPR2_REGOFFSET | ((15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP15) */
+#define ADC_CHANNEL_16_SMP                 (ADC_SMPR2_REGOFFSET | ((18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP16) */
+#define ADC_CHANNEL_17_SMP                 (ADC_SMPR2_REGOFFSET | ((21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP17) */
+#define ADC_CHANNEL_18_SMP                 (ADC_SMPR2_REGOFFSET | ((24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP18) */
+#define ADC_CHANNEL_19_SMP                 (ADC_SMPR2_REGOFFSET | ((27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR2_SMP19) */
+#define ADC_CHANNEL_20_SMP                 (ADC_SMPR1_REGOFFSET | (( 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP20) */
+#define ADC_CHANNEL_21_SMP                 (ADC_SMPR1_REGOFFSET | (( 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP21) */
+#define ADC_CHANNEL_22_SMP                 (ADC_SMPR1_REGOFFSET | (( 6U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP22) */
+#define ADC_CHANNEL_23_SMP                 (ADC_SMPR1_REGOFFSET | (( 9U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP23) */
+#define ADC_CHANNEL_24_SMP                 (ADC_SMPR1_REGOFFSET | ((12U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP24) */
+#define ADC_CHANNEL_25_SMP                 (ADC_SMPR1_REGOFFSET | ((15U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP25) */
+#define ADC_CHANNEL_26_SMP                 (ADC_SMPR1_REGOFFSET | ((18U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP26) */
 #if defined(ADC_SMPR0_SMP31)
-#define ADC_CHANNEL_27_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP27) */
-#define ADC_CHANNEL_28_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP28) */
-#define ADC_CHANNEL_29_SMP                 (ADC_SMPR1_REGOFFSET | (((uint32_t)27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP19) */
-#define ADC_CHANNEL_30_SMP                 (ADC_SMPR0_REGOFFSET | (((uint32_t) 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR0_SMP30) */
-#define ADC_CHANNEL_31_SMP                 (ADC_SMPR0_REGOFFSET | (((uint32_t) 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR0_SMP31) */
+#define ADC_CHANNEL_27_SMP                 (ADC_SMPR1_REGOFFSET | ((21U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP27) */
+#define ADC_CHANNEL_28_SMP                 (ADC_SMPR1_REGOFFSET | ((24U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP28) */
+#define ADC_CHANNEL_29_SMP                 (ADC_SMPR1_REGOFFSET | ((27U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR1_SMP19) */
+#define ADC_CHANNEL_30_SMP                 (ADC_SMPR0_REGOFFSET | (( 0U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR0_SMP30) */
+#define ADC_CHANNEL_31_SMP                 (ADC_SMPR0_REGOFFSET | (( 3U) << ADC_CHANNEL_SMPx_BITOFFSET_POS)) /* Value shifted is equivalent to POSITION_VAL(ADC_SMPR0_SMP31) */
 #endif /* ADC_SMPR0_SMP31 */
 
 
@@ -322,7 +320,7 @@ extern "C" {
 /*   selection of ADC group (ADC groups regular and-or injected).             */
 
 /* Internal register offset for ADC analog watchdog channel configuration */
-#define ADC_AWD_CR1_REGOFFSET              ((uint32_t)0x00000000U)
+#define ADC_AWD_CR1_REGOFFSET              0x00000000U
 
 #define ADC_AWD_CRX_REGOFFSET_MASK         (ADC_AWD_CR1_REGOFFSET)
 
@@ -330,26 +328,26 @@ extern "C" {
 #define ADC_AWD_CR_ALL_CHANNEL_MASK        (ADC_AWD_CR1_CHANNEL_MASK)
 
 /* Internal register offset for ADC analog watchdog threshold configuration */
-#define ADC_AWD_TR1_HIGH_REGOFFSET         ((uint32_t)0x00000000U)
-#define ADC_AWD_TR1_LOW_REGOFFSET          ((uint32_t)0x00000001U)
+#define ADC_AWD_TR1_HIGH_REGOFFSET         0x00000000U
+#define ADC_AWD_TR1_LOW_REGOFFSET          0x00000001U
 #define ADC_AWD_TRX_REGOFFSET_MASK         (ADC_AWD_TR1_HIGH_REGOFFSET | ADC_AWD_TR1_LOW_REGOFFSET)
 
 
 /* ADC registers bits positions */
-#define ADC_CR1_RES_BITOFFSET_POS          ((uint32_t)24U) /* Value equivalent to POSITION_VAL(ADC_CR1_RES) */
-#define ADC_TR_HT_BITOFFSET_POS            ((uint32_t)16U) /* Value equivalent to POSITION_VAL(ADC_TR_HT) */
+#define ADC_CR1_RES_BITOFFSET_POS          (24U) /* Value equivalent to POSITION_VAL(ADC_CR1_RES) */
+#define ADC_TR_HT_BITOFFSET_POS            (16U) /* Value equivalent to POSITION_VAL(ADC_TR_HT) */
 
 
 /* ADC internal channels related definitions */
 /* Internal voltage reference VrefInt */
-#define VREFINT_CAL_ADDR                   ((uint16_t*) ((uint32_t)0x1FF800F8U)) /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
-#define VREFINT_CAL_VREF                   ((uint32_t) 3000U)                    /* Analog voltage reference (Vref+) value with which temperature sensor has been calibrated in production (tolerance: +-10 mV) (unit: mV). */
+#define VREFINT_CAL_ADDR                   ((uint16_t*) (0x1FF800F8U)) /* Internal voltage reference, address of parameter VREFINT_CAL: VrefInt ADC raw data acquired at temperature 30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
+#define VREFINT_CAL_VREF                   ( 3000U)                    /* Analog voltage reference (Vref+) value with which temperature sensor has been calibrated in production (tolerance: +-10 mV) (unit: mV). */
 /* Temperature sensor */
-#define TEMPSENSOR_CAL1_ADDR               ((uint16_t*) ((uint32_t)0x1FF800FAU)) /* Internal temperature sensor, address of parameter TS_CAL1: On STM32L1, temperature sensor ADC raw data acquired at temperature  30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
-#define TEMPSENSOR_CAL2_ADDR               ((uint16_t*) ((uint32_t)0x1FF800FEU)) /* Internal temperature sensor, address of parameter TS_CAL2: On STM32L1, temperature sensor ADC raw data acquired at temperature 110 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
-#define TEMPSENSOR_CAL1_TEMP               (( int32_t)   30)                     /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL1_ADDR (tolerance: +-5 DegC) (unit: DegC). */
-#define TEMPSENSOR_CAL2_TEMP               (( int32_t)  110)                     /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL2_ADDR (tolerance: +-5 DegC) (unit: DegC). */
-#define TEMPSENSOR_CAL_VREFANALOG          ((uint32_t) 3000U)                    /* Analog voltage reference (Vref+) voltage with which temperature sensor has been calibrated in production (+-10 mV) (unit: mV). */
+#define TEMPSENSOR_CAL1_ADDR               ((uint16_t*) (0x1FF800FAU)) /* Internal temperature sensor, address of parameter TS_CAL1: On STM32L1, temperature sensor ADC raw data acquired at temperature  30 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
+#define TEMPSENSOR_CAL2_ADDR               ((uint16_t*) (0x1FF800FEU)) /* Internal temperature sensor, address of parameter TS_CAL2: On STM32L1, temperature sensor ADC raw data acquired at temperature 110 DegC (tolerance: +-5 DegC), Vref+ = 3.0 V (tolerance: +-10 mV). */
+#define TEMPSENSOR_CAL1_TEMP               (( int32_t)   30)           /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL1_ADDR (tolerance: +-5 DegC) (unit: DegC). */
+#define TEMPSENSOR_CAL2_TEMP               (( int32_t)  110)           /* Internal temperature sensor, temperature at which temperature sensor has been calibrated in production for data into TEMPSENSOR_CAL2_ADDR (tolerance: +-5 DegC) (unit: DegC). */
+#define TEMPSENSOR_CAL_VREFANALOG          ( 3000U)                    /* Analog voltage reference (Vref+) voltage with which temperature sensor has been calibrated in production (+-10 mV) (unit: mV). */
 
 
 /**
@@ -611,7 +609,7 @@ typedef struct
 /* List of ADC registers intended to be used (most commonly) with             */
 /* DMA transfer.                                                              */
 /* Refer to function @ref LL_ADC_DMA_GetRegAddr().                            */
-#define LL_ADC_DMA_REG_REGULAR_DATA          ((uint32_t)0x00000000U) /* ADC group regular conversion data register (corresponding to register DR) to be used with ADC configured in independent mode. Without DMA transfer, register accessed by LL function @ref LL_ADC_REG_ReadConversionData32() and other functions @ref LL_ADC_REG_ReadConversionDatax() */
+#define LL_ADC_DMA_REG_REGULAR_DATA          0x00000000U   /* ADC group regular conversion data register (corresponding to register DR) to be used with ADC configured in independent mode. Without DMA transfer, register accessed by LL function @ref LL_ADC_REG_ReadConversionData32() and other functions @ref LL_ADC_REG_ReadConversionDatax() */
 /**
   * @}
   */
@@ -619,7 +617,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_COMMON_CLOCK_SOURCE  ADC common - Clock source
   * @{
   */
-#define LL_ADC_CLOCK_ASYNC_DIV1            ((uint32_t)0x00000000U)                               /*!< ADC asynchronous clock without prescaler */
+#define LL_ADC_CLOCK_ASYNC_DIV1            0x00000000U                                           /*!< ADC asynchronous clock without prescaler */
 #define LL_ADC_CLOCK_ASYNC_DIV2            (ADC_CCR_ADCPRE_0)                                    /*!< ADC asynchronous clock with prescaler division by 2   */
 #define LL_ADC_CLOCK_ASYNC_DIV4            (ADC_CCR_ADCPRE_1)                                    /*!< ADC asynchronous clock with prescaler division by 4   */
 /**
@@ -634,7 +632,7 @@ typedef struct
 /*       If they are not listed below, they do not require any specific       */
 /*       path enable. In this case, Access to measurement path is done        */
 /*       only by selecting the corresponding ADC internal channel.            */
-#define LL_ADC_PATH_INTERNAL_NONE          ((uint32_t)0x00000000U)/*!< ADC measurement pathes all disabled */
+#define LL_ADC_PATH_INTERNAL_NONE          0x00000000U            /*!< ADC measurement pathes all disabled */
 #define LL_ADC_PATH_INTERNAL_VREFINT       (ADC_CCR_TSVREFE)      /*!< ADC measurement path to internal channel VrefInt */
 #define LL_ADC_PATH_INTERNAL_TEMPSENSOR    (ADC_CCR_TSVREFE)      /*!< ADC measurement path to internal channel temperature sensor */
 /**
@@ -644,7 +642,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_RESOLUTION  ADC instance - Resolution
   * @{
   */
-#define LL_ADC_RESOLUTION_12B              ((uint32_t)0x00000000U)             /*!< ADC resolution 12 bits */
+#define LL_ADC_RESOLUTION_12B              0x00000000U                         /*!< ADC resolution 12 bits */
 #define LL_ADC_RESOLUTION_10B              (                ADC_CR1_RES_0)     /*!< ADC resolution 10 bits */
 #define LL_ADC_RESOLUTION_8B               (ADC_CR1_RES_1                )     /*!< ADC resolution  8 bits */
 #define LL_ADC_RESOLUTION_6B               (ADC_CR1_RES_1 | ADC_CR1_RES_0)     /*!< ADC resolution  6 bits */
@@ -655,7 +653,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_DATA_ALIGN  ADC instance - Data alignment
   * @{
   */
-#define LL_ADC_DATA_ALIGN_RIGHT            ((uint32_t)0x00000000U)/*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
+#define LL_ADC_DATA_ALIGN_RIGHT            0x00000000U            /*!< ADC conversion data alignment: right aligned (alignment on data register LSB bit 0)*/
 #define LL_ADC_DATA_ALIGN_LEFT             (ADC_CR2_ALIGN)        /*!< ADC conversion data alignment: left aligned (aligment on data register MSB bit 15)*/
 /**
   * @}
@@ -664,7 +662,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_LP_MODE_AUTOWAIT  ADC instance - Low power mode auto wait (auto delay)
   * @{
   */
-#define LL_ADC_LP_AUTOWAIT_NONE               ((uint32_t)0x00000000U)                            /*!< ADC low power mode auto wait not activated */
+#define LL_ADC_LP_AUTOWAIT_NONE               0x00000000U                                        /*!< ADC low power mode auto wait not activated */
 #define LL_ADC_LP_AUTOWAIT                    (                                  ADC_CR2_DELS_0) /*!< ADC low power mode auto wait: Dynamic low power mode, ADC conversions are performed only when necessary (when previous ADC conversion data is read). See description with function @ref LL_ADC_SetLowPowerModeAutoWait(). */
 #define LL_ADC_LP_AUTOWAIT_7_APBCLOCKCYCLES   (                 ADC_CR2_DELS_1                 ) /*!< ADC low power mode auto wait: Insert a delay between ADC conversions: 7 APB clock cycles */
 #define LL_ADC_LP_AUTOWAIT_15_APBCLOCKCYCLES  (                 ADC_CR2_DELS_1 | ADC_CR2_DELS_0) /*!< ADC low power mode auto wait: Insert a delay between ADC conversions: 15 APB clock cycles */
@@ -679,7 +677,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_LP_MODE_AUTOPOWEROFF  ADC instance - Low power mode auto power-off
   * @{
   */
-#define LL_ADC_LP_AUTOPOWEROFF_NONE                 ((uint32_t)0x00000000U)                      /*!< ADC low power mode auto power-off not activated */
+#define LL_ADC_LP_AUTOPOWEROFF_NONE                 0x00000000U                                  /*!< ADC low power mode auto power-off not activated */
 #define LL_ADC_LP_AUTOPOWEROFF_IDLE_PHASE           (ADC_CR1_PDI)                                /*!< ADC low power mode auto power-off: ADC power off when ADC is not converting (idle phase) */
 #define LL_ADC_LP_AUTOPOWEROFF_AUTOWAIT_PHASE       (ADC_CR1_PDD)                                /*!< ADC low power mode auto power-off: ADC power off when a delay is inserted between conversions (refer to function @ref LL_ADC_SetLowPowerModeAutoWait() ) */
 #define LL_ADC_LP_AUTOPOWEROFF_IDLE_AUTOWAIT_PHASES (ADC_CR1_PDI | ADC_CR1_PDD)                  /*!< ADC low power mode auto power-off: ADC power off when ADC is not converting (idle phase) and when a delay is inserted between conversions (refer to function @ref LL_ADC_SetLowPowerModeAutoWait() ) */
@@ -690,8 +688,8 @@ typedef struct
 /** @defgroup ADC_LL_EC_SCAN_SELECTION ADC instance - Scan selection
   * @{
   */
-#define LL_ADC_SEQ_SCAN_DISABLE            ((uint32_t)0x00000000U)  /*!< ADC conversion is performed in unitary conversion mode (one channel converted, that defined in rank 1). Configuration of both groups regular and injected sequencers (sequence length, ...) is discarded: equivalent to length of 1 rank.*/
-#define LL_ADC_SEQ_SCAN_ENABLE             ((uint32_t)ADC_CR1_SCAN) /*!< ADC conversions are performed in sequence conversions mode, according to configuration of both groups regular and injected sequencers (sequence length, ...). */
+#define LL_ADC_SEQ_SCAN_DISABLE            0x00000000U    /*!< ADC conversion is performed in unitary conversion mode (one channel converted, that defined in rank 1). Configuration of both groups regular and injected sequencers (sequence length, ...) is discarded: equivalent to length of 1 rank.*/
+#define LL_ADC_SEQ_SCAN_ENABLE             (ADC_CR1_SCAN) /*!< ADC conversions are performed in sequence conversions mode, according to configuration of both groups regular and injected sequencers (sequence length, ...). */
 /**
   * @}
   */
@@ -700,8 +698,8 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNELS_BANK ADC instance - Channels bank
   * @{
   */
-#define LL_ADC_CHANNELS_BANK_A             ((uint32_t)0x00000000U) /*!< ADC channels bank A */
-#define LL_ADC_CHANNELS_BANK_B             ((uint32_t)ADC_CR2_CFG) /*!< ADC channels bank B, available in devices categories 3, 4, 5. */
+#define LL_ADC_CHANNELS_BANK_A             0x00000000U   /*!< ADC channels bank A */
+#define LL_ADC_CHANNELS_BANK_B             (ADC_CR2_CFG) /*!< ADC channels bank B, available in devices categories 3, 4, 5. */
 /**
   * @}
   */
@@ -710,9 +708,9 @@ typedef struct
 /** @defgroup ADC_LL_EC_GROUPS  ADC instance - Groups
   * @{
   */
-#define LL_ADC_GROUP_REGULAR               ((uint32_t)0x00000001U) /*!< ADC group regular (available on all STM32 devices) */
-#define LL_ADC_GROUP_INJECTED              ((uint32_t)0x00000002U) /*!< ADC group injected (not available on all STM32 devices)*/
-#define LL_ADC_GROUP_REGULAR_INJECTED      ((uint32_t)0x00000003U) /*!< ADC both groups regular and injected */
+#define LL_ADC_GROUP_REGULAR               0x00000001U   /*!< ADC group regular (available on all STM32 devices) */
+#define LL_ADC_GROUP_INJECTED              0x00000002U   /*!< ADC group injected (not available on all STM32 devices)*/
+#define LL_ADC_GROUP_REGULAR_INJECTED      0x00000003U   /*!< ADC both groups regular and injected */
 /**
   * @}
   */
@@ -771,7 +769,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_TRIGGER_SOURCE  ADC group regular - Trigger source
   * @{
   */
-#define LL_ADC_REG_TRIG_SOFTWARE           ((uint32_t)0x00000000U)                                                                                     /*!< ADC group regular conversion trigger internal: SW start. */
+#define LL_ADC_REG_TRIG_SOFTWARE           0x00000000U                                                                                                 /*!< ADC group regular conversion trigger internal: SW start. */
 #define LL_ADC_REG_TRIG_EXT_TIM2_TRGO      (ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                       /*!< ADC group regular conversion trigger from external IP: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_TIM2_CH3       (ADC_CR2_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                          /*!< ADC group regular conversion trigger from external IP: TIM2 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_TIM3_TRGO      (ADC_CR2_EXTSEL_2 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                          /*!< ADC group regular conversion trigger from external IP: TIM3 TRGO. Trigger edge set to rising edge (default setting). */
@@ -783,7 +781,7 @@ typedef struct
 #define LL_ADC_REG_TRIG_EXT_TIM6_TRGO      (ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_1 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                       /*!< ADC group regular conversion trigger from external IP: TIM6 TRGO. Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_TIM9_CH2       (ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                                             /*!< ADC group regular conversion trigger from external IP: TIM9 channel 2 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_REG_TRIG_EXT_TIM9_TRGO      (ADC_CR2_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT)                                                          /*!< ADC group regular conversion trigger from external IP: TIM9 TRGO. Trigger edge set to rising edge (default setting). */
-#define LL_ADC_REG_TRIG_EXT_EXTI_LINE11    (ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger external interrupt line 11. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_REG_TRIG_EXT_EXTI_LINE11    (ADC_CR2_EXTSEL_3 | ADC_CR2_EXTSEL_2 | ADC_CR2_EXTSEL_1 | ADC_CR2_EXTSEL_0 | ADC_REG_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group regular conversion trigger from external IP: external interrupt line 11. Trigger edge set to rising edge (default setting). */
 /**
   * @}
   */
@@ -801,7 +799,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_CONTINUOUS_MODE  ADC group regular - Continuous mode
 * @{
 */
-#define LL_ADC_REG_CONV_SINGLE             ((uint32_t)0x00000000U) /*!< ADC conversions are performed in single mode: one conversion per trigger */
+#define LL_ADC_REG_CONV_SINGLE             0x00000000U             /*!< ADC conversions are performed in single mode: one conversion per trigger */
 #define LL_ADC_REG_CONV_CONTINUOUS         (ADC_CR2_CONT)          /*!< ADC conversions are performed in continuous mode: after the first trigger, following conversions launched successively automatically */
 /**
   * @}
@@ -810,7 +808,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_DMA_TRANSFER  ADC group regular - DMA transfer of ADC conversion data
   * @{
   */
-#define LL_ADC_REG_DMA_TRANSFER_NONE       ((uint32_t)0x00000000U)              /*!< ADC conversions are not transferred by DMA */
+#define LL_ADC_REG_DMA_TRANSFER_NONE       0x00000000U              /*!< ADC conversions are not transferred by DMA */
 #define LL_ADC_REG_DMA_TRANSFER_LIMITED    (              ADC_CR2_DMA)          /*!< ADC conversion data are transferred by DMA, in limited mode (one shot mode): DMA transfer requests are stopped when number of DMA data transfers (number of ADC conversions) is reached. This ADC mode is intended to be used with DMA mode non-circular. */
 #define LL_ADC_REG_DMA_TRANSFER_UNLIMITED  (ADC_CR2_DDS | ADC_CR2_DMA)          /*!< ADC conversion data are transferred by DMA, in unlimited mode: DMA transfer requests are unlimited, whatever number of DMA data transferred (number of ADC conversions). This ADC mode is intended to be used with DMA mode circular. */
 /**
@@ -820,8 +818,8 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_FLAG_EOC_SELECTION ADC group regular - Flag EOC selection (unitary or sequence conversions)
   * @{
   */
-#define LL_ADC_REG_FLAG_EOC_SEQUENCE_CONV       ((uint32_t)0x00000000U)  /*!< ADC flag EOC (end of unitary conversion) selected */
-#define LL_ADC_REG_FLAG_EOC_UNITARY_CONV        ((uint32_t)ADC_CR2_EOCS) /*!< ADC flag EOS (end of sequence conversions) selected */
+#define LL_ADC_REG_FLAG_EOC_SEQUENCE_CONV       0x00000000U    /*!< ADC flag EOC (end of unitary conversion) selected */
+#define LL_ADC_REG_FLAG_EOC_UNITARY_CONV        (ADC_CR2_EOCS) /*!< ADC flag EOS (end of sequence conversions) selected */
 /**
   * @}
   */
@@ -829,7 +827,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_SEQ_SCAN_LENGTH  ADC group regular - Sequencer scan length
   * @{
   */
-#define LL_ADC_REG_SEQ_SCAN_DISABLE        ((uint32_t)0x00000000U)                                     /*!< ADC group regular sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
+#define LL_ADC_REG_SEQ_SCAN_DISABLE        0x00000000U                                                 /*!< ADC group regular sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_2RANKS  (                                             ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 2 ranks in the sequence */
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_3RANKS  (                              ADC_SQR1_L_1               ) /*!< ADC group regular sequencer enable with 3 ranks in the sequence */
 #define LL_ADC_REG_SEQ_SCAN_ENABLE_4RANKS  (                              ADC_SQR1_L_1 | ADC_SQR1_L_0) /*!< ADC group regular sequencer enable with 4 ranks in the sequence */
@@ -852,7 +850,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_REG_SEQ_DISCONT_MODE  ADC group regular - Sequencer discontinuous mode
   * @{
   */
-#define LL_ADC_REG_SEQ_DISCONT_DISABLE     ((uint32_t)0x00000000U)                                                          /*!< ADC group regular sequencer discontinuous mode disable */
+#define LL_ADC_REG_SEQ_DISCONT_DISABLE     0x00000000U                                                                  /*!< ADC group regular sequencer discontinuous mode disable */
 #define LL_ADC_REG_SEQ_DISCONT_1RANK       (                                                            ADC_CR1_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every rank */
 #define LL_ADC_REG_SEQ_DISCONT_2RANKS      (                                        ADC_CR1_DISCNUM_0 | ADC_CR1_DISCEN) /*!< ADC group regular sequencer discontinuous mode enabled with sequence interruption every 2 ranks */
 #define LL_ADC_REG_SEQ_DISCONT_3RANKS      (                    ADC_CR1_DISCNUM_1                     | ADC_CR1_DISCEN) /*!< ADC group regular sequencer discontinuous mode enable with sequence interruption every 3 ranks */
@@ -905,7 +903,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_INJ_TRIGGER_SOURCE  ADC group injected - Trigger source
   * @{
   */
-#define LL_ADC_INJ_TRIG_SOFTWARE           ((uint32_t)0x00000000U)                                                                                         /*!< ADC group injected conversion trigger internal: SW start. */
+#define LL_ADC_INJ_TRIG_SOFTWARE           0x00000000U                                                                                                     /*!< ADC group injected conversion trigger internal: SW start. */
 #define LL_ADC_INJ_TRIG_EXT_TIM9_CH1       (ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                                                 /*!< ADC group injected conversion trigger from external IP: TIM9 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_INJ_TRIG_EXT_TIM9_TRGO      (ADC_CR2_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                             /*!< ADC group injected conversion trigger from external IP: TIM9 TRGO. Trigger edge set to rising edge (default setting). */
 #define LL_ADC_INJ_TRIG_EXT_TIM2_TRGO      (ADC_CR2_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                             /*!< ADC group injected conversion trigger from external IP: TIM2 TRGO. Trigger edge set to rising edge (default setting). */
@@ -917,7 +915,7 @@ typedef struct
 #define LL_ADC_INJ_TRIG_EXT_TIM4_CH3       (ADC_CR2_JEXTSEL_3 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                                             /*!< ADC group injected conversion trigger from external IP: TIM4 channel 3 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_INJ_TRIG_EXT_TIM10_CH1      (ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                         /*!< ADC group injected conversion trigger from external IP: TIM10 channel 1 event (capture compare: input capture or output capture). Trigger edge set to rising edge (default setting). */
 #define LL_ADC_INJ_TRIG_EXT_TIM7_TRGO      (ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_1 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT)                                         /*!< ADC group injected conversion trigger from external IP: TIM7 TRGO. Trigger edge set to rising edge (default setting). */
-#define LL_ADC_INJ_TRIG_EXT_EXTI_LINE15    (ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group injected conversion trigger external interrupt line 15. Trigger edge set to rising edge (default setting). */
+#define LL_ADC_INJ_TRIG_EXT_EXTI_LINE15    (ADC_CR2_JEXTSEL_3 | ADC_CR2_JEXTSEL_2 | ADC_CR2_JEXTSEL_1 | ADC_CR2_JEXTSEL_0 | ADC_INJ_TRIG_EXT_EDGE_DEFAULT) /*!< ADC group injected conversion trigger from external IP: external interrupt line 15. Trigger edge set to rising edge (default setting). */
 /**
   * @}
   */
@@ -935,7 +933,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_INJ_TRIG_AUTO  ADC group injected - Automatic trigger mode
 * @{
 */
-#define LL_ADC_INJ_TRIG_INDEPENDENT        ((uint32_t)0x00000000U)/*!< ADC group injected conversion trigger independent. Setting mandatory if ADC group injected injected trigger source is set to an external trigger. */
+#define LL_ADC_INJ_TRIG_INDEPENDENT        0x00000000U            /*!< ADC group injected conversion trigger independent. Setting mandatory if ADC group injected injected trigger source is set to an external trigger. */
 #define LL_ADC_INJ_TRIG_FROM_GRP_REGULAR   (ADC_CR1_JAUTO)        /*!< ADC group injected conversion trigger from ADC group regular. Setting compliant only with group injected trigger source set to SW start, without any further action on  ADC group injected conversion start or stop: in this case, ADC group injected is controlled only from ADC group regular. */
 /**
   * @}
@@ -945,7 +943,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_INJ_SEQ_SCAN_LENGTH  ADC group injected - Sequencer scan length
   * @{
   */
-#define LL_ADC_INJ_SEQ_SCAN_DISABLE        ((uint32_t)0x00000000U)         /*!< ADC group injected sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
+#define LL_ADC_INJ_SEQ_SCAN_DISABLE        0x00000000U                     /*!< ADC group injected sequencer disable (equivalent to sequencer of 1 rank: ADC conversion on only 1 channel) */
 #define LL_ADC_INJ_SEQ_SCAN_ENABLE_2RANKS  (                ADC_JSQR_JL_0) /*!< ADC group injected sequencer enable with 2 ranks in the sequence */
 #define LL_ADC_INJ_SEQ_SCAN_ENABLE_3RANKS  (ADC_JSQR_JL_1                ) /*!< ADC group injected sequencer enable with 3 ranks in the sequence */
 #define LL_ADC_INJ_SEQ_SCAN_ENABLE_4RANKS  (ADC_JSQR_JL_1 | ADC_JSQR_JL_0) /*!< ADC group injected sequencer enable with 4 ranks in the sequence */
@@ -956,7 +954,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_INJ_SEQ_DISCONT_MODE  ADC group injected - Sequencer discontinuous mode
   * @{
   */
-#define LL_ADC_INJ_SEQ_DISCONT_DISABLE     ((uint32_t)0x00000000U)/*!< ADC group injected sequencer discontinuous mode disable */
+#define LL_ADC_INJ_SEQ_DISCONT_DISABLE     0x00000000U            /*!< ADC group injected sequencer discontinuous mode disable */
 #define LL_ADC_INJ_SEQ_DISCONT_1RANK       (ADC_CR1_JDISCEN)      /*!< ADC group injected sequencer discontinuous mode enable with sequence interruption every rank */
 /**
   * @}
@@ -976,7 +974,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNEL_SAMPLINGTIME  Channel - Sampling time
   * @{
   */
-#define LL_ADC_SAMPLINGTIME_4CYCLES        ((uint32_t)0x00000000U)                                  /*!< Sampling time 4 ADC clock cycles */
+#define LL_ADC_SAMPLINGTIME_4CYCLES        0x00000000U                                              /*!< Sampling time 4 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_9CYCLES        (ADC_SMPR3_SMP0_0)                                       /*!< Sampling time 9 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_16CYCLES       (ADC_SMPR3_SMP0_1)                                       /*!< Sampling time 16 ADC clock cycles */
 #define LL_ADC_SAMPLINGTIME_24CYCLES       (ADC_SMPR3_SMP0_1 | ADC_SMPR3_SMP0_0)                    /*!< Sampling time 24 ADC clock cycles */
@@ -1002,8 +1000,8 @@ typedef struct
 /** @defgroup ADC_LL_EC_CHANNEL_ROUTING_SELECTION  Channel - Routing selection
   * @{
   */
-#define LL_ADC_CHANNEL_ROUTING_DEFAULT     ((uint32_t)0x00000000U) /*!< ADC channel routing default: slow channel */
-#define LL_ADC_CHANNEL_ROUTING_DIRECT      ((uint32_t)0x00000001U) /*!< ADC channel routing direct: fast channel. */
+#define LL_ADC_CHANNEL_ROUTING_DEFAULT     0x00000000U  /*!< ADC channel routing default: slow channel */
+#define LL_ADC_CHANNEL_ROUTING_DIRECT      0x00000001U  /*!< ADC channel routing direct: fast channel. */
 /**
   * @}
   */
@@ -1020,7 +1018,7 @@ typedef struct
 /** @defgroup ADC_LL_EC_AWD_CHANNELS  Analog watchdog - Monitored channels
   * @{
   */
-#define LL_ADC_AWD_DISABLE                 ((uint32_t)0x00000000U)                                                                       /*!< ADC analog watchdog monitoring disabled */
+#define LL_ADC_AWD_DISABLE                 0x00000000U                                                                                   /*!< ADC analog watchdog monitoring disabled */
 #define LL_ADC_AWD_ALL_CHANNELS_REG        (                                                             ADC_CR1_AWDEN                 ) /*!< ADC analog watchdog monitoring of all channels, converted by group regular only */
 #define LL_ADC_AWD_ALL_CHANNELS_INJ        (                                            ADC_CR1_JAWDEN                                 ) /*!< ADC analog watchdog monitoring of all channels, converted by group injected only */
 #define LL_ADC_AWD_ALL_CHANNELS_REG_INJ    (                                            ADC_CR1_JAWDEN | ADC_CR1_AWDEN                 ) /*!< ADC analog watchdog monitoring of all channels, converted by either group regular or injected */
@@ -1183,13 +1181,13 @@ typedef struct
 /* Delay set to maximum value (refer to device datasheet,                     */
 /* parameter "TADC_BUF").                                                     */
 /* Unit: us                                                                   */
-#define LL_ADC_DELAY_VREFINT_STAB_US       ((uint32_t)  10U)  /*!< Delay for internal voltage reference stabilization time */
+#define LL_ADC_DELAY_VREFINT_STAB_US       (  10U)  /*!< Delay for internal voltage reference stabilization time */
 
 /* Delay for temperature sensor stabilization time.                           */
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tSTART").                                                       */
 /* Unit: us                                                                   */
-#define LL_ADC_DELAY_TEMPSENSOR_STAB_US    ((uint32_t)  10U)  /*!< Delay for internal voltage reference stabilization time */
+#define LL_ADC_DELAY_TEMPSENSOR_STAB_US    (  10U)  /*!< Delay for internal voltage reference stabilization time */
 
 /**
   * @}
@@ -1893,7 +1891,7 @@ typedef struct
   * @retval ADC conversion data equivalent voltage value (unit: mVolt)
   */
 #define __LL_ADC_DIGITAL_SCALE(__ADC_RESOLUTION__)                             \
-  (((uint32_t)0xFFFU) >> ((__ADC_RESOLUTION__) >> (ADC_CR1_RES_BITOFFSET_POS - 1U)))
+  (0xFFFU >> ((__ADC_RESOLUTION__) >> (ADC_CR1_RES_BITOFFSET_POS - 1U)))
 
 /**
   * @brief  Helper macro to convert the ADC conversion data from

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_bus.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_bus.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_bus.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of BUS LL module.
 
   @verbatim                
@@ -25,7 +23,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -89,7 +87,7 @@ extern "C" {
 /** @defgroup BUS_LL_EC_AHB1_GRP1_PERIPH  AHB1 GRP1 PERIPH
   * @{
   */
-#define LL_AHB1_GRP1_PERIPH_ALL            (uint32_t)0xFFFFFFFFU
+#define LL_AHB1_GRP1_PERIPH_ALL            0xFFFFFFFFU
 #define LL_AHB1_GRP1_PERIPH_GPIOA          RCC_AHBENR_GPIOAEN
 #define LL_AHB1_GRP1_PERIPH_GPIOB          RCC_AHBENR_GPIOBEN
 #define LL_AHB1_GRP1_PERIPH_GPIOC          RCC_AHBENR_GPIOCEN
@@ -124,7 +122,7 @@ extern "C" {
 /** @defgroup BUS_LL_EC_APB1_GRP1_PERIPH  APB1 GRP1 PERIPH
   * @{
   */
-#define LL_APB1_GRP1_PERIPH_ALL            (uint32_t)0xFFFFFFFFU
+#define LL_APB1_GRP1_PERIPH_ALL            0xFFFFFFFFU
 #define LL_APB1_GRP1_PERIPH_TIM2           RCC_APB1ENR_TIM2EN
 #define LL_APB1_GRP1_PERIPH_TIM3           RCC_APB1ENR_TIM3EN
 #define LL_APB1_GRP1_PERIPH_TIM4           RCC_APB1ENR_TIM4EN
@@ -166,7 +164,7 @@ extern "C" {
 /** @defgroup BUS_LL_EC_APB2_GRP1_PERIPH  APB2 GRP1 PERIPH
   * @{
   */
-#define LL_APB2_GRP1_PERIPH_ALL            (uint32_t)0xFFFFFFFFU
+#define LL_APB2_GRP1_PERIPH_ALL            0xFFFFFFFFU
 #define LL_APB2_GRP1_PERIPH_SYSCFG         RCC_APB2ENR_SYSCFGEN
 #define LL_APB2_GRP1_PERIPH_TIM9           RCC_APB2ENR_TIM9EN
 #define LL_APB2_GRP1_PERIPH_TIM10          RCC_APB2ENR_TIM10EN

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_comp.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_comp.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_comp.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   COMP LL module driver
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_comp.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_comp.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_comp.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of COMP LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -64,9 +62,9 @@ extern "C" {
   */
 
 /* COMP registers bits positions */
-#define LL_COMP_OUTPUT_LEVEL_COMP1_BITOFFSET_POS ((uint32_t) 7U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP1OUT) */
-#define LL_COMP_OUTPUT_LEVEL_COMP2_BITOFFSET_POS ((uint32_t)13U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP2OUT) */
-#define LL_COMP_ENABLE_COMP1_BITOFFSET_POS       ((uint32_t) 4U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP1EN) */
+#define LL_COMP_OUTPUT_LEVEL_COMP1_BITOFFSET_POS ( 7U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP1OUT) */
+#define LL_COMP_OUTPUT_LEVEL_COMP2_BITOFFSET_POS (13U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP2OUT) */
+#define LL_COMP_ENABLE_COMP1_BITOFFSET_POS       ( 4U) /* Value equivalent to POSITION_VAL(COMP_CSR_CMP1EN) */
 
 /**
   * @}
@@ -145,7 +143,7 @@ typedef struct
 /** @defgroup COMP_LL_EC_COMMON_WINDOWMODE Comparator common modes - Window mode
   * @{
   */
-#define LL_COMP_WINDOWMODE_DISABLE                 ((uint32_t)0x00000000U) /*!< Window mode disable: Comparators 1 and 2 are independent */
+#define LL_COMP_WINDOWMODE_DISABLE                 (0x00000000U)           /*!< Window mode disable: Comparators 1 and 2 are independent */
 #define LL_COMP_WINDOWMODE_COMP2_INPUT_PLUS_COMMON (COMP_CSR_WNDWE)        /*!< Window mode enable: Comparators instances pair COMP1 and COMP2 have their input plus connected together. The common input is COMP2 input plus (COMP1 input plus is no more accessible, either from GPIO and from ADC channel VCOMP). */
 /**
   * @}
@@ -154,7 +152,7 @@ typedef struct
 /** @defgroup COMP_LL_EC_POWERMODE Comparator modes - Power mode
   * @{
   */
-#define LL_COMP_POWERMODE_ULTRALOWPOWER   ((uint32_t)0x00000000U)     /*!< COMP power mode to low speed (specific to COMP instance: COMP2) */
+#define LL_COMP_POWERMODE_ULTRALOWPOWER   (0x00000000U)               /*!< COMP power mode to low speed (specific to COMP instance: COMP2) */
 #define LL_COMP_POWERMODE_MEDIUMSPEED     (COMP_CSR_SPEED)            /*!< COMP power mode to fast speed (specific to COMP instance: COMP2) */
 /**
   * @}
@@ -163,7 +161,7 @@ typedef struct
 /** @defgroup COMP_LL_EC_INPUT_PLUS Comparator inputs - Input plus (input non-inverting) selection
   * @{
   */
-#define LL_COMP_INPUT_PLUS_NONE         ((uint32_t)0x00000000U) /*!< Comparator input plus connected not connected */
+#define LL_COMP_INPUT_PLUS_NONE         (0x00000000U)           /*!< Comparator input plus connected not connected */
 #define LL_COMP_INPUT_PLUS_IO1          (RI_ASCR2_GR6_1)        /*!< Comparator input plus connected to IO1 (pin PB4 for COMP2) (specific to COMP instance: COMP2) */
 #define LL_COMP_INPUT_PLUS_IO2          (RI_ASCR2_GR6_2)        /*!< Comparator input plus connected to IO1 (pin PB5 for COMP2) (specific to COMP instance: COMP2) */
 #if defined(RI_ASCR1_CH_31)
@@ -229,7 +227,7 @@ typedef struct
 /** @defgroup COMP_LL_EC_INPUT_PULLING_RESISTOR Comparator input - Pulling resistor
   * @{
   */
-#define LL_COMP_INPUT_MINUS_PULL_NO        ((uint32_t)0x00000000U) /*!< Comparator input minus not connected to any pulling resistor */
+#define LL_COMP_INPUT_MINUS_PULL_NO        (0x00000000U)           /*!< Comparator input minus not connected to any pulling resistor */
 #define LL_COMP_INPUT_MINUS_PULL_UP_10K    (COMP_CSR_10KPU)        /*!< Comparator input minus connected to pull-up resistor of 10kOhm (specific to COMP instance: COMP1) */
 #define LL_COMP_INPUT_MINUS_PULL_UP_400K   (COMP_CSR_400KPU)       /*!< Comparator input minus connected to pull-up resistor of 400kOhm (specific to COMP instance: COMP1) */
 #define LL_COMP_INPUT_MINUS_PULL_DOWN_10K  (COMP_CSR_10KPD)        /*!< Comparator input minus connected to pull-down resistor of 10kOhm (specific to COMP instance: COMP1) */
@@ -243,7 +241,7 @@ typedef struct
   * @{
   */
 #define LL_COMP_OUTPUT_NONE             (COMP_CSR_OUTSEL_2 | COMP_CSR_OUTSEL_1 | COMP_CSR_OUTSEL_0) /*!< COMP output is not connected to other peripherals (except GPIO and EXTI that are always connected to COMP output) (specific to COMP instance: COMP2) */
-#define LL_COMP_OUTPUT_TIM2_IC4         ((uint32_t)0x00000000)                                      /*!< COMP output connected to TIM2 input capture 4  (specific to COMP instance: COMP2) */
+#define LL_COMP_OUTPUT_TIM2_IC4         (0x00000000)                                                /*!< COMP output connected to TIM2 input capture 4  (specific to COMP instance: COMP2) */
 #define LL_COMP_OUTPUT_TIM2_OCREFCLR    (                                        COMP_CSR_OUTSEL_0) /*!< COMP output connected to TIM2 OCREF clear      (specific to COMP instance: COMP2) */
 #define LL_COMP_OUTPUT_TIM3_IC4         (                    COMP_CSR_OUTSEL_1                    ) /*!< COMP output connected to TIM3 input capture 4  (specific to COMP instance: COMP2) */
 #define LL_COMP_OUTPUT_TIM3_OCREFCLR    (                    COMP_CSR_OUTSEL_1 | COMP_CSR_OUTSEL_0) /*!< COMP output connected to TIM3 OCREF clear      (specific to COMP instance: COMP2) */
@@ -257,8 +255,8 @@ typedef struct
 /** @defgroup COMP_LL_EC_OUTPUT_LEVEL Comparator output - Output level
   * @{
   */
-#define LL_COMP_OUTPUT_LEVEL_LOW        ((uint32_t)0x00000000U) /*!< Comparator output level low (if the polarity is not inverted, otherwise to be complemented) */
-#define LL_COMP_OUTPUT_LEVEL_HIGH       ((uint32_t)0x00000001U) /*!< Comparator output level high (if the polarity is not inverted, otherwise to be complemented) */
+#define LL_COMP_OUTPUT_LEVEL_LOW        (0x00000000U) /*!< Comparator output level low (if the polarity is not inverted, otherwise to be complemented) */
+#define LL_COMP_OUTPUT_LEVEL_HIGH       (0x00000001U) /*!< Comparator output level high (if the polarity is not inverted, otherwise to be complemented) */
 /**
   * @}
   */
@@ -276,7 +274,7 @@ typedef struct
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tSTART").                                                       */
 /* Unit: us                                                                   */
-#define LL_COMP_DELAY_STARTUP_US          ((uint32_t) 25U)  /*!< Delay for COMP startup time */
+#define LL_COMP_DELAY_STARTUP_US          (25U)  /*!< Delay for COMP startup time */
 
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_cortex.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_cortex.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_cortex.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CORTEX LL module.
   @verbatim
   ==============================================================================
@@ -23,7 +21,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -85,8 +83,8 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_CLKSOURCE_HCLK SYSTICK Clock Source
   * @{
   */
-#define LL_SYSTICK_CLKSOURCE_HCLK_DIV8     ((uint32_t)0x00000000U)                 /*!< AHB clock divided by 8 selected as SysTick clock source.*/
-#define LL_SYSTICK_CLKSOURCE_HCLK          ((uint32_t)SysTick_CTRL_CLKSOURCE_Msk) /*!< AHB clock selected as SysTick clock source. */
+#define LL_SYSTICK_CLKSOURCE_HCLK_DIV8     0x00000000U                 /*!< AHB clock divided by 8 selected as SysTick clock source.*/
+#define LL_SYSTICK_CLKSOURCE_HCLK          SysTick_CTRL_CLKSOURCE_Msk  /*!< AHB clock selected as SysTick clock source. */
 /**
   * @}
   */
@@ -106,7 +104,7 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_CTRL_HFNMI_PRIVDEF MPU Control
   * @{
   */
-#define LL_MPU_CTRL_HFNMI_PRIVDEF_NONE     ((uint32_t)0x00000000U)                            /*!< Disable NMI and privileged SW access */
+#define LL_MPU_CTRL_HFNMI_PRIVDEF_NONE     0x00000000U                                       /*!< Disable NMI and privileged SW access */
 #define LL_MPU_CTRL_HARDFAULT_NMI          MPU_CTRL_HFNMIENA_Msk                             /*!< Enables the operation of MPU during hard fault, NMI, and FAULTMASK handlers */
 #define LL_MPU_CTRL_PRIVILEGED_DEFAULT     MPU_CTRL_PRIVDEFENA_Msk                           /*!< Enable privileged software access to default memory map */
 #define LL_MPU_CTRL_HFNMI_PRIVDEF          (MPU_CTRL_HFNMIENA_Msk | MPU_CTRL_PRIVDEFENA_Msk) /*!< Enable NMI and privileged SW access */
@@ -117,14 +115,14 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_REGION MPU Region Number
   * @{
   */
-#define LL_MPU_REGION_NUMBER0              ((uint32_t)0x00U) /*!< REGION Number 0 */
-#define LL_MPU_REGION_NUMBER1              ((uint32_t)0x01U) /*!< REGION Number 1 */
-#define LL_MPU_REGION_NUMBER2              ((uint32_t)0x02U) /*!< REGION Number 2 */
-#define LL_MPU_REGION_NUMBER3              ((uint32_t)0x03U) /*!< REGION Number 3 */
-#define LL_MPU_REGION_NUMBER4              ((uint32_t)0x04U) /*!< REGION Number 4 */
-#define LL_MPU_REGION_NUMBER5              ((uint32_t)0x05U) /*!< REGION Number 5 */
-#define LL_MPU_REGION_NUMBER6              ((uint32_t)0x06U) /*!< REGION Number 6 */
-#define LL_MPU_REGION_NUMBER7              ((uint32_t)0x07U) /*!< REGION Number 7 */
+#define LL_MPU_REGION_NUMBER0              0x00U /*!< REGION Number 0 */
+#define LL_MPU_REGION_NUMBER1              0x01U /*!< REGION Number 1 */
+#define LL_MPU_REGION_NUMBER2              0x02U /*!< REGION Number 2 */
+#define LL_MPU_REGION_NUMBER3              0x03U /*!< REGION Number 3 */
+#define LL_MPU_REGION_NUMBER4              0x04U /*!< REGION Number 4 */
+#define LL_MPU_REGION_NUMBER5              0x05U /*!< REGION Number 5 */
+#define LL_MPU_REGION_NUMBER6              0x06U /*!< REGION Number 6 */
+#define LL_MPU_REGION_NUMBER7              0x07U /*!< REGION Number 7 */
 /**
   * @}
   */
@@ -132,34 +130,34 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_REGION_SIZE MPU Region Size
   * @{
   */
-#define LL_MPU_REGION_SIZE_32B             ((uint32_t)(0x04U << MPU_RASR_SIZE_Pos)) /*!< 32B Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_64B             ((uint32_t)(0x05U << MPU_RASR_SIZE_Pos)) /*!< 64B Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_128B            ((uint32_t)(0x06U << MPU_RASR_SIZE_Pos)) /*!< 128B Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_256B            ((uint32_t)(0x07U << MPU_RASR_SIZE_Pos)) /*!< 256B Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_512B            ((uint32_t)(0x08U << MPU_RASR_SIZE_Pos)) /*!< 512B Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_1KB             ((uint32_t)(0x09U << MPU_RASR_SIZE_Pos)) /*!< 1KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_2KB             ((uint32_t)(0x0AU << MPU_RASR_SIZE_Pos)) /*!< 2KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_4KB             ((uint32_t)(0x0BU << MPU_RASR_SIZE_Pos)) /*!< 4KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_8KB             ((uint32_t)(0x0CU << MPU_RASR_SIZE_Pos)) /*!< 8KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_16KB            ((uint32_t)(0x0DU << MPU_RASR_SIZE_Pos)) /*!< 16KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_32KB            ((uint32_t)(0x0EU << MPU_RASR_SIZE_Pos)) /*!< 32KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_64KB            ((uint32_t)(0x0FU << MPU_RASR_SIZE_Pos)) /*!< 64KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_128KB           ((uint32_t)(0x10U << MPU_RASR_SIZE_Pos)) /*!< 128KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_256KB           ((uint32_t)(0x11U << MPU_RASR_SIZE_Pos)) /*!< 256KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_512KB           ((uint32_t)(0x12U << MPU_RASR_SIZE_Pos)) /*!< 512KB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_1MB             ((uint32_t)(0x13U << MPU_RASR_SIZE_Pos)) /*!< 1MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_2MB             ((uint32_t)(0x14U << MPU_RASR_SIZE_Pos)) /*!< 2MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_4MB             ((uint32_t)(0x15U << MPU_RASR_SIZE_Pos)) /*!< 4MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_8MB             ((uint32_t)(0x16U << MPU_RASR_SIZE_Pos)) /*!< 8MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_16MB            ((uint32_t)(0x17U << MPU_RASR_SIZE_Pos)) /*!< 16MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_32MB            ((uint32_t)(0x18U << MPU_RASR_SIZE_Pos)) /*!< 32MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_64MB            ((uint32_t)(0x19U << MPU_RASR_SIZE_Pos)) /*!< 64MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_128MB           ((uint32_t)(0x1AU << MPU_RASR_SIZE_Pos)) /*!< 128MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_256MB           ((uint32_t)(0x1BU << MPU_RASR_SIZE_Pos)) /*!< 256MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_512MB           ((uint32_t)(0x1CU << MPU_RASR_SIZE_Pos)) /*!< 512MB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_1GB             ((uint32_t)(0x1DU << MPU_RASR_SIZE_Pos)) /*!< 1GB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_2GB             ((uint32_t)(0x1EU << MPU_RASR_SIZE_Pos)) /*!< 2GB Size of the MPU protection region */
-#define LL_MPU_REGION_SIZE_4GB             ((uint32_t)(0x1FU << MPU_RASR_SIZE_Pos)) /*!< 4GB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_32B             (0x04U << MPU_RASR_SIZE_Pos) /*!< 32B Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_64B             (0x05U << MPU_RASR_SIZE_Pos) /*!< 64B Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_128B            (0x06U << MPU_RASR_SIZE_Pos) /*!< 128B Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_256B            (0x07U << MPU_RASR_SIZE_Pos) /*!< 256B Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_512B            (0x08U << MPU_RASR_SIZE_Pos) /*!< 512B Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_1KB             (0x09U << MPU_RASR_SIZE_Pos) /*!< 1KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_2KB             (0x0AU << MPU_RASR_SIZE_Pos) /*!< 2KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_4KB             (0x0BU << MPU_RASR_SIZE_Pos) /*!< 4KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_8KB             (0x0CU << MPU_RASR_SIZE_Pos) /*!< 8KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_16KB            (0x0DU << MPU_RASR_SIZE_Pos) /*!< 16KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_32KB            (0x0EU << MPU_RASR_SIZE_Pos) /*!< 32KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_64KB            (0x0FU << MPU_RASR_SIZE_Pos) /*!< 64KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_128KB           (0x10U << MPU_RASR_SIZE_Pos) /*!< 128KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_256KB           (0x11U << MPU_RASR_SIZE_Pos) /*!< 256KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_512KB           (0x12U << MPU_RASR_SIZE_Pos) /*!< 512KB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_1MB             (0x13U << MPU_RASR_SIZE_Pos) /*!< 1MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_2MB             (0x14U << MPU_RASR_SIZE_Pos) /*!< 2MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_4MB             (0x15U << MPU_RASR_SIZE_Pos) /*!< 4MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_8MB             (0x16U << MPU_RASR_SIZE_Pos) /*!< 8MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_16MB            (0x17U << MPU_RASR_SIZE_Pos) /*!< 16MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_32MB            (0x18U << MPU_RASR_SIZE_Pos) /*!< 32MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_64MB            (0x19U << MPU_RASR_SIZE_Pos) /*!< 64MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_128MB           (0x1AU << MPU_RASR_SIZE_Pos) /*!< 128MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_256MB           (0x1BU << MPU_RASR_SIZE_Pos) /*!< 256MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_512MB           (0x1CU << MPU_RASR_SIZE_Pos) /*!< 512MB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_1GB             (0x1DU << MPU_RASR_SIZE_Pos) /*!< 1GB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_2GB             (0x1EU << MPU_RASR_SIZE_Pos) /*!< 2GB Size of the MPU protection region */
+#define LL_MPU_REGION_SIZE_4GB             (0x1FU << MPU_RASR_SIZE_Pos) /*!< 4GB Size of the MPU protection region */
 /**
   * @}
   */
@@ -167,12 +165,12 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_REGION_PRIVILEDGES MPU Region Privileges
   * @{
   */
-#define LL_MPU_REGION_NO_ACCESS            ((uint32_t)(0x00U << MPU_RASR_AP_Pos)) /*!< No access*/
-#define LL_MPU_REGION_PRIV_RW              ((uint32_t)(0x01U << MPU_RASR_AP_Pos)) /*!< RW privileged (privileged access only)*/
-#define LL_MPU_REGION_PRIV_RW_URO          ((uint32_t)(0x02U << MPU_RASR_AP_Pos)) /*!< RW privileged - RO user (Write in a user program generates a fault) */
-#define LL_MPU_REGION_FULL_ACCESS          ((uint32_t)(0x03U << MPU_RASR_AP_Pos)) /*!< RW privileged & user (Full access) */
-#define LL_MPU_REGION_PRIV_RO              ((uint32_t)(0x05U << MPU_RASR_AP_Pos)) /*!< RO privileged (privileged read only)*/
-#define LL_MPU_REGION_PRIV_RO_URO          ((uint32_t)(0x06U << MPU_RASR_AP_Pos)) /*!< RO privileged & user (read only) */
+#define LL_MPU_REGION_NO_ACCESS            (0x00U << MPU_RASR_AP_Pos) /*!< No access*/
+#define LL_MPU_REGION_PRIV_RW              (0x01U << MPU_RASR_AP_Pos) /*!< RW privileged (privileged access only)*/
+#define LL_MPU_REGION_PRIV_RW_URO          (0x02U << MPU_RASR_AP_Pos) /*!< RW privileged - RO user (Write in a user program generates a fault) */
+#define LL_MPU_REGION_FULL_ACCESS          (0x03U << MPU_RASR_AP_Pos) /*!< RW privileged & user (Full access) */
+#define LL_MPU_REGION_PRIV_RO              (0x05U << MPU_RASR_AP_Pos) /*!< RO privileged (privileged read only)*/
+#define LL_MPU_REGION_PRIV_RO_URO          (0x06U << MPU_RASR_AP_Pos) /*!< RO privileged & user (read only) */
 /**
   * @}
   */
@@ -180,10 +178,10 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_TEX MPU TEX Level
   * @{
   */
-#define LL_MPU_TEX_LEVEL0                  ((uint32_t)(0x00U << MPU_RASR_TEX_Pos)) /*!< b000 for TEX bits */
-#define LL_MPU_TEX_LEVEL1                  ((uint32_t)(0x01U << MPU_RASR_TEX_Pos)) /*!< b001 for TEX bits */
-#define LL_MPU_TEX_LEVEL2                  ((uint32_t)(0x02U << MPU_RASR_TEX_Pos)) /*!< b010 for TEX bits */
-#define LL_MPU_TEX_LEVEL4                  ((uint32_t)(0x04U << MPU_RASR_TEX_Pos)) /*!< b100 for TEX bits */
+#define LL_MPU_TEX_LEVEL0                  (0x00U << MPU_RASR_TEX_Pos) /*!< b000 for TEX bits */
+#define LL_MPU_TEX_LEVEL1                  (0x01U << MPU_RASR_TEX_Pos) /*!< b001 for TEX bits */
+#define LL_MPU_TEX_LEVEL2                  (0x02U << MPU_RASR_TEX_Pos) /*!< b010 for TEX bits */
+#define LL_MPU_TEX_LEVEL4                  (0x04U << MPU_RASR_TEX_Pos) /*!< b100 for TEX bits */
 /**
   * @}
   */
@@ -191,7 +189,7 @@ extern "C" {
 /** @defgroup CORTEX_LL_EC_INSTRUCTION_ACCESS MPU Instruction Access
   * @{
   */
-#define LL_MPU_INSTRUCTION_ACCESS_ENABLE   ((uint32_t)0x00U) /*!< Instruction fetches enabled */
+#define LL_MPU_INSTRUCTION_ACCESS_ENABLE   0x00U            /*!< Instruction fetches enabled */
 #define LL_MPU_INSTRUCTION_ACCESS_DISABLE  MPU_RASR_XN_Msk  /*!< Instruction fetches disabled*/
 /**
   * @}
@@ -201,7 +199,7 @@ extern "C" {
   * @{
   */
 #define LL_MPU_ACCESS_SHAREABLE            MPU_RASR_S_Msk   /*!< Shareable memory attribute */
-#define LL_MPU_ACCESS_NOT_SHAREABLE        ((uint32_t)0x00U) /*!< Not Shareable memory attribute */
+#define LL_MPU_ACCESS_NOT_SHAREABLE        0x00U            /*!< Not Shareable memory attribute */
 /**
   * @}
   */
@@ -210,7 +208,7 @@ extern "C" {
   * @{
   */
 #define LL_MPU_ACCESS_CACHEABLE            MPU_RASR_C_Msk   /*!< Cacheable memory attribute */
-#define LL_MPU_ACCESS_NOT_CACHEABLE        ((uint32_t)0x00U) /*!< Not Cacheable memory attribute */
+#define LL_MPU_ACCESS_NOT_CACHEABLE        0x00U            /*!< Not Cacheable memory attribute */
 /**
   * @}
   */
@@ -219,7 +217,7 @@ extern "C" {
   * @{
   */
 #define LL_MPU_ACCESS_BUFFERABLE           MPU_RASR_B_Msk   /*!< Bufferable memory attribute */
-#define LL_MPU_ACCESS_NOT_BUFFERABLE       ((uint32_t)0x00U) /*!< Not Bufferable memory attribute */
+#define LL_MPU_ACCESS_NOT_BUFFERABLE       0x00U            /*!< Not Bufferable memory attribute */
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_crc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_crc.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_crc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   CRC LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_crc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_crc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_crc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of CRC LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dac.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dac.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_dac.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   DAC LL module driver
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -40,7 +38,7 @@
 #include "stm32l1xx_ll_dac.h"
 #include "stm32l1xx_ll_bus.h"
 
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
   #include "stm32_assert.h"
 #else
   #define assert_param(expr) ((void)0U)

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dac.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dac.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_dac.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of DAC LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -70,36 +68,36 @@ extern "C" {
 /* - channel bits position into register SWTRIG                               */
 /* - channel register offset of data holding register DHRx                    */
 /* - channel register offset of data output register DORx                     */
-#define DAC_CR_CH1_BITOFFSET           ((uint32_t) 0U) /* Position of channel bits into registers CR, MCR, CCR, SHHR, SHRR of channel 1 */
-#define DAC_CR_CH2_BITOFFSET           ((uint32_t)16U) /* Position of channel bits into registers CR, MCR, CCR, SHHR, SHRR of channel 2 */
+#define DAC_CR_CH1_BITOFFSET           0U    /* Position of channel bits into registers CR, MCR, CCR, SHHR, SHRR of channel 1 */
+#define DAC_CR_CH2_BITOFFSET           16U   /* Position of channel bits into registers CR, MCR, CCR, SHHR, SHRR of channel 2 */
 #define DAC_CR_CHX_BITOFFSET_MASK      (DAC_CR_CH1_BITOFFSET | DAC_CR_CH2_BITOFFSET)
 
 #define DAC_SWTR_CH1                   (DAC_SWTRIGR_SWTRIG1) /* Channel bit into register SWTRIGR of channel 1. This bit is into area of LL_DAC_CR_CHx_BITOFFSET but excluded by mask DAC_CR_CHX_BITOFFSET_MASK (done to be enable to trig SW start of both DAC channels simultaneously). */
 #define DAC_SWTR_CH2                   (DAC_SWTRIGR_SWTRIG2) /* Channel bit into register SWTRIGR of channel 2. This bit is into area of LL_DAC_CR_CHx_BITOFFSET but excluded by mask DAC_CR_CHX_BITOFFSET_MASK (done to be enable to trig SW start of both DAC channels simultaneously). */
 #define DAC_SWTR_CHX_MASK              (DAC_SWTR_CH1 | DAC_SWTR_CH2)
 
-#define DAC_REG_DHR12R1_REGOFFSET      ((uint32_t)0x00000000U) /* Register DHR12Rx channel 1 taken as reference */
-#define DAC_REG_DHR12L1_REGOFFSET      ((uint32_t)0x00100000U) /* Register offset of DHR12Lx channel 1 versus DHR12Rx channel 1 (shifted left of 20 bits) */
-#define DAC_REG_DHR8R1_REGOFFSET       ((uint32_t)0x02000000U) /* Register offset of DHR8Rx  channel 1 versus DHR12Rx channel 1 (shifted left of 24 bits) */
-#define DAC_REG_DHR12R2_REGOFFSET      ((uint32_t)0x00030000U) /* Register offset of DHR12Rx channel 2 versus DHR12Rx channel 1 (shifted left of 16 bits) */
-#define DAC_REG_DHR12L2_REGOFFSET      ((uint32_t)0x00400000U) /* Register offset of DHR12Lx channel 2 versus DHR12Rx channel 1 (shifted left of 20 bits) */
-#define DAC_REG_DHR8R2_REGOFFSET       ((uint32_t)0x05000000U) /* Register offset of DHR8Rx  channel 2 versus DHR12Rx channel 1 (shifted left of 24 bits) */
-#define DAC_REG_DHR12RX_REGOFFSET_MASK ((uint32_t)0x000F0000U)
-#define DAC_REG_DHR12LX_REGOFFSET_MASK ((uint32_t)0x00F00000U)
-#define DAC_REG_DHR8RX_REGOFFSET_MASK  ((uint32_t)0x0F000000U)
+#define DAC_REG_DHR12R1_REGOFFSET      0x00000000U             /* Register DHR12Rx channel 1 taken as reference */
+#define DAC_REG_DHR12L1_REGOFFSET      0x00100000U             /* Register offset of DHR12Lx channel 1 versus DHR12Rx channel 1 (shifted left of 20 bits) */
+#define DAC_REG_DHR8R1_REGOFFSET       0x02000000U             /* Register offset of DHR8Rx  channel 1 versus DHR12Rx channel 1 (shifted left of 24 bits) */
+#define DAC_REG_DHR12R2_REGOFFSET      0x00030000U             /* Register offset of DHR12Rx channel 2 versus DHR12Rx channel 1 (shifted left of 16 bits) */
+#define DAC_REG_DHR12L2_REGOFFSET      0x00400000U             /* Register offset of DHR12Lx channel 2 versus DHR12Rx channel 1 (shifted left of 20 bits) */
+#define DAC_REG_DHR8R2_REGOFFSET       0x05000000U             /* Register offset of DHR8Rx  channel 2 versus DHR12Rx channel 1 (shifted left of 24 bits) */
+#define DAC_REG_DHR12RX_REGOFFSET_MASK 0x000F0000U
+#define DAC_REG_DHR12LX_REGOFFSET_MASK 0x00F00000U
+#define DAC_REG_DHR8RX_REGOFFSET_MASK  0x0F000000U
 #define DAC_REG_DHRX_REGOFFSET_MASK    (DAC_REG_DHR12RX_REGOFFSET_MASK | DAC_REG_DHR12LX_REGOFFSET_MASK | DAC_REG_DHR8RX_REGOFFSET_MASK)
 
-#define DAC_REG_DOR1_REGOFFSET         ((uint32_t)0x00000000U) /* Register DORx channel 1 taken as reference */
-#define DAC_REG_DOR2_REGOFFSET         ((uint32_t)0x10000000U)/* Register offset of DORx channel 1 versus DORx channel 2 (shifted left of 28 bits) */
+#define DAC_REG_DOR1_REGOFFSET         0x00000000U             /* Register DORx channel 1 taken as reference */
+#define DAC_REG_DOR2_REGOFFSET         0x10000000U             /* Register offset of DORx channel 1 versus DORx channel 2 (shifted left of 28 bits) */
 #define DAC_REG_DORX_REGOFFSET_MASK    (DAC_REG_DOR1_REGOFFSET | DAC_REG_DOR2_REGOFFSET)
 
 /* DAC registers bits positions */
-#define DAC_DHR12RD_DACC2DHR_BITOFFSET_POS ((uint32_t)16U) /* Value equivalent to POSITION_VAL(DAC_DHR12RD_DACC2DHR) */
-#define DAC_DHR12LD_DACC2DHR_BITOFFSET_POS ((uint32_t)20U) /* Value equivalent to POSITION_VAL(DAC_DHR12LD_DACC2DHR) */
-#define DAC_DHR8RD_DACC2DHR_BITOFFSET_POS  ((uint32_t) 8U) /* Value equivalent to POSITION_VAL(DAC_DHR8RD_DACC2DHR) */
+#define DAC_DHR12RD_DACC2DHR_BITOFFSET_POS                16U  /* Value equivalent to POSITION_VAL(DAC_DHR12RD_DACC2DHR) */
+#define DAC_DHR12LD_DACC2DHR_BITOFFSET_POS                20U  /* Value equivalent to POSITION_VAL(DAC_DHR12LD_DACC2DHR) */
+#define DAC_DHR8RD_DACC2DHR_BITOFFSET_POS                  8U  /* Value equivalent to POSITION_VAL(DAC_DHR8RD_DACC2DHR) */
 
 /* Miscellaneous data */
-#define DAC_DIGITAL_SCALE_12BITS           ((uint32_t)4095U)                     /* Full-scale digital value with a resolution of 12 bits (voltage range determined by analog voltage references Vref+ and Vref-, refer to reference manual) */
+#define DAC_DIGITAL_SCALE_12BITS                        4095U  /* Full-scale digital value with a resolution of 12 bits (voltage range determined by analog voltage references Vref+ and Vref-, refer to reference manual) */
 
 /**
   * @}
@@ -221,7 +219,7 @@ typedef struct
 #define LL_DAC_TRIG_SOFTWARE               (DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0) /*!< DAC channel conversion trigger internal (SW start) */
 #define LL_DAC_TRIG_EXT_TIM2_TRGO          (DAC_CR_TSEL1_2                                  ) /*!< DAC channel conversion trigger from external IP: TIM2 TRGO. */
 #define LL_DAC_TRIG_EXT_TIM4_TRGO          (DAC_CR_TSEL1_2                  | DAC_CR_TSEL1_0) /*!< DAC channel conversion trigger from external IP: TIM4 TRGO. */
-#define LL_DAC_TRIG_EXT_TIM6_TRGO          ((uint32_t)0x00000000U)                            /*!< DAC channel conversion trigger from external IP: TIM6 TRGO. */
+#define LL_DAC_TRIG_EXT_TIM6_TRGO          0x00000000U                                        /*!< DAC channel conversion trigger from external IP: TIM6 TRGO. */
 #define LL_DAC_TRIG_EXT_TIM7_TRGO          (                 DAC_CR_TSEL1_1                 ) /*!< DAC channel conversion trigger from external IP: TIM7 TRGO. */
 #define LL_DAC_TRIG_EXT_TIM9_TRGO          (                 DAC_CR_TSEL1_1 | DAC_CR_TSEL1_0) /*!< DAC channel conversion trigger from external IP: TIM15 TRGO. */
 #define LL_DAC_TRIG_EXT_EXTI_LINE9         (DAC_CR_TSEL1_2 | DAC_CR_TSEL1_1                 ) /*!< DAC channel conversion trigger from external IP: external interrupt line 9. */
@@ -232,7 +230,7 @@ typedef struct
 /** @defgroup DAC_LL_EC_WAVE_AUTO_GENERATION_MODE DAC waveform automatic generation mode
   * @{
   */
-#define LL_DAC_WAVE_AUTO_GENERATION_NONE     ((uint32_t)0x00000000U) /*!< DAC channel wave auto generation mode disabled. */
+#define LL_DAC_WAVE_AUTO_GENERATION_NONE     0x00000000U             /*!< DAC channel wave auto generation mode disabled. */
 #define LL_DAC_WAVE_AUTO_GENERATION_NOISE    (DAC_CR_WAVE1_0)        /*!< DAC channel wave auto generation mode enabled, set generated noise waveform. */
 #define LL_DAC_WAVE_AUTO_GENERATION_TRIANGLE (DAC_CR_WAVE1_1)        /*!< DAC channel wave auto generation mode enabled, set generated triangle waveform. */
 /**
@@ -242,7 +240,7 @@ typedef struct
 /** @defgroup DAC_LL_EC_WAVE_NOISE_LFSR_UNMASK_BITS DAC wave generation - Noise LFSR unmask bits
   * @{
   */
-#define LL_DAC_NOISE_LFSR_UNMASK_BIT0      ((uint32_t)0x00000000U)                                             /*!< Noise wave generation, unmask LFSR bit0, for the selected DAC channel */
+#define LL_DAC_NOISE_LFSR_UNMASK_BIT0      0x00000000U                                                         /*!< Noise wave generation, unmask LFSR bit0, for the selected DAC channel */
 #define LL_DAC_NOISE_LFSR_UNMASK_BITS1_0   (                                                   DAC_CR_MAMP1_0) /*!< Noise wave generation, unmask LFSR bits[1:0], for the selected DAC channel */
 #define LL_DAC_NOISE_LFSR_UNMASK_BITS2_0   (                                  DAC_CR_MAMP1_1                 ) /*!< Noise wave generation, unmask LFSR bits[2:0], for the selected DAC channel */
 #define LL_DAC_NOISE_LFSR_UNMASK_BITS3_0   (                                  DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Noise wave generation, unmask LFSR bits[3:0], for the selected DAC channel */
@@ -261,7 +259,7 @@ typedef struct
 /** @defgroup DAC_LL_EC_WAVE_TRIANGLE_AMPLITUDE DAC wave generation - Triangle amplitude
   * @{
   */
-#define LL_DAC_TRIANGLE_AMPLITUDE_1        ((uint32_t)0x00000000U)                                             /*!< Triangle wave generation, amplitude of 1 LSB of DAC output range, for the selected DAC channel */
+#define LL_DAC_TRIANGLE_AMPLITUDE_1        0x00000000U                                                         /*!< Triangle wave generation, amplitude of 1 LSB of DAC output range, for the selected DAC channel */
 #define LL_DAC_TRIANGLE_AMPLITUDE_3        (                                                   DAC_CR_MAMP1_0) /*!< Triangle wave generation, amplitude of 3 LSB of DAC output range, for the selected DAC channel */
 #define LL_DAC_TRIANGLE_AMPLITUDE_7        (                                  DAC_CR_MAMP1_1                 ) /*!< Triangle wave generation, amplitude of 7 LSB of DAC output range, for the selected DAC channel */
 #define LL_DAC_TRIANGLE_AMPLITUDE_15       (                                  DAC_CR_MAMP1_1 | DAC_CR_MAMP1_0) /*!< Triangle wave generation, amplitude of 15 LSB of DAC output range, for the selected DAC channel */
@@ -280,7 +278,7 @@ typedef struct
 /** @defgroup DAC_LL_EC_OUTPUT_BUFFER DAC channel output buffer
   * @{
   */
-#define LL_DAC_OUTPUT_BUFFER_ENABLE        ((uint32_t)0x00000000U) /*!< The selected DAC channel output is buffered: higher drive current capability, but also higher current consumption */
+#define LL_DAC_OUTPUT_BUFFER_ENABLE        0x00000000U             /*!< The selected DAC channel output is buffered: higher drive current capability, but also higher current consumption */
 #define LL_DAC_OUTPUT_BUFFER_DISABLE       (DAC_CR_BOFF1)          /*!< The selected DAC channel output is not buffered: lower drive current capability, but also lower current consumption */
 /**
   * @}
@@ -290,8 +288,8 @@ typedef struct
 /** @defgroup DAC_LL_EC_RESOLUTION  DAC channel output resolution
   * @{
   */
-#define LL_DAC_RESOLUTION_12B              ((uint32_t)0x00000000U) /*!< DAC channel resolution 12 bits */
-#define LL_DAC_RESOLUTION_8B               ((uint32_t)0x00000002U) /*!< DAC channel resolution 8 bits */
+#define LL_DAC_RESOLUTION_12B              0x00000000U             /*!< DAC channel resolution 12 bits */
+#define LL_DAC_RESOLUTION_8B               0x00000002U             /*!< DAC channel resolution 8 bits */
 /**
   * @}
   */
@@ -329,7 +327,7 @@ typedef struct
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tWAKEUP").                                                      */
 /* Unit: us                                                                   */
-#define LL_DAC_DELAY_STARTUP_VOLTAGE_SETTLING_US ((uint32_t) 15U)  /*!< Delay for DAC channel voltage settling time from DAC channel startup (transition from disable to enable) */
+#define LL_DAC_DELAY_STARTUP_VOLTAGE_SETTLING_US             15U  /*!< Delay for DAC channel voltage settling time from DAC channel startup (transition from disable to enable) */
 
 /* Delay for DAC channel voltage settling time.                               */
 /* Note: DAC channel startup time depends on board application environment:   */
@@ -342,7 +340,7 @@ typedef struct
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tSETTLING").                                                    */
 /* Unit: us                                                                   */
-#define LL_DAC_DELAY_VOLTAGE_SETTLING_US  ((uint32_t) 12U)  /*!< Delay for DAC channel voltage settling time */
+#define LL_DAC_DELAY_VOLTAGE_SETTLING_US                    12U  /*!< Delay for DAC channel voltage settling time */
 /**
   * @}
   */
@@ -443,7 +441,7 @@ typedef struct
   * @retval ADC conversion data equivalent voltage value (unit: mVolt)
   */
 #define __LL_DAC_DIGITAL_SCALE(__DAC_RESOLUTION__)                             \
-  (((uint32_t)0xFFFU) >> ((__DAC_RESOLUTION__) << 1U))
+  ((0x00000FFFU) >> ((__DAC_RESOLUTION__) << 1U))
 
 /**
   * @brief  Helper macro to calculate the DAC conversion data (unit: digital

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dma.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dma.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_dma.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   DMA LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -83,7 +81,7 @@
                                                  ((__VALUE__) == LL_DMA_MDATAALIGN_HALFWORD)  || \
                                                  ((__VALUE__) == LL_DMA_MDATAALIGN_WORD))
 
-#define IS_LL_DMA_NBDATA(__VALUE__)             ((__VALUE__)  <= (uint32_t)0x0000FFFFU)
+#define IS_LL_DMA_NBDATA(__VALUE__)             ((__VALUE__)  <= 0x0000FFFFU)
 
 
 #define IS_LL_DMA_PRIORITY(__VALUE__)           (((__VALUE__) == LL_DMA_PRIORITY_LOW)    || \
@@ -348,15 +346,15 @@ uint32_t LL_DMA_Init(DMA_TypeDef *DMAx, uint32_t Channel, LL_DMA_InitTypeDef *DM
 void LL_DMA_StructInit(LL_DMA_InitTypeDef *DMA_InitStruct)
 {
   /* Set DMA_InitStruct fields to default values */
-  DMA_InitStruct->PeriphOrM2MSrcAddress  = (uint32_t)0x00000000U;
-  DMA_InitStruct->MemoryOrM2MDstAddress  = (uint32_t)0x00000000U;
+  DMA_InitStruct->PeriphOrM2MSrcAddress  = 0x00000000U;
+  DMA_InitStruct->MemoryOrM2MDstAddress  = 0x00000000U;
   DMA_InitStruct->Direction              = LL_DMA_DIRECTION_PERIPH_TO_MEMORY;
   DMA_InitStruct->Mode                   = LL_DMA_MODE_NORMAL;
   DMA_InitStruct->PeriphOrM2MSrcIncMode  = LL_DMA_PERIPH_NOINCREMENT;
   DMA_InitStruct->MemoryOrM2MDstIncMode  = LL_DMA_MEMORY_NOINCREMENT;
   DMA_InitStruct->PeriphOrM2MSrcDataSize = LL_DMA_PDATAALIGN_BYTE;
   DMA_InitStruct->MemoryOrM2MDstDataSize = LL_DMA_MDATAALIGN_BYTE;
-  DMA_InitStruct->NbData                 = (uint32_t)0x00000000U;
+  DMA_InitStruct->NbData                 = 0x00000000U;
   DMA_InitStruct->Priority               = LL_DMA_PRIORITY_LOW;
 }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dma.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_dma.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_dma.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of DMA LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -77,17 +75,6 @@ static const uint8_t CHANNEL_OFFSET_TAB[] =
   */
 
 /* Private constants ---------------------------------------------------------*/
-/** @defgroup DMA_LL_Private_Constants DMA Private Constants
-  * @{
-  */
-/* Define used to get CSELR register offset */
-#define DMA_CSELR_OFFSET                  (uint32_t)(DMA1_CSELR_BASE - DMA1_BASE)
-
-/* Defines used for the bit position in the register and perform offsets */
-#define DMA_POSITION_CSELR_CXS            POSITION_VAL(DMA_CSELR_C1S << ((Channel-1U)*4U))
-/**
-  * @}
-  */
 
 /* Private macros ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -261,15 +248,15 @@ typedef struct
 /** @defgroup DMA_LL_EC_CHANNEL CHANNEL
   * @{
   */
-#define LL_DMA_CHANNEL_1                  ((uint32_t)0x00000001U) /*!< DMA Channel 1 */
-#define LL_DMA_CHANNEL_2                  ((uint32_t)0x00000002U) /*!< DMA Channel 2 */
-#define LL_DMA_CHANNEL_3                  ((uint32_t)0x00000003U) /*!< DMA Channel 3 */
-#define LL_DMA_CHANNEL_4                  ((uint32_t)0x00000004U) /*!< DMA Channel 4 */
-#define LL_DMA_CHANNEL_5                  ((uint32_t)0x00000005U) /*!< DMA Channel 5 */
-#define LL_DMA_CHANNEL_6                  ((uint32_t)0x00000006U) /*!< DMA Channel 6 */
-#define LL_DMA_CHANNEL_7                  ((uint32_t)0x00000007U) /*!< DMA Channel 7 */
+#define LL_DMA_CHANNEL_1                  0x00000001U /*!< DMA Channel 1 */
+#define LL_DMA_CHANNEL_2                  0x00000002U /*!< DMA Channel 2 */
+#define LL_DMA_CHANNEL_3                  0x00000003U /*!< DMA Channel 3 */
+#define LL_DMA_CHANNEL_4                  0x00000004U /*!< DMA Channel 4 */
+#define LL_DMA_CHANNEL_5                  0x00000005U /*!< DMA Channel 5 */
+#define LL_DMA_CHANNEL_6                  0x00000006U /*!< DMA Channel 6 */
+#define LL_DMA_CHANNEL_7                  0x00000007U /*!< DMA Channel 7 */
 #if defined(USE_FULL_LL_DRIVER)
-#define LL_DMA_CHANNEL_ALL                ((uint32_t)0xFFFF0000U) /*!< DMA Channel all (used only for function @ref LL_DMA_DeInit(). */
+#define LL_DMA_CHANNEL_ALL                0xFFFF0000U /*!< DMA Channel all (used only for function @ref LL_DMA_DeInit(). */
 #endif /*USE_FULL_LL_DRIVER*/
 /**
   * @}
@@ -278,7 +265,7 @@ typedef struct
 /** @defgroup DMA_LL_EC_DIRECTION Transfer Direction
   * @{
   */
-#define LL_DMA_DIRECTION_PERIPH_TO_MEMORY ((uint32_t)0x00000000U) /*!< Peripheral to memory direction */
+#define LL_DMA_DIRECTION_PERIPH_TO_MEMORY 0x00000000U             /*!< Peripheral to memory direction */
 #define LL_DMA_DIRECTION_MEMORY_TO_PERIPH DMA_CCR_DIR             /*!< Memory to peripheral direction */
 #define LL_DMA_DIRECTION_MEMORY_TO_MEMORY DMA_CCR_MEM2MEM         /*!< Memory to memory direction     */
 /**
@@ -288,7 +275,7 @@ typedef struct
 /** @defgroup DMA_LL_EC_MODE Transfer mode
   * @{
   */
-#define LL_DMA_MODE_NORMAL                ((uint32_t)0x00000000U) /*!< Normal Mode                  */
+#define LL_DMA_MODE_NORMAL                0x00000000U             /*!< Normal Mode                  */
 #define LL_DMA_MODE_CIRCULAR              DMA_CCR_CIRC            /*!< Circular Mode                */
 /**
   * @}
@@ -298,7 +285,7 @@ typedef struct
   * @{
   */
 #define LL_DMA_PERIPH_INCREMENT           DMA_CCR_PINC            /*!< Peripheral increment mode Enable */
-#define LL_DMA_PERIPH_NOINCREMENT         ((uint32_t)0x00000000U) /*!< Peripheral increment mode Disable */
+#define LL_DMA_PERIPH_NOINCREMENT         0x00000000U             /*!< Peripheral increment mode Disable */
 /**
   * @}
   */
@@ -307,7 +294,7 @@ typedef struct
   * @{
   */
 #define LL_DMA_MEMORY_INCREMENT           DMA_CCR_MINC            /*!< Memory increment mode Enable  */
-#define LL_DMA_MEMORY_NOINCREMENT         ((uint32_t)0x00000000U) /*!< Memory increment mode Disable */
+#define LL_DMA_MEMORY_NOINCREMENT         0x00000000U             /*!< Memory increment mode Disable */
 /**
   * @}
   */
@@ -315,7 +302,7 @@ typedef struct
 /** @defgroup DMA_LL_EC_PDATAALIGN Peripheral data alignment
   * @{
   */
-#define LL_DMA_PDATAALIGN_BYTE            ((uint32_t)0x00000000U) /*!< Peripheral data alignment : Byte     */
+#define LL_DMA_PDATAALIGN_BYTE            0x00000000U             /*!< Peripheral data alignment : Byte     */
 #define LL_DMA_PDATAALIGN_HALFWORD        DMA_CCR_PSIZE_0         /*!< Peripheral data alignment : HalfWord */
 #define LL_DMA_PDATAALIGN_WORD            DMA_CCR_PSIZE_1         /*!< Peripheral data alignment : Word     */
 /**
@@ -325,7 +312,7 @@ typedef struct
 /** @defgroup DMA_LL_EC_MDATAALIGN Memory data alignment
   * @{
   */
-#define LL_DMA_MDATAALIGN_BYTE            ((uint32_t)0x00000000U) /*!< Memory data alignment : Byte     */
+#define LL_DMA_MDATAALIGN_BYTE            0x00000000U             /*!< Memory data alignment : Byte     */
 #define LL_DMA_MDATAALIGN_HALFWORD        DMA_CCR_MSIZE_0         /*!< Memory data alignment : HalfWord */
 #define LL_DMA_MDATAALIGN_WORD            DMA_CCR_MSIZE_1         /*!< Memory data alignment : Word     */
 /**
@@ -335,7 +322,7 @@ typedef struct
 /** @defgroup DMA_LL_EC_PRIORITY Transfer Priority level
   * @{
   */
-#define LL_DMA_PRIORITY_LOW               ((uint32_t)0x00000000U) /*!< Priority level : Low       */
+#define LL_DMA_PRIORITY_LOW               0x00000000U             /*!< Priority level : Low       */
 #define LL_DMA_PRIORITY_MEDIUM            DMA_CCR_PL_0            /*!< Priority level : Medium    */
 #define LL_DMA_PRIORITY_HIGH              DMA_CCR_PL_1            /*!< Priority level : High      */
 #define LL_DMA_PRIORITY_VERYHIGH          DMA_CCR_PL              /*!< Priority level : Very_High */
@@ -973,7 +960,8 @@ __STATIC_INLINE uint32_t LL_DMA_GetDataLength(DMA_TypeDef *DMAx, uint32_t Channe
 
 /**
   * @brief  Configure the Source and Destination addresses.
-  * @note   Each IP using DMA provides an API to get directly the register adress (LL_PPP_DMA_GetRegAddr)
+  * @note   This API must not be called when the DMA channel is enabled.
+  * @note   Each IP using DMA provides an API to get directly the register adress (LL_PPP_DMA_GetRegAddr).
   * @rmtoll CPAR         PA            LL_DMA_ConfigAddresses\n
   *         CMAR         MA            LL_DMA_ConfigAddresses
   * @param  DMAx DMAx Instance
@@ -999,24 +987,21 @@ __STATIC_INLINE void LL_DMA_ConfigAddresses(DMA_TypeDef *DMAx, uint32_t Channel,
   /* Direction Memory to Periph */
   if (Direction == LL_DMA_DIRECTION_MEMORY_TO_PERIPH)
   {
-    MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, DMA_CMAR_MA,
-               SrcAddress);
-    MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, DMA_CPAR_PA,
-               DstAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, SrcAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, DstAddress);
   }
   /* Direction Periph to Memory and Memory to Memory */
   else
   {
-    MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, DMA_CPAR_PA,
-               SrcAddress);
-    MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, DMA_CMAR_MA,
-               DstAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, SrcAddress);
+    WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, DstAddress);
   }
 }
 
 /**
   * @brief  Set the Memory address.
   * @note   Interface used for direction LL_DMA_DIRECTION_PERIPH_TO_MEMORY or LL_DMA_DIRECTION_MEMORY_TO_PERIPH only.
+  * @note   This API must not be called when the DMA channel is enabled.
   * @rmtoll CMAR         MA            LL_DMA_SetMemoryAddress
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1032,13 +1017,13 @@ __STATIC_INLINE void LL_DMA_ConfigAddresses(DMA_TypeDef *DMAx, uint32_t Channel,
   */
 __STATIC_INLINE void LL_DMA_SetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
-  MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, DMA_CMAR_MA,
-             MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, MemoryAddress);
 }
 
 /**
   * @brief  Set the Peripheral address.
   * @note   Interface used for direction LL_DMA_DIRECTION_PERIPH_TO_MEMORY or LL_DMA_DIRECTION_MEMORY_TO_PERIPH only.
+  * @note   This API must not be called when the DMA channel is enabled.
   * @rmtoll CPAR         PA            LL_DMA_SetPeriphAddress
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1054,8 +1039,7 @@ __STATIC_INLINE void LL_DMA_SetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel
   */
 __STATIC_INLINE void LL_DMA_SetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t PeriphAddress)
 {
-  MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, DMA_CPAR_PA,
-             PeriphAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, PeriphAddress);
 }
 
 /**
@@ -1075,8 +1059,7 @@ __STATIC_INLINE void LL_DMA_SetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel
   */
 __STATIC_INLINE uint32_t LL_DMA_GetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
-  return (READ_BIT(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR,
-                   DMA_CMAR_MA));
+  return (READ_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR));
 }
 
 /**
@@ -1096,13 +1079,13 @@ __STATIC_INLINE uint32_t LL_DMA_GetMemoryAddress(DMA_TypeDef *DMAx, uint32_t Cha
   */
 __STATIC_INLINE uint32_t LL_DMA_GetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
-  return (READ_BIT(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR,
-                   DMA_CPAR_PA));
+  return (READ_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR));
 }
 
 /**
   * @brief  Set the Memory to Memory Source address.
   * @note   Interface used for direction LL_DMA_DIRECTION_MEMORY_TO_MEMORY only.
+  * @note   This API must not be called when the DMA channel is enabled.
   * @rmtoll CPAR         PA            LL_DMA_SetM2MSrcAddress
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1118,13 +1101,13 @@ __STATIC_INLINE uint32_t LL_DMA_GetPeriphAddress(DMA_TypeDef *DMAx, uint32_t Cha
   */
 __STATIC_INLINE void LL_DMA_SetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
-  MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, DMA_CPAR_PA,
-             MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR, MemoryAddress);
 }
 
 /**
   * @brief  Set the Memory to Memory Destination address.
   * @note   Interface used for direction LL_DMA_DIRECTION_MEMORY_TO_MEMORY only.
+  * @note   This API must not be called when the DMA channel is enabled.
   * @rmtoll CMAR         MA            LL_DMA_SetM2MDstAddress
   * @param  DMAx DMAx Instance
   * @param  Channel This parameter can be one of the following values:
@@ -1140,8 +1123,7 @@ __STATIC_INLINE void LL_DMA_SetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel
   */
 __STATIC_INLINE void LL_DMA_SetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel, uint32_t MemoryAddress)
 {
-  MODIFY_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, DMA_CMAR_MA,
-             MemoryAddress);
+  WRITE_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR, MemoryAddress);
 }
 
 /**
@@ -1161,8 +1143,7 @@ __STATIC_INLINE void LL_DMA_SetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel
   */
 __STATIC_INLINE uint32_t LL_DMA_GetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
-  return (READ_BIT(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR,
-                   DMA_CPAR_PA));
+  return (READ_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CPAR));
 }
 
 /**
@@ -1182,8 +1163,7 @@ __STATIC_INLINE uint32_t LL_DMA_GetM2MSrcAddress(DMA_TypeDef *DMAx, uint32_t Cha
   */
 __STATIC_INLINE uint32_t LL_DMA_GetM2MDstAddress(DMA_TypeDef *DMAx, uint32_t Channel)
 {
-  return (READ_BIT(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR,
-                   DMA_CMAR_MA));
+  return (READ_REG(((DMA_Channel_TypeDef *)((uint32_t)((uint32_t)DMAx + CHANNEL_OFFSET_TAB[Channel - 1U])))->CMAR));
 }
 
 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_exti.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_exti.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_exti.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   EXTI LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -107,7 +105,7 @@ uint32_t LL_EXTI_DeInit(void)
   LL_EXTI_WriteReg(FTSR,  0x00000000U);
   /* Software interrupt event register set to default reset values */
   LL_EXTI_WriteReg(SWIER, 0x00000000U);
-  /* Pending register set to default reset values */
+  /* Pending register clear */
   LL_EXTI_WriteReg(PR,    0x00FFFFFFU);
 
   return SUCCESS;

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_exti.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_exti.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_exti.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of EXTI LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -122,7 +120,9 @@ typedef struct
 #define LL_EXTI_LINE_16                EXTI_IMR_IM16          /*!< Extended line 16 */
 #endif
 #define LL_EXTI_LINE_17                EXTI_IMR_IM17          /*!< Extended line 17 */
+#if defined(EXTI_IMR_IM18)
 #define LL_EXTI_LINE_18                EXTI_IMR_IM18          /*!< Extended line 18 */
+#endif
 #define LL_EXTI_LINE_19                EXTI_IMR_IM19          /*!< Extended line 19 */
 #if defined(EXTI_IMR_IM20)
 #define LL_EXTI_LINE_20                EXTI_IMR_IM20          /*!< Extended line 20 */
@@ -161,10 +161,10 @@ typedef struct
 #define LL_EXTI_LINE_ALL_0_31          EXTI_IMR_IM            /*!< All Extended line not reserved*/
 
 
-#define LL_EXTI_LINE_ALL               ((uint32_t)0xFFFFFFFFU)  /*!< All Extended line */
+#define LL_EXTI_LINE_ALL               (0xFFFFFFFFU)  /*!< All Extended line */
 
 #if defined(USE_FULL_LL_DRIVER)
-#define LL_EXTI_LINE_NONE              ((uint32_t)0x00000000U)  /*!< None Extended line */
+#define LL_EXTI_LINE_NONE              (0x00000000U)  /*!< None Extended line */
 #endif /*USE_FULL_LL_DRIVER*/
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_fsmc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_fsmc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_fsmc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   FSMC Low Layer HAL module driver.
   *
   *          This file provides firmware functions to manage the following
@@ -39,7 +37,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_fsmc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_fsmc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_fsmc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of FSMC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -303,10 +301,10 @@ typedef struct
 /** @defgroup FSMC_NORSRAM_Bank FSMC NOR/SRAM Bank
   * @{
   */
-#define FSMC_NORSRAM_BANK1                       ((uint32_t)0x00000000)
-#define FSMC_NORSRAM_BANK2                       ((uint32_t)0x00000002)
-#define FSMC_NORSRAM_BANK3                       ((uint32_t)0x00000004)
-#define FSMC_NORSRAM_BANK4                       ((uint32_t)0x00000006)
+#define FSMC_NORSRAM_BANK1                       (0x00000000U)
+#define FSMC_NORSRAM_BANK2                       (0x00000002U)
+#define FSMC_NORSRAM_BANK3                       (0x00000004U)
+#define FSMC_NORSRAM_BANK4                       (0x00000006U)
 
 /**
   * @}
@@ -316,7 +314,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_DATA_ADDRESS_MUX_DISABLE            ((uint32_t)0x00000000)
+#define FSMC_DATA_ADDRESS_MUX_DISABLE            (0x00000000U)
 #define FSMC_DATA_ADDRESS_MUX_ENABLE             ((uint32_t)FSMC_BCRx_MUXEN)
 
 /**
@@ -327,7 +325,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_MEMORY_TYPE_SRAM                    ((uint32_t)0x00000000)
+#define FSMC_MEMORY_TYPE_SRAM                    (0x00000000U)
 #define FSMC_MEMORY_TYPE_PSRAM                   ((uint32_t)FSMC_BCRx_MTYP_0)
 #define FSMC_MEMORY_TYPE_NOR                     ((uint32_t)FSMC_BCRx_MTYP_1)
 
@@ -339,7 +337,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_NORSRAM_MEM_BUS_WIDTH_8             ((uint32_t)0x00000000)
+#define FSMC_NORSRAM_MEM_BUS_WIDTH_8             (0x00000000U)
 #define FSMC_NORSRAM_MEM_BUS_WIDTH_16            ((uint32_t)FSMC_BCRx_MWID_0)
 #define FSMC_NORSRAM_MEM_BUS_WIDTH_32            ((uint32_t)FSMC_BCRx_MWID_1)
 
@@ -352,7 +350,7 @@ typedef struct
   */
 
 #define FSMC_NORSRAM_FLASH_ACCESS_ENABLE         ((uint32_t)FSMC_BCRx_FACCEN)
-#define FSMC_NORSRAM_FLASH_ACCESS_DISABLE        ((uint32_t)0x00000000)
+#define FSMC_NORSRAM_FLASH_ACCESS_DISABLE        (0x00000000U)
 /**
   * @}
   */
@@ -361,7 +359,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_BURST_ACCESS_MODE_DISABLE           ((uint32_t)0x00000000)
+#define FSMC_BURST_ACCESS_MODE_DISABLE           (0x00000000U)
 #define FSMC_BURST_ACCESS_MODE_ENABLE            ((uint32_t)FSMC_BCRx_BURSTEN)
 
 /**
@@ -373,7 +371,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WAIT_SIGNAL_POLARITY_LOW            ((uint32_t)0x00000000)
+#define FSMC_WAIT_SIGNAL_POLARITY_LOW            (0x00000000U)
 #define FSMC_WAIT_SIGNAL_POLARITY_HIGH           ((uint32_t)FSMC_BCRx_WAITPOL)
 
 /**
@@ -384,7 +382,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WRAP_MODE_DISABLE                   ((uint32_t)0x00000000)
+#define FSMC_WRAP_MODE_DISABLE                   (0x00000000U)
 #define FSMC_WRAP_MODE_ENABLE                    ((uint32_t)FSMC_BCRx_WRAPMOD)
 
 /**
@@ -395,7 +393,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WAIT_TIMING_BEFORE_WS               ((uint32_t)0x00000000)
+#define FSMC_WAIT_TIMING_BEFORE_WS               (0x00000000U)
 #define FSMC_WAIT_TIMING_DURING_WS               ((uint32_t)FSMC_BCRx_WAITCFG)
 
 /**
@@ -406,7 +404,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WRITE_OPERATION_DISABLE             ((uint32_t)0x00000000)
+#define FSMC_WRITE_OPERATION_DISABLE             (0x00000000U)
 #define FSMC_WRITE_OPERATION_ENABLE              ((uint32_t)FSMC_BCRx_WREN)
 
 /**
@@ -417,7 +415,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WAIT_SIGNAL_DISABLE                 ((uint32_t)0x00000000)
+#define FSMC_WAIT_SIGNAL_DISABLE                 (0x00000000U)
 #define FSMC_WAIT_SIGNAL_ENABLE                  ((uint32_t)FSMC_BCRx_WAITEN)
 
 /**
@@ -428,7 +426,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_EXTENDED_MODE_DISABLE               ((uint32_t)0x00000000)
+#define FSMC_EXTENDED_MODE_DISABLE               (0x00000000U)
 #define FSMC_EXTENDED_MODE_ENABLE                ((uint32_t)FSMC_BCRx_EXTMOD)
 
 /**
@@ -439,7 +437,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_ASYNCHRONOUS_WAIT_DISABLE           ((uint32_t)0x00000000)
+#define FSMC_ASYNCHRONOUS_WAIT_DISABLE           (0x00000000U)
 #define FSMC_ASYNCHRONOUS_WAIT_ENABLE            ((uint32_t)FSMC_BCRx_ASYNCWAIT)
 
 /**
@@ -450,7 +448,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_WRITE_BURST_DISABLE                 ((uint32_t)0x00000000)
+#define FSMC_WRITE_BURST_DISABLE                 (0x00000000U)
 #define FSMC_WRITE_BURST_ENABLE                  ((uint32_t)FSMC_BCRx_CBURSTRW)
 
 /**
@@ -461,7 +459,7 @@ typedef struct
   * @{
   */
 
-#define FSMC_ACCESS_MODE_A                        ((uint32_t)0x00000000)
+#define FSMC_ACCESS_MODE_A                        (0x00000000U)
 #define FSMC_ACCESS_MODE_B                        ((uint32_t)FSMC_BTRx_ACCMOD_0)
 #define FSMC_ACCESS_MODE_C                        ((uint32_t)FSMC_BTRx_ACCMOD_1)
 #define FSMC_ACCESS_MODE_D                        ((uint32_t)(FSMC_BTRx_ACCMOD_0 | FSMC_BTRx_ACCMOD_1))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_gpio.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_gpio.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_gpio.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   GPIO LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -62,7 +60,7 @@
 /** @addtogroup GPIO_LL_Private_Macros
   * @{
   */
-#define IS_LL_GPIO_PIN(__VALUE__)          ((((uint32_t)0x00000000U) < (__VALUE__)) && ((__VALUE__) <= (LL_GPIO_PIN_ALL)))
+#define IS_LL_GPIO_PIN(__VALUE__)          (((0x00000000U) < (__VALUE__)) && ((__VALUE__) <= (LL_GPIO_PIN_ALL)))
 
 #define IS_LL_GPIO_MODE(__VALUE__)         (((__VALUE__) == LL_GPIO_MODE_INPUT)     ||\
                                             ((__VALUE__) == LL_GPIO_MODE_OUTPUT)    ||\
@@ -302,4 +300,3 @@ void LL_GPIO_StructInit(LL_GPIO_InitTypeDef *GPIO_InitStruct)
 #endif /* USE_FULL_LL_DRIVER */
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/
-

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_gpio.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_gpio.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_gpio.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of GPIO LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -152,7 +150,7 @@ typedef struct
 /** @defgroup GPIO_LL_EC_MODE Mode
   * @{
   */
-#define LL_GPIO_MODE_INPUT                 ((uint32_t)0x00000000U) /*!< Select input mode */
+#define LL_GPIO_MODE_INPUT                 (0x00000000U) /*!< Select input mode */
 #define LL_GPIO_MODE_OUTPUT                GPIO_MODER_MODER0_0  /*!< Select output mode */
 #define LL_GPIO_MODE_ALTERNATE             GPIO_MODER_MODER0_1  /*!< Select alternate function mode */
 #define LL_GPIO_MODE_ANALOG                GPIO_MODER_MODER0    /*!< Select analog mode */
@@ -163,7 +161,7 @@ typedef struct
 /** @defgroup GPIO_LL_EC_OUTPUT Output Type
   * @{
   */
-#define LL_GPIO_OUTPUT_PUSHPULL            ((uint32_t)0x00000000U) /*!< Select push-pull as output type */
+#define LL_GPIO_OUTPUT_PUSHPULL            (0x00000000U) /*!< Select push-pull as output type */
 #define LL_GPIO_OUTPUT_OPENDRAIN           GPIO_OTYPER_OT_0 /*!< Select open-drain as output type */
 /**
   * @}
@@ -172,7 +170,7 @@ typedef struct
 /** @defgroup GPIO_LL_EC_SPEED Output Speed
   * @{
   */
-#define LL_GPIO_SPEED_FREQ_LOW             ((uint32_t)0x00000000U) /*!< Select I/O low output speed    */
+#define LL_GPIO_SPEED_FREQ_LOW             (0x00000000U) /*!< Select I/O low output speed    */
 #define LL_GPIO_SPEED_FREQ_MEDIUM          GPIO_OSPEEDER_OSPEEDR0_0 /*!< Select I/O medium output speed */
 #define LL_GPIO_SPEED_FREQ_HIGH            GPIO_OSPEEDER_OSPEEDR0_1 /*!< Select I/O fast output speed   */
 #define LL_GPIO_SPEED_FREQ_VERY_HIGH       GPIO_OSPEEDER_OSPEEDR0   /*!< Select I/O high output speed   */
@@ -183,7 +181,7 @@ typedef struct
 /** @defgroup GPIO_LL_EC_PULL Pull Up Pull Down
   * @{
   */
-#define LL_GPIO_PULL_NO                    ((uint32_t)0x00000000U) /*!< Select I/O no pull */
+#define LL_GPIO_PULL_NO                    (0x00000000U) /*!< Select I/O no pull */
 #define LL_GPIO_PULL_UP                    GPIO_PUPDR_PUPDR0_0 /*!< Select I/O pull up */
 #define LL_GPIO_PULL_DOWN                  GPIO_PUPDR_PUPDR0_1 /*!< Select I/O pull down */
 /**
@@ -193,22 +191,22 @@ typedef struct
 /** @defgroup GPIO_LL_EC_AF Alternate Function
   * @{
   */
-#define LL_GPIO_AF_0                       ((uint32_t)0x0000000U) /*!< Select alternate function 0 */
-#define LL_GPIO_AF_1                       ((uint32_t)0x0000001U) /*!< Select alternate function 1 */
-#define LL_GPIO_AF_2                       ((uint32_t)0x0000002U) /*!< Select alternate function 2 */
-#define LL_GPIO_AF_3                       ((uint32_t)0x0000003U) /*!< Select alternate function 3 */
-#define LL_GPIO_AF_4                       ((uint32_t)0x0000004U) /*!< Select alternate function 4 */
-#define LL_GPIO_AF_5                       ((uint32_t)0x0000005U) /*!< Select alternate function 5 */
-#define LL_GPIO_AF_6                       ((uint32_t)0x0000006U) /*!< Select alternate function 6 */
-#define LL_GPIO_AF_7                       ((uint32_t)0x0000007U) /*!< Select alternate function 7 */
-#define LL_GPIO_AF_8                       ((uint32_t)0x0000008U) /*!< Select alternate function 8 */
-#define LL_GPIO_AF_9                       ((uint32_t)0x0000009U) /*!< Select alternate function 9 */
-#define LL_GPIO_AF_10                      ((uint32_t)0x000000AU) /*!< Select alternate function 10 */
-#define LL_GPIO_AF_11                      ((uint32_t)0x000000BU) /*!< Select alternate function 11 */
-#define LL_GPIO_AF_12                      ((uint32_t)0x000000CU) /*!< Select alternate function 12 */
-#define LL_GPIO_AF_13                      ((uint32_t)0x000000DU) /*!< Select alternate function 13 */
-#define LL_GPIO_AF_14                      ((uint32_t)0x000000EU) /*!< Select alternate function 14 */
-#define LL_GPIO_AF_15                      ((uint32_t)0x000000FU) /*!< Select alternate function 15 */
+#define LL_GPIO_AF_0                       (0x0000000U) /*!< Select alternate function 0 */
+#define LL_GPIO_AF_1                       (0x0000001U) /*!< Select alternate function 1 */
+#define LL_GPIO_AF_2                       (0x0000002U) /*!< Select alternate function 2 */
+#define LL_GPIO_AF_3                       (0x0000003U) /*!< Select alternate function 3 */
+#define LL_GPIO_AF_4                       (0x0000004U) /*!< Select alternate function 4 */
+#define LL_GPIO_AF_5                       (0x0000005U) /*!< Select alternate function 5 */
+#define LL_GPIO_AF_6                       (0x0000006U) /*!< Select alternate function 6 */
+#define LL_GPIO_AF_7                       (0x0000007U) /*!< Select alternate function 7 */
+#define LL_GPIO_AF_8                       (0x0000008U) /*!< Select alternate function 8 */
+#define LL_GPIO_AF_9                       (0x0000009U) /*!< Select alternate function 9 */
+#define LL_GPIO_AF_10                      (0x000000AU) /*!< Select alternate function 10 */
+#define LL_GPIO_AF_11                      (0x000000BU) /*!< Select alternate function 11 */
+#define LL_GPIO_AF_12                      (0x000000CU) /*!< Select alternate function 12 */
+#define LL_GPIO_AF_13                      (0x000000DU) /*!< Select alternate function 13 */
+#define LL_GPIO_AF_14                      (0x000000EU) /*!< Select alternate function 14 */
+#define LL_GPIO_AF_15                      (0x000000FU) /*!< Select alternate function 15 */
 /**
   * @}
   */
@@ -574,7 +572,7 @@ __STATIC_INLINE uint32_t LL_GPIO_GetPinPull(GPIO_TypeDef *GPIOx, uint32_t Pin)
   */
 __STATIC_INLINE void LL_GPIO_SetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Alternate)
 {
-  MODIFY_REG(GPIOx->AFR[0], (GPIO_AFRL_AFRL0 << (POSITION_VAL(Pin) * 4U)),
+  MODIFY_REG(GPIOx->AFR[0], (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * 4U)),
              (Alternate << (POSITION_VAL(Pin) * 4U)));
 }
 
@@ -612,7 +610,7 @@ __STATIC_INLINE void LL_GPIO_SetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin, uin
 __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
   return (uint32_t)(READ_BIT(GPIOx->AFR[0],
-                             (GPIO_AFRL_AFRL0 << (POSITION_VAL(Pin) * 4U))) >> (POSITION_VAL(Pin) * 4U));
+                             (GPIO_AFRL_AFSEL0 << (POSITION_VAL(Pin) * 4U))) >> (POSITION_VAL(Pin) * 4U));
 }
 
 /**
@@ -651,7 +649,7 @@ __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_0_7(GPIO_TypeDef *GPIOx, uint32_t Pin)
   */
 __STATIC_INLINE void LL_GPIO_SetAFPin_8_15(GPIO_TypeDef *GPIOx, uint32_t Pin, uint32_t Alternate)
 {
-  MODIFY_REG(GPIOx->AFR[1], (GPIO_AFRH_AFRH0 << (POSITION_VAL(Pin >> 8U) * 4U)),
+  MODIFY_REG(GPIOx->AFR[1], (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * 4U)),
              (Alternate << (POSITION_VAL(Pin >> 8U) * 4U)));
 }
 
@@ -690,7 +688,7 @@ __STATIC_INLINE void LL_GPIO_SetAFPin_8_15(GPIO_TypeDef *GPIOx, uint32_t Pin, ui
 __STATIC_INLINE uint32_t LL_GPIO_GetAFPin_8_15(GPIO_TypeDef *GPIOx, uint32_t Pin)
 {
   return (uint32_t)(READ_BIT(GPIOx->AFR[1],
-                             (GPIO_AFRH_AFRH0 << (POSITION_VAL(Pin >> 8U) * 4U))) >> (POSITION_VAL(Pin >> 8U) * 4U));
+                             (GPIO_AFRH_AFSEL8 << (POSITION_VAL(Pin >> 8U) * 4U))) >> (POSITION_VAL(Pin >> 8U) * 4U));
 }
 
 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_i2c.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_i2c.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_i2c.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   I2C LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -69,12 +67,12 @@
                                                  ((__VALUE__) == LL_I2C_MODE_SMBUS_DEVICE) || \
                                                  ((__VALUE__) == LL_I2C_MODE_SMBUS_DEVICE_ARP))
 
-#define IS_I2C_CLOCK_SPEED(__VALUE__)           (((__VALUE__) > 0) && ((__VALUE__) <= LL_I2C_MAX_SPEED_FAST))
+#define IS_I2C_CLOCK_SPEED(__VALUE__)           (((__VALUE__) > 0U) && ((__VALUE__) <= LL_I2C_MAX_SPEED_FAST))
 
 #define IS_I2C_DUTY_CYCLE(__VALUE__)            (((__VALUE__) == LL_I2C_DUTYCYCLE_2) || \
                                                  ((__VALUE__) == LL_I2C_DUTYCYCLE_16_9))
 
-#define IS_LL_I2C_OWN_ADDRESS1(__VALUE__)       ((__VALUE__) <= (uint32_t)0x000003FFU)
+#define IS_LL_I2C_OWN_ADDRESS1(__VALUE__)       ((__VALUE__) <= 0x000003FFU)
 
 #define IS_LL_I2C_TYPE_ACKNOWLEDGE(__VALUE__)   (((__VALUE__) == LL_I2C_ACK) || \
                                                  ((__VALUE__) == LL_I2C_NACK))

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_i2c.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_i2c.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_i2c.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of I2C LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -63,8 +61,6 @@ extern "C" {
 /** @defgroup I2C_LL_Private_Constants I2C Private Constants
   * @{
   */
-/* Defines used for the bit position in the register and perform offsets */
-#define LL_I2C_POSITION_SR2_PEC             (uint32_t)POSITION_VAL(I2C_SR2_PEC)
 
 /* Defines used to perform compute and check in the macros */
 #define LL_I2C_MAX_SPEED_STANDARD           100000U
@@ -1540,6 +1536,17 @@ __STATIC_INLINE void LL_I2C_EnableReset(I2C_TypeDef *I2Cx)
 }
 
 /**
+  * @brief  Disable Reset of I2C peripheral.
+  * @rmtoll CR1          SWRST         LL_I2C_DisableReset
+  * @param  I2Cx I2C Instance.
+  * @retval None
+  */
+__STATIC_INLINE void LL_I2C_DisableReset(I2C_TypeDef *I2Cx)
+{
+  CLEAR_BIT(I2Cx->CR1, I2C_CR1_SWRST);
+}
+
+/**
   * @brief  Check if the I2C peripheral is under reset state or not.
   * @rmtoll CR1          SWRST         LL_I2C_IsResetEnabled
   * @param  I2Cx I2C Instance.
@@ -1725,7 +1732,7 @@ __STATIC_INLINE uint32_t LL_I2C_IsEnabledSMBusPECCompare(I2C_TypeDef *I2Cx)
   */
 __STATIC_INLINE uint32_t LL_I2C_GetSMBusPEC(I2C_TypeDef *I2Cx)
 {
-  return (uint32_t)(READ_BIT(I2Cx->SR2, I2C_SR2_PEC) >> LL_I2C_POSITION_SR2_PEC);
+  return (uint32_t)(READ_BIT(I2Cx->SR2, I2C_SR2_PEC) >> I2C_SR2_PEC_Pos);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_iwdg.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_iwdg.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_iwdg.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of IWDG LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -64,10 +62,10 @@ extern "C" {
   * @{
   */
 
-#define LL_IWDG_KEY_RELOAD                 ((uint32_t)0x0000AAAAU)               /*!< IWDG Reload Counter Enable   */
-#define LL_IWDG_KEY_ENABLE                 ((uint32_t)0x0000CCCCU)               /*!< IWDG Peripheral Enable       */
-#define LL_IWDG_KEY_WR_ACCESS_ENABLE       ((uint32_t)0x00005555U)               /*!< IWDG KR Write Access Enable  */
-#define LL_IWDG_KEY_WR_ACCESS_DISABLE      ((uint32_t)0x00000000U)               /*!< IWDG KR Write Access Disable */
+#define LL_IWDG_KEY_RELOAD                 0x0000AAAAU               /*!< IWDG Reload Counter Enable   */
+#define LL_IWDG_KEY_ENABLE                 0x0000CCCCU               /*!< IWDG Peripheral Enable       */
+#define LL_IWDG_KEY_WR_ACCESS_ENABLE       0x00005555U               /*!< IWDG KR Write Access Enable  */
+#define LL_IWDG_KEY_WR_ACCESS_DISABLE      0x00000000U               /*!< IWDG KR Write Access Disable */
 
 /**
   * @}
@@ -95,7 +93,7 @@ extern "C" {
 /** @defgroup IWDG_LL_EC_PRESCALER  Prescaler Divider
   * @{
   */
-#define LL_IWDG_PRESCALER_4                ((uint32_t)0x00000000U)               /*!< Divider by 4   */
+#define LL_IWDG_PRESCALER_4                0x00000000U                           /*!< Divider by 4   */
 #define LL_IWDG_PRESCALER_8                (IWDG_PR_PR_0)                        /*!< Divider by 8   */
 #define LL_IWDG_PRESCALER_16               (IWDG_PR_PR_1)                        /*!< Divider by 16  */
 #define LL_IWDG_PRESCALER_32               (IWDG_PR_PR_1 | IWDG_PR_PR_0)         /*!< Divider by 32  */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_opamp.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_opamp.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_opamp.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   OPAMP LL module driver
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_opamp.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_opamp.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_opamp.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of OPAMP LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -70,8 +68,8 @@ extern "C" {
 /* - OPAMP trimming register offset                                           */
 
 /* Internal register offset for OPAMP trimming configuration */
-#define OPAMP_POWERMODE_OTR_REGOFFSET       ((uint32_t)0x00000000U)
-#define OPAMP_POWERMODE_LPOTR_REGOFFSET     ((uint32_t)0x00000001U)
+#define OPAMP_POWERMODE_OTR_REGOFFSET       (0x00000000U)
+#define OPAMP_POWERMODE_LPOTR_REGOFFSET     (0x00000001U)
 #define OPAMP_POWERMODE_OTR_REGOFFSET_MASK  (OPAMP_POWERMODE_OTR_REGOFFSET | OPAMP_POWERMODE_LPOTR_REGOFFSET)
 
 /* Mask for OPAMP power mode into control register */
@@ -82,7 +80,7 @@ extern "C" {
 /* To select into literal LL_OPAMP_TRIMMING_x the relevant bits for:          */
 /* - OPAMP trimming selection of transistors differential pair                */
 /* - OPAMP trimming values of transistors differential pair                   */
-#define OPAMP_TRIMMING_SELECT_SW_OFFSET     ((uint32_t)16U)
+#define OPAMP_TRIMMING_SELECT_SW_OFFSET     (16U)
 #define OPAMP_TRIMMING_SELECT_MASK          ((OPAMP_CSR_OPA1CAL_H | OPAMP_CSR_OPA1CAL_L) << OPAMP_TRIMMING_SELECT_SW_OFFSET)
 #define OPAMP_TRIMMING_VALUE_MASK           (OPAMP_OTR_AO1_OPT_OFFSET_TRIM_HIGH | OPAMP_OTR_AO1_OPT_OFFSET_TRIM_LOW)
 
@@ -193,7 +191,7 @@ typedef struct
 /** @defgroup OPAMP_LL_EC_POWERSUPPLY_RANGE OPAMP power supply range
   * @{
   */
-#define LL_OPAMP_POWERSUPPLY_RANGE_LOW  ((uint32_t)0x00000000U) /*!< Power supply range low. On STM32L1 serie: Vdda lower than 2.4V. */
+#define LL_OPAMP_POWERSUPPLY_RANGE_LOW  (0x00000000U)           /*!< Power supply range low. On STM32L1 serie: Vdda lower than 2.4V. */
 #define LL_OPAMP_POWERSUPPLY_RANGE_HIGH (OPAMP_CSR_AOP_RANGE)   /*!< Power supply range high. On STM32L1 serie: Vdda higher than 2.4V. */
 /**
   * @}
@@ -211,7 +209,7 @@ typedef struct
 /** @defgroup OPAMP_LL_EC_MODE OPAMP mode calibration or functional.
   * @{
   */
-#define LL_OPAMP_MODE_FUNCTIONAL        ((uint32_t)0x00000000U)                                                                        /*!< OPAMP functional mode */
+#define LL_OPAMP_MODE_FUNCTIONAL        (0x00000000U)                                                                                  /*!< OPAMP functional mode */
 #define LL_OPAMP_MODE_CALIBRATION       (OPAMP_CSR_S3SEL1 | OPAMP_CSR_S4SEL1 | OPAMP_CSR_S5SEL1 | OPAMP_CSR_S6SEL1 | OPAMP_CSR_S7SEL2) /*!< OPAMP calibration mode (on STM32L1 serie, it corresponds to all OPAMP input internal switches opened) */
 /**
   * @}
@@ -220,7 +218,7 @@ typedef struct
 /** @defgroup OPAMP_LL_EC_FUNCTIONAL_MODE OPAMP functional mode
   * @{
   */
-#define LL_OPAMP_MODE_STANDALONE        ((uint32_t)0x00000000U) /*!< OPAMP functional mode, OPAMP operation in standalone (on STM32L1 serie, it corresponds to OPAMP internal switches S3 opened (switch SanB state depends on switch S4 state)) */
+#define LL_OPAMP_MODE_STANDALONE        (0x00000000U)           /*!< OPAMP functional mode, OPAMP operation in standalone (on STM32L1 serie, it corresponds to OPAMP internal switches S3 opened (switch SanB state depends on switch S4 state)) */
 #define LL_OPAMP_MODE_FOLLOWER          (OPAMP_CSR_S3SEL1)      /*!< OPAMP functional mode, OPAMP operation in follower (on STM32L1 serie, it corresponds to OPAMP internal switches S3 and SanB closed) */
 /**
   * @}
@@ -244,7 +242,7 @@ typedef struct
   */
 #define LL_OPAMP_INPUT_INVERT_IO0        (OPAMP_CSR_S4SEL1)      /*!< OPAMP inverting input connected to GPIO pin (low leakage input). Note: OPAMP inverting input is used with OPAMP in mode standalone. Otherwise (OPAMP in mode follower), OPAMP inverting input is not used (not connected to GPIO pin). */
 #define LL_OPAMP_INPUT_INVERT_IO1        (OPAMP_CSR_ANAWSEL1)    /*!< OPAMP inverting input connected to GPIO pin (alternative IO pin, not low leakage, availability depends on STM32L1 serie devices packages). Note: OPAMP inverting input is used with OPAMP in mode standalone. Otherwise (OPAMP in mode follower), OPAMP inverting input is not used (not connected to GPIO pin). */
-#define LL_OPAMP_INPUT_INVERT_CONNECT_NO ((uint32_t)0x00000000U) /*!< OPAMP inverting input not externally connected (intended for OPAMP in mode follower) */
+#define LL_OPAMP_INPUT_INVERT_CONNECT_NO (0x00000000U)           /*!< OPAMP inverting input not externally connected (intended for OPAMP in mode follower) */
 /**
   * @}
   */
@@ -252,7 +250,7 @@ typedef struct
 /** @defgroup OPAMP_LL_EC_TRIMMING_MODE OPAMP trimming mode
   * @{
   */
-#define LL_OPAMP_TRIMMING_FACTORY       ((uint32_t)0x00000000U) /*!< OPAMP trimming factors set to factory values */
+#define LL_OPAMP_TRIMMING_FACTORY       (0x00000000U)           /*!< OPAMP trimming factors set to factory values */
 #define LL_OPAMP_TRIMMING_USER          (OPAMP_OTR_OT_USER)     /*!< OPAMP trimming factors set to user values */
 /**
   * @}
@@ -263,7 +261,7 @@ typedef struct
   */
 #define LL_OPAMP_TRIMMING_NMOS          (OPAMP_OTR_AO1_OPT_OFFSET_TRIM_HIGH | (OPAMP_CSR_OPA1CAL_H << OPAMP_TRIMMING_SELECT_SW_OFFSET)) /*!< OPAMP trimming of transistors differential pair NMOS */
 #define LL_OPAMP_TRIMMING_PMOS          (OPAMP_OTR_AO1_OPT_OFFSET_TRIM_LOW  | (OPAMP_CSR_OPA1CAL_L << OPAMP_TRIMMING_SELECT_SW_OFFSET)) /*!< OPAMP trimming of transistors differential pair PMOS */
-#define LL_OPAMP_TRIMMING_NONE          ((uint32_t)0x00000000U)                                                                         /*!< OPAMP trimming unselect transistors differential pair NMOS and PMOs */
+#define LL_OPAMP_TRIMMING_NONE          (0x00000000U)                                                                                   /*!< OPAMP trimming unselect transistors differential pair NMOS and PMOs */
 /**
   * @}
   */
@@ -285,7 +283,7 @@ typedef struct
 /* Literal set to maximum value (refer to device datasheet,                   */
 /* parameter "tWAKEUP").                                                      */
 /* Unit: us                                                                   */
-#define LL_OPAMP_DELAY_STARTUP_US         ((uint32_t) 30U)  /*!< Delay for OPAMP startup time */
+#define LL_OPAMP_DELAY_STARTUP_US         (30U)  /*!< Delay for OPAMP startup time */
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_pwr.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_pwr.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_pwr.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   PWR LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_pwr.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_pwr.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_pwr.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of PWR LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -58,11 +56,8 @@ extern "C" {
 
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-
 /* Private constants ---------------------------------------------------------*/
-
 /* Private macros ------------------------------------------------------------*/
-
 /* Exported types ------------------------------------------------------------*/
 /* Exported constants --------------------------------------------------------*/
 /** @defgroup PWR_LL_Exported_Constants PWR Exported Constants
@@ -85,17 +80,17 @@ extern "C" {
   */
 #define LL_PWR_CSR_WUF                     PWR_CSR_WUF            /*!< Wakeup flag */
 #define LL_PWR_CSR_SBF                     PWR_CSR_SBF            /*!< Standby flag */
-#if defined (PWR_PVD_SUPPORT)
+#if defined(PWR_PVD_SUPPORT)
 #define LL_PWR_CSR_PVDO                    PWR_CSR_PVDO           /*!< Power voltage detector output flag */
-#endif
-#if defined (PWR_CSR_VREFINTRDYF)
+#endif /* PWR_PVD_SUPPORT */
+#if defined(PWR_CSR_VREFINTRDYF)
 #define LL_PWR_CSR_VREFINTRDYF             PWR_CSR_VREFINTRDYF    /*!< VREFINT ready flag */
-#endif
-#define LL_PWR_CSR_VOSF                    PWR_CSR_VOSF           /*!< Voltage scaling select flag */
+#endif /* PWR_CSR_VREFINTRDYF */
+#define LL_PWR_CSR_VOS                     PWR_CSR_VOSF           /*!< Voltage scaling select flag */
 #define LL_PWR_CSR_REGLPF                  PWR_CSR_REGLPF         /*!< Regulator low power flag */
 #define LL_PWR_CSR_EWUP1                   PWR_CSR_EWUP1          /*!< Enable WKUP pin 1 */
 #define LL_PWR_CSR_EWUP2                   PWR_CSR_EWUP2          /*!< Enable WKUP pin 2 */
-#if defined (PWR_CSR_EWUP3)
+#if defined(PWR_CSR_EWUP3)
 #define LL_PWR_CSR_EWUP3                   PWR_CSR_EWUP3          /*!< Enable WKUP pin 3 */
 #endif /* PWR_CSR_EWUP3 */
 /**
@@ -115,8 +110,8 @@ extern "C" {
 /** @defgroup PWR_LL_EC_MODE_PWR Mode Power
   * @{
   */
-#define LL_PWR_MODE_STOP                   ((uint32_t)0x00000000U)        /*!< Enter Stop mode when the CPU enters deepsleep */
-#define LL_PWR_MODE_STANDBY                (PWR_CR_PDDS)                  /*!< Enter Standby mode when the CPU enters deepsleep */
+#define LL_PWR_MODE_STOP                      0x00000000U                    /*!< Enter Stop mode when the CPU enters deepsleep */
+#define LL_PWR_MODE_STANDBY                   (PWR_CR_PDDS)                  /*!< Enter Standby mode when the CPU enters deepsleep */
 /**
   * @}
   */
@@ -124,24 +119,23 @@ extern "C" {
 /** @defgroup PWR_LL_EC_REGU_MODE_LP_MODES  Regulator Mode In Low Power Modes
   * @{
   */
-#define LL_PWR_REGU_LPMODES_MAIN           ((uint32_t)0x00000000U)        /*!< Voltage regulator in main mode during deepsleep/sleep/low-power run mode */
-#define LL_PWR_REGU_LPMODES_LOW_POWER      (PWR_CR_LPSDSR)                /*!< Voltage regulator in low-power mode during deepsleep/sleep/low-power run mode */
+#define LL_PWR_REGU_LPMODES_MAIN           0x00000000U        /*!< Voltage Regulator in main mode during deepsleep/sleep/low-power run mode */
+#define LL_PWR_REGU_LPMODES_LOW_POWER      (PWR_CR_LPSDSR)    /*!< Voltage Regulator in low-power mode during deepsleep/sleep/low-power run mode */
 /**
   * @}
   */
-
 #if defined(PWR_CR_LPDS)
 /** @defgroup PWR_LL_EC_REGU_MODE_DS_MODE  Regulator Mode In Deep Sleep Mode
  * @{
  */
-#define LL_PWR_REGU_DSMODE_MAIN       ((uint32_t)0x00000000U)        /*!< Voltage regulator in main mode during deepsleep mode */
-#define LL_PWR_REGU_DSMODE_LOW_POWER  (PWR_CR_LPDS)                  /*!< Voltage regulator in low-power mode during deepsleep mode */
+#define LL_PWR_REGU_DSMODE_MAIN        0x00000000U           /*!< Voltage Regulator in main mode during deepsleep mode */
+#define LL_PWR_REGU_DSMODE_LOW_POWER   (PWR_CR_LPDS)         /*!< Voltage Regulator in low-power mode during deepsleep mode */
 /**
- * @}
- */
+  * @}
+  */
 #endif /* PWR_CR_LPDS */
 
-#if defined (PWR_PVD_SUPPORT)
+#if defined(PWR_PVD_SUPPORT)
 /** @defgroup PWR_LL_EC_PVDLEVEL Power Voltage Detector Level
   * @{
   */
@@ -156,14 +150,13 @@ extern "C" {
 /**
   * @}
   */
-#endif
-
+#endif /* PWR_PVD_SUPPORT */
 /** @defgroup PWR_LL_EC_WAKEUP_PIN  Wakeup Pins
-* @{
-*/
+  * @{
+  */
 #define LL_PWR_WAKEUP_PIN1                 (PWR_CSR_EWUP1)        /*!< WKUP pin 1 : PA0 */
 #define LL_PWR_WAKEUP_PIN2                 (PWR_CSR_EWUP2)        /*!< WKUP pin 2 : PC13 */
-#if defined (PWR_CSR_EWUP3)
+#if defined(PWR_CSR_EWUP3)
 #define LL_PWR_WAKEUP_PIN3                 (PWR_CSR_EWUP3)        /*!< WKUP pin 3 : PE6 or PA2 according to device */
 #endif /* PWR_CSR_EWUP3 */
 /**
@@ -206,7 +199,6 @@ extern "C" {
   * @}
   */
 
-
 /* Exported functions --------------------------------------------------------*/
 /** @defgroup PWR_LL_Exported_Functions PWR Exported Functions
   * @{
@@ -215,11 +207,10 @@ extern "C" {
 /** @defgroup PWR_LL_EF_Configuration Configuration
   * @{
   */
-
 /**
-  * @brief  Switch the regulator from main mode to low-power mode
+  * @brief  Switch the Regulator from main mode to low-power mode
   * @rmtoll CR    LPRUN       LL_PWR_EnableLowPowerRunMode
-  * @note   Remind to set the regulator to low power before enabling
+  * @note   Remind to set the Regulator to low power before enabling
   *         LowPower run mode (bit @ref LL_PWR_REGU_LPMODES_LOW_POWER).
   * @retval None
   */
@@ -229,7 +220,7 @@ __STATIC_INLINE void LL_PWR_EnableLowPowerRunMode(void)
 }
 
 /**
-  * @brief  Switch the regulator from low-power mode to main mode
+  * @brief  Switch the Regulator from low-power mode to main mode
   * @rmtoll CR    LPRUN       LL_PWR_DisableLowPowerRunMode
   * @retval None
   */
@@ -239,7 +230,7 @@ __STATIC_INLINE void LL_PWR_DisableLowPowerRunMode(void)
 }
 
 /**
-  * @brief  Check if the regulator is in low-power mode
+  * @brief  Check if the Regulator is in low-power mode
   * @rmtoll CR    LPRUN       LL_PWR_IsEnabledLowPowerRunMode
   * @retval State of bit (1 or 0).
   */
@@ -249,7 +240,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledLowPowerRunMode(void)
 }
 
 /**
-  * @brief  Set voltage regulator to low-power and switch from 
+  * @brief  Set voltage Regulator to low-power and switch from 
   *         run main mode to run low-power mode.
   * @rmtoll CR    LPSDSR       LL_PWR_EnterLowPowerRunMode\n
   *         CR    LPRUN        LL_PWR_EnterLowPowerRunMode
@@ -268,7 +259,7 @@ __STATIC_INLINE void LL_PWR_EnterLowPowerRunMode(void)
 }
 
 /**
-  * @brief  Set voltage regulator to main and switch from 
+  * @brief  Set voltage Regulator to main and switch from 
   *         run main mode to low-power mode.
   * @rmtoll CR    LPSDSR       LL_PWR_ExitLowPowerRunMode\n
   *         CR    LPRUN        LL_PWR_ExitLowPowerRunMode
@@ -285,9 +276,8 @@ __STATIC_INLINE void LL_PWR_ExitLowPowerRunMode(void)
   CLEAR_BIT(PWR->CR, PWR_CR_LPRUN);   /* => LL_PWR_DisableLowPowerRunMode() */
   CLEAR_BIT(PWR->CR, PWR_CR_LPSDSR);  /* => LL_PWR_SetRegulModeLP(LL_PWR_REGU_LPMODES_MAIN) */
 }
-
 /**
-  * @brief  Set the main internal regulator output voltage
+  * @brief  Set the main internal Regulator output voltage
   * @rmtoll CR    VOS       LL_PWR_SetRegulVoltageScaling
   * @param  VoltageScaling This parameter can be one of the following values:
   *         @arg @ref LL_PWR_REGU_VOLTAGE_SCALE1
@@ -301,7 +291,7 @@ __STATIC_INLINE void LL_PWR_SetRegulVoltageScaling(uint32_t VoltageScaling)
 }
 
 /**
-  * @brief  Get the main internal regulator output voltage
+  * @brief  Get the main internal Regulator output voltage
   * @rmtoll CR    VOS       LL_PWR_GetRegulVoltageScaling
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_PWR_REGU_VOLTAGE_SCALE1
@@ -344,7 +334,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledBkUpAccess(void)
 }
 
 /**
-  * @brief  Set voltage regulator mode during low power modes
+  * @brief  Set voltage Regulator mode during low power modes
   * @rmtoll CR    LPSDSR       LL_PWR_SetRegulModeLP
   * @param  RegulMode This parameter can be one of the following values:
   *         @arg @ref LL_PWR_REGU_LPMODES_MAIN
@@ -357,7 +347,7 @@ __STATIC_INLINE void LL_PWR_SetRegulModeLP(uint32_t RegulMode)
 }
 
 /**
-  * @brief  Get voltage regulator mode during low power modes
+  * @brief  Get voltage Regulator mode during low power modes
   * @rmtoll CR    LPSDSR       LL_PWR_GetRegulModeLP
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_PWR_REGU_LPMODES_MAIN
@@ -370,7 +360,7 @@ __STATIC_INLINE uint32_t LL_PWR_GetRegulModeLP(void)
 
 #if defined(PWR_CR_LPDS)
 /**
-  * @brief  Set voltage regulator mode during deep sleep mode
+  * @brief  Set voltage Regulator mode during deep sleep mode
   * @rmtoll CR    LPDS         LL_PWR_SetRegulModeDS
   * @param  RegulMode This parameter can be one of the following values:
   *         @arg @ref LL_PWR_REGU_DSMODE_MAIN
@@ -383,7 +373,7 @@ __STATIC_INLINE void LL_PWR_SetRegulModeDS(uint32_t RegulMode)
 }
 
 /**
-  * @brief  Get voltage regulator mode during deep sleep mode
+  * @brief  Get voltage Regulator mode during deep sleep mode
   * @rmtoll CR    LPDS         LL_PWR_GetRegulModeDS
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_PWR_REGU_DSMODE_MAIN
@@ -396,15 +386,15 @@ __STATIC_INLINE uint32_t LL_PWR_GetRegulModeDS(void)
 #endif /* PWR_CR_LPDS */
 
 /**
-  * @brief  Set power down mode when CPU enters deepsleep
+  * @brief  Set Power Down mode when CPU enters deepsleep
   * @rmtoll CR    PDDS         LL_PWR_SetPowerMode
   * @param  PDMode This parameter can be one of the following values:
   *         @arg @ref LL_PWR_MODE_STOP
   *         @arg @ref LL_PWR_MODE_STANDBY
-  * @note   Set the regulator to low power (bit @ref LL_PWR_REGU_LPMODES_LOW_POWER)  
-  *         before setting MODE_STOP. If the regulator remains in "main mode",   
+  * @note   Set the Regulator to low power (bit @ref LL_PWR_REGU_LPMODES_LOW_POWER)  
+  *         before setting MODE_STOP. If the Regulator remains in "main mode",   
   *         it consumes more power without providing any additional feature. 
-  *         In MODE_STANDBY the regulator is automatically off.
+  *         In MODE_STANDBY the Regulator is automatically off.
   * @retval None
   */
 __STATIC_INLINE void LL_PWR_SetPowerMode(uint32_t PDMode)
@@ -413,7 +403,7 @@ __STATIC_INLINE void LL_PWR_SetPowerMode(uint32_t PDMode)
 }
 
 /**
-  * @brief  Get power down mode when CPU enters deepsleep
+  * @brief  Get Power Down mode when CPU enters deepsleep
   * @rmtoll CR    PDDS         LL_PWR_GetPowerMode
   * @retval Returned value can be one of the following values:
   *         @arg @ref LL_PWR_MODE_STOP
@@ -424,7 +414,7 @@ __STATIC_INLINE uint32_t LL_PWR_GetPowerMode(void)
   return (uint32_t)(READ_BIT(PWR->CR, PWR_CR_PDDS));
 }
 
-#if defined (PWR_PVD_SUPPORT)
+#if defined(PWR_PVD_SUPPORT)
 /**
   * @brief  Configure the voltage threshold detected by the Power Voltage Detector
   * @rmtoll CR    PLS       LL_PWR_SetPVDLevel
@@ -491,13 +481,13 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledPVD(void)
 {
   return (READ_BIT(PWR->CR, PWR_CR_PVDE) == (PWR_CR_PVDE));
 }
-#endif
+#endif /* PWR_PVD_SUPPORT */
 
 /**
   * @brief  Enable the WakeUp PINx functionality
   * @rmtoll CSR   EWUP1       LL_PWR_EnableWakeUpPin\n
-  *         CSR   EWUP2       LL_PWR_EnableWakeUpPin\n
-  *         CSR   EWUP3       LL_PWR_EnableWakeUpPin
+  * @rmtoll CSR   EWUP2       LL_PWR_EnableWakeUpPin\n
+  * @rmtoll CSR   EWUP3       LL_PWR_EnableWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
@@ -514,8 +504,8 @@ __STATIC_INLINE void LL_PWR_EnableWakeUpPin(uint32_t WakeUpPin)
 /**
   * @brief  Disable the WakeUp PINx functionality
   * @rmtoll CSR   EWUP1       LL_PWR_DisableWakeUpPin\n
-  *         CSR   EWUP2       LL_PWR_DisableWakeUpPin\n
-  *         CSR   EWUP3       LL_PWR_DisableWakeUpPin
+  * @rmtoll CSR   EWUP2       LL_PWR_DisableWakeUpPin\n
+  * @rmtoll CSR   EWUP3       LL_PWR_DisableWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
@@ -532,8 +522,8 @@ __STATIC_INLINE void LL_PWR_DisableWakeUpPin(uint32_t WakeUpPin)
 /**
   * @brief  Check if the WakeUp PINx functionality is enabled
   * @rmtoll CSR   EWUP1       LL_PWR_IsEnabledWakeUpPin\n
-  *         CSR   EWUP2       LL_PWR_IsEnabledWakeUpPin\n
-  *         CSR   EWUP3       LL_PWR_IsEnabledWakeUpPin
+  * @rmtoll CSR   EWUP2       LL_PWR_IsEnabledWakeUpPin\n
+  * @rmtoll CSR   EWUP3       LL_PWR_IsEnabledWakeUpPin
   * @param  WakeUpPin This parameter can be one of the following values:
   *         @arg @ref LL_PWR_WAKEUP_PIN1
   *         @arg @ref LL_PWR_WAKEUP_PIN2
@@ -609,6 +599,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsEnabledFastWakeUp(void)
   return (READ_BIT(PWR->CR, PWR_CR_FWU) == (PWR_CR_FWU));
 }
 
+
 /**
   * @}
   */
@@ -637,7 +628,7 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_SB(void)
   return (READ_BIT(PWR->CSR, PWR_CSR_SBF) == (PWR_CSR_SBF));
 }
 
-#if defined (PWR_PVD_SUPPORT)
+#if defined(PWR_PVD_SUPPORT)
 /**
   * @brief  Indicate whether VDD voltage is below the selected PVD threshold
   * @rmtoll CSR   PVDO       LL_PWR_IsActiveFlag_PVDO
@@ -647,9 +638,9 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_PVDO(void)
 {
   return (READ_BIT(PWR->CSR, PWR_CSR_PVDO) == (PWR_CSR_PVDO));
 }
-#endif
+#endif /* PWR_PVD_SUPPORT */
 
-#if defined (PWR_CSR_VREFINTRDYF)
+#if defined(PWR_CSR_VREFINTRDYF)
 /**
   * @brief  Get Internal Reference VrefInt Flag
   * @rmtoll CSR   VREFINTRDYF       LL_PWR_IsActiveFlag_VREFINTRDY
@@ -659,29 +650,26 @@ __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_VREFINTRDY(void)
 {
   return (READ_BIT(PWR->CSR, PWR_CSR_VREFINTRDYF) == (PWR_CSR_VREFINTRDYF));
 }
-#endif
-
+#endif /* PWR_CSR_VREFINTRDYF */
 /**
-  * @brief  Indicate whether the regulator is ready in the selected voltage range or if its output voltage is still changing to the required voltage level
-  * @rmtoll CSR   VOSF       LL_PWR_IsActiveFlag_VOSF
+  * @brief  Indicate whether the Regulator is ready in the selected voltage range or if its output voltage is still changing to the required voltage level
+  * @rmtoll CSR   VOSF       LL_PWR_IsActiveFlag_VOS
   * @retval State of bit (1 or 0).
   */
-__STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_VOSF(void)
+__STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_VOS(void)
 {
-  return (READ_BIT(PWR->CSR, PWR_CSR_VOSF) == (PWR_CSR_VOSF));
+  return (READ_BIT(PWR->CSR, LL_PWR_CSR_VOS) == (LL_PWR_CSR_VOS));
 }
-
 /**
-  * @brief Indicate whether the regulator is ready in main mode or is in low-power mode
+  * @brief Indicate whether the Regulator is ready in main mode or is in low-power mode
   * @rmtoll CSR   REGLPF       LL_PWR_IsActiveFlag_REGLPF
-  * @note Take care, return value "0" means the regulator is ready.  Return value "1" means the output voltage range is still changing.
+  * @note Take care, return value "0" means the Regulator is ready.  Return value "1" means the output voltage range is still changing.
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_PWR_IsActiveFlag_REGLPF(void)
 {
   return (READ_BIT(PWR->CSR, PWR_CSR_REGLPF) == (PWR_CSR_REGLPF));
 }
-
 /**
   * @brief  Clear Standby Flag
   * @rmtoll CR   CSBF       LL_PWR_ClearFlag_SB
@@ -702,6 +690,9 @@ __STATIC_INLINE void LL_PWR_ClearFlag_WU(void)
   SET_BIT(PWR->CR, PWR_CR_CWUF);
 }
 
+/**
+  * @}
+  */
 
 #if defined(USE_FULL_LL_DRIVER)
 /** @defgroup PWR_LL_EF_Init De-initialization function
@@ -713,6 +704,12 @@ ErrorStatus LL_PWR_DeInit(void);
   */
 #endif /* USE_FULL_LL_DRIVER */
 
+/** @defgroup PWR_LL_EF_Legacy_Functions PWR legacy functions name
+  * @{
+  */
+/* Old functions name kept for legacy purpose, to be replaced by the          */
+/* current functions name.                                                    */
+#define LL_PWR_IsActiveFlag_VOSF  LL_PWR_IsActiveFlag_VOS
 /**
   * @}
   */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_rcc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   RCC LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -124,7 +122,7 @@ ErrorStatus LL_RCC_DeInit(void)
 
   /* Reset HSEBYP bit */
   LL_RCC_HSE_DisableBypass();
- 
+
   /* Reset CFGR register */
   LL_RCC_WriteReg(CFGR, 0x00000000U);
 

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rcc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_rcc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RCC LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -58,27 +56,19 @@ extern "C" {
 
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-/** @defgroup RCC_LL_Private_Variables RCC Private Variables
-  * @{
-  */
-
-/**
-  * @}
-  */
-
 /* Private constants ---------------------------------------------------------*/
 /** @defgroup RCC_LL_Private_Constants RCC Private Constants
   * @{
   */
 /* Defines used for the bit position in the register and perform offsets*/
+#define RCC_POSITION_MSICAL     (uint32_t)POSITION_VAL(RCC_ICSCR_MSICAL)  /*!< field position in register RCC_ICSCR */
+#define RCC_POSITION_MSITRIM    (uint32_t)POSITION_VAL(RCC_ICSCR_MSITRIM) /*!< field position in register RCC_ICSCR */
+#define RCC_POSITION_MSIRANGE   (uint32_t)POSITION_VAL(RCC_ICSCR_MSIRANGE) /*!< field position in register RCC_ICSCR */
 #define RCC_POSITION_HPRE       (uint32_t)POSITION_VAL(RCC_CFGR_HPRE)     /*!< field position in register RCC_CFGR */
 #define RCC_POSITION_PPRE1      (uint32_t)POSITION_VAL(RCC_CFGR_PPRE1)    /*!< field position in register RCC_CFGR */
 #define RCC_POSITION_PPRE2      (uint32_t)POSITION_VAL(RCC_CFGR_PPRE2)    /*!< field position in register RCC_CFGR */
 #define RCC_POSITION_HSICAL     (uint32_t)POSITION_VAL(RCC_ICSCR_HSICAL)     /*!< field position in register RCC_ICSCR */
 #define RCC_POSITION_HSITRIM    (uint32_t)POSITION_VAL(RCC_ICSCR_HSITRIM)    /*!< field position in register RCC_ICSCR */
-#define RCC_POSITION_MSICAL     (uint32_t)POSITION_VAL(RCC_ICSCR_MSICAL)  /*!< field position in register RCC_ICSCR */
-#define RCC_POSITION_MSITRIM    (uint32_t)POSITION_VAL(RCC_ICSCR_MSITRIM) /*!< field position in register RCC_ICSCR */
-#define RCC_POSITION_MSIRANGE   (uint32_t)POSITION_VAL(RCC_ICSCR_MSIRANGE) /*!< field position in register RCC_ICSCR */
 #define RCC_POSITION_PLLMUL     (uint32_t)POSITION_VAL(RCC_CFGR_PLLMUL)   /*!< field position in register RCC_CFGR */
 #define RCC_POSITION_PLLDIV     (uint32_t)POSITION_VAL(RCC_CFGR_PLLDIV)   /*!< field position in register RCC_CFGR */
 
@@ -129,19 +119,19 @@ typedef struct
   * @{
   */
 #if !defined  (HSE_VALUE)
-#define HSE_VALUE    ((uint32_t)8000000U)  /*!< Value of the HSE oscillator in Hz */
+#define HSE_VALUE    8000000U  /*!< Value of the HSE oscillator in Hz */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSI_VALUE)
-#define HSI_VALUE    ((uint32_t)16000000U) /*!< Value of the HSI oscillator in Hz */
+#define HSI_VALUE    16000000U  /*!< Value of the HSI oscillator in Hz */
 #endif /* HSI_VALUE */
 
 #if !defined  (LSE_VALUE)
-#define LSE_VALUE    ((uint32_t)32768U)    /*!< Value of the LSE oscillator in Hz */
+#define LSE_VALUE    32768U    /*!< Value of the LSE oscillator in Hz */
 #endif /* LSE_VALUE */
 
 #if !defined  (LSI_VALUE)
-#define LSI_VALUE    ((uint32_t)32000U)    /*!< Value of the LSI oscillator in Hz */
+#define LSI_VALUE    32000U    /*!< Value of the LSI oscillator in Hz */
 #endif /* LSI_VALUE */
 /**
   * @}
@@ -210,7 +200,7 @@ typedef struct
 /** @defgroup RCC_LL_EC_RTC_HSE_DIV RTC HSE Prescaler
   * @{
   */
-#define LL_RCC_RTC_HSE_DIV_2               (uint32_t)0x00000000U/*!< HSE is divided by 2 for RTC clock  */
+#define LL_RCC_RTC_HSE_DIV_2               0x00000000U          /*!< HSE is divided by 2 for RTC clock  */
 #define LL_RCC_RTC_HSE_DIV_4               RCC_CR_RTCPRE_0      /*!< HSE is divided by 4 for RTC clock  */
 #define LL_RCC_RTC_HSE_DIV_8               RCC_CR_RTCPRE_1      /*!< HSE is divided by 8 for RTC clock  */
 #define LL_RCC_RTC_HSE_DIV_16              RCC_CR_RTCPRE        /*!< HSE is divided by 16 for RTC clock */
@@ -324,8 +314,8 @@ typedef struct
 /** @defgroup RCC_LL_EC_PERIPH_FREQUENCY Peripheral clock frequency
   * @{
   */
-#define LL_RCC_PERIPH_FREQUENCY_NO         (uint32_t)0x00000000U      /*!< No clock enabled for the peripheral            */
-#define LL_RCC_PERIPH_FREQUENCY_NA         (uint32_t)0xFFFFFFFFU      /*!< Frequency cannot be provided as external clock */
+#define LL_RCC_PERIPH_FREQUENCY_NO         0x00000000U      /*!< No clock enabled for the peripheral            */
+#define LL_RCC_PERIPH_FREQUENCY_NA         0xFFFFFFFFU      /*!< Frequency cannot be provided as external clock */
 /**
   * @}
   */
@@ -336,7 +326,7 @@ typedef struct
 /** @defgroup RCC_LL_EC_RTC_CLKSOURCE  RTC clock source selection
   * @{
   */
-#define LL_RCC_RTC_CLKSOURCE_NONE          (uint32_t)0x00000000U         /*!< No clock used as RTC clock */
+#define LL_RCC_RTC_CLKSOURCE_NONE          0x00000000U                   /*!< No clock used as RTC clock */
 #define LL_RCC_RTC_CLKSOURCE_LSE           RCC_CSR_RTCSEL_LSE            /*!< LSE oscillator clock used as RTC clock */
 #define LL_RCC_RTC_CLKSOURCE_LSI           RCC_CSR_RTCSEL_LSI            /*!< LSI oscillator clock used as RTC clock */
 #define LL_RCC_RTC_CLKSOURCE_HSE           RCC_CSR_RTCSEL_HSE            /*!< HSE oscillator clock divided by a programmable prescaler 
@@ -456,7 +446,7 @@ typedef struct
   *         @arg @ref LL_RCC_SYSCLK_DIV_512
   * @retval HCLK clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_HCLK_FREQ(__SYSCLKFREQ__, __AHBPRESCALER__) ((__SYSCLKFREQ__) >> AHBPrescTable[((__AHBPRESCALER__) & RCC_CFGR_HPRE) >>  RCC_POSITION_HPRE])
+#define __LL_RCC_CALC_HCLK_FREQ(__SYSCLKFREQ__, __AHBPRESCALER__) ((__SYSCLKFREQ__) >> AHBPrescTable[((__AHBPRESCALER__) & RCC_CFGR_HPRE) >>  RCC_CFGR_HPRE_Pos])
 
 /**
   * @brief  Helper macro to calculate the PCLK1 frequency (ABP1)
@@ -471,7 +461,7 @@ typedef struct
   *         @arg @ref LL_RCC_APB1_DIV_16
   * @retval PCLK1 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__) ((__HCLKFREQ__) >> APBPrescTable[(__APB1PRESCALER__) >>  RCC_POSITION_PPRE1])
+#define __LL_RCC_CALC_PCLK1_FREQ(__HCLKFREQ__, __APB1PRESCALER__) ((__HCLKFREQ__) >> APBPrescTable[(__APB1PRESCALER__) >>  RCC_CFGR_PPRE1_Pos])
 
 /**
   * @brief  Helper macro to calculate the PCLK2 frequency (ABP2)
@@ -486,7 +476,7 @@ typedef struct
   *         @arg @ref LL_RCC_APB2_DIV_16
   * @retval PCLK2 clock frequency (in Hz)
   */
-#define __LL_RCC_CALC_PCLK2_FREQ(__HCLKFREQ__, __APB2PRESCALER__) ((__HCLKFREQ__) >> APBPrescTable[(__APB2PRESCALER__) >>  RCC_POSITION_PPRE2])
+#define __LL_RCC_CALC_PCLK2_FREQ(__HCLKFREQ__, __APB2PRESCALER__) ((__HCLKFREQ__) >> APBPrescTable[(__APB2PRESCALER__) >>  RCC_CFGR_PPRE2_Pos])
 
 /**
   * @brief  Helper macro to calculate the MSI frequency (in Hz)
@@ -668,7 +658,7 @@ __STATIC_INLINE uint32_t LL_RCC_HSI_IsReady(void)
   */
 __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibration(void)
 {
-  return (uint32_t)(READ_BIT(RCC->ICSCR, RCC_ICSCR_HSICAL) >> RCC_POSITION_HSICAL);
+  return (uint32_t)(READ_BIT(RCC->ICSCR, RCC_ICSCR_HSICAL) >> RCC_ICSCR_HSICAL_Pos);
 }
 
 /**
@@ -682,7 +672,7 @@ __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibration(void)
   */
 __STATIC_INLINE void LL_RCC_HSI_SetCalibTrimming(uint32_t Value)
 {
-  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, Value << RCC_POSITION_HSITRIM);
+  MODIFY_REG(RCC->ICSCR, RCC_ICSCR_HSITRIM, Value << RCC_ICSCR_HSITRIM_Pos);
 }
 
 /**
@@ -692,7 +682,7 @@ __STATIC_INLINE void LL_RCC_HSI_SetCalibTrimming(uint32_t Value)
   */
 __STATIC_INLINE uint32_t LL_RCC_HSI_GetCalibTrimming(void)
 {
-  return (uint32_t)(READ_BIT(RCC->ICSCR, RCC_ICSCR_HSITRIM) >> RCC_POSITION_HSITRIM);
+  return (uint32_t)(READ_BIT(RCC->ICSCR, RCC_ICSCR_HSITRIM) >> RCC_ICSCR_HSITRIM_Pos);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rtc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rtc.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_rtc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   RTC LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -62,12 +60,12 @@
   * @{
   */
 /* Default values used for prescaler */
-#define RTC_ASYNCH_PRESC_DEFAULT     ((uint32_t) 0x0000007FU)
-#define RTC_SYNCH_PRESC_DEFAULT      ((uint32_t) 0x000000FFU)
+#define RTC_ASYNCH_PRESC_DEFAULT     0x0000007FU
+#define RTC_SYNCH_PRESC_DEFAULT      0x000000FFU
 
 /* Values used for timeout */
-#define RTC_INITMODE_TIMEOUT         ((uint32_t) 1000U) /* 1s when tick set to 1ms */
-#define RTC_SYNCHRO_TIMEOUT          ((uint32_t) 1000U) /* 1s when tick set to 1ms */
+#define RTC_INITMODE_TIMEOUT         1000U /* 1s when tick set to 1ms */
+#define RTC_SYNCHRO_TIMEOUT          1000U /* 1s when tick set to 1ms */
 /**
   * @}
   */
@@ -80,9 +78,9 @@
 #define IS_LL_RTC_HOURFORMAT(__VALUE__) (((__VALUE__) == LL_RTC_HOURFORMAT_24HOUR) \
                                       || ((__VALUE__) == LL_RTC_HOURFORMAT_AMPM))
 
-#define IS_LL_RTC_ASYNCH_PREDIV(__VALUE__)   ((__VALUE__) <= (uint32_t)0x7FU)
+#define IS_LL_RTC_ASYNCH_PREDIV(__VALUE__)   ((__VALUE__) <= 0x7FU)
 
-#define IS_LL_RTC_SYNCH_PREDIV(__VALUE__)    ((__VALUE__) <= (uint32_t)0x7FFFU)
+#define IS_LL_RTC_SYNCH_PREDIV(__VALUE__)    ((__VALUE__) <= 0x7FFFU)
 
 #define IS_LL_RTC_FORMAT(__VALUE__) (((__VALUE__) == LL_RTC_FORMAT_BIN) \
                                   || ((__VALUE__) == LL_RTC_FORMAT_BCD))
@@ -103,7 +101,7 @@
                                    || ((__VALUE__) == LL_RTC_WEEKDAY_SATURDAY) \
                                    || ((__VALUE__) == LL_RTC_WEEKDAY_SUNDAY))
 
-#define IS_LL_RTC_DAY(__DAY__)    (((__DAY__) >= (uint32_t)1U) && ((__DAY__) <= (uint32_t)31U))
+#define IS_LL_RTC_DAY(__DAY__)    (((__DAY__) >= 1U) && ((__DAY__) <= 31U))
 
 #define IS_LL_RTC_MONTH(__VALUE__) (((__VALUE__) == LL_RTC_MONTH_JANUARY) \
                                  || ((__VALUE__) == LL_RTC_MONTH_FEBRUARY) \

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rtc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_rtc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_rtc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of RTC LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -63,58 +61,20 @@ extern "C" {
   * @{
   */
 /* Masks Definition */
-#define RTC_INIT_MASK                 ((uint32_t)0xFFFFFFFFU)
-#define RTC_RSF_MASK                  ((uint32_t)0xFFFFFF5FU)
+#define RTC_INIT_MASK                 (0xFFFFFFFFU)
+#define RTC_RSF_MASK                  (0xFFFFFF5FU)
 
 /* Write protection defines */
 #define RTC_WRITE_PROTECTION_DISABLE  ((uint8_t)0xFFU)
 #define RTC_WRITE_PROTECTION_ENABLE_1 ((uint8_t)0xCAU)
 #define RTC_WRITE_PROTECTION_ENABLE_2 ((uint8_t)0x53U)
 
-/* Defines used for the bit position in the register and perform offsets */
-#define RTC_POSITION_TR_HT            (uint32_t)POSITION_VAL(RTC_TR_HT)
-#define RTC_POSITION_TR_HU            (uint32_t)POSITION_VAL(RTC_TR_HU)
-#define RTC_POSITION_TR_MT            (uint32_t)POSITION_VAL(RTC_TR_MNT)
-#define RTC_POSITION_TR_MU            (uint32_t)POSITION_VAL(RTC_TR_MNU)
-#define RTC_POSITION_TR_ST            (uint32_t)POSITION_VAL(RTC_TR_ST)
-#define RTC_POSITION_TR_SU            (uint32_t)POSITION_VAL(RTC_TR_SU)
-#define RTC_POSITION_DR_YT            (uint32_t)POSITION_VAL(RTC_DR_YT)
-#define RTC_POSITION_DR_YU            (uint32_t)POSITION_VAL(RTC_DR_YU)
-#define RTC_POSITION_DR_MT            (uint32_t)POSITION_VAL(RTC_DR_MT)
-#define RTC_POSITION_DR_MU            (uint32_t)POSITION_VAL(RTC_DR_MU)
-#define RTC_POSITION_DR_DT            (uint32_t)POSITION_VAL(RTC_DR_DT)
-#define RTC_POSITION_DR_DU            (uint32_t)POSITION_VAL(RTC_DR_DU)
-#define RTC_POSITION_DR_WDU           (uint32_t)POSITION_VAL(RTC_DR_WDU)
-#define RTC_POSITION_ALMA_DT          (uint32_t)POSITION_VAL(RTC_ALRMAR_DT)
-#define RTC_POSITION_ALMA_DU          (uint32_t)POSITION_VAL(RTC_ALRMAR_DU)
-#define RTC_POSITION_ALMA_HT          (uint32_t)POSITION_VAL(RTC_ALRMAR_HT)
-#define RTC_POSITION_ALMA_HU          (uint32_t)POSITION_VAL(RTC_ALRMAR_HU)
-#define RTC_POSITION_ALMA_MT          (uint32_t)POSITION_VAL(RTC_ALRMAR_MNT)
-#define RTC_POSITION_ALMA_MU          (uint32_t)POSITION_VAL(RTC_ALRMAR_MNU)
-#define RTC_POSITION_ALMA_SU          (uint32_t)POSITION_VAL(RTC_ALRMAR_SU)
-#define RTC_POSITION_ALMA_ST          (uint32_t)POSITION_VAL(RTC_ALRMAR_ST)
-#define RTC_POSITION_ALMB_DT          (uint32_t)POSITION_VAL(RTC_ALRMBR_DT)
-#define RTC_POSITION_ALMB_DU          (uint32_t)POSITION_VAL(RTC_ALRMBR_DU)
-#define RTC_POSITION_ALMB_HT          (uint32_t)POSITION_VAL(RTC_ALRMBR_HT)
-#define RTC_POSITION_ALMB_HU          (uint32_t)POSITION_VAL(RTC_ALRMBR_HU)
-#define RTC_POSITION_ALMB_MT          (uint32_t)POSITION_VAL(RTC_ALRMBR_MNT)
-#define RTC_POSITION_ALMB_MU          (uint32_t)POSITION_VAL(RTC_ALRMBR_MNU)
-#define RTC_POSITION_ALMB_SU          (uint32_t)POSITION_VAL(RTC_ALRMBR_SU)
-#define RTC_POSITION_ALMB_ST          (uint32_t)POSITION_VAL(RTC_ALRMBR_ST)
-#define RTC_POSITION_PRER_PREDIV_A    (uint32_t)POSITION_VAL(RTC_PRER_PREDIV_A)
-#define RTC_POSITION_ALMA_MASKSS      (uint32_t)POSITION_VAL(RTC_ALRMASSR_MASKSS)
-#define RTC_POSITION_ALMB_MASKSS      (uint32_t)POSITION_VAL(RTC_ALRMBSSR_MASKSS)
-#define RTC_POSITION_TS_HU            (uint32_t)POSITION_VAL(RTC_TSTR_HU)
-#define RTC_POSITION_TS_MNU           (uint32_t)POSITION_VAL(RTC_TSTR_MNU)
-#define RTC_POSITION_TS_WDU           (uint32_t)POSITION_VAL(RTC_TSDR_WDU)
-#define RTC_POSITION_TS_MU            (uint32_t)POSITION_VAL(RTC_TSDR_MU)
-
 /* Defines used to combine date & time */
-#define RTC_OFFSET_WEEKDAY            (uint32_t)24U
-#define RTC_OFFSET_DAY                (uint32_t)16U
-#define RTC_OFFSET_MONTH              (uint32_t)8U
-#define RTC_OFFSET_HOUR               (uint32_t)16U
-#define RTC_OFFSET_MINUTE             (uint32_t)8U
+#define RTC_OFFSET_WEEKDAY            24U
+#define RTC_OFFSET_DAY                16U
+#define RTC_OFFSET_MONTH              8U
+#define RTC_OFFSET_HOUR               16U
+#define RTC_OFFSET_MINUTE             8U
 
 /**
   * @}
@@ -261,8 +221,8 @@ typedef struct
 /** @defgroup RTC_LL_EC_FORMAT FORMAT
   * @{
   */
-#define LL_RTC_FORMAT_BIN                  ((uint32_t)0x000000000U) /*!< Binary data format */
-#define LL_RTC_FORMAT_BCD                  ((uint32_t)0x000000001U) /*!< BCD data format */
+#define LL_RTC_FORMAT_BIN                  0x000000000U /*!< Binary data format */
+#define LL_RTC_FORMAT_BCD                  0x000000001U /*!< BCD data format */
 /**
   * @}
   */
@@ -270,7 +230,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMA_WEEKDAY_SELECTION RTC Alarm A Date WeekDay
   * @{
   */
-#define LL_RTC_ALMA_DATEWEEKDAYSEL_DATE    ((uint32_t)0x00000000U) /*!< Alarm A Date is selected */
+#define LL_RTC_ALMA_DATEWEEKDAYSEL_DATE    0x00000000U             /*!< Alarm A Date is selected */
 #define LL_RTC_ALMA_DATEWEEKDAYSEL_WEEKDAY RTC_ALRMAR_WDSEL        /*!< Alarm A WeekDay is selected */
 /**
   * @}
@@ -279,7 +239,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMB_WEEKDAY_SELECTION RTC Alarm B Date WeekDay
   * @{
   */
-#define LL_RTC_ALMB_DATEWEEKDAYSEL_DATE    ((uint32_t)0x00000000U) /*!< Alarm B Date is selected */
+#define LL_RTC_ALMB_DATEWEEKDAYSEL_DATE    0x00000000U             /*!< Alarm B Date is selected */
 #define LL_RTC_ALMB_DATEWEEKDAYSEL_WEEKDAY RTC_ALRMBR_WDSEL        /*!< Alarm B WeekDay is selected */
 /**
   * @}
@@ -362,7 +322,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_HOURFORMAT  HOUR FORMAT
   * @{
   */
-#define LL_RTC_HOURFORMAT_24HOUR           (uint32_t)0x00000000U /*!< 24 hour/day format */
+#define LL_RTC_HOURFORMAT_24HOUR           0x00000000U           /*!< 24 hour/day format */
 #define LL_RTC_HOURFORMAT_AMPM             RTC_CR_FMT            /*!< AM/PM hour format */
 /**
   * @}
@@ -371,7 +331,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALARMOUT  ALARM OUTPUT
   * @{
   */
-#define LL_RTC_ALARMOUT_DISABLE            ((uint32_t)0x00000000U) /*!< Output disabled */
+#define LL_RTC_ALARMOUT_DISABLE            0x00000000U             /*!< Output disabled */
 #define LL_RTC_ALARMOUT_ALMA               RTC_CR_OSEL_0           /*!< Alarm A output enabled */
 #define LL_RTC_ALARMOUT_ALMB               RTC_CR_OSEL_1           /*!< Alarm B output enabled */
 #define LL_RTC_ALARMOUT_WAKEUP             RTC_CR_OSEL             /*!< Wakeup output enabled */
@@ -382,7 +342,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALARM_OUTPUTTYPE  ALARM OUTPUT TYPE
   * @{
   */
-#define LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN  (uint32_t)0x00000000U  /*!< RTC_ALARM, when mapped on PC13, is open-drain output */
+#define LL_RTC_ALARM_OUTPUTTYPE_OPENDRAIN  0x00000000U                          /*!< RTC_ALARM, when mapped on PC13, is open-drain output */
 #define LL_RTC_ALARM_OUTPUTTYPE_PUSHPULL   RTC_TAFCR_ALARMOUTTYPE /*!< RTC_ALARM, when mapped on PC13, is push-pull output */
 /**
   * @}
@@ -391,7 +351,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_OUTPUTPOLARITY_PIN  OUTPUT POLARITY PIN
   * @{
   */
-#define LL_RTC_OUTPUTPOLARITY_PIN_HIGH     (uint32_t)0x00000000U /*!< Pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL)*/
+#define LL_RTC_OUTPUTPOLARITY_PIN_HIGH     0x00000000U           /*!< Pin is high when ALRAF/ALRBF/WUTF is asserted (depending on OSEL)*/
 #define LL_RTC_OUTPUTPOLARITY_PIN_LOW      RTC_CR_POL            /*!< Pin is low when ALRAF/ALRBF/WUTF is asserted (depending on OSEL) */
 /**
   * @}
@@ -400,7 +360,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TIME_FORMAT TIME FORMAT
   * @{
   */
-#define LL_RTC_TIME_FORMAT_AM_OR_24        (uint32_t)0x00000000U /*!< AM or 24-hour format */
+#define LL_RTC_TIME_FORMAT_AM_OR_24        0x00000000U           /*!< AM or 24-hour format */
 #define LL_RTC_TIME_FORMAT_PM              RTC_TR_PM             /*!< PM */
 /**
   * @}
@@ -410,7 +370,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_SHIFT_SECOND  SHIFT SECOND
   * @{
   */
-#define LL_RTC_SHIFT_SECOND_DELAY          (uint32_t)0x00000000U /* Delay (seconds) = SUBFS / (PREDIV_S + 1) */
+#define LL_RTC_SHIFT_SECOND_DELAY          0x00000000U           /* Delay (seconds) = SUBFS / (PREDIV_S + 1) */
 #define LL_RTC_SHIFT_SECOND_ADVANCE        RTC_SHIFTR_ADD1S      /* Advance (seconds) = (1 - (SUBFS / (PREDIV_S + 1))) */
 /**
   * @}
@@ -420,7 +380,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMA_MASK  ALARMA MASK
   * @{
   */
-#define LL_RTC_ALMA_MASK_NONE              ((uint32_t)0x00000000U) /*!< No masks applied on Alarm A*/
+#define LL_RTC_ALMA_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm A*/
 #define LL_RTC_ALMA_MASK_DATEWEEKDAY       RTC_ALRMAR_MSK4         /*!< Date/day do not care in Alarm A comparison */
 #define LL_RTC_ALMA_MASK_HOURS             RTC_ALRMAR_MSK3         /*!< Hours do not care in Alarm A comparison */
 #define LL_RTC_ALMA_MASK_MINUTES           RTC_ALRMAR_MSK2         /*!< Minutes do not care in Alarm A comparison */
@@ -433,7 +393,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMA_TIME_FORMAT  ALARMA TIME FORMAT
   * @{
   */
-#define LL_RTC_ALMA_TIME_FORMAT_AM         (uint32_t)0x00000000U /*!< AM or 24-hour format */
+#define LL_RTC_ALMA_TIME_FORMAT_AM         0x00000000U           /*!< AM or 24-hour format */
 #define LL_RTC_ALMA_TIME_FORMAT_PM         RTC_ALRMAR_PM         /*!< PM */
 /**
   * @}
@@ -442,7 +402,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMB_MASK  ALARMB MASK
   * @{
   */
-#define LL_RTC_ALMB_MASK_NONE              ((uint32_t)0x00000000U) /*!< No masks applied on Alarm B*/
+#define LL_RTC_ALMB_MASK_NONE              0x00000000U             /*!< No masks applied on Alarm B*/
 #define LL_RTC_ALMB_MASK_DATEWEEKDAY       RTC_ALRMBR_MSK4         /*!< Date/day do not care in Alarm B comparison */
 #define LL_RTC_ALMB_MASK_HOURS             RTC_ALRMBR_MSK3         /*!< Hours do not care in Alarm B comparison */
 #define LL_RTC_ALMB_MASK_MINUTES           RTC_ALRMBR_MSK2         /*!< Minutes do not care in Alarm B comparison */
@@ -455,7 +415,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_ALMB_TIME_FORMAT  ALARMB TIME FORMAT
   * @{
   */
-#define LL_RTC_ALMB_TIME_FORMAT_AM         (uint32_t)0x00000000U /*!< AM or 24-hour format */
+#define LL_RTC_ALMB_TIME_FORMAT_AM         0x00000000U           /*!< AM or 24-hour format */
 #define LL_RTC_ALMB_TIME_FORMAT_PM         RTC_ALRMBR_PM         /*!< PM */
 /**
   * @}
@@ -464,7 +424,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TIMESTAMP_EDGE  TIMESTAMP EDGE
   * @{
   */
-#define LL_RTC_TIMESTAMP_EDGE_RISING       (uint32_t)0x00000000U /*!< RTC_TS input rising edge generates a time-stamp event */
+#define LL_RTC_TIMESTAMP_EDGE_RISING       0x00000000U           /*!< RTC_TS input rising edge generates a time-stamp event */
 #define LL_RTC_TIMESTAMP_EDGE_FALLING      RTC_CR_TSEDGE         /*!< RTC_TS input falling edge generates a time-stamp even */
 /**
   * @}
@@ -473,7 +433,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TS_TIME_FORMAT  TIMESTAMP TIME FORMAT
   * @{
   */
-#define LL_RTC_TS_TIME_FORMAT_AM           (uint32_t)0x00000000U /*!< AM or 24-hour format */
+#define LL_RTC_TS_TIME_FORMAT_AM           0x00000000U           /*!< AM or 24-hour format */
 #define LL_RTC_TS_TIME_FORMAT_PM           RTC_TSTR_PM           /*!< PM */
 /**
   * @}
@@ -531,7 +491,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TAMPER_DURATION  TAMPER DURATION
   * @{
   */
-#define LL_RTC_TAMPER_DURATION_1RTCCLK     ((uint32_t)0x00000000U) /*!< Tamper pins are pre-charged before sampling during 1 RTCCLK cycle  */
+#define LL_RTC_TAMPER_DURATION_1RTCCLK     0x00000000U                             /*!< Tamper pins are pre-charged before sampling during 1 RTCCLK cycle  */
 #define LL_RTC_TAMPER_DURATION_2RTCCLK     RTC_TAFCR_TAMPPRCH_0  /*!< Tamper pins are pre-charged before sampling during 2 RTCCLK cycles */
 #define LL_RTC_TAMPER_DURATION_4RTCCLK     RTC_TAFCR_TAMPPRCH_1  /*!< Tamper pins are pre-charged before sampling during 4 RTCCLK cycles */
 #define LL_RTC_TAMPER_DURATION_8RTCCLK     RTC_TAFCR_TAMPPRCH    /*!< Tamper pins are pre-charged before sampling during 8 RTCCLK cycles */
@@ -544,7 +504,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TAMPER_FILTER  TAMPER FILTER
   * @{
   */
-#define LL_RTC_TAMPER_FILTER_DISABLE       ((uint32_t)0x00000000U)  /*!< Tamper filter is disabled */
+#define LL_RTC_TAMPER_FILTER_DISABLE       0x00000000U                              /*!< Tamper filter is disabled */
 #define LL_RTC_TAMPER_FILTER_2SAMPLE       RTC_TAFCR_TAMPFLT_0    /*!< Tamper is activated after 2 consecutive samples at the active level */
 #define LL_RTC_TAMPER_FILTER_4SAMPLE       RTC_TAFCR_TAMPFLT_1    /*!< Tamper is activated after 4 consecutive samples at the active level */
 #define LL_RTC_TAMPER_FILTER_8SAMPLE       RTC_TAFCR_TAMPFLT      /*!< Tamper is activated after 8 consecutive samples at the active level. */
@@ -557,7 +517,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_TAMPER_SAMPLFREQDIV  TAMPER SAMPLING FREQUENCY DIVIDER
   * @{
   */
-#define LL_RTC_TAMPER_SAMPLFREQDIV_32768   ((uint32_t)0x00000000U)                          /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 32768 */
+#define LL_RTC_TAMPER_SAMPLFREQDIV_32768   0x00000000U                                                      /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 32768 */
 #define LL_RTC_TAMPER_SAMPLFREQDIV_16384   RTC_TAFCR_TAMPFREQ_0                           /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 16384 */
 #define LL_RTC_TAMPER_SAMPLFREQDIV_8192    RTC_TAFCR_TAMPFREQ_1                           /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 8192 */
 #define LL_RTC_TAMPER_SAMPLFREQDIV_4096    (RTC_TAFCR_TAMPFREQ_1 | RTC_TAFCR_TAMPFREQ_0) /*!< Each of the tamper inputs are sampled with a frequency =  RTCCLK / 4096 */
@@ -589,7 +549,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_WAKEUPCLOCK_DIV  WAKEUP CLOCK DIV
   * @{
   */
-#define LL_RTC_WAKEUPCLOCK_DIV_16          ((uint32_t)0x00000000U)               /*!< RTC/16 clock is selected */
+#define LL_RTC_WAKEUPCLOCK_DIV_16          0x00000000U                           /*!< RTC/16 clock is selected */
 #define LL_RTC_WAKEUPCLOCK_DIV_8           (RTC_CR_WUCKSEL_0)                    /*!< RTC/8 clock is selected */
 #define LL_RTC_WAKEUPCLOCK_DIV_4           (RTC_CR_WUCKSEL_1)                    /*!< RTC/4 clock is selected */
 #define LL_RTC_WAKEUPCLOCK_DIV_2           (RTC_CR_WUCKSEL_1 | RTC_CR_WUCKSEL_0) /*!< RTC/2 clock is selected */
@@ -603,45 +563,45 @@ typedef struct
 /** @defgroup RTC_LL_EC_BKP  BACKUP
   * @{
   */
-#define LL_RTC_BKP_DR0                     ((uint32_t)0x00000000U)
-#define LL_RTC_BKP_DR1                     ((uint32_t)0x00000001U)
-#define LL_RTC_BKP_DR2                     ((uint32_t)0x00000002U)
-#define LL_RTC_BKP_DR3                     ((uint32_t)0x00000003U)
-#define LL_RTC_BKP_DR4                     ((uint32_t)0x00000004U)
+#define LL_RTC_BKP_DR0                     0x00000000U
+#define LL_RTC_BKP_DR1                     0x00000001U
+#define LL_RTC_BKP_DR2                     0x00000002U
+#define LL_RTC_BKP_DR3                     0x00000003U
+#define LL_RTC_BKP_DR4                     0x00000004U
 #if RTC_BKP_NUMBER > 5
-#define LL_RTC_BKP_DR5                     ((uint32_t)0x00000005U)
-#define LL_RTC_BKP_DR6                     ((uint32_t)0x00000006U)
-#define LL_RTC_BKP_DR7                     ((uint32_t)0x00000007U)
-#define LL_RTC_BKP_DR8                     ((uint32_t)0x00000008U)
-#define LL_RTC_BKP_DR9                     ((uint32_t)0x00000009U)
-#define LL_RTC_BKP_DR10                    ((uint32_t)0x0000000AU)
-#define LL_RTC_BKP_DR11                    ((uint32_t)0x0000000BU)
-#define LL_RTC_BKP_DR12                    ((uint32_t)0x0000000CU)
-#define LL_RTC_BKP_DR13                    ((uint32_t)0x0000000DU)
-#define LL_RTC_BKP_DR14                    ((uint32_t)0x0000000EU)
-#define LL_RTC_BKP_DR15                    ((uint32_t)0x0000000FU)
+#define LL_RTC_BKP_DR5                     0x00000005U
+#define LL_RTC_BKP_DR6                     0x00000006U
+#define LL_RTC_BKP_DR7                     0x00000007U
+#define LL_RTC_BKP_DR8                     0x00000008U
+#define LL_RTC_BKP_DR9                     0x00000009U
+#define LL_RTC_BKP_DR10                    0x0000000AU
+#define LL_RTC_BKP_DR11                    0x0000000BU
+#define LL_RTC_BKP_DR12                    0x0000000CU
+#define LL_RTC_BKP_DR13                    0x0000000DU
+#define LL_RTC_BKP_DR14                    0x0000000EU
+#define LL_RTC_BKP_DR15                    0x0000000FU
 #endif /* RTC_BKP_NUMBER > 5 */
 
 #if RTC_BKP_NUMBER > 16
-#define LL_RTC_BKP_DR16                    ((uint32_t)0x00000010U)
-#define LL_RTC_BKP_DR17                    ((uint32_t)0x00000011U)
-#define LL_RTC_BKP_DR18                    ((uint32_t)0x00000012U)
-#define LL_RTC_BKP_DR19                    ((uint32_t)0x00000013U)
+#define LL_RTC_BKP_DR16                    0x00000010U
+#define LL_RTC_BKP_DR17                    0x00000011U
+#define LL_RTC_BKP_DR18                    0x00000012U
+#define LL_RTC_BKP_DR19                    0x00000013U
 #endif /* RTC_BKP_NUMBER > 16 */
 
 #if RTC_BKP_NUMBER > 20
-#define LL_RTC_BKP_DR20                    ((uint32_t)0x00000014U)
-#define LL_RTC_BKP_DR21                    ((uint32_t)0x00000015U)
-#define LL_RTC_BKP_DR22                    ((uint32_t)0x00000016U)
-#define LL_RTC_BKP_DR23                    ((uint32_t)0x00000017U)
-#define LL_RTC_BKP_DR24                    ((uint32_t)0x00000018U)
-#define LL_RTC_BKP_DR25                    ((uint32_t)0x00000019U)
-#define LL_RTC_BKP_DR26                    ((uint32_t)0x0000001AU)
-#define LL_RTC_BKP_DR27                    ((uint32_t)0x0000001BU)
-#define LL_RTC_BKP_DR28                    ((uint32_t)0x0000001CU)
-#define LL_RTC_BKP_DR29                    ((uint32_t)0x0000001DU)
-#define LL_RTC_BKP_DR30                    ((uint32_t)0x0000001EU)
-#define LL_RTC_BKP_DR31                    ((uint32_t)0x0000001FU)
+#define LL_RTC_BKP_DR20                    0x00000014U
+#define LL_RTC_BKP_DR21                    0x00000015U
+#define LL_RTC_BKP_DR22                    0x00000016U
+#define LL_RTC_BKP_DR23                    0x00000017U
+#define LL_RTC_BKP_DR24                    0x00000018U
+#define LL_RTC_BKP_DR25                    0x00000019U
+#define LL_RTC_BKP_DR26                    0x0000001AU
+#define LL_RTC_BKP_DR27                    0x0000001BU
+#define LL_RTC_BKP_DR28                    0x0000001CU
+#define LL_RTC_BKP_DR29                    0x0000001DU
+#define LL_RTC_BKP_DR30                    0x0000001EU
+#define LL_RTC_BKP_DR31                    0x0000001FU
 #endif /* RTC_BKP_NUMBER > 20 */
 /**
   * @}
@@ -651,11 +611,11 @@ typedef struct
 /** @defgroup RTC_LL_EC_CALIB_OUTPUT  Calibration output
   * @{
   */
-#define LL_RTC_CALIB_OUTPUT_NONE           (uint32_t)0x00000000U       /*!< Calibration output disabled */
+#define LL_RTC_CALIB_OUTPUT_NONE           0x00000000U                 /*!< Calibration output disabled */
 #if defined(RTC_CR_COSEL)
-#define LL_RTC_CALIB_OUTPUT_1HZ            (RTC_CR_COE | RTC_CR_COSEL) /*!< Calibration output is 512 Hz */
+#define LL_RTC_CALIB_OUTPUT_1HZ            (RTC_CR_COE | RTC_CR_COSEL) /*!< Calibration output is 1 Hz */
 #endif
-#define LL_RTC_CALIB_OUTPUT_512HZ          (RTC_CR_COE)                /*!< Calibration output is 1 Hz */
+#define LL_RTC_CALIB_OUTPUT_512HZ          (RTC_CR_COE)                /*!< Calibration output is 512 Hz */
 /**
   * @}
   */
@@ -663,7 +623,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_CALIB_SIGN Coarse digital calibration sign
   * @{
   */
-#define LL_RTC_CALIB_SIGN_POSITIVE         (uint32_t)0x00000000U /*!< Positive calibration: calendar update frequency is increased */
+#define LL_RTC_CALIB_SIGN_POSITIVE         0x00000000U           /*!< Positive calibration: calendar update frequency is increased */
 #define LL_RTC_CALIB_SIGN_NEGATIVE         RTC_CALIBR_DCS        /*!< Negative calibration: calendar update frequency is decreased */
 /**
   * @}
@@ -672,7 +632,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_CALIB_INSERTPULSE  Calibration pulse insertion 
   * @{
   */
-#define LL_RTC_CALIB_INSERTPULSE_NONE      (uint32_t)0x00000000U /*!< No RTCCLK pulses are added */
+#define LL_RTC_CALIB_INSERTPULSE_NONE      0x00000000U           /*!< No RTCCLK pulses are added */
 #define LL_RTC_CALIB_INSERTPULSE_SET       RTC_CALR_CALP         /*!< One RTCCLK pulse is effectively inserted every 2exp11 pulses (frequency increased by 488.5 ppm) */
 /**
   * @}
@@ -681,7 +641,7 @@ typedef struct
 /** @defgroup RTC_LL_EC_CALIB_PERIOD  Calibration period
   * @{
   */
-#define LL_RTC_CALIB_PERIOD_32SEC          (uint32_t)0x00000000U /*!< Use a 32-second calibration cycle period */
+#define LL_RTC_CALIB_PERIOD_32SEC          0x00000000U           /*!< Use a 32-second calibration cycle period */
 #define LL_RTC_CALIB_PERIOD_16SEC          RTC_CALR_CALW16       /*!< Use a 16-second calibration cycle period */
 #define LL_RTC_CALIB_PERIOD_8SEC           RTC_CALR_CALW8        /*!< Use a 8-second calibration cycle period */
 /**
@@ -1056,7 +1016,7 @@ __STATIC_INLINE void LL_RTC_DisableRefClock(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_SetAsynchPrescaler(RTC_TypeDef *RTCx, uint32_t AsynchPrescaler)
 {
-  MODIFY_REG(RTCx->PRER, RTC_PRER_PREDIV_A, AsynchPrescaler << RTC_POSITION_PRER_PREDIV_A);
+  MODIFY_REG(RTCx->PRER, RTC_PRER_PREDIV_A, AsynchPrescaler << RTC_PRER_PREDIV_A_Pos);
 }
 
 /**
@@ -1079,7 +1039,7 @@ __STATIC_INLINE void LL_RTC_SetSynchPrescaler(RTC_TypeDef *RTCx, uint32_t SynchP
   */
 __STATIC_INLINE uint32_t LL_RTC_GetAsynchPrescaler(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->PRER, RTC_PRER_PREDIV_A) >> RTC_POSITION_PRER_PREDIV_A);
+  return (uint32_t)(READ_BIT(RTCx->PRER, RTC_PRER_PREDIV_A) >> RTC_PRER_PREDIV_A_Pos);
 }
 
 /**
@@ -1171,7 +1131,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetFormat(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_TIME_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
 {
   MODIFY_REG(RTCx->TR, (RTC_TR_HT | RTC_TR_HU),
-             (((Hours & 0xF0U) << (RTC_POSITION_TR_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_TR_HU)));
+             (((Hours & 0xF0U) << (RTC_TR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos)));
 }
 
 /**
@@ -1192,7 +1152,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetHour(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->TR, (RTC_TR_HT | RTC_TR_HU));
-  return (uint32_t)((((temp & RTC_TR_HT) >> RTC_POSITION_TR_HT) << 4U) | ((temp & RTC_TR_HU) >> RTC_POSITION_TR_HU));
+  return (uint32_t)((((temp & RTC_TR_HT) >> RTC_TR_HT_Pos) << 4U) | ((temp & RTC_TR_HU) >> RTC_TR_HU_Pos));
 }
 
 /**
@@ -1209,7 +1169,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetHour(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_TIME_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
 {
   MODIFY_REG(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU),
-             (((Minutes & 0xF0U) << (RTC_POSITION_TR_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_TR_MU)));
+             (((Minutes & 0xF0U) << (RTC_TR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_TR_MNU_Pos)));
 }
 
 /**
@@ -1230,7 +1190,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetMinute(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->TR, (RTC_TR_MNT | RTC_TR_MNU));
-  return (uint32_t)((((temp & RTC_TR_MNT) >> RTC_POSITION_TR_MT) << 4U) | ((temp & RTC_TR_MNU) >> RTC_POSITION_TR_MU));
+  return (uint32_t)((((temp & RTC_TR_MNT) >> RTC_TR_MNT_Pos) << 4U) | ((temp & RTC_TR_MNU) >> RTC_TR_MNU_Pos));
 }
 
 /**
@@ -1247,7 +1207,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetMinute(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_TIME_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
 {
   MODIFY_REG(RTCx->TR, (RTC_TR_ST | RTC_TR_SU),
-             (((Seconds & 0xF0U) << (RTC_POSITION_TR_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_TR_SU)));
+             (((Seconds & 0xF0U) << (RTC_TR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos)));
 }
 
 /**
@@ -1268,7 +1228,7 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_GetSecond(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->TR, (RTC_TR_ST | RTC_TR_SU));
-  return (uint32_t)((((temp & RTC_TR_ST) >> RTC_POSITION_TR_ST) << 4U) | ((temp & RTC_TR_SU) >> RTC_POSITION_TR_SU));
+  return (uint32_t)((((temp & RTC_TR_ST) >> RTC_TR_ST_Pos) << 4U) | ((temp & RTC_TR_SU) >> RTC_TR_SU_Pos));
 }
 
 /**
@@ -1297,9 +1257,9 @@ __STATIC_INLINE void LL_RTC_TIME_Config(RTC_TypeDef *RTCx, uint32_t Format12_24,
   register uint32_t temp = 0U;
 
   temp = Format12_24                                                                                    | \
-         (((Hours & 0xF0U) << (RTC_POSITION_TR_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_TR_HU))     | \
-         (((Minutes & 0xF0U) << (RTC_POSITION_TR_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_TR_MU)) | \
-         (((Seconds & 0xF0U) << (RTC_POSITION_TR_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_TR_SU));
+         (((Hours & 0xF0U) << (RTC_TR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_TR_HU_Pos))     | \
+         (((Minutes & 0xF0U) << (RTC_TR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_TR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_TR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_TR_SU_Pos));
   MODIFY_REG(RTCx->TR, (RTC_TR_PM | RTC_TR_HT | RTC_TR_HU | RTC_TR_MNT | RTC_TR_MNU | RTC_TR_ST | RTC_TR_SU), temp);
 }
 
@@ -1328,36 +1288,36 @@ __STATIC_INLINE uint32_t LL_RTC_TIME_Get(RTC_TypeDef *RTCx)
 /**
   * @brief  Memorize whether the daylight saving time change has been performed
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @rmtoll CR           BCK           LL_RTC_TIME_EnableDayLightStore
+  * @rmtoll CR           BKP           LL_RTC_TIME_EnableDayLightStore
   * @param  RTCx RTC Instance
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TIME_EnableDayLightStore(RTC_TypeDef *RTCx)
 {
-  SET_BIT(RTCx->CR, RTC_CR_BCK);
+  SET_BIT(RTCx->CR, RTC_CR_BKP);
 }
 
 /**
   * @brief  Disable memorization whether the daylight saving time change has been performed.
   * @note   Bit is write-protected. @ref LL_RTC_DisableWriteProtection function should be called before.
-  * @rmtoll CR           BCK           LL_RTC_TIME_DisableDayLightStore
+  * @rmtoll CR           BKP           LL_RTC_TIME_DisableDayLightStore
   * @param  RTCx RTC Instance
   * @retval None
   */
 __STATIC_INLINE void LL_RTC_TIME_DisableDayLightStore(RTC_TypeDef *RTCx)
 {
-  CLEAR_BIT(RTCx->CR, RTC_CR_BCK);
+  CLEAR_BIT(RTCx->CR, RTC_CR_BKP);
 }
 
 /**
   * @brief  Check if RTC Day Light Saving stored operation has been enabled or not
-  * @rmtoll CR           BCK           LL_RTC_TIME_IsDayLightStoreEnabled
+  * @rmtoll CR           BKP           LL_RTC_TIME_IsDayLightStoreEnabled
   * @param  RTCx RTC Instance
   * @retval State of bit (1 or 0).
   */
 __STATIC_INLINE uint32_t LL_RTC_TIME_IsDayLightStoreEnabled(RTC_TypeDef *RTCx)
 {
-  return (READ_BIT(RTCx->CR, RTC_CR_BCK) == (RTC_CR_BCK));
+  return (READ_BIT(RTCx->CR, RTC_CR_BKP) == (RTC_CR_BKP));
 }
 
 /**
@@ -1445,7 +1405,7 @@ __STATIC_INLINE void LL_RTC_TIME_Synchronize(RTC_TypeDef *RTCx, uint32_t ShiftSe
 __STATIC_INLINE void LL_RTC_DATE_SetYear(RTC_TypeDef *RTCx, uint32_t Year)
 {
   MODIFY_REG(RTCx->DR, (RTC_DR_YT | RTC_DR_YU),
-             (((Year & 0xF0U) << (RTC_POSITION_DR_YT - 4U)) | ((Year & 0x0FU) << RTC_POSITION_DR_YU)));
+             (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos)));
 }
 
 /**
@@ -1463,7 +1423,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetYear(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->DR, (RTC_DR_YT | RTC_DR_YU));
-  return (uint32_t)((((temp & RTC_DR_YT) >> RTC_POSITION_DR_YT) << 4U) | ((temp & RTC_DR_YU) >> RTC_POSITION_DR_YU));
+  return (uint32_t)((((temp & RTC_DR_YT) >> RTC_DR_YT_Pos) << 4U) | ((temp & RTC_DR_YU) >> RTC_DR_YU_Pos));
 }
 
 /**
@@ -1482,7 +1442,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetYear(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_DATE_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
 {
-  MODIFY_REG(RTCx->DR, RTC_DR_WDU, WeekDay << RTC_POSITION_DR_WDU);
+  MODIFY_REG(RTCx->DR, RTC_DR_WDU, WeekDay << RTC_DR_WDU_Pos);
 }
 
 /**
@@ -1502,7 +1462,7 @@ __STATIC_INLINE void LL_RTC_DATE_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
   */
 __STATIC_INLINE uint32_t LL_RTC_DATE_GetWeekDay(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->DR, RTC_DR_WDU) >> RTC_POSITION_DR_WDU);
+  return (uint32_t)(READ_BIT(RTCx->DR, RTC_DR_WDU) >> RTC_DR_WDU_Pos);
 }
 
 /**
@@ -1529,7 +1489,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetWeekDay(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_DATE_SetMonth(RTC_TypeDef *RTCx, uint32_t Month)
 {
   MODIFY_REG(RTCx->DR, (RTC_DR_MT | RTC_DR_MU),
-             (((Month & 0xF0U) << (RTC_POSITION_DR_MT - 4U)) | ((Month & 0x0FU) << RTC_POSITION_DR_MU)));
+             (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)));
 }
 
 /**
@@ -1559,7 +1519,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetMonth(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->DR, (RTC_DR_MT | RTC_DR_MU));
-  return (uint32_t)((((temp & RTC_DR_MT) >> RTC_POSITION_DR_MT) << 4U) | ((temp & RTC_DR_MU) >> RTC_POSITION_DR_MU));
+  return (uint32_t)((((temp & RTC_DR_MT) >> RTC_DR_MT_Pos) << 4U) | ((temp & RTC_DR_MU) >> RTC_DR_MU_Pos));
 }
 
 /**
@@ -1574,7 +1534,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetMonth(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_DATE_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
 {
   MODIFY_REG(RTCx->DR, (RTC_DR_DT | RTC_DR_DU),
-             (((Day & 0xF0U) << (RTC_POSITION_DR_DT - 4U)) | ((Day & 0x0FU) << RTC_POSITION_DR_DU)));
+             (((Day & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_DR_DU_Pos)));
 }
 
 /**
@@ -1592,7 +1552,7 @@ __STATIC_INLINE uint32_t LL_RTC_DATE_GetDay(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->DR, (RTC_DR_DT | RTC_DR_DU));
-  return (uint32_t)((((temp & RTC_DR_DT) >> RTC_POSITION_DR_DT) << 4U) | ((temp & RTC_DR_DU) >> RTC_POSITION_DR_DU));
+  return (uint32_t)((((temp & RTC_DR_DT) >> RTC_DR_DT_Pos) << 4U) | ((temp & RTC_DR_DU) >> RTC_DR_DU_Pos));
 }
 
 /**
@@ -1634,10 +1594,10 @@ __STATIC_INLINE void LL_RTC_DATE_Config(RTC_TypeDef *RTCx, uint32_t WeekDay, uin
 {
   register uint32_t temp = 0U;
 
-  temp = (WeekDay << RTC_POSITION_DR_WDU)                                                        | \
-         (((Year & 0xF0U) << (RTC_POSITION_DR_YT - 4U)) | ((Year & 0x0FU) << RTC_POSITION_DR_YU))   | \
-         (((Month & 0xF0U) << (RTC_POSITION_DR_MT - 4U)) | ((Month & 0x0FU) << RTC_POSITION_DR_MU)) | \
-         (((Day & 0xF0U) << (RTC_POSITION_DR_DT - 4U)) | ((Day & 0x0FU) << RTC_POSITION_DR_DU));
+  temp = (WeekDay << RTC_DR_WDU_Pos)                                                        | \
+         (((Year & 0xF0U) << (RTC_DR_YT_Pos - 4U)) | ((Year & 0x0FU) << RTC_DR_YU_Pos))   | \
+         (((Month & 0xF0U) << (RTC_DR_MT_Pos - 4U)) | ((Month & 0x0FU) << RTC_DR_MU_Pos)) | \
+         (((Day & 0xF0U) << (RTC_DR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_DR_DU_Pos));
 
   MODIFY_REG(RTCx->DR, (RTC_DR_WDU | RTC_DR_MT | RTC_DR_MU | RTC_DR_DT | RTC_DR_DU | RTC_DR_YT | RTC_DR_YU), temp);
 }
@@ -1770,7 +1730,7 @@ __STATIC_INLINE void LL_RTC_ALMA_DisableWeekday(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMA_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
 {
   MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU),
-             (((Day & 0xF0U) << (RTC_POSITION_ALMA_DT - 4U)) | ((Day & 0x0FU) << RTC_POSITION_ALMA_DU)));
+             (((Day & 0xF0U) << (RTC_ALRMAR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_ALRMAR_DU_Pos)));
 }
 
 /**
@@ -1786,7 +1746,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetDay(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_DT | RTC_ALRMAR_DU));
-  return (uint32_t)((((temp & RTC_ALRMAR_DT) >> RTC_POSITION_ALMA_DT) << 4U) | ((temp & RTC_ALRMAR_DU) >> RTC_POSITION_ALMA_DU));
+  return (uint32_t)((((temp & RTC_ALRMAR_DT) >> RTC_ALRMAR_DT_Pos) << 4U) | ((temp & RTC_ALRMAR_DU) >> RTC_ALRMAR_DU_Pos));
 }
 
 /**
@@ -1805,7 +1765,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetDay(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMA_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
 {
-  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_DU, WeekDay << RTC_POSITION_ALMA_DU);
+  MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_DU, WeekDay << RTC_ALRMAR_DU_Pos);
 }
 
 /**
@@ -1823,7 +1783,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetWeekDay(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->ALRMAR, RTC_ALRMAR_DU) >> RTC_POSITION_ALMA_DU);
+  return (uint32_t)(READ_BIT(RTCx->ALRMAR, RTC_ALRMAR_DU) >> RTC_ALRMAR_DU_Pos);
 }
 
 /**
@@ -1865,7 +1825,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetTimeFormat(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMA_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
 {
   MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU),
-             (((Hours & 0xF0U) << (RTC_POSITION_ALMA_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_ALMA_HU)));
+             (((Hours & 0xF0U) << (RTC_ALRMAR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMAR_HU_Pos)));
 }
 
 /**
@@ -1881,7 +1841,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetHour(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_HT | RTC_ALRMAR_HU));
-  return (uint32_t)((((temp & RTC_ALRMAR_HT) >> RTC_POSITION_ALMA_HT) << 4U) | ((temp & RTC_ALRMAR_HU) >> RTC_POSITION_ALMA_HU));
+  return (uint32_t)((((temp & RTC_ALRMAR_HT) >> RTC_ALRMAR_HT_Pos) << 4U) | ((temp & RTC_ALRMAR_HU) >> RTC_ALRMAR_HU_Pos));
 }
 
 /**
@@ -1896,7 +1856,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetHour(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMA_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
 {
   MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU),
-             (((Minutes & 0xF0U) << (RTC_POSITION_ALMA_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_ALMA_MU)));
+             (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)));
 }
 
 /**
@@ -1912,7 +1872,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetMinute(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_MNT | RTC_ALRMAR_MNU));
-  return (uint32_t)((((temp & RTC_ALRMAR_MNT) >> RTC_POSITION_ALMA_MT) << 4U) | ((temp & RTC_ALRMAR_MNU) >> RTC_POSITION_ALMA_MU));
+  return (uint32_t)((((temp & RTC_ALRMAR_MNT) >> RTC_ALRMAR_MNT_Pos) << 4U) | ((temp & RTC_ALRMAR_MNU) >> RTC_ALRMAR_MNU_Pos));
 }
 
 /**
@@ -1927,7 +1887,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetMinute(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMA_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
 {
   MODIFY_REG(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU),
-             (((Seconds & 0xF0U) << (RTC_POSITION_ALMA_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_ALMA_SU)));
+             (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos)));
 }
 
 /**
@@ -1943,7 +1903,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetSecond(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMAR, (RTC_ALRMAR_ST | RTC_ALRMAR_SU));
-  return (uint32_t)((((temp & RTC_ALRMAR_ST) >> RTC_POSITION_ALMA_ST) << 4U) | ((temp & RTC_ALRMAR_SU) >> RTC_POSITION_ALMA_SU));
+  return (uint32_t)((((temp & RTC_ALRMAR_ST) >> RTC_ALRMAR_ST_Pos) << 4U) | ((temp & RTC_ALRMAR_SU) >> RTC_ALRMAR_SU_Pos));
 }
 
 /**
@@ -1968,9 +1928,9 @@ __STATIC_INLINE void LL_RTC_ALMA_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12
 {
   register uint32_t temp = 0U;
 
-  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_POSITION_ALMA_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_ALMA_HU))    | \
-         (((Minutes & 0xF0U) << (RTC_POSITION_ALMA_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_ALMA_MU)) | \
-         (((Seconds & 0xF0U) << (RTC_POSITION_ALMA_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_ALMA_SU));
+  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMAR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMAR_HU_Pos))    | \
+         (((Minutes & 0xF0U) << (RTC_ALRMAR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMAR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_ALRMAR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMAR_SU_Pos));
 
   MODIFY_REG(RTCx->ALRMAR, RTC_ALRMAR_PM | RTC_ALRMAR_HT | RTC_ALRMAR_HU | RTC_ALRMAR_MNT | RTC_ALRMAR_MNU | RTC_ALRMAR_ST | RTC_ALRMAR_SU, temp);
 }
@@ -2005,7 +1965,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMA_GetTime(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMA_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Mask)
 {
-  MODIFY_REG(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS, Mask << RTC_POSITION_ALMA_MASKSS);
+  MODIFY_REG(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS, Mask << RTC_ALRMASSR_MASKSS_Pos);
 }
 
 /**
@@ -2016,7 +1976,7 @@ __STATIC_INLINE void LL_RTC_ALMA_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Ma
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMA_GetSubSecondMask(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS) >> RTC_POSITION_ALMA_MASKSS);
+  return (uint32_t)(READ_BIT(RTCx->ALRMASSR, RTC_ALRMASSR_MASKSS) >> RTC_ALRMASSR_MASKSS_Pos);
 }
 
 /**
@@ -2150,7 +2110,7 @@ __STATIC_INLINE void LL_RTC_ALMB_DisableWeekday(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMB_SetDay(RTC_TypeDef *RTCx, uint32_t Day)
 {
   MODIFY_REG(RTC->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU),
-             (((Day & 0xF0U) << (RTC_POSITION_ALMB_DT - 4U)) | ((Day & 0x0FU) << RTC_POSITION_ALMB_DU)));
+             (((Day & 0xF0U) << (RTC_ALRMBR_DT_Pos - 4U)) | ((Day & 0x0FU) << RTC_ALRMBR_DU_Pos)));
 }
 
 /**
@@ -2166,7 +2126,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetDay(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_DT | RTC_ALRMBR_DU));
-  return (uint32_t)((((temp & RTC_ALRMBR_DT) >> RTC_POSITION_ALMB_DT) << 4U) | ((temp & RTC_ALRMBR_DU) >> RTC_POSITION_ALMB_DU));
+  return (uint32_t)((((temp & RTC_ALRMBR_DT) >> RTC_ALRMBR_DT_Pos) << 4U) | ((temp & RTC_ALRMBR_DU) >> RTC_ALRMBR_DU_Pos));
 }
 
 /**
@@ -2185,7 +2145,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetDay(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMB_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
 {
-  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_DU, WeekDay << RTC_POSITION_ALMB_DU);
+  MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_DU, WeekDay << RTC_ALRMBR_DU_Pos);
 }
 
 /**
@@ -2203,7 +2163,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetWeekDay(RTC_TypeDef *RTCx, uint32_t WeekDay)
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetWeekDay(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->ALRMBR, RTC_ALRMBR_DU) >> RTC_POSITION_ALMB_DU);
+  return (uint32_t)(READ_BIT(RTCx->ALRMBR, RTC_ALRMBR_DU) >> RTC_ALRMBR_DU_Pos);
 }
 
 /**
@@ -2245,7 +2205,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetTimeFormat(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMB_SetHour(RTC_TypeDef *RTCx, uint32_t Hours)
 {
   MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU),
-             (((Hours & 0xF0U) << (RTC_POSITION_ALMB_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_ALMB_HU)));
+             (((Hours & 0xF0U) << (RTC_ALRMBR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMBR_HU_Pos)));
 }
 
 /**
@@ -2261,7 +2221,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetHour(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_HT | RTC_ALRMBR_HU));
-  return (uint32_t)((((temp & RTC_ALRMBR_HT) >> RTC_POSITION_ALMB_HT) << 4U) | ((temp & RTC_ALRMBR_HU) >> RTC_POSITION_ALMB_HU));
+  return (uint32_t)((((temp & RTC_ALRMBR_HT) >> RTC_ALRMBR_HT_Pos) << 4U) | ((temp & RTC_ALRMBR_HU) >> RTC_ALRMBR_HU_Pos));
 }
 
 /**
@@ -2276,7 +2236,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetHour(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMB_SetMinute(RTC_TypeDef *RTCx, uint32_t Minutes)
 {
   MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU),
-             (((Minutes & 0xF0U) << (RTC_POSITION_ALMB_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_ALMB_MU)));
+             (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)));
 }
 
 /**
@@ -2292,7 +2252,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetMinute(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_MNT | RTC_ALRMBR_MNU));
-  return (uint32_t)((((temp & RTC_ALRMBR_MNT) >> RTC_POSITION_ALMB_MT) << 4U) | ((temp & RTC_ALRMBR_MNU) >> RTC_POSITION_ALMB_MU));
+  return (uint32_t)((((temp & RTC_ALRMBR_MNT) >> RTC_ALRMBR_MNT_Pos) << 4U) | ((temp & RTC_ALRMBR_MNU) >> RTC_ALRMBR_MNU_Pos));
 }
 
 /**
@@ -2307,7 +2267,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetMinute(RTC_TypeDef *RTCx)
 __STATIC_INLINE void LL_RTC_ALMB_SetSecond(RTC_TypeDef *RTCx, uint32_t Seconds)
 {
   MODIFY_REG(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU),
-             (((Seconds & 0xF0U) << (RTC_POSITION_ALMB_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_ALMB_SU)));
+             (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos)));
 }
 
 /**
@@ -2323,7 +2283,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetSecond(RTC_TypeDef *RTCx)
   register uint32_t temp = 0U;
 
   temp = READ_BIT(RTCx->ALRMBR, (RTC_ALRMBR_ST | RTC_ALRMBR_SU));
-  return (uint32_t)((((temp & RTC_ALRMBR_ST) >> RTC_POSITION_ALMB_ST) << 4U) | ((temp & RTC_ALRMBR_SU) >> RTC_POSITION_ALMB_SU));
+  return (uint32_t)((((temp & RTC_ALRMBR_ST) >> RTC_ALRMBR_ST_Pos) << 4U) | ((temp & RTC_ALRMBR_SU) >> RTC_ALRMBR_SU_Pos));
 }
 
 /**
@@ -2348,9 +2308,9 @@ __STATIC_INLINE void LL_RTC_ALMB_ConfigTime(RTC_TypeDef *RTCx, uint32_t Format12
 {
   register uint32_t temp = 0U;
 
-  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_POSITION_ALMB_HT - 4U)) | ((Hours & 0x0FU) << RTC_POSITION_ALMB_HU))    | \
-         (((Minutes & 0xF0U) << (RTC_POSITION_ALMB_MT - 4U)) | ((Minutes & 0x0FU) << RTC_POSITION_ALMB_MU)) | \
-         (((Seconds & 0xF0U) << (RTC_POSITION_ALMB_ST - 4U)) | ((Seconds & 0x0FU) << RTC_POSITION_ALMB_SU));
+  temp = Format12_24 | (((Hours & 0xF0U) << (RTC_ALRMBR_HT_Pos - 4U)) | ((Hours & 0x0FU) << RTC_ALRMBR_HU_Pos))    | \
+         (((Minutes & 0xF0U) << (RTC_ALRMBR_MNT_Pos - 4U)) | ((Minutes & 0x0FU) << RTC_ALRMBR_MNU_Pos)) | \
+         (((Seconds & 0xF0U) << (RTC_ALRMBR_ST_Pos - 4U)) | ((Seconds & 0x0FU) << RTC_ALRMBR_SU_Pos));
 
   MODIFY_REG(RTCx->ALRMBR, RTC_ALRMBR_PM| RTC_ALRMBR_HT | RTC_ALRMBR_HU | RTC_ALRMBR_MNT | RTC_ALRMBR_MNU | RTC_ALRMBR_ST | RTC_ALRMBR_SU, temp);
 }
@@ -2385,7 +2345,7 @@ __STATIC_INLINE uint32_t LL_RTC_ALMB_GetTime(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE void LL_RTC_ALMB_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Mask)
 {
-  MODIFY_REG(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS, Mask << RTC_POSITION_ALMB_MASKSS);
+  MODIFY_REG(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS, Mask << RTC_ALRMBSSR_MASKSS_Pos);
 }
 
 /**
@@ -2396,7 +2356,7 @@ __STATIC_INLINE void LL_RTC_ALMB_SetSubSecondMask(RTC_TypeDef *RTCx, uint32_t Ma
   */
 __STATIC_INLINE uint32_t LL_RTC_ALMB_GetSubSecondMask(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS)  >> RTC_POSITION_ALMB_MASKSS);
+  return (uint32_t)(READ_BIT(RTCx->ALRMBSSR, RTC_ALRMBSSR_MASKSS)  >> RTC_ALRMBSSR_MASKSS_Pos);
 }
 
 /**
@@ -2508,7 +2468,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetTimeFormat(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE uint32_t LL_RTC_TS_GetHour(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_HT | RTC_TSTR_HU) >> RTC_POSITION_TS_HU);
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_HT | RTC_TSTR_HU) >> RTC_TSTR_HU_Pos);
 }
 
 /**
@@ -2521,7 +2481,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetHour(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE uint32_t LL_RTC_TS_GetMinute(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_MNT | RTC_TSTR_MNU) >> RTC_POSITION_TS_MNU);
+  return (uint32_t)(READ_BIT(RTCx->TSTR, RTC_TSTR_MNT | RTC_TSTR_MNU) >> RTC_TSTR_MNU_Pos);
 }
 
 /**
@@ -2571,7 +2531,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetTime(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE uint32_t LL_RTC_TS_GetWeekDay(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_WDU) >> RTC_POSITION_TS_WDU);
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_WDU) >> RTC_TSDR_WDU_Pos);
 }
 
 /**
@@ -2596,7 +2556,7 @@ __STATIC_INLINE uint32_t LL_RTC_TS_GetWeekDay(RTC_TypeDef *RTCx)
   */
 __STATIC_INLINE uint32_t LL_RTC_TS_GetMonth(RTC_TypeDef *RTCx)
 {
-  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_MT | RTC_TSDR_MU) >> RTC_POSITION_TS_MU);
+  return (uint32_t)(READ_BIT(RTCx->TSDR, RTC_TSDR_MT | RTC_TSDR_MU) >> RTC_TSDR_MU_Pos);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_sdmmc.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_sdmmc.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_sdmmc.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SDMMC Low Layer HAL module driver.
   *    
   *          This file provides firmware functions to manage the following 
@@ -137,7 +135,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -323,7 +321,7 @@ HAL_StatusTypeDef SDIO_PowerState_ON(SDIO_TypeDef *SDIOx)
 HAL_StatusTypeDef SDIO_PowerState_OFF(SDIO_TypeDef *SDIOx)
 {
   /* Set power state to OFF */
-  SDIOx->POWER = (uint32_t)0x00000000;
+  SDIOx->POWER = 0x00000000U;
   
   return HAL_OK;
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_sdmmc.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_sdmmc.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_sdmmc.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SDMMC HAL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -151,7 +149,7 @@ typedef struct
 /** @defgroup SDIO_Clock_Edge Clock Edge
   * @{
   */
-#define SDIO_CLOCK_EDGE_RISING               ((uint32_t)0x00000000)
+#define SDIO_CLOCK_EDGE_RISING               (0x00000000U)
 #define SDIO_CLOCK_EDGE_FALLING              SDIO_CLKCR_NEGEDGE
 
 #define IS_SDIO_CLOCK_EDGE(EDGE) (((EDGE) == SDIO_CLOCK_EDGE_RISING) || \
@@ -163,7 +161,7 @@ typedef struct
 /** @defgroup SDIO_Clock_Bypass Clock Bypass
   * @{
   */
-#define SDIO_CLOCK_BYPASS_DISABLE             ((uint32_t)0x00000000)
+#define SDIO_CLOCK_BYPASS_DISABLE             (0x00000000U)
 #define SDIO_CLOCK_BYPASS_ENABLE              SDIO_CLKCR_BYPASS   
 
 #define IS_SDIO_CLOCK_BYPASS(BYPASS) (((BYPASS) == SDIO_CLOCK_BYPASS_DISABLE) || \
@@ -175,7 +173,7 @@ typedef struct
 /** @defgroup SDIO_Clock_Power_Save Clock Power Saving
   * @{
   */
-#define SDIO_CLOCK_POWER_SAVE_DISABLE         ((uint32_t)0x00000000)
+#define SDIO_CLOCK_POWER_SAVE_DISABLE         (0x00000000U)
 #define SDIO_CLOCK_POWER_SAVE_ENABLE          SDIO_CLKCR_PWRSAV
 
 #define IS_SDIO_CLOCK_POWER_SAVE(SAVE) (((SAVE) == SDIO_CLOCK_POWER_SAVE_DISABLE) || \
@@ -187,7 +185,7 @@ typedef struct
 /** @defgroup SDIO_Bus_Wide Bus Width
   * @{
   */
-#define SDIO_BUS_WIDE_1B                      ((uint32_t)0x00000000)
+#define SDIO_BUS_WIDE_1B                      (0x00000000U)
 #define SDIO_BUS_WIDE_4B                      SDIO_CLKCR_WIDBUS_0
 #define SDIO_BUS_WIDE_8B                      SDIO_CLKCR_WIDBUS_1
 
@@ -201,7 +199,7 @@ typedef struct
 /** @defgroup SDIO_Hardware_Flow_Control Hardware Flow Control
   * @{
   */
-#define SDIO_HARDWARE_FLOW_CONTROL_DISABLE    ((uint32_t)0x00000000)
+#define SDIO_HARDWARE_FLOW_CONTROL_DISABLE    (0x00000000U)
 #define SDIO_HARDWARE_FLOW_CONTROL_ENABLE     SDIO_CLKCR_HWFC_EN
 
 #define IS_SDIO_HARDWARE_FLOW_CONTROL(CONTROL) (((CONTROL) == SDIO_HARDWARE_FLOW_CONTROL_DISABLE) || \
@@ -229,7 +227,7 @@ typedef struct
 /** @defgroup SDIO_Response_Type Response Type
   * @{
   */
-#define SDIO_RESPONSE_NO                    ((uint32_t)0x00000000)
+#define SDIO_RESPONSE_NO                    (0x00000000U)
 #define SDIO_RESPONSE_SHORT                 SDIO_CMD_WAITRESP_0
 #define SDIO_RESPONSE_LONG                  SDIO_CMD_WAITRESP
 
@@ -243,7 +241,7 @@ typedef struct
 /** @defgroup SDIO_Wait_Interrupt_State Wait Interrupt
   * @{
   */
-#define SDIO_WAIT_NO                        ((uint32_t)0x00000000)
+#define SDIO_WAIT_NO                        (0x00000000U)
 #define SDIO_WAIT_IT                        SDIO_CMD_WAITINT 
 #define SDIO_WAIT_PEND                      SDIO_CMD_WAITPEND
 
@@ -257,7 +255,7 @@ typedef struct
 /** @defgroup SDIO_CPSM_State CPSM State
   * @{
   */
-#define SDIO_CPSM_DISABLE                   ((uint32_t)0x00000000)
+#define SDIO_CPSM_DISABLE                   (0x00000000U)
 #define SDIO_CPSM_ENABLE                    SDIO_CMD_CPSMEN
 
 #define IS_SDIO_CPSM(CPSM) (((CPSM) == SDIO_CPSM_DISABLE) || \
@@ -269,10 +267,10 @@ typedef struct
 /** @defgroup SDIO_Response_Registers Response Register
   * @{
   */
-#define SDIO_RESP1                          ((uint32_t)0x00000000)
-#define SDIO_RESP2                          ((uint32_t)0x00000004)
-#define SDIO_RESP3                          ((uint32_t)0x00000008)
-#define SDIO_RESP4                          ((uint32_t)0x0000000C)
+#define SDIO_RESP1                          (0x00000000U)
+#define SDIO_RESP2                          (0x00000004U)
+#define SDIO_RESP3                          (0x00000008U)
+#define SDIO_RESP4                          (0x0000000CU)
 
 #define IS_SDIO_RESP(RESP) (((RESP) == SDIO_RESP1) || \
                             ((RESP) == SDIO_RESP2) || \
@@ -293,21 +291,21 @@ typedef struct
 /** @defgroup SDIO_Data_Block_Size Data Block Size
   * @{
   */
-#define SDIO_DATABLOCK_SIZE_1B               ((uint32_t)0x00000000)
+#define SDIO_DATABLOCK_SIZE_1B               (0x00000000U)
 #define SDIO_DATABLOCK_SIZE_2B               SDIO_DCTRL_DBLOCKSIZE_0
 #define SDIO_DATABLOCK_SIZE_4B               SDIO_DCTRL_DBLOCKSIZE_1
-#define SDIO_DATABLOCK_SIZE_8B               ((uint32_t)0x00000030)
+#define SDIO_DATABLOCK_SIZE_8B               (0x00000030U)
 #define SDIO_DATABLOCK_SIZE_16B              SDIO_DCTRL_DBLOCKSIZE_2
-#define SDIO_DATABLOCK_SIZE_32B              ((uint32_t)0x00000050)
-#define SDIO_DATABLOCK_SIZE_64B              ((uint32_t)0x00000060)
-#define SDIO_DATABLOCK_SIZE_128B             ((uint32_t)0x00000070)
+#define SDIO_DATABLOCK_SIZE_32B              (0x00000050U)
+#define SDIO_DATABLOCK_SIZE_64B              (0x00000060U)
+#define SDIO_DATABLOCK_SIZE_128B             (0x00000070U)
 #define SDIO_DATABLOCK_SIZE_256B             SDIO_DCTRL_DBLOCKSIZE_3
-#define SDIO_DATABLOCK_SIZE_512B             ((uint32_t)0x00000090)
-#define SDIO_DATABLOCK_SIZE_1024B            ((uint32_t)0x000000A0)
-#define SDIO_DATABLOCK_SIZE_2048B            ((uint32_t)0x000000B0)
-#define SDIO_DATABLOCK_SIZE_4096B            ((uint32_t)0x000000C0)
-#define SDIO_DATABLOCK_SIZE_8192B            ((uint32_t)0x000000D0)
-#define SDIO_DATABLOCK_SIZE_16384B           ((uint32_t)0x000000E0)
+#define SDIO_DATABLOCK_SIZE_512B             (0x00000090U)
+#define SDIO_DATABLOCK_SIZE_1024B            (0x000000A0U)
+#define SDIO_DATABLOCK_SIZE_2048B            (0x000000B0U)
+#define SDIO_DATABLOCK_SIZE_4096B            (0x000000C0U)
+#define SDIO_DATABLOCK_SIZE_8192B            (0x000000D0U)
+#define SDIO_DATABLOCK_SIZE_16384B           (0x000000E0U)
 
 #define IS_SDIO_BLOCK_SIZE(SIZE) (((SIZE) == SDIO_DATABLOCK_SIZE_1B)    || \
                                   ((SIZE) == SDIO_DATABLOCK_SIZE_2B)    || \
@@ -331,7 +329,7 @@ typedef struct
 /** @defgroup SDIO_Transfer_Direction Transfer Direction
   * @{
   */
-#define SDIO_TRANSFER_DIR_TO_CARD            ((uint32_t)0x00000000)
+#define SDIO_TRANSFER_DIR_TO_CARD            (0x00000000U)
 #define SDIO_TRANSFER_DIR_TO_SDIO            SDIO_DCTRL_DTDIR
 
 #define IS_SDIO_TRANSFER_DIR(DIR) (((DIR) == SDIO_TRANSFER_DIR_TO_CARD) || \
@@ -343,7 +341,7 @@ typedef struct
 /** @defgroup SDIO_Transfer_Type Transfer Type
   * @{
   */
-#define SDIO_TRANSFER_MODE_BLOCK             ((uint32_t)0x00000000)
+#define SDIO_TRANSFER_MODE_BLOCK             (0x00000000U)
 #define SDIO_TRANSFER_MODE_STREAM            SDIO_DCTRL_DTMODE
 
 #define IS_SDIO_TRANSFER_MODE(MODE) (((MODE) == SDIO_TRANSFER_MODE_BLOCK) || \
@@ -355,7 +353,7 @@ typedef struct
 /** @defgroup SDIO_DPSM_State DPSM State
   * @{
   */
-#define SDIO_DPSM_DISABLE                    ((uint32_t)0x00000000)
+#define SDIO_DPSM_DISABLE                    (0x00000000U)
 #define SDIO_DPSM_ENABLE                     SDIO_DCTRL_DTEN
 
 #define IS_SDIO_DPSM(DPSM) (((DPSM) == SDIO_DPSM_DISABLE) ||\
@@ -367,8 +365,8 @@ typedef struct
 /** @defgroup SDIO_Read_Wait_Mode Read Wait Mode
   * @{
   */
-#define SDIO_READ_WAIT_MODE_DATA2             ((uint32_t)0x00000000)
-#define SDIO_READ_WAIT_MODE_CLK               ((uint32_t)0x00000001)
+#define SDIO_READ_WAIT_MODE_DATA2             (0x00000000U)
+#define SDIO_READ_WAIT_MODE_CLK               (0x00000001U)
 
 #define IS_SDIO_READWAIT_MODE(MODE) (((MODE) == SDIO_READ_WAIT_MODE_CLK) || \
                                      ((MODE) == SDIO_READ_WAIT_MODE_DATA2))
@@ -811,13 +809,13 @@ typedef struct
   * @brief  Enable the CE-ATA interrupt.
   * @retval None
   */    
-#define __SDIO_CEATA_ENABLE_IT()   (*(__IO uint32_t *) CMD_NIEN_BB = (uint32_t)0)
+#define __SDIO_CEATA_ENABLE_IT()   (*(__IO uint32_t *) CMD_NIEN_BB = 0U)
 
 /**
   * @brief  Disable the CE-ATA interrupt.
   * @retval None
   */  
-#define __SDIO_CEATA_DISABLE_IT()   (*(__IO uint32_t *) CMD_NIEN_BB = (uint32_t)1)
+#define __SDIO_CEATA_DISABLE_IT()   (*(__IO uint32_t *) CMD_NIEN_BB = 1U)
 
 /**
   * @brief  Enable send CE-ATA command (CMD61).

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_spi.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_spi.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_spi.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   SPI LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -422,22 +420,15 @@ ErrorStatus LL_I2S_Init(SPI_TypeDef *SPIx, LL_I2S_InitTypeDef *I2S_InitStruct)
      * - AudioFreq:     SPI_I2SPR_I2SDIV[7:0] and SPI_I2SPR_ODD bits
      */
 
-    /* If the default value has to be written, reinitialize i2sdiv and i2sodd*/
-    if (I2S_InitStruct->AudioFreq == LL_I2S_AUDIOFREQ_DEFAULT)
+    /* If the requested audio frequency is not the default, compute the prescaler (i2sodd, i2sdiv)
+     * else, default values are used:  i2sodd = 0U, i2sdiv = 2U.
+     */
+    if (I2S_InitStruct->AudioFreq != LL_I2S_AUDIOFREQ_DEFAULT)
     {
-      i2sodd = 0U;
-      i2sdiv = 2U;
-    }
-    /* If the requested audio frequency is not the default, compute the prescaler */
-    else
-    {
-      /* Check the frame length (For the Prescaler computing) */
-      if (I2S_InitStruct->DataFormat == LL_I2S_DATAFORMAT_16B)
-      {
-        /* Packet length is 16 bits */
-        packetlength = 1U;
-      }
-      else
+      /* Check the frame length (For the Prescaler computing)
+       * Default value: LL_I2S_DATAFORMAT_16B (packetlength = 1U).
+       */
+      if (I2S_InitStruct->DataFormat != LL_I2S_DATAFORMAT_16B)
       {
         /* Packet length is 32 bits */
         packetlength = 2U;

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_spi.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_spi.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_spi.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SPI LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -141,7 +139,6 @@ typedef struct
 #define LL_SPI_SR_RXNE                     SPI_SR_RXNE               /*!< Rx buffer not empty flag         */
 #define LL_SPI_SR_TXE                      SPI_SR_TXE                /*!< Tx buffer empty flag             */
 #define LL_SPI_SR_BSY                      SPI_SR_BSY                /*!< Busy flag                        */
-#define LL_SPI_SR_UDR                      SPI_SR_UDR                /*!< Underrun flag                    */
 #define LL_SPI_SR_CRCERR                   SPI_SR_CRCERR             /*!< CRC error flag                   */
 #define LL_SPI_SR_MODF                     SPI_SR_MODF               /*!< Mode fault flag                  */
 #define LL_SPI_SR_OVR                      SPI_SR_OVR                /*!< Overrun flag                     */
@@ -165,7 +162,7 @@ typedef struct
   * @{
   */
 #define LL_SPI_MODE_MASTER                 (SPI_CR1_MSTR | SPI_CR1_SSI)    /*!< Master configuration  */
-#define LL_SPI_MODE_SLAVE                  ((uint32_t)0x00000000U)         /*!< Slave configuration   */
+#define LL_SPI_MODE_SLAVE                  0x00000000U                    /*!< Slave configuration   */
 /**
   * @}
   */
@@ -174,7 +171,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_PROTOCOL Serial Protocol
   * @{
   */
-#define LL_SPI_PROTOCOL_MOTOROLA           ((uint32_t)0x00000000U)   /*!< Motorola mode. Used as default value */
+#define LL_SPI_PROTOCOL_MOTOROLA           0x00000000U               /*!< Motorola mode. Used as default value */
 #define LL_SPI_PROTOCOL_TI                 (SPI_CR2_FRF)             /*!< TI mode                              */
 /**
   * @}
@@ -184,7 +181,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_PHASE Clock Phase
   * @{
   */
-#define LL_SPI_PHASE_1EDGE                 ((uint32_t)0x00000000U)   /*!< First clock transition is the first data capture edge  */
+#define LL_SPI_PHASE_1EDGE                 0x00000000U               /*!< First clock transition is the first data capture edge  */
 #define LL_SPI_PHASE_2EDGE                 (SPI_CR1_CPHA)            /*!< Second clock transition is the first data capture edge */
 /**
   * @}
@@ -193,7 +190,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_POLARITY Clock Polarity
   * @{
   */
-#define LL_SPI_POLARITY_LOW                ((uint32_t)0x00000000U)   /*!< Clock to 0 when idle */
+#define LL_SPI_POLARITY_LOW                0x00000000U               /*!< Clock to 0 when idle */
 #define LL_SPI_POLARITY_HIGH               (SPI_CR1_CPOL)            /*!< Clock to 1 when idle */
 /**
   * @}
@@ -202,7 +199,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_BAUDRATEPRESCALER Baud Rate Prescaler
   * @{
   */
-#define LL_SPI_BAUDRATEPRESCALER_DIV2      ((uint32_t)0x00000000U)                        /*!< BaudRate control equal to fPCLK/2   */
+#define LL_SPI_BAUDRATEPRESCALER_DIV2      0x00000000U                                    /*!< BaudRate control equal to fPCLK/2   */
 #define LL_SPI_BAUDRATEPRESCALER_DIV4      (SPI_CR1_BR_0)                                 /*!< BaudRate control equal to fPCLK/4   */
 #define LL_SPI_BAUDRATEPRESCALER_DIV8      (SPI_CR1_BR_1)                                 /*!< BaudRate control equal to fPCLK/8   */
 #define LL_SPI_BAUDRATEPRESCALER_DIV16     (SPI_CR1_BR_1 | SPI_CR1_BR_0)                  /*!< BaudRate control equal to fPCLK/16  */
@@ -218,7 +215,7 @@ typedef struct
   * @{
   */
 #define LL_SPI_LSB_FIRST                   (SPI_CR1_LSBFIRST)        /*!< Data is transmitted/received with the LSB first */
-#define LL_SPI_MSB_FIRST                   ((uint32_t)0x00000000U)   /*!< Data is transmitted/received with the MSB first */
+#define LL_SPI_MSB_FIRST                   0x00000000U               /*!< Data is transmitted/received with the MSB first */
 /**
   * @}
   */
@@ -226,7 +223,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_TRANSFER_MODE Transfer Mode
   * @{
   */
-#define LL_SPI_FULL_DUPLEX                 ((uint32_t)0x00000000U)              /*!< Full-Duplex mode. Rx and Tx transfer on 2 lines */
+#define LL_SPI_FULL_DUPLEX                 0x00000000U                          /*!< Full-Duplex mode. Rx and Tx transfer on 2 lines */
 #define LL_SPI_SIMPLEX_RX                  (SPI_CR1_RXONLY)                     /*!< Simplex Rx mode.  Rx transfer only on 1 line    */
 #define LL_SPI_HALF_DUPLEX_RX              (SPI_CR1_BIDIMODE)                   /*!< Half-Duplex Rx mode. Rx transfer on 1 line      */
 #define LL_SPI_HALF_DUPLEX_TX              (SPI_CR1_BIDIMODE | SPI_CR1_BIDIOE)  /*!< Half-Duplex Tx mode. Tx transfer on 1 line      */
@@ -238,7 +235,7 @@ typedef struct
   * @{
   */
 #define LL_SPI_NSS_SOFT                    (SPI_CR1_SSM)                     /*!< NSS managed internally. NSS pin not used and free              */
-#define LL_SPI_NSS_HARD_INPUT              ((uint32_t)0x00000000U)           /*!< NSS pin used in Input. Only used in Master mode                */
+#define LL_SPI_NSS_HARD_INPUT              0x00000000U                       /*!< NSS pin used in Input. Only used in Master mode                */
 #define LL_SPI_NSS_HARD_OUTPUT             (((uint32_t)SPI_CR2_SSOE << 16U)) /*!< NSS pin used in Output. Only used in Slave mode as chip select */
 /**
   * @}
@@ -247,7 +244,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_DATAWIDTH Datawidth
   * @{
   */
-#define LL_SPI_DATAWIDTH_8BIT              ((uint32_t)0x00000000U)           /*!< Data length for SPI transfer:  8 bits */
+#define LL_SPI_DATAWIDTH_8BIT              0x00000000U                       /*!< Data length for SPI transfer:  8 bits */
 #define LL_SPI_DATAWIDTH_16BIT             (SPI_CR1_DFF)                     /*!< Data length for SPI transfer:  16 bits */
 /**
   * @}
@@ -257,7 +254,7 @@ typedef struct
 /** @defgroup SPI_LL_EC_CRC_CALCULATION CRC Calculation
   * @{
   */
-#define LL_SPI_CRCCALCULATION_DISABLE      ((uint32_t)0x00000000U)           /*!< CRC calculation disabled */
+#define LL_SPI_CRCCALCULATION_DISABLE      0x00000000U                       /*!< CRC calculation disabled */
 #define LL_SPI_CRCCALCULATION_ENABLE       (SPI_CR1_CRCEN)                   /*!< CRC calculation enabled  */
 /**
   * @}
@@ -1122,7 +1119,8 @@ __STATIC_INLINE uint16_t LL_SPI_ReceiveData16(SPI_TypeDef *SPIx)
   */
 __STATIC_INLINE void LL_SPI_TransmitData8(SPI_TypeDef *SPIx, uint8_t TxData)
 {
-  *((__IO uint8_t *)&SPIx->DR) = TxData;
+  __IO uint8_t *spidr = ((__IO uint8_t *)&SPIx->DR);
+  *spidr = TxData;
 }
 
 /**
@@ -1134,7 +1132,8 @@ __STATIC_INLINE void LL_SPI_TransmitData8(SPI_TypeDef *SPIx, uint8_t TxData)
   */
 __STATIC_INLINE void LL_SPI_TransmitData16(SPI_TypeDef *SPIx, uint16_t TxData)
 {
-  *((__IO uint16_t *)&SPIx->DR) = TxData;
+  __IO uint16_t *spidr = ((__IO uint16_t *)&SPIx->DR);
+  *spidr = TxData;
 }
 
 /**
@@ -1236,7 +1235,7 @@ typedef struct
 #define LL_I2S_SR_RXNE                     LL_SPI_SR_RXNE            /*!< Rx buffer not empty flag         */
 #define LL_I2S_SR_TXE                      LL_SPI_SR_TXE             /*!< Tx buffer empty flag             */
 #define LL_I2S_SR_BSY                      LL_SPI_SR_BSY             /*!< Busy flag                        */
-#define LL_I2S_SR_UDR                      LL_SPI_SR_UDR             /*!< Underrun flag                    */
+#define LL_I2S_SR_UDR                      SPI_SR_UDR                /*!< Underrun flag                    */
 #define LL_I2S_SR_OVR                      LL_SPI_SR_OVR             /*!< Overrun flag                     */
 #define LL_I2S_SR_FRE                      LL_SPI_SR_FRE             /*!< TI mode frame format error flag  */
 /**
@@ -1257,7 +1256,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_DATA_FORMAT Data format
   * @{
   */
-#define LL_I2S_DATAFORMAT_16B              ((uint32_t)0x00000000U)                       /*!< Data length 16 bits, Channel lenght 16bit */
+#define LL_I2S_DATAFORMAT_16B              0x00000000U                                   /*!< Data length 16 bits, Channel lenght 16bit */
 #define LL_I2S_DATAFORMAT_16B_EXTENDED     (SPI_I2SCFGR_CHLEN)                           /*!< Data length 16 bits, Channel lenght 32bit */
 #define LL_I2S_DATAFORMAT_24B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_0)    /*!< Data length 24 bits, Channel lenght 32bit */
 #define LL_I2S_DATAFORMAT_32B              (SPI_I2SCFGR_CHLEN | SPI_I2SCFGR_DATLEN_1)    /*!< Data length 16 bits, Channel lenght 32bit */
@@ -1268,7 +1267,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_POLARITY Clock Polarity
   * @{
   */
-#define LL_I2S_POLARITY_LOW                ((uint32_t)0x00000000U)   /*!< Clock steady state is low level  */
+#define LL_I2S_POLARITY_LOW                0x00000000U               /*!< Clock steady state is low level  */
 #define LL_I2S_POLARITY_HIGH               (SPI_I2SCFGR_CKPOL)       /*!< Clock steady state is high level */
 /**
   * @}
@@ -1277,7 +1276,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_STANDARD I2s Standard
   * @{
   */
-#define LL_I2S_STANDARD_PHILIPS            ((uint32_t)0x00000000U)                                             /*!< I2S standard philips                      */
+#define LL_I2S_STANDARD_PHILIPS            0x00000000U                                                         /*!< I2S standard philips                      */
 #define LL_I2S_STANDARD_MSB                (SPI_I2SCFGR_I2SSTD_0)                                              /*!< MSB justified standard (left justified)   */
 #define LL_I2S_STANDARD_LSB                (SPI_I2SCFGR_I2SSTD_1)                                              /*!< LSB justified standard (right justified)  */
 #define LL_I2S_STANDARD_PCM_SHORT          (SPI_I2SCFGR_I2SSTD_0 | SPI_I2SCFGR_I2SSTD_1)                       /*!< PCM standard, short frame synchronization */
@@ -1289,7 +1288,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_MODE Operation Mode
   * @{
   */
-#define LL_I2S_MODE_SLAVE_TX               ((uint32_t)0x00000000U)                       /*!< Slave Tx configuration  */
+#define LL_I2S_MODE_SLAVE_TX               0x00000000U                                   /*!< Slave Tx configuration  */
 #define LL_I2S_MODE_SLAVE_RX               (SPI_I2SCFGR_I2SCFG_0)                        /*!< Slave Rx configuration  */
 #define LL_I2S_MODE_MASTER_TX              (SPI_I2SCFGR_I2SCFG_1)                        /*!< Master Tx configuration */
 #define LL_I2S_MODE_MASTER_RX              (SPI_I2SCFGR_I2SCFG_0 | SPI_I2SCFGR_I2SCFG_1) /*!< Master Rx configuration */
@@ -1300,7 +1299,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_PRESCALER_FACTOR Prescaler Factor
   * @{
   */
-#define LL_I2S_PRESCALER_PARITY_EVEN       ((uint32_t)0x00000000U)   /*!< Odd factor: Real divider value is =  I2SDIV * 2    */
+#define LL_I2S_PRESCALER_PARITY_EVEN       0x00000000U               /*!< Odd factor: Real divider value is =  I2SDIV * 2    */
 #define LL_I2S_PRESCALER_PARITY_ODD        (SPI_I2SPR_ODD >> 8U)     /*!< Odd factor: Real divider value is = (I2SDIV * 2)+1 */
 /**
   * @}
@@ -1311,7 +1310,7 @@ typedef struct
 /** @defgroup I2S_LL_EC_MCLK_OUTPUT MCLK Output
   * @{
   */
-#define LL_I2S_MCLK_OUTPUT_DISABLE         ((uint32_t)0x00000000U)   /*!< Master clock output is disabled */
+#define LL_I2S_MCLK_OUTPUT_DISABLE         0x00000000U               /*!< Master clock output is disabled */
 #define LL_I2S_MCLK_OUTPUT_ENABLE          (SPI_I2SPR_MCKOE)         /*!< Master clock output is enabled  */
 /**
   * @}
@@ -1321,16 +1320,16 @@ typedef struct
   * @{
   */
 
-#define LL_I2S_AUDIOFREQ_192K              ((uint32_t)192000)        /*!< Audio Frequency configuration 192000 Hz       */
-#define LL_I2S_AUDIOFREQ_96K               ((uint32_t) 96000)        /*!< Audio Frequency configuration  96000 Hz       */
-#define LL_I2S_AUDIOFREQ_48K               ((uint32_t) 48000)        /*!< Audio Frequency configuration  48000 Hz       */
-#define LL_I2S_AUDIOFREQ_44K               ((uint32_t) 44100)        /*!< Audio Frequency configuration  44100 Hz       */
-#define LL_I2S_AUDIOFREQ_32K               ((uint32_t) 32000)        /*!< Audio Frequency configuration  32000 Hz       */
-#define LL_I2S_AUDIOFREQ_22K               ((uint32_t) 22050)        /*!< Audio Frequency configuration  22050 Hz       */
-#define LL_I2S_AUDIOFREQ_16K               ((uint32_t) 16000)        /*!< Audio Frequency configuration  16000 Hz       */
-#define LL_I2S_AUDIOFREQ_11K               ((uint32_t) 11025)        /*!< Audio Frequency configuration  11025 Hz       */
-#define LL_I2S_AUDIOFREQ_8K                ((uint32_t)  8000)        /*!< Audio Frequency configuration   8000 Hz       */
-#define LL_I2S_AUDIOFREQ_DEFAULT           ((uint32_t)     2)        /*!< Audio Freq not specified. Register I2SDIV = 2 */
+#define LL_I2S_AUDIOFREQ_192K              192000U      /*!< Audio Frequency configuration 192000 Hz       */
+#define LL_I2S_AUDIOFREQ_96K               96000U       /*!< Audio Frequency configuration  96000 Hz       */
+#define LL_I2S_AUDIOFREQ_48K               48000U       /*!< Audio Frequency configuration  48000 Hz       */
+#define LL_I2S_AUDIOFREQ_44K               44100U       /*!< Audio Frequency configuration  44100 Hz       */
+#define LL_I2S_AUDIOFREQ_32K               32000U       /*!< Audio Frequency configuration  32000 Hz       */
+#define LL_I2S_AUDIOFREQ_22K               22050U       /*!< Audio Frequency configuration  22050 Hz       */
+#define LL_I2S_AUDIOFREQ_16K               16000U       /*!< Audio Frequency configuration  16000 Hz       */
+#define LL_I2S_AUDIOFREQ_11K               11025U       /*!< Audio Frequency configuration  11025 Hz       */
+#define LL_I2S_AUDIOFREQ_8K                8000U        /*!< Audio Frequency configuration   8000 Hz       */
+#define LL_I2S_AUDIOFREQ_DEFAULT           2U           /*!< Audio Freq not specified. Register I2SDIV = 2 */
 /**
   * @}
   */
@@ -1419,7 +1418,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsEnabled(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Set I2S Data frame length
+  * @brief  Set I2S data frame length
   * @rmtoll I2SCFGR      DATLEN        LL_I2S_SetDataFormat\n
   *         I2SCFGR      CHLEN         LL_I2S_SetDataFormat
   * @param  SPIx SPI Instance
@@ -1436,7 +1435,7 @@ __STATIC_INLINE void LL_I2S_SetDataFormat(SPI_TypeDef *SPIx, uint32_t DataFormat
 }
 
 /**
-  * @brief  Get I2S Data frame length
+  * @brief  Get I2S data frame length
   * @rmtoll I2SCFGR      DATLEN        LL_I2S_GetDataFormat\n
   *         I2SCFGR      CHLEN         LL_I2S_GetDataFormat
   * @param  SPIx SPI Instance
@@ -1479,7 +1478,7 @@ __STATIC_INLINE uint32_t LL_I2S_GetClockPolarity(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Set I2S Standard Protocol
+  * @brief  Set I2S standard protocol
   * @rmtoll I2SCFGR      I2SSTD        LL_I2S_SetStandard\n
   *         I2SCFGR      PCMSYNC       LL_I2S_SetStandard
   * @param  SPIx SPI Instance
@@ -1497,7 +1496,7 @@ __STATIC_INLINE void LL_I2S_SetStandard(SPI_TypeDef *SPIx, uint32_t Standard)
 }
 
 /**
-  * @brief  Get I2S Standard Protocol
+  * @brief  Get I2S standard protocol
   * @rmtoll I2SCFGR      I2SSTD        LL_I2S_GetStandard\n
   *         I2SCFGR      PCMSYNC       LL_I2S_GetStandard
   * @param  SPIx SPI Instance
@@ -1514,7 +1513,7 @@ __STATIC_INLINE uint32_t LL_I2S_GetStandard(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Set I2S Transfer Mode
+  * @brief  Set I2S transfer mode
   * @rmtoll I2SCFGR      I2SCFG        LL_I2S_SetTransferMode
   * @param  SPIx SPI Instance
   * @param  Mode This parameter can be one of the following values:
@@ -1530,7 +1529,7 @@ __STATIC_INLINE void LL_I2S_SetTransferMode(SPI_TypeDef *SPIx, uint32_t Mode)
 }
 
 /**
-  * @brief  Get I2S Transfer Mode
+  * @brief  Get I2S transfer mode
   * @rmtoll I2SCFGR      I2SCFG        LL_I2S_GetTransferMode
   * @param  SPIx SPI Instance
   * @retval Returned value can be one of the following values:
@@ -1595,7 +1594,7 @@ __STATIC_INLINE uint32_t LL_I2S_GetPrescalerParity(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Enable the Master Clock Ouput (Pin MCK)
+  * @brief  Enable the master clock ouput (Pin MCK)
   * @rmtoll I2SPR        MCKOE         LL_I2S_EnableMasterClock
   * @param  SPIx SPI Instance
   * @retval None
@@ -1606,7 +1605,7 @@ __STATIC_INLINE void LL_I2S_EnableMasterClock(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Disable the Master Clock Ouput (Pin MCK)
+  * @brief  Disable the master clock ouput (Pin MCK)
   * @rmtoll I2SPR        MCKOE         LL_I2S_DisableMasterClock
   * @param  SPIx SPI Instance
   * @retval None
@@ -1617,7 +1616,7 @@ __STATIC_INLINE void LL_I2S_DisableMasterClock(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Check if the Master Clock Ouput (Pin MCK) is enabled
+  * @brief  Check if the master clock ouput (Pin MCK) is enabled
   * @rmtoll I2SPR        MCKOE         LL_I2S_IsEnabledMasterClock
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -1658,7 +1657,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_TXE(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Get Busy flag
+  * @brief  Get busy flag
   * @rmtoll SR           BSY           LL_I2S_IsActiveFlag_BSY
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -1669,7 +1668,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_BSY(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Get Overrun error flag
+  * @brief  Get overrun error flag
   * @rmtoll SR           OVR           LL_I2S_IsActiveFlag_OVR
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -1680,7 +1679,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_OVR(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Get Underrun error flag
+  * @brief  Get underrun error flag
   * @rmtoll SR           UDR           LL_I2S_IsActiveFlag_UDR
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -1691,7 +1690,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_UDR(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Get Frame format error flag
+  * @brief  Get frame format error flag
   * @rmtoll SR           FRE           LL_I2S_IsActiveFlag_FRE
   * @param  SPIx SPI Instance
   * @retval State of bit (1 or 0).
@@ -1702,7 +1701,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_FRE(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Get Channel side flag.
+  * @brief  Get channel side flag.
   * @note   0: Channel Left has to be transmitted or has been received\n
   *         1: Channel Right has to be transmitted or has been received\n
   *         It has no significance in PCM mode.
@@ -1716,7 +1715,7 @@ __STATIC_INLINE uint32_t LL_I2S_IsActiveFlag_CHSIDE(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Clear Overrun error flag
+  * @brief  Clear overrun error flag
   * @rmtoll SR           OVR           LL_I2S_ClearFlag_OVR
   * @param  SPIx SPI Instance
   * @retval None
@@ -1727,7 +1726,7 @@ __STATIC_INLINE void LL_I2S_ClearFlag_OVR(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Clear Underrun error flag
+  * @brief  Clear underrun error flag
   * @rmtoll SR           UDR           LL_I2S_ClearFlag_UDR
   * @param  SPIx SPI Instance
   * @retval None
@@ -1740,7 +1739,7 @@ __STATIC_INLINE void LL_I2S_ClearFlag_UDR(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Clear Frame format error flag
+  * @brief  Clear frame format error flag
   * @rmtoll SR           FRE           LL_I2S_ClearFlag_FRE
   * @param  SPIx SPI Instance
   * @retval None
@@ -1793,7 +1792,7 @@ __STATIC_INLINE void LL_I2S_EnableIT_TXE(SPI_TypeDef *SPIx)
 }
 
 /**
-  * @brief  Disable Error IT
+  * @brief  Disable error IT
   * @note   This bit controls the generation of an interrupt when an error condition occurs (OVR, UDR and FRE in I2S mode).
   * @rmtoll CR2          ERRIE         LL_I2S_DisableIT_ERR
   * @param  SPIx SPI Instance

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_system.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_system.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_system.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of SYSTEM LL module.
   @verbatim
   ==============================================================================
@@ -21,7 +19,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -77,15 +75,12 @@ extern "C" {
   * @{
   */
 
-/* Defines used for position in the register */
-#define DBGMCU_REVID_POSITION         (uint32_t)POSITION_VAL(DBGMCU_IDCODE_REV_ID)
-
 /**
  * @brief Power-down in Run mode Flash key
  */
-#define FLASH_PDKEY1                  ((uint32_t)0x04152637U) /*!< Flash power down key1 */
-#define FLASH_PDKEY2                  ((uint32_t)0xFAFBFCFDU) /*!< Flash power down key2: used with FLASH_PDKEY1 
-                                                                   to unlock the RUN_PD bit in FLASH_ACR */
+#define FLASH_PDKEY1                  (0x04152637U) /*!< Flash power down key1 */
+#define FLASH_PDKEY2                  (0xFAFBFCFDU) /*!< Flash power down key2: used with FLASH_PDKEY1 
+                                                       to unlock the RUN_PD bit in FLASH_ACR */
 
 /**
   * @}
@@ -102,7 +97,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_REMAP SYSCFG REMAP
 * @{
 */
-#define LL_SYSCFG_REMAP_FLASH              (uint32_t)0x00000000U                                  /*<! Main Flash memory mapped at 0x00000000 */
+#define LL_SYSCFG_REMAP_FLASH              (0x00000000U)                                         /*<! Main Flash memory mapped at 0x00000000 */
 #define LL_SYSCFG_REMAP_SYSTEMFLASH        SYSCFG_MEMRMP_MEM_MODE_0                              /*<! System Flash memory mapped at 0x00000000 */
 #define LL_SYSCFG_REMAP_SRAM               (SYSCFG_MEMRMP_MEM_MODE_1 | SYSCFG_MEMRMP_MEM_MODE_0) /*<! Embedded SRAM mapped at 0x00000000 */
 #if defined(FSMC_R_BASE)
@@ -115,7 +110,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_BOOT SYSCFG BOOT MODE
   * @{
   */
-#define LL_SYSCFG_BOOTMODE_FLASH               ((uint32_t)0x00000000U)   /*<! Main Flash memory boot mode */
+#define LL_SYSCFG_BOOTMODE_FLASH               (0x00000000U)             /*<! Main Flash memory boot mode */
 #define LL_SYSCFG_BOOTMODE_SYSTEMFLASH         SYSCFG_MEMRMP_BOOT_MODE_0 /*<! System Flash memory boot mode */
 #if defined(FSMC_BANK1)
 #define LL_SYSCFG_BOOTMODE_FSMC                SYSCFG_MEMRMP_BOOT_MODE_1 /*<! FSMC boot mode */
@@ -143,20 +138,20 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_EXTI SYSCFG EXTI PORT
   * @{
   */
-#define LL_SYSCFG_EXTI_PORTA               (uint32_t)0U /*!< EXTI PORT A                        */
-#define LL_SYSCFG_EXTI_PORTB               (uint32_t)1U /*!< EXTI PORT B                        */
-#define LL_SYSCFG_EXTI_PORTC               (uint32_t)2U /*!< EXTI PORT C                        */
-#define LL_SYSCFG_EXTI_PORTD               (uint32_t)3U /*!< EXTI PORT D                        */
+#define LL_SYSCFG_EXTI_PORTA               0U /*!< EXTI PORT A                        */
+#define LL_SYSCFG_EXTI_PORTB               1U /*!< EXTI PORT B                        */
+#define LL_SYSCFG_EXTI_PORTC               2U /*!< EXTI PORT C                        */
+#define LL_SYSCFG_EXTI_PORTD               3U /*!< EXTI PORT D                        */
 #if defined(GPIOE)
-#define LL_SYSCFG_EXTI_PORTE               (uint32_t)4U /*!< EXTI PORT E                        */
+#define LL_SYSCFG_EXTI_PORTE               4U /*!< EXTI PORT E                        */
 #endif /* GPIOE */
 #if defined(GPIOF)
-#define LL_SYSCFG_EXTI_PORTF               (uint32_t)6U /*!< EXTI PORT F                        */
+#define LL_SYSCFG_EXTI_PORTF               6U /*!< EXTI PORT F                        */
 #endif /* GPIOF */
 #if defined(GPIOG)
-#define LL_SYSCFG_EXTI_PORTG               (uint32_t)7U /*!< EXTI PORT G                        */
+#define LL_SYSCFG_EXTI_PORTG               7U /*!< EXTI PORT G                        */
 #endif /* GPIOG */
-#define LL_SYSCFG_EXTI_PORTH               (uint32_t)5U /*!< EXTI PORT H                        */
+#define LL_SYSCFG_EXTI_PORTH               5U /*!< EXTI PORT H                        */
 /**
   * @}
   */
@@ -187,7 +182,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_TRACE DBGMCU TRACE Pin Assignment
   * @{
   */
-#define LL_DBGMCU_TRACE_NONE               (uint32_t)0x00000000U                           /*!< TRACE pins not assigned (default state) */
+#define LL_DBGMCU_TRACE_NONE               0x00000000U                                     /*!< TRACE pins not assigned (default state) */
 #define LL_DBGMCU_TRACE_ASYNCH             DBGMCU_CR_TRACE_IOEN                            /*!< TRACE pin assignment for Asynchronous Mode */
 #define LL_DBGMCU_TRACE_SYNCH_SIZE1        (DBGMCU_CR_TRACE_IOEN | DBGMCU_CR_TRACE_MODE_0) /*!< TRACE pin assignment for Synchronous Mode with a TRACEDATA size of 1 */
 #define LL_DBGMCU_TRACE_SYNCH_SIZE2        (DBGMCU_CR_TRACE_IOEN | DBGMCU_CR_TRACE_MODE_1) /*!< TRACE pin assignment for Synchronous Mode with a TRACEDATA size of 2 */
@@ -231,7 +226,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_TIM_SELECT RI TIM selection
   * @{
   */
-#define LL_RI_TIM_SELECT_NONE              ((uint32_t)0x00000000U) /*!< No timer selected */
+#define LL_RI_TIM_SELECT_NONE              (0x00000000U)           /*!< No timer selected */
 #define LL_RI_TIM_SELECT_TIM2              RI_ICR_TIM_0            /*!< Timer 2 selected */
 #define LL_RI_TIM_SELECT_TIM3              RI_ICR_TIM_1            /*!< Timer 3 selected */
 #define LL_RI_TIM_SELECT_TIM4              RI_ICR_TIM              /*!< Timer 4 selected */
@@ -253,24 +248,24 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_INPUTCAPTUREROUTING RI Input Capture Routing
   * @{
   */
-                                                                   /* TIMx_IC1 TIMx_IC2  TIMx_IC3  TIMx_IC4   */  
-#define LL_RI_INPUTCAPTUREROUTING_0        ((uint32_t)0x00000000U) /*!< PA0       PA1      PA2       PA3      */
-#define LL_RI_INPUTCAPTUREROUTING_1        ((uint32_t)0x00000001U) /*!< PA4       PA5      PA6       PA7      */
-#define LL_RI_INPUTCAPTUREROUTING_2        ((uint32_t)0x00000002U) /*!< PA8       PA9      PA10      PA11     */
-#define LL_RI_INPUTCAPTUREROUTING_3        ((uint32_t)0x00000003U) /*!< PA12      PA13     PA14      PA15     */
-#define LL_RI_INPUTCAPTUREROUTING_4        ((uint32_t)0x00000004U) /*!< PC0       PC1      PC2       PC3      */
-#define LL_RI_INPUTCAPTUREROUTING_5        ((uint32_t)0x00000005U) /*!< PC4       PC5      PC6       PC7      */
-#define LL_RI_INPUTCAPTUREROUTING_6        ((uint32_t)0x00000006U) /*!< PC8       PC9      PC10      PC11     */
-#define LL_RI_INPUTCAPTUREROUTING_7        ((uint32_t)0x00000007U) /*!< PC12      PC13     PC14      PC15     */
-#define LL_RI_INPUTCAPTUREROUTING_8        ((uint32_t)0x00000008U) /*!< PD0       PD1      PD2       PD3      */
-#define LL_RI_INPUTCAPTUREROUTING_9        ((uint32_t)0x00000009U) /*!< PD4       PD5      PD6       PD7      */
-#define LL_RI_INPUTCAPTUREROUTING_10       ((uint32_t)0x0000000AU) /*!< PD8       PD9      PD10      PD11     */
-#define LL_RI_INPUTCAPTUREROUTING_11       ((uint32_t)0x0000000BU) /*!< PD12      PD13     PD14      PD15     */
+                                                         /* TIMx_IC1 TIMx_IC2  TIMx_IC3  TIMx_IC4   */  
+#define LL_RI_INPUTCAPTUREROUTING_0        (0x00000000U) /*!< PA0       PA1      PA2       PA3      */
+#define LL_RI_INPUTCAPTUREROUTING_1        (0x00000001U) /*!< PA4       PA5      PA6       PA7      */
+#define LL_RI_INPUTCAPTUREROUTING_2        (0x00000002U) /*!< PA8       PA9      PA10      PA11     */
+#define LL_RI_INPUTCAPTUREROUTING_3        (0x00000003U) /*!< PA12      PA13     PA14      PA15     */
+#define LL_RI_INPUTCAPTUREROUTING_4        (0x00000004U) /*!< PC0       PC1      PC2       PC3      */
+#define LL_RI_INPUTCAPTUREROUTING_5        (0x00000005U) /*!< PC4       PC5      PC6       PC7      */
+#define LL_RI_INPUTCAPTUREROUTING_6        (0x00000006U) /*!< PC8       PC9      PC10      PC11     */
+#define LL_RI_INPUTCAPTUREROUTING_7        (0x00000007U) /*!< PC12      PC13     PC14      PC15     */
+#define LL_RI_INPUTCAPTUREROUTING_8        (0x00000008U) /*!< PD0       PD1      PD2       PD3      */
+#define LL_RI_INPUTCAPTUREROUTING_9        (0x00000009U) /*!< PD4       PD5      PD6       PD7      */
+#define LL_RI_INPUTCAPTUREROUTING_10       (0x0000000AU) /*!< PD8       PD9      PD10      PD11     */
+#define LL_RI_INPUTCAPTUREROUTING_11       (0x0000000BU) /*!< PD12      PD13     PD14      PD15     */
 #if defined(GPIOE)
-#define LL_RI_INPUTCAPTUREROUTING_12       ((uint32_t)0x0000000CU) /*!< PE0       PE1      PE2       PE3      */
-#define LL_RI_INPUTCAPTUREROUTING_13       ((uint32_t)0x0000000DU) /*!< PE4       PE5      PE6       PE7      */
-#define LL_RI_INPUTCAPTUREROUTING_14       ((uint32_t)0x0000000EU) /*!< PE8       PE9      PE10      PE11     */
-#define LL_RI_INPUTCAPTUREROUTING_15       ((uint32_t)0x0000000FU) /*!< PE12      PE13     PE14      PE15     */
+#define LL_RI_INPUTCAPTUREROUTING_12       (0x0000000CU) /*!< PE0       PE1      PE2       PE3      */
+#define LL_RI_INPUTCAPTUREROUTING_13       (0x0000000DU) /*!< PE4       PE5      PE6       PE7      */
+#define LL_RI_INPUTCAPTUREROUTING_14       (0x0000000EU) /*!< PE8       PE9      PE10      PE11     */
+#define LL_RI_INPUTCAPTUREROUTING_15       (0x0000000FU) /*!< PE12      PE13     PE14      PE15     */
 #endif /* GPIOE */
 /**
   * @}
@@ -355,18 +350,18 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_HSYTERESIS_PORT RI HSYTERESIS PORT
   * @{
   */
-#define LL_RI_HSYTERESIS_PORT_A            (uint32_t)0U         /*!< HYSTERESIS PORT A  */
-#define LL_RI_HSYTERESIS_PORT_B            (uint32_t)1U         /*!< HYSTERESIS PORT B  */
-#define LL_RI_HSYTERESIS_PORT_C            (uint32_t)2U         /*!< HYSTERESIS PORT C  */
-#define LL_RI_HSYTERESIS_PORT_D            (uint32_t)3U         /*!< HYSTERESIS PORT D  */
+#define LL_RI_HSYTERESIS_PORT_A            0U         /*!< HYSTERESIS PORT A  */
+#define LL_RI_HSYTERESIS_PORT_B            1U         /*!< HYSTERESIS PORT B  */
+#define LL_RI_HSYTERESIS_PORT_C            2U         /*!< HYSTERESIS PORT C  */
+#define LL_RI_HSYTERESIS_PORT_D            3U         /*!< HYSTERESIS PORT D  */
 #if defined(GPIOE)
-#define LL_RI_HSYTERESIS_PORT_E            (uint32_t)4U         /*!< HYSTERESIS PORT E  */
+#define LL_RI_HSYTERESIS_PORT_E            4U         /*!< HYSTERESIS PORT E  */
 #endif /* GPIOE */
 #if defined(GPIOF)
-#define LL_RI_HSYTERESIS_PORT_F            (uint32_t)5U         /*!< HYSTERESIS PORT F  */
+#define LL_RI_HSYTERESIS_PORT_F            5U         /*!< HYSTERESIS PORT F  */
 #endif /* GPIOF */
 #if defined(GPIOG)
-#define LL_RI_HSYTERESIS_PORT_G            (uint32_t)6U         /*!< HYSTERESIS PORT G  */
+#define LL_RI_HSYTERESIS_PORT_G            6U         /*!< HYSTERESIS PORT G  */
 #endif /* GPIOG */
 /**
   * @}
@@ -400,14 +395,14 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_PORT RI PORT
   * @{
   */
-#define LL_RI_PORT_A                       (uint32_t)0U         /*!< PORT A   */
-#define LL_RI_PORT_B                       (uint32_t)1U         /*!< PORT B   */
-#define LL_RI_PORT_C                       (uint32_t)2U         /*!< PORT C   */
+#define LL_RI_PORT_A                       0U         /*!< PORT A   */
+#define LL_RI_PORT_B                       1U         /*!< PORT B   */
+#define LL_RI_PORT_C                       2U         /*!< PORT C   */
 #if defined(GPIOF)
-#define LL_RI_PORT_F                       (uint32_t)3U         /*!< PORT F   */
+#define LL_RI_PORT_F                       3U         /*!< PORT F   */
 #endif /* GPIOF */
 #if defined(GPIOG)
-#define LL_RI_PORT_G                       (uint32_t)4U         /*!< PORT G   */
+#define LL_RI_PORT_G                       4U         /*!< PORT G   */
 #endif /* GPIOG */
 /**
   * @}
@@ -419,7 +414,7 @@ extern "C" {
 /** @defgroup SYSTEM_LL_EC_LATENCY FLASH LATENCY
   * @{
   */
-#define LL_FLASH_LATENCY_0                 ((uint32_t)0x00000000U) /*!< FLASH Zero Latency cycle */
+#define LL_FLASH_LATENCY_0                 0x00000000U             /*!< FLASH Zero Latency cycle */
 #define LL_FLASH_LATENCY_1                 FLASH_ACR_LATENCY       /*!< FLASH One Latency cycle */
 /**
   * @}
@@ -779,7 +774,7 @@ __STATIC_INLINE uint32_t LL_DBGMCU_GetDeviceID(void)
   */
 __STATIC_INLINE uint32_t LL_DBGMCU_GetRevisionID(void)
 {
-  return (uint32_t)(READ_BIT(DBGMCU->IDCODE, DBGMCU_IDCODE_REV_ID) >> DBGMCU_REVID_POSITION);
+  return (uint32_t)(READ_BIT(DBGMCU->IDCODE, DBGMCU_IDCODE_REV_ID) >> DBGMCU_IDCODE_REV_ID_Pos);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_tim.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_tim.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_tim.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   TIM LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -248,7 +246,7 @@ void LL_TIM_StructInit(LL_TIM_InitTypeDef *TIM_InitStruct)
   /* Set the default configuration */
   TIM_InitStruct->Prescaler         = (uint16_t)0x0000U;
   TIM_InitStruct->CounterMode       = LL_TIM_COUNTERMODE_UP;
-  TIM_InitStruct->Autoreload        = (uint32_t)0xFFFFFFFFU;
+  TIM_InitStruct->Autoreload        = 0xFFFFFFFFU;
   TIM_InitStruct->ClockDivision     = LL_TIM_CLOCKDIVISION_DIV1;
 }
 
@@ -309,7 +307,7 @@ void LL_TIM_OC_StructInit(LL_TIM_OC_InitTypeDef *TIM_OC_InitStruct)
   /* Set the default configuration */
   TIM_OC_InitStruct->OCMode       = LL_TIM_OCMODE_FROZEN;
   TIM_OC_InitStruct->OCState      = LL_TIM_OCSTATE_DISABLE;
-  TIM_OC_InitStruct->CompareValue = (uint32_t)0x00000000U;
+  TIM_OC_InitStruct->CompareValue = 0x00000000U;
   TIM_OC_InitStruct->OCPolarity   = LL_TIM_OCPOLARITY_HIGH;
 }
 
@@ -486,7 +484,6 @@ ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, LL_TIM_ENCODER_InitTypeDef *T
 
   return SUCCESS;
 }
-
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_tim.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_tim.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_tim.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of TIM LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -116,19 +114,18 @@ static const uint8_t SHIFT_TAB_CCxP[] =
   */
 
 
-#define TIMx_OR_RMP_SHIFT  ((uint32_t)16U)
-#define TIMx_OR_RMP_MASK   ((uint32_t)0x0000FFFFU)
-#define TIM_OR_RMP_MASK    ((uint32_t)((TIM_OR_TI1RMP | TIM_OR_ETR_RMP | TIM_OR_TI1_RMP_RI)  << TIMx_OR_RMP_SHIFT))
-#define TIM9_OR_RMP_MASK   ((uint32_t)((TIM_OR_TI1RMP | TIM9_OR_ITR1_RMP) << TIMx_OR_RMP_SHIFT))
-#define TIM2_OR_RMP_MASK   ((uint32_t)(TIM2_OR_ITR1_RMP << TIMx_OR_RMP_SHIFT))
-#define TIM3_OR_RMP_MASK   ((uint32_t)(TIM3_OR_ITR2_RMP << TIMx_OR_RMP_SHIFT))
+#define TIMx_OR_RMP_SHIFT  16U
+#define TIMx_OR_RMP_MASK   0x0000FFFFU
+#define TIM_OR_RMP_MASK    ((TIM_OR_TI1RMP | TIM_OR_ETR_RMP | TIM_OR_TI1_RMP_RI) << TIMx_OR_RMP_SHIFT)
+#define TIM9_OR_RMP_MASK   ((TIM_OR_TI1RMP | TIM9_OR_ITR1_RMP) << TIMx_OR_RMP_SHIFT)
+#define TIM2_OR_RMP_MASK   (TIM2_OR_ITR1_RMP << TIMx_OR_RMP_SHIFT)
+#define TIM3_OR_RMP_MASK   (TIM3_OR_ITR2_RMP << TIMx_OR_RMP_SHIFT)
 
 
 
 /**
   * @}
   */
-
 
 /* Private macros ------------------------------------------------------------*/
 /** @defgroup TIM_LL_Private_Macros TIM Private Macros
@@ -173,7 +170,7 @@ typedef struct
 
                                    This feature can be modified afterwards using unitary function @ref LL_TIM_SetCounterMode().*/
 
-  uint32_t Autoreload;       /*!< Specifies the auto reload value to be loaded into the active
+  uint32_t Autoreload;        /*!< Specifies the auto reload value to be loaded into the active
                                    Auto-Reload Register at the next update event.
                                    This parameter must be a number between Min_Data=0x0000 and Max_Data=0xFFFF.
                                    Some timer instances may support 32 bits counters. In that case this parameter must be a number between 0x0000 and 0xFFFFFFFF.
@@ -210,6 +207,7 @@ typedef struct
                                This parameter can be a value of @ref TIM_LL_EC_OCPOLARITY.
 
                                This feature can be modified afterwards using unitary function @ref LL_TIM_OC_SetPolarity().*/
+
 
 } LL_TIM_OC_InitTypeDef;
 
@@ -340,8 +338,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_UPDATESOURCE Update Source
   * @{
   */
-#define LL_TIM_UPDATESOURCE_REGULAR            ((uint32_t)0x00000000U) /*!< Counter overflow/underflow, Setting the UG bit or Update generation through the slave mode controller generates an update request */
-#define LL_TIM_UPDATESOURCE_COUNTER            TIM_CR1_URS            /*!< Only counter overflow/underflow generates an update request */
+#define LL_TIM_UPDATESOURCE_REGULAR            0x00000000U          /*!< Counter overflow/underflow, Setting the UG bit or Update generation through the slave mode controller generates an update request */
+#define LL_TIM_UPDATESOURCE_COUNTER            TIM_CR1_URS          /*!< Only counter overflow/underflow generates an update request */
 /**
   * @}
   */
@@ -349,8 +347,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_ONEPULSEMODE One Pulse Mode
   * @{
   */
-#define LL_TIM_ONEPULSEMODE_SINGLE             TIM_CR1_OPM            /*!< Counter is not stopped at update event */
-#define LL_TIM_ONEPULSEMODE_REPETITIVE         ((uint32_t)0x00000000U) /*!< Counter stops counting at the next update event */
+#define LL_TIM_ONEPULSEMODE_SINGLE             TIM_CR1_OPM          /*!< Counter is not stopped at update event */
+#define LL_TIM_ONEPULSEMODE_REPETITIVE         0x00000000U          /*!< Counter stops counting at the next update event */
 /**
   * @}
   */
@@ -358,11 +356,11 @@ typedef struct
 /** @defgroup TIM_LL_EC_COUNTERMODE Counter Mode
   * @{
   */
-#define LL_TIM_COUNTERMODE_UP                  ((uint32_t)0x00000000U) /*!<Counter used as upcounter */
-#define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR             /*!< Counter used as downcounter */
-#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_0           /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
-#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_1           /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
-#define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS             /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
+#define LL_TIM_COUNTERMODE_UP                  0x00000000U          /*!<Counter used as upcounter */
+#define LL_TIM_COUNTERMODE_DOWN                TIM_CR1_DIR          /*!< Counter used as downcounter */
+#define LL_TIM_COUNTERMODE_CENTER_UP           TIM_CR1_CMS_0        /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting down. */
+#define LL_TIM_COUNTERMODE_CENTER_DOWN         TIM_CR1_CMS_1        /*!<The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up */
+#define LL_TIM_COUNTERMODE_CENTER_UP_DOWN      TIM_CR1_CMS          /*!< The counter counts up and down alternatively. Output compare interrupt flags of output channels  are set only when the counter is counting up or down. */
 /**
   * @}
   */
@@ -370,9 +368,9 @@ typedef struct
 /** @defgroup TIM_LL_EC_CLOCKDIVISION Clock Division
   * @{
   */
-#define LL_TIM_CLOCKDIVISION_DIV1              ((uint32_t)0x00000000U) /*!< tDTS=tCK_INT */
-#define LL_TIM_CLOCKDIVISION_DIV2              TIM_CR1_CKD_0           /*!< tDTS=2*tCK_INT */
-#define LL_TIM_CLOCKDIVISION_DIV4              TIM_CR1_CKD_1           /*!< tDTS=4*tCK_INT */
+#define LL_TIM_CLOCKDIVISION_DIV1              0x00000000U          /*!< tDTS=tCK_INT */
+#define LL_TIM_CLOCKDIVISION_DIV2              TIM_CR1_CKD_0        /*!< tDTS=2*tCK_INT */
+#define LL_TIM_CLOCKDIVISION_DIV4              TIM_CR1_CKD_1        /*!< tDTS=4*tCK_INT */
 /**
   * @}
   */
@@ -380,8 +378,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_COUNTERDIRECTION Counter Direction
   * @{
   */
-#define LL_TIM_COUNTERDIRECTION_UP             ((uint32_t)0x00000000U) /*!< Timer counter counts up */
-#define LL_TIM_COUNTERDIRECTION_DOWN           TIM_CR1_DIR             /*!< Timer counter counts down */
+#define LL_TIM_COUNTERDIRECTION_UP             0x00000000U          /*!< Timer counter counts up */
+#define LL_TIM_COUNTERDIRECTION_DOWN           TIM_CR1_DIR          /*!< Timer counter counts down */
 /**
   * @}
   */
@@ -390,8 +388,8 @@ typedef struct
 /** @defgroup TIM_LL_EC_CCDMAREQUEST Capture Compare DMA Request
   * @{
   */
-#define LL_TIM_CCDMAREQUEST_CC                 ((uint32_t)0x00000000U) /*!< CCx DMA request sent when CCx event occurs */
-#define LL_TIM_CCDMAREQUEST_UPDATE             TIM_CR2_CCDS            /*!< CCx DMA requests sent when update event occurs */
+#define LL_TIM_CCDMAREQUEST_CC                 0x00000000U          /*!< CCx DMA request sent when CCx event occurs */
+#define LL_TIM_CCDMAREQUEST_UPDATE             TIM_CR2_CCDS         /*!< CCx DMA requests sent when update event occurs */
 /**
   * @}
   */
@@ -412,7 +410,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCSTATE Output Configuration State
   * @{
   */
-#define LL_TIM_OCSTATE_DISABLE                 ((uint32_t)0x00000000U) /*!< OCx is not active */
+#define LL_TIM_OCSTATE_DISABLE                 0x00000000U             /*!< OCx is not active */
 #define LL_TIM_OCSTATE_ENABLE                  TIM_CCER_CC1E           /*!< OCx signal is output on the corresponding output pin */
 /**
   * @}
@@ -422,11 +420,11 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCMODE Output Configuration Mode
   * @{
   */
-#define LL_TIM_OCMODE_FROZEN                   ((uint32_t)0x00000000U)                                  /*!<The comparison between the output compare register TIMx_CCRy and the counter TIMx_CNT has no effect on the output channel level */
+#define LL_TIM_OCMODE_FROZEN                   0x00000000U                                              /*!<The comparison between the output compare register TIMx_CCRy and the counter TIMx_CNT has no effect on the output channel level */
 #define LL_TIM_OCMODE_ACTIVE                   TIM_CCMR1_OC1M_0                                         /*!<OCyREF is forced high on compare match*/
 #define LL_TIM_OCMODE_INACTIVE                 TIM_CCMR1_OC1M_1                                         /*!<OCyREF is forced low on compare match*/
 #define LL_TIM_OCMODE_TOGGLE                   (TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0)                    /*!<OCyREF toggles on compare match*/
-#define LL_TIM_OCMODE_FORCED_INACTIVE          (TIM_CCMR1_OC1M_2)                                       /*!<OCyREF is forced low*/
+#define LL_TIM_OCMODE_FORCED_INACTIVE          TIM_CCMR1_OC1M_2                                       /*!<OCyREF is forced low*/
 #define LL_TIM_OCMODE_FORCED_ACTIVE            (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_0)                    /*!<OCyREF is forced high*/
 #define LL_TIM_OCMODE_PWM1                     (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1)                    /*!<In upcounting, channel y is active as long as TIMx_CNT<TIMx_CCRy else inactive.  In downcounting, channel y is inactive as long as TIMx_CNT>TIMx_CCRy else active.*/
 #define LL_TIM_OCMODE_PWM2                     (TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_0) /*!<In upcounting, channel y is inactive as long as TIMx_CNT<TIMx_CCRy else active.  In downcounting, channel y is active as long as TIMx_CNT>TIMx_CCRy else inactive*/
@@ -437,7 +435,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCPOLARITY Output Configuration Polarity
   * @{
   */
-#define LL_TIM_OCPOLARITY_HIGH                 ((uint32_t)0x00000000U)     /*!< OCxactive high*/
+#define LL_TIM_OCPOLARITY_HIGH                 0x00000000U                 /*!< OCxactive high*/
 #define LL_TIM_OCPOLARITY_LOW                  TIM_CCER_CC1P               /*!< OCxactive low*/
 /**
   * @}
@@ -448,9 +446,9 @@ typedef struct
 /** @defgroup TIM_LL_EC_ACTIVEINPUT Active Input Selection
   * @{
   */
-#define LL_TIM_ACTIVEINPUT_DIRECTTI            (uint32_t)(TIM_CCMR1_CC1S_0 << 16U) /*!< ICx is mapped on TIx */
-#define LL_TIM_ACTIVEINPUT_INDIRECTTI          (uint32_t)(TIM_CCMR1_CC1S_1 << 16U) /*!< ICx is mapped on TIy */
-#define LL_TIM_ACTIVEINPUT_TRC                 (uint32_t)(TIM_CCMR1_CC1S << 16U)   /*!< ICx is mapped on TRC */
+#define LL_TIM_ACTIVEINPUT_DIRECTTI            (TIM_CCMR1_CC1S_0 << 16U) /*!< ICx is mapped on TIx */
+#define LL_TIM_ACTIVEINPUT_INDIRECTTI          (TIM_CCMR1_CC1S_1 << 16U) /*!< ICx is mapped on TIy */
+#define LL_TIM_ACTIVEINPUT_TRC                 (TIM_CCMR1_CC1S << 16U)   /*!< ICx is mapped on TRC */
 /**
   * @}
   */
@@ -458,10 +456,10 @@ typedef struct
 /** @defgroup TIM_LL_EC_ICPSC Input Configuration Prescaler
   * @{
   */
-#define LL_TIM_ICPSC_DIV1                      ((uint32_t)0x00000000U) /*!< No prescaler, capture is done each time an edge is detected on the capture input */
-#define LL_TIM_ICPSC_DIV2                      (uint32_t)(TIM_CCMR1_IC1PSC_0 << 16U)    /*!< Capture is done once every 2 events */
-#define LL_TIM_ICPSC_DIV4                      (uint32_t)(TIM_CCMR1_IC1PSC_1 << 16U)    /*!< Capture is done once every 4 events */
-#define LL_TIM_ICPSC_DIV8                      (uint32_t)(TIM_CCMR1_IC1PSC << 16U)      /*!< Capture is done once every 8 events */
+#define LL_TIM_ICPSC_DIV1                      0x00000000U                              /*!< No prescaler, capture is done each time an edge is detected on the capture input */
+#define LL_TIM_ICPSC_DIV2                      (TIM_CCMR1_IC1PSC_0 << 16U)    /*!< Capture is done once every 2 events */
+#define LL_TIM_ICPSC_DIV4                      (TIM_CCMR1_IC1PSC_1 << 16U)    /*!< Capture is done once every 4 events */
+#define LL_TIM_ICPSC_DIV8                      (TIM_CCMR1_IC1PSC << 16U)      /*!< Capture is done once every 8 events */
 /**
   * @}
   */
@@ -469,22 +467,22 @@ typedef struct
 /** @defgroup TIM_LL_EC_IC_FILTER Input Configuration Filter
   * @{
   */
-#define LL_TIM_IC_FILTER_FDIV1                 ((uint32_t)0x00000000U)                                         /*!< No filter, sampling is done at fDTS */
-#define LL_TIM_IC_FILTER_FDIV1_N2              (uint32_t)(TIM_CCMR1_IC1F_0 << 16U)                                          /*!< fSAMPLING=fCK_INT, N=2 */
-#define LL_TIM_IC_FILTER_FDIV1_N4              (uint32_t)(TIM_CCMR1_IC1F_1 << 16U)                                          /*!< fSAMPLING=fCK_INT, N=4 */
-#define LL_TIM_IC_FILTER_FDIV1_N8              (uint32_t)((TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fCK_INT, N=8 */
-#define LL_TIM_IC_FILTER_FDIV2_N6              (uint32_t)(TIM_CCMR1_IC1F_2 << 16U)                                          /*!< fSAMPLING=fDTS/2, N=6 */
-#define LL_TIM_IC_FILTER_FDIV2_N8              (uint32_t)((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fDTS/2, N=8 */
-#define LL_TIM_IC_FILTER_FDIV4_N6              (uint32_t)((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1) << 16U)                     /*!< fSAMPLING=fDTS/4, N=6 */
-#define LL_TIM_IC_FILTER_FDIV4_N8              (uint32_t)((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/4, N=8 */
-#define LL_TIM_IC_FILTER_FDIV8_N6              (uint32_t)(TIM_CCMR1_IC1F_3 << 16U)                                          /*!< fSAMPLING=fDTS/8, N=6 */
-#define LL_TIM_IC_FILTER_FDIV8_N8              (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fDTS/8, N=8 */
-#define LL_TIM_IC_FILTER_FDIV16_N5             (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_1) << 16U)                     /*!< fSAMPLING=fDTS/16, N=5 */
-#define LL_TIM_IC_FILTER_FDIV16_N6             (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/16, N=6 */
-#define LL_TIM_IC_FILTER_FDIV16_N8             (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2) << 16U)                     /*!< fSAMPLING=fDTS/16, N=8 */
-#define LL_TIM_IC_FILTER_FDIV32_N5             (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/32, N=5 */
-#define LL_TIM_IC_FILTER_FDIV32_N6             (uint32_t)((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1) << 16U)  /*!< fSAMPLING=fDTS/32, N=6 */
-#define LL_TIM_IC_FILTER_FDIV32_N8             (uint32_t)(TIM_CCMR1_IC1F << 16U)                                            /*!< fSAMPLING=fDTS/32, N=8 */
+#define LL_TIM_IC_FILTER_FDIV1                 0x00000000U                                                        /*!< No filter, sampling is done at fDTS */
+#define LL_TIM_IC_FILTER_FDIV1_N2              (TIM_CCMR1_IC1F_0 << 16U)                                          /*!< fSAMPLING=fCK_INT, N=2 */
+#define LL_TIM_IC_FILTER_FDIV1_N4              (TIM_CCMR1_IC1F_1 << 16U)                                          /*!< fSAMPLING=fCK_INT, N=4 */
+#define LL_TIM_IC_FILTER_FDIV1_N8              ((TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fCK_INT, N=8 */
+#define LL_TIM_IC_FILTER_FDIV2_N6              (TIM_CCMR1_IC1F_2 << 16U)                                          /*!< fSAMPLING=fDTS/2, N=6 */
+#define LL_TIM_IC_FILTER_FDIV2_N8              ((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fDTS/2, N=8 */
+#define LL_TIM_IC_FILTER_FDIV4_N6              ((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1) << 16U)                     /*!< fSAMPLING=fDTS/4, N=6 */
+#define LL_TIM_IC_FILTER_FDIV4_N8              ((TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/4, N=8 */
+#define LL_TIM_IC_FILTER_FDIV8_N6              (TIM_CCMR1_IC1F_3 << 16U)                                          /*!< fSAMPLING=fDTS/8, N=6 */
+#define LL_TIM_IC_FILTER_FDIV8_N8              ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_0) << 16U)                     /*!< fSAMPLING=fDTS/8, N=8 */
+#define LL_TIM_IC_FILTER_FDIV16_N5             ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_1) << 16U)                     /*!< fSAMPLING=fDTS/16, N=5 */
+#define LL_TIM_IC_FILTER_FDIV16_N6             ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_1 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/16, N=6 */
+#define LL_TIM_IC_FILTER_FDIV16_N8             ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2) << 16U)                     /*!< fSAMPLING=fDTS/16, N=8 */
+#define LL_TIM_IC_FILTER_FDIV32_N5             ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_0) << 16U)  /*!< fSAMPLING=fDTS/32, N=5 */
+#define LL_TIM_IC_FILTER_FDIV32_N6             ((TIM_CCMR1_IC1F_3 | TIM_CCMR1_IC1F_2 | TIM_CCMR1_IC1F_1) << 16U)  /*!< fSAMPLING=fDTS/32, N=6 */
+#define LL_TIM_IC_FILTER_FDIV32_N8             (TIM_CCMR1_IC1F << 16U)                                            /*!< fSAMPLING=fDTS/32, N=8 */
 /**
   * @}
   */
@@ -492,7 +490,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_IC_POLARITY Input Configuration Polarity
   * @{
   */
-#define LL_TIM_IC_POLARITY_RISING              ((uint32_t)0x00000000U)          /*!< The circuit is sensitive to TIxFP1 rising edge, TIxFP1 is not inverted */
+#define LL_TIM_IC_POLARITY_RISING              0x00000000U                      /*!< The circuit is sensitive to TIxFP1 rising edge, TIxFP1 is not inverted */
 #define LL_TIM_IC_POLARITY_FALLING             TIM_CCER_CC1P                    /*!< The circuit is sensitive to TIxFP1 falling edge, TIxFP1 is inverted */
 #define LL_TIM_IC_POLARITY_BOTHEDGE            (TIM_CCER_CC1P | TIM_CCER_CC1NP) /*!< The circuit is sensitive to both TIxFP1 rising and falling edges, TIxFP1 is not inverted */
 /**
@@ -502,9 +500,9 @@ typedef struct
 /** @defgroup TIM_LL_EC_CLOCKSOURCE Clock Source
   * @{
   */
-#define LL_TIM_CLOCKSOURCE_INTERNAL            ((uint32_t)0x00000000U)                              /*!< The timer is clocked by the internal clock provided from the RCC */
-#define LL_TIM_CLOCKSOURCE_EXT_MODE1           (TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0 ) /*!< Counter counts at each rising or falling edge on a selected inpu t*/
-#define LL_TIM_CLOCKSOURCE_EXT_MODE2           TIM_SMCR_ECE                                        /*!< Counter counts at each rising or falling edge on the external trigger input ETR */
+#define LL_TIM_CLOCKSOURCE_INTERNAL            0x00000000U                                          /*!< The timer is clocked by the internal clock provided from the RCC */
+#define LL_TIM_CLOCKSOURCE_EXT_MODE1           (TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1 | TIM_SMCR_SMS_0)   /*!< Counter counts at each rising or falling edge on a selected inpu t*/
+#define LL_TIM_CLOCKSOURCE_EXT_MODE2           TIM_SMCR_ECE                                         /*!< Counter counts at each rising or falling edge on the external trigger input ETR */
 /**
   * @}
   */
@@ -522,7 +520,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_TRGO Trigger Output
   * @{
   */
-#define LL_TIM_TRGO_RESET                      ((uint32_t)0x00000000U)                         /*!< UG bit from the TIMx_EGR register is used as trigger output */
+#define LL_TIM_TRGO_RESET                      0x00000000U                                     /*!< UG bit from the TIMx_EGR register is used as trigger output */
 #define LL_TIM_TRGO_ENABLE                     TIM_CR2_MMS_0                                   /*!< Counter Enable signal (CNT_EN) is used as trigger output */
 #define LL_TIM_TRGO_UPDATE                     TIM_CR2_MMS_1                                   /*!< Update event is used as trigger output */
 #define LL_TIM_TRGO_CC1IF                      (TIM_CR2_MMS_1 | TIM_CR2_MMS_0)                 /*!< CC1 capture or a compare match is used as trigger output */
@@ -538,7 +536,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_SLAVEMODE Slave Mode
   * @{
   */
-#define LL_TIM_SLAVEMODE_DISABLED              ((uint32_t)0x00000000U)             /*!< Slave mode disabled */
+#define LL_TIM_SLAVEMODE_DISABLED              0x00000000U                         /*!< Slave mode disabled */
 #define LL_TIM_SLAVEMODE_RESET                 TIM_SMCR_SMS_2                      /*!< Reset Mode - Rising edge of the selected trigger input (TRGI) reinitializes the counter */
 #define LL_TIM_SLAVEMODE_GATED                 (TIM_SMCR_SMS_2 | TIM_SMCR_SMS_0)   /*!< Gated Mode - The counter clock is enabled when the trigger input (TRGI) is high */
 #define LL_TIM_SLAVEMODE_TRIGGER               (TIM_SMCR_SMS_2 | TIM_SMCR_SMS_1)   /*!< Trigger Mode - The counter starts at a rising edge of the trigger TRGI */
@@ -549,14 +547,14 @@ typedef struct
 /** @defgroup TIM_LL_EC_TS Trigger Selection
   * @{
   */
-#define LL_TIM_TS_ITR0                         ((uint32_t)0x00000000U)         /*!< Internal Trigger 0 (ITR0) is used as trigger input */
-#define LL_TIM_TS_ITR1                         TIM_SMCR_TS_0                   /*!< Internal Trigger 1 (ITR1) is used as trigger input */
-#define LL_TIM_TS_ITR2                         TIM_SMCR_TS_1                   /*!< Internal Trigger 2 (ITR2) is used as trigger input */
-#define LL_TIM_TS_ITR3                         (TIM_SMCR_TS_0 | TIM_SMCR_TS_1) /*!< Internal Trigger 3 (ITR3) is used as trigger input */
-#define LL_TIM_TS_TI1F_ED                      TIM_SMCR_TS_2                   /*!< TI1 Edge Detector (TI1F_ED) is used as trigger input */
-#define LL_TIM_TS_TI1FP1                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_0) /*!< Filtered Timer Input 1 (TI1FP1) is used as trigger input */
-#define LL_TIM_TS_TI2FP2                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_1) /*!< Filtered Timer Input 2 (TI12P2) is used as trigger input */
-#define LL_TIM_TS_ETRF                         TIM_SMCR_TS                     /*!< Filtered external Trigger (ETRF) is used as trigger input */
+#define LL_TIM_TS_ITR0                         0x00000000U                                      /*!< Internal Trigger 0 (ITR0) is used as trigger input */
+#define LL_TIM_TS_ITR1                         TIM_SMCR_TS_0                                    /*!< Internal Trigger 1 (ITR1) is used as trigger input */
+#define LL_TIM_TS_ITR2                         TIM_SMCR_TS_1                                    /*!< Internal Trigger 2 (ITR2) is used as trigger input */
+#define LL_TIM_TS_ITR3                         (TIM_SMCR_TS_0 | TIM_SMCR_TS_1)                  /*!< Internal Trigger 3 (ITR3) is used as trigger input */
+#define LL_TIM_TS_TI1F_ED                      TIM_SMCR_TS_2                                    /*!< TI1 Edge Detector (TI1F_ED) is used as trigger input */
+#define LL_TIM_TS_TI1FP1                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_0)                  /*!< Filtered Timer Input 1 (TI1FP1) is used as trigger input */
+#define LL_TIM_TS_TI2FP2                       (TIM_SMCR_TS_2 | TIM_SMCR_TS_1)                  /*!< Filtered Timer Input 2 (TI12P2) is used as trigger input */
+#define LL_TIM_TS_ETRF                         (TIM_SMCR_TS_2 | TIM_SMCR_TS_1 | TIM_SMCR_TS_0)  /*!< Filtered external Trigger (ETRF) is used as trigger input */
 /**
   * @}
   */
@@ -564,7 +562,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_ETR_POLARITY External Trigger Polarity
   * @{
   */
-#define LL_TIM_ETR_POLARITY_NONINVERTED        ((uint32_t)0x00000000U) /*!< ETR is non-inverted, active at high level or rising edge */
+#define LL_TIM_ETR_POLARITY_NONINVERTED        0x00000000U             /*!< ETR is non-inverted, active at high level or rising edge */
 #define LL_TIM_ETR_POLARITY_INVERTED           TIM_SMCR_ETP            /*!< ETR is inverted, active at low level or falling edge */
 /**
   * @}
@@ -573,7 +571,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_ETR_PRESCALER External Trigger Prescaler
   * @{
   */
-#define LL_TIM_ETR_PRESCALER_DIV1              ((uint32_t)0x00000000U) /*!< ETR prescaler OFF */
+#define LL_TIM_ETR_PRESCALER_DIV1              0x00000000U             /*!< ETR prescaler OFF */
 #define LL_TIM_ETR_PRESCALER_DIV2              TIM_SMCR_ETPS_0         /*!< ETR frequency is divided by 2 */
 #define LL_TIM_ETR_PRESCALER_DIV4              TIM_SMCR_ETPS_1         /*!< ETR frequency is divided by 4 */
 #define LL_TIM_ETR_PRESCALER_DIV8              TIM_SMCR_ETPS           /*!< ETR frequency is divided by 8 */
@@ -584,21 +582,21 @@ typedef struct
 /** @defgroup TIM_LL_EC_ETR_FILTER External Trigger Filter
   * @{
   */
-#define LL_TIM_ETR_FILTER_FDIV1                ((uint32_t)0x00000000U)                              /*!< No filter, sampling is done at fDTS */
+#define LL_TIM_ETR_FILTER_FDIV1                0x00000000U                                          /*!< No filter, sampling is done at fDTS */
 #define LL_TIM_ETR_FILTER_FDIV1_N2             TIM_SMCR_ETF_0                                       /*!< fSAMPLING=fCK_INT, N=2 */
 #define LL_TIM_ETR_FILTER_FDIV1_N4             TIM_SMCR_ETF_1                                       /*!< fSAMPLING=fCK_INT, N=4 */
 #define LL_TIM_ETR_FILTER_FDIV1_N8             (TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fCK_INT, N=8 */
 #define LL_TIM_ETR_FILTER_FDIV2_N6             TIM_SMCR_ETF_2                                       /*!< fSAMPLING=fDTS/2, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV2_N8             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fDTS/2, N=8 */
-#define LL_TIM_ETR_FILTER_FDIV4_N6             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1 )                   /*!< fSAMPLING=fDTS/4, N=6 */
+#define LL_TIM_ETR_FILTER_FDIV4_N6             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1)                    /*!< fSAMPLING=fDTS/4, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV4_N8             (TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/4, N=8 */
 #define LL_TIM_ETR_FILTER_FDIV8_N6             TIM_SMCR_ETF_3                                       /*!< fSAMPLING=fDTS/8, N=8 */
 #define LL_TIM_ETR_FILTER_FDIV8_N8             (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_0)                    /*!< fSAMPLING=fDTS/16, N=5 */
-#define LL_TIM_ETR_FILTER_FDIV16_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1 )                   /*!< fSAMPLING=fDTS/16, N=6 */
+#define LL_TIM_ETR_FILTER_FDIV16_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1)                    /*!< fSAMPLING=fDTS/16, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV16_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_1 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/16, N=8 */
-#define LL_TIM_ETR_FILTER_FDIV16_N8            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2 )                   /*!< fSAMPLING=fDTS/16, N=5 */
-#define LL_TIM_ETR_FILTER_FDIV32_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2  | TIM_SMCR_ETF_0)  /*!< fSAMPLING=fDTS/32, N=5 */
-#define LL_TIM_ETR_FILTER_FDIV32_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2  | TIM_SMCR_ETF_1)  /*!< fSAMPLING=fDTS/32, N=6 */
+#define LL_TIM_ETR_FILTER_FDIV16_N8            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2)                    /*!< fSAMPLING=fDTS/16, N=5 */
+#define LL_TIM_ETR_FILTER_FDIV32_N5            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2 | TIM_SMCR_ETF_0)   /*!< fSAMPLING=fDTS/32, N=5 */
+#define LL_TIM_ETR_FILTER_FDIV32_N6            (TIM_SMCR_ETF_3 | TIM_SMCR_ETF_2 | TIM_SMCR_ETF_1)   /*!< fSAMPLING=fDTS/32, N=6 */
 #define LL_TIM_ETR_FILTER_FDIV32_N8            TIM_SMCR_ETF                                         /*!< fSAMPLING=fDTS/32, N=8 */
 /**
   * @}
@@ -613,7 +611,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_DMABURST_BASEADDR DMA Burst Base Address
   * @{
   */
-#define LL_TIM_DMABURST_BASEADDR_CR1           ((uint32_t)0x00000000U)                                          /*!< TIMx_CR1 register is the DMA base address for DMA burst */
+#define LL_TIM_DMABURST_BASEADDR_CR1           0x00000000U                                                      /*!< TIMx_CR1 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_CR2           TIM_DCR_DBA_0                                                    /*!< TIMx_CR2 register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_SMCR          TIM_DCR_DBA_1                                                    /*!< TIMx_SMCR register is the DMA base address for DMA burst */
 #define LL_TIM_DMABURST_BASEADDR_DIER          (TIM_DCR_DBA_1 |  TIM_DCR_DBA_0)                                 /*!< TIMx_DIER register is the DMA base address for DMA burst */
@@ -637,7 +635,7 @@ typedef struct
 /** @defgroup TIM_LL_EC_DMABURST_LENGTH DMA Burst Length
   * @{
   */
-#define LL_TIM_DMABURST_LENGTH_1TRANSFER       ((uint32_t)0x00000000U)                                         /*!< Transfer is done to 1 register starting from the DMA burst base address */
+#define LL_TIM_DMABURST_LENGTH_1TRANSFER       0x00000000U                                                     /*!< Transfer is done to 1 register starting from the DMA burst base address */
 #define LL_TIM_DMABURST_LENGTH_2TRANSFERS      TIM_DCR_DBL_0                                                   /*!< Transfer is done to 2 registers starting from the DMA burst base address */
 #define LL_TIM_DMABURST_LENGTH_3TRANSFERS      TIM_DCR_DBL_1                                                   /*!< Transfer is done to 3 registers starting from the DMA burst base address */
 #define LL_TIM_DMABURST_LENGTH_4TRANSFERS      (TIM_DCR_DBL_1 |  TIM_DCR_DBL_0)                                /*!< Transfer is done to 4 registers starting from the DMA burst base address */
@@ -660,9 +658,9 @@ typedef struct
   */
 
 /** @defgroup TIM_LL_EC_TIM10_TI1_RMP  TIM10 input 1 remapping capability
-* @{
-*/
-#define LL_TIM_TIM10_TI1_RMP_GPIO   ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)               /*!< TIM10 channel1 is connected to GPIO */
+  * @{
+  */
+#define LL_TIM_TIM10_TI1_RMP_GPIO   TIM_OR_RMP_MASK                                         /*!< TIM10 channel1 is connected to GPIO */
 #define LL_TIM_TIM10_TI1_RMP_LSI    (TIM_OR_TI1RMP_0 | TIM_OR_RMP_MASK)                     /*!< TIM10 channel1 is connected to LSI internal clock */
 #define LL_TIM_TIM10_TI1_RMP_LSE    (TIM_OR_TI1RMP_1 | TIM_OR_RMP_MASK)                     /*!< TIM10 channel1 is connected to LSE internal clock */
 #define LL_TIM_TIM10_TI1_RMP_RTC    (TIM_OR_TI1RMP_0 | TIM_OR_TI1RMP_1 | TIM_OR_RMP_MASK)   /*!< TIM10 channel1 is connected to RTC wakeup interrupt signal */
@@ -671,9 +669,9 @@ typedef struct
   */
 
 /** @defgroup TIM_LL_EC_TIM10_ETR_RMP  TIM10 ETR remap
-* @{
-*/
-#define LL_TIM_TIM10_ETR_RMP_LSE      ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)               /*!< TIM10 ETR input is connected to LSE */
+  * @{
+  */
+#define LL_TIM_TIM10_ETR_RMP_LSE      TIM_OR_RMP_MASK                                         /*!< TIM10 ETR input is connected to LSE */
 #define LL_TIM_TIM10_ETR_RMP_TIM9_TGO (TIM_OR_ETR_RMP | TIM_OR_RMP_MASK)                      /*!< TIM10 ETR input is connected to TIM9 TGO */
 /**
   * @}
@@ -682,16 +680,16 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM10_TI1_RMP_RI TIM10 Input 1 remap for Routing Interface (RI)
 * @{
 */
-#define LL_TIM_TIM10_TI1_RMP          ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)               /*!< TIM10 Channel1 connection depends on TI1_RMP[1:0] bit values */
+#define LL_TIM_TIM10_TI1_RMP          TIM_OR_RMP_MASK                                         /*!< TIM10 Channel1 connection depends on TI1_RMP[1:0] bit values */
 #define LL_TIM_TIM10_TI1_RMP_RI       (TIM_OR_TI1_RMP_RI | TIM_OR_RMP_MASK)                   /*!< TIM10 channel1 is connected to RI */
 /**
   * @}
   */
 
 /** @defgroup TIM_LL_EC_TIM11_TI1_RMP  TIM11 input 1 remapping capability
-* @{
-*/
-#define LL_TIM_TIM11_TI1_RMP_GPIO       ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)             /*!< TIM11 channel1 is connected to GPIO */
+  * @{
+  */
+#define LL_TIM_TIM11_TI1_RMP_GPIO       TIM_OR_RMP_MASK                                       /*!< TIM11 channel1 is connected to GPIO */
 #define LL_TIM_TIM11_TI1_RMP_MSI        (TIM_OR_TI1RMP_0 | TIM_OR_RMP_MASK)                   /*!< TIM11 channel1 is connected to MSI internal clock */
 #define LL_TIM_TIM11_TI1_RMP_HSE_RTC    (TIM_OR_TI1RMP_1 | TIM_OR_RMP_MASK)                   /*!< TIM11 channel1 is connected to HSE RTC clock */
 #define LL_TIM_TIM11_TI1_RMP_GPIO1      (TIM_OR_TI1RMP_0 | TIM_OR_TI1RMP_1 | TIM_OR_RMP_MASK) /*!< TIM11 channel1 is connected to GPIO */
@@ -700,27 +698,27 @@ typedef struct
   */
 
 /** @defgroup TIM_LL_EC_TIM11_ETR_RMP  TIM11 ETR remap
-* @{
-*/
-#define LL_TIM_TIM11_ETR_RMP_LSE      ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)               /*!< TIM11 ETR input is connected to LSE */
+  * @{
+  */
+#define LL_TIM_TIM11_ETR_RMP_LSE      TIM_OR_RMP_MASK                                         /*!< TIM11 ETR input is connected to LSE */
 #define LL_TIM_TIM11_ETR_RMP_TIM9_TGO (TIM_OR_ETR_RMP | TIM_OR_RMP_MASK)                      /*!< TIM11 ETR input is connected to TIM9 TGO clock */
 /**
   * @}
   */
 
 /** @defgroup TIM_LL_EC_TIM11_TI1_RMP_RI TIM11 Input 1 remap for Routing Interface (RI)
-* @{
-*/
-#define LL_TIM_TIM11_TI1_RMP          ((uint32_t)0x00000000U | TIM_OR_RMP_MASK)               /*!< TIM11 Channel1 connection depends on TI1_RMP[1:0] bit values */
+  * @{
+  */
+#define LL_TIM_TIM11_TI1_RMP          TIM_OR_RMP_MASK                                         /*!< TIM11 Channel1 connection depends on TI1_RMP[1:0] bit values */
 #define LL_TIM_TIM11_TI1_RMP_RI       (TIM_OR_TI1_RMP_RI | TIM_OR_RMP_MASK)                   /*!< TIM11 channel1 is connected to RI */
 /**
   * @}
   */
 
 /** @defgroup TIM_LL_EC_TIM9_TI1_RMP TIM9 Input 1 remap
-* @{
-*/
-#define LL_TIM_TIM9_TI1_RMP_GPIO     ((uint32_t)0x00000000U | TIM9_OR_RMP_MASK)                /*!< TIM9 channel1 is connected to GPIO */
+  * @{
+  */
+#define LL_TIM_TIM9_TI1_RMP_GPIO     TIM9_OR_RMP_MASK                                          /*!< TIM9 channel1 is connected to GPIO */
 #define LL_TIM_TIM9_TI1_RMP_LSE      (TIM_OR_TI1RMP_0 | TIM9_OR_RMP_MASK)                      /*!< TIM9 channel1 is connected to LSE internal clock */
 #define LL_TIM_TIM9_TI1_RMP_GPIO1    (TIM_OR_TI1RMP_1 | TIM9_OR_RMP_MASK)                      /*!< TIM9 channel1 is connected to GPIO */
 #define LL_TIM_TIM9_TI1_RMP_GPIO2    (TIM_OR_TI1RMP_0 | TIM_OR_TI1RMP_1 | TIM9_OR_RMP_MASK)    /*!< TIM9 channel1 is connected to GPIO */
@@ -729,9 +727,9 @@ typedef struct
   */
 
 /** @defgroup TIM_LL_EC_TIM9_ITR1_RMP  TIM9 ITR1 remap
-* @{
-*/
-#define LL_TIM_TIM9_ITR1_RMP_TIM3_TGO   ((uint32_t)0x00000000U | TIM9_OR_RMP_MASK)           /*!< TIM9 channel1 is connected to TIM3 TGO signal */
+  * @{
+  */
+#define LL_TIM_TIM9_ITR1_RMP_TIM3_TGO   TIM9_OR_RMP_MASK                                     /*!< TIM9 channel1 is connected to TIM3 TGO signal */
 #define LL_TIM_TIM9_ITR1_RMP_TOUCH_IO   (TIM9_OR_ITR1_RMP | TIM9_OR_RMP_MASK)                /*!< TIM9 channel1 is connected to touch sensing I/O */
 /**
   * @}
@@ -740,16 +738,16 @@ typedef struct
 /** @defgroup TIM_LL_EC_TIM2_ITR1_RMP  TIM2 internal trigger 1 remap
 * @{
 */
-#define LL_TIM_TIM2_TIR1_RMP_TIM10_OC    ((uint32_t)0x00000000U | TIM9_OR_RMP_MASK)           /*!< TIM2 ITR1 input is connected to TIM10 OC*/
+#define LL_TIM_TIM2_TIR1_RMP_TIM10_OC    TIM9_OR_RMP_MASK                                     /*!< TIM2 ITR1 input is connected to TIM10 OC*/
 #define LL_TIM_TIM2_TIR1_RMP_TIM5_TGO    (TIM2_OR_ITR1_RMP | TIM9_OR_RMP_MASK)                /*!< TIM2 ITR1 input is connected to TIM5 TGO */
 /**
   * @}
   */
 
 /** @defgroup TIM_LL_EC_TIM3_ITR2_RMP  TIM3 internal trigger 2 remap
-* @{
-*/
-#define LL_TIM_TIM3_TIR2_RMP_TIM11_OC    ((uint32_t)0x00000000U | TIM9_OR_RMP_MASK)           /*!< TIM3 ITR2 input is connected to TIM11 OC */
+  * @{
+  */
+#define LL_TIM_TIM3_TIR2_RMP_TIM11_OC    TIM9_OR_RMP_MASK                                     /*!< TIM3 ITR2 input is connected to TIM11 OC */
 #define LL_TIM_TIM3_TIR2_RMP_TIM5_TGO    (TIM3_OR_ITR2_RMP | TIM9_OR_RMP_MASK)                /*!< TIM3 ITR2 input is connected to TIM5 TGO */
 /**
   * @}
@@ -759,12 +757,11 @@ typedef struct
 /** @defgroup TIM_LL_EC_OCREF_CLR_INT OCREF clear input selection
   * @{
   */
-#define LL_TIM_OCREF_CLR_INT_OCREF_CLR     ((uint32_t)0x00000000U ) /*!< OCREF_CLR_INT is connected to the OCREF_CLR input */
-#define LL_TIM_OCREF_CLR_INT_ETR           TIM_SMCR_OCCS            /*!< OCREF_CLR_INT is connected to ETRF */
+#define LL_TIM_OCREF_CLR_INT_OCREF_CLR     0x00000000U         /*!< OCREF_CLR_INT is connected to the OCREF_CLR input */
+#define LL_TIM_OCREF_CLR_INT_ETR           TIM_SMCR_OCCS       /*!< OCREF_CLR_INT is connected to ETRF */
 /**
   * @}
   */
-
 
 /**
   * @}
@@ -860,7 +857,7 @@ typedef struct
   * @retval Input capture prescaler ratio (1, 2, 4 or 8)
   */
 #define __LL_TIM_GET_ICPSC_RATIO(__ICPSC__)  \
-   ((uint32_t)((uint32_t)0x01U << (((__ICPSC__) >> 16U) >> TIM_CCMR1_IC1PSC_Pos)))
+   ((uint32_t)(0x01U << (((__ICPSC__) >> 16U) >> TIM_CCMR1_IC1PSC_Pos)))
 
 
 /**
@@ -921,7 +918,7 @@ __STATIC_INLINE uint32_t LL_TIM_IsEnabledCounter(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_EnableUpdateEvent(TIM_TypeDef *TIMx)
 {
-  SET_BIT(TIMx->CR1, TIM_CR1_UDIS);
+  CLEAR_BIT(TIMx->CR1, TIM_CR1_UDIS);
 }
 
 /**
@@ -932,7 +929,7 @@ __STATIC_INLINE void LL_TIM_EnableUpdateEvent(TIM_TypeDef *TIMx)
   */
 __STATIC_INLINE void LL_TIM_DisableUpdateEvent(TIM_TypeDef *TIMx)
 {
-  CLEAR_BIT(TIMx->CR1, TIM_CR1_UDIS);
+  SET_BIT(TIMx->CR1, TIM_CR1_UDIS);
 }
 
 /**
@@ -2560,11 +2557,11 @@ __STATIC_INLINE void LL_TIM_SetRemap(TIM_TypeDef *TIMx, uint32_t Remap)
   * @{
   */
 /**
-  * @brief  Set the OCREF clear source
+  * @brief  Set the OCREF clear input source
   * @note The OCxREF signal of a given channel can be cleared when a high level is applied on the OCREF_CLR_INPUT
   * @note This function can only be used in Output compare and PWM modes.
   * @note the ETR signal can be connected to the output of a comparator to be used for current handling
-  * @rmtoll SMCR          OCCS           LL_TIM_SetOCRefClearInputSource
+  * @rmtoll SMCR          OCCS                LL_TIM_SetOCRefClearInputSource
   * @param  TIMx Timer instance
   * @param  OCRefClearInputSource This parameter can be one of the following values:
   *         @arg @ref LL_TIM_OCREF_CLR_INT_OCREF_CLR
@@ -3327,5 +3324,4 @@ ErrorStatus LL_TIM_ENCODER_Init(TIM_TypeDef *TIMx, LL_TIM_ENCODER_InitTypeDef *T
 #endif
 
 #endif /* __STM32L1xx_LL_TIM_H */
-
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_usart.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_usart.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_usart.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   USART LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_usart.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_usart.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_usart.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of USART LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -58,17 +56,7 @@ extern "C" {
 
 /* Private types -------------------------------------------------------------*/
 /* Private variables ---------------------------------------------------------*/
-
 /* Private constants ---------------------------------------------------------*/
-/** @defgroup USART_LL_Private_Constants USART Private Constants
-  * @{
-  */
-
-/* Defines used for the bit position in the register and perform offsets*/
-#define USART_POSITION_GTPR_GT                  USART_GTPR_GT_Pos
-/**
-  * @}
-  */
 
 /* Private macros ------------------------------------------------------------*/
 #if defined(USE_FULL_LL_DRIVER)
@@ -207,7 +195,7 @@ typedef struct
 /** @defgroup USART_LL_EC_DIRECTION Communication Direction
   * @{
   */
-#define LL_USART_DIRECTION_NONE                 (uint32_t)0x00000000U              /*!< Transmitter and Receiver are disabled */
+#define LL_USART_DIRECTION_NONE                 0x00000000U                        /*!< Transmitter and Receiver are disabled */
 #define LL_USART_DIRECTION_RX                   USART_CR1_RE                       /*!< Transmitter is disabled and Receiver is enabled */
 #define LL_USART_DIRECTION_TX                   USART_CR1_TE                       /*!< Transmitter is enabled and Receiver is disabled */
 #define LL_USART_DIRECTION_TX_RX                (USART_CR1_TE |USART_CR1_RE)       /*!< Transmitter and Receiver are enabled */
@@ -218,7 +206,7 @@ typedef struct
 /** @defgroup USART_LL_EC_PARITY Parity Control
   * @{
   */
-#define LL_USART_PARITY_NONE                    (uint32_t)0x00000000U                /*!< Parity control disabled */
+#define LL_USART_PARITY_NONE                    0x00000000U                          /*!< Parity control disabled */
 #define LL_USART_PARITY_EVEN                    USART_CR1_PCE                        /*!< Parity control enabled and Even Parity is selected */
 #define LL_USART_PARITY_ODD                     (USART_CR1_PCE | USART_CR1_PS)       /*!< Parity control enabled and Odd Parity is selected */
 /**
@@ -228,7 +216,7 @@ typedef struct
 /** @defgroup USART_LL_EC_WAKEUP Wakeup
   * @{
   */
-#define LL_USART_WAKEUP_IDLELINE                (uint32_t)0x00000000U /*!<  USART wake up from Mute mode on Idle Line */
+#define LL_USART_WAKEUP_IDLELINE                0x00000000U           /*!<  USART wake up from Mute mode on Idle Line */
 #define LL_USART_WAKEUP_ADDRESSMARK             USART_CR1_WAKE        /*!<  USART wake up from Mute mode on Address Mark */
 /**
   * @}
@@ -237,7 +225,7 @@ typedef struct
 /** @defgroup USART_LL_EC_DATAWIDTH Datawidth
   * @{
   */
-#define LL_USART_DATAWIDTH_8B                   (uint32_t)0x00000000U   /*!< 8 bits word length : Start bit, 8 data bits, n stop bits */
+#define LL_USART_DATAWIDTH_8B                   0x00000000U             /*!< 8 bits word length : Start bit, 8 data bits, n stop bits */
 #define LL_USART_DATAWIDTH_9B                   USART_CR1_M             /*!< 9 bits word length : Start bit, 9 data bits, n stop bits */
 /**
   * @}
@@ -246,7 +234,7 @@ typedef struct
 /** @defgroup USART_LL_EC_OVERSAMPLING Oversampling
   * @{
   */
-#define LL_USART_OVERSAMPLING_16                (uint32_t)0x00000000U  /*!< Oversampling by 16 */
+#define LL_USART_OVERSAMPLING_16                0x00000000U            /*!< Oversampling by 16 */
 #define LL_USART_OVERSAMPLING_8                 USART_CR1_OVER8        /*!< Oversampling by 8 */
 /**
   * @}
@@ -257,7 +245,7 @@ typedef struct
   * @{
   */
 
-#define LL_USART_CLOCK_DISABLE                  (uint32_t)0x00000000U  /*!< Clock signal not provided */
+#define LL_USART_CLOCK_DISABLE                  0x00000000U            /*!< Clock signal not provided */
 #define LL_USART_CLOCK_ENABLE                   USART_CR2_CLKEN        /*!< Clock signal provided */
 /**
   * @}
@@ -267,7 +255,7 @@ typedef struct
 /** @defgroup USART_LL_EC_LASTCLKPULSE Last Clock Pulse
   * @{
   */
-#define LL_USART_LASTCLKPULSE_NO_OUTPUT         (uint32_t)0x00000000U /*!< The clock pulse of the last data bit is not output to the SCLK pin */
+#define LL_USART_LASTCLKPULSE_NO_OUTPUT         0x00000000U           /*!< The clock pulse of the last data bit is not output to the SCLK pin */
 #define LL_USART_LASTCLKPULSE_OUTPUT            USART_CR2_LBCL        /*!< The clock pulse of the last data bit is output to the SCLK pin */
 /**
   * @}
@@ -276,7 +264,7 @@ typedef struct
 /** @defgroup USART_LL_EC_PHASE Clock Phase
   * @{
   */
-#define LL_USART_PHASE_1EDGE                    (uint32_t)0x00000000U /*!< The first clock transition is the first data capture edge */
+#define LL_USART_PHASE_1EDGE                    0x00000000U           /*!< The first clock transition is the first data capture edge */
 #define LL_USART_PHASE_2EDGE                    USART_CR2_CPHA        /*!< The second clock transition is the first data capture edge */
 /**
   * @}
@@ -285,7 +273,7 @@ typedef struct
 /** @defgroup USART_LL_EC_POLARITY Clock Polarity
   * @{
   */
-#define LL_USART_POLARITY_LOW                   (uint32_t)0x00000000U /*!< Steady low value on SCLK pin outside transmission window*/
+#define LL_USART_POLARITY_LOW                   0x00000000U           /*!< Steady low value on SCLK pin outside transmission window*/
 #define LL_USART_POLARITY_HIGH                  USART_CR2_CPOL        /*!< Steady high value on SCLK pin outside transmission window */
 /**
   * @}
@@ -295,7 +283,7 @@ typedef struct
   * @{
   */
 #define LL_USART_STOPBITS_0_5                   USART_CR2_STOP_0                           /*!< 0.5 stop bit */
-#define LL_USART_STOPBITS_1                     (uint32_t)0x00000000U                      /*!< 1 stop bit */
+#define LL_USART_STOPBITS_1                     0x00000000U                                /*!< 1 stop bit */
 #define LL_USART_STOPBITS_1_5                   (USART_CR2_STOP_0 | USART_CR2_STOP_1)      /*!< 1.5 stop bits */
 #define LL_USART_STOPBITS_2                     USART_CR2_STOP_1                           /*!< 2 stop bits */
 /**
@@ -305,7 +293,7 @@ typedef struct
 /** @defgroup USART_LL_EC_HWCONTROL Hardware Control
   * @{
   */
-#define LL_USART_HWCONTROL_NONE                 (uint32_t)0x00000000U                /*!< CTS and RTS hardware flow control disabled */
+#define LL_USART_HWCONTROL_NONE                 0x00000000U                          /*!< CTS and RTS hardware flow control disabled */
 #define LL_USART_HWCONTROL_RTS                  USART_CR3_RTSE                       /*!< RTS output enabled, data is only requested when there is space in the receive buffer */
 #define LL_USART_HWCONTROL_CTS                  USART_CR3_CTSE                       /*!< CTS mode enabled, data is only transmitted when the nCTS input is asserted (tied to 0) */
 #define LL_USART_HWCONTROL_RTS_CTS              (USART_CR3_RTSE | USART_CR3_CTSE)    /*!< CTS and RTS hardware flow control enabled */
@@ -316,7 +304,7 @@ typedef struct
 /** @defgroup USART_LL_EC_IRDA_POWER IrDA Power
   * @{
   */
-#define LL_USART_IRDA_POWER_NORMAL              (uint32_t)0x00000000U /*!< IrDA normal power mode */
+#define LL_USART_IRDA_POWER_NORMAL              0x00000000U           /*!< IrDA normal power mode */
 #define LL_USART_IRDA_POWER_LOW                 USART_CR3_IRLP        /*!< IrDA low power mode */
 /**
   * @}
@@ -325,7 +313,7 @@ typedef struct
 /** @defgroup USART_LL_EC_LINBREAK_DETECT LIN Break Detection Length
   * @{
   */
-#define LL_USART_LINBREAK_DETECT_10B            (uint32_t)0x00000000U /*!< 10-bit break detection method selected */
+#define LL_USART_LINBREAK_DETECT_10B            0x00000000U           /*!< 10-bit break detection method selected */
 #define LL_USART_LINBREAK_DETECT_11B            USART_CR2_LBDL        /*!< 11-bit break detection method selected */
 /**
   * @}
@@ -1318,7 +1306,7 @@ __STATIC_INLINE uint32_t LL_USART_GetSmartcardPrescaler(USART_TypeDef *USARTx)
   */
 __STATIC_INLINE void LL_USART_SetSmartcardGuardTime(USART_TypeDef *USARTx, uint32_t GuardTime)
 {
-  MODIFY_REG(USARTx->GTPR, USART_GTPR_GT, GuardTime << USART_POSITION_GTPR_GT);
+  MODIFY_REG(USARTx->GTPR, USART_GTPR_GT, GuardTime << USART_GTPR_GT_Pos);
 }
 
 /**
@@ -1332,7 +1320,7 @@ __STATIC_INLINE void LL_USART_SetSmartcardGuardTime(USART_TypeDef *USARTx, uint3
   */
 __STATIC_INLINE uint32_t LL_USART_GetSmartcardGuardTime(USART_TypeDef *USARTx)
 {
-  return (uint32_t)(READ_BIT(USARTx->GTPR, USART_GTPR_GT) >> USART_POSITION_GTPR_GT);
+  return (uint32_t)(READ_BIT(USARTx->GTPR, USART_GTPR_GT) >> USART_GTPR_GT_Pos);
 }
 
 /**

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_utils.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_utils.c
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_utils.c
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   UTILS LL module driver.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -54,23 +52,23 @@
 /** @addtogroup UTILS_LL_Private_Constants
   * @{
   */
-#define UTILS_MAX_FREQUENCY_SCALE1  ((uint32_t)32000000U)        /*!< Maximum frequency for system clock at power scale1, in Hz */
-#define UTILS_MAX_FREQUENCY_SCALE2  ((uint32_t)16000000U)        /*!< Maximum frequency for system clock at power scale2, in Hz */
-#define UTILS_MAX_FREQUENCY_SCALE3  ((uint32_t)4000000U)         /*!< Maximum frequency for system clock at power scale3, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE1  32000000U        /*!< Maximum frequency for system clock at power scale1, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE2  16000000U        /*!< Maximum frequency for system clock at power scale2, in Hz */
+#define UTILS_MAX_FREQUENCY_SCALE3   4000000U        /*!< Maximum frequency for system clock at power scale3, in Hz */
 
 /* Defines used for PLL range */
-#define UTILS_PLLVCO_OUTPUT_SCALE1  ((uint32_t)96000000U)        /*!< Frequency max for PLLVCO output at power scale1, in Hz  */
-#define UTILS_PLLVCO_OUTPUT_SCALE2  ((uint32_t)48000000U)        /*!< Frequency max for PLLVCO output at power scale2, in Hz  */
-#define UTILS_PLLVCO_OUTPUT_SCALE3  ((uint32_t)24000000U)        /*!< Frequency max for PLLVCO output at power scale3, in Hz  */
+#define UTILS_PLLVCO_OUTPUT_SCALE1  96000000U        /*!< Frequency max for PLLVCO output at power scale1, in Hz  */
+#define UTILS_PLLVCO_OUTPUT_SCALE2  48000000U        /*!< Frequency max for PLLVCO output at power scale2, in Hz  */
+#define UTILS_PLLVCO_OUTPUT_SCALE3  24000000U        /*!< Frequency max for PLLVCO output at power scale3, in Hz  */
 
 /* Defines used for HSE range */
-#define UTILS_HSE_FREQUENCY_MIN     ((uint32_t)1000000U)         /*!< Frequency min for HSE frequency, in Hz   */
-#define UTILS_HSE_FREQUENCY_MAX     ((uint32_t)24000000U)        /*!< Frequency max for HSE frequency, in Hz   */
+#define UTILS_HSE_FREQUENCY_MIN      1000000U       /*!< Frequency min for HSE frequency, in Hz   */
+#define UTILS_HSE_FREQUENCY_MAX     24000000U       /*!< Frequency max for HSE frequency, in Hz   */
 
 /* Defines used for FLASH latency according to HCLK Frequency */
-#define UTILS_SCALE1_LATENCY1_FREQ  ((uint32_t)16000000U)        /*!< HCLK frequency to set FLASH latency 1 in power scale 1 */
-#define UTILS_SCALE2_LATENCY1_FREQ  ((uint32_t)8000000U)         /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
-#define UTILS_SCALE3_LATENCY1_FREQ  ((uint32_t)2000000U)         /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
+#define UTILS_SCALE1_LATENCY1_FREQ  16000000U        /*!< HCLK frequency to set FLASH latency 1 in power scale 1 */
+#define UTILS_SCALE2_LATENCY1_FREQ   8000000U        /*!< HCLK frequency to set FLASH latency 1 in power scale 2 */
+#define UTILS_SCALE3_LATENCY1_FREQ   2000000U        /*!< HCLK frequency to set FLASH latency 1 in power scale 3 */
 /**
   * @}
   */
@@ -134,7 +132,9 @@
   */
 static uint32_t    UTILS_GetPLLOutputFrequency(uint32_t PLL_InputFrequency,
                                                LL_UTILS_PLLInitTypeDef *UTILS_PLLInitStruct);
+#if defined(FLASH_ACR_LATENCY)
 static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency);
+#endif /* FLASH_ACR_LATENCY */
 static ErrorStatus UTILS_EnablePLLAndSwitchSystem(uint32_t SYSCLK_Frequency, LL_UTILS_ClkInitTypeDef *UTILS_ClkInitStruct);
 static ErrorStatus UTILS_PLL_IsBusy(void);
 /**
@@ -338,6 +338,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   /* Check if one of the PLL is enabled */
   if (UTILS_PLL_IsBusy() == SUCCESS)
   {
+
     /* Calculate the new PLL output frequency */
     pllfreq = UTILS_GetPLLOutputFrequency(HSEFrequency, UTILS_PLLInitStruct);
 
@@ -396,6 +397,7 @@ ErrorStatus LL_PLL_ConfigSystemClock_HSE(uint32_t HSEFrequency, uint32_t HSEBypa
   *          - SUCCESS: Latency has been modified
   *          - ERROR: Latency cannot be modified
   */
+#if defined(FLASH_ACR_LATENCY)
 static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
 {
   ErrorStatus status = SUCCESS;
@@ -454,6 +456,7 @@ static ErrorStatus UTILS_SetFlashLatency(uint32_t Frequency)
   }
   return status;
 }
+#endif /* FLASH_ACR_LATENCY */
 
 /**
   * @brief  Function to check that PLL can be modified
@@ -502,7 +505,6 @@ static ErrorStatus UTILS_PLL_IsBusy(void)
     /* PLL configuration cannot be modified */
     status = ERROR;
   }
-
 
   return status;
 }

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_utils.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_utils.h
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_utils.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of UTILS LL module.
   @verbatim
   ==============================================================================
@@ -20,7 +18,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -75,7 +73,7 @@ extern "C" {
   */
 
 /* Max delay can be used in LL_mDelay */
-#define LL_MAX_DELAY                  (uint32_t)0xFFFFFFFFU
+#define LL_MAX_DELAY                  0xFFFFFFFFU
 
 /**
  * @brief Unique device ID register base address
@@ -157,8 +155,8 @@ typedef struct
 /** @defgroup UTILS_EC_HSE_BYPASS HSE Bypass activation
   * @{
   */
-#define LL_UTILS_HSEBYPASS_OFF        (uint32_t)0x00000000U       /*!< HSE Bypass is not enabled                */
-#define LL_UTILS_HSEBYPASS_ON         (uint32_t)0x00000001U       /*!< HSE Bypass is enabled                    */
+#define LL_UTILS_HSEBYPASS_OFF        0x00000000U       /*!< HSE Bypass is not enabled                */
+#define LL_UTILS_HSEBYPASS_ON         0x00000001U       /*!< HSE Bypass is enabled                    */
 /**
   * @}
   */
@@ -219,6 +217,7 @@ __STATIC_INLINE uint32_t LL_GetFlashSize(void)
 {
   return (uint16_t)(READ_REG(*((uint32_t *)FLASHSIZE_BASE_ADDRESS)));
 }
+
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_wwdg.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/stm32l1xx_ll_wwdg.h
@@ -2,13 +2,11 @@
   ******************************************************************************
   * @file    stm32l1xx_ll_wwdg.h
   * @author  MCD Application Team
-  * @version V1.2.0
-  * @date    01-July-2016
   * @brief   Header file of WWDG LL module.
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -82,7 +80,7 @@ extern "C" {
 /** @defgroup WWDG_LL_EC_PRESCALER  PRESCALER
 * @{
 */
-#define LL_WWDG_PRESCALER_1                (uint32_t)0x00000000U                                   /*!< WWDG counter clock = (PCLK1/4096)/1 */
+#define LL_WWDG_PRESCALER_1                0x00000000U                                             /*!< WWDG counter clock = (PCLK1/4096)/1 */
 #define LL_WWDG_PRESCALER_2                WWDG_CFR_WDGTB_0                                        /*!< WWDG counter clock = (PCLK1/4096)/2 */
 #define LL_WWDG_PRESCALER_4                WWDG_CFR_WDGTB_1                                        /*!< WWDG counter clock = (PCLK1/4096)/4 */
 #define LL_WWDG_PRESCALER_8                (WWDG_CFR_WDGTB_0 | WWDG_CFR_WDGTB_1)                   /*!< WWDG counter clock = (PCLK1/4096)/8 */

--- a/targets/TARGET_STM/TARGET_STM32L1/device/system_stm32l1xx.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/device/system_stm32l1xx.c
@@ -2,8 +2,6 @@
   ******************************************************************************
   * @file    system_stm32l1xx.c
   * @author  MCD Application Team
-  * @version V2.2.0
-  * @date    01-July-2016
   * @brief   CMSIS Cortex-M3 Device Peripheral Access Layer System Source File.
   *             
   *   This file provides two functions and one global variable to be called from 
@@ -23,7 +21,7 @@
   ******************************************************************************
   * @attention
   *
-  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
   *
   * Redistribution and use in source and binary forms, with or without modification,
   * are permitted provided that the following conditions are met:
@@ -80,12 +78,12 @@
   * @{
   */
 #if !defined  (HSE_VALUE) 
-  #define HSE_VALUE    ((uint32_t)8000000) /*!< Default value of the External oscillator in Hz.
+  #define HSE_VALUE    ((uint32_t)8000000U) /*!< Default value of the External oscillator in Hz.
                                                 This value can be provided and adapted by the user application. */
 #endif /* HSE_VALUE */
 
 #if !defined  (HSI_VALUE)
-  #define HSI_VALUE    ((uint32_t)8000000) /*!< Default value of the Internal oscillator in Hz.
+  #define HSI_VALUE    ((uint32_t)8000000U) /*!< Default value of the Internal oscillator in Hz.
                                                 This value can be provided and adapted by the user application. */
 #endif /* HSI_VALUE */
 
@@ -96,7 +94,7 @@
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */ 
 /* #define VECT_TAB_SRAM */
-#define VECT_TAB_OFFSET  0x0 /*!< Vector Table base offset field. 
+#define VECT_TAB_OFFSET  0x00U /*!< Vector Table base offset field. 
                                   This value must be a multiple of 0x200. */
 /**
   * @}
@@ -121,10 +119,10 @@
                is no need to call the 2 first functions listed above, since SystemCoreClock
                variable is updated automatically.
   */
-uint32_t SystemCoreClock        = 2097000;
-const uint8_t PLLMulTable[9]    = {3, 4, 6, 8, 12, 16, 24, 32, 48};
-const uint8_t AHBPrescTable[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
-const uint8_t APBPrescTable[8]  = {0, 0, 0, 0, 1, 2, 3, 4};
+uint32_t SystemCoreClock        = 2097000U;
+const uint8_t PLLMulTable[9]    = {3U, 4U, 6U, 8U, 12U, 16U, 24U, 32U, 48U};
+const uint8_t AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
+const uint8_t APBPrescTable[8]  = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
 
 /**
   * @}


### PR DESCRIPTION
### Description

CubeL1: from V1.6.0 to V1.8.1
HAL driver: from V1.2.0 to 1.3.1
CMSIS device: from V2.2.0 to V2.2.3

[test_report.zip](https://github.com/ARMmbed/mbed-os/files/1856548/test_report.zip)

### Pull request type

[ ] Fix  
[X] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
