### PR TITLE
Macro expansion leads to a bare expression

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_stack.c
@@ -855,7 +855,7 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
         if (lwip_blocking) {
             if (sys_arch_sem_wait(&lwip_netif_linked, 15000) == SYS_ARCH_TIMEOUT) {
                 if (ppp) {
-                    ppp_lwip_disconnect();
+                    (void)ppp_lwip_disconnect();
                 }
                 return NSAPI_ERROR_NO_CONNECTION;
             }
@@ -872,7 +872,7 @@ nsapi_error_t mbed_lwip_bringup_2(bool dhcp, bool ppp, const char *ip, const cha
         if (!mbed_lwip_get_ip_addr(true, &lwip_netif)) {
             if (sys_arch_sem_wait(&lwip_netif_has_any_addr, DHCP_TIMEOUT * 1000) == SYS_ARCH_TIMEOUT) {
                 if (ppp) {
-                    ppp_lwip_disconnect();
+                    (void)ppp_lwip_disconnect();
                 }
                 return NSAPI_ERROR_DHCP_FAILURE;
             }


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->
```
Compile: lwip_stack.c
In file included from ../features/FEATURE_LWIP/lwip-interface/lwip_stack.c:41:0:
../features/FEATURE_LWIP/lwip-interface/lwip_stack.c: In function 'mbed_lwip_bringup_2':
../features/FEATURE_LWIP/lwip-interface/ppp_lwip.h:58:44: warning: statement with no effect [-Wunused-value]
 #define ppp_lwip_disconnect()              ERR_IF
                                            ^
../features/FEATURE_LWIP/lwip-interface/lwip_stack.c:858:21: note: in expansion of macro 'ppp_lwip_disconnect'
                     ppp_lwip_disconnect();
                     ^~~~~~~~~~~~~~~~~~~
../features/FEATURE_LWIP/lwip-interface/ppp_lwip.h:58:44: warning: statement with no effect [-Wunused-value]
 #define ppp_lwip_disconnect()              ERR_IF
                                            ^
../features/FEATURE_LWIP/lwip-interface/lwip_stack.c:875:21: note: in expansion of macro 'ppp_lwip_disconnect'
                     ppp_lwip_disconnect();

                     ^~~~~~~~~~~~~~~~~~~
```

If the implementation used functions, a function returning a bare value wouldn't be a problem, but here the 'return' is done by macro expansion.  Since the value isn't assigned to anything, it turns out to be a bare expression, thus the warning message.

Cast to void to ignore, technique distilled from https://stackoverflow.com/questions/777261/avoiding-unused-variables-warnings-when-using-assert-in-a-release-build


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
