### PR TITLE
STM32 LPTICKER update for targets supporting RTC

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2017, STMicroelectronics
+ * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,16 +30,24 @@
 
 #if DEVICE_LPTICKER
 
-#include "rtc_api_hal.h"
-
+/***********************************************************************/
+/* lpticker_lptim config is 1 in json config file                      */
+/* LPTICKER is based on LPTIM feature from ST drivers. RTC is not used */
 #if MBED_CONF_TARGET_LPTICKER_LPTIM
+
+#include "lp_ticker_api.h"
+#include "mbed_error.h"
 
 LPTIM_HandleTypeDef LptimHandle;
 
 const ticker_info_t* lp_ticker_get_info()
 {
     static const ticker_info_t info = {
-        RTC_CLOCK,
+#if MBED_CONF_TARGET_LSE_AVAILABLE
+        LSE_VALUE,
+#else
+        LSI_VALUE,
+#endif
         16
     };
     return &info;
@@ -224,8 +232,14 @@ void lp_ticker_clear_interrupt(void)
     NVIC_ClearPendingIRQ(LPTIM1_IRQn);
 }
 
+
+
+/*****************************************************************/
+/* lpticker_lptim config is 0 or not defined in json config file */
+/* LPTICKER is based on RTC wake up feature from ST drivers      */
 #else /* MBED_CONF_TARGET_LPTICKER_LPTIM */
 
