### PR TITLE
Fix compiler warnings for Maxim platforms

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32620C/analogin_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/analogin_api.c
@@ -50,7 +50,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Set the object pointer and channel encoding
     obj->adc = MXC_ADC;
-    obj->channel = pinmap_find_function(pin, PinMap_ADC);
+    obj->channel = (mxc_adc_chsel_t)pinmap_find_function(pin, PinMap_ADC);
 
     if (!initialized) {
         MBED_ASSERT(ADC_Init() == E_NO_ERROR);
@@ -93,4 +93,3 @@ uint16_t analogin_read_u16(analogin_t *obj)
 
     return result;
 }
-

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/i2c_api.c
@@ -78,7 +78,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_Init(obj->i2c, &obj->sys_cfg, hz);
+    I2CM_Init(obj->i2c, &obj->sys_cfg, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/lp.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/lp.c
@@ -179,7 +179,7 @@ int LP_ConfigGPIOWakeUpDetect(const gpio_cfg_t *gpio, unsigned int act_high, lp_
     return result;
 }
 
-uint8_t LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio)
+int LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio)
 {
     uint8_t gpioWokeUp = 0;
 

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/lp.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/lp.h
@@ -138,7 +138,7 @@ int LP_ClearGPIOWakeUpDetect(const gpio_cfg_t *gpio);
  *          nonzero = at least one of the gpio passed in triggered a wake up
  *                    the bit set represents which pin is the wake up source
  */
-uint8_t LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio);
+int LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio);
 
 /**
  * @brief   Wake on USB plug or unplug

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/mxc_sys.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/mxc_sys.h
@@ -125,7 +125,7 @@ uint32_t SYS_CPU_GetFreq(void);
  * @returns     E_NO_ERROR if everything is successful
  */
 int SYS_ADC_Init(void);
-  
+
 /**
  * @brief       System level initialization for AES module.
  * @returns     E_NO_ERROR if everything is successful
@@ -240,13 +240,13 @@ int SYS_SPIX_Init(const sys_cfg_spix_t *sys_cfg, uint32_t baud);
  * @brief System level shutdown for SPIX module
  * @returns         E_NO_ERROR if everything is successful
  */
-int SYS_SPIX_Shutdown();
+int SYS_SPIX_Shutdown(void);
 
 /**
  * @brief Get the frequency of the SPIX module source clock
  * @returns         frequency in Hz
  */
-uint32_t SYS_SPIX_GetFreq();
+uint32_t SYS_SPIX_GetFreq(void);
 
 /**
  * @brief System level initialization for SPIS module.
@@ -259,13 +259,13 @@ int SYS_SPIS_Init(const sys_cfg_spix_t *sys_cfg);
  * @brief System level shutdown for SPIS module
  * @returns         E_NO_ERROR if everything is successful
  */
-int SYS_SPIS_Shutdown();
+int SYS_SPIS_Shutdown(void);
 
 /**
  * @brief Get the frequency of the SPIS module source clock
  * @returns         frequency in Hz
  */
-uint32_t SYS_SPIS_GetFreq();
+uint32_t SYS_SPIS_GetFreq(void);
 
 /**
  * @brief System level initialization for OWM module.
@@ -436,7 +436,7 @@ uint32_t SYS_SRAM_GetSize(void);
  * @returns size of Flash in bytes
  */
 uint32_t SYS_FLASH_GetSize(void);
-  
+
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/spis.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/mxc/spis.c
@@ -46,9 +46,9 @@
 #include "spis.h"
 
 /**
- * @ingroup spis 
+ * @ingroup spis
  * @{
- */ 
+ */
 /* **** Definitions **** */
 #define SPIS_FIFO_BUFFER        6
 
@@ -119,7 +119,7 @@ int SPIS_Shutdown(mxc_spis_regs_t *spis)
     }
 
     // Clear system level configurations
