### PR TITLE
Add platform setup and teardown calls to mbedtls tests

### DIFF
--- a/TESTS/mbedtls/multi/main.cpp
+++ b/TESTS/mbedtls/multi/main.cpp
@@ -23,6 +23,17 @@
 
 #include "mbedtls/sha256.h"
 
+#if defined(MBEDTLS_PLATFORM_C)
+#include "mbedtls/platform.h"
+#else
+#include <stdio.h>
+#include <stdlib.h>
+#define mbedtls_printf     printf
+#define mbedtls_snprintf   snprintf
+#define mbedtls_exit       exit
+#define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
+#define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
+#endif
 
 using namespace utest::v1;
 
@@ -163,5 +174,18 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {
 Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
 
 int main() {
-    Harness::run(specification);
+    int ret = 0;
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_context platform_ctx;
+    if((ret = mbedtls_platform_setup(&platform_ctx))!= 0)
+    {
+        mbedtls_printf("Mbed TLS selftest failed! mbedtls_platform_setup returned %d\n", ret);
+        return 1;
+    }
+#endif
+    ret = (Harness::run(specification) ? 0 : 1);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(&platform_ctx);
+#endif
+    return ret;
 }

--- a/TESTS/mbedtls/multi/main.cpp
+++ b/TESTS/mbedtls/multi/main.cpp
@@ -27,12 +27,7 @@
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
-#include <stdlib.h>
 #define mbedtls_printf     printf
-#define mbedtls_snprintf   snprintf
-#define mbedtls_exit       exit
-#define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
-#define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
 
 using namespace utest::v1;
@@ -179,7 +174,7 @@ int main() {
     mbedtls_platform_context platform_ctx;
     if((ret = mbedtls_platform_setup(&platform_ctx))!= 0)
     {
-        mbedtls_printf("Mbed TLS selftest failed! mbedtls_platform_setup returned %d\n", ret);
+        mbedtls_printf("Mbed TLS multitest failed! mbedtls_platform_setup returned %d\n", ret);
         return 1;
     }
 #endif

--- a/TESTS/mbedtls/selftest/main.cpp
+++ b/TESTS/mbedtls/selftest/main.cpp
@@ -97,6 +97,19 @@ utest::v1::status_t test_setup(const size_t num_cases) {
 Specification specification(test_setup, cases);
 
 int main() {
-    return !Harness::run(specification);
+    int ret = 0;
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_context platform_ctx;
+    if((ret = mbedtls_platform_setup(&platform_ctx))!= 0)
+    {
+        mbedtls_printf("Mbed TLS selftest failed! mbedtls_platform_setup returned %d\n", ret);
+        return 1;
+    }
+#endif
+    ret = (Harness::run(specification) ? 0 : 1);
+#if defined(MBEDTLS_PLATFORM_C)
+    mbedtls_platform_teardown(&platform_ctx);
+#endif
+    return ret;
 }
 

--- a/TESTS/mbedtls/selftest/main.cpp
+++ b/TESTS/mbedtls/selftest/main.cpp
@@ -39,12 +39,7 @@ using namespace utest::v1;
 #include "mbedtls/platform.h"
 #else
 #include <stdio.h>
-#include <stdlib.h>
 #define mbedtls_printf     printf
-#define mbedtls_snprintf   snprintf
-#define mbedtls_exit       exit
-#define MBEDTLS_EXIT_SUCCESS EXIT_SUCCESS
-#define MBEDTLS_EXIT_FAILURE EXIT_FAILURE
 #endif
 
 #define MBEDTLS_SELF_TEST_TEST_CASE(self_test_function) \


### PR DESCRIPTION
### Description

This test adds platform setup and teardown calls to Mbed TLS tests, so that all of the custom cryptographic hardware setup can be performed before running any tests. This has been tested using the current head of mbed-os master, on K64F with GCC_ARM.


### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

