### PR TITLE
KL82Z: Fix clock selection for PWMOUT driver

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/pwmout_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/pwmout_api.c
@@ -36,9 +36,9 @@ void pwmout_init(pwmout_t* obj, PinName pin)
 
     uint32_t pwm_base_clock;
 
-    /* Set the TPM clock source to be IRC 48M */
+    /* Set the TPM clock source to be MCG FLL clock */
     CLOCK_SetTpmClock(1U);
-    pwm_base_clock = CLOCK_GetFreq(kCLOCK_McgIrc48MClk);
+    pwm_base_clock = CLOCK_GetFreq(kCLOCK_PllFllSelClk);
     float clkval = (float)pwm_base_clock / 1000000.0f;
     uint32_t clkdiv = 0;
     while (clkval > 1) {


### PR DESCRIPTION
This was verified using the ci-test shield

Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>

### Description
The PWM out clock selection was incorrect which resulted in incorrect PWM frequency. This was verified via the ci-test-shield

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

