### PR TITLE
Uninitialized variable warning in UARTSerial at -O3

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -305,12 +305,11 @@ void UARTSerial::rx_irq(void)
 void UARTSerial::tx_irq(void)
 {
     bool was_full = _txbuf.full();
+    char data;
 
     /* Write to the peripheral if there is something to write
      * and if the peripheral is available to write. */
-    while (!_txbuf.empty() && SerialBase::writeable()) {
-        char data;
-        _txbuf.pop(data);
+    while (SerialBase::writeable() && _txbuf.pop(data)) {
         SerialBase::_base_putc(data);
     }
 


### PR DESCRIPTION
### Description

Appears when complied with -O3 optimization level
```
Compile: UARTSerial.cpp
../drivers/UARTSerial.cpp: In member function 'void mbed::UARTSerial::tx_irq()':
../drivers/UARTSerial.cpp:314:31: warning: 'data' may be used uninitialized in this function [-Wmaybe-uninitialized]
         SerialBase::_base_putc(data);
```

### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
