### PR TITLE
Qspi fix configure format

### DIFF
--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -76,8 +76,11 @@ public:
      *  @param io3 4th IO pin used for sending/receiving data during data phase of a transaction
      *  @param sclk QSPI Clock pin
      *  @param ssel QSPI chip select pin
+     *  @param mode Mode specifies the SPI mode(Mode=0 uses CPOL=0, CPHA=0, Mode=1 uses CPOL=1, CPHA=1)
+     *         default value = 0
+     *
      */
-    QSPI(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, PinName ssel=NC);
+    QSPI(PinName io0, PinName io1, PinName io2, PinName io3, PinName sclk, PinName ssel=NC, int mode=0);
 
     /** Configure the data transmission format
      *
@@ -88,7 +91,6 @@ public:
      *  @param alt_size Size in bits used by alt phase(Valid values are 8,16,24,32)
      *  @param data_width Bus width used by data phase(Valid values are 1,2,4)
      *  @param dummy_cycles Number of dummy clock cycles to be used after alt phase
-     *  @param mode Mode specifies the SPI mode(Mode=0 uses CPOL=0, CPHA=0, Mode=1 uses CPOL=1, CPHA=1)
      *
      */
     qspi_status_t configure_format(qspi_bus_width_t inst_width, 
@@ -97,8 +99,7 @@ public:
                    qspi_bus_width_t alt_width, 
                    qspi_alt_size_t alt_size,   
                    qspi_bus_width_t data_width,
-                   int dummy_cycles,
-                   int mode);
+                   int dummy_cycles);
 
     /** Set the qspi bus clock frequency
      *

--- a/drivers/QSPI.h
+++ b/drivers/QSPI.h
@@ -135,7 +135,6 @@ public:
      *
      *  @param instruction Instruction value to be used in instruction phase
      *  @param alt Alt value to be used in instruction phase
-     *  @param dummy_cnt Amount of dummy cycles to be sent after instruction phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param rx_buffer Buffer for data to be read from the peripheral                          
      *  @param rx_length Pointer to a variable containing the length of rx_buffer, and on return this variable will be updated with the actual number of bytes read
@@ -143,13 +142,12 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t read(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, char *rx_buffer, size_t *rx_length);
+    qspi_status_t read(unsigned int instruction, unsigned int alt, unsigned int address, char *rx_buffer, size_t *rx_length);
 
     /** Write to QSPI peripheral using custom write instruction, alt values
      *
      *  @param instruction Instruction value to be used in instruction phase
      *  @param alt Alt value to be used in instruction phase
-     *  @param dummy_cnt Amount of dummy cycles to be sent after instruction phase
      *  @param address Address to be accessed in QSPI peripheral
      *  @param tx_buffer Buffer containing data to be sent to peripheral                          
      *  @param tx_length Pointer to a variable containing the length of data to be transmitted, and on return this variable will be updated with the actual number of bytes written
@@ -157,7 +155,7 @@ public:
      *  @returns
      *    Returns QSPI_STATUS_SUCCESS on successful reads and QSPI_STATUS_ERROR on failed reads.
      */
-    qspi_status_t write(unsigned int instruction, unsigned int alt, unsigned int dummy_cnt, unsigned int address, const char *tx_buffer, size_t *tx_length);
+    qspi_status_t write(unsigned int instruction, unsigned int alt, unsigned int address, const char *tx_buffer, size_t *tx_length);
 
     /** Perform a transaction to write to an address(a control register) and get the status results
      *
@@ -198,6 +196,7 @@ protected:
     qspi_alt_size_t _alt_size;
     qspi_bus_width_t _data_width; //Bus width for Data phase
     qspi_command_t _qspi_command; //QSPI Hal command struct
+    unsigned int _num_dummy_cycles; //Number of dummy cycles to be used
     int _hz; //Bus Frequency
     int _mode; //SPI mode
     bool _initialized;
@@ -213,7 +212,7 @@ private:
     /* 
      * This function builds the qspi command struct to be send to Hal
      */
-    inline void _build_qspi_command(int instruction, int address, int alt, int dummy_cnt);
+    inline void _build_qspi_command(int instruction, int address, int alt);
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description
QSPI::configure_format is supposed to modify command format, not the hw module itself. 
It should not call the QSPI::_initialize function

_mode (clock polarity and clock phase) is only used at initialization of the module.

Then : _mode (clock polarity and phase) cannot be modified inside QSPI::configure_format. This has been moved to QSPI::QSPI function
I've reverted PR#6429 commit, since now dummy count can be modified inside configure_format again.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
cc @0xc0170 