### PR TITLE
Travis: Fix rate-limit issue with Github requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ matrix:
         # update status if we succeeded, compare with master if possible
         - |
           CURR=$(grep -o '[0-9]\+ cycles' prof | awk '{sum += $1} END {print sum}')
-          PREV=$(curl https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
+          PREV=$(curl -u "$MBED_BOT" https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
               | jq -re "select(.sha != \"$TRAVIS_COMMIT\")
                   | .statuses[] | select(.context == \"travis-ci/$NAME\").description
                   | capture(\"runtime is (?<runtime>[0-9]+)\").runtime" \
@@ -193,7 +193,7 @@ matrix:
         # update status if we succeeded, compare with master if possible
         - |
           CURR=$(tail -n1 sizes | awk '{print $1}')
-          PREV=$(curl https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
+          PREV=$(curl -u "$MBED_BOT" https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
               | jq -re "select(.sha != \"$TRAVIS_COMMIT\")
                   | .statuses[] | select(.context == \"travis-ci/$NAME\").description
                   | capture(\"code size is (?<size>[0-9]+)\").size" \


### PR DESCRIPTION
Using credentials avoids rate-limiting based on Travis's IP address

### Description

Sometimes curl commands against the Github API fail. Turns out this is caused by rate-limiting when credentials aren't provided, which is then based on Travis's IP address. Always using credentials even for GETs to public endpoints fixes the problem.

Note, this isn't high priority since right now we're only using uncredentialed GETs in status messages.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[✓] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
