### PR TITLE
GenericGattClient: Fix discovery termination.

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericGattClient.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericGattClient.cpp
@@ -147,6 +147,7 @@ struct GenericGattClient::DiscoveryControlBlock : public ProcedureControlBlock {
 				const AttErrorResponse& error = static_cast<const AttErrorResponse&>(message);
 				if (error.error_code != AttErrorResponse::ATTRIBUTE_NOT_FOUND) {
 					terminate(client);
+					return;
 				}
 
 				switch (error.request_opcode) {


### PR DESCRIPTION
### Description

The procedure should be terminated whenever the server returns an error not equal
to ATTRIBUTE_NOT_FOUND. The block was effectivelly terminated but the
procedure was not. As a result the discovery was operating on already
freed memory.

It should fixes #6806 .

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

