### PR TITLE
Add NetworkInterface::get_default_instance()

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -160,3 +160,13 @@ bool LoWPANNDInterface::getRouterIpAddress(char *address, int8_t len)
 {
     return _interface->get_gateway(address, len);
 }
+
+#define LOWPAN 0x2345
+#if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == LOWPAN && DEVICE_802_15_4_PHY
+MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
+{
+    static LoWPANNDInterface lowpan(NanostackRfPhy::get_default_instance());
+
+    return lowpan;
+}
+#endif

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -183,3 +183,10 @@ nsapi_error_t InterfaceNanostack::set_blocking(bool blocking)
     _blocking = blocking;
     return NSAPI_ERROR_OK;
 }
+
+#if !DEVICE_802_15_4_PHY
+MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
+{
+    return NULL;
+}
+#endif

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -231,3 +231,13 @@ mesh_error_t Nanostack::ThreadInterface::device_pskd_set(const char *pskd)
 {
     return (mesh_error_t)thread_tasklet_device_pskd_set(pskd);
 }
+
+#define THREAD 0x2345
+#if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == THREAD && DEVICE_802_15_4_PHY
+MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
+{
+    static ThreadInterface thread(NanostackRfPhy::get_default_instance());
+
+    return thread;
+}
+#endif

--- a/features/nanostack/nanostack-interface/NanostackRfPhy.h
+++ b/features/nanostack/nanostack-interface/NanostackRfPhy.h
@@ -24,6 +24,13 @@
 class NanostackRfPhy : public NanostackPhy {
 public:
 
+    /** Return the default on-board NanostackRfPhy
+     *
+     * Returns the default on-board NanostackRfPhy - this will be target-specific, and
+     * may not be available on all targets.
+     */
+    static NanostackRfPhy &get_default_instance();
+
     /** Register this physical interface with Nanostack
      *
      *  @return         Device driver ID or a negative error

--- a/features/netsocket/CellularBase.h
+++ b/features/netsocket/CellularBase.h
@@ -26,6 +26,17 @@ class CellularBase: public NetworkInterface {
 
 public:
 
+    /** Get the default Cellular interface.
+     *
+     * This is provided as a weak method so applications can override.
+     * Default behaviour is to get the target's default interface, if
+     * any.
+     *
+     * @return pointer to interface, if any
+     */
+
+    static CellularBase *get_default_instance();
+
     /** Set the Cellular network credentials
      *
      *  Please check documentation of connect() for default behaviour of APN settings.
@@ -102,6 +113,17 @@ public:
     virtual const char *get_gateway() = 0;
 
     virtual CellularBase *cellularBase() { return this; }
+
+protected:
+    /** Get the target's default Cellular interface.
+     *
+     * This is provided as a weak method so targets can override. The
+     * default implementation configures and returns the OnBoardModemInterface
+     * if available.
+     *
+     * @return pointer to interface, if any
+     */
+    static CellularBase *get_target_default_instance();
 };
 
 #endif //CELLULAR_BASE_H

--- a/features/netsocket/EthInterface.h
+++ b/features/netsocket/EthInterface.h
@@ -29,7 +29,31 @@
  */
 class EthInterface : public virtual NetworkInterface
 {
+public:
+
     virtual EthInterface *ethInterface() { return this; }
+
+    /** Get the default Ethernet interface.
+     *
+     * This is provided as a weak method so applications can override.
+     * Default behaviour is to get the target's default interface, if
+     * any.
+     *
+     * @return pointer to interface, if any
+     */
+    static EthInterface *get_default_instance();
+
+protected:
+
+    /** Get the target's default Ethernet interface.
+     *
+     * This is provided as a weak method so targets can override. The
+     * default implementation will invoke EthernetInterface with the
+     * default EMAC and default network stack, if DEVICE_EMAC is set.
+     *
+     * @return pointer to interface, if any
+     */
+    static EthInterface *get_target_default_instance();
 };
 
 

--- a/features/netsocket/EthernetInterface.cpp
+++ b/features/netsocket/EthernetInterface.cpp
@@ -1,0 +1,34 @@
+/* LWIP implementation of NetworkInterfaceAPI
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "EthernetInterface.h"
+
+/* No actual interface implementation here, as EthernetInterface is
+ * just an EMACInterface. But we can be the default EthInterface - step up
+ * if the target has a default EMAC.
+ */
+#if DEVICE_EMAC
+MBED_WEAK EthInterface *EthInterface::get_target_default_instance()
+{
+    static EthernetInterface ethernet;
+    return &ethernet;
+}
+#else
+MBED_WEAK EthInterface *EthInterface::get_target_default_instance()
+{
+    return NULL;
+}
+#endif

