### PR TITLE
Move Mbed 5 support check so that it affects the exporters

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -486,11 +486,6 @@ def scan_resources(src_paths, toolchain, dependencies_paths=None,
     # Set the toolchain's configuration data
     toolchain.set_config_data(toolchain.config.get_config_data())
 
-    if  (hasattr(toolchain.target, "release_versions") and
-            "5" not in toolchain.target.release_versions and
-            "rtos" in toolchain.config.lib_config_data):
-            raise NotSupportedException("Target does not support mbed OS 5")
-
     return resources
 
 def build_project(src_paths, build_path, target, toolchain_name,

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -30,7 +30,8 @@ from jinja2 import FileSystemLoader, StrictUndefined
 from jinja2.environment import Environment
 from jsonschema import Draft4Validator, RefResolver
 
-from ..utils import json_file_to_dict, intelhex_offset, integer
+from ..utils import (json_file_to_dict, intelhex_offset, integer,
+                     NotSupportedException)
 from ..arm_pack_manager import Cache
 from ..targets import (CUMULATIVE_ATTRIBUTES, TARGET_MAP, generate_py_target,
                        get_resolution_order, Target)
@@ -1028,6 +1029,11 @@ class Config(object):
 
             prev_features = features
         self.validate_config()
+
+        if  (hasattr(self.target, "release_versions") and
+             "5" not in self.target.release_versions and
+             "rtos" in self.lib_config_data):
+            raise NotSupportedException("Target does not support mbed OS 5")
 
         return resources
 


### PR DESCRIPTION
### Description

A recent PR of mine stopped the exporters from using the build_api's
unified scan_resourcses method. Instead, I moved the supported check to
the earliest location that we have this informaiton: the end of the
config object's load_resources method.

 ### Pull request type

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change