-    if ((err = SYS_SPIS_Shutdown(spis)) != E_NO_ERROR) {
+    if ((err = SYS_SPIS_Shutdown()) != E_NO_ERROR) {
         return err;
     }
 
@@ -162,7 +162,7 @@ int SPIS_Trans(mxc_spis_regs_t *spis, spis_req_t *req)
 
     // Start the transaction, keep calling the handler until complete
     spis->intfl = (MXC_F_SPIS_INTFL_SS_DEASSERTED | MXC_F_SPIS_INTFL_TX_UNDERFLOW);
-    while(SPIS_TransHandler(spis, req, spis_num) & (MXC_F_SPIS_INTEN_RX_FIFO_AF | 
+    while(SPIS_TransHandler(spis, req, spis_num) & (MXC_F_SPIS_INTEN_RX_FIFO_AF |
         MXC_F_SPIS_INTEN_TX_FIFO_AE)) {
 
         if((req->tx_data != NULL) && (spis->intfl & MXC_F_SPIS_INTFL_TX_UNDERFLOW)) {
@@ -174,7 +174,7 @@ int SPIS_Trans(mxc_spis_regs_t *spis, spis_req_t *req)
         }
 
         if((req->deass) && (spis->intfl & MXC_F_SPIS_INTFL_SS_DEASSERTED)) {
-            if(((req->rx_data != NULL) && ((req->read_num + SPIS_NumReadAvail(spis)) < req->len)) || 
+            if(((req->rx_data != NULL) && ((req->read_num + SPIS_NumReadAvail(spis)) < req->len)) ||
                 ((req->tx_data != NULL) && (req->write_num < req->len))) {
 
                 return E_COMM_ERR;
@@ -306,7 +306,7 @@ void SPIS_Handler(mxc_spis_regs_t *spis)
     if((flags & MXC_F_SPIS_INTFL_SS_DEASSERTED) && (req != NULL) &&
         (req->deass)) {
 
-        if(((req->rx_data != NULL) && ((req->read_num + SPIS_NumReadAvail(spis)) < req->len)) || 
+        if(((req->rx_data != NULL) && ((req->read_num + SPIS_NumReadAvail(spis)) < req->len)) ||
             ((req->tx_data != NULL) && (req->write_num < req->len))) {
 
             // Unlock this SPIS

--- a/targets/TARGET_Maxim/TARGET_MAX32620C/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/rtc_api.c
@@ -35,6 +35,7 @@
 #include "lp_ticker_api.h"
 #include "rtc.h"
 #include "lp.h"
+#include <string.h>
 
 // LOG2 for 32-bit powers of 2
 #define LOG2_1(n) (((n) >= (1 <<  1)) ? 1 : 0)
@@ -65,7 +66,8 @@ static void init_rtc(void)
      * if it is already running.
      */
     if (!RTC_IsActive()) {
-        rtc_cfg_t cfg = { 0 };
+        rtc_cfg_t cfg;
+        memset(&cfg, 0, sizeof(rtc_cfg_t));
         cfg.prescaler = LP_TIMER_PRESCALE;
         cfg.snoozeMode = RTC_SNOOZE_DISABLE;
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/analogin_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/analogin_api.c
@@ -50,7 +50,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Set the object pointer and channel encoding
     obj->adc = MXC_ADC;
-    obj->channel = pinmap_find_function(pin, PinMap_ADC);
+    obj->channel = (mxc_adc_chsel_t)pinmap_find_function(pin, PinMap_ADC);
 
     if (!initialized) {
         MBED_ASSERT(ADC_Init() == E_NO_ERROR);
@@ -93,4 +93,3 @@ uint16_t analogin_read_u16(analogin_t *obj)
 
     return result;
 }
-

--- a/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/i2c_api.c
@@ -79,7 +79,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_SetFrequency(obj->i2c, hz);
+    I2CM_SetFrequency(obj->i2c, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32625/mxc/lp.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/mxc/lp.c
@@ -178,7 +178,7 @@ int LP_ConfigGPIOWakeUpDetect(const gpio_cfg_t *gpio, unsigned int act_high, lp_
     return result;
 }
 
-uint8_t LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio)
+int LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio)
 {
     uint8_t gpioWokeUp = 0;
 

--- a/targets/TARGET_Maxim/TARGET_MAX32625/mxc/lp.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/mxc/lp.h
@@ -138,7 +138,7 @@ int LP_ClearGPIOWakeUpDetect(const gpio_cfg_t *gpio);
  *          nonzero = at least one of the gpio passed in triggered a wake up
  *                    the bit set represents which pin is the wake up source
  */
-uint8_t LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio);
+int LP_IsGPIOWakeUpSource(const gpio_cfg_t *gpio);
 
 /**
  * @brief   Wake on USB plug or unplug

--- a/targets/TARGET_Maxim/TARGET_MAX32625/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/rtc_api.c
@@ -35,6 +35,7 @@
 #include "lp_ticker_api.h"
 #include "rtc.h"
 #include "lp.h"
+#include <string.h>
 
 // LOG2 for 32-bit powers of 2
 #define LOG2_1(n) (((n) >= (1 <<  1)) ? 1 : 0)
@@ -65,7 +66,8 @@ static void init_rtc(void)
      * if it is already running.
      */
     if (!RTC_IsActive()) {
-        rtc_cfg_t cfg = { 0 };
+        rtc_cfg_t cfg;
+        memset(&cfg, 0, sizeof(rtc_cfg_t));
         cfg.prescaler = LP_TIMER_PRESCALE;
         cfg.snoozeMode = RTC_SNOOZE_DISABLE;
 

--- a/targets/TARGET_Maxim/TARGET_MAX32630/analogin_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/analogin_api.c
@@ -50,7 +50,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     // Set the object pointer and channel encoding
     obj->adc = MXC_ADC;
-    obj->channel = pinmap_find_function(pin, PinMap_ADC);
+    obj->channel = (mxc_adc_chsel_t)pinmap_find_function(pin, PinMap_ADC);
 
     if (!initialized) {
         MBED_ASSERT(ADC_Init() == E_NO_ERROR);
@@ -93,4 +93,3 @@ uint16_t analogin_read_u16(analogin_t *obj)
 
     return result;
 }
-

--- a/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/i2c_api.c
@@ -78,7 +78,7 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 //******************************************************************************
 void i2c_frequency(i2c_t *obj, int hz)
 {
-    I2CM_Init(obj->i2c, &obj->sys_cfg, hz);
+    I2CM_Init(obj->i2c, &obj->sys_cfg, (i2cm_speed_t)hz);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32630/mxc/mxc_sys.h
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/mxc/mxc_sys.h
@@ -92,50 +92,50 @@ typedef struct {
  */
 typedef sys_cfg_t sys_cfg_uart_t;
 
-/** 
+/**
  * Structure type for I2CM System Configuration.
  * @ingroup  i2cm
  */
 typedef sys_cfg_t sys_cfg_i2cm_t;
 
-/** 
- * Structure type for I2CS System Configuration. 
+/**
+ * Structure type for I2CS System Configuration.
  * @ingroup i2cs
  */
 typedef sys_cfg_t sys_cfg_i2cs_t;
 
-/** 
- * Structure type for SPIM System Configuration. 
+/**
+ * Structure type for SPIM System Configuration.
  * @ingroup spim
  */
 typedef sys_cfg_t sys_cfg_spim_t;
 
-/** 
- * Structure type for SPIX System Configuration. 
- * @ingroup spix 
+/**
+ * Structure type for SPIX System Configuration.
+ * @ingroup spix
  */
 typedef sys_cfg_t sys_cfg_spix_t;
 
-/** 
- * Structure type for OWM System Configuration. 
+/**
+ * Structure type for OWM System Configuration.
  * @ingroup owm
  */
 typedef sys_cfg_t sys_cfg_owm_t;
 
-/** 
- * Structure type for Timer System Configuration. 
+/**
+ * Structure type for Timer System Configuration.
  * @ingroup timer
  */
 typedef gpio_cfg_t sys_cfg_tmr_t;
 
-/** 
+/**
  * Structure type for Pulse Train System Configuration.
  * @ingroup pulsetrain
  */
 typedef gpio_cfg_t sys_cfg_pt_t;
 
 /**
- * Structure type for Pulse Train Clock Scale Configuration. 
+ * Structure type for Pulse Train Clock Scale Configuration.
  * @ingroup clkman
  * @ingroup pulsetrain
  */
@@ -168,7 +168,7 @@ uint32_t SYS_CPU_GetFreq(void);
  * @ingroup    adc
  */
 int SYS_ADC_Init(void);
-  
+
 /**
  * @brief      System level initialization for the AES module.
  * @return     #E_NO_ERROR if everything is successful
@@ -299,14 +299,14 @@ int SYS_SPIX_Init(const sys_cfg_spix_t *sys_cfg, uint32_t baud);
  * @return     #E_NO_ERROR if everything is successful
  * @ingroup    spix
  */
-int SYS_SPIX_Shutdown();
+int SYS_SPIX_Shutdown(void);
 
 /**
  * @brief      Get the frequency of the SPIX module source clock
  * @return     frequency in Hz
  * @ingroup    spix
  */
-uint32_t SYS_SPIX_GetFreq();
+uint32_t SYS_SPIX_GetFreq(void);
 
 /**
  * @brief      System level initialization for OWM module.

--- a/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
@@ -35,6 +35,7 @@
 #include "lp_ticker_api.h"
 #include "rtc.h"
 #include "lp.h"
+#include <string.h>
 
 // LOG2 for 32-bit powers of 2
 #define LOG2_1(n) (((n) >= (1 <<  1)) ? 1 : 0)
@@ -65,7 +66,8 @@ static void init_rtc(void)
      * if it is already running.
      */
     if (!RTC_IsActive()) {
-        rtc_cfg_t cfg = {0};
+        rtc_cfg_t cfg;
+        memset(&cfg, 0, sizeof(rtc_cfg_t));
         cfg.prescaler = LP_TIMER_PRESCALE;
         cfg.snoozeMode = RTC_SNOOZE_DISABLE;
 


### PR DESCRIPTION
### Description
Tested GCC_ARM, and online compiler with MAX32620FTHR, MAX32625MBED, and MAX32630FTHR.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/guidelines.html#workflow (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

