### PR TITLE
Add non-blocking DNS functionality to network interface

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/LWIPStack.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPStack.cpp
@@ -207,11 +207,6 @@ void LWIP::tcpip_thread_callback(void *ptr)
     }
 }
 
-nsapi_error_t LWIP::call(mbed::Callback<void()> func)
-{
-    return call_in(0, func);
-}
-
 nsapi_error_t LWIP::call_in(int delay, mbed::Callback<void()> func)
 {
     lwip_callback *cb = new lwip_callback;
@@ -227,6 +222,12 @@ nsapi_error_t LWIP::call_in(int delay, mbed::Callback<void()> func)
     }
 
     return NSAPI_ERROR_OK;
+}
+
+LWIP::call_in_callback_cb_t LWIP::get_call_in_callback()
+{
+    call_in_callback_cb_t cb(this, &LWIP::call_in);
+    return cb;
 }
 
 const char *LWIP::get_ip_address()

--- a/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
@@ -209,27 +209,6 @@ public:
      */
     virtual nsapi_error_t get_dns_server(int index, SocketAddress *address);
 
-    /** Call a callback
-     *
-     *  Call a callback from the network stack context. If returns error
-     *  callback will not be called.
-     *
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call(mbed::Callback<void()> func);
-
-    /** Call a callback after a delay
-     *
-     *  Call a callback from the network stack context after a delay. If
-     *  returns error callback will not be called.
-     *
-     *  @param delay    Delay in milliseconds
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
-
     /** Get the local IP address
      *
      *  @return         Null-terminated representation of the local IP address
@@ -437,6 +416,37 @@ protected:
     virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level,
                                      int optname, void *optval, unsigned *optlen);
 private:
+
+    /** Call in callback
+      *
+      *  Callback is used to call the call in method of the network stack.
+      */
+    typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_cb)> call_in_callback_cb_t;
+
+    /** Get a call in callback
+     *
+     *  Get a call in callback from the network stack context.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
+     *
+     *  @return         Call in callback
+     */
+    virtual call_in_callback_cb_t get_call_in_callback();
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If function
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
 
     struct mbed_lwip_socket {
         bool in_use;

--- a/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPStack.h
@@ -198,29 +198,44 @@ public:
      */
     nsapi_error_t _add_ppp_interface(void *pcb, bool default_if, LWIP::Interface **interface_out);
 
-    /** Translates a hostname to an IP address with specific version
+    /** Get a domain name server from a list of servers to query
      *
-     *  The hostname may be either a domain name or an IP address. If the
-     *  hostname is an IP address, no network transactions will be performed.
+     *  Returns a DNS server address for a index. If returns error no more
+     *  DNS servers to read.
      *
-     *  If no stack-specific DNS resolution is provided, the hostname
-     *  will be resolve using a UDP socket on the stack.
-     *
-     *  @param host     Hostname to resolve
-     *  @param address  Destination for the host SocketAddress
-     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
-     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t gethostbyname(const char *host,
-            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
-
-    /** Add a domain name server to list of servers to query
-     *
+     *  @param index    Index of the DNS server, starts from zero
      *  @param address  Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t add_dns_server(const SocketAddress &address);
+    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address);
+
+    /** Call a callback
+     *
+     *  Call a callback from the network stack context. If returns error
+     *  callback will not be called.
+     *
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call(mbed::Callback<void()> func);
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
+
+    /** Get the local IP address
+     *
+     *  @return         Null-terminated representation of the local IP address
+     *                  or null if not yet connected
+     */
+    virtual const char *get_ip_address();
 
 protected:
     LWIP();
@@ -439,6 +454,11 @@ private:
         uint32_t         multicast_memberships_registry;
     };
 
+    struct lwip_callback {
+        unsigned int delay;
+        mbed::Callback<void()> callback;
+    };
+
     static nsapi_error_t err_remap(err_t err);
     static bool is_local_addr(const ip_addr_t *ip_addr);
     static const ip_addr_t *get_ip_addr(bool any_addr, const struct netif *netif);
@@ -475,9 +495,14 @@ private:
     static void socket_callback(struct netconn *nc, enum netconn_evt eh, u16_t len);
 
     static void tcpip_init_irq(void *handle);
+    static void tcpip_thread_callback(void *ptr);
+
+    char ip_address[40];
     rtos::Semaphore tcpip_inited;
     Interface *default_interface;
     LWIPMemoryManager memory_manager;
+    osThreadId tcpip_thread_id;
+    rtos::Mutex adaptation;
 };
 
 #endif /* LWIPSTACK_H_ */

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -480,6 +480,24 @@ void sys_msleep(u32_t ms) {
     osDelay(ms);
 }
 
