### PR TITLE
Add SAI HAL API tests.

### DIFF
--- a/TESTS/mbed_hal/sai/main.cpp
+++ b/TESTS/mbed_hal/sai/main.cpp
@@ -1,0 +1,507 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2016 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "greentea-client/test_env.h"
+#include "mbed.h"
+#include "math.h"
+#include "sai_api.h"
+
+#if !DEVICE_SAI
+#error [NOT_SUPPORTED] SAI not supported for this target
+#endif
+
+using namespace utest::v1;
+
+/* Since boards on CI do not have wire loop-back connection, some of the functional
+ * tests can not be executed.
+ * If you want to fully test SAI support please connect pins as follows:
+ * - SAI_A_SD   <--> SAI_B_SD
+ * - SAI_A_BCLK <--> SAI_B_BCLK
+ * - SAI_A_WCLK <--> SAI_B_WCLK
+ * and enable loop-back tests by setting LOOPBACK_CONNECTION to true.
+ */
+#define LOOPBACK_CONNECTION (false)
+
+#define BUFFER_SIZE 100
+
+#define SAMPLE_1 123
+#define SAMPLE_2 124
+
+typedef enum
+{
+    LOOPBACK_TEST_OK,
+    LOOPBACK_TEST_SKIP,
+    LOOPBACK_TEST_FAILURE
+} loopback_test_tatus_t;
+
+static uint32_t transmit_buffer[BUFFER_SIZE];
+static uint32_t receive_buffer[BUFFER_SIZE];
+
+/* Auxiliary function which inits SAI config structure. */
+static void sai_config_create(sai_init_t *p_config, bool is_receiver, uint32_t sample_rate,
+        const sai_format_t * p_format)
+{
+    if (is_receiver) {
+        p_config->mclk = SAI_A_MCLK;
+        p_config->sd = SAI_A_SD;
+        p_config->bclk = SAI_A_BCLK;
+        p_config->wclk = SAI_A_WCLK;
+        p_config->is_receiver = true;
+    } else {
+        p_config->mclk = SAI_B_MCLK;
+        p_config->sd = SAI_B_SD;
+        p_config->bclk = SAI_B_BCLK;
+        p_config->wclk = SAI_B_WCLK;
+        p_config->is_receiver = false;
+    }
+    memcpy(&p_config->format, p_format, sizeof(p_config->format));
+    p_config->sample_rate = sample_rate;
+    p_config->mclk_source = SAI_CLOCK_SOURCE_INTERNAL;
+    p_config->input_mclk_frequency = 0; // 0 means find it by yourself.
+    p_config->output_mclk_frequency = p_config->format.word_length * p_config->sample_rate;
+}
+
+/* Auxiliary function which sets the specified buffer using specified pattern. */
+static void set_buffer(void * buffer, uint32_t size, char pattern)
+{
+    char* p_byte = (char*) buffer;
+
+    while (size--) {
+        *p_byte = pattern;
+        p_byte++;
+    }
+}
+
+/* Auxiliary function which compares two buffers and returns true if both are the same. */
+static bool compare_buffers(const void *buffer1, const void *buffer2, uint32_t size)
+{
+    const unsigned char *p1 = (const unsigned char *) buffer1;
+    const unsigned char *p2 = (const unsigned char *) buffer2;
+    while (size--) {
+        if (*p1 != *p2) {
+            return false;
+        } else {
+            p1++;
+            p2++;
+        }
+    }
+
+    return true;
+}
+
+/* Number of formats which must be supported by SAI device.
+ * This variable defines number of obligate formats in test_sai_formats array. */
+const uint32_t required_formats_count = 5;
+
+/* Array of tested formats. */
+static sai_format_t test_sai_formats[] =
+{
+// Formats which are requested for all SAI devices
+    sai_mode_i2s16,
+    sai_mode_i2s16w32,
+    sai_mode_i2s32,
+    sai_mode_pcm16l,
+    sai_mode_pcm16s,
+// Other formats
+
+};
+
+/* Array of tested sample rates [Hz]. */
+static uint32_t test_sample_rates[] =
+{
+    SAI_DEFAULT_SAMPLE_RATE,
+
+};
+
+/* Auxiliary function to test SAI loop-back communication using specified format and sample rate. */
+static loopback_test_tatus_t sai_loopback_communication_test(sai_format_t *format, uint32_t sample_rate)
+{
+    sai_t sai_transmitter;
+    sai_t sai_receiver;
+
+    sai_init_t sai_transmitter_init = { };
+    sai_init_t sai_receiver_init = { };
+
+    sai_config_create(&sai_transmitter_init, false, SAI_DEFAULT_SAMPLE_RATE, format);
+    sai_config_create(&sai_receiver_init, true, SAI_DEFAULT_SAMPLE_RATE, format);
+
+    const sai_result_t transmitter_init_status = sai_init(&sai_transmitter, &sai_transmitter_init);
+    const sai_result_t receiver_init_status = sai_init(&sai_receiver, &sai_receiver_init);
+
+    /* Continue test only if SAI device has been successfully configured. */
+    if (transmitter_init_status == SAI_RESULT_OK && receiver_init_status == SAI_RESULT_OK) {
+
+        const uint32_t data_len = sai_receiver_init.format.data_length;
+        const uint32_t data_mask = ((1 << data_len) - 1);
+
+        /* Set to unexpected. */
+        set_buffer(receive_buffer, sizeof(receive_buffer), 0xFF);
+
+        for (int i = 0; i < BUFFER_SIZE; i++) {
+            transmit_buffer[i] = data_mask / 100 * i;
+        }
+
+        uint32_t write_cnt = 0;
+        uint32_t read_cnt = 0;
+        uint32_t sample;
+
+        /* Send samples and read them back. */
+        while (1) {
+            if (write_cnt < BUFFER_SIZE) {
+                sample = transmit_buffer[write_cnt];
+                if (sai_transfer(&sai_transmitter, &sample) == true) {
+                    write_cnt++;
+                }
+            }
+
+            if (sai_transfer(&sai_receiver, &sample) == true) {
+                receive_buffer[read_cnt] = sample;
+                read_cnt++;
+            }
+
+            if (read_cnt == BUFFER_SIZE) {
+                break;
+            }
+        }
+
+        sai_free(&sai_transmitter);
+        sai_free(&sai_receiver);
+
+        if (compare_buffers(transmit_buffer, receive_buffer, BUFFER_SIZE) == true) {
+            return LOOPBACK_TEST_OK;
+        } else {
+            return LOOPBACK_TEST_FAILURE;
+        }
+    }
+
+    if (transmitter_init_status == SAI_RESULT_OK) {
+        sai_free(&sai_transmitter);
+    }
+
+    if (receiver_init_status == SAI_RESULT_OK) {
+        sai_free(&sai_receiver);
+    }
+
+    return LOOPBACK_TEST_SKIP;
+}
+
+/* Test that SAI devices supports required formats. */
+void sai_transmission_test()
+{
+
+    if (!LOOPBACK_CONNECTION) {
+        TEST_IGNORE_MESSAGE("NO LOOPBACK CONNECTION - TEST SKIPPED!");
+        return;
+    }
+
+    char message[50];
+
+    for (uint32_t f_idx = 0; f_idx < (sizeof(test_sai_formats) / sizeof(sai_format_t)); f_idx++) {
+        for (uint32_t sr_idx = 0; sr_idx < (sizeof(test_sample_rates) / sizeof(uint32_t)); sr_idx++) {
+            const loopback_test_tatus_t result = sai_loopback_communication_test(&test_sai_formats[f_idx],
+                    test_sample_rates[sr_idx]);
+
+            /* First `required_formats_count` formats are obligate, so we expect that
+             * communication tests passes. Others formats may be supported, so test can pass or be skipped.
+             */
+            sprintf(message, "format idx: %lu, sample rate idx: %lu", f_idx, sr_idx);
+            if (f_idx < required_formats_count) {
+                TEST_ASSERT_EQUAL_MESSAGE(LOOPBACK_TEST_OK, result, message);
+            } else {
+                TEST_ASSERT_NOT_EQUAL_MESSAGE(LOOPBACK_TEST_FAILURE, result, message);
+            }
+        }
+    }
+}
+
+/* Test that sai_init() returns `SAI_RESULT_ALREADY_INITIALIZED` if SAI is to be re-initialised. */
+void sai_reinit_test()
+{
+    sai_t sai_obj = { };
+    sai_init_t sai_init_data = { };
+
+    sai_config_create(&sai_init_data, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    /* Change config (format) and try to re-init. */
+    sai_config_create(&sai_init_data, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_ALREADY_INITIALIZED, sai_init(&sai_obj, &sai_init_data));
+
+    sai_free(&sai_obj);
+}
+
+/* Test that `sai_init` returns `SAI_RESULT_INVALID_PARAM` if at least one of the given parameters is
+ * invalid. */
+void sai_init_invalid_param_test()
+{
+    sai_t sai_obj;
+    sai_init_t sai_init_data = { };
+
+    /* Provide NULL pointers. */
+    TEST_ASSERT_EQUAL(SAI_RESULT_INVALID_PARAM, sai_init(NULL, &sai_init_data));
+    TEST_ASSERT_EQUAL(SAI_RESULT_INVALID_PARAM, sai_init(&sai_obj, NULL));
+
+    /* Create invalid configuration: invalid sample rate. */
+    sai_config_create(&sai_init_data, false, 0, &sai_mode_i2s16w32);
+    TEST_ASSERT_EQUAL(SAI_RESULT_INVALID_PARAM, sai_init(&sai_obj, &sai_init_data));
+
+    /* Create invalid configuration: invalid format (word length inconsistent with data length). */
+    sai_config_create(&sai_init_data, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+    sai_init_data.format.word_length = 16;
+    sai_init_data.format.data_length = 32;
+    TEST_ASSERT_EQUAL(SAI_RESULT_INVALID_PARAM, sai_init(&sai_obj, &sai_init_data));
+}
+
+/* Test that sai_free() handles invalid (undefined) parameter. */
+void sai_free_invalid_param_test()
+{
+    /* Call free with invalid param and check if no exception is generated. */
+    sai_free((sai_t *) NULL);
+
+    TEST_ASSERT_TRUE(true);
+}
+
+/* Test that SAI can be successfully re-initialised after it has been freed. */
+void sai_reinit_after_free_test()
+{
+    sai_t sai_obj = { };
+    sai_init_t sai_init_data = { };
+
+    sai_config_create(&sai_init_data, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    sai_free(&sai_obj);
+
+    /* Change configuration. */
+    sai_config_create(&sai_init_data, true, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    sai_free(&sai_obj);
+}
+
+/* Test that sai_transfer() of the SAI receiver returns false if pointer to
+ * the `sai_t` object is NULL. */
+void sai_transfer_receiver_invalid_param_test()
+{
+    sai_t sai_obj = { };
+    sai_init_t sai_init_data = { };
+
+    sai_config_create(&sai_init_data, true, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    uint32_t sample = 0xABABABAB;
+
+    const bool result = sai_transfer((sai_t *) NULL, &sample);
+
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL(0xABABABAB, sample);
+
+    sai_free(&sai_obj);
+}
+
+/* Test that `sai_transfer` of the SAI receiver returns false if there's no sample in the FIFO. */
+void sai_transfer_receiver_empty_fifo_test()
+{
+    sai_t sai_obj = { };
+    sai_init_t sai_init_data = { };
+
+    sai_config_create(&sai_init_data, true, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    uint32_t sample = 0xABABABAB;
+
+    /* Assume that no sample has been sent. */
+    const bool result = sai_transfer(&sai_obj, &sample);
+
+    TEST_ASSERT_FALSE(result);
+
+    sai_free(&sai_obj);
+}
+
+/* Test that sai_transfer() of the SAI receiver pops 1 sample from the FIFO,
+ * stores it to the address pointed by `psample`(if defined), and returns true. */
+static void sai_transfer_receiver_psample_test()
+{
+    if (!LOOPBACK_CONNECTION) {
+        TEST_IGNORE_MESSAGE("NO LOOPBACK CONNECTION - TEST SKIPPED!");
+        return;
+    }
+
+    sai_t sai_transmitter;
+    sai_t sai_receiver;
+
+    sai_init_t sai_transmitter_init = { };
+    sai_init_t sai_receiver_init = { };
+
+    sai_config_create(&sai_transmitter_init, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+    sai_config_create(&sai_receiver_init, true, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    const sai_result_t transmitter_init_status = sai_init(&sai_transmitter, &sai_transmitter_init);
+    const sai_result_t receiver_init_status = sai_init(&sai_receiver, &sai_receiver_init);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, transmitter_init_status);
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, receiver_init_status);
+
+    uint32_t write_cnt = 0;
+    uint32_t read_cnt = 0;
+    uint32_t sample;
+
+    /* Send SAMPLE_1 and SAMPLE_2 alternately. Try to read samples using
+     * undefined and defined `psample` parameter.
+     */
+    while (1) {
+        if (write_cnt < BUFFER_SIZE) {
+            (write_cnt & 1) ? sample = SAMPLE_1 : sample = SAMPLE_2;
+            if (sai_transfer(&sai_transmitter, &sample) == true) {
+                write_cnt++;
+            }
+        }
+
+        if (read_cnt & 1) {
+            if (sai_transfer(&sai_receiver, NULL) == true) {
+                read_cnt++;
+                // SAMPLE_1 has been popped from receive FIFO.
+            }
+        } else {
+            if (sai_transfer(&sai_receiver, &sample) == true) {
+                read_cnt++;
+                TEST_ASSERT_EQUAL(SAMPLE_2, sample);
+            }
+        }
+
+        if (read_cnt == BUFFER_SIZE) {
+            break;
+        }
+    }
+
+    sai_free(&sai_transmitter);
+    sai_free(&sai_receiver);
+}
+
+/* Test that sai_transfer() of the SAI transmitter returns false if pointer to
+ * the `sai_t` object is NULL. */
+void sai_transfer_transmitter_invalid_param_test()
+{
+    sai_t sai_obj = { };
+    sai_init_t sai_init_data = { };
+
+    sai_config_create(&sai_init_data, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, sai_init(&sai_obj, &sai_init_data));
+
+    uint32_t sample = 0xABABABAB;
+
+    const bool result = sai_transfer((sai_t *) NULL, &sample);
+
+    TEST_ASSERT_FALSE(result);
+    TEST_ASSERT_EQUAL(0xABABABAB, sample);
+
+    sai_free(&sai_obj);
+}
+
+/* Test that sai_transfer() of the SAI transmitter pushes the pointed sample (or 0 if undefined)
+ * to the FIFO and returns true. */
+static void sai_transfer_transmitter_psample_test()
+{
+    if (!LOOPBACK_CONNECTION) {
+        TEST_IGNORE_MESSAGE("NO LOOPBACK CONNECTION - TEST SKIPPED!");
+        return;
+    }
+
+    sai_t sai_transmitter;
+    sai_t sai_receiver;
+
+    sai_init_t sai_transmitter_init = { };
+    sai_init_t sai_receiver_init = { };
+
+    sai_config_create(&sai_transmitter_init, false, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+    sai_config_create(&sai_receiver_init, true, SAI_DEFAULT_SAMPLE_RATE, &sai_mode_i2s16w32);
+
+    const sai_result_t transmitter_init_status = sai_init(&sai_transmitter, &sai_transmitter_init);
+    const sai_result_t receiver_init_status = sai_init(&sai_receiver, &sai_receiver_init);
+
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, transmitter_init_status);
+    TEST_ASSERT_EQUAL(SAI_RESULT_OK, receiver_init_status);
+
+    uint32_t write_cnt = 0;
+    uint32_t read_cnt = 0;
+    uint32_t sample = 0xFFFFFFFF;
+
+    /* Send SAMPLE_1 and undefined sample alternately, read them back and
+     * verify results.
+     */
+    while (1) {
+        if (write_cnt < BUFFER_SIZE) {
+
+            if (write_cnt & 1) {
+                if (sai_transfer(&sai_transmitter, NULL) == true) {
+                    write_cnt++;
+                }
+            } else {
+                sample = SAMPLE_1;
+                if (sai_transfer(&sai_transmitter, &sample) == true) {
+                    write_cnt++;
+                }
+            }
+        }
+
+        if (sai_transfer(&sai_receiver, &sample) == true) {
+            const uint32_t exp_result = (read_cnt & 1) ? 0 : SAMPLE_1;
+            TEST_ASSERT_EQUAL(exp_result, sample);
+            read_cnt++;
+        }
+
+        if (read_cnt == BUFFER_SIZE) {
+            break;
+        }
+    }
+
+    sai_free(&sai_transmitter);
+    sai_free(&sai_receiver);
+}
+
+Case cases[] = {
+    Case("sai_init() - invalid parameter.", sai_init_invalid_param_test),
+    Case("sai_init() - re-init.", sai_reinit_test),
+    Case("sai_free() - invalid parameter.", sai_free_invalid_param_test),
+    Case("sai_free()/sai_init() - re-init after free.", sai_reinit_after_free_test),
+    Case("receiver: sai_transfer() - invalid param", sai_transfer_receiver_invalid_param_test),
+    Case("receiver: sai_transfer() - empty FIFO", sai_transfer_receiver_empty_fifo_test),
+    Case("receiver: sai_transfer() - psample defined/undefined", sai_transfer_receiver_psample_test),
+    Case("transmitter: sai_transfer() - invalid param", sai_transfer_transmitter_invalid_param_test),
+    Case("transmitter: sai_transfer() - psample defined/undefined", sai_transfer_transmitter_psample_test),
+    Case("SAI transmission test", sai_transmission_test),
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(30, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main()
+{
+    Harness::run(specification);
+}

--- a/TESTS/mbed_hal/sai/sai_api_tests.h
+++ b/TESTS/mbed_hal/sai/sai_api_tests.h
@@ -1,0 +1,142 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2017-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** \addtogroup hal_sai_tests
+ *  @{
+ */
+
+#ifndef SAI_API_TESTS_H
+#define SAI_API_TESTS_H
+
+#include "device.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Test that `sai_init` returns `SAI_RESULT_INVALID_PARAM` if at least one of the given parameters is
+ *   invalid.
+ *
+ * Given is platform with SAI support.
+ * When SAI is initialised with uinvalid parameter.
+ * Then `SAI_RESULT_INVALID_PARAM` initialisation status is returned.
+ */
+void sai_init_invalid_param_test(void);
+
+/** Test that `sai_init` returns `SAI_RESULT_ALREADY_INITIALIZED` if SAI is to be re-initialised.
+ *
+ * Given is platform with SAI support.
+ * When SAI is already initialised and `sai_init` is called again.
+ * Then `SAI_RESULT_ALREADY_INITIALIZED` initialisation status is returned.
+ *
+ */
+void sai_reinit_test(void);
+
+/** Test that `sai_free` handles invalid (undefined) parameter.
+ *
+ * Given is platform with SAI support.
+ * When `sai_free` is called with invalid (undefined) parameter.
+ * Then no exception is generated.
+ */
+void sai_free_invalid_param_test(void);
+
+/** Test that SAI can be successfully re-initialised after it has been freed.
+ *
+ * Given is platform with SAI support.
+ * When SAI has been initialised and freed.
+ * Then SAI can be successfully initialised again with different config.
+ */
+void sai_reinit_after_free_test(void);
+
+/** Test that `sai_xfer` of the SAI receiver returns false if pointer to
+ * the `sai_t` object is NULL.
+ *
+ * Given is platform with SAI support.
+ * When SAI receiver has been successfully configured.
+ * Then `sai_xfer` returns false if pointer to the `sai_t` object is NULL.
+ */
+void sai_xfer_receiver_invalid_param_test(void);
+
+/** Test that `sai_xfer` of the SAI receiver returns false if there's no sample in the FIFO.
+ *
+ * Given is platform with SAI support.
+ * When SAI receiver has been successfully configured and no data have been received.
+ * Then `sai_xfer` returns false.
+ */
+void sai_xfer_receiver_empty_fifo_test(void);
+
+/** Test that `sai_xfer` of the SAI receiver pops 1 sample from the FIFO,
+ * stores it to the address pointed by `psample`(if defined), and returns true.
+ *
+ * Given is platform with SAI support and SAI is successfully configured as receiver.
+ * When `sai_xfer` is called with undefined (NULL) `psample` parameter.
+ * Then `sai_xfer` pops 1 sample from the FiFo and returns true
+ *
+ * Given is platform with SAI support and SAI is successfully configured as receiver.
+ * When `sai_xfer` is called with defined (not NULL) `psample` parameter.
+ * Then `sai_xfer` it pops 1 sample from the FiFo, stores it to the address pointed by `psample`, and returns true.
+ *
+ * @note:
+ * This test requires wire loop-back connection to be executed.
+ */
+void sai_xfer_receiver_psample_test(void);
+
+/** Test that `sai_xfer` of the SAI transmitter returns false if pointer to
+ * the `sai_t` object is NULL.
+ *
+ * Given is platform with SAI support.
+ * When SAI transmitter has been successfully configured.
+ * Then `sai_xfer` returns false if pointer to the `sai_t` object is NULL.
+ */
+void sai_xfer_transmitter_invalid_param_test(void);
+
+/** Test that `sai_xfer` of the SAI transmitter pushes the pointed sample (or 0 if undefined)
+ *  to the FIFO and returns true.
+ *
+ * Given is platform with SAI support and SAI is successfully configured as transmitter.
+ * When `sai_xfer` is called with undefined (NULL) `psample` parameter.
+ * Then `sai_xfer` pushes one '0' sample to the FIFO and returns true.
+ *
+ * Given is platform with SAI support and SAI is successfully configured as transmitter.
+ * When `sai_xfer` is called with defined (not NULL) `psample` parameter.
+ * Then `sai_xfer` pushes the pointed sample to the FIFO and returns true.
+ *
+ * @note:
+ * This test requires wire loop-back connection to be executed.
+ */
+void sai_xfer_transmitter_psample_test(void);
+
+/** Test that SAI devices supports required formats.
+ *
+ * Given is platform with SAI support configured in loop-back mode.
+ * When the loop-back communication test is performed using obligate format.
+ * Then all samples are successfully transmitted.
+ *
+ * @note:
+ * This test requires wire loop-back connection to be executed.
+ */
+void sai_transmission_test(void);
+
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/**@}*/

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
@@ -217,14 +217,14 @@ typedef enum {
     USBRX = PTB16,
 
     // Audio bus
-    SAI_A_MCLK = PTC6,
-    SAI_A_SD   = PTE7,
-    SAI_A_BCLK = PTE9,
-    SAI_A_WCLK = PTE8,
     SAI_B_MCLK = PTC6,
-    SAI_B_SD   = PTC1,
-    SAI_B_BCLK = PTE12,
-    SAI_B_WCLK = PTE11,
+    SAI_B_SD   = PTE7,
+    SAI_B_BCLK = PTE9,
+    SAI_B_WCLK = PTE8,
+    SAI_A_MCLK = PTC6,
+    SAI_A_SD   = PTC1,
+    SAI_A_BCLK = PTE12,
+    SAI_A_WCLK = PTE11,
 
     // Arduino Headers
     D0 = PTC3,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -213,14 +213,14 @@ typedef enum {
     USBRX = PTB16,
 
     // Audio bus
-    SAI_A_MCLK  = PTC8,
-    SAI_A_SD    = PTC1,
-    SAI_A_BCLK  = PTB18,
-    SAI_A_WCLK  = PTB19,
     SAI_B_MCLK  = PTC8,
-    SAI_B_SD   = PTC5,
-    SAI_B_BCLK = PTC9,
-    SAI_B_WCLK = PTC7,
+    SAI_B_SD    = PTC1,
+    SAI_B_BCLK  = PTB18,
+    SAI_B_WCLK  = PTB19,
+    SAI_A_MCLK  = PTC8,
+    SAI_A_SD   = PTC5,
+    SAI_A_BCLK = PTC9,
+    SAI_A_WCLK = PTC7,
 
     // Arduino Headers
     D0 = PTC16,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/sai_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/sai_api.c
@@ -155,18 +155,21 @@ bool sai_transfer(sai_t *obj, uint32_t *sample) {
 
     bool ret = false;
     if (obj->is_receiver) {
-        if (sample != NULL) {
-            uint32_t flags = SAI_RxGetStatusFlag(obj->base);
-            if ((flags & I2S_RCSR_RE_MASK) == 0) {
-                SAI_RxEnable(obj->base, true);
+        uint32_t flags = SAI_RxGetStatusFlag(obj->base);
+        if ((flags & I2S_RCSR_RE_MASK) == 0) {
+            SAI_RxEnable(obj->base, true);
+        }
+        ret = (flags & I2S_RCSR_FRF_MASK) == I2S_RCSR_FRF_MASK;
+        uint32_t tmpsample = 0;
+        if (ret) {
+            tmpsample = SAI_ReadData(obj->base, obj->channel);
+
+            if (sample != NULL) {
+                *sample = tmpsample;
             }
-            ret = (flags & I2S_RCSR_FRF_MASK) == I2S_RCSR_FRF_MASK;
-            if (ret) {
-                *sample = SAI_ReadData(obj->base, obj->channel);
-            }
-            if ((flags & I2S_RCSR_FEF_MASK) == I2S_RCSR_FEF_MASK) {
-                SAI_RxClearStatusFlags(obj->base, I2S_RCSR_FEF_MASK);
-            }
+        }
+        if ((flags & I2S_RCSR_FEF_MASK) == I2S_RCSR_FEF_MASK) {
+            SAI_RxClearStatusFlags(obj->base, I2S_RCSR_FEF_MASK);
         }
     } else {
         uint32_t tmp_sample = 0;


### PR DESCRIPTION
### Description

Add SAI HAL API test.

This test has been created based on the following requirements:

https://github.com/ithinuel/mbed-os/blob/fdf7ba4143957fb2c3b6454a34eb3f3518412154/hal/sai_api.h#L30-L77

### Status

IN DEVELOPMENT

### Related PRs

PR https://github.com/ARMmbed/mbed-os/pull/6136 - provides SAI HAL API definition and example drivers for K66F and NUCLEO-F411RE platforms. Needs to be merged before this one.

### Todos

Missing test cases:
 - `sai_init()` returns `SAI_RESULT_CONFIG_MISMATCH` if the device is not able to support this configuration at this point time because of other 'live' constraints (such as a shared  format/clock configuration with a sibling).
- `sai_xfer()` returns false if the fifo is full and `*psample` could not be pushed.
- extend requirements and tests.

@ithinuel please review.