### PR TITLE
Prevent compiling with unsupported compilers

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -289,6 +289,13 @@ def get_mbed_official_release(version):
 
     return mbed_official_release
 
+ARM_COMPILERS = ("ARM", "ARMC6", "uARM")
+def target_supports_toolchain(target, toolchain_name):
+    if toolchain_name in ARM_COMPILERS:
+        return any(tc in target.supported_toolchains for tc in ARM_COMPILERS)
+    else:
+        return toolchain_name in target.supported_toolchains
+
 
 def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
@@ -322,6 +329,11 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     # If the configuration object was not yet created, create it now
     config = config or Config(target, src_paths, app_config=app_config)
     target = config.target
+    if not target_supports_toolchain(target, toolchain_name):
+        raise NotSupportedException(
+            "Target {} is not supported by toolchain {}".format(
+                target.name, toolchain_name))
+
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]
     except KeyError:

--- a/tools/test/config/app_override_libs/targets.json
+++ b/tools/test/config/app_override_libs/targets.json
@@ -3,6 +3,7 @@
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],
-        "default_lib": "std"
+        "default_lib": "std",
+        "supported_toolchains": ["GCC_ARM"]
     }
 }

--- a/tools/test/config/compound_inheritance/targets.json
+++ b/tools/test/config/compound_inheritance/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",

--- a/tools/test/config/double_define/targets.json
+++ b/tools/test/config/double_define/targets.json
@@ -1,5 +1,6 @@
 {
     "first_base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",
@@ -10,6 +11,7 @@
         }
     },
     "second_base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",

--- a/tools/test/config/feature_compesition/targets.json
+++ b/tools/test/config/feature_compesition/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/feature_recursive_add/targets.json
+++ b/tools/test/config/feature_recursive_add/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/feature_recursive_complex/targets.json
+++ b/tools/test/config/feature_recursive_complex/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/feature_remove/targets.json
+++ b/tools/test/config/feature_remove/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": ["IPV4"],

--- a/tools/test/config/feature_uvisor/targets.json
+++ b/tools/test/config/feature_uvisor/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/macro_inheritance/targets.json
+++ b/tools/test/config/macro_inheritance/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/override_labels_libs/targets.json
+++ b/tools/test/config/override_labels_libs/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0"

--- a/tools/test/config/override_labels_libs_more/targets.json
+++ b/tools/test/config/override_labels_libs_more/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0"

--- a/tools/test/config/override_labels_targets/targets.json
+++ b/tools/test/config/override_labels_targets/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",

--- a/tools/test/config/override_precidence/targets.json
+++ b/tools/test/config/override_precidence/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",

--- a/tools/test/config/override_undefined/targets.json
+++ b/tools/test/config/override_undefined/targets.json
@@ -1,5 +1,6 @@
 {
     "first_base_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",
@@ -21,6 +22,7 @@
         }
     },
     "second_base_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "config": {
             "base2_1": "v_base2_1_b2",
             "base2_2": "v_base2_2_b2"

--- a/tools/test/config/override_undefined_libs/targets.json
+++ b/tools/test/config/override_undefined_libs/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0"

--- a/tools/test/config/override_with_labels/targets.json
+++ b/tools/test/config/override_with_labels/targets.json
@@ -1,5 +1,6 @@
 {
     "base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0"

--- a/tools/test/config/simple_features/targets.json
+++ b/tools/test/config/simple_features/targets.json
@@ -1,5 +1,6 @@
 {
     "test_target": {
+        "supported_toolchains": ["GCC_ARM"],
         "core": "Cortex-M0",
         "extra_labels": [],
         "features": [],

--- a/tools/test/config/simple_iheritance/targets.json
+++ b/tools/test/config/simple_iheritance/targets.json
@@ -1,5 +1,6 @@
 {
     "first_base": {
+        "supported_toolchains": ["GCC_ARM"],
         "extra_labels": [],
         "default_lib": "std",
         "core": "Cortex-M0",
@@ -21,6 +22,7 @@
         }
     },
     "second_base": {
+        "supported_toolchains": ["GCC_ARM"],
         "config": {
             "base2_1": "v_base2_1_b2",
             "base2_2": "v_base2_2_b2"


### PR DESCRIPTION
### Description

Before this change it is possible to compile with a compiler that a
device port does not support. Afterwards it will not be.

It is possible to override the supported toolchains in the application
configuration and compile with the unsupported toolchain after this change.

Resolves #5109

 ### Pull request type

[✓] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change