### PR TITLE
Add common define MBED_ALL_STATS_ENABLED to enable all statistics

### DIFF
--- a/mbed.h
+++ b/mbed.h
@@ -92,6 +92,7 @@
 #include "platform/DirHandle.h"
 #include "platform/CriticalSectionLock.h"
 #include "platform/DeepSleepLock.h"
+#include "platform/mbed_stats.h"
 
 // mbed Non-hardware components
 #include "platform/Callback.h"

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include "mbed_assert.h"
 
-#if MBED_CONF_RTOS_PRESENT
+#ifdef MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
 #endif
 
@@ -13,7 +13,7 @@ void mbed_stats_stack_get(mbed_stats_stack_t *stats)
 {
     memset(stats, 0, sizeof(mbed_stats_stack_t));
 
-#if MBED_STACK_STATS_ENABLED && MBED_CONF_RTOS_PRESENT
+#if defined(MBED_STACK_STATS_ENABLED) && defined(MBED_CONF_RTOS_PRESENT)
     uint32_t thread_n = osThreadGetCount();
     unsigned i;
     osThreadId_t *threads;
@@ -41,7 +41,7 @@ size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count)
     memset(stats, 0, count*sizeof(mbed_stats_stack_t));
     size_t i = 0;
 
-#if MBED_STACK_STATS_ENABLED && MBED_CONF_RTOS_PRESENT
+#if defined(MBED_STACK_STATS_ENABLED) && defined(MBED_CONF_RTOS_PRESENT)
     osThreadId_t *threads;
 
     threads = malloc(sizeof(osThreadId_t) * count);
@@ -65,6 +65,6 @@ size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count)
     return i;
 }
 
-#if MBED_STACK_STATS_ENABLED && !MBED_CONF_RTOS_PRESENT
+#if defined(MBED_STACK_STATS_ENABLED) && !defined(MBED_CONF_RTOS_PRESENT)
 #warning Stack statistics are currently not supported without the rtos.
 #endif

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -29,6 +29,11 @@
 extern "C" {
 #endif
 
+#ifdef MBED_ALL_STATS_ENABLED
+#define MBED_STACK_STATS_ENABLED    1
+#define MBED_HEAP_STATS_ENABLED     1
+#endif
+
 /**
  * struct mbed_stats_heap_t definition
  */

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -45,11 +45,7 @@
 #error "OS Tickrate must be 1000 for system timing"
 #endif
 
-#if !defined(OS_STACK_WATERMARK) && defined(MBED_STACK_STATS_ENABLED)
-#define OS_STACK_WATERMARK          1
-#endif
-
-#if !defined(OS_STACK_WATERMARK) && defined(MBED_ALL_STATS_ENABLED)
+#if !defined(OS_STACK_WATERMARK) && (defined(MBED_STACK_STATS_ENABLED) || defined(MBED_ALL_STATS_ENABLED))
 #define OS_STACK_WATERMARK          1
 #endif
 

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -45,7 +45,11 @@
 #error "OS Tickrate must be 1000 for system timing"
 #endif
 
-#if !defined(OS_STACK_WATERMARK) && (defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED)
+#if !defined(OS_STACK_WATERMARK) && defined(MBED_STACK_STATS_ENABLED)
+#define OS_STACK_WATERMARK          1
+#endif
+
+#if !defined(OS_STACK_WATERMARK) && defined(MBED_ALL_STATS_ENABLED)
 #define OS_STACK_WATERMARK          1
 #endif
 


### PR DESCRIPTION
### Description

Requirement: All mbed OS statistics should be enabled with single macro `MBED_ALL_STATS_ENABLED`

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

CC @SenRamakri 