### PR TITLE
Fix MCUXpresso LPC I2C driver 

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_i2c.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/drivers/fsl_i2c.c
@@ -163,6 +163,8 @@ status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direct
     /* Start the transfer */
     base->MSTCTL = I2C_MSTCTL_MSTSTART_MASK;
 
+    I2C_PendingStatusWait(base);
+
     return kStatus_Success;
 }
 
@@ -171,6 +173,9 @@ status_t I2C_MasterStop(I2C_Type *base)
     I2C_PendingStatusWait(base);
 
     base->MSTCTL = I2C_MSTCTL_MSTSTOP_MASK;
+
+    I2C_PendingStatusWait(base);
+
     return kStatus_Success;
 }
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/drivers/fsl_i2c.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/drivers/fsl_i2c.c
@@ -201,6 +201,12 @@ status_t I2C_MasterStart(I2C_Type *base, uint8_t address, i2c_direction_t direct
     /* Start the transfer */
     base->MSTCTL = I2C_MSTCTL_MSTSTART_MASK;
 
+    result = I2C_PendingStatusWait(base);
+    if (result == kStatus_I2C_Timeout)
+    {
+        return kStatus_I2C_Timeout;
+    }
+
     return kStatus_Success;
 }
 
@@ -214,6 +220,13 @@ status_t I2C_MasterStop(I2C_Type *base)
     }
 
     base->MSTCTL = I2C_MSTCTL_MSTSTOP_MASK;
+
+    result = I2C_PendingStatusWait(base);
+    if (result == kStatus_I2C_Timeout)
+    {
+        return kStatus_I2C_Timeout;
+    }
+
     return kStatus_Success;
 }
 


### PR DESCRIPTION
### Description
These failures were seen when running the ci-shield tests. All I2C tests pass after these patches.

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
