### PR TITLE
feature-emac: Rework nonblocking connect

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/LWIPInterface.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPInterface.cpp
@@ -216,11 +216,6 @@ void LWIP::Interface::netif_status_irq(struct netif *netif)
     }
 }
 
-void LWIP::Interface::set_blocking(bool block)
-{
-    blocking = block;
-}
-
 void LWIP::Interface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     client_callback = status_cb;
@@ -420,7 +415,7 @@ nsapi_error_t LWIP::_add_ppp_interface(void *hw, bool default_if, LWIP::Interfac
 }
 
 
-nsapi_error_t LWIP::Interface::bringup(bool dhcp, const char *ip, const char *netmask, const char *gw, const nsapi_ip_stack_t stack)
+nsapi_error_t LWIP::Interface::bringup(bool dhcp, const char *ip, const char *netmask, const char *gw, const nsapi_ip_stack_t stack, bool block)
 {
     // Check if we've already connected
     if (connected == NSAPI_STATUS_GLOBAL_UP) {
@@ -430,6 +425,7 @@ nsapi_error_t LWIP::Interface::bringup(bool dhcp, const char *ip, const char *ne
     }
 
     connected = NSAPI_STATUS_CONNECTING;
+    blocking = block;
 
 #if LWIP_DHCP
     if (stack != IPV6_STACK && dhcp) {

--- a/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
@@ -46,14 +46,13 @@ public:
          * @param    netmask    Net mask to be used for the interface as "W:X:Y:Z" or NULL
          * @param    gw         Gateway address to be used for the interface as "W:X:Y:Z" or NULL
          * @param    stack      Allow manual selection of IPv4 and/or IPv6.
+         * @param    blocking   Specify whether bringup blocks for connection completion.
          * @return              NSAPI_ERROR_OK on success, or error code
          */
         virtual nsapi_error_t bringup(bool dhcp, const char *ip,
                                       const char *netmask, const char *gw,
-                                      nsapi_ip_stack_t stack
-        #ifdef __cplusplus
-                                                   = DEFAULT_STACK
-        #endif
+                                      nsapi_ip_stack_t stack = DEFAULT_STACK,
+                                      bool blocking = true
                                       );
 
         /** Disconnect interface from the network
@@ -79,13 +78,6 @@ public:
          *  @return         The connection status according to ConnectionStatusType
          */
         virtual nsapi_connection_status_t get_connection_status() const;
-
-        /** Set blocking behaviour for bringup
-         *
-         * Controls whether bringup blocks or returns immediately.
-         *  @param blocking true if bringup is blocking
-         */
-        virtual void set_blocking(bool blocking);
 
         /** Return MAC address of the network interface
          *

--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -57,6 +57,7 @@ static FileHandle *my_stream;
 static LWIP::Interface *my_interface;
 static ppp_pcb *my_ppp_pcb;
 static bool ppp_active = false;
+static bool blocking_connect = true;
 static const char *login;
 static const char *pwd;
 static sys_sem_t ppp_close_sem;
@@ -356,7 +357,7 @@ nsapi_error_t nsapi_ppp_error_code()
 
 nsapi_error_t nsapi_ppp_set_blocking(bool blocking)
 {
-    my_interface->set_blocking(blocking);
+    blocking_connect = blocking;
     return NSAPI_ERROR_OK;
 }
 
@@ -384,7 +385,7 @@ nsapi_error_t nsapi_ppp_connect(FileHandle *stream, Callback<void(nsapi_event_t,
 
     // mustn't start calling input until after connect -
     // attach deferred until ppp_lwip_connect, called from mbed_lwip_bringup
-    retcode = my_interface->bringup(false, NULL, NULL, NULL, stack);
+    retcode = my_interface->bringup(false, NULL, NULL, NULL, stack, blocking_connect);
 
     if (retcode != NSAPI_ERROR_OK && connect_error_code != NSAPI_ERROR_OK) {
         return connect_error_code;

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -31,7 +31,6 @@ public:
     virtual char *get_gateway(char *buf, nsapi_size_t buflen);
     virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
     virtual nsapi_connection_status_t get_connection_status() const;
-    virtual void set_blocking(bool blocking);
 
     void get_mac_address(uint8_t *buf) const { interface_phy.get_mac_address(buf); }
 
@@ -115,6 +114,8 @@ protected:
 
     char ip_addr_str[40];
     char mac_addr_str[24];
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    bool _blocking;
 };
 
 class MeshInterfaceNanostack : public InterfaceNanostack, public MeshInterface, private mbed::NonCopyable<MeshInterfaceNanostack> {

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
@@ -25,7 +25,8 @@ class Nanostack::EthernetInterface : public Nanostack::Interface {
 public:
     virtual nsapi_error_t bringup(bool dhcp, const char *ip,
                                   const char *netmask, const char *gw,
-                                  nsapi_ip_stack_t stack = DEFAULT_STACK);
+                                  nsapi_ip_stack_t stack = DEFAULT_STACK,
+                                  bool blocking = true);
     virtual nsapi_error_t bringdown();
 
 private:

--- a/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/FEATURE_NANOSTACK/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -69,11 +69,6 @@ void Nanostack::Interface::attach(
     _connection_status_cb = status_cb;
 }
 
-void Nanostack::Interface::set_blocking(bool blocking)
-{
-    _blocking = blocking;
-}
-
 Nanostack::Interface::Interface(NanostackPhy &phy) : interface_phy(phy), interface_id(-1), _device_id(-1),
       _connect_status(NSAPI_STATUS_DISCONNECTED), _blocking(true)
 {
@@ -83,7 +78,7 @@ Nanostack::Interface::Interface(NanostackPhy &phy) : interface_phy(phy), interfa
 
 InterfaceNanostack::InterfaceNanostack()
     : _interface(NULL),
-      ip_addr_str(), mac_addr_str()
+      ip_addr_str(), mac_addr_str(), _blocking(true)
 {
     // Nothing to do
 }
@@ -167,17 +162,24 @@ const char *InterfaceNanostack::get_mac_address()
 
 nsapi_connection_status_t InterfaceNanostack::get_connection_status() const
 {
-    return _interface->get_connection_status();
+    if (_interface) {
+        return _interface->get_connection_status();
+    } else {
+        return NSAPI_STATUS_DISCONNECTED;
+    }
 }
 
 void InterfaceNanostack::attach(
     mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
-    _interface->attach(status_cb);
+    _connection_status_cb = status_cb;
+    if (_interface) {
+        _interface->attach(status_cb);
+    }
 }
 
 nsapi_error_t InterfaceNanostack::set_blocking(bool blocking)
 {
-    _interface->set_blocking(blocking);
+    _blocking = blocking;
     return NSAPI_ERROR_OK;
 }

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -163,10 +163,12 @@ protected:
     OnboardNetworkStack &_stack;
     OnboardNetworkStack::Interface *_interface;
     bool _dhcp;
+    bool _blocking;
     char _mac_address[NSAPI_MAC_SIZE];
     char _ip_address[NSAPI_IPv6_SIZE];
     char _netmask[NSAPI_IPv4_SIZE];
     char _gateway[NSAPI_IPv4_SIZE];
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 
 #endif

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -58,11 +58,13 @@ public:
          * @param    netmask    Net mask to be used for the interface as "W:X:Y:Z" or NULL
          * @param    gw         Gateway address to be used for the interface as "W:X:Y:Z" or NULL
          * @param    stack      Allow manual selection of IPv4 and/or IPv6.
+         * @param    blocking   Specify whether bringup blocks for connection completion.
          * @return              NSAPI_ERROR_OK on success, or error code
          */
         virtual nsapi_error_t bringup(bool dhcp, const char *ip,
                               const char *netmask, const char *gw,
-                              nsapi_ip_stack_t stack = DEFAULT_STACK) = 0;
+                              nsapi_ip_stack_t stack = DEFAULT_STACK,
+                              bool blocking = true) = 0;
 
         /** Disconnect interface from the network
          *
@@ -87,13 +89,6 @@ public:
          *  @return         The connection status according to ConnectionStatusType
          */
         virtual nsapi_connection_status_t get_connection_status() const = 0;
-
-        /** Set blocking behaviour for bringup
-         *
-         * Controls whether bringup blocks or returns immediately.
-         *  @param blocking true if bringup is blocking
-         */
-        virtual void set_blocking(bool blocking) = 0;
 
         /** Return MAC address of the network interface
          *


### PR DESCRIPTION
### Description

Nonblocking connect implementations of set_blocking() and attach()
were working on the assumption that associated OnboardNetworkStack::Interface
already been created.

This is not the case, and it is desirable to defer
the creation until first NetworkInterface::connect(), as creation
invokes EMAC power-up, and may need to take time and return errors.

Change the implementations to remember callback and blocking settings,
and pass them to the ONS::Interface as it's created and brought up.

### Pull request type

[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
