### PR TITLE
mbed_ticker_api remove specific case for 32768 in favor of all frequencies divisible by 2

### DIFF
--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -42,8 +42,8 @@ static void initialize(const ticker_data_t *ticker)
         frequency = 1000000;
     }
 
-    uint32_t frequency_shifts = 0;
-    for (int i = 31; i > 0; --i) {
+    uint8_t frequency_shifts = 0;
+    for (uint8_t i = 31; i > 0; --i) {
         if ((1 << i) == frequency) {
             frequency_shifts = i;
             break;

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -73,7 +73,6 @@ typedef struct {
     ticker_event_handler event_handler; /**< Event handler */
     ticker_event_t *head;               /**< A pointer to head */
     uint32_t frequency;                 /**< Frequency of the timer in Hz */
-    uint32_t frequency_shifts;          /**< Frequency shift if divisible by 2, ohterwise 0 */
     uint32_t bitmask;                   /**< Mask to be applied to time values read */
     uint32_t max_delta;                 /**< Largest delta in ticks that can be used when scheduling */
     uint64_t max_delta_us;              /**< Largest delta in us that can be used when scheduling */
@@ -81,6 +80,7 @@ typedef struct {
     uint64_t tick_remainder;            /**< Ticks that have not been added to base_time */
     us_timestamp_t present_time;        /**< Store the timestamp used for present time */
     bool initialized;                   /**< Indicate if the instance is initialized */
+    uint8_t frequency_shifts;           /**< If frequency is a value of 2^n, this is n, otherwise 0 */ 
 } ticker_event_queue_t;
 
 /** Ticker's data structure

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -73,6 +73,7 @@ typedef struct {
     ticker_event_handler event_handler; /**< Event handler */
     ticker_event_t *head;               /**< A pointer to head */
     uint32_t frequency;                 /**< Frequency of the timer in Hz */
+    uint32_t frequency_shifts;          /**< Frequency shift if divisible by 2, ohterwise 0 */
     uint32_t bitmask;                   /**< Mask to be applied to time values read */
     uint32_t max_delta;                 /**< Largest delta in ticks that can be used when scheduling */
     uint64_t max_delta_us;              /**< Largest delta in us that can be used when scheduling */


### PR DESCRIPTION
### Description

In case of the STM32 lp-ticker the clock is 32768/4 or 8192 which wasn't optimized. There probably are some other clocks out there as well that can be easily optimized by determining once what the shift is and using that later on.

This was just an idea I had for an implementation, if there are more changes coming for the ticker or there is a better way to solve this please go ahead.

### Pull request type
  - [x] Fix
  - [ ] Refactor
  - [ ] New target
  - [ ] Feature
  - [ ] Breaking change
