### PR TITLE
Fix for issue #5308 - RTC set/get time issue on NCS36510

### DIFF
--- a/TESTS/mbed_drivers/rtc/main.cpp
+++ b/TESTS/mbed_drivers/rtc/main.cpp
@@ -144,7 +144,7 @@ void test_attach_RTC_stub_funtions()
     TEST_ASSERT_EQUAL(false, rtc_init_called);
 
     /* Check if time has been successfully set and retrieved. */
-    TEST_ASSERT_EQUAL(CUSTOM_TIME_1, seconds);
+    TEST_ASSERT_UINT32_WITHIN(RTC_DELTA, CUSTOM_TIME_1, seconds);
 }
 
 /* This test verifies if attach_rtc provides availability to
@@ -183,7 +183,7 @@ void test_attach_RTC_org_funtions()
     TEST_ASSERT_EQUAL(false, rtc_init_called);
 
     /* Check if time has been successfully set and retrieved. */
-    TEST_ASSERT_EQUAL(CUSTOM_TIME_1, seconds);
+    TEST_ASSERT_UINT32_WITHIN(RTC_DELTA, CUSTOM_TIME_1, seconds);
 }
 
 /* This test verifies if time() function returns
@@ -430,7 +430,7 @@ void test_functional_set()
     set_time(timeValue);
 
     /* Get current time and verify that new value has been set. */
-    TEST_ASSERT_EQUAL(timeValue, time(NULL));
+    TEST_ASSERT_UINT32_WITHIN(1, timeValue, time(NULL));
 }
 
 /* This test verifies if RTC counts seconds.

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3736,7 +3736,7 @@
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
-        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE"],
+        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "LOWPOWERTIMER", "TRNG", "SPISLAVE", "RTC"],
         "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {


### PR DESCRIPTION
### Description

The problem was caused by wrong implementation of `rtc_read()` and `rtc_write()` routines which were operating on us instead of seconds.

Provide fix for Issue# https://github.com/ARMmbed/mbed-os/issues/5308.
Modify `tests-mbed_drivers-rtc` test: add one second tolerance(min possible) in functional tests. 
Enable `RTC` support for `NCS36510`.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

