### PR TITLE
Allow library configs to override target configs

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -903,7 +903,7 @@ class Config(object):
         all_params = self.get_target_config_data()
         lib_params, macros = self.get_lib_config_data(all_params)
         self.get_app_config_data(lib_params, macros)
-        return all_params, macros
+        return lib_params, macros
 
     @staticmethod
     def _check_required_parameters(params):

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -864,14 +864,13 @@ class Config(object):
 
         Arguments: None
         """
-        all_params, macros = {}, {}
+        macros = {}
         for lib_name, lib_data in self.lib_config_data.items():
-            all_params.update(self._process_config_and_overrides(lib_data, target_data,
-                                                                 lib_name,
-                                                                 "library"))
+            self._process_config_and_overrides(
+                lib_data, target_data, lib_name, "library")
             _process_macros(lib_data.get("macros", []), macros, lib_name,
                             "library")
-        return all_params, macros
+        return target_data, macros
 
     def get_app_config_data(self, params, macros):
         """ Read and interpret the configuration data defined by the target. The

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -117,7 +117,7 @@ class ConfigParameter(object):
                                       unit_name, unit_kind, label)))
         prefix = temp[0]
         # Check if the given parameter prefix matches the expected prefix
-        if (unit_kind == "library" and prefix != unit_name) or \
+        if (unit_kind == "library" and prefix not in [unit_name, "target"]) or \
            (unit_kind == "target" and prefix != "target"):
             raise ConfigException(
                 "Invalid prefix '%s' for parameter name '%s' in '%s'" %
@@ -857,7 +857,7 @@ class Config(object):
                 params[full_name].set_value(val, tname, "target")
         return params
 
-    def get_lib_config_data(self):
+    def get_lib_config_data(self, target_data):
         """ Read and interpret configuration data defined by libraries. It is
         assumed that "add_config_files" above was already called and the library
         configuration data exists in self.lib_config_data
@@ -866,7 +866,7 @@ class Config(object):
         """
         all_params, macros = {}, {}
         for lib_name, lib_data in self.lib_config_data.items():
-            all_params.update(self._process_config_and_overrides(lib_data, {},
+            all_params.update(self._process_config_and_overrides(lib_data, target_data,
                                                                  lib_name,
                                                                  "library"))
             _process_macros(lib_data.get("macros", []), macros, lib_name,
@@ -901,9 +901,8 @@ class Config(object):
         Arguments: None
         """
         all_params = self.get_target_config_data()
-        lib_params, macros = self.get_lib_config_data()
-        all_params.update(lib_params)
-        self.get_app_config_data(all_params, macros)
+        lib_params, macros = self.get_lib_config_data(all_params)
+        self.get_app_config_data(lib_params, macros)
         return all_params, macros
 
     @staticmethod


### PR DESCRIPTION
### Description

 The documentation currently claims that libraries are allowed to
 override target configuration. This fixes a bug that would prevent a
 library configuration from overriding a target configuration.
 Application configuration is unaffected.

 ### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change