### PR TITLE
LPC4088: Fix hardfault occuring after power-cycle

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC408X/sleep.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/sleep.c
@@ -19,12 +19,13 @@
 
 void hal_sleep(void) {
     LPC_SC->PCON = 0x0;
-    
+
     // SRC[SLEEPDEEP] set to 0 = sleep
     SCB->SCR &= ~SCB_SCR_SLEEPDEEP_Msk;
-    
+
     // wait for interrupt
     __WFI();
+    __NOP();
 }
 
 /*


### PR DESCRIPTION
### Description

Since revision 5499db1e8 (mbed-os-5.6.0) a hardfault occurs after a **power-cycle**. It doesn't occur after a reset when the application has been downloaded using drag-and-drop or via debugger. This is probably the reason why this problem isn't detected when testing new mbed releases.

The hardfault occured in hal_sleep(). Adding a __NOP after __WFI solves the problem although I don't fully understand why. 


- Revision ca661f9d2 is the last revision where the problem doesn't occur.  
- The problem doesn't occur when compiling with GCC instead of ARM compiler
- This issue describes a similar, but not identical problem and led me to test adding a __NOP: [https://github.com/ARMmbed/mbed-os/issues/5065](https://github.com/ARMmbed/mbed-os/issues/5065)



### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[ X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
