### PR TITLE
Nuvoton: Fix RTOS-less crash with ARM/ARMC6

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/M453.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00040000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
@@ -29,9 +34,9 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x8000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x8000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 256 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20008000)   ; 32 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20008000)   ; 32 KB SRAM
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/M453.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00040000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 64)) {  ; Reserve for vectors
@@ -29,9 +34,9 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x8000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x8000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 256 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20008000)   ; 32 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20008000)   ; 32 KB SRAM
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/TOOLCHAIN_ARM_STD/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M451/device/startup_M451Series.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/device/startup_M451Series.c
@@ -48,7 +48,7 @@ void FUN(void) __attribute__ ((weak, alias(#FUN_ALIAS)));
 
 /* Initialize segments */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-extern uint32_t Image$$ARM_LIB_STACK$$ZI$$Limit;
+extern uint32_t Image$$ARM_LIB_STACK_$$ZI$$Limit;
 extern void __main(void);
 #elif defined(__ICCARM__)
 void __iar_program_start(void);
@@ -165,7 +165,7 @@ const uint32_t __vector_handlers[] = {
 
     /* Configure Initial Stack Pointer, using linker-generated symbols */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    (uint32_t) &Image$$ARM_LIB_STACK$$ZI$$Limit,
+    (uint32_t) &Image$$ARM_LIB_STACK_$$ZI$$Limit,
 #elif defined(__ICCARM__)
     //(uint32_t) __sfe("CSTACK"),
     (uint32_t) &CSTACK$$Limit,

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/M487.sct
@@ -11,6 +11,11 @@
 #define SPIM_CCM_START  0x20020000
 #define SPIM_CCM_END    0x20028000
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -22,7 +27,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 96)) {  ; Reserve for vectors
@@ -32,8 +37,8 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x28000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x28000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))  ; 512 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20028000)   ; 160 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20028000)   ; 160 KB SRAM

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/M487.sct
@@ -11,6 +11,11 @@
 #define SPIM_CCM_START  0x20020000
 #define SPIM_CCM_END    0x20028000
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -22,7 +27,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 96)) {  ; Reserve for vectors
@@ -32,8 +37,8 @@ LR_IROM1 MBED_APP_START {
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x28000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x28000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))  ; 512 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20028000)   ; 160 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20028000)   ; 160 KB SRAM

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_ARM_STD/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/startup_M480.c
@@ -51,7 +51,7 @@ void FUN(void) __attribute__ ((weak, alias(#FUN_ALIAS)));
 
 /* Initialize segments */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-extern uint32_t Image$$ARM_LIB_STACK$$ZI$$Limit;
+extern uint32_t Image$$ARM_LIB_STACK_$$ZI$$Limit;
 extern void __main(void);
 #elif defined(__ICCARM__)
 void __iar_program_start(void);
@@ -202,7 +202,7 @@ const uint32_t __vector_handlers[] = {
 #endif
 
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    (uint32_t) &Image$$ARM_LIB_STACK$$ZI$$Limit,
+    (uint32_t) &Image$$ARM_LIB_STACK_$$ZI$$Limit,
 #elif defined(__ICCARM__)
     (uint32_t) &CSTACK$$Limit,
 #elif defined(__GNUC__)
@@ -407,7 +407,7 @@ void Reset_Handler_1(void)
     SYS_LockReg();
     
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    Reset_Handler_Cascade((void *) &Image$$ARM_LIB_STACK$$ZI$$Limit, (void *) Reset_Handler_2);
+    Reset_Handler_Cascade((void *) &Image$$ARM_LIB_STACK_$$ZI$$Limit, (void *) Reset_Handler_2);
 #elif defined(__ICCARM__)
     Reset_Handler_Cascade((void *) &CSTACK$$Limit, (void *) Reset_Handler_2);
 #elif defined(__GNUC__)

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/NANO130.sct
@@ -1,3 +1,7 @@
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
 
 LR_IROM1 0x00000000 {
   ER_IROM1 0x00000000 {  ; load address = execution address
@@ -10,16 +14,16 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x4000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x4000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= 0x00020000)    ; 128 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20004000)   ; 16 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20004000)   ; 16 KB SRAM
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/NANO130.sct
@@ -1,3 +1,7 @@
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
 
 LR_IROM1 0x00000000 {
   ER_IROM1 0x00000000 {  ; load address = execution address
@@ -10,16 +14,16 @@ LR_IROM1 0x00000000 {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   RW_IRAM1 AlignExpr(+0, 16) {  ; 16 byte-aligned
    .ANY (+RW +ZI)
   }
   
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x4000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x4000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= 0x00020000)    ; 128 KB APROM
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x20004000)   ; 16 KB SRAM
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x20004000)   ; 16 KB SRAM
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_ARM_STD/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/startup_Nano100Series.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/startup_Nano100Series.c
@@ -46,7 +46,7 @@ void FUN(void) __attribute__ ((weak, alias(#FUN_ALIAS)));
 
 /* Initialize segments */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-extern uint32_t Image$$ARM_LIB_STACK$$ZI$$Limit;
+extern uint32_t Image$$ARM_LIB_STACK_$$ZI$$Limit;
 extern void __main(void);
 #elif defined(__ICCARM__)
 void __iar_program_start(void);
@@ -127,7 +127,7 @@ const uint32_t __vector_handlers[] = {
 
     /* Configure Initial Stack Pointer, using linker-generated symbols */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    (uint32_t) &Image$$ARM_LIB_STACK$$ZI$$Limit,
+    (uint32_t) &Image$$ARM_LIB_STACK_$$ZI$$Limit,
 #elif defined(__ICCARM__)
     (uint32_t) &CSTACK$$Limit,
 #elif defined(__GNUC__)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
@@ -35,10 +40,10 @@ LR_IROM1 MBED_APP_START {
   }
   
   ; Extern SRAM for HEAP
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x60000000 + 0x100000 - AlignExpr(ImageLimit(ER_XRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x60000000 + 0x100000 - AlignExpr(ImageLimit(ER_XRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 512 KB APROM
 ScatterAssert(ImageLimit(RW_IRAM1) <= 0x20010000)   ; 64 KB SRAM (internal)
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x60100000)   ; 1 MB SRAM (external)
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x60100000)   ; 1 MB SRAM (external)
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
@@ -30,7 +35,7 @@ LR_IROM1 MBED_APP_START {
   }
   
   ; Extern SRAM for HEAP
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x10000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x10000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 512 KB APROM

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_SUPPORTED/NUC472.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
@@ -37,10 +42,10 @@ LR_IROM1 MBED_APP_START {
   }
   
   ; Extern SRAM for HEAP
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x60000000 + 0x100000 - AlignExpr(ImageLimit(ER_XRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x60000000 + 0x100000 - AlignExpr(ImageLimit(ER_XRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 512 KB APROM
 ScatterAssert(ImageLimit(RW_IRAM1) <= 0x20010000)   ; 64 KB SRAM (internal)
-ScatterAssert(ImageLimit(ARM_LIB_HEAP) <= 0x60100000)   ; 1 MB SRAM (external)
+ScatterAssert(ImageLimit(ARM_LIB_HEAP_) <= 0x60100000)   ; 1 MB SRAM (external)
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/TARGET_NU_XRAM_UNSUPPORTED/NUC472.sct
@@ -8,6 +8,11 @@
   #define MBED_APP_SIZE 0x00080000
 #endif
 
+/* If ARM_LIB_STACK/ARM_LIB_HEAP sections are defined, we cannot override __user_setup_stackheap.
+ * Otherwise, we would fail in C run-time initialization with RTOS-less build. Because __user_setup_stackheap
+ * has been re-implemented in platform/mbed_retarget.cpp, we rename ARM_LIB_STACK/ARM_LIB_HEAP to 
+ * ARM_LIB_STACK_/ARM_LIB_HEAP_ to avoid such error. */
+
 LR_IROM1 MBED_APP_START {
   ER_IROM1 MBED_APP_START {  ; load address = execution address
    *(RESET, +First)
@@ -19,7 +24,7 @@ LR_IROM1 MBED_APP_START {
   ;  uvisor-lib.a (+RW +ZI)
   ;}
   
-  ARM_LIB_STACK 0x20000000 EMPTY 0x800 {
+  ARM_LIB_STACK_ 0x20000000 EMPTY 0x800 {
   }
   
   ER_IRAMVEC 0x20000800 EMPTY (4*(16 + 142)) {  ; Reserve for vectors
@@ -30,7 +35,7 @@ LR_IROM1 MBED_APP_START {
   }
   
   ; Extern SRAM for HEAP
-  ARM_LIB_HEAP AlignExpr(+0, 16) EMPTY (0x20000000 + 0x10000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
+  ARM_LIB_HEAP_ AlignExpr(+0, 16) EMPTY (0x20000000 + 0x10000 - AlignExpr(ImageLimit(RW_IRAM1), 16)) {
   }
 }
 ScatterAssert(LoadLimit(LR_IROM1) <= (MBED_APP_START + MBED_APP_SIZE))    ; 512 KB APROM

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/sys.cpp
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/TOOLCHAIN_ARM_STD/sys.cpp
@@ -16,14 +16,23 @@ extern "C" {
 #include <rt_misc.h>
 #include <stdint.h>
 
-extern char Image$$ARM_LIB_STACK$$ZI$$Limit[];
-extern char Image$$ARM_LIB_HEAP$$Base[];
-extern char Image$$ARM_LIB_HEAP$$ZI$$Limit[];
+/* The single region memory model would check stack collision at run time, verifying that
+ * the heap pointer is underneath the stack pointer. With two-region memory model/RTOS-less or
+ * multiple threads(stacks)/RTOS, the check gets meaningless and we must disable it. */
+#if defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)
+__asm(".global __use_two_region_memory\n\t");
+__asm(".global __use_no_semihosting\n\t");
+#else
+#pragma import(__use_two_region_memory)
+#endif
+
+extern char Image$$ARM_LIB_HEAP_$$Base[];
+extern char Image$$ARM_LIB_HEAP_$$ZI$$Limit[];
 extern __value_in_regs struct __initial_stackheap _mbed_user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
 
     struct __initial_stackheap r;
-    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP$$Base;
-    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP$$ZI$$Limit;
+    r.heap_base = (uint32_t)Image$$ARM_LIB_HEAP_$$Base;
+    r.heap_limit = (uint32_t)Image$$ARM_LIB_HEAP_$$ZI$$Limit;
     return r;
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/startup_NUC472_442.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/startup_NUC472_442.c
@@ -48,7 +48,7 @@ void FUN(void) __attribute__ ((weak, alias(#FUN_ALIAS)));
 
 /* Initialize segments */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-extern uint32_t Image$$ARM_LIB_STACK$$ZI$$Limit;
+extern uint32_t Image$$ARM_LIB_STACK_$$ZI$$Limit;
 extern void __main(void);
 #elif defined(__ICCARM__)
 void __iar_program_start(void);
@@ -245,7 +245,7 @@ const uint32_t __vector_handlers[] = {
 
     /* Configure Initial Stack Pointer, using linker-generated symbols */
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    (uint32_t) &Image$$ARM_LIB_STACK$$ZI$$Limit,
+    (uint32_t) &Image$$ARM_LIB_STACK_$$ZI$$Limit,
 #elif defined(__ICCARM__)
     //(uint32_t) __sfe("CSTACK"),
     (uint32_t) &CSTACK$$Limit,

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -22,14 +22,14 @@
 #if defined(TARGET_NUVOTON)
 
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Base[];
-    extern uint32_t               Image$$ARM_LIB_HEAP$$ZI$$Length[];
-    extern uint32_t               Image$$ARM_LIB_STACK$$ZI$$Base[];
-    extern uint32_t               Image$$ARM_LIB_STACK$$ZI$$Length[];
-    #define HEAP_START            ((unsigned char*) Image$$ARM_LIB_HEAP$$ZI$$Base)
-    #define HEAP_SIZE             ((uint32_t) Image$$ARM_LIB_HEAP$$ZI$$Length)
-    #define ISR_STACK_START       ((unsigned char*)Image$$ARM_LIB_STACK$$ZI$$Base)
-    #define ISR_STACK_SIZE        ((uint32_t)Image$$ARM_LIB_STACK$$ZI$$Length)
+    extern uint32_t               Image$$ARM_LIB_HEAP_$$ZI$$Base[];
+    extern uint32_t               Image$$ARM_LIB_HEAP_$$ZI$$Length[];
+    extern uint32_t               Image$$ARM_LIB_STACK_$$ZI$$Base[];
+    extern uint32_t               Image$$ARM_LIB_STACK_$$ZI$$Length[];
+    #define HEAP_START            ((unsigned char*) Image$$ARM_LIB_HEAP_$$ZI$$Base)
+    #define HEAP_SIZE             ((uint32_t) Image$$ARM_LIB_HEAP_$$ZI$$Length)
+    #define ISR_STACK_START       ((unsigned char*)Image$$ARM_LIB_STACK_$$ZI$$Base)
+    #define ISR_STACK_SIZE        ((uint32_t)Image$$ARM_LIB_STACK_$$ZI$$Length)
 #elif defined(__GNUC__)
     extern uint32_t               __StackTop[];
     extern uint32_t               __StackLimit[];


### PR DESCRIPTION
### Description
This PR tries to fix RTOS-less crash with ARM/ARMC6. To re-produce the crash, I test with the environment:
**mbed-os-example-blinky**
5.8.3

**mbed-os**
5.8.3

**.mbedignore** (for RTOS-less)
```
*/test/*
mbed-os/rtos/*
mbed-os/events/*
mbed-os/features/FEATURE_LWIP/*
mbed-os/features/FEATURE_BLE/*
mbed-os/features/FEATURE_COMMON_PAL/mbed-client-randlib/*
mbed-os/features/FEATURE_COMMON_PAL/mbed-coap/*
mbed-os/features/FEATURE_COMMON_PAL/nanostack-hal-mbed-cmsis-rtos/*
mbed-os/features/FEATURE_COMMON_PAL/sal-stack-nanostack-eventloop/*
mbed-os/features/FEATURE_COMMON_PAL/mbed-trace/source/*
mbed-os/features/FEATURE_COMMON_PAL/mbed-trace/test/*
mbed-os/features/FEATURE_COMMON_PAL/nanostack-libservice/source/*
mbed-os/features/FEATURE_COMMON_PAL/nanostack-libservice/test/*
mbed-os/features/FEATURE_UVISOR/*
mbed-os/features/cellular/*
mbed-os/features/frameworks/*
mbed-os/features/nanostack/*
mbed-os/features/netsocket/*
mbed-os/features/storage/*
mbed-os/features/filesystem/littlefs/*
mbed-os/features/filesystem/fat/*
mbed-os/features/lorawan/*
mbed-os/features/nvstore/*
mbed-os/features/unsupported/*
mbed-cloud-client/update-client-hub/source/*
mbed-cloud-client/update-client-hub/modules/atomic-queue/*
mbed-cloud-client/update-client-hub/modules/control-center/*
mbed-cloud-client/update-client-hub/modules/firmware-manager/*
mbed-cloud-client/update-client-hub/modules/manifest-manager/*
mbed-cloud-client/update-client-hub/modules/pal-linux/*
mbed-cloud-client/update-client-hub/modules/source/*
mbed-cloud-client/update-client-hub/modules/source-http-socket/*
mbed-cloud-client/update-client-hub/modules/device-identity/*
mbed-cloud-client/update-client-hub/modules/lwm2m-mbed/*
mbed-cloud-client/update-client-hub/modules/monitor/*
mbed-cloud-client/update-client-hub/modules/pal-filesystem/*
mbed-cloud-client/update-client-hub/modules/pal-target-specific/*
mbed-cloud-client/update-client-hub/modules/source-http/*
mbed-cloud-client/update-client-hub/modules/source-manager/*
mbed-cloud-client/update-client-hub/modules/common/source/arm_uc_scheduler.c
mbed-cloud-client/mbed-client-pal/Test/*
mbed-cloud-client/mbed-client-pal/Utils/*
mbed-cloud-client/mbed-client-pal/Examples/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/pal_init.c
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Crypto/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Networking/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/RTOS/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/TLS/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Update/*
mbed-cloud-client/mbed-client-pal/Source/PAL-Impl/Modules/Storage/FileSystem/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/Lib_Specific/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/FreeRTOS/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Networking/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/RTOS/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Update/*
mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/mbedOS/Storage/FileSystem/*
mbed-cloud-client/CMakeLists.txt
mbed-cloud-client/DOXYGEN_FRONTPAGE.md
mbed-cloud-client/Jenkinsfile
mbed-cloud-client/LICENSE
mbed-cloud-client/README.md
mbed-cloud-client/contributions.md
mbed-cloud-client/doxygen/*
mbed-cloud-client/factory-configurator-client/CMakeLists.txt
mbed-cloud-client/factory-configurator-client/DOXYGEN_FRONTPAGE.md
mbed-cloud-client/factory-configurator-client/common_includes.cmake
mbed-cloud-client/factory-configurator-client/crypto-service/*
mbed-cloud-client/factory-configurator-client/factory-configurator-client/*
mbed-cloud-client/factory-configurator-client/fcc-bundle-handler/*
mbed-cloud-client/factory-configurator-client/fcc-output-info-handler/*
mbed-cloud-client/factory-configurator-client/ftcd-comm-base/*
mbed-cloud-client/factory-configurator-client/ftcd-comm-serial/*
mbed-cloud-client/factory-configurator-client/ftcd-comm-socket/*
mbed-cloud-client/factory-configurator-client/key-config-manager/*
mbed-cloud-client/factory-configurator-client/logger/*
mbed-cloud-client/factory-configurator-client/mbed-trace-helper/*
mbed-cloud-client/factory-configurator-client/secsrv-cbor/*
mbed-cloud-client/factory-configurator-client/storage/*
mbed-cloud-client/factory-configurator-client/utils/*
mbed-cloud-client/factory-configurator-client/mbed-client-esfs/Test/*
mbed-cloud-client/factory-configurator-client/mbed-client-esfs/Tools/*
mbed-cloud-client/factory-configurator-client/mbed-client-esfs/source/esfs.c
mbed-cloud-client/factory-configurator-client/mbed-client-esfs/source/esfs_file_name.c
mbed-cloud-client/factory-configurator-client/mbed-client-esfs/source/esfs_performance.c
mbed-cloud-client/mbed-client/*
mbed-cloud-client/mbed-client-randlib/*
mbed-cloud-client/mbed-cloud-client/*
mbed-cloud-client/mbed-coap/*
mbed-cloud-client/mbed-trace/*
mbed-cloud-client/mbed_lib.json
mbed-cloud-client/nanostack-libservice/*
mbed-cloud-client/ns-hal-pal/*
mbed-cloud-client/sal-stack-nanostack-eventloop/*
mbed-cloud-client/source/*
```

We have the following major modifications:
1. Per test, defining `ARM_LIB_STACK`/`ARM_LIB_HEAP` sections and re-implementing `__user_setup_stackheap` cannot co-exist. `__user_setup_stackheap`  is re-implemented in `mbed-os/platform/mbed_retarget.cpp`, so we rename `ARM_LIB_STACK`/`ARM_LIB_HEAP` to `ARM_LIB_STACK_`/`ARM_LIB_HEAP_` to remove special meanings of these section names.
1. Add two-region memory model pragma to avoid stack pointer check for single-region memory model.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

