### PR TITLE
STM32 PCD negative numbers issue

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/device/stm32f1xx_hal_pcd.c
@@ -1152,7 +1152,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
 {
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
   USB_OTG_EPTypeDef *ep = NULL;
-  int32_t len = 0;
+  uint32_t len;
   uint32_t len32b = 0U;
   uint32_t fifoemptymsk = 0U;
   
@@ -1185,7 +1185,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
   
-  if(len <= 0)
+  if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x01U << epnum;
     USBx_DEVICE->DIEPEMPMSK &= ~fifoemptymsk;

--- a/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/device/stm32f2xx_hal_pcd.c
@@ -1213,7 +1213,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
 {
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
   USB_OTG_EPTypeDef *ep;
-  int32_t len = 0U;
+  uint32_t len;
   uint32_t len32b;
   uint32_t fifoemptymsk = 0U;
 
@@ -1247,7 +1247,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
   
-  if(len <= 0U)
+  if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1U << epnum;
     atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk);

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
@@ -1311,7 +1311,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
 {
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
   USB_OTG_EPTypeDef *ep;
-  int32_t len = 0U;
+  uint32_t len;
   uint32_t len32b;
   uint32_t fifoemptymsk = 0U;
 
@@ -1345,7 +1345,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
   
-  if(len <= 0U)
+  if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1U << epnum;
 /* MBED */

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c
@@ -1301,15 +1301,13 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
   USB_OTG_EPTypeDef *ep;
   uint32_t len;
-  int32_t ilen;
   uint32_t len32b;
   uint32_t fifoemptymsk = 0;
 
   ep = &hpcd->IN_ep[epnum];
-  ilen = ep->xfer_len - ep->xfer_count;
-  len = ilen;
+  len = ep->xfer_len - ep->xfer_count;
 
-  if ((ilen > 0) && (len > ep->maxpacket))
+  if (((int32_t)len > 0) && (len > ep->maxpacket))
   {
     len = ep->maxpacket;
   }
@@ -1322,10 +1320,9 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
             ep->xfer_len != 0)
   {
     /* Write the FIFO */
-    ilen = ep->xfer_len - ep->xfer_count;
-    len = ilen;
+    len = ep->xfer_len - ep->xfer_count;
 
-    if ((ilen > 0) && (len > ep->maxpacket))
+    if (((int32_t)len > 0) && (len > ep->maxpacket))
     {
       len = ep->maxpacket;
     }
@@ -1337,7 +1334,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
 
-  if(ilen <= 0)
+  if ((int32_t)len <= 0)
   {
     fifoemptymsk = 0x1 << epnum;
     atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk); // MBED: changed

--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c
@@ -1307,7 +1307,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
   ep = &hpcd->IN_ep[epnum];
   len = ep->xfer_len - ep->xfer_count;
 
-  if (((int32_t)len > 0) && (len > ep->maxpacket))
+  if (len > ep->maxpacket)
   {
     len = ep->maxpacket;
   }
@@ -1322,7 +1322,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     /* Write the FIFO */
     len = ep->xfer_len - ep->xfer_count;
 
-    if (((int32_t)len > 0) && (len > ep->maxpacket))
+    if (len > ep->maxpacket)
     {
       len = ep->maxpacket;
     }
@@ -1334,7 +1334,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
 
-  if ((int32_t)len <= 0)
+  if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1 << epnum;
     atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk); // MBED: changed

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.c
@@ -1428,7 +1428,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
 {
   USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;  
   USB_OTG_EPTypeDef *ep = NULL;
-  int32_t len = 0U;
+  uint32_t len;
   uint32_t len32b = 0;
   uint32_t fifoemptymsk = 0;
 
@@ -1462,7 +1462,7 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
     ep->xfer_count += len;
   }
   
-  if(len <= 0)
+  if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1 << epnum;
     // Added for MBED PR #3062


### PR DESCRIPTION

### Description

This issue was initiated by a compiler warning
```
Compile: stm32f7xx_hal_pcd.c
../targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c: In function 'PCD_WriteEmptyTxFifo':
../targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c:1310:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (len > ep->maxpacket)
           ^
../targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c:1325:13: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (len > ep->maxpacket)
             ^
```

My first pass at fixing this issue concentrated on the comparison itself.  The implementation can be seen at https://github.com/pauluap/mbed-os/commit/c6ca03df764a16b4a36e5598f881acf601fb9b0f

Upon inspection, I determined that there were further problems 

https://github.com/pauluap/mbed-os/blob/c6ca03df764a16b4a36e5598f881acf601fb9b0f/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_pcd.c#L1318
The line   `len32b = (len + 3) / 4;` (and an identical one a bit further on) could end up negative even if the warning message was cleaned up.

After thinking about it for a while, I observed that the magnitude of a negative length wasn't important, the essential point is to guard the algorithm from processing negative numbers, so I refactored to make the guard operation more evident and eliminate the need for an signed integer variable.

@jeromecoutant, this is related to https://github.com/ARMmbed/mbed-os/pull/6599

### Pull request type

[X ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
