### PR TITLE
Let targets override default mbed_start_application implementation

### DIFF
--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -18,6 +18,7 @@
 #include <stdarg.h>
 #include "device.h"
 #include "platform/mbed_application.h"
+#include "platform/mbed_toolchain.h"
 
 #if MBED_APPLICATION_SUPPORT
 
@@ -25,7 +26,7 @@ static void powerdown_nvic(void);
 static void powerdown_scb(uint32_t vtor);
 static void start_new_application(void *sp, void *pc);
 
-void mbed_start_application(uintptr_t address)
+MBED_WEAK void mbed_start_application(uintptr_t address)
 {
     void *sp;
     void *pc;


### PR DESCRIPTION

### Description

Targets like the NRF52 need a custom mbed_start_application
implementation.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