+osThreadId_t lwip_tcpip_thread_id = 0;
+
+bool sys_tcpip_thread_set(void)
+{
+    lwip_tcpip_thread_id = osThreadGetId();
+}
+
+bool sys_tcpip_thread_check(void)
+{
+    osThreadId_t thread_id = osThreadGetId();
+
+    if (thread_id == lwip_tcpip_thread_id) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 // Keep a pool of thread structures
 static int thread_pool_index = 0;
 static sys_thread_data_t thread_pool[SYS_THREAD_POOL_N];

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -482,20 +482,14 @@ void sys_msleep(u32_t ms) {
 
 osThreadId_t lwip_tcpip_thread_id = 0;
 
-bool sys_tcpip_thread_set(void)
+void sys_tcpip_thread_set(void)
 {
     lwip_tcpip_thread_id = osThreadGetId();
 }
 
 bool sys_tcpip_thread_check(void)
 {
-    osThreadId_t thread_id = osThreadGetId();
-
-    if (thread_id == lwip_tcpip_thread_id) {
-        return true;
-    } else {
-        return false;
-    }
+    return osThreadGetId() == lwip_tcpip_thread_id;
 }
 
 // Keep a pool of thread structures

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
@@ -85,6 +85,9 @@ typedef sys_thread_data_t* sys_thread_t;
 // === PROTECTION ===
 typedef int sys_prot_t;
 
+bool sys_tcpip_thread_set(void);
+bool sys_tcpip_thread_check(void);
+
 #else
 #ifdef  __cplusplus
 extern "C" {

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/sys_arch.h
@@ -85,7 +85,7 @@ typedef sys_thread_data_t* sys_thread_t;
 // === PROTECTION ===
 typedef int sys_prot_t;
 
-bool sys_tcpip_thread_set(void);
+void sys_tcpip_thread_set(void);
 bool sys_tcpip_thread_check(void);
 
 #else

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_lib.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_lib.c
@@ -102,11 +102,18 @@ netconn_apimsg(tcpip_callback_fn fn, struct api_msg *apimsg)
   apimsg->op_completed_sem = LWIP_NETCONN_THREAD_SEM_GET();
 #endif /* LWIP_NETCONN_SEM_PER_THREAD */
 
-  err = tcpip_send_msg_wait_sem(fn, apimsg, LWIP_API_MSG_SEM(apimsg));
-  if (err == ERR_OK) {
-    return apimsg->err;
+  if (sys_tcpip_thread_check()) {
+      fn(apimsg);
+      return ERR_OK;
+  } else {
+      err = tcpip_send_msg_wait_sem(fn, apimsg, LWIP_API_MSG_SEM(apimsg));
+
+      if (err == ERR_OK) {
+        return apimsg->err;
+      }
+
+      return err;
   }
-  return err;
 }
 
 /**

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_lib.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_lib.c
@@ -910,6 +910,8 @@ netconn_join_leave_group(struct netconn *conn,
 #endif /* LWIP_IGMP || (LWIP_IPV6 && LWIP_IPV6_MLD) */
 
 #if LWIP_DNS
+#if LWIP_FULL_DNS
+
 /**
  * @ingroup netconn_common
  * Execute a DNS query, only one IP address is returned
@@ -989,6 +991,8 @@ netconn_gethostbyname(const char *name, ip_addr_t *addr)
   API_VAR_FREE(MEMP_DNS_API_MSG, msg);
   return err;
 }
+
+#endif /* LWIP_FULL_DNS */
 #endif /* LWIP_DNS*/
 
 #if LWIP_NETCONN_SEM_PER_THREAD

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_msg.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/api/lwip_api_msg.c
@@ -1892,6 +1892,7 @@ lwip_netconn_do_join_leave_group(void *m)
 #endif /* LWIP_IGMP || (LWIP_IPV6 && LWIP_IPV6_MLD) */
 
 #if LWIP_DNS
+#if LWIP_FULL_DNS
 /**
  * Callback function that is called when DNS name is resolved
  * (or on timeout). A waiting application thread is waked up by
@@ -1943,5 +1944,6 @@ lwip_netconn_do_gethostbyname(void *arg)
   }
 }
 #endif /* LWIP_DNS */
+#endif /* LWIP_FULL_DNS */
 
 #endif /* LWIP_NETCONN */

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_dns.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/core/lwip_dns.c
@@ -283,16 +283,18 @@ static void dns_init_local(void);
 static err_t dns_lookup_local(const char *hostname, ip_addr_t *addr LWIP_DNS_ADDRTYPE_ARG(u8_t dns_addrtype));
 #endif /* DNS_LOCAL_HOSTLIST */
 
-
+#if LWIP_FULL_DNS
 /* forward declarations */
 static void dns_recv(void *s, struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *addr, u16_t port);
 static void dns_check_entries(void);
 static void dns_call_found(u8_t idx, ip_addr_t* addr);
+#endif
 
 /*-----------------------------------------------------------------------------
  * Globals
  *----------------------------------------------------------------------------*/
 
+#if LWIP_FULL_DNS
 /* DNS variables */
 static struct udp_pcb        *dns_pcbs[DNS_MAX_SOURCE_PORTS];
 #if ((LWIP_DNS_SECURE & LWIP_DNS_SECURE_RAND_SRC_PORT) != 0)
@@ -301,6 +303,7 @@ static u8_t                   dns_last_pcb_idx;
 static u8_t                   dns_seqno;
 static struct dns_table_entry dns_table[DNS_TABLE_SIZE];
 static struct dns_req_entry   dns_requests[DNS_MAX_REQUESTS];
+#endif
 static ip_addr_t              dns_servers[DNS_MAX_SERVERS];
 
 #if LWIP_IPV4
@@ -324,6 +327,7 @@ dns_init(void)
   dns_setserver(0, &dnsserver);
 #endif /* DNS_SERVER_ADDRESS */
 
+#if LWIP_FULL_DNS
   LWIP_ASSERT("sanity check SIZEOF_DNS_QUERY",
     sizeof(struct dns_query) == SIZEOF_DNS_QUERY);
   LWIP_ASSERT("sanity check SIZEOF_DNS_ANSWER",
@@ -351,6 +355,7 @@ dns_init(void)
 #if DNS_LOCAL_HOSTLIST
   dns_init_local();
 #endif
+#endif /* LWIP_FULL_DNS */
 }
 
 /**
@@ -397,9 +402,13 @@ dns_getserver(u8_t numdns)
 void
 dns_tmr(void)
 {
+#if LWIP_FULL_DNS
   LWIP_DEBUGF(DNS_DEBUG, ("dns_tmr: dns_check_entries\n"));
   dns_check_entries();
+#endif
 }
+
+#if LWIP_FULL_DNS
 
 #if DNS_LOCAL_HOSTLIST
 static void
@@ -1569,5 +1578,7 @@ dns_gethostbyname_addrtype(const char *hostname, ip_addr_t *addr, dns_found_call
   return dns_enqueue(hostname, hostnamelen, found, callback_arg LWIP_DNS_ADDRTYPE_ARG(dns_addrtype)
      LWIP_DNS_ISMDNS_ARG(is_mdns));
 }
+
+#endif /* LWIP_FULL_DNS */
 
 #endif /* LWIP_DNS */

--- a/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/api.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwip/src/include/lwip/api.h
@@ -290,8 +290,8 @@ struct netconn {
 /** @ingroup netconn_common
  * Create new netconn connection
  * @param t @ref netconn_type */
-#define netconn_new(t)                  netconn_new_with_proto_and_callback(t, 0, NULL)
-#define netconn_new_with_callback(t, c) netconn_new_with_proto_and_callback(t, 0, c)
+#define netconn_new(t)                             netconn_new_with_proto_and_callback(t, 0, NULL)
+#define netconn_new_with_callback(t, c)            netconn_new_with_proto_and_callback(t, 0, c)
 struct netconn *netconn_new_with_proto_and_callback(enum netconn_type t, u8_t proto,
                                              netconn_callback callback);
 err_t   netconn_delete(struct netconn *conn);

--- a/features/FEATURE_LWIP/lwip-interface/lwip_tools.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/lwip_tools.cpp
@@ -157,19 +157,22 @@ void LWIP::arena_init(void)
 
 struct LWIP::mbed_lwip_socket *LWIP::arena_alloc()
 {
-    sys_prot_t prot = sys_arch_protect();
+    LWIP &lwip = LWIP::get_instance();
+
+    lwip.adaptation.lock();
 
     for (int i = 0; i < MEMP_NUM_NETCONN; i++) {
         if (!arena[i].in_use) {
             struct mbed_lwip_socket *s = &arena[i];
             memset(s, 0, sizeof(*s));
             s->in_use = true;
-            sys_arch_unprotect(prot);
+            lwip.adaptation.unlock();
             return s;
         }
     }
 
-    sys_arch_unprotect(prot);
+    lwip.adaptation.unlock();
+
     return 0;
 }
 

--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -214,6 +214,8 @@
 #endif
 
 #define LWIP_DNS                    1
+// Only DNS address storage is enabled
+#define LWIP_FULL_DNS               0
 #define LWIP_SOCKET                 0
 
 #define SO_REUSE                    1

--- a/features/nanostack/nanostack-interface/Nanostack.cpp
+++ b/features/nanostack/nanostack-interface/Nanostack.cpp
@@ -461,11 +461,6 @@ void Nanostack::call_event_tasklet_main(arm_event_s *event)
     }
 }
 
-nsapi_error_t Nanostack::call(mbed::Callback<void()> func)
-{
-    return call_in(0, func);
-}
-
 nsapi_error_t Nanostack::call_in(int delay, mbed::Callback<void()> func)
 {
     if (call_event_tasklet < 0) {
@@ -494,15 +489,23 @@ nsapi_error_t Nanostack::call_in(int delay, mbed::Callback<void()> func)
     if (delay) {
         uint32_t ticks = eventOS_event_timer_ms_to_ticks(delay);
         if (!eventOS_event_send_in(&event, ticks)) {
+            delete cb;
             return NSAPI_ERROR_NO_MEMORY;
         }
     } else {
         if (eventOS_event_send(&event) < 0) {
+            delete cb;
             return NSAPI_ERROR_NO_MEMORY;
         }
     }
 
     return NSAPI_ERROR_OK;
+}
+
+Nanostack::call_in_callback_cb_t Nanostack::get_call_in_callback()
+{
+    call_in_callback_cb_t cb(this, &Nanostack::call_in);
+    return cb;
 }
 
 const char * Nanostack::get_ip_address()

--- a/features/nanostack/nanostack-interface/Nanostack.h
+++ b/features/nanostack/nanostack-interface/Nanostack.h
@@ -44,27 +44,6 @@ public:
     /* Local variant with stronger typing and manual address specification */
     nsapi_error_t add_ethernet_interface(EMAC &emac, bool default_if, Nanostack::EthernetInterface **interface_out, const uint8_t *mac_addr = NULL);
 
-    /** Call a callback
-     *
-     *  Call a callback from the network stack context. If returns error
-     *  callback will not be called.
-     *
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call(mbed::Callback<void()> func);
-
-    /** Call a callback after a delay
-     *
-     *  Call a callback from the network stack context after a delay. If
-     *  returns error callback will not be called.
-     *
-     *  @param delay    Delay in milliseconds
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
-
 protected:
 
     Nanostack();
@@ -266,6 +245,38 @@ protected:
     virtual nsapi_error_t getsockopt(void *handle, int level, int optname, void *optval, unsigned *optlen);
 
 private:
+
+    /** Call in callback
+      *
+      *  Callback is used to call the call in method of the network stack.
+      */
+    typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_cb)> call_in_callback_cb_t;
+
+    /** Get a call in callback
+     *
+     *  Get a call in callback from the network stack context.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
+     *
+     *  @return         Call in callback
+     */
+    virtual call_in_callback_cb_t get_call_in_callback();
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If function
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
+
     struct nanostack_callback {
         mbed::Callback<void()> callback;
     };

--- a/features/netsocket/DNS.h
+++ b/features/netsocket/DNS.h
@@ -69,11 +69,12 @@ public:
      *  @param callback Callback that is called for result
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
-     *  @return         0 on success, negative error code on failure or an unique id that
-     *                  represents the hostname translation operation and can be passed to
-     *                  cancel
+     *  @return         0 on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique id that represents the hostname translation operation
+     *                  and can be passed to cancel
      */
-    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
             nsapi_version_t version = NSAPI_UNSPEC) = 0;
 
     /** Cancels asynchronous hostname translation
@@ -83,7 +84,7 @@ public:
      *  @param id       Unique id of the hostname translation operation
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t gethostbyname_async_cancel(nsapi_error_t id) = 0;
+    virtual nsapi_error_t gethostbyname_async_cancel(int id) = 0;
 
     /** Add a domain name server to list of servers to query
      *

--- a/features/netsocket/DNS.h
+++ b/features/netsocket/DNS.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef DNS_H
+#define DNS_H
+
+class DNS {
+public:
+
+    /** Translates a hostname to an IP address with specific version
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param host     Hostname to resolve
+     *  @param address  Destination for the host SocketAddress
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname(const char *host,
+            SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC) = 0;
+
+    /** Hostname translation callback (asynchronous)
+     *
+     *  Callback will be called after DNS resolution completes or a failure occurs.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
+     *
+     *  @param status  0 on success, negative error code on failure
+     *  @param address On success, destination for the host SocketAddress
+     */
+    typedef mbed::Callback<void (nsapi_error_t result, SocketAddress *address)> hostbyname_cb_t;
+
+    /** Translates a hostname to an IP address (asynchronous)
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  Call is non-blocking. Result of the DNS operation is returned by the callback.
+     *  If this function returns failure, callback will not be called. In case result
+     *  is success (IP address was found from DNS cache), callback will be called
+     *  before function returns.
+     *
+     *  @param host     Hostname to resolve
+     *  @param callback Callback that is called for result
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure or an unique id that
+     *                  represents the hostname translation operation and can be passed to
+     *                  cancel
+     */
+    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
+            nsapi_version_t version = NSAPI_UNSPEC) = 0;
+
+    /** Cancels asynchronous hostname translation
+     *
+     *  When translation is cancelled, callback will not be called.
+     *
+     *  @param id       Unique id of the hostname translation operation
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname_async_cancel(nsapi_error_t id) = 0;
+
+    /** Add a domain name server to list of servers to query
+     *
+     *  @param address  Destination for the host address
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t add_dns_server(const SocketAddress &address) = 0;
+};
+
+#endif

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -60,9 +60,14 @@ nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *a
     return get_stack()->gethostbyname(name, address, version);
 }
 
-nsapi_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, void *data, nsapi_version_t version)
+nsapi_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version)
 {
-    return get_stack()->gethostbyname_async(host, callback, data, version);
+    return get_stack()->gethostbyname_async(host, callback, version);
+}
+
+nsapi_error_t NetworkInterface::gethostbyname_async_cancel(nsapi_error_t handle)
+{
+    return get_stack()->gethostbyname_async_cancel(handle);
 }
 
 nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -60,6 +60,11 @@ nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *a
     return get_stack()->gethostbyname(name, address, version);
 }
 
+nsapi_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, void *data, nsapi_version_t version)
+{
+    return get_stack()->gethostbyname_async(host, callback, data, version);
+}
+
 nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)
 {
     return get_stack()->add_dns_server(address);

--- a/features/netsocket/NetworkInterface.cpp
+++ b/features/netsocket/NetworkInterface.cpp
@@ -60,14 +60,14 @@ nsapi_error_t NetworkInterface::gethostbyname(const char *name, SocketAddress *a
     return get_stack()->gethostbyname(name, address, version);
 }
 
-nsapi_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version)
+nsapi_value_or_error_t NetworkInterface::gethostbyname_async(const char *host, hostbyname_cb_t callback, nsapi_version_t version)
 {
     return get_stack()->gethostbyname_async(host, callback, version);
 }
 
-nsapi_error_t NetworkInterface::gethostbyname_async_cancel(nsapi_error_t handle)
+nsapi_error_t NetworkInterface::gethostbyname_async_cancel(int id)
 {
-    return get_stack()->gethostbyname_async_cancel(handle);
+    return get_stack()->gethostbyname_async_cancel(id);
 }
 
 nsapi_error_t NetworkInterface::add_dns_server(const SocketAddress &address)

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -161,11 +161,12 @@ public:
      *  @param callback Callback that is called for result
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
-     *  @return         0 on success, negative error code on failure or an unique id that
-     *                  represents the hostname translation operation and can be passed to
-     *                  cancel
+     *  @return         0 on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique id that represents the hostname translation operation
+     *                  and can be passed to cancel
      */
