### PR TITLE
Add missing carriage returns to fault handler

### DIFF
--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -220,6 +220,9 @@ void fault_print_str(char *fmtstr, uint32_t *values)
                 serial_putc(&stdio_uart, hex_str[idx]);
             }
         } else {
+            if (fmtstr[i] == '\n') {
+                serial_putc(&stdio_uart, '\r');
+            }
             serial_putc(&stdio_uart, fmtstr[i]);
         }
         i++;


### PR DESCRIPTION
### Description

Fault handler was outputting just LFs between lines, when standard
terminals require CR+LF, leading to messy output.

### Pull request type

[ ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[X] Breaking change

Marked "breaking change" because it could conceivably trip up some automation relying on parsing fault handler output that expects odd formatting - it does change the output.

Seems unlikely though, as most normal output will be CR+LF terminated, either because apps do `\r\n` manually (yuck) or because `platform.stdio-convert-newlines` is turned on as it should be. So anything parsing general output will be expecting that.
