### PR TITLE
Cellular: Fix to prefer IPv6 single stack with fallback to IPv4

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -459,7 +459,7 @@ bool AT_CellularNetwork::set_new_context(int cid)
             strncpy(pdp_type, "IPV6", sizeof(pdp_type));
             break;
         case IPV4V6_STACK:
-            strncpy(pdp_type, "IPV4V6", sizeof(pdp_type));
+            strncpy(pdp_type, "IPV6", sizeof(pdp_type)); // try first IPV6 and then fall-back to IPv4
             break;
         default:
             break;

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -81,6 +81,11 @@ const char * AT_CellularStack::get_ip_address()
     return _ip;
 }
 
+nsapi_error_t AT_CellularStack::socket_stack_init()
+{
+    return NSAPI_ERROR_OK;
+}
+
 nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto)
 {
     if (!is_protocol_supported(proto) || !handle) {
@@ -90,6 +95,10 @@ nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protoc
     int max_socket_count = get_max_socket_count();
 
     if (!_socket) {
+        if (socket_stack_init() != NSAPI_ERROR_OK) {
+            return NSAPI_ERROR_NO_SOCKET;
+        }
+
         _socket = new CellularSocket*[max_socket_count];
         if (!_socket) {
             tr_error("No memory to open socket!");

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -46,6 +46,13 @@ public: // NetworkStack
     virtual const char *get_ip_address();
 protected: // NetworkStack
 
+    /**
+     * Modem specific socket stack initialization
+     *
+     *  @return 0 on success
+     */
+    virtual nsapi_error_t socket_stack_init();
+
     virtual nsapi_error_t socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto);
 
     virtual nsapi_error_t socket_close(nsapi_socket_t handle);
@@ -87,8 +94,10 @@ protected:
         SocketAddress localAddress;
         void (*_cb)(void *);
         void *_data;
-        bool created;
-        bool rx_avail; // used to synchronize reading from modem
+        bool created; // socket has been created on modem stack
+        bool started; // socket has been opened on modem stack
+        bool tx_ready; // socket is ready for sending on modem stack
+        bool rx_avail; // socket has data for reading on modem stack
     };
 
     /**


### PR DESCRIPTION
### Description

Cellular accepted IPV4V6 dual stack but actual stack implementation supports only IPv4 or IPv6 single stack. At this same change also added stack init and socket flags to initialize modem stack for IPv4/IPv6 and to sync socket states.

### Pull request type

[X ] Fix  
[ ] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
