### PR TITLE
Lora: Fix max tx power check

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -880,9 +880,7 @@ bool LoRaPHY::tx_config(tx_config_params_t* tx_conf, int8_t* tx_power,
     band_t *bands = (band_t *)phy_params.bands.table;
 
     // limit TX power if set to too much
-    if (tx_conf->tx_power > bands[band_idx].max_tx_pwr) {
-        tx_conf->tx_power = bands[band_idx].max_tx_pwr;
-    }
+    tx_conf->tx_power = MAX(tx_conf->tx_power, bands[band_idx].max_tx_pwr);
 
     uint8_t bandwidth = get_bandwidth(tx_conf->datarate);
     int8_t phy_tx_power = 0;


### PR DESCRIPTION

### Description

In LoRa TX power value 0 means the maximum allowed TX power and values >0
are limiting the allowed TX power to lower.

tx_config was incorrectly checking the power level and causing the maximum
TX power to be always used. Lora gateway can request node to use lower TX
power with LinkAdrReq MAC command.

This fix proposal has been tested with our internal LoRa tests.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

