### PR TITLE
Cleanup get_config (mbed compile --config)

### DIFF
--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -63,11 +63,12 @@ if __name__ == '__main__':
         if params:
             print("Configuration parameters")
             print("------------------------")
-            for p in sorted(params):
-                for s in options.prefix:
-                    if p.startswith(s):
-                        print(str(params[p]) if not options.verbose else params[p].get_verbose_description())
-                        break
+            for p in sorted(list(params.keys())):
+                if any(p.startswith(s) for s in options.prefix):
+                    if options.verbose:
+                        print(params[p].get_verbose_description())
+                    else:
+                        print(str(params[p]))
             print("")
 
         print("Macros")

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -74,7 +74,8 @@ if __name__ == '__main__':
         print("Macros")
         print("------")
         for m in Config.config_macros_to_macros(macros):
-            print(m)
+            if any(m.startswith(s) for s in options.prefix):
+                print(m)
 
     except KeyboardInterrupt as e:
         print("\n[CTRL+c] exit")

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -18,8 +18,7 @@ limitations under the License.
 """
 from __future__ import print_function
 import sys
-from os.path import isdir, abspath, dirname, join
-from os import _exit
+from os.path import abspath, dirname, join
 
 # Be sure that the tools directory is in the search path
 ROOT = abspath(join(dirname(__file__), ".."))
@@ -31,10 +30,6 @@ from tools.options import extract_mcus
 from tools.build_api import get_config
 from tools.config import Config
 from tools.utils import argparse_filestring_type
-try:
-    import tools.private_settings as ps
-except:
-    ps = object()
 
 if __name__ == '__main__':
     # Parse Options

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -34,12 +34,16 @@ from tools.utils import argparse_filestring_type
 if __name__ == '__main__':
     # Parse Options
     parser = get_default_options_parser(add_clean=False, add_options=False)
-    parser.add_argument("--source", dest="source_dir", type=argparse_filestring_type, required=True,
-                        default=[], help="The source (input) directory", action="append")
-    parser.add_argument("--prefix", dest="prefix", action="append",
-                      default=[], help="Restrict listing to parameters that have this prefix")
-    parser.add_argument("-v", "--verbose", action="store_true", dest="verbose",
-                      default=False, help="Verbose diagnostic output")
+    parser.add_argument(
+        "--source", dest="source_dir", type=argparse_filestring_type,
+        required=True, default=[], help="The source (input) directory",
+        action="append")
+    parser.add_argument(
+        "--prefix", dest="prefix", action="append", default=[],
+        help="Restrict listing to parameters that have this prefix")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true", dest="verbose", default=False,
+        help="Verbose diagnostic output")
 
     options = parser.parse_args()
 
@@ -56,7 +60,8 @@ if __name__ == '__main__':
     options.prefix = options.prefix or [""]
 
     try:
-        params, macros, features = get_config(options.source_dir, target, toolchain)
+        params, macros, features = get_config(
+            options.source_dir, target, toolchain)
         if not params and not macros:
             print("No configuration data available.")
             sys.exit(0)

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -73,9 +73,8 @@ if __name__ == '__main__':
 
         print("Macros")
         print("------")
-        if macros:
-            print('Defined with "macros":', Config.config_macros_to_macros(macros))
-        print("Generated from configuration parameters:", Config.parameters_to_macros(params))
+        for m in Config.config_macros_to_macros(macros):
+            print(m)
 
     except KeyboardInterrupt as e:
         print("\n[CTRL+c] exit")

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
         params, macros, features = get_config(options.source_dir, target, toolchain)
         if not params and not macros:
             print("No configuration data available.")
-            _exit(0)
+            sys.exit(0)
         if params:
             print("Configuration parameters")
             print("------------------------")


### PR DESCRIPTION
### Description

 I made get_config a little nicer to read, and the output a little nicer
 to read.
before
```

Macros
------
Defined with "macros": [u'UNITY_INCLUDE_CONFIG_H']
Generated from configuration parameters: [u'MBED_CONF_LORA_DEVICE_ADDRESS=0x00000000', u'MBED_CONF_CELLULAR_USE_APN_LOOKUP=1', u'MBED_CONF_LORA_DEVICE_EUI={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}', u'MBED_CONF_LWIP_IPV4_ENABLED=1', u'MBED_CONF_LWIP_DEFAULT_THREAD_STACKSIZE=512', u'MBED_CONF_LWIP_IP_VER_PREF=4', u'MBED_CONF_EVENTS_PRESENT=1', u'NSAPI_PPP_IPV4_AVAILABLE=1', u'MBED_CONF_PLATFORM_FORCE_NON_COPYABLE_ERROR=0', u'MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE=256', u'NVSTORE_MAX_KEYS=16', u'MBED_CONF_LWIP_ADDR_TIMEOUT=5', u'CFSTORE_STORAGE_DISABLE=0', u'MBED_LFS_BLOCK_SIZE=512', u'MBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL=0', u'MBED_CONF_LORA_NWKSKEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}', u'MBED_CONF_LORA_DUTY_CYCLE_ON=1', u'MBED_CONF_LWIP_TCP_SERVER_MAX=4', u'MBED_LFS_READ_SIZE=64', u'MBED_CONF_LORA_TX_MAX_SIZE=64', u'MBED_CONF_LORA_APPSKEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}', u'MBED_CONF_LWIP_TCP_ENABLED=1', u'MBED_CONF_LORA_APP_PORT=15', u'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_TIMEOUT=8000', u'MBED_CONF_EVENTS_SHARED_STACKSIZE=1024', u'MBED_CONF_LORA_APPLICATION_EUI={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}', u'NSAPI_PPP_AVAILABLE=0', u'MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP=1', u'MBED_LFS_LOOKAHEAD=512', u'MBED_CONF_LWIP_USE_MBED_TRACE=0', u'MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES=0', u'MBED_CONF_LORA_OVER_THE_AIR_ACTIVATION=1', u'MBED_CONF_LORA_ADR_ON=1', u'MBED_CONF_LWIP_ETHERNET_ENABLED=1', u'MBED_LFS_ENABLE_INFO=0', u'MBED_CONF_LORA_PUBLIC_NETWORK=1', u'MBED_CONF_LWIP_ENABLE_PPP_TRACE=0', u'MBED_CONF_EVENTS_SHARED_DISPATCH_FROM_APPLICATION=0', u'MBED_CONF_LWIP_UDP_SOCKET_MAX=4', u'MBED_CONF_LWIP_TCPIP_THREAD_STACKSIZE=1200', u'MBED_LFS_PROG_SIZE=64', u'MBED_CONF_LWIP_PPP_THREAD_STACKSIZE=768', u'MBED_CONF_LORA_PHY=0', u'NSAPI_PPP_IPV6_AVAILABLE=0', u'MBED_CONF_NSAPI_PRESENT=1', u'MBED_CONF_FILESYSTEM_PRESENT=1', u'MBED_CONF_PPP_CELL_IFACE_BAUD_RATE=115200', u'MBED_CONF_PPP_CELL_IFACE_AT_PARSER_BUFFER_SIZE=256', u'MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT=1', u'MBED_CONF_LORA_NB_TRIALS=12', u'MBED_CONF_PLATFORM_STDIO_BAUD_RATE=9600', u'MBED_CONF_LWIP_IPV6_ENABLED=0', u'MBED_LFS_INTRINSICS=1', u'MBED_CONF_EVENTS_SHARED_HIGHPRIO_STACKSIZE=1024', u'NVSTORE_ENABLED=1', u'MBED_CONF_LORA_LBT_ON=0', u'MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE=9600', u'MBED_CONF_LWIP_TCP_SOCKET_MAX=4', u'MBED_CONF_EVENTS_SHARED_EVENTSIZE=256', u'MBED_CONF_LWIP_DEBUG_ENABLED=0', u'MBED_CONF_CELLULAR_RANDOM_MAX_START_DELAY=0', u'MBED_CONF_LWIP_SOCKET_MAX=4', u'MBED_CONF_DRIVERS_UART_SERIAL_TXBUF_SIZE=256', u'MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES=0', u'MBED_CONF_EVENTS_USE_LOWPOWER_TIMER_TICKER=0', u'MBED_CONF_LORA_APPLICATION_KEY={0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}', u'MBED_CONF_LWIP_ADDR_TIMEOUT_MODE=1', u'MBED_CONF_RTOS_PRESENT=1', u'MBED_CONF_EVENTS_SHARED_HIGHPRIO_EVENTSIZE=256']
```
(Yes, it's all one line and contains config)

After
```

Macros
------
UNITY_INCLUDE_CONFIG_H
```

Each macro on a line, like the config section, and does not contain config because that's redundant.

 ### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change