### PR TITLE
LoRa: Internal include paths corrected

### DIFF
--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -19,7 +19,7 @@
 #ifndef LORAWAN_BASE_H_
 #define LORAWAN_BASE_H_
 
-#include "lorawan/system/lorawan_data_structures.h"
+#include "system/lorawan_data_structures.h"
 #include "events/EventQueue.h"
 
 class LoRaWANBase {

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -19,7 +19,7 @@
  * limitations under the License.
  */
 
-#include "lorawan/LoRaWANInterface.h"
+#include "LoRaWANInterface.h"
 
 using namespace events;
 

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -19,9 +19,9 @@
 #define LORAWANINTERFACE_H_
 
 #include "platform/Callback.h"
-#include "lorawan/LoRaWANStack.h"
-#include "lorawan/LoRaRadio.h"
-#include "lorawan/LoRaWANBase.h"
+#include "LoRaWANStack.h"
+#include "LoRaRadio.h"
+#include "LoRaWANBase.h"
 
 class LoRaWANInterface: public LoRaWANBase {
 

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -27,7 +27,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <stdlib.h>
 #include "platform/Callback.h"
 #include "events/EventQueue.h"
-#include "lorawan/LoRaWANStack.h"
+
+#include "LoRaWANStack.h"
 #if defined(FEATURE_COMMON_PAL)
 #include "mbed_trace.h"
 #define TRACE_GROUP "LSTK"

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -44,9 +44,10 @@
 #include "events/EventQueue.h"
 #include "platform/Callback.h"
 #include "platform/NonCopyable.h"
-#include "lorawan/system/LoRaWANTimer.h"
+
 #include "lorastack/mac/LoRaMac.h"
-#include "lorawan/system/lorawan_data_structures.h"
+#include "system/LoRaWANTimer.h"
+#include "system/lorawan_data_structures.h"
 #include "LoRaRadio.h"
 
 class LoRaWANStack: private mbed::NonCopyable<LoRaWANStack> {

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -22,6 +22,7 @@ Copyright (c) 2017, Arm Limited and affiliates.
 SPDX-License-Identifier: BSD-3-Clause
 */
 #include <stdlib.h>
+
 #include "LoRaMac.h"
 #include "LoRaMacCrypto.h"
 

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -40,13 +40,16 @@
 #ifndef MBED_LORAWAN_MAC_H__
 #define MBED_LORAWAN_MAC_H__
 
-#include "lorawan/system/LoRaWANTimer.h"
-#include "lorastack/phy/LoRaPHY.h"
-#include "lorawan/system/lorawan_data_structures.h"
-#include "LoRaMacCommand.h"
 #include "events/EventQueue.h"
+
+#include "lorastack/phy/loraphy_target.h"
+#include "lorastack/phy/LoRaPHY.h"
+
+#include "system/LoRaWANTimer.h"
+#include "system/lorawan_data_structures.h"
+
 #include "LoRaMacChannelPlan.h"
-#include "loraphy_target.h"
+#include "LoRaMacCommand.h"
 
 class LoRaMac {
 

--- a/features/lorawan/lorastack/mac/LoRaMacChannelPlan.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacChannelPlan.cpp
@@ -23,7 +23,7 @@ Copyright (c) 2017, Arm Limited and affiliates.
 SPDX-License-Identifier: BSD-3-Clause
 */
 
-#include "lorastack/mac/LoRaMacChannelPlan.h"
+#include "LoRaMacChannelPlan.h"
 
 LoRaMacChannelPlan::LoRaMacChannelPlan() : _lora_phy(NULL)
 {

--- a/features/lorawan/lorastack/mac/LoRaMacChannelPlan.h
+++ b/features/lorawan/lorastack/mac/LoRaMacChannelPlan.h
@@ -28,7 +28,7 @@ SPDX-License-Identifier: BSD-3-Clause
 #ifndef MBED_LORAWAN_LORAMACCHANNELPLAN_H_
 #define MBED_LORAWAN_LORAMACCHANNELPLAN_H_
 
-#include "lorawan/system/lorawan_data_structures.h"
+#include "system/lorawan_data_structures.h"
 #include "lorastack/phy/LoRaPHY.h"
 
 class LoRaMacChannelPlan {

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -21,6 +21,7 @@ Copyright (c) 2017, Arm Limited and affiliates.
 
 SPDX-License-Identifier: BSD-3-Clause
 */
+
 #include "LoRaMacCommand.h"
 #include "LoRaMac.h"
 

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.h
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.h
@@ -41,8 +41,8 @@
 #define __LORAMACCOMMAND_H__
 
 #include <stdint.h>
-#include "lorawan/system/lorawan_data_structures.h"
-#include "lorawan/lorastack/phy/LoRaPHY.h"
+#include "system/lorawan_data_structures.h"
+#include "lorastack/phy/LoRaPHY.h"
 
 /*!
  * Maximum MAC commands buffer size

--- a/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCrypto.cpp
@@ -25,11 +25,13 @@
 
 #include <stdlib.h>
 #include <stdint.h>
-#include "lorastack/mac/LoRaMacCrypto.h"
-#include "lorawan/system/lorawan_data_structures.h"
 
 #include "mbedtls/aes.h"
 #include "mbedtls/cmac.h"
+
+#include "LoRaMacCrypto.h"
+#include "system/lorawan_data_structures.h"
+
 
 #if defined(MBEDTLS_CMAC_C) && defined(MBEDTLS_AES_C) && defined(MBEDTLS_CIPHER_C)
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -26,7 +26,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include <string.h>
 #include <stdint.h>
 #include <math.h>
-#include "lorawan/lorastack/phy/LoRaPHY.h"
+
+#include "LoRaPHY.h"
 
 #define BACKOFF_DC_1_HOUR       100
 #define BACKOFF_DC_10_HOURS     1000

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -34,10 +34,11 @@
 #ifndef MBED_OS_LORAPHY_BASE_
 #define MBED_OS_LORAPHY_BASE_
 
-#include "lorawan/LoRaRadio.h"
-#include "lorawan/system/LoRaWANTimer.h"
-#include "lorawan/lorastack/phy/lora_phy_ds.h"
 #include "platform/NonCopyable.h"
+
+#include "system/LoRaWANTimer.h"
+#include "LoRaRadio.h"
+#include "lora_phy_ds.h"
 
 class LoRaPHY : private mbed::NonCopyable<LoRaPHY> {
 

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
@@ -34,7 +34,6 @@
 
 #include "LoRaPHY.h"
 
-
 /*!
  * LoRaMac maximum number of channels
  */

--- a/features/lorawan/lorastack/phy/lora_phy_ds.h
+++ b/features/lorawan/lorastack/phy/lora_phy_ds.h
@@ -31,7 +31,7 @@
 #ifndef MBED_OS_LORA_PHY_DATASTRUCTURES_
 #define MBED_OS_LORA_PHY_DATASTRUCTURES_
 
-#include "lorawan/system/lorawan_data_structures.h"
+#include "system/lorawan_data_structures.h"
 
 /*!
  * \brief Returns the minimum value between a and b.

--- a/features/lorawan/system/LoRaWANTimer.cpp
+++ b/features/lorawan/system/LoRaWANTimer.cpp
@@ -18,7 +18,7 @@ Copyright (c) 2017, Arm Limited and affiliates.
 SPDX-License-Identifier: BSD-3-Clause
 */
 
-#include "lorawan/system/LoRaWANTimer.h"
+#include "LoRaWANTimer.h"
 
 LoRaWANTimeHandler::LoRaWANTimeHandler()
     : _queue(NULL)

--- a/features/lorawan/system/LoRaWANTimer.h
+++ b/features/lorawan/system/LoRaWANTimer.h
@@ -22,8 +22,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #define MBED_LORAWAN_SYS_TIMER_H__
 
 #include <stdint.h>
-#include "lorawan/system/lorawan_data_structures.h"
 #include "events/EventQueue.h"
+
+#include "lorawan_data_structures.h"
 
 class LoRaWANTimeHandler
 {


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->
Internal include paths were using paths starting with lorawan which is not necessary.
In some cases .cpp files included it's .h file with full internal path.
These are now harmonised in this PR.

This is 5.9 content

### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[ ] Fix  
[ X] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
