### PR TITLE
Implement get_erase_size for HeapBlockDevice class

### DIFF
--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -87,6 +87,12 @@ bd_size_t HeapBlockDevice::get_erase_size(bd_addr_t addr) const
     return _erase_size;
 }
 
+int HeapBlockDevice::get_erase_value() const
+{
+    MBED_ASSERT(_blocks != NULL);
+    return 0;
+}
+
 bd_size_t HeapBlockDevice::size() const
 {
     MBED_ASSERT(_blocks != NULL);

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -138,6 +138,17 @@ public:
      */
     virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
+    /** Get the value of storage when erased
+     *
+     *  If get_erase_value returns a non-negative byte value, the underlying
+     *  storage is set to that value when erased, and storage containing
+     *  that value can be programmed without another erase.
+     *
+     *  @return         The value of storage when erased, or -1 if you can't
+     *                  rely on the value of erased storage
+     */
+    virtual int get_erase_value() const;
+
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes


### PR DESCRIPTION
### Description

Implement the get_erase_size for the HeapBlockDevice  class (just return 0).


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
