### PR TITLE
Add check for existing block before freeing it in ns_mem_free

### DIFF
--- a/features/FEATURE_COMMON_PAL/nanostack-libservice/source/nsdynmemLIB/nsdynmemLIB.c
+++ b/features/FEATURE_COMMON_PAL/nanostack-libservice/source/nsdynmemLIB/nsdynmemLIB.c
@@ -438,7 +438,10 @@ void ns_mem_free(ns_mem_book_t *book, void *block)
     platform_exit_critical();
 #else
     platform_enter_critical();
-    free(block);
+    if (block)
+    {
+        free(block);
+    }
     platform_exit_critical();
 #endif
 }


### PR DESCRIPTION
### Description

Add a check for allocated memory area before freeing it (in case of usage of ```STANDARD_MALLOC```)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change