### PR TITLE
Fix deep sleep locking for Timeout class

### DIFF
--- a/drivers/Timeout.cpp
+++ b/drivers/Timeout.cpp
@@ -18,7 +18,9 @@
 namespace mbed {
 
 void Timeout::handler() {
-    _function.call();
+    Callback<void()> local = _function;
+    detach();
+    local.call();
 }
 
 } // namespace mbed


### PR DESCRIPTION
### Description
Detach in the Timeout::handler so deep sleep is properly unlocked.

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
