### PR TITLE
Correct armc6 detection logic for STM32L4

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
@@ -32,7 +32,7 @@
   *
   ******************************************************************************  
   */ 
-#if (defined(TWO_RAM_REGIONS) && defined(__GNUC__) && !defined(__CC_ARM))
+#if (defined(TWO_RAM_REGIONS) && defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION))
 #include <errno.h>
 #include "stm32l4xx.h"
 extern uint32_t __mbed_sbrk_start;

--- a/targets/TARGET_STM/mbed_rtx.h
+++ b/targets/TARGET_STM/mbed_rtx.h
@@ -122,7 +122,7 @@
 #endif
 
 #endif // INITIAL_SP
-#if (defined(__GNUC__) && !defined(__CC_ARM) && defined(TWO_RAM_REGIONS))
+#if (defined(__GNUC__) && !defined(__CC_ARM) && !defined(__ARMCC_VERSION) && defined(TWO_RAM_REGIONS))
     extern uint32_t               __StackLimit[];
     extern uint32_t               __StackTop[];
     extern uint32_t               __end__[];


### PR DESCRIPTION
### Description

The following targets did not compile tests before this change:
 * NUCLEO_L476RG
 * NUCLEO_L486RG

They now compile tests


 ### Pull request type


[✓] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change