--- a/features/netsocket/MeshInterface.h
+++ b/features/netsocket/MeshInterface.h
@@ -29,7 +29,31 @@
  */
 class MeshInterface : public virtual NetworkInterface
 {
+public:
+
     virtual MeshInterface *meshInterface() { return this; }
+
+    /** Get the default Mesh interface.
+     *
+     * This is provided as a weak method so applications can override.
+     * Default behaviour is to get the target's default interface, if
+     * any.
+     *
+     * @return pointer to interface, if any
+     */
+    static MeshInterface *get_default_instance();
+
+protected:
+
+    /** Get the target's default Mesh interface.
+     *
+     * This is provided as a weak method so targets can override. The
+     * default implementation will invoke LoWPANNDInterface or ThreadInterface
+     * with the default NanostackRfPhy.
+     *
+     * @return pointer to interface, if any
+     */
+    static MeshInterface *get_target_default_instance();
 };
 
 

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -39,9 +39,45 @@ class EMACInterface;
 class NetworkInterface: public DNS {
 public:
 
-
-
     virtual ~NetworkInterface() {};
+
+    /** Return the default network interface
+     *
+     * Returns the default network interface, as determined by JSON option
+     * target.network-default-interface-type or other overrides.
+     *
+     * The type of the interface returned can be tested via the ethInterface()
+     * etc downcasts.
+     *
+     * The default behaviour is to return the default interface for the
+     * interface type specified by target.network-default-interface-type. Targets
+     * should set this in their targets.json to guide default selection,
+     * and applications may override.
+     *
+     * The interface returned should be already configured for use such that its
+     * connect() method works with no parameters. For connection types needing
+     * configuration, settings should normally be obtained from JSON - the
+     * settings for the core types are under the "nsapi" JSON config tree.
+     *
+     * The list of possible settings for default interface type is open-ended,
+     * as is the number of possible providers. Core providers are:
+     *
+     * * ETHERNET: EthernetInterface, using default EMAC and OnboardNetworkStack
+     * * MESH: ThreadInterface or LoWPANNDInterface, using default NanostackRfPhy
+     * * CELLULAR: OnboardModemInterface
+     * * WIFI: None - always provided by a specific class
+     *
+     * Specific drivers may be activated by other settings of the
+     * default-network-interface-type configuration.  This will depend on the
+     * target and the driver. For example a board may have its default setting
+     * as "AUTO" which causes it to autodetect an Ethernet cable. This should
+     * be described in the target's documentation.
+     *
+     * An application can override all target settings by implementing
+     * NetworkInterface::get_default_instance() themselves - the default
+     * definition is weak, and calls get_target_default_instance().
+     */
+    static NetworkInterface *get_default_instance();
 
     /** Get the local MAC address
      *
@@ -237,6 +273,37 @@ protected:
      *  @return The underlying NetworkStack object
      */
     virtual NetworkStack *get_stack() = 0;
+
+    /** Get the target's default network instance.
+     *
+     * This method can be overridden by the target. Default implementations
+     * are provided weakly by various subsystems as described in
+     * NetworkInterface::get_default_instance(), so targets should not
+     * need to override in simple cases.
+     *
+     * If a target has more elaborate interface selection, it can completely
+     * override this behaviour by implementing
+     * NetworkInterface::get_target_default_instance() themselves, either
+     * unconditionally, or for a specific network-default-interface-type setting
+     *
+     * For example, a device with both Ethernet and Wi-fi could be set up its
+     * target so that:
+     *    * DEVICE_EMAC is set, and it provides EMAC::get_default_instance(),
+     *      which means EthernetInterface provides EthInterface::get_target_instance()
+     *      based on that EMAC.
+     *    * It provides WifiInterface::get_target_default_instance().
+     *    * The core will route NetworkInterface::get_default_instance() to
+     *      either of those if network-default-interface-type is set to
+     *      ETHERNET or WIFI.
+     *    * The board overrides NetworkInterface::get_target_default_instance()
+     *      if network-default-interface-type is set to AUTO. This returns
+     *      either EthInterface::get_default_instance() or WiFIInterface::get_default_instance()
+     *      depending on a cable detection.
+     *
+     *
+     * performs the search described by get_default_instance.
+     */
+    static NetworkInterface *get_target_default_instance();
 };
 
 