-    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
             nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Cancels asynchronous hostname translation
@@ -175,7 +176,7 @@ public:
      *  @param id       Unique id of the hostname translation operation
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t gethostbyname_async_cancel(nsapi_error_t id);
+    virtual nsapi_error_t gethostbyname_async_cancel(int id);
 
     /** Add a domain name server to list of servers to query
      *

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -127,6 +127,38 @@ public:
     virtual nsapi_error_t gethostbyname(const char *host,
             SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
+    /** Hostname translation callback (asynchronous)
+     *
+     *  Callback will be called after DNS resolution completes or a failure
+     *  occurs.
+     *
+     *  @param status  0 on success, negative error code on failure
+     *  @param address On success, destination for the host SocketAddress
+     *  @param data    Caller defined data
+     */
+    typedef mbed::Callback<void (nsapi_error_t result, SocketAddress *address, void *data)> hostbyname_cb_t;
+
+    /** Translates a hostname to an IP address (asynchronous)
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  Call is non-blocking. Result of the DNS operation is returned by the callback.
+     *  If this function returns failure, callback will not be called.
+     *
+     *  @param host     Hostname to resolve
+     *  @param callback Callback that is called for result
+     *  @param data     Caller defined data returned in callback
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, void *data,
+            nsapi_version_t version = NSAPI_UNSPEC);
+
     /** Add a domain name server to list of servers to query
      *
      *  @param address  Destination for the host address

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -49,7 +49,7 @@ nsapi_error_t NetworkStack::gethostbyname(const char *name, SocketAddress *addre
     return nsapi_dns_query(this, name, address, version);
 }
 
-nsapi_error_t NetworkStack::gethostbyname_async(const char *name, hostbyname_cb_t callback, nsapi_version_t version)
+nsapi_value_or_error_t NetworkStack::gethostbyname_async(const char *name, hostbyname_cb_t callback, nsapi_version_t version)
 {
     SocketAddress address;
 
@@ -77,9 +77,9 @@ nsapi_error_t NetworkStack::gethostbyname_async(const char *name, hostbyname_cb_
     return nsapi_dns_query_async(this, name, callback, call_in_cb, version);
 }
 
-nsapi_error_t NetworkStack::gethostbyname_async_cancel(nsapi_error_t handle)
+nsapi_error_t NetworkStack::gethostbyname_async_cancel(int id)
 {
-    return nsapi_dns_query_async_cancel(handle);
+    return nsapi_dns_query_async_cancel(id);
 }
 
 nsapi_error_t NetworkStack::add_dns_server(const SocketAddress &address)
@@ -115,6 +115,7 @@ nsapi_error_t NetworkStack::getsockopt(void *handle, int level, int optname, voi
 nsapi_error_t NetworkStack::call_in(int delay, mbed::Callback<void()> func)
 {
     events::EventQueue *event_queue = mbed::mbed_event_queue();
+
     if (!event_queue) {
         return NSAPI_ERROR_NO_MEMORY;
     }
@@ -132,19 +133,11 @@ nsapi_error_t NetworkStack::call_in(int delay, mbed::Callback<void()> func)
     return NSAPI_ERROR_OK;
 }
 
-typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_cb)> call_in_callback_cb_t;
-
 call_in_callback_cb_t NetworkStack::get_call_in_callback()
 {
-    events::EventQueue *event_queue = mbed::mbed_event_queue();
-    if (!event_queue) {
-        return NULL;
-    }
-
     call_in_callback_cb_t cb(this, &NetworkStack::call_in);
     return cb;
 }
-
 
 // NetworkStackWrapper class for encapsulating the raw nsapi_stack structure
 class NetworkStackWrapper : public NetworkStack

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -21,6 +21,7 @@
 #include "nsapi_types.h"
 #include "netsocket/SocketAddress.h"
 #include "netsocket/NetworkInterface.h"
+#include "DNS.h"
 
 // Predeclared classes
 class OnboardNetworkStack;
@@ -33,7 +34,7 @@ class OnboardNetworkStack;
  *  for instantiating network sockets.
  *  @addtogroup netsocket
  */
