### PR TITLE
Fixed cellular unittests

### DIFF
--- a/features/cellular/UNITTESTS/at/at_cellularnetwork/at_cellularnetworktest.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularnetwork/at_cellularnetworktest.cpp
@@ -82,6 +82,11 @@ TEST(AT_CellularNetwork, test_AT_CellularNetwork_get_attach)
     unit->test_AT_CellularNetwork_get_attach();
 }
 
+TEST(AT_CellularNetwork, test_AT_CellularNetwork_detach)
+{
+    unit->test_AT_CellularNetwork_detach();
+}
+
 TEST(AT_CellularNetwork, test_AT_CellularNetwork_get_rate_control)
 {
     unit->test_AT_CellularNetwork_get_rate_control();
@@ -157,3 +162,7 @@ TEST(AT_CellularNetwork, test_AT_CellularNetwork_get_operator_params)
     unit->test_AT_CellularNetwork_get_operator_params();
 }
 
+TEST(AT_CellularNetwork, test_AT_CellularNetwork_get_operator_names)
+{
+    unit->test_AT_CellularNetwork_get_operator_names();
+}

--- a/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.cpp
@@ -81,7 +81,7 @@ void Test_AT_CellularNetwork::test_AT_CellularNetwork_connect()
 
     AT_CellularNetwork cn(at);
     cn.set_stack_type(IPV4V6_STACK);
-    CHECK(NSAPI_ERROR_NO_CONNECTION == cn.connect("APN", "a", "b"));
+    CHECK(NSAPI_ERROR_UNSUPPORTED == cn.connect("APN", "a", "b"));
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
     CHECK(NSAPI_ERROR_NO_CONNECTION == cn.connect("APN"));
@@ -152,6 +152,17 @@ void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_attach()
     CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.get_attach(stat));
 }
 
+void Test_AT_CellularNetwork::test_AT_CellularNetwork_detach()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularNetwork cn(at);
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
+    CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.detach());
+}
+
 void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_rate_control()
 {
     EventQueue que;
@@ -174,9 +185,11 @@ void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_apn_backoff_timer()
     AT_CellularNetwork cn(at);
     int time;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
+    CHECK(NSAPI_ERROR_PARAMETER == cn.get_apn_backoff_timer(time));
+
+    cn.set_credentials("internet", NULL, NULL);
     CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.get_apn_backoff_timer(time));
 }
-
 
 void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_ip_address()
 {
@@ -306,8 +319,8 @@ void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_cell_id()
 
     AT_CellularNetwork cn(at);
     int id;
-    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
-    CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.get_cell_id(id));
+    CHECK(NSAPI_ERROR_OK == cn.get_cell_id(id));
+    CHECK(id == -1);
 }
 
 void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_3gpp_error()
@@ -332,5 +345,20 @@ void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_operator_params()
     CellularNetwork::operator_t ops;
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
     CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.get_operator_params(format, ops));
+}
+
+void Test_AT_CellularNetwork::test_AT_CellularNetwork_get_operator_names()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularNetwork cn(at);
+    CellularNetwork::operator_names_list name_list;
+
+    CHECK(NSAPI_ERROR_OK == cn.get_operator_names(name_list));
+
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_CONNECTION_LOST;
+    CHECK(NSAPI_ERROR_CONNECTION_LOST == cn.get_operator_names(name_list));
 }
 

--- a/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.h
+++ b/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.h
@@ -42,6 +42,8 @@ public:
 
     void test_AT_CellularNetwork_get_attach();
 
+    void test_AT_CellularNetwork_detach();
+
     void test_AT_CellularNetwork_get_rate_control();
 
     void test_AT_CellularNetwork_get_apn_backoff_timer();
@@ -71,6 +73,8 @@ public:
     void test_AT_CellularNetwork_get_3gpp_error();
 
     void test_AT_CellularNetwork_get_operator_params();
+
+    void test_AT_CellularNetwork_get_operator_names();
 };
 
 #endif // TEST_AT_CELLULARNETWORK_H

--- a/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -151,6 +151,10 @@ nsapi_error_t AT_CellularNetwork::get_attach(AttachStatus &status)
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t AT_CellularNetwork::detach()
+{
+    return NSAPI_ERROR_OK;
+}
 
 nsapi_error_t AT_CellularNetwork::get_apn_backoff_timer(int &backoffTime)
 {
@@ -253,3 +257,7 @@ int AT_CellularNetwork::get_3gpp_error()
     return 0;
 }
 
+nsapi_error_t AT_CellularNetwork::get_operator_names(operator_names_list &op_names)
+{
+    return NSAPI_ERROR_OK;
+}

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -744,7 +744,8 @@ nsapi_error_t AT_CellularNetwork::get_registration_status(RegistrationType type,
 
 nsapi_error_t AT_CellularNetwork::get_cell_id(int &cell_id)
 {
-    return _cell_id;
+    cell_id = _cell_id;
+    return NSAPI_ERROR_OK;
 }
 
 bool AT_CellularNetwork::has_registration(RegistrationType reg_type)

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -118,6 +118,7 @@ public: // CellularNetwork
 
     virtual nsapi_error_t set_registration_urc(RegistrationType type, bool on);
 
+    virtual nsapi_error_t get_operator_names(operator_names_list &op_names);
 protected:
 
     /** Check if modem supports the given stack type.
@@ -141,7 +142,6 @@ protected:
      */
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology op_rat);
 
-    virtual nsapi_error_t get_operator_names(operator_names_list &op_names);
 private:
     //  "NO CARRIER" urc
     void urc_no_carrier();


### PR DESCRIPTION
### Description

Fixed cellular unit tests. 
Moved one method from protected to public as it was accidentally set as protected in AT_CellularNetwork. Now that method also can be unit tested.

@AnttiKauppila please review

Internal ref to defect: IOTCELL-799

### Pull request type
[X] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
