### PR TITLE
CPU Statistics

### DIFF
--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -39,7 +39,7 @@ static void busy_thread()
 {
     volatile uint64_t i = ~0;
     
-    while(i--) {
+    while (i--) {
         led1 = !led1;
         wait_us(wait_time);
     }
@@ -52,7 +52,7 @@ void get_cpu_usage()
     mbed_stats_cpu_get(&stats);
 
     uint64_t diff = (stats.idle_time - prev_idle_time);
-    uint8_t usage = 100 - ((diff * 100) / (SAMPLE_TIME*1000));
+    uint8_t usage = 100 - ((diff * 100) / (SAMPLE_TIME * 1000));
     prev_idle_time = stats.idle_time;
 
     TEST_ASSERT_NOT_EQUAL(0, usage);

--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -63,6 +63,8 @@ void get_cpu_usage()
 void test_cpu_info(void)
 {
     mbed_stats_cpu_t stats;
+    // Additional read to make sure timer is initialized
+    mbed_stats_cpu_get(&stats);
     Thread::wait(1);
     mbed_stats_cpu_get(&stats);
     TEST_ASSERT_NOT_EQUAL(0, stats.uptime);

--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -1,0 +1,106 @@
+
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest/utest.h"
+
+#include "mbed.h"
+
+#if !defined(MBED_CPU_STATS_ENABLED)
+#error [NOT_SUPPORTED] test not supported
+#endif
+
+using namespace utest::v1;
+
+DigitalOut led1(LED1);
+
+#define MAX_THREAD_STACK        384
+#define SAMPLE_TIME             1000    // msec
+#define LOOP_TIME               2000    // msec
+
+static int32_t wait_time = 5000;
+
+static void busy_thread()
+{
+    volatile uint64_t i = ~0;
+    
+    while(i--) {
+        led1 = !led1;
+        wait_us(wait_time);
+    }
+}
+
+void get_cpu_usage()
+{
+    static uint64_t prev_idle_time = 0;
+    mbed_stats_cpu_t stats;
+    mbed_stats_cpu_get(&stats);
+
+    uint64_t diff = (stats.idle_time - prev_idle_time);
+    uint8_t usage = 100 - ((diff * 100) / (SAMPLE_TIME*1000));
+    prev_idle_time = stats.idle_time;
+
+    TEST_ASSERT_NOT_EQUAL(0, usage);
+}
+
+void test_cpu_info(void)
+{
+    mbed_stats_cpu_t stats;
+    Thread::wait(0.1);
+    TEST_ASSERT_NOT_EQUAL(0, stats.uptime);
+    TEST_ASSERT_NOT_EQUAL(0, stats.idle_time);
+    return;
+}
+
+void test_cpu_load(void)
+{
+    EventQueue *stats_queue = mbed_event_queue();
+    int id = stats_queue->call_every(SAMPLE_TIME, get_cpu_usage);
+    Thread thread(osPriorityNormal, MAX_THREAD_STACK);
+
+    thread.start(busy_thread);
+
+    // Steadily increase the system load
+    for (int count = 1; ; count++) {
+        Thread::wait(LOOP_TIME);
+        if (wait_time <= 0) {
+            break;
+        }
+        wait_time -= 1000;  // usec
+    }
+    thread.terminate();
+    stats_queue->cancel(id);
+}
+
+Case cases[] = {
+    Case("Test CPU Info", test_cpu_info),
+    Case("Test CPU load", test_cpu_load)
+};
+
+utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(20, "default_auto");
+    return greentea_test_setup_handler(number_of_cases);
+}
+
+Specification specification(greentea_test_setup, cases, greentea_test_teardown_handler);
+
+int main()
+{
+    Harness::run(specification);
+}

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -31,18 +31,18 @@
 
 // deep sleep locking counter. A target is allowed to deep sleep if counter == 0
 static uint16_t deep_sleep_lock = 0U;
-static uint64_t sleep_time = 0;
-static uint64_t deep_sleep_time = 0;
+static us_timestamp_t sleep_time = 0;
+static us_timestamp_t deep_sleep_time = 0;
 
 #if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LOWPOWERTIMER)
 static ticker_data_t *sleep_ticker = NULL;
 #endif
 
-static inline uint64_t read_us(void)
+static inline us_timestamp_t read_us(void)
 {
 #if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LOWPOWERTIMER)
     if (NULL == sleep_ticker) {
-        sleep_ticker = (ticker_data_t*) get_lp_ticker_data();
+        sleep_ticker = (ticker_data_t *)get_lp_ticker_data();
     }
     return ticker_read_us(sleep_ticker);
 #else
@@ -50,29 +50,22 @@ static inline uint64_t read_us(void)
 #endif
 }
 
-uint64_t mbed_time_idle(void)
+us_timestamp_t mbed_time_idle(void)
 {
-    return (sleep_time+deep_sleep_time);
+    return (sleep_time + deep_sleep_time);
 }
 
-uint64_t mbed_uptime(void)
+us_timestamp_t mbed_uptime(void)
 {
-#if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LOWPOWERTIMER)
-    if (NULL == sleep_ticker) {
-        sleep_ticker = (ticker_data_t*) get_lp_ticker_data();
-    }
-    return ticker_read_us(sleep_ticker);
-#else
-    return 0;
-#endif
+    return read_us();
 }
 
-uint64_t mbed_time_sleep(void)
+us_timestamp_t mbed_time_sleep(void)
 {
     return sleep_time;
 }
 
-uint64_t mbed_time_deepsleep(void)
+us_timestamp_t mbed_time_deepsleep(void)
 {
     return deep_sleep_time;
 }
@@ -83,7 +76,7 @@ uint64_t mbed_time_deepsleep(void)
 #define STATISTIC_COUNT  10
 
 typedef struct sleep_statistic {
-    const char* identifier;
+    const char *identifier;
     uint8_t count;
 } sleep_statistic_t;
 
@@ -132,7 +125,7 @@ static void sleep_tracker_print_stats(void)
     }
 }
 