-class NetworkStack
+class NetworkStack: public DNS
 {
 public:
     virtual ~NetworkStack() {};
@@ -64,14 +65,18 @@ public:
 
     /** Hostname translation callback (asynchronous)
      *
-     *  Callback will be called after DNS resolution completes or a failure
-     *  occurs.
+     *  Callback will be called after DNS resolution completes or a failure occurs.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
      *
      *  @param status  0 on success, negative error code on failure
      *  @param address On success, destination for the host SocketAddress
-     *  @param data    Caller defined data
      */
-    typedef mbed::Callback<void (nsapi_error_t result, SocketAddress *address, void *data)> hostbyname_cb_t;
+    typedef mbed::Callback<void (nsapi_error_t result, SocketAddress *address)> hostbyname_cb_t;
 
     /** Translates a hostname to an IP address (asynchronous)
      *
@@ -82,17 +87,29 @@ public:
      *  will be resolve using a UDP socket on the stack.
      *
      *  Call is non-blocking. Result of the DNS operation is returned by the callback.
-     *  If this function returns failure, callback will not be called.
+     *  If this function returns failure, callback will not be called. In case result
+     *  is success (IP address was found from DNS cache), callback will be called
+     *  before function returns.
      *
      *  @param host     Hostname to resolve
      *  @param callback Callback that is called for result
-     *  @param data     Caller defined data returned in callback
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure or an unique id that
+     *                  represents the hostname translation operation and can be passed to
+     *                  cancel
+     */
+    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
+            nsapi_version_t version = NSAPI_UNSPEC);
+
+    /** Cancels asynchronous hostname translation
+     *
+     *  When translation is cancelled, callback will not be called.
+     *
+     *  @param id       Unique id of the hostname translation operation
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, void *data,
-            nsapi_version_t version = NSAPI_UNSPEC);
+    virtual nsapi_error_t gethostbyname_async_cancel(nsapi_error_t id);
 
     /** Add a domain name server to list of servers to query
      *
@@ -347,8 +364,40 @@ protected:
      */
     virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level,
             int optname, void *optval, unsigned *optlen);
