### PR TITLE
Lora: fix RX datarate

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -868,7 +868,7 @@ bool LoRaPHY::rx_config(rx_config_params_t* rx_conf, int8_t* datarate)
 
     _radio->unlock();
 
-    *datarate = phy_dr;
+    *datarate = dr;
 
     return true;
 }


### PR DESCRIPTION

### Description

rx_config() incorrectly returns a physical layer datarate value when an index to datarate table should be returned.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

