### PR TITLE
BLE: add force-indication option to GattServer::write

### DIFF
--- a/features/FEATURE_BLE/ble/GattServer.h
+++ b/features/FEATURE_BLE/ble/GattServer.h
@@ -286,13 +286,13 @@ public:
      *
      * @param[in] attributeHandle Handle of the attribute to write.
      * @param[in] value A pointer to a buffer holding the new value.
-     * @param[in] size Size in bytes of the new value (in bytes).
+     * @param[in] size Size of the new value (in bytes).
      * @param[in] localOnly If this flag is false and the attribute handle
      * written is a characteristic value, then the server sends an update
      * containing the new value to all clients that have subscribed to the
      * characteristic's notifications or indications. Otherwise, the update does
      * not generate a single server initiated event.
-     * @param[in] forceIndicate Forces an indication to be sent instead of a notifiaction
+     * @param[in] forceIndicate Forces an indication to be sent instead of a notification
      * in case both notification and indication properties are
      * enabled for the characteristic. Enabling this when the
      * indication property is not set is invalid.
@@ -322,15 +322,20 @@ public:
     /**
      * Update the value of an attribute present in the local GATT server.
      *
+     * The connection handle parameter allows application code to direct
+     * notification or indication resulting from the update to a specific client.
+     *
+     * @param[in] connectionHandle Connection handle.
      * @param[in] attributeHandle Handle of the attribute to write.
      * @param[in] value A pointer to a buffer holding the new value.
-     * @param[in] size Size in bytes of the new value (in bytes).
+     * @param[in] size Size of the new value (in bytes).
      * @param[in] localOnly If this flag is false and the attribute handle
      * written is a characteristic value, then the server sends an update
-     * containing the new value to all clients that have subscribed to the
-     * characteristic's notifications or indications. Otherwise, the update does
-     * not generate a single server initiated event.
-     * @param[in] forceIndicate Forces an indication to be sent instead of a notifiaction
+     * containing the new value to the client identified by the parameter
+     * @p connectionHandle if it is subscribed to the characteristic's
+     * notifications or indications. Otherwise, the update does not generate a
+     * single server initiated event.
+     * @param[in] forceIndicate Forces an indication to be sent instead of a notification
      * in case both notification and indication properties are
      * enabled for the characteristic. Enabling this when the
      * indication property is not set is invalid.

--- a/features/FEATURE_BLE/ble/GattServer.h
+++ b/features/FEATURE_BLE/ble/GattServer.h
@@ -292,6 +292,10 @@ public:
      * containing the new value to all clients that have subscribed to the
      * characteristic's notifications or indications. Otherwise, the update does
      * not generate a single server initiated event.
+     * @param[in] forceIndicate Forces an indication to be sent instead of a notifiaction
+     * in case both notification and indication properties are
+     * enabled for the characteristic. Enabling this when the
+     * indication property is not set is invalid.
      *
      * @return BLE_ERROR_NONE if the attribute value has been successfully
      * updated.
@@ -300,13 +304,15 @@ public:
         GattAttribute::Handle_t attributeHandle,
         const uint8_t *value,
         uint16_t size,
-        bool localOnly = false
+        bool localOnly = false,
+        bool forceIndicate = false
     ) {
         /* Avoid compiler warnings about unused variables. */
         (void)attributeHandle;
         (void)value;
         (void)size;
         (void)localOnly;
+        (void)forceIndicate;
 
         /* Requesting action from porters: override this API if this capability
            is supported. */
@@ -316,20 +322,18 @@ public:
     /**
      * Update the value of an attribute present in the local GATT server.
      *
-     * The connection handle parameter allows application code to direct
-     * notification or indication resulting from the update to a specific client.
-     *
-     * @param[in] connectionHandle Connection handle.
-     * @param[in] attributeHandle Handle for the value attribute of the
-     * characteristic.
+     * @param[in] attributeHandle Handle of the attribute to write.
      * @param[in] value A pointer to a buffer holding the new value.
-     * @param[in] size Size of the new value (in bytes).
+     * @param[in] size Size in bytes of the new value (in bytes).
      * @param[in] localOnly If this flag is false and the attribute handle
      * written is a characteristic value, then the server sends an update
-     * containing the new value to the client identified by the parameter
-     * @p connectionHandle if it is subscribed to the characteristic's
-     * notifications or indications. Otherwise, the update does not generate a
-     * single server initiated event.
+     * containing the new value to all clients that have subscribed to the
+     * characteristic's notifications or indications. Otherwise, the update does
+     * not generate a single server initiated event.
+     * @param[in] forceIndicate Forces an indication to be sent instead of a notifiaction
+     * in case both notification and indication properties are
+     * enabled for the characteristic. Enabling this when the
+     * indication property is not set is invalid.
      *
      * @return BLE_ERROR_NONE if the attribute value has been successfully
      * updated.
@@ -339,7 +343,8 @@ public:
         GattAttribute::Handle_t attributeHandle,
         const uint8_t *value,
         uint16_t size,
-        bool localOnly = false
+        bool localOnly = false,
+        bool forceIndicate = false
     ) {
         /* Avoid compiler warnings about unused variables. */
         (void)connectionHandle;
