### PR TITLE
Update idle loop to reduce calls to suspend

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -128,7 +128,7 @@ const ticker_data_t mock_ticker_data = {
 void mock_ticker_reset()
 {
     mock_ticker_timestamp = 0;
-    mock_ticker_event_queue = {0};
+    memset(&mock_ticker_event_queue, 0, sizeof mock_ticker_event_queue);
 }
 
 /** Test tick count is zero upon creation

--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -44,7 +44,9 @@ private:
     Semaphore _sem;
     virtual void handler()
     {
-        increment_tick();
+        core_util_critical_section_enter();
+        _increment_tick();
+        core_util_critical_section_exit();
         _sem.release();
     }
 
@@ -79,26 +81,29 @@ void test_created_with_zero_tick_count(void)
 /** Test tick count is updated correctly
  *
  * Given a SysTimer
- * When @a update_tick method is called immediately after creation
+ * When the @a suspend and @a resume methods are called immediately after creation
  * Then the tick count is not updated
- * When @a update_tick is called again after a delay
+ * When @a suspend and @a resume methods are called again after a delay
  * Then the tick count is updated
  *     and the number of ticks incremented is equal TEST_TICKS - 1
- * When @a update_tick is called again without a delay
+ * When @a suspend and @a resume methods are called again without a delay
  * Then the tick count is not updated
  */
 void test_update_tick(void)
 {
     SysTimerTest st;
-    TEST_ASSERT_EQUAL_UINT32(0, st.update_tick());
+    st.suspend(TEST_TICKS * 2);
+    TEST_ASSERT_EQUAL_UINT32(0, st.resume());
     TEST_ASSERT_EQUAL_UINT32(0, st.get_tick());
     us_timestamp_t test_ticks_elapsed_ts = st.get_time() + DELAY_US;
 
+    st.suspend(TEST_TICKS * 2);
     while (st.get_time() <= test_ticks_elapsed_ts) {}
-    TEST_ASSERT_EQUAL_UINT32(TEST_TICKS - 1, st.update_tick());
+    TEST_ASSERT_EQUAL_UINT32(TEST_TICKS - 1, st.resume());
     TEST_ASSERT_EQUAL_UINT32(TEST_TICKS - 1, st.get_tick());
 
-    TEST_ASSERT_EQUAL_UINT32(0, st.update_tick());
+    st.suspend(TEST_TICKS * 2);
+    TEST_ASSERT_EQUAL_UINT32(0, st.resume());
     TEST_ASSERT_EQUAL_UINT32(TEST_TICKS - 1, st.get_tick());
 }
 

--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -50,6 +50,12 @@ SysTimer::SysTimer() :
     _suspended = false;
 }
 
+SysTimer::SysTimer(const ticker_data_t *data) :
+        TimerEvent(data), _start_time(0), _tick(0)
+{
+    _start_time = ticker_read_us(_ticker_data);
+}
+
 void SysTimer::setup_irq()
 {
 #if (defined(NO_SYSTICK))

--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -49,6 +49,7 @@ class SysTimer: private mbed::TimerEvent, private mbed::NonCopyable<SysTimer> {
 public:
 
     SysTimer();
+    SysTimer(const ticker_data_t *data);
     virtual ~SysTimer();
 
     /**

--- a/rtos/TARGET_CORTEX/SysTimer.h
+++ b/rtos/TARGET_CORTEX/SysTimer.h
@@ -57,6 +57,34 @@ public:
     static void setup_irq();
 
     /**
+     * Set wakeup time and schedule a wakeup event after delta ticks
+     *
+     * After suspend has been called the function suspend_time_passed
+     * can be used to determine if the suspend time has passed.
+     *
+     * @param delta Ticks to remain suspended
+     */
+    void suspend(uint32_t delta);
+
+    /**
+     * Check if the suspend time has passed
+     *
+     * @return true if the specified number of ticks has passed otherwise false
+     */
+    bool suspend_time_passed();
+
+    /**
+     * Exit suspend mode and return elapsed ticks
+     *
+     * Due to a scheduling issue, the number of ticks returned is decremented
+     * by 1 so that a handler can be called and update to the current value.
+     * This allows scheduling restart successfully after the OS is resumed.
+     *
+     * @return the number of elapsed ticks minus 1
+     */
+    uint32_t resume();
+
+    /**
      * Schedule an os tick to fire
      *
      * @param delta Tick to fire at relative to current tick
@@ -78,17 +106,6 @@ public:
     uint32_t get_tick();
 
     /**
-     * Update the internal tick count
-     *
-     * @return The number of ticks incremented
-     *
-     * @note Due to a scheduling issue, the number of ticks returned is decremented
-     * by 1 so that a handler can be called and update to the current value.
-     * This allows scheduling restart successfully after the OS is resumed.
-     */
-    uint32_t update_tick();
-
-    /**
      * Get the time
      *
      * @return Current time in microseconds
@@ -97,10 +114,12 @@ public:
 
 protected:
     virtual void handler();
-    void increment_tick();
-    static void set_irq_pending();
+    void _increment_tick();
+    static void _set_irq_pending();
     us_timestamp_t _start_time;
     uint64_t _tick;
+    bool _suspend_time_passed;
+    bool _suspended;
 };
 
 /**


### PR DESCRIPTION
Change tickless handling to use public RTX calls and to prevent unnecessary calls to suspend/resume by looping until the kernel needs to be resumed.