### PR TITLE
Nordic SecurityManager: Add signing parameter to init.

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xSecurityManager.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/source/nRF5xSecurityManager.h
@@ -30,7 +30,8 @@ public:
     virtual ble_error_t init(bool                     enableBonding,
                              bool                     requireMITM,
                              SecurityIOCapabilities_t iocaps,
-                             const Passkey_t          passkey) {
+                             const Passkey_t          passkey,
+                             bool                     signing) {
         return btle_initializeSecurity(enableBonding, requireMITM, iocaps, passkey);
     }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xSecurityManager.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/nRF5xSecurityManager.h
@@ -30,7 +30,8 @@ public:
     virtual ble_error_t init(bool                     enableBonding,
                              bool                     requireMITM,
                              SecurityIOCapabilities_t iocaps,
-                             const Passkey_t          passkey) {
+                             const Passkey_t          passkey,
+                             bool                     signing) {
         return btle_initializeSecurity(enableBonding, requireMITM, iocaps, passkey);
     }
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5x/source/nRF5xSecurityManager.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5x/source/nRF5xSecurityManager.h
@@ -30,7 +30,8 @@ public:
     virtual ble_error_t init(bool                     enableBonding,
                              bool                     requireMITM,
                              SecurityIOCapabilities_t iocaps,
-                             const Passkey_t          passkey) {
+                             const Passkey_t          passkey,
+                             bool                     signing) {
         return btle_initializeSecurity(enableBonding, requireMITM, iocaps, passkey);
     }
 


### PR DESCRIPTION
### Description

This parameter has been introduced with the refactoring of the
SecurityManager and not propagated to the old Nordic implementation.

Ot should fixes #6812 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

