### PR TITLE
Add status code/get call to SAI and children classes

### DIFF
--- a/drivers/SAI.cpp
+++ b/drivers/SAI.cpp
@@ -38,9 +38,7 @@ SAI::SAI(PinName mclk, PinName bclk, PinName wclk, PinName sd,
 
     init.format = *fmt;
 
-    if (sai_init(&_sai, &init) != SAI_RESULT_OK) {
-        // it failed :o
-    }
+    _status = sai_init(&_sai, &init);
 }
 
 bool SAI::xfer(uint32_t *value) {
@@ -48,6 +46,10 @@ bool SAI::xfer(uint32_t *value) {
     bool ret = sai_transfer(&_sai, value);
     unlock();
     return ret;
+}
+
+sai_result_t SAI::status(void) {
+    return _status;
 }
 
 void SAI::lock() {

--- a/drivers/SAI.h
+++ b/drivers/SAI.h
@@ -41,11 +41,19 @@ public:
         const sai_format_t *fmt = &sai_mode_i2s32, bool is_input = false,
         uint32_t master_clock = 0, bool internal_mclk = false);
 
+    /** Retreive the object status. Allows the ctor to
+     * funnel init errors/warnings back up to the application.
+     */
+    virtual sai_result_t status(void);
+    
     /** Push a sample to the Fifo & try to read a new sample.
      * it may return 0 if no sample was available.
      */
     virtual bool xfer(uint32_t *value);
 
+    virtual ~SAI() {}
+
+protected:
     /** Acquire exclusive access to this SAI bus
      */
     virtual void lock(void);
@@ -54,17 +62,14 @@ public:
      */
     virtual void unlock(void);
 
-
-public:
-    virtual ~SAI() {}
-
-protected:
+    ////////////////////////////////////////////
     sai_t           _sai;
     PlatformMutex   _mutex;
     bool            _is_input;
+    sai_result_t    _status;
 };
 
-class SAITransmitter : private SAI {
+class SAITransmitter : public SAI {
     public:
         SAITransmitter(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                        const sai_format_t *fmt = &sai_mode_i2s32)
@@ -75,7 +80,7 @@ class SAITransmitter : private SAI {
         }
 };
 
-class SAIReceiver : private SAI {
+class SAIReceiver : public SAI {
     public:
         SAIReceiver(PinName mclk, PinName bclk, PinName wclk, PinName sd,
                     const sai_format_t *fmt = &sai_mode_i2s32)

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -245,7 +245,7 @@
         "mbed": [],
         "test-repo-source": "github",
         "features" : [],
-        "targets" : [],
+        "targets" : ["DISCO_L072CZ_LRWAN1", "MTB_MTS_XDOT", "MTS_MDOT_F411RE"],
         "toolchains" : [],
         "exporters": [],
         "compile" : true,


### PR DESCRIPTION
Restructure SAI inheritance to allow common status class method in children classes.