### PR TITLE
Stm32 eth remove tx rx locking interrupt perforation

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_eth.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/device/stm32f7xx_hal_eth.c
@@ -667,9 +667,6 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
 {
   uint32_t bufcount = 0, size = 0, i = 0;
   
-  /* Process Locked */
-  __HAL_LOCK(heth);
-  
   /* Set the ETH peripheral state to BUSY */
   heth->State = HAL_ETH_STATE_BUSY;
   
@@ -677,9 +674,6 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
   {
     /* Set ETH HAL state to READY */
     heth->State = HAL_ETH_STATE_READY;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
     
     return  HAL_ERROR;                                    
   }  
@@ -689,9 +683,6 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
   {  
     /* OWN bit set */
     heth->State = HAL_ETH_STATE_BUSY_TX;
-    
-    /* Process Unlocked */
-    __HAL_UNLOCK(heth);
     
     return HAL_ERROR;
   }
@@ -776,9 +767,6 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
   /* Set ETH HAL State to Ready */
   heth->State = HAL_ETH_STATE_READY;
   
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
-  
   /* Return function status */
   return HAL_OK;
 }
@@ -792,9 +780,6 @@ HAL_StatusTypeDef HAL_ETH_TransmitFrame(ETH_HandleTypeDef *heth, uint32_t FrameL
 HAL_StatusTypeDef HAL_ETH_GetReceivedFrame(ETH_HandleTypeDef *heth)
 {
   uint32_t framelength = 0;
-  
-  /* Process Locked */
-  __HAL_LOCK(heth);
   
   /* Check the ETH state to BUSY */
   heth->State = HAL_ETH_STATE_BUSY;
@@ -930,9 +915,6 @@ HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth)
       /* Set HAL State to Ready */
       heth->State = HAL_ETH_STATE_READY;
       
-      /* Process Unlocked */
-      __HAL_UNLOCK(heth);
-  
       /* Return function status */
       return HAL_OK;
     }
@@ -940,9 +922,6 @@ HAL_StatusTypeDef HAL_ETH_GetReceivedFrame_IT(ETH_HandleTypeDef *heth)
 
   /* Set HAL State to Ready */
   heth->State = HAL_ETH_STATE_READY;
-  
-  /* Process Unlocked */
-  __HAL_UNLOCK(heth);
   
   /* Return function status */
   return HAL_ERROR;


### PR DESCRIPTION
### Description

This set of changes resulted from an investigation into Ethernet issues with the F769 Discovery board.  There is a long thread of discussion at https://github.com/ARMmbed/mbed-os/issues/6262

One tangent was that the HAL locking approach for the eth implementation (at least) was questioned.  Since there is no mutex involved, the locking is not thread safe.

What makes it strange is that there are a couple of places where the HAL lock is unlocked without a corresponding lock.  @kjbracey-arm called that a 'perforation' and I like the term.  The interrupt handler always perforates the HAL lock.  From the perspective of user code, that would be akin to an act of nature in the cases of when the HAL lock disappears from under them.

Further, the rationale is suspect in the context of the RX and TX operations, DMA channels are independent of each other.

The issue thread has a lot of logic analyzer traces examining the locking behavior.  The bottom line was that I ended up removing the locks in the TX and RX functions as well as the ISR.  I didn't touch the remaining locks because I'm presuming that there is at least some rationale for locking which needs to be maintained.

The "fix" here is the removal of the necessity to have the ISR perforate the HAL lock

@jeromecoutant Also related to the ethernet support in F769/etc

This branch also throws in some memory barriers prior to DMA release just for good measure

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
