### PR TITLE
KW41Z: Update SDK TPM driver

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/MKW41Z4_features.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/MKW41Z4_features.h
@@ -1680,14 +1680,29 @@
 #define FSL_FEATURE_TPM_HAS_PAUSE_COUNTER_ON_TRIGGER (1)
 /* @brief Has external trigger selection. */
 #define FSL_FEATURE_TPM_HAS_EXTERNAL_TRIGGER_SELECTION (1)
-/* @brief Has TPM_COMBINE. */
+/* @brief Has TPM_COMBINE register. */
 #define FSL_FEATURE_TPM_HAS_COMBINE (1)
+/* @brief Whether COMBINE register has effect. */
+#define FSL_FEATURE_TPM_COMBINE_HAS_EFFECTn(x) \
+    ((x) == TPM0 ? (0) : \
+    ((x) == TPM1 ? (1) : \
+    ((x) == TPM2 ? (1) : (-1))))
 /* @brief Has TPM_POL. */
 #define FSL_FEATURE_TPM_HAS_POL (1)
-/* @brief Has TPM_FILTER. */
+/* @brief Has TPM_FILTER register. */
 #define FSL_FEATURE_TPM_HAS_FILTER (1)
-/* @brief Has TPM_QDCTRL. */
+/* @brief Whether FILTER register has effect. */
+#define FSL_FEATURE_TPM_FILTER_HAS_EFFECTn(x) \
+    ((x) == TPM0 ? (0) : \
+    ((x) == TPM1 ? (1) : \
+    ((x) == TPM2 ? (1) : (-1))))
+/* @brief Has TPM_QDCTRL register. */
 #define FSL_FEATURE_TPM_HAS_QDCTRL (1)
+/* @brief Whether QDCTRL register has effect. */
+#define FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(x) \
+    ((x) == TPM0 ? (0) : \
+    ((x) == TPM1 ? (1) : \
+    ((x) == TPM2 ? (1) : (-1))))
 
 /* TRNG0 module features */
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_tpm.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/drivers/fsl_tpm.c
@@ -162,6 +162,12 @@ status_t TPM_SetupPwm(TPM_Type *base,
     assert(pwmFreq_Hz);
     assert(numOfChnls);
     assert(srcClock_Hz);
+#if defined(FSL_FEATURE_TPM_HAS_COMBINE) && FSL_FEATURE_TPM_HAS_COMBINE
+    if(mode == kTPM_CombinedPwm)
+    {
+        assert(FSL_FEATURE_TPM_COMBINE_HAS_EFFECTn(base));
+    }
+#endif
 
     uint32_t mod;
     uint32_t tpmClock = (srcClock_Hz / (1U << (base->SC & TPM_SC_PS_MASK)));
@@ -169,8 +175,12 @@ status_t TPM_SetupPwm(TPM_Type *base,
     uint8_t i;
 
 #if defined(FSL_FEATURE_TPM_HAS_QDCTRL) && FSL_FEATURE_TPM_HAS_QDCTRL
-    /* Clear quadrature Decoder mode because in quadrature Decoder mode PWM doesn't operate*/
-    base->QDCTRL &= ~TPM_QDCTRL_QUADEN_MASK;
+    /* The TPM's QDCTRL register required to be effective */
+    if( FSL_FEATURE_TPM_QDCTRL_HAS_EFFECTn(base) )
+    {
+        /* Clear quadrature Decoder mode because in quadrature Decoder mode PWM doesn't operate*/
+        base->QDCTRL &= ~TPM_QDCTRL_QUADEN_MASK;
+    }
 #endif
 
     switch (mode)


### PR DESCRIPTION
### Description
Certain instances of the TPM are missing some registers. The updated SDK TPM driver handles this variation. This issue was discovered when running the PWMOUT tests using the ci-test-shield

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