+#include "rtc_api_hal.h"
 void lp_ticker_init(void)
 {
     rtc_init();

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2017, STMicroelectronics
+ * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -32,6 +32,7 @@
 
 #include "rtc_api_hal.h"
 #include "mbed_mktime.h"
+#include "mbed_error.h"
 
 static RTC_HandleTypeDef RtcHandle;
 

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -53,7 +53,11 @@ void rtc_init(void)
     __HAL_RCC_PWR_CLK_ENABLE();
     HAL_PWR_EnableBkUpAccess();
 
+#if DEVICE_LPTICKER
+    if ( (rtc_isenabled()) && ((RTC->PRER & RTC_PRER_PREDIV_S) == PREDIV_S_VALUE) ) {
+#else /* DEVICE_LPTICKER */
     if (rtc_isenabled()) {
+#endif /* DEVICE_LPTICKER */
         return;
     }
 
@@ -107,19 +111,8 @@ void rtc_init(void)
     RtcHandle.Init.AsynchPrediv = RTC_AUTO_1_SECOND;
 #else /* TARGET_STM32F1 */
     RtcHandle.Init.HourFormat     = RTC_HOURFORMAT_24;
-
-    /* PREDIV_A : 7-bit asynchronous prescaler */
-#if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
-    /* PREDIV_A is set to a small value to improve the SubSeconds resolution */
-    /* with a 32768Hz clock, PREDIV_A=7 gives a precision of 244us */
-    RtcHandle.Init.AsynchPrediv = 7;
-#else
-    /* PREDIV_A is set to the maximum value to improve the consumption */
-    RtcHandle.Init.AsynchPrediv   = 0x007F;
-#endif
-    /* PREDIV_S : 15-bit synchronous prescaler */
-    /* PREDIV_S is set in order to get a 1 Hz clock */
-    RtcHandle.Init.SynchPrediv    = RTC_CLOCK / (RtcHandle.Init.AsynchPrediv + 1) - 1;
+    RtcHandle.Init.AsynchPrediv   = PREDIV_A_VALUE;
+    RtcHandle.Init.SynchPrediv    = PREDIV_S_VALUE;
     RtcHandle.Init.OutPut         = RTC_OUTPUT_DISABLE;
     RtcHandle.Init.OutPutPolarity = RTC_OUTPUT_POLARITY_HIGH;
     RtcHandle.Init.OutPutType     = RTC_OUTPUT_TYPE_OPENDRAIN;

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
 *******************************************************************************
-* Copyright (c) 2017, STMicroelectronics
+* Copyright (c) 2018, STMicroelectronics
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without
@@ -31,15 +31,8 @@
 #ifndef MBED_RTC_API_HAL_H
 #define MBED_RTC_API_HAL_H
 
-#include <stdint.h>
 #include "rtc_api.h"
-#include "ticker_api.h"
 #include "lp_ticker_api.h"
-#include "us_ticker_api.h"
-#include "hal_tick.h"
-#include "mbed_critical.h"
-#include "mbed_error.h"
-#include "mbed_debug.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -44,31 +44,26 @@ extern "C" {
 #define RTC_CLOCK LSI_VALUE
 #endif
 
-/* PREDIV_A : 7-bit asynchronous prescaler */
-/* PREDIV_S : 15-bit synchronous prescaler */
-/* PREDIV_S is set in order to get a 1 Hz clock */
 #if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
-/* PREDIV_A is set to a small value to improve the SubSeconds resolution */
-/* with a 32768Hz clock, PREDIV_A=7 gives a precision of 244us */
-#define PREDIV_A_VALUE 7
-#else /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
-/* PREDIV_A is set to the maximum value to improve the consumption */
-#define PREDIV_A_VALUE 127
-#endif /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
+/* PREDIV_A : 7-bit asynchronous prescaler */
+/* PREDIV_A is set to set LPTICKER frequency to RTC_CLOCK/4 */
+#define PREDIV_A_VALUE 3
 
-#define PREDIV_S_VALUE RTC_CLOCK / (PREDIV_A_VALUE + 1) - 1
-
-/** Read RTC time with subsecond precision.
+/** Read RTC counter with sub second precision
  *
- * @return Time is microsecond
+ * @return LP ticker counter
  */
-uint32_t rtc_read_us(void);
+uint32_t rtc_read_lp(void);
 
-/** Program a wake up timer event in delta microseconds.
+/** Program a wake up timer event
  *
- * @param delta    The time to wait
+ * @param timestamp: counter to set
  */
-void rtc_set_wake_up_timer(uint32_t delta);
+void rtc_set_wake_up_timer(timestamp_t timestamp);
+
+/** Call RTC Wake Up IT
+ */
+void rtc_fire_interrupt(void);
 
 /** Disable the wake up timer event.
  *
@@ -76,12 +71,23 @@ void rtc_set_wake_up_timer(uint32_t delta);
  */
 void rtc_deactivate_wake_up_timer(void);
 
+#else /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
+
+/* PREDIV_A : 7-bit asynchronous prescaler */
+/* PREDIV_A is set to the maximum value to improve the consumption */
+#define PREDIV_A_VALUE 127
+
+#endif /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
+
+/* PREDIV_S : 15-bit synchronous prescaler */
+/* PREDIV_S is set in order to get a 1 Hz clock */
+#define PREDIV_S_VALUE RTC_CLOCK / (PREDIV_A_VALUE + 1) - 1
+
 /** Synchronise the RTC shadow registers.
  *
  * Must be called after a deepsleep.
  */
 void rtc_synchronize(void);
-
 
 #ifdef __cplusplus
 }

--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -51,6 +51,20 @@ extern "C" {
 #define RTC_CLOCK LSI_VALUE
 #endif
 
+/* PREDIV_A : 7-bit asynchronous prescaler */
+/* PREDIV_S : 15-bit synchronous prescaler */
+/* PREDIV_S is set in order to get a 1 Hz clock */
+#if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
+/* PREDIV_A is set to a small value to improve the SubSeconds resolution */
+/* with a 32768Hz clock, PREDIV_A=7 gives a precision of 244us */
+#define PREDIV_A_VALUE 7
+#else /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
+/* PREDIV_A is set to the maximum value to improve the consumption */
+#define PREDIV_A_VALUE 127
+#endif /* DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM */
+
+#define PREDIV_S_VALUE RTC_CLOCK / (PREDIV_A_VALUE + 1) - 1
+
 /** Read RTC time with subsecond precision.
  *
  * @return Time is microsecond

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -1,6 +1,6 @@
 /* mbed Microcontroller Library
  *******************************************************************************
- * Copyright (c) 2016, STMicroelectronics
+ * Copyright (c) 2018, STMicroelectronics
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -30,10 +30,14 @@
 #if DEVICE_SLEEP
 
 #include "sleep_api.h"
-#include "rtc_api_hal.h"
+#include "us_ticker_api.h"
+#include "hal_tick.h"
+#include "mbed_critical.h"
+#include "mbed_error.h"
 
 extern void HAL_SuspendTick(void);
 extern void HAL_ResumeTick(void);
+extern void rtc_synchronize(void);
 
 /*  Wait loop - assuming tick is 1 us */
 static void wait_loop(uint32_t timeout)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -718,7 +718,7 @@
                 "help": "default RX STDIO pins is defined in PinNames.h file, but it can be overridden"
             }
         },
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER"]
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "LPTICKER"]
     },
     "MIMXRT1050_EVK": {
         "supported_form_factors": ["ARDUINO"],
@@ -903,6 +903,7 @@
         },
         "detect_code": ["0700"],
         "device_has_add": ["CAN", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_remove": ["LPTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F103RB"
     },
