### PR TITLE
NANO130: Change initial stack size to 1K

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
@@ -10,7 +10,7 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x400 {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
@@ -10,7 +10,7 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK 0x20000000 EMPTY 0x400 {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/NANO130.ld
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/NANO130.ld
@@ -2,7 +2,7 @@
  * Nuvoton NANO130 GCC linker script file
  */
 
-StackSize = 0x600;
+StackSize = 0x400;
 
 MEMORY
 {

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_IAR/NANO130.icf
@@ -9,7 +9,7 @@ define symbol __ICFEDIT_region_ROM_end__   = 0x00020000 - 1;
 define symbol __ICFEDIT_region_IRAM_start__ = 0x20000000;
 define symbol __ICFEDIT_region_IRAM_end__   = 0x20004000 - 1;
 /*-Sizes-*/
-define symbol __ICFEDIT_size_cstack__ = 0x600;
+define symbol __ICFEDIT_size_cstack__ = 0x400;
 define symbol __ICFEDIT_size_heap__   = 0x1200;
 /**** End of ICF editor section. ###ICF###*/
 


### PR DESCRIPTION
### Description
This PR tries to spare more memory for adding new feature by decreasing initial stack size, especially for IAR with which heap size is statically allocated.

#### Related PR
#6768 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

@deepikabhavnani 
