### PR TITLE
Fix UART initialization for NRF52

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/serial_api.c
@@ -1046,24 +1046,22 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         uart_object->rx = rx;
     }
 
-    /* Set default parity and baud rate. */
+    /* Set default parity, baud rate, and callback handler. */
     uart_object->parity = NRF_UART_PARITY_EXCLUDED;
     uart_object->baudrate = NRF_UART_BAUDRATE_9600;
     uart_object->cts = NRF_UART_PSEL_DISCONNECTED;
     uart_object->rts = NRF_UART_PSEL_DISCONNECTED;
     uart_object->hwfc = NRF_UART_HWFC_DISABLED;
+    uart_object->handler = 0;
 
     /* The STDIO object is stored in this file. Set the flag once initialized. */
     if (obj == &stdio_uart) {
         stdio_uart_inited = 1;
     }
 
-    /* Initializing the serial object does not make it the owner of an instance. 
-     * Only when the serial object is being used will the object take ownership 
-     * over the instance.
-     */
+    /* Take ownership and configure UART. */
     uart_object->update = true;
-    uart_object->handler = 0;
+    nordic_nrf5_serial_configure(obj);
 }
 
 /** Release the serial peripheral, not currently invoked. It requires further


### PR DESCRIPTION
### Description

Delayed initialization can cause problems when both UARTE instances
are in use. This change causes each UART object to initialize the
underlying UARTE instance immediately.


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