@@ -926,6 +927,7 @@
         "detect_code": ["0835"],
         "macros_add": ["USBHOST_OTHER"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "FLASH"],
+        "device_has_remove": ["LPTICKER"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F207ZG"
@@ -1049,7 +1051,7 @@
             }
         },
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER", "HSE_VALUE=25000000"],
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH", "LPTICKER"],
+        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "FLASH"],
         "overrides": {"lse_available": 0},
         "release_versions": ["2", "5"],
         "device_name": "STM32F401VE"
@@ -1071,7 +1073,7 @@
             }
         },
         "detect_code": ["0744"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F410RB"
     },
@@ -1179,7 +1181,7 @@
         },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },
@@ -1201,7 +1203,7 @@
         },
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },
@@ -1348,7 +1350,7 @@
         "macros_add": ["USBHOST_OTHER"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0816"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746ZG",
@@ -1377,7 +1379,7 @@
         "macros_add": ["TRANSACTION_QUEUE_SIZE_SPI=2", "USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0819"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F756ZG"
@@ -1405,7 +1407,7 @@
         "supported_form_factors": ["ARDUINO"],
         "macros_add": ["USBHOST_OTHER"],
         "detect_code": ["0818"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F767ZI",
@@ -1430,7 +1432,7 @@
             }
         },
         "detect_code": ["0780"],
-        "device_has_add": ["LPTICKER", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L011K4"
@@ -1453,7 +1455,7 @@
             }
         },
         "detect_code": ["0790"],
-        "device_has_add": ["LPTICKER", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L031K6"
@@ -1475,7 +1477,7 @@
             }
         },
         "detect_code": ["0715"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053R8"
@@ -1497,7 +1499,7 @@
             }
         },
         "detect_code": ["0760"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L073RZ"
     },
@@ -1535,7 +1537,7 @@
             }
         },
         "detect_code": ["0770"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L432KC",
         "bootloader_supported": true
@@ -1557,7 +1559,7 @@
             }
         },
         "detect_code": ["0779"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L433RC",
         "bootloader_supported": true
@@ -1577,6 +1579,7 @@
         "overrides": {"lse_available": 0},
         "release_versions": ["5"],
         "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "CAN", "TRNG", "FLASH"],
+        "device_has_remove": ["LPTICKER"],
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT"],
         "device_name" : "STM32L443RC",
         "detect_code": ["0458"],
@@ -1600,7 +1603,7 @@
         },
         "detect_code": ["0765"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476RG",
         "bootloader_supported": true
@@ -1641,7 +1644,7 @@
         },
         "detect_code": ["0827"],
         "macros_add": ["USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L486RG"
     },
