### PR TITLE
Add IAR export for STM32L496AG

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -2,6 +2,9 @@
     "STM32L443RC": {
         "OGChipSelectEditMenu": "STM32L443RC\tST STM32L443RC"
     },
+    "STM32L496AG": {
+        "OGChipSelectEditMenu": "STM32L496AG\tST STM32L496AG"
+    },
     "STM32L496ZG": {
         "OGChipSelectEditMenu": "STM32L496ZG\tST STM32L496ZG"
     },


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->
Add IAR export for STM32L496AG. Required for the DISCO_L496AG platform.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise) or
    change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
