### PR TITLE
Nano 100: Lower HEAP size for IAR

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -10,7 +10,7 @@ define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
 define symbol __ICFEDIT_size_cstack__ = 0x600;
-define symbol __ICFEDIT_size_heap__   = 0x1200;
+define symbol __ICFEDIT_size_heap__   = 0x1000;
 /**** End of ICF editor section. ###ICF###*/
 
 


### PR DESCRIPTION
### Description

IAR 7.8 does not support dynamic heap, and some test/addition of new feature fail on this device because of less static RAM memory. Reducing the heap memory size for the same reason.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

@ccli8 @ccchang12 