### PR TITLE
Update watchdog tests -- allow shorter timeouts

### DIFF
--- a/TESTS/mbed_drivers/watchdog/main.cpp
+++ b/TESTS/mbed_drivers/watchdog/main.cpp
@@ -24,6 +24,7 @@
 #include "unity/unity.h"
 #include "drivers/Watchdog.h"
 #include "Watchdog_tests.h"
+#include "mbed.h"
 
 /* This is platform specific and depends on the watchdog timer implementation,
  * e.g. STM32F4 uses 32kHz internal RC oscillator to clock the IWDG, so
@@ -33,6 +34,10 @@
 #define WORST_TIMEOUT_RESOLUTION_MS 8UL
 
 #define TIMEOUT_DELTA_MS (WORST_TIMEOUT_RESOLUTION_MS)
+
+// Do not set watchdog timeout shorter than 50 ms as it may cause the
+// host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
+// performs reset during test suite teardown.
 #define WDG_TIMEOUT_MS 500UL
 
 #define MSG_VALUE_DUMMY "0"
@@ -49,6 +54,18 @@ int CASE_INDEX_CURRENT;
 using utest::v1::Case;
 using utest::v1::Specification;
 using utest::v1::Harness;
+
+Thread wdg_kicking_thread;
+Semaphore kick_wdg_during_test_teardown(0, 1);
+
+void wdg_kicking_thread_fun()
+{
+    kick_wdg_during_test_teardown.wait();
+    while (true){
+        hal_watchdog_kick();
+        wait_ms(20);
+    }
+}
 
 void test_max_timeout_is_valid()
 {
@@ -112,6 +129,8 @@ utest::v1::status_t case_setup_sync_on_reset(const Case * const source, const si
 utest::v1::status_t case_teardown_sync_on_reset(const Case * const source, const size_t passed, const size_t failed,
         const utest::v1::failure_t failure)
 {
+    // Unlock kicking the watchdog during teardown.
+    kick_wdg_during_test_teardown.release();
     utest::v1::status_t status = utest::v1::greentea_case_teardown_handler(source, passed, failed, failure);
     if (failed) {
         /* Return immediately and skip the device reset, if the test case failed.
@@ -190,6 +209,10 @@ int testsuite_setup_sync_on_reset(const size_t number_of_cases)
         return utest::v1::STATUS_ABORT;
     }
 
+    // The thread is started here, but feeding the watchdog will start
+    // when the semaphore is released during a test case teardown.
+    wdg_kicking_thread.start(mbed::callback(wdg_kicking_thread_fun));
+
     utest_printf("Starting with test case index %i of all %i defined test cases.\n", CASE_INDEX_START, number_of_cases);
     return CASE_INDEX_START;
 }
@@ -200,9 +223,6 @@ Case cases[] = {
     Case("Restart multiple times", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
         test_restart, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
 
-    // Do not set watchdog timeout shorter than 500 ms as it may cause the
-    // host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
-    // performs reset during test suite teardown.
     Case("Start, 500 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
         test_start<500UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
     Case("Start, max_timeout", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,

--- a/TESTS/mbed_drivers/watchdog/main.cpp
+++ b/TESTS/mbed_drivers/watchdog/main.cpp
@@ -38,7 +38,7 @@
 // Do not set watchdog timeout shorter than 50 ms as it may cause the
 // host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
 // performs reset during test suite teardown.
-#define WDG_TIMEOUT_MS 500UL
+#define WDG_TIMEOUT_MS 100UL
 
 #define MSG_VALUE_DUMMY "0"
 #define MSG_VALUE_LEN 24
@@ -223,8 +223,8 @@ Case cases[] = {
     Case("Restart multiple times", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
         test_restart, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
 
-    Case("Start, 500 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
-        test_start<500UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+    Case("Start, 100 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_start<100UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
     Case("Start, max_timeout", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
         test_start_max_timeout, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
 

--- a/TESTS/mbed_drivers/watchdog_reset/main.cpp
+++ b/TESTS/mbed_drivers/watchdog_reset/main.cpp
@@ -24,8 +24,8 @@
 #include "Watchdog_reset_tests.h"
 #include "mbed.h"
 
-#define TIMEOUT_MS 500UL
-#define TIMEOUT_DELTA_MS 50UL
+#define TIMEOUT_MS 100UL
+#define TIMEOUT_DELTA_MS 10UL
 
 #define MSG_VALUE_DUMMY "0"
 #define CASE_DATA_INVALID 0xffffffffUL

--- a/TESTS/mbed_hal/watchdog/main.cpp
+++ b/TESTS/mbed_hal/watchdog/main.cpp
@@ -36,7 +36,7 @@
 // Do not set watchdog timeout shorter than 50 ms as it may cause the
 // host-test-runner return 'TIMEOUT' instead of 'FAIL' / 'PASS' if watchdog
 // performs reset during test suite teardown.
-#define WDG_TIMEOUT_MS 500UL
+#define WDG_TIMEOUT_MS 100UL
 
 #define MSG_VALUE_DUMMY "0"
 #define MSG_VALUE_LEN 24
@@ -224,8 +224,8 @@ Case cases[] = {
         test_update_config,
         (utest::v1::case_teardown_handler_t) case_teardown_wdg_stop_or_reset),
 
-    Case("Init, 500 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
-        test_init<500UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
+    Case("Init, 100 ms", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
+        test_init<100UL>, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
     Case("Init, max_timeout", (utest::v1::case_setup_handler_t) case_setup_sync_on_reset,
         test_init_max_timeout, (utest::v1::case_teardown_handler_t) case_teardown_sync_on_reset),
 };

--- a/TESTS/mbed_hal/watchdog_reset/main.cpp
+++ b/TESTS/mbed_hal/watchdog_reset/main.cpp
@@ -24,8 +24,8 @@
 #include "watchdog_reset_tests.h"
 #include "mbed.h"
 
-#define TIMEOUT_MS 500UL
-#define TIMEOUT_DELTA_MS 50UL
+#define TIMEOUT_MS 100UL
+#define TIMEOUT_DELTA_MS 10UL
 
 #define MSG_VALUE_DUMMY "0"
 #define CASE_DATA_INVALID 0xffffffffUL


### PR DESCRIPTION
### Description

Added a mechanism which will prevent an initialised watchdog from resetting the device during final greentea communication.

This change lowers the minimal testable timeout value from 500 ms to 50 ms, which is necessary to test all the partners' boards, as some of them only support timeout values up to 150 ms.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise) or
    change the layout.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
-->

[ ] Fix  
[ ] Refactor  
[ ] New target  
[X] Feature  
[ ] Breaking change

CC @scartmell-arm @jamesbeyond @0xc0170 @bulislaw 