--- a/features/netsocket/NetworkInterfaceDefaults.cpp
+++ b/features/netsocket/NetworkInterfaceDefaults.cpp
@@ -1,0 +1,145 @@
+/* Network interface defaults
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "netsocket/NetworkInterface.h"
+
+#include "EthInterface.h"
+#include "WiFiInterface.h"
+#include "CellularBase.h"
+#include "MeshInterface.h"
+
+/* Weak default instance static classes for the various abstract classes.
+ * Applications can override these.
+ */
+
+MBED_WEAK EthInterface *EthInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+MBED_WEAK WiFiInterface *WiFiInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+MBED_WEAK CellularBase *CellularBase::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+/* For other types, we can provide a reasonable get_target_default_instance
+ * in some cases. This is done in EthernetInterface.cpp, mbed-mesh-api and
+ * OnboardCellularInterface.cpp. We have no implementation for WiFi, so a
+ * default empty one lives here.
+ */
+
+MBED_WEAK WiFiInterface *WiFiInterface::get_target_default_instance()
+{
+    return NULL;
+}
+
+/* The top-level get_default_instance() call. Weak for application override. */
+MBED_WEAK NetworkInterface *NetworkInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+/* Finally the dispatch from the JSON default interface type to the specific
+ * subclasses. It's our job to configure - the default NetworkInterface is
+ * preconfigured - the specific subtypes' defaults are not (necessarily).
+ */
+#define ETHERNET 1
+#define WIFI 2
+#define MESH 3
+#define CELLULAR 4
+#if MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == ETHERNET
+MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
+{
+    return EthInterface::get_default_instance();
+}
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI
+MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
+{
+    /* WiFi is not expected to work unless we have configuration parameters.
+     * We do not hook up to WifiInterface::get_default_instance() unless
+     * we have at least an access point name.
+     */
+#ifdef MBED_CONF_DEFAULT_WIFI_SSID
+    WiFiInterface *wifi = WifiInterface::get_default_instance();
+    if (!wifi) {
+        return NULL;
+    }
+#ifndef MBED_CONF_DEFAULT_WIFI_PASSWORD
+#define MBED_CONF_DEFAULT_WIFI_PASSWORD NULL
+#endif
+#ifndef MBED_CONF_DEFAULT_WIFI_SECURITY
+#define MBED_CONF_DEFAULT_WIFI_SECURITY NONE
+#endif
+#define concat_(x,y) x##y
+#define concat(x,y) concat_(x,y)
+#define SECURITY concat(NSAPI_SECURITY_,MBED_CONF_DEFAULT_WIFI_SECURITY)
+    wifi->set_credentials(MBED_CONF_DEFAULT_WIFI_SSID, MBED_CONF_DEFAULT_WIFI_PASSWORD, SECURITY);
+#else
+#error "WIFI configured as default interface without SSID"
+    return NULL;
+#endif
+}
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == MESH
+MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
+{
+    return MeshInterface::get_default_instance();
+}
+#elif MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == CELLULAR
+MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
+{
+    CellularBase *cellular = CellularBase::get_default_instance();
+    if (!cellular) {
+        return NULL;
+    }
+    /* CellularBase is expected to attempt to work without any parameters - we
+     * will try, at least.
+     */
+#ifdef MBED_CONF_DEFAULT_CELLULAR_APN
+#ifndef MBED_CONF_DEFAULT_CELLULAR_USERNAME
+#define MBED_CONF_DEFAULT_CELLULAR_USERNAME NULL
+#endif
+#ifndef MBED_CONF_DEFAULT_CELLULAR_PASSWORD
+#define MBED_CONF_DEFAULT_CELLULAR_PASSWORD NULL
+#endif
+    cellular->set_credentials(MBED_CONF_DEFAULT_CELLULAR_APN, MBED_CONF_DEFAULT_CELLULAR_USERNAME, MBED_CONF_DEFAULT_CELLULAR_PASSWORD);
+#endif
+#ifdef MBED_CONF_DEFAULT_CELLULAR_SIM_PIN
+    cellular->set_sim_pin(MBED_CONF_DEFAULT_CELLULAR_SIM_PIN);
+#endif
+
+    return cellular;
+}
+#elif defined(MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE)
+/* If anyone invents a new JSON value, they must have their own default weak
+ * implementation.
+ */
+#else
+/* When the default type is null */
+MBED_WEAK NetworkInterface *NetworkInterface::get_target_default_instance()
+{
+    return NULL;
+}
+#endif

