### PR TITLE
tools: Pass app-config to get_config

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -120,7 +120,7 @@ def add_result_to_report(report, result):
     result_wrap = {0: result}
     report[target][toolchain][id_name].append(result_wrap)
 
-def get_config(src_paths, target, toolchain_name):
+def get_config(src_paths, target, toolchain_name, app_config=None):
     """Get the configuration object for a target-toolchain combination
 
     Positional arguments:
@@ -133,7 +133,8 @@ def get_config(src_paths, target, toolchain_name):
         src_paths = [src_paths]
 
     # Pass all params to the unified prepare_resources()
-    toolchain = prepare_toolchain(src_paths, None, target, toolchain_name)
+    toolchain = prepare_toolchain(src_paths, None, target, toolchain_name,
+                                  app_config=app_config)
 
     # Scan src_path for config files
     resources = toolchain.scan_resources(src_paths[0])

--- a/tools/get_config.py
+++ b/tools/get_config.py
@@ -33,7 +33,8 @@ from tools.utils import argparse_filestring_type
 
 if __name__ == '__main__':
     # Parse Options
-    parser = get_default_options_parser(add_clean=False, add_options=False)
+    parser = get_default_options_parser(add_clean=False, add_options=False,
+                                        add_app_config=True)
     parser.add_argument(
         "--source", dest="source_dir", type=argparse_filestring_type,
         required=True, default=[], help="The source (input) directory",
@@ -61,7 +62,7 @@ if __name__ == '__main__':
 
     try:
         params, macros, features = get_config(
-            options.source_dir, target, toolchain)
+            options.source_dir, target, toolchain, app_config=options.app_config)
         if not params and not macros:
             print("No configuration data available.")
             sys.exit(0)

--- a/tools/test/test_api/test_api_test.py
+++ b/tools/test/test_api/test_api_test.py
@@ -78,9 +78,11 @@ def test_find_tests_app_config(build_path, target, toolchain_name, app_config):
     src_paths = ['.']
     set_targets_json_location()
     with patch('tools.test_api.scan_resources') as mock_scan_resources,\
-         patch('tools.test_api.build_project') as mock_build_project:
+         patch('tools.test_api.build_project') as mock_build_project,\
+         patch('tools.test_api.get_config') as mock_get_config:
         mock_build_project.return_value = "build_project"
         mock_scan_resources().inc_dirs.return_value = []
+        mock_get_config.return_value = ({}, "", "")
 
         build_tests(tests, src_paths, build_path, target, toolchain_name,
                     app_config=app_config)
@@ -91,3 +93,5 @@ def test_find_tests_app_config(build_path, target, toolchain_name, app_config):
                 "build_tests was not called with app_config"
             assert args[1]['app_config'] == app_config,\
                 "build_tests was called with an incorrect app_config"
+        mock_get_config.called_with(src_paths, target,
+                                    toolchain_name, app_conifg=app_config)

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2220,7 +2220,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
     base_path = norm_relative_path(build_path, execution_directory)
 
     target_name = target.name if isinstance(target, Target) else target
-    cfg, _, _ = get_config(base_source_paths, target_name, toolchain_name)
+    cfg, _, _ = get_config(base_source_paths, target_name, toolchain_name, app_config=app_config)
 
     baud_rate = 9600
     if 'platform.stdio-baud-rate' in cfg:


### PR DESCRIPTION
### Description

The `mbed test` subcommand will run a quick `get_config` before building.
This `get_config` call was missing the `--app-config` parameter, because
`get_config` did not accept the `--app-config` parameter. This is resolved.

This has a side affect of fixing a bug with `--app-config` handling in 
`mbed test`: Required parameters that are filled in by the `--app-conifg`
do not fail the build anymore.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change