### PR TITLE
Macro expansion results in a constant boolean expression

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -1135,7 +1135,7 @@ static nsapi_error_t mbed_lwip_socket_bind(nsapi_stack_t *stack, nsapi_socket_t 
         return NSAPI_ERROR_PARAMETER;
     }
 
-    if (!ip_addr_isany(&ip_addr) && !mbed_lwip_is_local_addr(&ip_addr)) {
+    if (!ip_addr_isany_val(ip_addr) && !mbed_lwip_is_local_addr(&ip_addr)) {
         return NSAPI_ERROR_PARAMETER;
     }
 


### PR DESCRIPTION


### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->
```
In file included from .././features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/ip_addr.h:43:0,
                 from .././features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/netif.h:46,
                 from ../features/FEATURE_LWIP/lwip-interface/lwip_stack.h:23,
                 from ../features/FEATURE_LWIP/lwip-interface/lwip_stack.c:23:
../features/FEATURE_LWIP/lwip-interface/lwip_stack.c: In function 'mbed_lwip_socket_bind':
.././features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/ip4_addr.h:171:40: warning: the comparison will always evaluate as 'false' for the address of 'ip_addr' will never be NULL [-Waddress]
 #define ip4_addr_isany(addr1) ((addr1) == NULL || ip4_addr_isany_val(*(addr1)))
                                        ^
.././features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/ip_addr.h:272:49: note: in expansion of macro 'ip4_addr_isany'
 #define ip_addr_isany(ipaddr)                   ip4_addr_isany(ipaddr)
                                                 ^~~~~~~~~~~~~~
../features/FEATURE_LWIP/lwip-interface/lwip_stack.c:1138:10: note: in expansion of macro 'ip_addr_isany'
     if (!ip_addr_isany(&ip_addr) && !mbed_lwip_is_local_addr(&ip_addr)) {
          ^~~~~~~~~~~~~
```

Because the function ip_addr_isany() is actually a macro, it ends up being expanded in place with a constant boolean result.

My solution is a dirty trick, providing a pointer variable alias.  My thought that is the ideal solution would use a function rather than a macro, but there's probably other considerations

### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
