### PR TITLE
ADI: Add BUTTON pin names for EV_COG_AD4050LZ and EV_COG_AD3029LZ

### DIFF
--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/PinNames.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/TARGET_EV_COG_AD3029LZ/PinNames.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * Copyright (c) 2010-2018 Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -120,6 +120,9 @@ typedef enum {
     //Push buttons
     PB0 = P1_00,        // BTN1
     PB1 = P0_09,        // BTN2
+    BUTTON1 = P1_00,    // BTN1
+    BUTTON2 = P0_09,    // BTN2
+
     BOOT = P1_01,
     WAKE0 = P0_15,      // JP15 to select
     WAKE1 = P1_00,      // JP8 (BTN1 jumper) to select

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/PinNames.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/TARGET_EV_COG_AD4050LZ/PinNames.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2017 Analog Devices, Inc.
+ * Copyright (c) 2010-2018 Analog Devices, Inc.
  *
  * All rights reserved.
  *
@@ -135,6 +135,9 @@ typedef enum {
     //Push buttons
     PB0 = P1_00,        // BTN1
     PB1 = P0_09,        // BTN2
+    BUTTON1 = P1_00,    // BTN1
+    BUTTON2 = P0_09,    // BTN2
+
     BOOT = P1_01,
     WAKE0 = P0_15,      // JP15 to select
     WAKE1 = P1_00,      // JP8 (BTN1 jumper) to select


### PR DESCRIPTION
### Description

Apart from Reset  and Boot buttons, there are 2 more general purpose buttons:
- BUTTON1
- BUTTON2

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise) or
    change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

- [X] Fix  
- [ ] Refactor  
- [ ] New target  
- [ ] Feature  
- [ ] Breaking change
