### PR TITLE
export: Fix invalid config header path in Sw4STM32

### DIFF
--- a/tools/export/sw4stm32/__init__.py
+++ b/tools/export/sw4stm32/__init__.py
@@ -17,7 +17,7 @@ limitations under the License.
 from __future__ import print_function, absolute_import
 from builtins import str
 
-from os.path import splitext, basename, join
+from os.path import splitext, basename, relpath, join
 import shutil
 from tools.utils import mkdir
 from tools.export.gnuarmeclipse import GNUARMEclipse
@@ -290,7 +290,6 @@ class Sw4STM32(GNUARMEclipse):
         },
     }
 
-
     @classmethod
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
@@ -434,7 +433,10 @@ class Sw4STM32(GNUARMEclipse):
 
         self.resources.win_to_unix()
 
-        config_header = self.filter_dot(self.toolchain.get_config_header())
+        config_header = self.toolchain.get_config_header()
+        if config_header:
+            config_header = relpath(config_header, self.resources.file_basepath[config_header])
+        print('Config header: ' + config_header)
 
         libraries = []
         for lib in self.resources.libraries:

--- a/tools/export/sw4stm32/__init__.py
+++ b/tools/export/sw4stm32/__init__.py
@@ -436,7 +436,6 @@ class Sw4STM32(GNUARMEclipse):
         config_header = self.toolchain.get_config_header()
         if config_header:
             config_header = relpath(config_header, self.resources.file_basepath[config_header])
-        print('Config header: ' + config_header)
 
         libraries = []
         for lib in self.resources.libraries:

--- a/tools/export/sw4stm32/cproject_common.tmpl
+++ b/tools/export/sw4stm32/cproject_common.tmpl
@@ -28,7 +28,7 @@
 							<option id="fr.ac6.managedbuild.option.gnu.cross.floatabi.{{u.id}}" name="Floating-point ABI" superClass="fr.ac6.managedbuild.option.gnu.cross.floatabi" value="fr.ac6.managedbuild.option.gnu.cross.floatabi.{{opts['common']['arm.target.fpu.abi']}}" valueType="enumerated"/>
 							{% endif %}
 							<targetPlatform archList="all" binaryParser="org.eclipse.cdt.core.ELF" id="fr.ac6.managedbuild.targetPlatform.gnu.cross.{{u.id}}" isAbstract="false" osList="all" superClass="fr.ac6.managedbuild.targetPlatform.gnu.cross"/>
-							<builder buildPath="${workspace_loc:/{{name}}}/{{opts['name']}}" id="fr.ac6.managedbuild.builder.gnu.cross.{{u.id}}" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" superClass="fr.ac6.managedbuild.builder.gnu.cross"/>
+							<builder buildPath="${workspace_loc:/{{name}}}/{{opts['name']}}" id="fr.ac6.managedbuild.builder.gnu.cross.{{u.id}}" keepEnvironmentInBuildfile="false" managedBuildOn="true" name="Gnu Make Builder" parallelBuildOn="true" parallelizationNumber="optimal" superClass="fr.ac6.managedbuild.builder.gnu.cross"/>
 							<tool id="fr.ac6.managedbuild.tool.gnu.cross.c.compiler.{{opts['uid']['tool_c_compiler']}}" name="MCU GCC Compiler" superClass="fr.ac6.managedbuild.tool.gnu.cross.c.compiler">
 								{% if cfg_id == 'debug' %}
 								<option id="fr.ac6.managedbuild.gnu.c.compiler.option.optimization.level.{{u.id}}" name="Optimization Level" superClass="fr.ac6.managedbuild.gnu.c.compiler.option.optimization.level" useByScannerDiscovery="false" value="fr.ac6.managedbuild.gnu.c.optimization.level.more" valueType="enumerated"/>


### PR DESCRIPTION

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Removed tmp-path from config header path, when project is exported in online compiler. Fixes #5619 

Parallel build is now enabled by default. In Windows build is terribly slow if parallel build is not enabled.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

