### PR TITLE
mbed test: add argument `--ignore` to allow passing in mbedignore patterns

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -502,7 +502,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
                   notify=None, name=None, macros=None, inc_dirs=None, jobs=1,
                   report=None, properties=None, project_id=None,
                   project_description=None, config=None,
-                  app_config=None, build_profile=None, stats_depth=None):
+                  app_config=None, build_profile=None, stats_depth=None, ignore=None):
     """ Build a project. A project may be a test or a user program.
 
     Positional arguments:
@@ -529,6 +529,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler
     stats_depth - depth level for memap to display file/dirs
+    ignore - list of paths to add to mbedignore
     """
 
     # Convert src_path to a list if needed
@@ -547,6 +548,10 @@ def build_project(src_paths, build_path, target, toolchain_name,
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
         app_config=app_config, build_profile=build_profile)
+
+    if ignore:
+        toolchain.add_ignore_patterns(root=".", base_path=".",
+                                      patterns=ignore)
 
     # The first path will give the name to the library
     name = (name or toolchain.config.name or
@@ -643,7 +648,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
                   archive=True, notify=None, macros=None, inc_dirs=None, jobs=1,
                   report=None, properties=None, project_id=None,
                   remove_config_header_file=False, app_config=None,
-                  build_profile=None):
+                  build_profile=None, ignore=None):
     """ Build a library
 
     Positional arguments:
@@ -668,6 +673,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
     remove_config_header_file - delete config header file when done building
     app_config - location of a chosen mbed_app.json file
     build_profile - a dict of flags that will be passed to the compiler
+    ignore - list of paths to add to mbedignore
     """
 
     # Convert src_path to a list if needed
@@ -692,6 +698,10 @@ def build_library(src_paths, build_path, target, toolchain_name,
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, app_config=app_config,
         build_profile=build_profile)
+
+    if ignore:
+        toolchain.add_ignore_patterns(root=".", base_path=".",
+                                      patterns=ignore)
 
     # The first path will give the name to the library
     if name is None:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -301,7 +301,7 @@ def target_supports_toolchain(target, toolchain_name):
 def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
                       macros=None, clean=False, jobs=1,
                       notify=None, config=None, app_config=None,
-                      build_profile=None):
+                      build_profile=None, ignore=None):
     """ Prepares resource related objects - toolchain, target, config
 
     Positional arguments:
@@ -317,6 +317,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     config - a Config object to use instead of creating one
     app_config - location of a chosen mbed_app.json file
     build_profile - a list of mergeable build profiles
+    ignore - list of paths to add to mbedignore
     """
 
     # We need to remove all paths which are repeated to avoid
@@ -347,6 +348,9 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     toolchain.config = config
     toolchain.jobs = jobs
     toolchain.build_all = clean
+
+    if ignore:
+        toolchain.add_ignore_patterns(root=".", base_path=".", patterns=ignore)
 
     return toolchain
 
@@ -547,11 +551,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
-        app_config=app_config, build_profile=build_profile)
-
-    if ignore:
-        toolchain.add_ignore_patterns(root=".", base_path=".",
-                                      patterns=ignore)
+        app_config=app_config, build_profile=build_profile, ignore=ignore)
 
     # The first path will give the name to the library
     name = (name or toolchain.config.name or
@@ -697,11 +697,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
     toolchain = prepare_toolchain(
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, app_config=app_config,
-        build_profile=build_profile)
-
-    if ignore:
-        toolchain.add_ignore_patterns(root=".", base_path=".",
-                                      patterns=ignore)
+        build_profile=build_profile, ignore=ignore)
 
     # The first path will give the name to the library
     if name is None:
@@ -803,7 +799,7 @@ def mbed2_obj_path(target_name, toolchain_name):
 
 def build_lib(lib_id, target, toolchain_name, clean=False, macros=None,
               notify=None, jobs=1, report=None, properties=None,
-              build_profile=None):
+              build_profile=None, ignore=None):
     """ Legacy method for building mbed libraries
 
     Positional arguments:
@@ -819,6 +815,7 @@ def build_lib(lib_id, target, toolchain_name, clean=False, macros=None,
     report - a dict where a result may be appended
     properties - UUUUHHHHH beats me
     build_profile - a dict of flags that will be passed to the compiler
+    ignore - list of paths to add to mbedignore
     """
     lib = Library(lib_id)
     if not lib.is_supported(target, toolchain_name):
