### PR TITLE
littlefs: Fix some issues with lookahead trust

### DIFF
--- a/features/filesystem/littlefs/littlefs/lfs.c
+++ b/features/filesystem/littlefs/littlefs/lfs.c
@@ -270,8 +270,7 @@ int lfs_deorphan(lfs_t *lfs);
 static int lfs_alloc_lookahead(void *p, lfs_block_t block) {
     lfs_t *lfs = p;
 
-    lfs_block_t off = (((lfs_soff_t)(block - lfs->free.begin)
-                % (lfs_soff_t)(lfs->cfg->block_count))
+    lfs_block_t off = ((block - lfs->free.off)
             + lfs->cfg->block_count) % lfs->cfg->block_count;
 
     if (off < lfs->free.size) {
@@ -283,20 +282,22 @@ static int lfs_alloc_lookahead(void *p, lfs_block_t block) {
 
 static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
     while (true) {
-        while (lfs->free.off != lfs->free.size) {
-            lfs_block_t off = lfs->free.off;
-            lfs->free.off += 1;
+        while (lfs->free.index != lfs->free.size) {
+            lfs_block_t off = lfs->free.index;
+            lfs->free.index += 1;
+            lfs->free.ack -= 1;
 
             if (!(lfs->free.buffer[off / 32] & (1U << (off % 32)))) {
                 // found a free block
-                *block = (lfs->free.begin + off) % lfs->cfg->block_count;
+                *block = (lfs->free.off + off) % lfs->cfg->block_count;
 
                 // eagerly find next off so an alloc ack can
                 // discredit old lookahead blocks
-                while (lfs->free.off != lfs->free.size &&
-                        (lfs->free.buffer[lfs->free.off / 32] &
-                            (1U << (lfs->free.off % 32)))) {
-                    lfs->free.off += 1;
+                while (lfs->free.index != lfs->free.size &&
+                        (lfs->free.buffer[lfs->free.index / 32]
+                            & (1U << (lfs->free.index % 32)))) {
+                    lfs->free.index += 1;
+                    lfs->free.ack -= 1;
                 }
 
                 return 0;
@@ -304,15 +305,15 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
         }
 
         // check if we have looked at all blocks since last ack
-        if (lfs->free.off == lfs->free.ack - lfs->free.begin) {
-            LFS_WARN("No more free space %ld", lfs->free.off + lfs->free.begin);
+        if (lfs->free.ack == 0) {
+            LFS_WARN("No more free space %ld", lfs->free.index+lfs->free.off);
             return LFS_ERR_NOSPC;
         }
 
-        lfs->free.begin += lfs->free.size;
-        lfs->free.size = lfs_min(lfs->cfg->lookahead,
-                lfs->free.ack - lfs->free.begin);
-        lfs->free.off = 0;
+        lfs->free.off = (lfs->free.off + lfs->free.size)
+                % lfs->cfg->block_count;
+        lfs->free.size = lfs_min(lfs->cfg->lookahead, lfs->free.ack);
+        lfs->free.index = 0;
 
         // find mask of free blocks from tree
         memset(lfs->free.buffer, 0, lfs->cfg->lookahead/8);
@@ -324,7 +325,7 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
 }
 
 static void lfs_alloc_ack(lfs_t *lfs) {
-    lfs->free.ack = lfs->free.begin+lfs->free.off + lfs->cfg->block_count;
+    lfs->free.ack = lfs->cfg->block_count;
 }
 
 
@@ -2103,9 +2104,9 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
 
     // create free lookahead
     memset(lfs->free.buffer, 0, lfs->cfg->lookahead/8);
-    lfs->free.begin = 0;
-    lfs->free.size = lfs_min(lfs->cfg->lookahead, lfs->cfg->block_count);
     lfs->free.off = 0;
+    lfs->free.size = lfs_min(lfs->cfg->lookahead, lfs->cfg->block_count);
+    lfs->free.index = 0;
     lfs_alloc_ack(lfs);
 
     // create superblock dir
@@ -2182,9 +2183,9 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     }
 
     // setup free lookahead
-    lfs->free.begin = 0;
-    lfs->free.size = 0;
     lfs->free.off = 0;
+    lfs->free.size = 0;
+    lfs->free.index = 0;
     lfs_alloc_ack(lfs);
 
     // load superblock

--- a/features/filesystem/littlefs/littlefs/lfs.h
+++ b/features/filesystem/littlefs/littlefs/lfs.h
@@ -259,9 +259,9 @@ typedef struct lfs_superblock {
 } lfs_superblock_t;
 
 typedef struct lfs_free {
-    lfs_block_t begin;
-    lfs_block_t size;
     lfs_block_t off;
+    lfs_block_t size;
+    lfs_block_t index;
     lfs_block_t ack;
     uint32_t *buffer;
 } lfs_free_t;


### PR DESCRIPTION
### Description

Two somewhat related issues were found over here: https://github.com/geky/littlefs/issues/46

After quite a bit of discussion the result is some fixes a bit of simplification of the lookahead management. Most significantly, removing the dependency on integer overflow. This should hopefully remove a lot of the issues we've been seeing around allocation.

1. Fix issue with lookahead trusting old lookahead blocks 

   One of the big simplifications in littlefs's implementation is the complete lack of tracking free blocks, allowing operations to simply drop blocks that are no longer in use.

   However, this means the lookahead buffer can easily contain outdated blocks that were previously deleted. This is usually fine, as littlefs will rescan the storage if it can't find a free block in the lookahead
buffer, but after changes that caused littlefs to more conservatively respect the alloc acks (e611cf5), any scanned blocks after an ack would be incorrectly trusted.

   The fix is to eagerly scan ahead in the lookahead when we allocate so that alloc acks are better able to discredit old lookahead blocks. Since usually alloc acks are tightly coupled to allocations of one or two blocks, this allows littlefs to properly rescan every set of allocations.

   This may still be a concern if there is a long series of worn out blocks, but in the worst case littlefs will conservatively avoid using blocks it's not sure about.

2. Fixed lookahead overflow and removed unbounded lookahead pointers

   The lookahead pointer modular arithmetic does not work around integer overflow when the pointer size is not a multiple of the block count.

   To avoid overflow problems, the easy solution is to stop trying to work around integer overflows and keep the lookahead offset inside the block device. To make this work, the ack was modified into a resetable counter that is decremented every block allocation.

   As a plus, quite a bit of the allocation logic ended up simplified.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[✓] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