-};
 
+private:
+
+    /** Call in callback
+      *
+      *  Callback is used to call the call in method of the network stack.
+      */
+    typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_cb)> call_in_callback_cb_t;
+
+    /** Get a call in callback
+     *
+     *  Get a call in callback from the network stack context.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
+     *
+     *  @return         Call in callback
+     */
+    virtual call_in_callback_cb_t get_call_in_callback();
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If function
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
+};
 
 /** Convert a raw nsapi_stack_t object into a C++ NetworkStack object
  *

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -22,6 +22,8 @@
 #include "netsocket/SocketAddress.h"
 #include "netsocket/NetworkInterface.h"
 
+// Predeclared classes
+class OnboardNetworkStack;
 
 /** NetworkStack class
  *
@@ -37,13 +39,10 @@ public:
     virtual ~NetworkStack() {};
 
     /** Get the local IP address
-     *  @deprecated
      *
      *  @return         Null-terminated representation of the local IP address
      *                  or null if not yet connected
      */
-    MBED_DEPRECATED_SINCE("mbed-os-5.7",
-        "Use NetworkInterface::get_ip_address()")
     virtual const char *get_ip_address();
 
     /** Translates a hostname to an IP address with specific version
@@ -63,12 +62,55 @@ public:
     virtual nsapi_error_t gethostbyname(const char *host,
             SocketAddress *address, nsapi_version_t version = NSAPI_UNSPEC);
 
+    /** Hostname translation callback (asynchronous)
+     *
+     *  Callback will be called after DNS resolution completes or a failure
+     *  occurs.
+     *
+     *  @param status  0 on success, negative error code on failure
+     *  @param address On success, destination for the host SocketAddress
+     *  @param data    Caller defined data
+     */
+    typedef mbed::Callback<void (nsapi_error_t result, SocketAddress *address, void *data)> hostbyname_cb_t;
+
+    /** Translates a hostname to an IP address (asynchronous)
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  Call is non-blocking. Result of the DNS operation is returned by the callback.
+     *  If this function returns failure, callback will not be called.
+     *
+     *  @param host     Hostname to resolve
+     *  @param callback Callback that is called for result
+     *  @param data     Caller defined data returned in callback
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback, void *data,
+            nsapi_version_t version = NSAPI_UNSPEC);
+
     /** Add a domain name server to list of servers to query
      *
      *  @param address  Destination for the host address
      *  @return         0 on success, negative error code on failure
      */
     virtual nsapi_error_t add_dns_server(const SocketAddress &address);