@@ -882,7 +879,8 @@ def build_lib(lib_id, target, toolchain_name, clean=False, macros=None,
 
         toolchain = prepare_toolchain(
             src_paths, tmp_path, target, toolchain_name, macros=macros,
-            notify=notify, build_profile=build_profile, jobs=jobs, clean=clean)
+            notify=notify, build_profile=build_profile, jobs=jobs, clean=clean,
+            ignore=ignore)
 
         notify.info("Building library %s (%s, %s)" %
                        (name.upper(), target.name, toolchain_name))
@@ -958,7 +956,7 @@ def build_lib(lib_id, target, toolchain_name, clean=False, macros=None,
 # library
 def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
                     notify=None, jobs=1, report=None, properties=None,
-                    build_profile=None):
+                    build_profile=None, ignore=None):
     """ Function returns True is library was built and false if building was
     skipped
 
@@ -974,6 +972,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
     report - a dict where a result may be appended
     properties - UUUUHHHHH beats me
     build_profile - a dict of flags that will be passed to the compiler
+    ignore - list of paths to add to mbedignore
     """
 
     if report != None:
@@ -1017,7 +1016,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
 
         toolchain = prepare_toolchain(
             [""], tmp_path, target, toolchain_name, macros=macros, notify=notify,
-            build_profile=build_profile, jobs=jobs, clean=clean)
+            build_profile=build_profile, jobs=jobs, clean=clean, ignore=ignore)
 
         # Take into account the library configuration (MBED_CONFIG_FILE)
         config = toolchain.config

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -221,7 +221,8 @@ def zip_export(file_name, prefix, resources, project_files, inc_repos, notify):
 def export_project(src_paths, export_path, target, ide, libraries_paths=None,
                    linker_script=None, notify=None, name=None, inc_dirs=None,
                    jobs=1, config=None, macros=None, zip_proj=None,
-                   inc_repos=False, build_profile=None, app_config=None):
+                   inc_repos=False, build_profile=None, app_config=None,
+                   ignore=None):
     """Generates a project file and creates a zip archive if specified
 
     Positional Arguments:
@@ -242,6 +243,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     macros - User-defined macros
     zip_proj - string name of the zip archive you wish to creat (exclude arg
      if you do not wish to create an archive
+    ignore - list of paths to add to mbedignore
     """
 
     # Convert src_path to a list if needed
@@ -269,7 +271,7 @@ def export_project(src_paths, export_path, target, ide, libraries_paths=None,
     toolchain = prepare_toolchain(
         paths, "", target, toolchain_name, macros=macros, jobs=jobs,
         notify=notify, config=config, build_profile=build_profile,
-        app_config=app_config)
+        app_config=app_config, ignore=ignore)
 
     toolchain.RESPONSE_FILES = False
     if name is None:

--- a/tools/make.py
+++ b/tools/make.py
@@ -140,6 +140,8 @@ if __name__ == '__main__':
                       default=None, help="The build (output) directory")
     parser.add_argument("-N", "--artifact-name", dest="artifact_name",
                       default=None, help="The built project's name")
+    parser.add_argument("--ignore", dest="ignore", type=argparse_many(str),
+                        default=None, help="Comma separated list of patterns to add to mbedignore (eg. ./main.cpp)")
     parser.add_argument("-d", "--disk", dest="disk",
                       default=None, help="The mbed disk")
     parser.add_argument("-s", "--serial", dest="serial",
@@ -284,7 +286,8 @@ if __name__ == '__main__':
                                      build_profile=extract_profile(parser,
                                                                    options,
                                                                    toolchain),
-                                     stats_depth=options.stats_depth)
+                                     stats_depth=options.stats_depth,
+                                     ignore=options.ignore)
             print('Image: %s'% bin_file)
 
             if options.disk:

