### PR TITLE
Re-enable flash clock test for NRF52 but with higher tolerance

### DIFF
--- a/TESTS/mbed_hal/flash/functional_tests/main.cpp
+++ b/TESTS/mbed_hal/flash/functional_tests/main.cpp
@@ -28,7 +28,13 @@
 using namespace utest::v1;
 
 #define TEST_CYCLES         10000000
+
+#ifdef TARGET_NRF52
+/* The increased tolerance is to account for the imprecise timers on the NRF52. */
+#define ALLOWED_DRIFT_PPM   (1000000/50000)   //5.0%
+#else
 #define ALLOWED_DRIFT_PPM   (1000000/5000)    //0.5%
+#endif
 
 /*
     return values to be checked are documented at:
@@ -279,9 +285,7 @@ Case cases[] = {
     Case("Flash - erase sector", flash_erase_sector_test),
     Case("Flash - program page", flash_program_page_test),
     Case("Flash - buffer alignment test", flash_buffer_alignment_test),
-#ifndef MCU_NRF52
     Case("Flash - clock and cache test", flash_clock_and_cache_test),
-#endif
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases) {


### PR DESCRIPTION
### Description

The flash clock test is disabled for the NRF52 series. This change
re-enables the test but with a higher tolerance to accommodate the
high jitter on the current ticker implementation.


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

