### PR TITLE
LPC54XXX: Set the pin function to Digital mode

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/pinmap.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/pinmap.c
@@ -29,6 +29,9 @@ void pin_function(PinName pin, int function)
     CLOCK_EnableClock(gpio_clocks[port_number]);
     CLOCK_EnableClock(kCLOCK_Iocon);
 
+    /* Set the DIGIMODE bit */
+    IOCON->PIO[port_number][pin_number] |= IOCON_PIO_DIGIMODE_MASK;
+
     reg = IOCON->PIO[port_number][pin_number];
     reg = (reg & ~0x7) | (function & 0x7);
     IOCON->PIO[port_number][pin_number] = reg;


### PR DESCRIPTION
### Description
We cannot rely on the default value as a pin could be use for Analog purposes in which this bit is cleared. This was discovered when running AnalogIn ci-shield tests that uses the pin for Analog Input and then switches the pin to GPIO output.

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

