### PR TITLE
[feature-nrf528xx] Fix off-by-one error in NRF52 serial implementation

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
@@ -1104,7 +1104,8 @@ void serial_free(serial_t *obj)
 
     int instance = uart_object->instance;
 
-    if (nordic_nrf5_uart_state[instance].usage_counter > 1) {
+    /* Only consider disabling UARTE if number of users is not zero. */
+    if (nordic_nrf5_uart_state[instance].usage_counter > 0) {
 
         /* Decrement usage counter for this instance. */
         nordic_nrf5_uart_state[instance].usage_counter--;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

Off-by-one error prevented UART from being disabled even when no  instance(s) were in user.

### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
