### PR TITLE
DISCO_F769NI: set clock_source to USE_PLL_HSE_EXTC

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1842,7 +1842,7 @@
         "config": {
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
-                "value": "USE_PLL_HSE_XTAL|USE_PLL_HSI",
+                "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             },
             "lowpowertimer_lptim": {


### PR DESCRIPTION
### Description

As noticed in Issue #6549 the clock_source configuration was incorrectly set for this board. The MCU is clocked with an external clock on OSCIN pin and not using an XTAL on OSCIN/OSCOUT pins.

Tested OK on all compilers.
 
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
