### PR TITLE
GenericSecurityManager: Fix crypto_toolbox_f4 signature.

### DIFF
--- a/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
+++ b/features/FEATURE_BLE/ble/generic/GenericSecurityManager.h
@@ -354,8 +354,8 @@ private:
      * @return true if cryptography functioned worked
      */
     static bool crypto_toolbox_f4(
-        const public_key_t &U,
-        const public_key_t &V,
+        const public_key_coord_t &U,
+        const public_key_coord_t &V,
         const oob_lesc_value_t &X,
         oob_confirm_t &confirm
     );


### PR DESCRIPTION
### Description

The type exposed in the header file were not aligned to the one used in
the implementation: ble::public_key_t instead of ble::public_key_coord_t.

This PR should fix #6760 .

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

