### PR TITLE
cellular: ATHandler send delay

### DIFF
--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -75,7 +75,7 @@ public:
      *  @param timeout          Timeout when reading for AT response
      *  @param output_delimiter delimiter used when parsing at responses, "\r" should be used as output_delimiter
      */
-    ATHandler(FileHandle *fh, events::EventQueue &queue, int timeout, const char *output_delimiter);
+    ATHandler(FileHandle *fh, events::EventQueue &queue, int timeout, const char *output_delimiter, uint16_t send_delay = 0);
     ~ATHandler();
 
     /** Return used file handle.
@@ -195,6 +195,9 @@ private:
     bool _response_terminated;
     uint32_t _at_timeout;
     uint32_t _previous_at_timeout;
+
+    uint16_t _at_send_delay;
+    uint64_t _last_response_stop;
 
     bool _fh_sigio_set;
 

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -74,6 +74,7 @@ public:
      *  @param queue            Event queue used to transfer sigio events to this thread
      *  @param timeout          Timeout when reading for AT response
      *  @param output_delimiter delimiter used when parsing at responses, "\r" should be used as output_delimiter
+     *  @param send_delay       the minimum delay in ms between the end of last response and the beginning of a new command
      */
     ATHandler(FileHandle *fh, events::EventQueue &queue, int timeout, const char *output_delimiter, uint16_t send_delay = 0);
     ~ATHandler();

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -60,7 +60,7 @@ ATHandler* AT_CellularDevice::get_at_handler(FileHandle *fileHandle)
         atHandler = atHandler->_nextATHandler;
     }
 
-    atHandler = new ATHandler(fileHandle, _queue, _default_timeout, "\r");
+    atHandler = new ATHandler(fileHandle, _queue, _default_timeout, "\r", get_send_delay());
     if (atHandler) {
         if (_modem_debug_on) {
             atHandler->enable_debug(_modem_debug_on);
@@ -223,6 +223,11 @@ void AT_CellularDevice::set_timeout(int timeout)
         atHandler->set_at_timeout(_default_timeout, true); // set as default timeout
         atHandler = atHandler->_nextATHandler;
     }
+}
+
+uint16_t AT_CellularDevice::get_send_delay()
+{
+    return 0;
 }
 
 void AT_CellularDevice::modem_debug_on(bool on)

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -77,6 +77,8 @@ public: // CellularDevice
 
     virtual void set_timeout(int timeout);
 
+    virtual uint16_t get_send_delay();
+
     virtual void modem_debug_on(bool on);
 
     virtual NetworkStack *get_stack();

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -58,3 +58,9 @@ CellularNetwork *TELIT_HE910::open_network(FileHandle *fh)
     }
     return _network;
 }
+
+uint16_t TELIT_HE910::get_send_delay()
+{
+    return DEFAULT_DELAY_BETWEEN_AT_COMMANDS;
+}
+

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.h
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.h
@@ -20,6 +20,9 @@
 
 #include "AT_CellularDevice.h"
 
+//the delay between sending AT commands
+#define DEFAULT_DELAY_BETWEEN_AT_COMMANDS 20
+
 namespace mbed {
 
 class TELIT_HE910 : public AT_CellularDevice
@@ -32,6 +35,7 @@ public:
 public: // from CellularDevice
     virtual CellularPower *open_power(FileHandle *fh);
     virtual CellularNetwork *open_network(FileHandle *fh);
+    virtual uint16_t get_send_delay();
 };
 } // namespace mbed
 #endif /* CELLULAR_TARGETS_TELIT_HE910_TELIT_HE910_H_ */


### PR DESCRIPTION
### Description
For some modems there is a minimum delay between the end of the response of the previous command and the beginning of a new command, and this change takes into account that kind of requirement. The delay set to 20 ms for Telit HE910 modems. The change is tested with a Telit HE910 modem


### Pull request type
[ X ] Fix  
[ ] Refactor  
[ ] New target  
[  ] Feature  
[ ] Breaking change
