### PR TITLE
Drop include paths for ARM assembler

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -22,7 +22,7 @@
  *
  */
 
-#include "memory_zones.h"
+#include "../memory_zones.h"
 
 __initial_sp    EQU     ZBT_SSRAM23_START + ZBT_SSRAM23_SIZE ; Top of ZBT SSRAM2 and 3, used for data
 

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -394,7 +394,7 @@
               <MiscControls>{{asm_flags}}</MiscControls>
               <Define></Define>
               <Undefine></Undefine>
-              <IncludePath>{{include_paths}}</IncludePath>
+              <IncludePath></IncludePath>
             </VariousControls>
           </Aads>
           <LDads>

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -71,7 +71,7 @@ class ARM(mbedToolchain):
 
         ARM_BIN = join(TOOLCHAIN_PATHS['ARM'], "bin")
         ARM_INC = join(TOOLCHAIN_PATHS['ARM'], "include")
-        
+
         main_cc = join(ARM_BIN, "armcc")
 
         self.flags['common'] += ["--cpu=%s" % cpu]
@@ -155,7 +155,7 @@ class ARM(mbedToolchain):
         dir = join(dirname(object), '.temp')
         mkdir(dir)
         tempfile = join(dir, basename(object) + '.E.s')
-        
+
         # Build preprocess assemble command
         cmd_pre = self.asm
         cmd_pre.extend(self.get_compile_options(
@@ -168,7 +168,7 @@ class ARM(mbedToolchain):
         # Call cmdline hook
         cmd_pre = self.hook.get_cmdline_assembler(cmd_pre)
         cmd = self.hook.get_cmdline_assembler(cmd)
-       
+
         # Return command array, don't execute
         return [cmd_pre, cmd]
 
@@ -176,9 +176,9 @@ class ARM(mbedToolchain):
     def compile(self, cc, source, object, includes):
         # Build compile command
         cmd = cc + self.get_compile_options(self.get_symbols(), includes)
-        
+
         cmd.extend(self.get_dep_option(object))
-            
+
         cmd.extend(["-o", object, source])
 
         # Call cmdline hook

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -157,7 +157,7 @@ class ARM(mbedToolchain):
         tempfile = join(dir, basename(object) + '.E.s')
 
         # Build preprocess assemble command
-        cmd_pre = self.asm
+        cmd_pre = copy(self.asm)
         cmd_pre.extend(self.get_compile_options(
             self.get_symbols(True), includes, True))
         cmd_pre.extend(["-E", "-o", tempfile, source])

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -135,17 +135,18 @@ class ARM(mbedToolchain):
     def get_config_option(self, config_header):
         return ['--preinclude=' + config_header]
 
-    def get_compile_options(self, defines, includes, for_asm=False):        
+    def get_compile_options(self, defines, includes, for_asm=False):
         opts = ['-D%s' % d for d in defines]
+        if for_asm:
+            return opts
         if self.RESPONSE_FILES:
             opts += ['--via', self.get_inc_file(includes)]
         else:
             opts += ["-I%s" % i for i in includes]
 
-        if not for_asm:
-            config_header = self.get_config_header()
-            if config_header is not None:
-                opts = opts + self.get_config_option(config_header)
+        config_header = self.get_config_header()
+        if config_header is not None:
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool
@@ -156,7 +157,10 @@ class ARM(mbedToolchain):
         tempfile = join(dir, basename(object) + '.E.s')
         
         # Build preprocess assemble command
-        cmd_pre = self.asm + self.get_compile_options(self.get_symbols(True), includes) + ["-E", "-o", tempfile, source]
+        cmd_pre = self.asm
+        cmd_pre.extend(self.get_compile_options(
+            self.get_symbols(True), includes, True))
+        cmd_pre.extend(["-E", "-o", tempfile, source])
 
         # Build main assemble command
         cmd = self.asm + ["-o", object, tempfile]


### PR DESCRIPTION
### Description


The arm assembler would include many, many include paths on the command
line corresponding to anywhere it's possible to locate a header file.
This caused the following problem in uvision:

```
assembling startup_nrf52832.S...
startup_nrf52832.S: error: A3907U: Via file
'.\build\startup_nrf52832._ia' command too long for buffer.
```

We work around this issue by dropping the include paths from the
assembler in both `mbed compile` and `mbed export`. This has the
advantage that it's consistent with IAR.


 ### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change