--- a/tools/project.py
+++ b/tools/project.py
@@ -73,7 +73,7 @@ def setup_project(ide, target, program=None, source_dir=None, build=None, export
 
 def export(target, ide, build=None, src=None, macros=None, project_id=None,
            zip_proj=False, build_profile=None, export_path=None, notify=None,
-           app_config=None):
+           app_config=None, ignore=None):
     """Do an export of a project.
 
     Positional arguments:
@@ -87,6 +87,7 @@ def export(target, ide, build=None, src=None, macros=None, project_id=None,
     project_id - the name of the project
     clean - start from a clean state before exporting
     zip_proj - create a zip file or not
+    ignore - list of paths to add to mbedignore
 
     Returns an object of type Exporter (tools/exports/exporters.py)
     """
@@ -98,7 +99,7 @@ def export(target, ide, build=None, src=None, macros=None, project_id=None,
     return export_project(src, project_dir, target, ide, name=name,
                           macros=macros, libraries_paths=lib, zip_proj=zip_name,
                           build_profile=build_profile, notify=notify,
-                          app_config=app_config)
+                          app_config=app_config, ignore=ignore)
 
 
 def main():
@@ -197,6 +198,9 @@ def main():
                         dest="app_config",
                         default=None)
 
+    parser.add_argument("--ignore", dest="ignore", type=argparse_many(str),
+                        default=None, help="Comma separated list of patterns to add to mbedignore (eg. ./main.cpp)")
+
     options = parser.parse_args()
 
     # Print available tests in order and exit
@@ -273,7 +277,8 @@ def main():
                src=options.source_dir, macros=options.macros,
                project_id=options.program, zip_proj=zip_proj,
                build_profile=profile, app_config=options.app_config,
-               export_path=options.build_dir, notify = notify)
+               export_path=options.build_dir, notify=notify,
+               ignore=options.ignore)
     except NotSupportedException as exc:
         print("[ERROR] %s" % str(exc))
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -112,6 +112,9 @@ if __name__ == '__main__':
                             default=2,
                             help="Depth level for static memory report")
 
+        parser.add_argument("--ignore", dest="ignore", type=argparse_many(str),
+                          default=None, help="Comma separated list of patterns to add to mbedignore (eg. ./main.cpp)")
+
         options = parser.parse_args()
 
         # Filter tests by path if specified
@@ -152,6 +155,7 @@ if __name__ == '__main__':
 
         if not config:
             config = get_default_config(options.source_dir or ['.'], mcu)
+
 
         # Find all tests in the relevant paths
         for path in all_paths:
@@ -205,7 +209,8 @@ if __name__ == '__main__':
                               macros=options.macros,
                               notify=notify, archive=False,
                               app_config=config,
-                              build_profile=profile)
+                              build_profile=profile,
+                              ignore=options.ignore)
 
                 library_build_success = True
             except ToolException as e:
@@ -233,7 +238,8 @@ if __name__ == '__main__':
                         continue_on_build_fail=options.continue_on_build_fail,
                         app_config=config,
                         build_profile=profile,
-                        stats_depth=options.stats_depth)
+                        stats_depth=options.stats_depth,
+                        ignore=options.ignore)
 
                 # If a path to a test spec is provided, write it to a file
                 if options.test_spec:

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2210,7 +2210,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
                 clean=False, notify=None, jobs=1, macros=None,
                 silent=False, report=None, properties=None,
                 continue_on_build_fail=False, app_config=None,
-                build_profile=None, stats_depth=None):
+                build_profile=None, stats_depth=None, ignore=None):
     """Given the data structure from 'find_tests' and the typical build parameters,
     build all the tests
 


### PR DESCRIPTION
### Description
This patch adds an extra arg `--ignore` to `test.py` for use when running unit tests. 
`--ignore` lets you specify a comma separated list of extra lines to dynamically add to mbedignore for the building of tests.

In particular this simplifies ignoring a project main.cpp file when running unit tests to remove the multiple definition of `main(void)` function.

Example:
```
python mbed-os/tools/test.py -t GCC_ARM -m NRF51_DK --source . --build BUILD\tests\NRF51_DK\GCC_ARM --test-spec BUILD\tests\NRF51_DK\GCC_ARM\test_spec.json --ignore src/main.cpp,src/errors.cpp
```

For this to be used with mbed cli tool the --ignore arg needs to be added there to only pass it on to test.py, else it gets passed to mbed-gt tool as well which then fails due to unknown arg.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

