### PR TITLE
Cellular: Add dynamic alloc and destruction to easycellular

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -102,7 +102,8 @@ public:
      */
     nsapi_error_t start_dispatch();
 
-    /** Stop event queue dispatching and close cellular interfaces
+    /** Stop event queue dispatching and close cellular interfaces. After calling stop(), init() must be called
+     *  before any other methods.
      */
     void stop();
 
@@ -153,6 +154,7 @@ public:
      *  @return      string format of the given state
      */
     const char* get_state_string(CellularState state);
+
 private:
     bool power_on();
     bool open_sim();

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -63,7 +63,6 @@ static const uint8_t map_3gpp_errors[][2] =  {
 
 ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, int timeout, const char *output_delimiter, uint16_t send_delay) :
     _nextATHandler(0),
-    _fileHandle(fh),
     _queue(queue),
     _last_err(NSAPI_ERROR_OK),
     _last_3gpp_error(0),
@@ -109,9 +108,7 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, int timeout, const char 
     set_tag(&_info_stop, CRLF);
     set_tag(&_elem_stop, ")");
 
-    _fileHandle->set_blocking(false);
-
-    set_filehandle_sigio();
+    set_file_handle(fh);
 }
 
 void ATHandler::enable_debug(bool enable)
@@ -153,7 +150,20 @@ FileHandle *ATHandler::get_file_handle()
 
 void ATHandler::set_file_handle(FileHandle *fh)
 {
+    _fh_sigio_set = false;
     _fileHandle = fh;
+    _fileHandle->set_blocking(false);
+    set_filehandle_sigio();
+}
+
+void ATHandler::set_filehandle_sigio()
+{
+    if (_fh_sigio_set) {
+        return;
+    }
+
+    _fileHandle->sigio(mbed::Callback<void()>(this, &ATHandler::event));
+    _fh_sigio_set = true;
 }
 
 nsapi_error_t ATHandler::set_urc_handler(const char *prefix, mbed::Callback<void()> callback)
@@ -308,15 +318,6 @@ void ATHandler::process_oob()
     flush(); // consume anything that could not be handled
 
     unlock();
-}
-
-void ATHandler::set_filehandle_sigio()
-{
-    if (_fh_sigio_set) {
-        return;
-    }
-    _fileHandle->sigio(mbed::Callback<void()>(this, &ATHandler::event));
-    _fh_sigio_set = true;
 }
 
 void ATHandler::reset_buffer()
@@ -1023,8 +1024,8 @@ void ATHandler::cmd_start(const char* cmd)
         if (time_difference < (uint64_t)_at_send_delay) {
             wait_ms((uint64_t)_at_send_delay - time_difference);
             tr_debug("AT wait %llu %llu", current_time, _last_response_stop);
-        } 
-    } 
+        }
+    }
 
     at_debug("AT cmd %s (err %d)\n", cmd, _last_err);
 
@@ -1088,7 +1089,7 @@ void ATHandler::cmd_stop()
 size_t ATHandler::write_bytes(const uint8_t *data, size_t len)
 {
     at_debug("AT write bytes %d (err %d)\n", len, _last_err);
-    
+
     if (_last_err != NSAPI_ERROR_OK) {
         return 0;
     }

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -86,12 +86,6 @@ public:
      */
     FileHandle *get_file_handle();
 
-    /** Set file handle, which is used for reading AT responses and writing AT commands
-     *
-     *  @param fh file handle used for reading AT responses and writing AT commands
-     */
-    void set_file_handle(FileHandle *fh);
-
     /** Locks the mutex for file handle if AT_HANDLER_MUTEX is defined.
      */
     void lock();
@@ -165,6 +159,11 @@ public:
      */
     void clear_error();
 
+    /**
+     * Flushes the underlying stream
+     */
+    void flush();
+
     /** Tries to find oob's from the AT response. Call the urc callback if one is found.
      */
     void process_oob();
@@ -173,10 +172,11 @@ public:
      */
     void set_filehandle_sigio();
 
-    /**
-     * Flushes the underlying stream
+    /** Set file handle, which is used for reading AT responses and writing AT commands
+     *
+     *  @param fh file handle used for reading AT responses and writing AT commands
      */
-    void flush();
+    void set_file_handle(FileHandle *fh);
 
 protected:
     void event();

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -48,6 +48,19 @@ AT_CellularNetwork::AT_CellularNetwork(ATHandler &atHandler) : AT_CellularBase(a
 
 AT_CellularNetwork::~AT_CellularNetwork()
 {
+#if NSAPI_PPP_AVAILABLE
+    (void)disconnect();
+#else
+    delete _stack;
+#endif // NSAPI_PPP_AVAILABLE
+
+    for (int type = 0; type < CellularNetwork::C_MAX; type++) {
+        if (has_registration((RegistrationType)type)) {
+            _at.remove_urc_handler(at_reg[type].urc_prefix, _urc_funcs[type]);
+        }
+    }
+
+    _at.remove_urc_handler("NO CARRIER", callback(this, &AT_CellularNetwork::urc_no_carrier));
     free_credentials();
 }
 


### PR DESCRIPTION
### Description

Added dynamic alloc and destruction to easycellular.
Now application can call connect and disconnect multiple times and resources are freed and constructed properly. Also whole easycellular can be deleted and constructed again.

Internal ref to defect: IOTCELL-814

@AriParkkila please review

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

