### PR TITLE
Inrease thread stack size to 1024 bytes in NVStore test for NRF52

### DIFF
--- a/features/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -40,8 +40,13 @@ static const size_t basic_func_max_data_size = 128;
 static const int thr_test_num_buffs = 5;
 static const int thr_test_num_secs = 5;
 static const int thr_test_max_data_size = 32;
-static const int thr_test_stack_size = 768;
 static const int thr_test_num_threads = 3;
+
+#ifdef TARGET_NRF52
+static const int thr_test_stack_size = 1024;
+#else
+static const int thr_test_stack_size = 768;
+#endif
 
 typedef struct {
     uint8_t *buffs[max_test_keys][thr_test_num_buffs];


### PR DESCRIPTION
### Description

On the NRF52, the NVStore test is running at the stack boundary so on certain compiler versions the test will fail due to stack overflow. This PR increases the stack size for the NRF52 target.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
