### PR TITLE
littlefs: Map LFS_ERR_CORRUPT to EILSEQ

### DIFF
--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -35,6 +35,7 @@ static int lfs_toerror(int err)
         case LFS_ERR_INVAL:     return -EINVAL;
         case LFS_ERR_NOSPC:     return -ENOSPC;
         case LFS_ERR_NOMEM:     return -ENOMEM;
+        case LFS_ERR_CORRUPT:   return -EILSEQ;
         default:                return err;
     }
 }


### PR DESCRIPTION
### Description

Previously EBAD (invalid exchange), mapping the error CORRUPT to EILSEQ (illegal byte sequence) makes more sense as a description of the type of error.

Will change the underlying error code inside littlefs on the next major version.

related https://github.com/ARMmbed/mbed-os/pull/6336
cc @davidsaada, @kjbracey-arm, @deepikabhavnani 

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

### TODO

- [x] will squash

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [✗] Breaking change

