### PR TITLE
Fix IPv4 address parsing due to not-so-portable scanf modifier

### DIFF
--- a/features/netsocket/SocketAddress.cpp
+++ b/features/netsocket/SocketAddress.cpp
@@ -66,13 +66,15 @@ static void ipv4_from_address(uint8_t *bytes, const char *addr)
     int i = 0;
 
     for (; count < NSAPI_IPv4_BYTES; count++) {
-        unsigned char b;
-        int scanned = sscanf(&addr[i], "%hhu", &b);
+        unsigned d;
+        // Not using %hh, since it might be missing in newlib-based toolchains.
+        // See also: https://git.io/vxiw5
+        int scanned = sscanf(&addr[i], "%u", &d);
         if (scanned < 1) {
             return;
         }
 
-        bytes[count] = b;
+        bytes[count] = static_cast<uint8_t>(d);
 
         for (; addr[i] != '.'; i++) {
             if (!addr[i]) {


### PR DESCRIPTION
### Description

If newlib is compiled without C99 switch, `%hhu` will be missing. Newlib sources:

https://github.com/eblot/newlib/blob/2a63fa0fd26ffb6603f69d9e369e944fe449c246/newlib/libc/stdio/vfscanf.c#L588-L596

### Forum bug

Created as https://os.mbed.com/forum/bugs-suggestions/topic/30567/
Proceed there for more info.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
