### PR TITLE
USB reset test fix

### DIFF
--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -112,29 +112,28 @@ void device_reset_test()
     if (strcmp(_value, "false") != 0) {
 
         USBTester serial(vendor_id, product_id, product_release, true);
-
-        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         serial.clear_reset_count();
-        // Wait for host before terminating
+        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         while(serial.get_reset_count() == 0);
+        // Wait for host before terminating
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         TEST_ASSERT_EQUAL_STRING("pass", _key);
 
         while(!serial.configured());
 
-        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         serial.clear_reset_count();
-        // Wait for host before terminating
+        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         while(serial.get_reset_count() == 0);
+        // Wait for host before terminating
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         TEST_ASSERT_EQUAL_STRING("pass", _key);
 
         while(!serial.configured());
 
-        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         serial.clear_reset_count();
-        // Wait for host before terminating
+        greentea_send_kv("device_reset_test", serial.get_serial_desc_string());
         while(serial.get_reset_count() == 0);
+        // Wait for host before terminating
         greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
         TEST_ASSERT_EQUAL_STRING("pass", _key);
 


### PR DESCRIPTION
### Description

USB device reset test fix.
reset_count flag should be cleared before test start


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise) or
    change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
