### PR TITLE
Remove automatic I2C stop after each read

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
@@ -145,11 +145,6 @@ int i2c_byte_read(i2c_t *obj, int last)
         if (I2CM_WriteTxFifo(i2cm, fifo, MXC_S_I2CM_TRANS_TAG_RXDATA_NACK) != E_NO_ERROR) {
             goto byte_read_err;
         }
-
-        // Send the stop condition
-        if (I2CM_WriteTxFifo(i2cm, fifo, MXC_S_I2CM_TRANS_TAG_STOP) != E_NO_ERROR) {
-            goto byte_read_err;
-        }
     } else {
         if (I2CM_WriteTxFifo(i2cm, fifo, MXC_S_I2CM_TRANS_TAG_RXDATA_COUNT) != E_NO_ERROR) {
             goto byte_read_err;


### PR DESCRIPTION
### Description
Remove stop after each read to allow sending repeated start.

Tested all supported toolchains with MAX32620FTHR.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise) or
    change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[x] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
