### PR TITLE
Lora: fix AU915 build

### DIFF
--- a/features/lorawan/lorastack/phy/loraphy_target.h
+++ b/features/lorawan/lorastack/phy/loraphy_target.h
@@ -58,7 +58,7 @@
   #define LoRaPHY_region LoRaPHYAS923
  #elif LORA_REGION    == LORA_REGION_AU915
   #include "lorawan/lorastack/phy/LoRaPHYAU915.h"
- #define LoRaPHY_region LoRaPHYAU915;
+ #define LoRaPHY_region LoRaPHYAU915
  #elif LORA_REGION    == LORA_REGION_CN470
   #include "lorawan/lorastack/phy/LoRaPHYCN470.h"
   #define LoRaPHY_region LoRaPHYCN470


### PR DESCRIPTION

### Description

There was a typo in the code making it fail to compile.

This PR should go to master. mbed-os 5.8.x branch is handled with a different PR (https://github.com/ARMmbed/mbed-os/pull/6829) as code is moved to another place.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

