### PR TITLE
rtl8195am - fix excessive compiler warnings

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
@@ -169,7 +169,7 @@ typedef enum {
     DA_1  = (PORT_U<<4|1),
 
     // Not connected
-    NC = (uint32_t)0xFFFFFFFF,
+    NC = (int)0xFFFFFFFF,
 
     // Generic signals namings
     /* LED1~4 are defined as alias of GPIO pins, they are not the LEDs on board*/

--- a/targets/TARGET_Realtek/TARGET_AMEBA/sdk/soc/realtek/8195a/fwlib/hal_i2c.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/sdk/soc/realtek/8195a/fwlib/hal_i2c.h
@@ -324,10 +324,9 @@ typedef uint32_t I2C_ERR_TYPE;
 typedef uint32_t *PI2C_ERR_TYPE;
 
 // I2C Time Out type
-enum _I2C_TIMEOUT_TYPE_ {
-    I2C_TIMEOOUT_DISABLE    =   0x00,           
-    I2C_TIMEOOUT_ENDLESS    =   0xFFFFFFFF,
-};
+#define I2C_TIMEOOUT_DISABLE    0x00
+#define I2C_TIMEOOUT_ENDLESS    0xFFFFFFFF
+
 typedef uint32_t I2C_TIMEOUT_TYPE;
 typedef uint32_t *PI2C_TIMEOUT_TYPE;
 


### PR DESCRIPTION
### Description

Fix hundreds of excessive compiler warnings due to out of enum type range

Examples shown as follows:
mbed-os.lib/targets/TARGET_Realtek/TARGET_AMEBA/sdk/soc/realtek/8195a/fwlib/hal_i2c.h", Line: 329, Col: 34
mbed-os.lib/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h", Line: 172, Col: 11

### Pull request type

[x ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