+
+    /** Get a domain name server from a list of servers to query
+     *
+     *  Returns a DNS server address for a index. If returns error no more
+     *  DNS servers to read.
+     *
+     *  @param index    Index of the DNS server, starts from zero
+     *  @param address  Destination for the host address
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t get_dns_server(int index, SocketAddress *address);
 
     /*  Set stack options
      *
@@ -100,6 +142,9 @@ public:
      *  @return         0 on success, negative error code on failure
      */
     virtual nsapi_error_t getstackopt(int level, int optname, void *optval, unsigned *optlen);
+
+    /** Dynamic downcast to a OnboardNetworkStack */
+    virtual OnboardNetworkStack *onboardNetworkStack() { return 0; }
 
 protected:
     friend class Socket;

--- a/features/netsocket/NetworkStack.h
+++ b/features/netsocket/NetworkStack.h
@@ -95,11 +95,12 @@ public:
      *  @param callback Callback that is called for result
      *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
      *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
-     *  @return         0 on success, negative error code on failure or an unique id that
-     *                  represents the hostname translation operation and can be passed to
-     *                  cancel
+     *  @return         0 on immediate success,
+     *                  negative error code on immediate failure or
+     *                  a positive unique id that represents the hostname translation operation
+     *                  and can be passed to cancel
      */