@@ -1659,6 +1662,7 @@
         "detect_code": ["0460"],
         "macros_add": ["MBEDTLS_CONFIG_HW_SUPPORT", "WISE_1570"],
         "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_remove": ["LPTICKER"],
         "release_versions": ["5"],
         "device_name": "STM32L486RG",
         "OUTPUT_EXT": "hex"
@@ -1696,6 +1700,7 @@
         "extra_labels_add": ["STM32F1", "STM32F100RB"],
         "supported_toolchains": ["GCC_ARM"],
         "device_has_add": [],
+        "device_has_remove": ["LPTICKER"],
         "device_name": "STM32F100RB"
     },
     "DISCO_F303VC": {
@@ -1809,7 +1814,7 @@
             }
         },
         "overrides": {"lse_available": 0},
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "FLASH"],
         "default_lib": "small",
         "release_versions": ["2"],
         "device_name": "STM32L053C8"
@@ -1831,7 +1836,7 @@
             }
         },
         "detect_code": ["0833"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L072CZ"
     },
@@ -1841,6 +1846,7 @@
         "extra_labels_add": ["STM32L0", "STM32L0x2xZ", "STM32L082CZ", "STM32L082xx"],
         "detect_code": ["0456"],
         "device_has_add": ["ANALOGOUT", "SERIAL_FC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_remove": ["LPTICKER"],
         "release_versions": ["5"],
         "device_name": "STM32L082CZ"
     },
@@ -1866,7 +1872,7 @@
         },
         "detect_code": ["0815"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746NG"
@@ -1889,7 +1895,7 @@
         },
         "detect_code": ["0817"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F769NI"
@@ -1912,7 +1918,7 @@
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L475VG",
         "bootloader_supported": true
@@ -1934,7 +1940,7 @@
         },
         "detect_code": ["0820"],
         "macros_add": ["USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476VG",
         "bootloader_supported": true
@@ -2097,7 +2103,7 @@
         "extra_labels_add": ["STM32F4", "STM32F439", "STM32F439ZI","STM32F439xx", "STM32F439xI"],
         "macros": ["MBEDTLS_CONFIG_HW_SUPPORT", "HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000", "CB_INTERFACE_SDIO","CB_CHIP_WL18XX","SUPPORT_80211D_ALWAYS","WLAN_ENABLED","MBEDTLS_ARC4_C","MBEDTLS_DES_C","MBEDTLS_MD4_C","MBEDTLS_MD5_C","MBEDTLS_SHA1_C"],
         "device_has_add": ["CAN", "EMAC", "TRNG", "FLASH"],
-        "device_has_remove": ["RTC", "SLEEP"],
+        "device_has_remove": ["RTC", "SLEEP", "LPTICKER"],
         "features": ["LWIP"],
         "device_name": "STM32F439ZI",
         "public": false,
@@ -3677,7 +3683,7 @@
         "extra_labels_add": ["STM32F1", "STM32F103C8"],
         "supported_toolchains": ["GCC_ARM"],
         "device_has_add": [],
-        "device_has_remove": ["RTC", "STDIO_MESSAGES"]
+        "device_has_remove": ["RTC", "STDIO_MESSAGES", "LPTICKER"]
     },
     "NUMAKER_PFM_NUC472": {
         "core": "Cortex-M4F",
@@ -3901,7 +3907,7 @@
             }
         },
         "detect_code": ["0822"],
-        "device_has_add": ["ANALOGOUT", "CAN", "LPTICKER", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L496AG"
     },
@@ -3922,7 +3928,7 @@
             }
         },
         "detect_code": ["0823"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L496ZG"
     },


### PR DESCRIPTION
### Description

STM32 LPTICKER update for targets supporting RTC

This completes #6474
And should be the last PR from ST in the ticker feature branch

Targets: 
 - STM32L1, STM32F0, STM32F3, most of STM32F4
 - STM32L0, STM32L4, STM32F7 and few STM32F4 if user decides to disable lpticker_lptim config

@bulislaw @c1728p9 @screamerbg


### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

