### PR TITLE
Adding missing @deprecated to function inline documentation

### DIFF
--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -105,6 +105,7 @@ public:
      *  @returns
      *    0 on success,
      *   -1 on error.
+     *  @deprecated Replaced by `DirHandle::close'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::close")
     virtual int closedir() { return close(); };
@@ -116,6 +117,7 @@ public:
      *  A pointer to a dirent structure representing the
      *  directory entry at the current position, or NULL on reaching
      *  end of directory or error.
+     * @deprecated Replaced by `DirHandle::read'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::read")
     virtual struct dirent *readdir()
@@ -125,6 +127,7 @@ public:
     }
 
     /** Resets the position to the beginning of the directory.
+     * @deprecated Replaced by `DirHandle::rewind'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::rewind")
     virtual void rewinddir() { rewind(); }
@@ -134,6 +137,7 @@ public:
      * @returns
      *   the current position,
      *  -1 on error.
+     * @deprecated Replaced by `DirHandle::tell'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::tell")
     virtual off_t telldir() { return tell(); }
@@ -141,6 +145,7 @@ public:
     /** Sets the position of the DirHandle.
      *
      *  @param location The location to seek to. Must be a value returned by telldir.
+     *  @deprecated Replaced by `DirHandle::seek'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::seek")
     virtual void seekdir(off_t location) { seek(location); }

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -105,7 +105,7 @@ public:
      *  @returns
      *    0 on success,
      *   -1 on error.
-     *  @deprecated Replaced by `DirHandle::close'
+     *  @deprecated Replaced by `int DirHandle::close()'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::close")
     virtual int closedir() { return close(); };
@@ -117,7 +117,7 @@ public:
      *  A pointer to a dirent structure representing the
      *  directory entry at the current position, or NULL on reaching
      *  end of directory or error.
-     * @deprecated Replaced by `DirHandle::read'
+     * @deprecated Replaced by `ssize_t DirHandle::read(struct dirent *ent)
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::read")
     virtual struct dirent *readdir()
@@ -127,7 +127,7 @@ public:
     }
 
     /** Resets the position to the beginning of the directory.
-     * @deprecated Replaced by `DirHandle::rewind'
+     * @deprecated Replaced by `void DirHandle::rewind()'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::rewind")
     virtual void rewinddir() { rewind(); }
@@ -137,7 +137,7 @@ public:
      * @returns
      *   the current position,
      *  -1 on error.
-     * @deprecated Replaced by `DirHandle::tell'
+     * @deprecated Replaced by `off_t DirHandle::tell()'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::tell")
     virtual off_t telldir() { return tell(); }
@@ -145,7 +145,7 @@ public:
     /** Sets the position of the DirHandle.
      *
      *  @param location The location to seek to. Must be a value returned by telldir.
-     *  @deprecated Replaced by `DirHandle::seek'
+     *  @deprecated Replaced by `void DirHandle::seek(off_t offset)'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by DirHandle::seek")
     virtual void seekdir(off_t location) { seek(location); }

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -146,7 +146,7 @@ public:
      *  @returns
      *    new file position on success,
      *    -1 on failure or unsupported
-     *  @deprecated Replaced by `FileHandle::seek'
+     *  @deprecated Replaced by `off_t FileHandle::seek(off_t offset, int whence = SEEK_SET)'
      *
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::seek")
@@ -161,7 +161,7 @@ public:
      *  @returns
      *    0 on success or un-needed,
      *   -1 on error
-     *  @deprecated Replaced by `FileHandle::sync'
+     *  @deprecated Replaced by `int FileHandle::sync()'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::sync")
     virtual int fsync()
@@ -173,7 +173,7 @@ public:
      *
      *  @returns
      *   Length of the file
-     *  @deprecated Replaced by `FileHandle::size'
+     *  @deprecated Replaced by `off_t FileHandle::size()'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::size")
     virtual off_t flen()

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -146,6 +146,8 @@ public:
      *  @returns
      *    new file position on success,
      *    -1 on failure or unsupported
+     *  @deprecated Replaced by `FileHandle::seek'
+     *
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::seek")
     virtual off_t lseek(off_t offset, int whence)
@@ -159,6 +161,7 @@ public:
      *  @returns
      *    0 on success or un-needed,
      *   -1 on error
+     *  @deprecated Replaced by `FileHandle::sync'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::sync")
     virtual int fsync()
@@ -170,6 +173,7 @@ public:
      *
      *  @returns
      *   Length of the file
+     *  @deprecated Replaced by `FileHandle::size'
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.4", "Replaced by FileHandle::size")
     virtual off_t flen()


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

In this refactoring we fix only the inline documentation of function which already has the MBED_DEPRECATED macro but the @deprecated  is not updated.

### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x] Refactor  

