### PR TITLE
Fix compile error with DirectSerial in serial-less build

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -126,7 +126,6 @@ void remove_filehandle(FileHandle *file) {
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
-#endif
 
 /* Private FileHandle to implement backwards-compatible functionality of
  * direct HAL serial access for default stdin/stdout/stderr.
@@ -193,6 +192,7 @@ short DirectSerial::poll(short events) const {
     }
     return revents;
 }
+#endif
 
 class Sink : public FileHandle {
 public:


### PR DESCRIPTION
### Description
This PR tries to fix compile error with `DirectSerial` in serial-less build. My `mbed_app.json` has the following content for this build:

<pre>
{
    "target_overrides": {
        "*": {
            "platform.stdio-baud-rate": 9600,
            "platform.stdio-convert-newlines": true
        },
        <b>
        "NUMAKER_PFM_M2351_S": {
            "target.device_has_remove": ["SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES"]
        </b>
        }
    }
}
</pre>

#### Related PR
#6747 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

