### PR TITLE
Optional hardware flow control for STDOUT

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -72,6 +72,16 @@ static SingletonPtr<PlatformMutex> _mutex;
 
 #define FILE_HANDLE_RESERVED    ((FileHandle*)0xFFFFFFFF)
 
+/**
+ * Macros for setting console flow control.
+ */
+#define CONSOLE_FLOWCONTROL_RTS     1
+#define CONSOLE_FLOWCONTROL_CTS     2
+#define CONSOLE_FLOWCONTROL_RTSCTS  3
+#define mbed_console_concat_(x) CONSOLE_FLOWCONTROL_##x
+#define mbed_console_concat(x) mbed_console_concat_(x)
+#define CONSOLE_FLOWCONTROL mbed_console_concat(MBED_CONF_TARGET_CONSOLE_UART_FLOW_CONTROL)
+
 using namespace mbed;
 
 #if defined(__MICROLIB) && (__ARMCC_VERSION>5030000)
@@ -147,6 +157,13 @@ DirectSerial::DirectSerial(PinName tx, PinName rx, int baud) {
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, tx, rx);
     serial_baud(&stdio_uart, baud);
+#if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS
+    serial_set_flow_control(&stdio_uart, FlowControlRTS, STDIO_UART_RTS, NC);
+#elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_CTS
+    serial_set_flow_control(&stdio_uart, FlowControlCTS, NC, STDIO_UART_CTS);
+#elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTSCTS
+    serial_set_flow_control(&stdio_uart, FlowControlRTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
+#endif
 }
 
 ssize_t DirectSerial::write(const void *buffer, size_t size) {
@@ -216,6 +233,13 @@ static FileHandle* default_console()
 #if DEVICE_SERIAL
 #  if MBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL
     static UARTSerial console(STDIO_UART_TX, STDIO_UART_RX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
+#   if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS
+        console.set_flow_control(SerialBase::RTS, STDIO_UART_RTS, NC);
+#   elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_CTS
+        console.set_flow_control(SerialBase::CTS, NC, STDIO_UART_CTS);
+#   elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTSCTS
+        console.set_flow_control(SerialBase::RTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
+#   endif
 #  else
     static DirectSerial console(STDIO_UART_TX, STDIO_UART_RX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
 #  endif

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -11,7 +11,13 @@
         "detect_code": [],
         "public": false,
         "default_lib": "std",
-        "bootloader_supported": false
+        "bootloader_supported": false,
+        "config": {
+            "console-uart-flow-control": {
+                "help": "Console hardware flow control. Options: null, RTS, CTS, RTSCTS.",
+                "value": null
+            }
+        }
     },
     "CM4_UARM": {
         "inherits": ["Target"],


### PR DESCRIPTION
### Description

Some platforms have interface chips with hardware flow control
enabled by default. This commit adds configurable flow control to
STDOUT.

Usage:

* Define pin names STDIO_UART_RTS for Rx-flow-control and
  STDIO_UART_CTS for Tx-flow-control.
* Set target.console-uart-flow-control-type to any SerialBase::Flow.
* Enable flow control by setting target.console-uart-flow-control to true.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