-    virtual nsapi_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
+    virtual nsapi_value_or_error_t gethostbyname_async(const char *host, hostbyname_cb_t callback,
             nsapi_version_t version = NSAPI_UNSPEC);
 
     /** Cancels asynchronous hostname translation
@@ -109,7 +110,7 @@ public:
      *  @param id       Unique id of the hostname translation operation
      *  @return         0 on success, negative error code on failure
      */
-    virtual nsapi_error_t gethostbyname_async_cancel(nsapi_error_t id);
+    virtual nsapi_error_t gethostbyname_async_cancel(int id);
 
     /** Add a domain name server to list of servers to query
      *

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -39,8 +39,6 @@ public:
      */
     static OnboardNetworkStack &get_default_instance();
 
-    virtual OnboardNetworkStack *onboardNetworkStack() { return this; }
-
     /** Representation of a stack's view of an interface.
      *
      * Provides facilities required by a driver to implement the application
@@ -122,27 +120,6 @@ public:
          */
         virtual char *get_gateway(char *buf, nsapi_size_t buflen) = 0;
     };
-
-    /** Call a callback
-     *
-     *  Call a callback from the network stack context. If returns error
-     *  callback will not be called.
-     *
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call(mbed::Callback<void()> func) = 0;
-
-    /** Call a callback after a delay
-     *
-     *  Call a callback from the network stack context after a delay. If
-     *  returns error callback will not be called.
-     *
-     *  @param delay    Delay in milliseconds
-     *  @param func     Callback to be called
-     *  @return         0 on success, negative error code on failure
-     */
-    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func) = 0;
 
     /** Register a network interface with the IP stack
      *

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -39,6 +39,8 @@ public:
      */
     static OnboardNetworkStack &get_default_instance();
 
