### PR TITLE
Cellular: AT debugging improved

### DIFF
--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -303,6 +303,17 @@ public:
      */
     ssize_t read_string(char *str, size_t size, bool read_even_stop_tag = false);
 
+    /** Reads chars representing hex ascii values and converts them to the corresponding chars.
+     *  For example: "4156" to "AV".
+     *  Terminates with null. Skips the quotation marks.
+     *  Stops on delimiter or stop tag.
+     *
+     *  @param str output buffer for the read
+     *  @param size maximum number of chars to output
+     *  @return length of output string or -1 in case of read timeout before delimiter or stop tag is found
+     */
+    ssize_t read_hex_string(char *str, size_t size);
+
     /** Reads as string and converts result to integer. Supports only positive integers.
      *
      *  @return the positive integer or -1 in case of error.
@@ -358,7 +369,7 @@ public:
 public: // just for debugging
     /**
      * AT debugging, when enabled will print all data read and written,
-     * non-printable chars are printed as "[%02x]".
+     * non-printable chars are printed as "[%d]".
      *
      * AT debug can be enabled at compile time using MBED_CONF_CELLULAR_DEBUG_AT flag or at runtime
      * calling set_debug(). Note that MBED_CONF_MBED_TRACE_ENABLE must also be enabled.
@@ -493,6 +504,11 @@ private:
 
     // check is urc is already added
     bool find_urc_handler(const char *prefix, mbed::Callback<void()> callback);
+
+    ssize_t read(char *buf, size_t size, bool read_even_stop_tag, bool hex);
+
+    // print contents of a buffer to trace log
+    void debug_print(char *p, int len);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -350,16 +350,27 @@ public:
      */
     bool consume_to_stop_tag();
 
-    /**  Sets _debug_on flag.
-     *
-     *  @param enable value to be set for _debug_on flag
-     */
-    void enable_debug(bool enable);
-
     /** Return the last 3GPP error code.
      *  @return last 3GPP error code
      */
     int get_3gpp_error();
+
+public: // just for debugging
+    /**
+     * AT debugging, when enabled will print all data read and written,
+     * non-printable chars are printed as "[%02x]".
+     *
+     * AT debug can be enabled at compile time using MBED_CONF_CELLULAR_DEBUG_AT flag or at runtime
+     * calling set_debug(). Note that MBED_CONF_MBED_TRACE_ENABLE must also be enabled.
+     *
+     *  @param debug_on Enable/disable debugging
+     */
+    void set_debug(bool debug_on);
+
+    /**
+     * Check that AT is responsive for debugging purposes.
+     */
+    void sync();
 
 private:
 

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -62,7 +62,7 @@ ATHandler* AT_CellularDevice::get_at_handler(FileHandle *fileHandle)
     atHandler = new ATHandler(fileHandle, _queue, _default_timeout, "\r", get_send_delay());
     if (atHandler) {
         if (_modem_debug_on) {
-            atHandler->enable_debug(_modem_debug_on);
+            atHandler->set_debug(_modem_debug_on);
         }
         atHandler->_nextATHandler = _atHandlers;
         _atHandlers = atHandler;
@@ -234,7 +234,7 @@ void AT_CellularDevice::modem_debug_on(bool on)
 
     ATHandler *atHandler = _atHandlers;
     while (atHandler) {
-        atHandler->enable_debug(_modem_debug_on);
+        atHandler->set_debug(_modem_debug_on);
         atHandler = atHandler->_nextATHandler;
     }
 }

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -8,6 +8,10 @@
         "random_max_start_delay": {
             "help": "Maximum random delay value used in start-up sequence in milliseconds",
             "value": 0
+        },
+        "debug-at": {
+            "help": "Enable AT debug prints",
+            "value": false
         }
     }
 }


### PR DESCRIPTION
### Description

AT debugging, when enabled will print all data read and written, non-printable chars are printed as "[%02x]". AT debug can be enabled at compile time using MBED_CONF_CELLULAR_DEBUG_AT flag or at runtime calling set_debug().

A minor fix was made to read_string() at line 488 to return properly 0 length on empty strings "".

### Pull request type

[X] Fix  
[X] Refactor  
[ ] New target  
[ ] Feature  
[ ] Breaking change
