### PR TITLE
mbed_wait_api: add comments to warn the func will lock deep sleep

### DIFF
--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -53,18 +53,27 @@ extern "C" {
  *  the accuracy of single precision floating point).
  *
  *  @param s number of seconds to wait
+ * 
+ *  @note
+ *    This func will lock the deep sleep, if you want device entry deep sleep mode, please use Thread::wait()
  */
 void wait(float s);
 
 /** Waits a number of milliseconds.
  *
  *  @param ms the whole number of milliseconds to wait
+ * 
+ *  @note
+ *    This func will lock the deep sleep, if you want device entry deep sleep mode, please use Thread::wait()
  */
 void wait_ms(int ms);
 
 /** Waits a number of microseconds.
  *
  *  @param us the whole number of microseconds to wait
+ * 
+ *  @note
+ *    This func will lock the deep sleep.
  */
 void wait_us(int us);
 

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -55,7 +55,7 @@ extern "C" {
  *  @param s number of seconds to wait
  * 
  *  @note
- *    This function always spins to get the exact number of microseconds, 
+ *    If the RTOS is present, this function always spins to get the exact number of microseconds, 
  *    which potentially affects power (such as preventing deep sleep) and multithread performance. 
  *    You can avoid it by using Thread::wait().
  */
@@ -66,7 +66,7 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  * 
  *  @note
- *    This function always spins to get the exact number of microseconds, 
+ *    If the RTOS is present, this function always spins to get the exact number of microseconds, 
  *    which potentially affects power (such as preventing deep sleep) and multithread performance. 
  *    You can avoid it by using Thread::wait().
  */
@@ -77,7 +77,7 @@ void wait_ms(int ms);
  *  @param us the whole number of microseconds to wait
  * 
  *  @note
- *    This function always spins to get the exact number of microseconds, 
+ *    If the RTOS is present, this function always spins to get the exact number of microseconds, 
  *    which potentially affects power (such as preventing deep sleep) and multithread performance.
  */
 void wait_us(int us);

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -55,7 +55,7 @@ extern "C" {
  *  @param s number of seconds to wait
  * 
  *  @note
- *    This func will lock the deep sleep, if you want device entry deep sleep mode, please use Thread::wait()
+ *    This func will lock deep sleep. If you want device entry deep sleep mode, please use Thread::wait()
  */
 void wait(float s);
 
@@ -64,7 +64,7 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  * 
  *  @note
- *    This func will lock the deep sleep, if you want device entry deep sleep mode, please use Thread::wait()
+ *    This func will lock deep sleep. If you want device entry deep sleep mode, please use Thread::wait()
  */
 void wait_ms(int ms);
 
@@ -73,7 +73,7 @@ void wait_ms(int ms);
  *  @param us the whole number of microseconds to wait
  * 
  *  @note
- *    This func will lock the deep sleep.
+ *    This func will lock deep sleep.
  */
 void wait_us(int us);
 

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -55,7 +55,9 @@ extern "C" {
  *  @param s number of seconds to wait
  * 
  *  @note
- *    This func will lock deep sleep. If you want device entry deep sleep mode, please use Thread::wait()
+ *    This func always spin to get an exact number of microseconds, potentially 
+ *    impacting power(like can't deep sleep) and multi-thread performance. 
+ *    You can avoided by Thread::wait().
  */
 void wait(float s);
 
@@ -64,7 +66,9 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  * 
  *  @note
- *    This func will lock deep sleep. If you want device entry deep sleep mode, please use Thread::wait()
+ *    This func always spin to get an exact number of microseconds, potentially 
+ *    impacting power(like can't deep sleep) and multi-thread performance. 
+ *    You can avoided by Thread::wait().
  */
 void wait_ms(int ms);
 
@@ -73,7 +77,8 @@ void wait_ms(int ms);
  *  @param us the whole number of microseconds to wait
  * 
  *  @note
- *    This func will lock deep sleep.
+ *    This func always spin to get an exact number of microseconds, potentially 
+ *    impacting power(like can't deep sleep) and multi-thread performance. 
  */
 void wait_us(int us);
 

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -55,9 +55,9 @@ extern "C" {
  *  @param s number of seconds to wait
  * 
  *  @note
- *    This func always spin to get an exact number of microseconds, potentially 
- *    impacting power(like can't deep sleep) and multi-thread performance. 
- *    You can avoided by Thread::wait().
+ *    This function always spins to get the exact number of microseconds, 
+ *    which potentially affects power (such as preventing deep sleep) and multithread performance. 
+ *    You can avoid it by using Thread::wait().
  */
 void wait(float s);
 
@@ -66,9 +66,9 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  * 
  *  @note
- *    This func always spin to get an exact number of microseconds, potentially 
- *    impacting power(like can't deep sleep) and multi-thread performance. 
- *    You can avoided by Thread::wait().
+ *    This function always spins to get the exact number of microseconds, 
+ *    which potentially affects power (such as preventing deep sleep) and multithread performance. 
+ *    You can avoid it by using Thread::wait().
  */
 void wait_ms(int ms);
 
@@ -77,8 +77,8 @@ void wait_ms(int ms);
  *  @param us the whole number of microseconds to wait
  * 
  *  @note
- *    This func always spin to get an exact number of microseconds, potentially 
- *    impacting power(like can't deep sleep) and multi-thread performance. 
+ *    This function always spins to get the exact number of microseconds, 
+ *    which potentially affects power (such as preventing deep sleep) and multithread performance.
  */
 void wait_us(int us);
 


### PR DESCRIPTION
### Description
Add some comments to warn the wait() will lock deep sleep.

### Pull request type
[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change

discuss: https://github.com/ARMmbed/mbed-os/issues/6574
