### PR TITLE
Nanostack hal timer shortcut

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
@@ -41,7 +41,10 @@ static const osThreadAttr_t event_thread_attr = {
 };
 #endif
 
+#if !MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION
 static osThreadId_t event_thread_id;
+#endif
+
 static mbed_rtos_storage_mutex_t event_mutex;
 static const osMutexAttr_t event_mutex_attr = {
   .name = "nanostack_event_mutex",


### PR DESCRIPTION
### Description

nanostack-hal: timer: conditionalize the use of high pri event thread

nanostack-hal.critical-section-usable-from-interrupt -tunable was
previously added to optionally make critical section code interrupt safe.
The IRQ safe critical section is a prequisite for interrupt safe timer
callbacks.

The same flag can be used to enable calling of the timer callbacks
directly from the timer interrupt context, without bouncing them via
event thread. This removes the code and RAM consumed by EventQueue
and the thread serving the high priority events.

If the system does not have any dependencies on mbed_shared_queues,
by setting this flag the static RAM usage is now further reduced
by ~1600 bytes and code size by 4KB.

Note: the default behavior is not changed, one needs to override the
"nanostack-hal.critical-section-usable-from-interrupt" to have "true".


### Pull request type

<!-- 
    Required
    Please tick only one of the following types. Do not tick more or change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