--- a/features/netsocket/WiFiInterface.h
+++ b/features/netsocket/WiFiInterface.h
@@ -30,9 +30,15 @@
 class WiFiInterface: public virtual NetworkInterface
 {
 public:
-    /** WiFiInterface lifetime
+    /** Get the default WiFi interface.
+     *
+     * This is provided as a weak method so applications can override.
+     * Default behaviour is to get the target's default interface, if
+     * any.
+     *
+     * @return pointer to interface, if any
      */
-    virtual ~WiFiInterface() {};
+    static WiFiInterface *get_default_instance();
 
     /** Set the WiFi network credentials
      *
@@ -101,6 +107,17 @@ public:
     virtual nsapi_size_or_error_t scan(WiFiAccessPoint *res, nsapi_size_t count) = 0;
 
     virtual WiFiInterface *wifiInterface() { return this; }
+
+protected:
+
+    /** Get the target's default WiFi interface.
+     *
+     * This is provided as a weak method so targets can override. The
+     * default implementation returns NULL.
+     *
+     * @return pointer to interface, if any
+     */
+    static WiFiInterface *get_target_default_instance();
 };
 
 #endif

--- a/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.cpp
@@ -13,6 +13,8 @@
  * limitations under the License.
  */
 
+#include "mbed_toolchain.h"
+#include "CellularBase.h"
 #include "OnboardCellularInterface.h"
 
 #ifndef CELLULAR_DEVICE
@@ -58,4 +60,19 @@ void OnboardCellularInterface::modem_power_down()
 }
 #endif
 
+
 #endif // CELLULAR_DEVICE
+
+#ifdef ONBOARD_CELLULAR_INTERFACE_AVAILABLE
+MBED_WEAK CellularBase *CellularBase::get_target_default_instance()
+{
+    static OnboardCellularInterface cellular;
+
+    return &cellular;
+}
+#else
+MBED_WEAK CellularBase *CellularBase::get_target_default_instance()
+{
+    return NULL;
+}
+#endif

--- a/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/OnboardCellularInterface.h
@@ -19,6 +19,7 @@
 #include "EasyCellularConnection.h"
 #ifdef CELLULAR_DEVICE
 typedef mbed::EasyCellularConnection OnboardCellularInterface;
+#define ONBOARD_CELLULAR_INTERFACE_AVAILABLE
 #elif MODEM_ON_BOARD && MODEM_ON_BOARD_UART && NSAPI_PPP_AVAILABLE
 
 #include "UARTCellularInterface.h"
@@ -94,6 +95,8 @@ protected:
     MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, use mbed-os/features/cellular/framework/API/CellularPower.h instead.")
     virtual void modem_power_down();
 };
+
+#define ONBOARD_CELLULAR_INTERFACE_AVAILABLE
 
 #endif //MODEM_ON_BOARD && MODEM_ON_BOARD_UART && NSAPI_PPP_AVAILABLE
 #endif //ONBOARD_CELLULAR_INTERFACE_

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -3,6 +3,17 @@
     "config": {
         "present": 1,
         "default-stack": "LWIP",
+        "default-interface-type": {
+            "help": "This guides the choice of the default NetworkInterface. Exactly what effect it has, and what settings are available, will depend on the target platform. Suggested values: ETHERNET, WIFI, CELLULAR, MESH.",
+            "value": "ETHERNET"
+        },
+        "default-wifi-ssid": null,
+        "default-wifi-password": null,
+        "default-wifi-security": "NONE",
+        "default-cellular-apn": null,
+        "default-cellular-username": null,
+        "default-cellular-password": null,
+        "default-mesh-type": "THREAD",
         "dns-response-wait-time": {
             "help": "How long the DNS translator waits for a reply from a server in milliseconds",
             "value": 5000

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -16,6 +16,10 @@
             "console-uart-flow-control": {
                 "help": "Console hardware flow control. Options: null, RTS, CTS, RTSCTS.",
                 "value": null
+            },
+            "network-default-interface-type": {
+                "help": "Default network interface type. Typical options: null, ETHERNET, WIFI, CELLULAR, MESH",
+                "value": null
             }
         }
     },
