### PR TITLE
UARTSerial: UARTSerial::wait_ms() use ::wait_ms()

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -20,11 +20,7 @@
 #include "UARTSerial.h"
 #include "platform/mbed_poll.h"
 
-#if MBED_CONF_RTOS_PRESENT
-#include "rtos/Thread.h"
-#else
 #include "platform/mbed_wait_api.h"
-#endif
 
 namespace mbed {
 

--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -330,11 +330,7 @@ void UARTSerial::wait_ms(uint32_t millisec)
     /* wait_ms implementation for RTOS spins until exact microseconds - we
      * want to just sleep until next tick.
      */
-#if MBED_CONF_RTOS_PRESENT
-    rtos::Thread::wait(millisec);
-#else
     ::wait_ms(millisec);
-#endif
 }
 } //namespace mbed
 


### PR DESCRIPTION
### Description
::wait_ms() in mbed_wait_api_rtos.cpp and mbed_wait_api_no_rtos.c has already check the macro "MBED_CONF_RTOS_PRESENT"
no need to do once in UARTSerial::wait_ms()

### Pull request type
[X ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
