### PR TITLE
rtl8195am : fix greentea test fails (test_timeout & test_timerevent)

### DIFF
--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -199,6 +199,9 @@ void test_no_wait(void)
     Semaphore sem(0, 1);
     T timeout;
     timeout.attach_callback(mbed::callback(sem_callback, &sem), 0ULL);
+#if defined(TARGET_RTL8195A)
+    wait_us(62);
+#endif
 
     int32_t sem_slots = sem.wait(0);
     TEST_ASSERT_EQUAL(1, sem_slots);

--- a/TESTS/mbed_drivers/timerevent/main.cpp
+++ b/TESTS/mbed_drivers/timerevent/main.cpp
@@ -93,6 +93,9 @@ public:
 
     void set_past_timestamp(void) {
         insert_absolute(::ticker_read_us(_ticker_data) - 1ULL);
+#if defined(TARGET_RTL8195A)
+        wait_us(62);
+#endif
     }
 };
 
@@ -160,6 +163,9 @@ void test_insert_zero(void) {
     TestTimerEvent tte;
 
     tte.insert_absolute(0ULL);
+#if defined(TARGET_RTL8195A)
+    wait_us(62);
+#endif
     int32_t sem_slots = tte.sem_wait(0);
     TEST_ASSERT_EQUAL(1, sem_slots);
 


### PR DESCRIPTION
### Description

Two greentea tests have the same issues.
- Test-timeout, case ”Zero delay (attach)" and case” Zero delay (attach_us)”
   This issue is metioned in issue #6410 .
- Test-timerevent, case "Test insert_absolute zero" and case "Test insert_absolute timestamp from the past”.

RTL8195AM has a hardware limitation which is 30.5 us per tick for us_ticker. When execute these tests, it is necessary to wait at least two whole tick, 62 us.

Both of the tests, are using `Semaphore to release() attach callback with 0 delay` and `wait() with 0 delay`, then compare the `sem_slots`. However, when apply the `attach callback`, the ticker is being used (https://docs.mbed.com/docs/mbed-os-api-reference/en/latest/APIs/tasks/Ticker/) and this is linked to the ticker hardware limitation.


### Pull request type
[X] Fix

