### PR TITLE
Add mbed-os 5 build support for LPC11C24

### DIFF
--- a/targets/TARGET_NXP/mbed_rtx.h
+++ b/targets/TARGET_NXP/mbed_rtx.h
@@ -24,6 +24,7 @@
 #endif
 
 #elif defined(TARGET_LPC11U24)        \
+     || defined(TARGET_LPC11CXX)  \
      || defined(TARGET_LPC11U35_401)  \
      || defined(TARGET_LPC11U35_501)  \
      || defined(TARGET_LPCCAPPUCCINO)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -50,6 +50,7 @@
         "inherits": ["LPCTarget"],
         "core": "Cortex-M0",
         "extra_labels": ["NXP", "LPC11XX_11CXX", "LPC11CXX"],
+        "OUTPUT_EXT": "hex",
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],


### PR DESCRIPTION
### Description
Fix support for building LPC11C24.

Based on: https://os.mbed.com/blog/entry/Reducing-memory-usage-by-tuning-RTOS-con/

```
# .gitignore
rtos/*
features/FEATURE_CLIENT/*
features/FEATURE_COMMON_PAL/*
features/FEATURE_UVISOR/*
features/frameworks/*
features/cellular/*
features/lorawan/*
features/net/*
features/filesystem/*
features/netsocket/*
features/storage/*
```

### Pull request type
[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
