### PR TITLE
BLE: Conditional compilation of H4 driver

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/doc/PortingGuide.md
@@ -93,8 +93,10 @@ More information about the architecture can be found in the
 
 #### HCITransport 
 
-> **Note:** If the Bluetooth controller uses an H4 communication interface, this 
-step can be skipped.
+> **Note:** If the Bluetooth controller uses an H4 communication interface and
+the host exposes serial flow control in mbed then this step can be skipped and
+the class `ble::vendor::cordio::H4TransportDriver` can be used as the transport
+driver.
 
 An empty transport driver can be coded as: 
 

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.cpp
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#if DEVICE_SERIAL && DEVICE_SERIAL_FC
+
 #include "H4TransportDriver.h"
 
 namespace ble {
@@ -68,3 +70,5 @@ void H4TransportDriver::on_controller_irq()
 } // namespace cordio
 } // namespace vendor
 } // namespace ble
+
+#endif

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
@@ -17,6 +17,8 @@
 #ifndef CORDIO_H4_TRANSPORT_DRIVER_H_
 #define CORDIO_H4_TRANSPORT_DRIVER_H_
 
+#if (DEVICE_SERIAL && DEVICE_SERIAL_FC) || defined(DOXYGEN_ONLY)
+
 #include <stdint.h>
 #include "mbed.h"
 #include "CordioHCITransportDriver.h"
@@ -27,6 +29,9 @@ namespace cordio {
 
 /**
  * Implementation of the H4 driver.
+ *
+ * @note This HCI transport implementation is not accessible to devices that do
+ * not expose serial flow control.
  */
 class H4TransportDriver : public CordioHCITransportDriver {
 public:
@@ -72,5 +77,7 @@ private:
 } // namespace cordio
 } // namespace vendor
 } // namespace ble
+
+#endif
 
 #endif /* CORDIO_H4_TRANSPORT_DRIVER_H_ */


### PR DESCRIPTION
### Description

The H4 driver requires UART to exposes flow control; this patch prevents symbol definition and compilation of the driver if `DEVICE_SERIAL_FC` is not defined by the target.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

