### PR TITLE
Only schedule mbed_ticker interrupt if queue->head is changed

### DIFF
--- a/TESTS/mbed_hal/ticker/main.cpp
+++ b/TESTS/mbed_hal/ticker/main.cpp
@@ -697,6 +697,7 @@ static void test_legacy_insert_event_multiple_overflow()
     interface_stub.timestamp = 
         last_timestamp_to_insert + 
         ((ref_event_timestamp - last_timestamp_to_insert) / 2);
+    ticker_irq_handler(&ticker_stub);
 
     for (size_t i = 0; i < MBED_ARRAY_SIZE(events); ++i) { 
         ticker_insert_event(

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -359,14 +359,12 @@ void ticker_insert_event_us(const ticker_data_t *const ticker, ticker_event_t *o
     /* if prev is NULL we're at the head */
     if (prev == NULL) {
         ticker->queue->head = obj;
+        schedule_interrupt(ticker);
     } else {
         prev->next = obj;
     }
 
-    schedule_interrupt(ticker);
-
     core_util_critical_section_exit();
-
 }
 
 void ticker_remove_event(const ticker_data_t *const ticker, ticker_event_t *obj)


### PR DESCRIPTION
Reverts change from commit 10577201142eb2064ffe3a76dea8a1ddb4bdeef2

### Description
It seems to me it is unneccesary to schedule a new interrupt the new event is further in the queue and head is still the same. This is essentially the same as is done in the remove_event function: only reschedule if the head is removed.

Doesn't really fix any issues but does result in better response time. Only tested on a STM32L072 in low power configuration.

### Pull request type

[ ] Fix  
[x] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
