### PR TITLE
Remove obsolete OS_IDLE_THREAD_STACK_SIZE from NRF52

### DIFF
--- a/targets/TARGET_NORDIC/mbed_rtx.h
+++ b/targets/TARGET_NORDIC/mbed_rtx.h
@@ -37,16 +37,11 @@
 #define INITIAL_SP              (0x20010000UL)
 #endif
 
-#define OS_IDLE_THREAD_STACK_SIZE  512
-
 #elif defined(TARGET_MCU_NRF52840)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20040000UL)
 #endif
-
-// More than 256 bytes are needed for the idle thread stack on the NRF52840
-#define OS_IDLE_THREAD_STACK_SIZE  512
 
 #endif // defined(TARGET_MCU_NRF51822)...
 


### PR DESCRIPTION
### Description

Custom size is the same as the default size anyway.


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

