### PR TITLE
Fix compile error with MBED_MEM_TRACING_ENABLED and ARMC6

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1339,7 +1339,7 @@ extern "C" void __cxa_guard_abort(int *guard_object_p)
 
 #endif
 
-#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__))
+#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
 
 // If the memory tracing is enabled, the wrappers in mbed_alloc_wrappers.cpp
 // provide the implementation for these. Note: this needs to use the wrappers


### PR DESCRIPTION
### Description
This PR tries to fix the compile error. Take `mbed-os-example-blinky` for example. If I compile with:

```
mbed compile -m NUMAKER_PFM_NUC472 -t ARMC6 -DMBED_MEM_TRACING_ENABLED=1
```

I meet error with:
```
Compile [ 77.1%]: mbed_interface.c
Compile [ 77.3%]: mbed_mem_trace.cpp
Compile [ 77.6%]: mbed_poll.cpp
Compile [ 77.8%]: mbed_sdk_boot.c
Compile [ 78.1%]: mbed_retarget.cpp
[ERROR] .\mbed-os\platform\mbed_retarget.cpp:1390:10: fatal error: 'reent.h' file not found
#include <reent.h>
         ^~~~~~~~~
1 error generated.
```

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