@@ -347,6 +352,7 @@ public:
         (void)value;
         (void)size;
         (void)localOnly;
+        (void)forceIndicate;
 
         /* Requesting action from porters: override this API if this capability
            is supported. */

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.cpp
@@ -239,12 +239,12 @@ ble_error_t nRF5xGattServer::read(Gap::Handle_t connectionHandle, GattAttribute:
                 Everything executed properly
 */
 /**************************************************************************/
-ble_error_t nRF5xGattServer::write(GattAttribute::Handle_t attributeHandle, const uint8_t buffer[], uint16_t len, bool localOnly)
+ble_error_t nRF5xGattServer::write(GattAttribute::Handle_t attributeHandle, const uint8_t buffer[], uint16_t len, bool localOnly, bool forceIndicate)
 {
-    return write(BLE_CONN_HANDLE_INVALID, attributeHandle, buffer, len, localOnly);
+    return write(BLE_CONN_HANDLE_INVALID, attributeHandle, buffer, len, localOnly, forceIndicate);
 }
 
-ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, const uint8_t buffer[], uint16_t len, bool localOnly)
+ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, const uint8_t buffer[], uint16_t len, bool localOnly, bool forceIndicate)
 {
     ble_error_t returnValue = BLE_ERROR_NONE;
 
@@ -270,7 +270,7 @@ ble_error_t nRF5xGattServer::write(Gap::Handle_t connectionHandle, GattAttribute
 
         hvx_params.handle = attributeHandle;
         hvx_params.type   =
-            (p_characteristics[characteristicIndex]->getProperties() & GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY) ? BLE_GATT_HVX_NOTIFICATION : BLE_GATT_HVX_INDICATION;
+            (p_characteristics[characteristicIndex]->getProperties() & GattCharacteristic::BLE_GATT_CHAR_PROPERTIES_NOTIFY) && !forceIndicate ? BLE_GATT_HVX_NOTIFICATION : BLE_GATT_HVX_INDICATION;
         hvx_params.offset = 0;
         hvx_params.p_data = const_cast<uint8_t *>(buffer);
         hvx_params.p_len  = &len;

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xGattServer.h
@@ -31,8 +31,8 @@ public:
     virtual ble_error_t addService(GattService &);
     virtual ble_error_t read(GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
     virtual ble_error_t read(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
-    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
-    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
+    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false, bool forceIndicate = false);
+    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false, bool forceIndicate = false);
     virtual ble_error_t areUpdatesEnabled(const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t areUpdatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t reset(void);

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.h
@@ -31,8 +31,8 @@ public:
     virtual ble_error_t addService(GattService &);
     virtual ble_error_t read(GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
     virtual ble_error_t read(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
-    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
-    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false);
+    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false,  bool forceNotify = false);
+    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false,  bool forceNotify = false);
     virtual ble_error_t areUpdatesEnabled(const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t areUpdatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t reset(void);

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xGattServer.h
@@ -31,8 +31,8 @@ public:
     virtual ble_error_t addService(GattService &);
     virtual ble_error_t read(GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
     virtual ble_error_t read(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP);
-    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false,  bool forceNotify = false);
-    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false,  bool forceNotify = false);
+    virtual ble_error_t write(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false, bool forceIndicate = false);
+    virtual ble_error_t write(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false, bool forceIndicate = false);
     virtual ble_error_t areUpdatesEnabled(const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t areUpdatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic, bool *enabledP);
     virtual ble_error_t reset(void);


### PR DESCRIPTION
### Description

Add a `forceIndication` option to the `GattServer::write` function. This allows to force the use of BLE indications iof. notifications when both options are enabled for a characteristic.

If both notifications and indications are enabled the default behaviour of the NRF5 targets is to send a notification. Other targets seem to have a different behaviour (e.g the Maxim target seems to send both a notification and an indication).

### Pull request type

[ ] Fix  
[ ] Refactor  
[ ] New target  
[X] Feature  
[ ] Breaking change