+    virtual OnboardNetworkStack *onboardNetworkStack() { return this; }
+
     /** Representation of a stack's view of an interface.
      *
      * Provides facilities required by a driver to implement the application
@@ -121,6 +123,26 @@ public:
         virtual char *get_gateway(char *buf, nsapi_size_t buflen) = 0;
     };
 
+    /** Call a callback
+     *
+     *  Call a callback from the network stack context. If returns error
+     *  callback will not be called.
+     *
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call(mbed::Callback<void()> func) = 0;
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func) = 0;
 
     /** Register a network interface with the IP stack
      *

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -4,15 +4,15 @@
         "present": 1,
         "default-stack": "LWIP",
         "dns-response-wait-time": {
-            "help": "How long the DNS translator waits for a reply from a server",
+            "help": "How long the DNS translator waits for a reply from a server in milliseconds",
             "value": 5000
         },
-        "dns-total-retries": {
-            "help": "Number of total DNS query retries that the DNS translator makes",
+        "dns-total-attempts": {
+            "help": "Number of total DNS query attempts that the DNS translator makes",
             "value": 3
         },
         "dns-retries": {
-            "help": "Number of DNS query retries that the DNS translator makes per server",
+            "help": "Number of DNS query retries that the DNS translator makes per server, before moving on to the next server. Total retries/attempts is always limited by dns-total-attempts.",
             "value": 0
         },
         "dns-cache-size": {

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -2,6 +2,22 @@
     "name": "nsapi",
     "config": {
         "present": 1,
-        "default-stack": "LWIP"
+        "default-stack": "LWIP",
+        "dns-response-wait-time": {
+            "help": "How long the DNS translator waits for a reply from a server",
+            "value": 5000
+        },
+        "dns-total-retries": {
+            "help": "Number of total DNS query retries that the DNS translator makes",
+            "value": 3
+        },
+        "dns-retries": {
+            "help": "Number of DNS query retries that the DNS translator makes per server",
+            "value": 0
+        },
+        "dns-cache-size": {
+            "help": "Number of cached host name resolutions",
+            "value": 3
+        }
     }
 }

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -80,6 +80,19 @@ nsapi_error_t nsapi_dns_query(NetworkStack *stack, const char *host,
  *
  *  @param stack    Network stack as target for DNS query
  *  @param host     Hostname to resolve
+ *  @param callback Callback that is called for result*
+ *  @param data     Caller defined data returned in callback
+ *  @param version  IP version to resolve (defaults to NSAPI_IPv4)
+ *  @return         0 on success, negative error code on failure
+ *                  NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ */
+nsapi_error_t nsapi_dns_query_async(NetworkStack *stack, const char *host,
+        NetworkStack::hostbyname_cb_t callback, void *data, nsapi_version_t version = NSAPI_IPv4);
+
+/** Query a domain name server for an IP address of a given hostname (asynchronous)
+ *
+ *  @param stack    Network stack as target for DNS query
+ *  @param host     Hostname to resolve
  *  @param addr     Destination for the host address
  *  @param version  IP version to resolve (defaults to NSAPI_IPv4)
  *  @return         0 on success, negative error code on failure
@@ -117,6 +130,20 @@ nsapi_error_t nsapi_dns_query(S *stack, const char *host,
 nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *host,
         SocketAddress *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
 
+/** Query a domain name server for an IP address of a given hostname (asynchronous)
+ *
+ *  @param stack      Network stack as target for DNS query
+ *  @param host       Hostname to resolve
+ *  @param callback   Callback that is called for result
+ *  @param data       Caller defined data returned in callback
+ *  @param addr_count Number of addresses allocated in the array
+ *  @param version    IP version to resolve (defaults to NSAPI_IPv4)
+ *  @return           0 on success, negative error code on failure
+ *                    NSAPI_ERROR_DNS_FAILURE indicates the host could not be found
+ */
+nsapi_size_or_error_t nsapi_dns_query_multiple_async(NetworkStack *stack, const char *host,
+        NetworkStack::hostbyname_cb_t callback, void *data, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
+
 /** Query a domain name server for multiple IP address of a given hostname
  *
  *  @param stack      Network stack as target for DNS query
@@ -129,6 +156,7 @@ nsapi_size_or_error_t nsapi_dns_query_multiple(NetworkStack *stack, const char *
  */
 extern "C" nsapi_size_or_error_t nsapi_dns_query_multiple(nsapi_stack_t *stack, const char *host,
         nsapi_addr_t *addr, nsapi_size_t addr_count, nsapi_version_t version = NSAPI_IPv4);
+
 
 /** Query a domain name server for multiple IP address of a given hostname
  *

--- a/features/netsocket/nsapi_dns.h
+++ b/features/netsocket/nsapi_dns.h
@@ -188,6 +188,16 @@ nsapi_size_or_error_t nsapi_dns_query_multiple(S *stack, const char *host,
   */
 nsapi_error_t nsapi_dns_query_async_cancel(nsapi_error_t id);
 
+/** Set a call in callback
+ *
+ *  Can be used to provide an application specific call in callback to
+ *  DNS resolver. When callback is set it is used instead of stack
+ *  specific call in callbacks.
+ *
+ *  @param callback  Callback
+ */
+void nsapi_dns_call_in_set(call_in_callback_cb_t callback);
+
 /** Add a domain name server to list of servers to query
  *
  *  @param addr     Destination for the host address

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -103,6 +103,13 @@ typedef unsigned int nsapi_size_t;
  */
 typedef signed int nsapi_size_or_error_t;
 
+/** Type used to represent either a value or error
+ *
+ *  A valid nsapi_value_or_error_t is either a non-negative value or a
+ *  negative error code from the nsapi_error_t
+ */
+typedef signed int nsapi_value_or_error_t;
+
 /** Enum of encryption types
  *
  *  The security type specifies a particular security to use when


### PR DESCRIPTION
### Description

- Added non-blocking DNS interface to network interface and network stack.
- Added caching of DNS replies.
- Added a network stack function to get DNS addresses from stack.
- Added call and call_in hooks to onboard network stack to allow calling functions from onboard stack context.
- Added support to call and call_in functions to LWIP and Nanostack.
- Disabled LWIP DNS translator with the exception of DNS address storage used in DNS address get.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

