### PR TITLE
Enlarge timer thread stack size for Cortex-M23/M33

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -34,13 +34,19 @@
 
 #define OS_STACK_SIZE               MBED_CONF_APP_THREAD_STACK_SIZE
 
-#ifndef OS_TIMER_THREAD_STACK_SIZE
-#define OS_TIMER_THREAD_STACK_SIZE  768
+/** The timer thread's stack size can be configured by the application, if not explicitly specified, it'll default to 768 */
+#ifndef MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
+#define MBED_CONF_APP_TIMER_THREAD_STACK_SIZE   768
 #endif
 
-#ifndef OS_IDLE_THREAD_STACK_SIZE
-#define OS_IDLE_THREAD_STACK_SIZE  512
+#define OS_TIMER_THREAD_STACK_SIZE  MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
+
+/** The idle thread's stack size can be configured by the application, if not explicitly specified, it'll default to 512 */
+#ifndef MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
+#define MBED_CONF_APP_IDLE_THREAD_STACK_SIZE    512
 #endif
+
+#define OS_IDLE_THREAD_STACK_SIZE   MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
 
 #define OS_DYNAMIC_MEM_SIZE         0
 

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -35,12 +35,7 @@
 #define OS_STACK_SIZE               MBED_CONF_APP_THREAD_STACK_SIZE
 
 #ifndef OS_TIMER_THREAD_STACK_SIZE
-    #if (defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)) ||\
-        (defined(__DOMAIN_NS) && (__DOMAIN_NS == 1U))
-        #define OS_TIMER_THREAD_STACK_SIZE  1280
-    #else
-        #define OS_TIMER_THREAD_STACK_SIZE  768
-    #endif
+#define OS_TIMER_THREAD_STACK_SIZE  768
 #endif
 
 #ifndef OS_IDLE_THREAD_STACK_SIZE

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -34,7 +34,15 @@
 
 #define OS_STACK_SIZE               MBED_CONF_APP_THREAD_STACK_SIZE
 
-#define OS_TIMER_THREAD_STACK_SIZE 768
+#ifndef OS_TIMER_THREAD_STACK_SIZE
+    #if (defined(__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)) ||\
+        (defined(__DOMAIN_NS) && (__DOMAIN_NS == 1U))
+        #define OS_TIMER_THREAD_STACK_SIZE  1280
+    #else
+        #define OS_TIMER_THREAD_STACK_SIZE  768
+    #endif
+#endif
+
 #ifndef OS_IDLE_THREAD_STACK_SIZE
 #define OS_IDLE_THREAD_STACK_SIZE  512
 #endif


### PR DESCRIPTION
### Description
This PR tries to enlarge default size of timer thread stack for Cortex-M23/M33 targets. The adjustment is based on port of our on-going **NUMAKER_PFM_M2351** target.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