-void sleep_tracker_lock(const char* const filename, int line)
+void sleep_tracker_lock(const char *const filename, int line)
 {
     sleep_statistic_t *stat = sleep_tracker_find(filename);
 
@@ -196,7 +189,7 @@ void sleep_manager_sleep_auto(void)
     sleep_tracker_print_stats();
 #endif
     core_util_critical_section_enter();
-    uint64_t start = read_us();
+    us_timestamp_t start = read_us();
     bool deep = false;
 
 // debug profile should keep debuggers attached, no deep sleep allowed
@@ -211,8 +204,8 @@ void sleep_manager_sleep_auto(void)
     }
 #endif
 
-    uint64_t end = read_us();
-    if(true == deep) {
+    us_timestamp_t end = read_us();
+    if (true == deep) {
         deep_sleep_time += end - start;
     } else {
         sleep_time += end - start;

--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -205,6 +205,32 @@ static inline void system_reset(void)
 {
     NVIC_SystemReset();
 }
+ 
+/** Provides the time spent in sleep mode, since system is up and running
+ *
+ *  @return  Time spent in sleep
+ */
+uint64_t mbed_time_sleep(void);
+
+/** Provides the time spent in deep sleep mode, since system is up and running
+ *
+ *  @return  Time spent in deep sleep
+ */
+uint64_t mbed_time_deepsleep(void);
+
+/** Provides the time spent in idle thread since the system is up
+ *
+ * @return  Idle thread time.
+ */
+uint64_t mbed_time_idle(void);
+
+
+/** Provides the time since the system is up and running
+ *
+ * @return  System uptime.
+ */
+uint64_t mbed_uptime(void);
+
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -25,6 +25,7 @@
 
 #include "sleep_api.h"
 #include "mbed_toolchain.h"
+#include "hal/ticker_api.h"
 #include <stdbool.h>
 
 #ifdef __cplusplus
@@ -206,31 +207,33 @@ static inline void system_reset(void)
     NVIC_SystemReset();
 }
  
-/** Provides the time spent in sleep mode, since system is up and running
+/** Provides the time spent in sleep mode since boot.
  *
  *  @return  Time spent in sleep
+ *  @note  Works only if platform supports LP ticker.
  */
-uint64_t mbed_time_sleep(void);
+us_timestamp_t mbed_time_sleep(void);
 
-/** Provides the time spent in deep sleep mode, since system is up and running
+/** Provides the time spent in deep sleep mode since boot.
  *
  *  @return  Time spent in deep sleep
+ *  @note  Works only if platform supports LP ticker.
  */
-uint64_t mbed_time_deepsleep(void);
+us_timestamp_t mbed_time_deepsleep(void);
 
-/** Provides the time spent in idle thread since the system is up
+/** Provides the time spent in idle mode since boot.
  *
  * @return  Idle thread time.
+ * @note  Works only if platform supports LP ticker.
  */
-uint64_t mbed_time_idle(void);
+us_timestamp_t mbed_time_idle(void);
 
-
-/** Provides the time since the system is up and running
+/** Provides the time since the system is up i.e. boot.
  *
  * @return  System uptime.
+ * @note  Works only if platform supports LP ticker.
  */
-uint64_t mbed_uptime(void);
-
+us_timestamp_t mbed_uptime(void);
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -1,16 +1,33 @@
 #include "mbed_stats.h"
+#include "mbed_power_mgmt.h"
 #include <string.h>
 #include <stdlib.h>
 #include "mbed_assert.h"
 
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "cmsis_os2.h"
-#elif defined(MBED_STACK_STATS_ENABLED) || defined(MBED_THREAD_STATS_ENABLED)
+#include "rtos_idle.h"
+#elif defined(MBED_STACK_STATS_ENABLED) || defined(MBED_THREAD_STATS_ENABLED) || defined(MBED_CPU_STATS_ENABLED)
 #warning Statistics are currently not supported without the rtos.
 #endif
 
-// note: mbed_stats_heap_get defined in mbed_alloc_wrappers.cpp
+#if defined(MBED_CPU_STATS_ENABLED) && (!defined(DEVICE_LOWPOWERTIMER) || !defined(DEVICE_SLEEP))
+#warning CPU statistics are not supported without low power timer support.
+#endif
 
+void mbed_stats_cpu_get(mbed_stats_cpu_t *stats)
+{
+    MBED_ASSERT(stats != NULL);
+    memset(stats, 0, sizeof(mbed_stats_cpu_t));
+#if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LOWPOWERTIMER) && defined(DEVICE_SLEEP)
+    stats->uptime = mbed_uptime();
+    stats->idle_time = mbed_time_idle();
+    stats->sleep_time = mbed_time_sleep();
+    stats->deep_sleep_time = mbed_time_deepsleep();
+#endif
+}
+
+// note: mbed_stats_heap_get defined in mbed_alloc_wrappers.cpp
 void mbed_stats_stack_get(mbed_stats_stack_t *stats)
 {
     MBED_ASSERT(stats != NULL);

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -24,6 +24,7 @@
 #define MBED_STATS_H
 #include <stdint.h>
 #include <stddef.h>
+#include "hal/ticker_api.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -87,10 +88,10 @@ size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count);
  * struct mbed_stats_cpu_t definition
  */
 typedef struct {
-    uint64_t uptime;            /**< Time since system is up and running */
-    uint64_t idle_time;         /**< Time spent in idle thread since system is up and running */
-    uint64_t sleep_time;        /**< Time spent in sleep since system is up and running */
-    uint64_t deep_sleep_time;   /**< Time spent in deep sleep since system is up and running */
+    us_timestamp_t uptime;            /**< Time since system is up and running */
+    us_timestamp_t idle_time;         /**< Time spent in idle thread since system is up and running */
+    us_timestamp_t sleep_time;        /**< Time spent in sleep since system is up and running */
+    us_timestamp_t deep_sleep_time;   /**< Time spent in deep sleep since system is up and running */
 } mbed_stats_cpu_t;
 
 /**

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -31,6 +31,7 @@ extern "C" {
 
 #ifdef MBED_ALL_STATS_ENABLED
 #define MBED_STACK_STATS_ENABLED    1
+#define MBED_CPU_STATS_ENABLED      1
 #define MBED_HEAP_STATS_ENABLED     1
 #define MBED_THREAD_STATS_ENABLED   1
 #endif
@@ -81,6 +82,23 @@ void mbed_stats_stack_get(mbed_stats_stack_t *stats);
  *                  this is equal to the number of stacks on the system.
  */
 size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count);
+
+/**
+ * struct mbed_stats_cpu_t definition
+ */
+typedef struct {
+    uint64_t uptime;            /**< Time since system is up and running */
+    uint64_t idle_time;         /**< Time spent in idle thread since system is up and running */
+    uint64_t sleep_time;        /**< Time spent in sleep since system is up and running */
+    uint64_t deep_sleep_time;   /**< Time spent in deep sleep since system is up and running */
+} mbed_stats_cpu_t;
+
+/**
+ *  Fill the passed in CPU stat structure with CPU statistics.
+ *
+ *  @param stats    A pointer to the mbed_stats_cpu_t structure to fill
+ */
+void mbed_stats_cpu_get(mbed_stats_cpu_t *stats);
 
 /**
  * struct mbed_stats_thread_t definition

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -34,14 +34,6 @@ extern "C" {
 
 using namespace mbed;
 
-static const ticker_data_t *const cpu_usage_ticker = get_lp_ticker_data();
-static uint32_t idle_time = 0;
-
-extern uint32_t mbed_time_idle(void)
-{
-    return idle_time;
-}
-
 #ifdef MBED_TICKLESS
 
 #include "rtos/TARGET_CORTEX/SysTimer.h"
@@ -106,7 +98,6 @@ static void default_idle_hook(void)
     uint32_t ticks_to_sleep = osKernelSuspend();
     os_timer->suspend(ticks_to_sleep);
 
-    uint32_t start = ticker_read_us(cpu_usage_ticker);
     bool event_pending = false;
     while (!os_timer->suspend_time_passed() && !event_pending) {
 
@@ -122,8 +113,6 @@ static void default_idle_hook(void)
         __ISB();
     }
     osKernelResume(os_timer->resume());
-    uint32_t end = ticker_read_us(cpu_usage_ticker);
-    idle_time += end - start;
 }
 
 #elif defined(FEATURE_UVISOR)
@@ -140,12 +129,9 @@ static void default_idle_hook(void)
 {
     // critical section to complete sleep with locked deepsleep
     core_util_critical_section_enter();
-    uint32_t start = ticker_read_us(cpu_usage_ticker);
     sleep_manager_lock_deep_sleep();
     sleep();
     sleep_manager_unlock_deep_sleep();
-    uint32_t end = ticker_read_us(cpu_usage_ticker);
-    idle_time += end - start;
     core_util_critical_section_exit();
 }
 


### PR DESCRIPTION
### Description
API to get CPU stats like sleep/deepsleep time, uptime and idle time. These can be used by application to know the CPU Usage runtime.

Preceding PR dependency: #https://github.com/ARMmbed/mbed-os/pull/6821

Status: In progress

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

CC @SenRamakri 
