### PR TITLE
Updated macro that disables flash cache test

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -279,7 +279,7 @@ Case cases[] = {
     Case("Flash - erase sector", flash_erase_sector_test),
     Case("Flash - program page", flash_program_page_test),
     Case("Flash - buffer alignment test", flash_buffer_alignment_test),
-#ifndef MCU_NRF52
+#if !defined TARGET_NRF52840_DK && !defined TARGET_NRF52_DK
     Case("Flash - clock and cache test", flash_clock_and_cache_test),
 #endif
 };


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->
A continuation of https://github.com/ARMmbed/mbed-os/pull/6340. That PR did not actually disable the test. A different macro has been used and verified to work.

Greentea logs showing that the sub-test in question is appropriately disabled.
[nrf52.txt](https://github.com/ARMmbed/mbed-os/files/1873489/nrf52.txt)
[lpc1768.txt](https://github.com/ARMmbed/mbed-os/files/1873490/lpc1768.txt)

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
