### PR TITLE
nrf5x: Fix assert test on SERIAL_RESERVED_CHAR_MATCH

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
@@ -1697,7 +1697,7 @@ void serial_rx_asynch(serial_t *obj, void *rx, size_t rx_length, uint8_t rx_widt
     MBED_ASSERT(obj);
     MBED_ASSERT(rx_width == 8);
     MBED_ASSERT(rx_length < 256);
-    MBED_ASSERT(char_match == SERIAL_RESERVED_CHAR_MATCH);
+    MBED_ASSERT(char_match == SERIAL_RESERVED_CHAR_MATCH);  // EasyDMA based UART handling does not support char_match
 
     int instance = obj->serial.instance;
 


### PR DESCRIPTION
### Description

I'm migrating an existing project to the recently-merged nrf52 / sdk 14.2 codebase in master.
I use a uart serial with match character for automatic depacketizing.

On current master I now get an assert fail as it's testing that  `char_match == SERIAL_RESERVED_CHAR_MATCH` where I believe it should be the opposite; `char_match` should not be allowed to be  `SERIAL_RESERVED_CHAR_MATCH`

This is with GCC and the debug.json build profile.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

