### PR TITLE
Modifying echo test to be driven more from the device.

### DIFF
--- a/TESTS/host_tests/device_echo.py
+++ b/TESTS/host_tests/device_echo.py
@@ -1,0 +1,32 @@
+"""
+mbed SDK
+Copyright (c) 2011-2016 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import uuid
+from mbed_host_tests import BaseHostTest
+
+class Device_Echo(BaseHostTest):
+
+    def _callback_repeat(self, key, value, _):
+        self.send_kv(key, value)
+
+    def setup(self):
+        self.register_callback("echo", self._callback_repeat)
+        self.register_callback("echo_count", self._callback_repeat)
+
+    def teardown(self):
+        pass


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->

Previously, the echo test followed a flow like the following:

```
-STEP-	-HOST PC-                  -DEVICE-
0	send _sync
1				   echo back _sync
2				   send echo_count
3	echo back echo_count
4	send first echo packet
5				   echo back echo packet
	(repeat steps 4 + 5)
```

However, as noted by issue #6659, this test would somtimes fail between
steps 4 and 5. To ensure each KV pair makes it to the correct destination,
we usually write the KV back. Step 4 does not wait for this to happen
and starts sending echo packets. So the device is acting as the "echo
server".

This change makes the host PC the "echo server". The idea being that the
device will be slower and the host pc should always be able to keep up
with it, not the other way around.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

cc @cmonr 

