### PR TITLE
Fix typo with NVStore

### DIFF
--- a/features/nvstore/source/nvstore.cpp
+++ b/features/nvstore/source/nvstore.cpp
@@ -134,7 +134,7 @@ NVStore::NVStore() : _init_done(0), _init_attempts(0), _active_area(0), _max_key
       _active_area_version(0), _free_space_offset(0), _size(0), _mutex(0), _offset_by_key(0), _flash(0),
       _min_prog_size(0), _page_buf(0)
 {
-    memcpy(_flash_area_params, 0, sizeof(_flash_area_params));
+    memset(_flash_area_params, 0, sizeof(_flash_area_params));
 }
 
 NVStore::~NVStore()


### PR DESCRIPTION
### Description

I believe the below code is a typo:

**mbed-os/features/nvstore/source/nvstore.cpp**:
```
memcpy(_flash_area_params, 0, sizeof(_flash_area_params));
```
And I fix as below:

```
memset(_flash_area_params, 0, sizeof(_flash_area_params));
```

Because `_flash_area_params` will be re-initialized later, the typo won't cause trouble on most targets. But it will on **NUMAKER_PFM_M2351** port of which is on-going. **NUMAKER_PFM_M2351** is Cortex-M23 based and has TrustZone support. Read flash address `0` is not always legal because flash is partitioned into secure/non-secure.
 
[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