@@ -243,7 +247,10 @@
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
         "device_name": "LPC1768",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "LPC1769": {
         "inherits": ["LPC1768"],
@@ -260,7 +267,10 @@
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
         "device_name": "LPC1768",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "UBLOX_C027": {
         "supported_form_factors": ["ARDUINO"],
@@ -285,7 +295,10 @@
         "release_versions": ["2", "5"],
         "features": ["LWIP"],
         "device_name": "LPC1768",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "XBED_LPC1768": {
         "inherits": ["LPCTarget"],
@@ -357,7 +370,10 @@
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["LWIP"],
-        "device_name": "LPC4088FBD144"
+        "device_name": "LPC4088FBD144",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "LPC4088": {
         "inherits": ["MCU_LPC4088"],
@@ -619,7 +635,10 @@
         "features": ["LWIP", "STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK64FN1M0xxx12",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "EV_COG_AD4050LZ": {
         "inherits": ["Target"],
@@ -683,7 +702,10 @@
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "MK66FN2M0xxx18",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "K82F": {
         "supported_form_factors": ["ARDUINO"],
@@ -758,7 +780,10 @@
         "inherits": ["Target"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH", "TRNG"],
         "features": ["LWIP"],
-        "device_name" : "LPC54628J512ET180"
+        "device_name" : "LPC54628J512ET180",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "LPC546XX": {
         "supported_form_factors": ["ARDUINO"],
@@ -931,7 +956,10 @@
         "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "SERIAL_FC", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F207ZG"
+        "device_name": "STM32F207ZG",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_F302R8": {
         "inherits": ["FAMILY_STM32"],
@@ -1246,7 +1274,10 @@
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F429ZI",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_F439ZI": {
         "inherits": ["FAMILY_STM32"],
@@ -1276,7 +1307,10 @@
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name" : "STM32F439ZI",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_F446RE": {
         "inherits": ["FAMILY_STM32"],
@@ -1352,7 +1386,10 @@
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746ZG",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_F756ZG": {
         "inherits": ["FAMILY_STM32"],
@@ -1380,7 +1417,10 @@
         "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F756ZG"
+        "device_name": "STM32F756ZG",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_F767ZI": {
         "inherits": ["FAMILY_STM32"],
@@ -1409,7 +1449,10 @@
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F767ZI",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NUCLEO_L011K4": {
         "inherits": ["FAMILY_STM32"],
@@ -1869,7 +1912,10 @@
         "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F746NG"
+        "device_name": "STM32F746NG",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "DISCO_F769NI": {
         "inherits": ["FAMILY_STM32"],
@@ -1892,7 +1938,10 @@
         "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "LOWPOWERTIMER", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "features": ["LWIP"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F769NI"
+        "device_name": "STM32F769NI",
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "DISCO_L475VG_IOT01A": {
         "inherits": ["FAMILY_STM32"],
@@ -2101,7 +2150,10 @@
         "features": ["LWIP"],
         "device_name": "STM32F439ZI",
         "public": false,
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "UBLOX_EVK_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
@@ -2164,7 +2216,10 @@
         "features": ["LWIP"],
         "public": false,
         "device_name": "STM32F437VG",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "UBLOX_C030_U201": {
         "inherits": ["UBLOX_C030"],
@@ -2721,7 +2776,10 @@
         "extra_labels": ["RENESAS", "RZ_A1XX"],
         "device_has": ["ANALOGIN", "CAN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "features": ["LWIP"],
-        "program_cycle_s": 2
+        "program_cycle_s": 2,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "RZ_A1H": {
         "inherits": ["RZ_A1XX"],
@@ -2743,7 +2801,10 @@
         "device_has_add": ["TRNG"],
         "device_has_remove": ["ETHERNET"],
         "features_remove": ["LWIP"],
-        "release_versions": ["2", "5"]
+        "release_versions": ["2", "5"],
+        "overrides": {
+            "network-default-interface-type": null
+        }
     },
     "MAXWSNENV": {
         "inherits": ["Target"],
@@ -3702,7 +3763,10 @@
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "NUC472HI8AE",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "NCS36510": {
         "inherits": ["Target"],
@@ -3843,7 +3907,10 @@
             "function": "RTL8195ACode.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
         },
-        "release_versions": ["5"]
+        "release_versions": ["5"],
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "VBLUNO51_LEGACY": {
         "supported_form_factors": ["ARDUINO"],
@@ -3967,7 +4034,10 @@
         "features": ["LWIP"],
         "release_versions": ["5"],
         "device_name": "M487JIDAE",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
+        }
     },
     "TMPM066": {
         "inherits": ["Target"],


### PR DESCRIPTION
### Description

Provide a framework to make it easier to find a default network
interface.

New version of #6108 

Envisaged use:

NetworkInterface &net = NetworkInterface::get_default_instance();
net.connect();

// for advanced users:
WiFiInterface *wifi = net.wifiInterface();
if (wifi) {
    wifi->do_something_wifiy();
}

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

