### PR TITLE
IAR: Fixed #6670

### DIFF
--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -16,10 +16,11 @@ limitations under the License.
 """
 import re
 from os import remove
-from os.path import join, splitext, exists
+from os.path import join, splitext, exists, dirname, basename
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
+from tools.utils import mkdir
 
 class IAR(mbedToolchain):
     LIBRARY_EXT = '.a'
@@ -157,14 +158,24 @@ class IAR(mbedToolchain):
 
     @hook_tool
     def assemble(self, source, object, includes):
-        # Build assemble command
-        cmd = self.asm + self.get_compile_options(self.get_symbols(True), includes, True) + ["-o", object, source]
+
+        # Preprocess first, then assemble
+        dir = join(dirname(object), '.temp')
+        mkdir(dir)
+        tempfile = join(dir, basename(object) + '.E.s')
+
+        # Build preprocess assemble command
+        cmd_pre = self.cc + self.get_compile_options(self.get_symbols(True), includes) + ["--preprocess=n", tempfile, source]
+
+        # Build main assemble command
+        cmd = self.asm + ["-o", object, tempfile]
 
         # Call cmdline hook
+        cmd_pre = self.hook.get_cmdline_assembler(cmd_pre)
         cmd = self.hook.get_cmdline_assembler(cmd)
 
         # Return command array, don't execute
-        return [cmd]
+        return [cmd_pre, cmd]
 
     @hook_tool
     def compile(self, cc, source, object, includes):


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This fix implements preprocessing of assembler files similar to the ARM toolchain.

The fix has been tested on the mbed-os-example-blinky example, with the same configuration
changes as described in #6670.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

