### PR TITLE
Error Handling and error coding

### DIFF
--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -274,11 +274,11 @@ void test_error_logging()
     SET_WARNING(ERROR_INVALID_DATA_DETECTED, "Invalid data", 4 );
     SET_WARNING(ERROR_INVALID_OPERATION, "Invalid operation", 5 );
     
-    status = get_error_log_info( 3, &error_ctx );
+    status = get_error_log_info( 2, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_DATA_DETECTED, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(4, error_ctx.error_value);
     
-    status = get_error_log_info( 4, &error_ctx );
+    status = get_error_log_info( 3, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_OPERATION, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(5, error_ctx.error_value);
     
@@ -288,12 +288,11 @@ void test_error_logging()
     SET_WARNING(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
     SET_WARNING(ERROR_NOT_READY, "Not ready error", 9 );
     
-    //Last 5 entries
+    //Last 4 entries
     SET_WARNING(ERROR_TIME_OUT, "Timeout error", 10 );
     SET_WARNING(ERROR_ALREADY_IN_USE, "Already in use error", 11 );
     SET_WARNING(ERROR_UNSUPPORTED, "Not supported error", 12 );
     SET_WARNING(ERROR_ACCESS_DENIED, "Access denied error", 13 );
-    SET_WARNING(ERROR_ITEM_NOT_FOUND, "Not found error", 14 );
     
     status = get_error_log_info( 0, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_TIME_OUT, error_ctx.error_status);
@@ -310,10 +309,6 @@ void test_error_logging()
     status = get_error_log_info( 3, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_ACCESS_DENIED, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(13, error_ctx.error_value);
-    
-    status = get_error_log_info( 4, &error_ctx );
-    TEST_ASSERT_EQUAL_UINT(ERROR_ITEM_NOT_FOUND, error_ctx.error_status);
-    TEST_ASSERT_EQUAL_UINT(14, error_ctx.error_value);
     
     //Try an index which is invalid, we should get ERROR_INVALID_ARGUMENT back
     status = get_error_log_info( 99, &error_ctx );

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -27,9 +27,9 @@ using utest::v1::Case;
  */
 void test_system_errors()
 {
-    MbedErrorStatus error = MAKE_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
+    mbed_error_status_t error = MAKE_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
     SET_WARNING(error, "Error Unknown", 0xAABBCCDD );
-    MbedErrorStatus lastError = get_last_error();
+    mbed_error_status_t lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
@@ -57,9 +57,9 @@ void test_system_errors()
  */
 void test_custom_errors()
 {
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
+    mbed_error_status_t error = MAKE_CUSTOM_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
     SET_WARNING(error, "Custom Error Unknown", 0x1234 );
-    MbedErrorStatus lastError = get_last_error();
+    mbed_error_status_t lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
@@ -82,7 +82,7 @@ void test_custom_errors()
 void test_posix_errors()
 {
     SET_WARNING(ERROR_EPERM, "Posix Error Eperm", 0x1234 );
-    MbedErrorStatus lastError = get_last_error();
+    mbed_error_status_t lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_EPERM, lastError);
     
@@ -113,7 +113,7 @@ void test_first_and_last_error_capture()
     SET_WARNING(ERROR_MUTEX_UNLOCK_FAILED, "Mutex unlock failed", 0x99AA );
     SET_WARNING(ERROR_SEMAPHORE_UNLOCK_FAILED, "Semaphore unlock failed", 0xBBCC );
     
-    MbedErrorStatus error = get_last_error();
+    mbed_error_status_t error = get_last_error();
     printf("\nlastError = 0x%08X", error );
     TEST_ASSERT_EQUAL_UINT(ERROR_SEMAPHORE_UNLOCK_FAILED, error);
     
@@ -149,13 +149,13 @@ void test_error_count_and_reset()
 void test_error_encoding()
 {
     SET_WARNING(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
-    MbedErrorStatus lastError = get_last_error();
+    mbed_error_status_t lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
     TEST_ASSERT_EQUAL_UINT(MODULE_UNKNOWN, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_OUT_OF_RESOURCES, GET_MBED_ERROR_CODE(lastError));
     
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    mbed_error_status_t error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
     SET_WARNING(error, "Custom Error Type", 0x2233);
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
@@ -202,11 +202,11 @@ void test_error_value()
     mbed_error_ctx error_ctx = {0};
     
     SET_WARNING(ERROR_OUT_OF_RESOURCES, "System type error", error_value );
-    MbedErrorStatus status = get_last_error_log_info( &error_ctx );
+    mbed_error_status_t status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
     
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    mbed_error_status_t error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
     error_value = 0xABCD;
     SET_WARNING(error, "Custom Error Type", error_value);
     status = get_last_error_log_info( &error_ctx );
@@ -228,7 +228,7 @@ void test_error_context_capture()
     mbed_error_ctx error_ctx = {0};
     
     SET_WARNING(ERROR_INVALID_ARGUMENT, "System type error", error_value );
-    MbedErrorStatus status = get_last_error_log_info( &error_ctx );
+    mbed_error_status_t status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
     TEST_ASSERT_EQUAL_UINT(osThreadGetId(), error_ctx.thread_id);
@@ -258,7 +258,7 @@ void test_error_logging()
     SET_WARNING(ERROR_INVALID_SIZE, "Invalid size error", 2 );
     SET_WARNING(ERROR_INVALID_FORMAT, "Invalid format error", 3 );
     
-    MbedErrorStatus status = get_error_log_info( 0, &error_ctx );
+    mbed_error_status_t status = get_error_log_info( 0, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_ARGUMENT, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(1, error_ctx.error_value);
     
@@ -319,7 +319,7 @@ void test_error_logging()
 #define NUM_TEST_THREADS 10
 
 //Error logger threads
-void err_thread_func(MbedErrorStatus *error_status)
+void err_thread_func(mbed_error_status_t *error_status)
 {
     //printf("\nError Status = 0x%08X\n",*error_status);
     SET_WARNING(*error_status, "Error from Multi-Threaded error logging test", *error_status );
@@ -333,7 +333,7 @@ void test_error_logging_multithread()
     mbed_error_ctx error_ctx = {0};
     int i=0;
     Thread errThread[NUM_TEST_THREADS];
-    MbedErrorStatus error_status[NUM_TEST_THREADS] = { 
+    mbed_error_status_t error_status[NUM_TEST_THREADS] = { 
                                         ERROR_INVALID_ARGUMENT, ERROR_INVALID_DATA_DETECTED, ERROR_INVALID_FORMAT, ERROR_INVALID_SIZE, ERROR_INVALID_OPERATION, 
                                         ERROR_ITEM_NOT_FOUND, ERROR_ACCESS_DENIED, ERROR_FAILED_OPERATION, ERROR_OPERATION_PROHIBITED, ERROR_OPERATION_ABORTED
     };
@@ -350,7 +350,7 @@ void test_error_logging_multithread()
     i = get_error_log_count()-1;
     //printf("\nError log count = %d\n", i+1);
     for(;i>=0;--i) {
-        MbedErrorStatus status = get_error_log_info( i, &error_ctx );
+        mbed_error_status_t status = get_error_log_info( i, &error_ctx );
         if(status != ERROR_SUCCESS) {
             TEST_FAIL();
         }

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -316,7 +316,7 @@ void test_error_logging()
     
 }
 
-#define NUM_TEST_THREADS 10
+#define NUM_TEST_THREADS 5
 
 //Error logger threads
 void err_thread_func(mbed_error_status_t *error_status)
@@ -471,7 +471,7 @@ void test_save_error_log()
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(100, "default_auto");
+    GREENTEA_SETUP(300, "default_auto");
     return utest::v1::verbose_test_setup_handler(number_of_cases);
 }
 

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -1,0 +1,411 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "mbed.h"
+
+using utest::v1::Case;
+
+/** Test logging of system errors
+ *  and ensure the status/erro code is correct
+ */
+void test_system_errors()
+{
+    MbedErrorStatus error = MAKE_ERROR(ENTITY_APPLICATION, ERROR_CODE_UNKNOWN);
+    SET_ERROR(error, "Error Unknown", 0xAABBCCDD );
+    MbedErrorStatus lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+    
+    error = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_ERROR(error, "Error Platform", 0xABCDABCD );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+    
+    error = MAKE_ERROR(ENTITY_DRIVER_SERIAL, ERROR_CODE_OUT_OF_RESOURCES);
+    SET_ERROR(error, "Error Serial driver", 0xAA );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+    
+    error = MAKE_ERROR(ENTITY_UNKNOWN, ERROR_CODE_OUT_OF_MEMORY);
+    SET_ERROR(error, "Error Out of resources", 0x11223344 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+}
+
+/** Test logging of custom errors
+ *  and ensure the status/erro code is correct
+ */
+void test_custom_errors()
+{
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_APPLICATION, ERROR_CODE_UNKNOWN);
+    SET_ERROR(error, "Custom Error Unknown", 0x1234 );
+    MbedErrorStatus lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+    
+    error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_ERROR(error, "Custom Error Platform", 0x5555 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+    
+    error = MAKE_CUSTOM_ERROR(ENTITY_HAL, ERROR_CODE_OUT_OF_MEMORY);
+    SET_ERROR(error, "Custom Error Unknown", 0x33445566 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(error, lastError);
+}
+
+/** Test logging of posix errors
+ *  and ensure the status/erro code is correct
+ */
+void test_posix_errors()
+{
+    SET_ERROR(ERROR_EPERM, "Posix Error Eperm", 0x1234 );
+    MbedErrorStatus lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_EPERM, lastError);
+    
+    SET_ERROR(ERROR_EBADF, "Posix Error, bad file descriptor", 0x5555 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_EBADF, lastError);
+    
+    SET_ERROR(ERROR_ENOENT, "Posix error, no file or dir", 0x33445566 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_ENOENT, lastError);
+}
+
+/** Test first and last error capture
+ */
+void test_first_and_last_error_capture()
+{
+    //clear the errors and error count to 0
+    clear_all_errors();
+    
+    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
+    SET_ERROR(ERROR_OUT_OF_MEMORY, "Out of memory", 0x2233);
+    SET_ERROR(ERROR_SEMAPHORE_LOCK_FAILED, "Sem lock failed", 0x3344 );
+    SET_ERROR(ERROR_MUTEX_LOCK_FAILED, "Mutex lock failed", 0x4455 );
+    SET_ERROR(ERROR_CREATE_FAILED, "Create failed", 0x5566 );
+    SET_ERROR(ERROR_TIMEOUT, "Time out error", 0x7788 );
+    SET_ERROR(ERROR_MUTEX_UNLOCK_FAILED, "Mutex unlock failed", 0x99AA );
+    SET_ERROR(ERROR_SEMAPHORE_UNLOCK_FAILED, "Semaphore unlock failed", 0xBBCC );
+    
+    MbedErrorStatus error = get_last_error();
+    printf("\nlastError = 0x%08X", error );
+    TEST_ASSERT_EQUAL_UINT(ERROR_SEMAPHORE_UNLOCK_FAILED, error);
+    
+    error = get_first_error();
+    printf("\nfirstError = 0x%08X", error );
+    TEST_ASSERT_EQUAL_UINT(ERROR_OUT_OF_RESOURCES, error);
+    
+}
+
+/** Test error count and reset functionality
+ */
+void test_error_count_and_reset()
+{
+    int count = 7;
+    
+    //Log multiple errors and get the error count and make sure its 15
+    for(int i=0; i<count; i++) {
+        SET_ERROR(ERROR_OUT_OF_MEMORY, "Out of memory", i);
+    }
+    
+    TEST_ASSERT_EQUAL_INT(count, get_error_count());
+    
+    //clear the errors and error count to 0
+    clear_all_errors();
+    
+    //Now the error count should be 0
+    TEST_ASSERT_EQUAL_INT(0, get_error_count());
+    
+}
+
+/** Test error type encoding
+ */
+void test_error_encoding()
+{
+    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
+    MbedErrorStatus lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_OUT_OF_RESOURCES, GET_MBED_ERROR_CODE(lastError));
+    
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_ERROR(error, "Custom Error Type", 0x2233);
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_CUSTOM, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_PLATFORM, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_CREATE_FAILED, GET_MBED_ERROR_CODE(lastError));
+    
+    SET_ERROR(ERROR_EACCES, "Posix Error 1", 0x3344 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_POSIX, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_EACCES, GET_MBED_ERROR_CODE(lastError));
+    
+    SET_ERROR(ERROR_ERANGE, "Posix Error 2", 0x3355 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_POSIX, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_ERANGE, GET_MBED_ERROR_CODE(lastError));
+    
+    error = MAKE_ERROR(ENTITY_HAL, ERROR_CODE_UNKNOWN);
+    SET_ERROR(error, "HAL Entity error", 0x5566 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_HAL, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_UNKNOWN, GET_MBED_ERROR_CODE(lastError));
+    
+    SET_ERROR(ERROR_UNKNOWN, "Unknown Entity error", 7788 );
+    lastError = get_last_error();
+    printf("\nlastError = 0x%08X", lastError );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
+    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(ERROR_CODE_UNKNOWN, GET_MBED_ERROR_CODE(lastError));
+    
+}
+
+/** Test error value
+ */
+void test_error_value()
+{
+    uint32_t error_value = 0xAA11BB22;
+    mbed_error_ctx error_ctx = {0};
+    
+    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", error_value );
+    MbedErrorStatus status = get_last_error_log_info( &error_ctx );
+    TEST_ASSERT(status == ERROR_SUCCESS);
+    TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
+    
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    error_value = 0xABCD;
+    SET_ERROR(error, "Custom Error Type", error_value);
+    status = get_last_error_log_info( &error_ctx );
+    TEST_ASSERT(status == ERROR_SUCCESS);
+    TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
+    
+    error_value = 0x11223344;
+    SET_ERROR(ERROR_EACCES, "Posix Error 1", error_value );
+    status = get_last_error_log_info( &error_ctx );
+    TEST_ASSERT(status == ERROR_SUCCESS);
+    TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
+}
+
+/** Test error context capture
+ */
+void test_error_context_capture()
+{
+    uint32_t error_value = 0xABCD;
+    mbed_error_ctx error_ctx = {0};
+    
+    SET_ERROR(ERROR_INVALID_ARGUMENT, "System type error", error_value );
+    MbedErrorStatus status = get_last_error_log_info( &error_ctx );
+    TEST_ASSERT(status == ERROR_SUCCESS);
+    TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
+    TEST_ASSERT_EQUAL_UINT(osThreadGetId(), error_ctx.thread_id);
+    
+    //Capture thread info and compare
+    osRtxThread_t *current_thread = osRtxInfo.thread.run.curr;
+    TEST_ASSERT_EQUAL_UINT((uint32_t)current_thread->thread_addr, error_ctx.thread_entry_address);
+    TEST_ASSERT_EQUAL_UINT((uint32_t)current_thread->stack_size, error_ctx.thread_stack_size);
+    TEST_ASSERT_EQUAL_UINT((uint32_t)current_thread->stack_mem, error_ctx.thread_stack_mem);
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+    TEST_ASSERT_EQUAL_STRING(MBED_FILENAME, error_ctx.error_filename);
+#endif    
+}
+
+#ifndef MBED_CONF_ERROR_LOG_DISABLED  
+/** Test error logging functionality
+ */
+void test_error_logging()
+{
+    mbed_error_ctx error_ctx = {0};
+    
+    //clear the current errors first
+    clear_all_errors();
+    
+    //log 3 errors and retrieve them to ensure they are correct
+    SET_ERROR(ERROR_INVALID_ARGUMENT, "Invalid argument error", 1 );
+    SET_ERROR(ERROR_INVALID_SIZE, "Invalid size error", 2 );
+    SET_ERROR(ERROR_INVALID_FORMAT, "Invalid format error", 3 );
+    
+    MbedErrorStatus status = get_error_log_info( 0, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_ARGUMENT, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(1, error_ctx.error_value);
+    
+    status = get_error_log_info( 1, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_SIZE, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(2, error_ctx.error_value);
+    
+    status = get_error_log_info( 2, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_FORMAT, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(3, error_ctx.error_value);
+    
+    //log 2 more errors to fill the log and then read them out to ensure that its correct
+    SET_ERROR(ERROR_INVALID_DATA, "Invalid data", 4 );
+    SET_ERROR(ERROR_INVALID_OPERATION, "Invalid operation", 5 );
+    
+    status = get_error_log_info( 3, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_DATA, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(4, error_ctx.error_value);
+    
+    status = get_error_log_info( 4, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_OPERATION, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(5, error_ctx.error_value);
+    
+    //Log a bunch of errors to overflow the error log and retrieve them
+    SET_ERROR(ERROR_INVALID_ARGUMENT, "Invalid argument error", 6 );
+    SET_ERROR(ERROR_INVALID_SIZE, "Invalid size error", 7 );
+    SET_ERROR(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
+    SET_ERROR(ERROR_NOT_READY, "Not ready error", 9 );
+    
+    //Last 5 entries
+    SET_ERROR(ERROR_TIMEOUT, "Timeout error", 10 );
+    SET_ERROR(ERROR_ALREADY_IN_USE, "Already in use error", 11 );
+    SET_ERROR(ERROR_NOT_SUPPORTED, "Not supported error", 12 );
+    SET_ERROR(ERROR_ACCESS_DENIED, "Access denied error", 13 );
+    SET_ERROR(ERROR_NOT_FOUND, "Not found error", 14 );
+    
+    status = get_error_log_info( 0, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_TIMEOUT, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(10, error_ctx.error_value);
+    
+    status = get_error_log_info( 1, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_ALREADY_IN_USE, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(11, error_ctx.error_value);
+    
+    status = get_error_log_info( 2, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_NOT_SUPPORTED, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(12, error_ctx.error_value);
+    
+    status = get_error_log_info( 3, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_ACCESS_DENIED, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(13, error_ctx.error_value);
+    
+    status = get_error_log_info( 4, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_NOT_FOUND, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(14, error_ctx.error_value);
+    
+    //Try an index which is invalid, we should get ERROR_INVALID_ARGUMENT back
+    status = get_error_log_info( 99, &error_ctx );
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_ARGUMENT, status);
+    
+}
+
+#define NUM_TEST_THREADS 15
+
+//Error logger threads
+void err_thread_func(MbedErrorStatus *error_status)
+{
+    printf("\nError Status = 0x%08X\n",*error_status);
+    SET_ERROR(*error_status, "Error from Multi-Threaded error logging test", *error_status );
+}
+
+
+/** Test error logging multithreaded
+ */
+void test_error_logging_multithread()
+{
+    mbed_error_ctx error_ctx = {0};
+    int i=0;
+    Thread errThread[NUM_TEST_THREADS];
+    MbedErrorStatus error_status[NUM_TEST_THREADS] = { 
+                                        ERROR_INVALID_ARGUMENT, ERROR_INVALID_DATA, ERROR_INVALID_FORMAT, ERROR_INVALID_SIZE, ERROR_INVALID_OPERATION, 
+                                        ERROR_NOT_FOUND, ERROR_ACCESS_DENIED, ERROR_FAILED_OPERATION, ERROR_OPERATION_PROHIBITED, ERROR_OPERATION_ABORTED, 
+                                        ERROR_NO_RESPONSE, ERROR_SEMAPHORE_LOCK_FAILED, ERROR_MUTEX_LOCK_FAILED, ERROR_OPEN_FAILED, ERROR_CLOSE_FAILED
+    };
+    
+        
+    for(; i<NUM_TEST_THREADS; i++) {
+        errThread[i].start(callback(err_thread_func, &error_status[i]));
+    }
+    wait(2.0);
+    for(i=0; i<NUM_TEST_THREADS; i++) {
+        errThread[i].join();
+    }
+    
+    i = get_error_log_count()-1;
+    printf("\nError log count = %d\n", i+1);
+    for(;i>=0;--i) {
+        MbedErrorStatus status = get_error_log_info( i, &error_ctx );
+        printf("\nError Status[%d] = 0x%08X Value = 0x%08X\n", i, error_ctx.error_status, error_ctx.error_value);
+        TEST_ASSERT_EQUAL_UINT((unsigned int)error_ctx.error_value, (unsigned int)error_ctx.error_status);
+    }
+}
+#endif
+
+static Semaphore    callback_sem;
+void MyErrorHook(const mbed_error_ctx *error_ctx)
+{
+    callback_sem.release();
+}
+
+/** Test error hook
+ */
+void test_error_hook()
+{
+    if( ERROR_SUCCESS != set_error_hook(MyErrorHook)) {
+        TEST_FAIL();
+    }
+    
+    SET_ERROR(ERROR_INVALID_ARGUMENT, "Test for error hook", 1234);
+    int32_t sem_status = callback_sem.wait(5000);
+    
+    TEST_ASSERT(sem_status > 0);
+}
+
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(100, "default_auto");
+    return utest::v1::verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Test error counting and reset", test_error_count_and_reset),
+    Case("Test system errors", test_system_errors),
+    Case("Test custom errors", test_custom_errors),
+    Case("Test posix errors", test_posix_errors),
+    Case("Test first and last error capture", test_first_and_last_error_capture),
+    Case("Test error encoding", test_error_encoding),
+    Case("Test error value", test_error_value),
+    Case("Test error context capture", test_error_context_capture),
+    Case("Test error hook", test_error_hook),
+#ifndef MBED_CONF_ERROR_LOG_DISABLED    
+    Case("Test error logging", test_error_logging),
+    Case("Test error handling multi-threaded", test_error_logging_multithread),
+#endif    
+};
+
+utest::v1::Specification specification(test_setup, cases);
+
+int main()
+{
+    return !utest::v1::Harness::run(specification);
+}

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -27,26 +27,26 @@ using utest::v1::Case;
  */
 void test_system_errors()
 {
-    MbedErrorStatus error = MAKE_ERROR(ENTITY_APPLICATION, ERROR_CODE_UNKNOWN);
-    SET_ERROR(error, "Error Unknown", 0xAABBCCDD );
+    MbedErrorStatus error = MAKE_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
+    SET_WARNING(error, "Error Unknown", 0xAABBCCDD );
     MbedErrorStatus lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
-    error = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
-    SET_ERROR(error, "Error Platform", 0xABCDABCD );
+    error = MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_WARNING(error, "Error Platform", 0xABCDABCD );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
-    error = MAKE_ERROR(ENTITY_DRIVER_SERIAL, ERROR_CODE_OUT_OF_RESOURCES);
-    SET_ERROR(error, "Error Serial driver", 0xAA );
+    error = MAKE_ERROR(MODULE_DRIVER_SERIAL, ERROR_CODE_OUT_OF_RESOURCES);
+    SET_WARNING(error, "Error Serial driver", 0xAA );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
-    error = MAKE_ERROR(ENTITY_UNKNOWN, ERROR_CODE_OUT_OF_MEMORY);
-    SET_ERROR(error, "Error Out of resources", 0x11223344 );
+    error = MAKE_ERROR(MODULE_UNKNOWN, ERROR_CODE_OUT_OF_MEMORY);
+    SET_WARNING(error, "Error Out of resources", 0x11223344 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
@@ -57,20 +57,20 @@ void test_system_errors()
  */
 void test_custom_errors()
 {
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_APPLICATION, ERROR_CODE_UNKNOWN);
-    SET_ERROR(error, "Custom Error Unknown", 0x1234 );
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_APPLICATION, ERROR_CODE_UNKNOWN);
+    SET_WARNING(error, "Custom Error Unknown", 0x1234 );
     MbedErrorStatus lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
-    error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
-    SET_ERROR(error, "Custom Error Platform", 0x5555 );
+    error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_WARNING(error, "Custom Error Platform", 0x5555 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
     
-    error = MAKE_CUSTOM_ERROR(ENTITY_HAL, ERROR_CODE_OUT_OF_MEMORY);
-    SET_ERROR(error, "Custom Error Unknown", 0x33445566 );
+    error = MAKE_CUSTOM_ERROR(MODULE_HAL, ERROR_CODE_OUT_OF_MEMORY);
+    SET_WARNING(error, "Custom Error Unknown", 0x33445566 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(error, lastError);
@@ -81,17 +81,17 @@ void test_custom_errors()
  */
 void test_posix_errors()
 {
-    SET_ERROR(ERROR_EPERM, "Posix Error Eperm", 0x1234 );
+    SET_WARNING(ERROR_EPERM, "Posix Error Eperm", 0x1234 );
     MbedErrorStatus lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_EPERM, lastError);
     
-    SET_ERROR(ERROR_EBADF, "Posix Error, bad file descriptor", 0x5555 );
+    SET_WARNING(ERROR_EBADF, "Posix Error, bad file descriptor", 0x5555 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_EBADF, lastError);
     
-    SET_ERROR(ERROR_ENOENT, "Posix error, no file or dir", 0x33445566 );
+    SET_WARNING(ERROR_ENOENT, "Posix error, no file or dir", 0x33445566 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_ENOENT, lastError);
@@ -104,14 +104,14 @@ void test_first_and_last_error_capture()
     //clear the errors and error count to 0
     clear_all_errors();
     
-    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
-    SET_ERROR(ERROR_OUT_OF_MEMORY, "Out of memory", 0x2233);
-    SET_ERROR(ERROR_SEMAPHORE_LOCK_FAILED, "Sem lock failed", 0x3344 );
-    SET_ERROR(ERROR_MUTEX_LOCK_FAILED, "Mutex lock failed", 0x4455 );
-    SET_ERROR(ERROR_CREATE_FAILED, "Create failed", 0x5566 );
-    SET_ERROR(ERROR_TIMEOUT, "Time out error", 0x7788 );
-    SET_ERROR(ERROR_MUTEX_UNLOCK_FAILED, "Mutex unlock failed", 0x99AA );
-    SET_ERROR(ERROR_SEMAPHORE_UNLOCK_FAILED, "Semaphore unlock failed", 0xBBCC );
+    SET_WARNING(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
+    SET_WARNING(ERROR_OUT_OF_MEMORY, "Out of memory", 0x2233);
+    SET_WARNING(ERROR_SEMAPHORE_LOCK_FAILED, "Sem lock failed", 0x3344 );
+    SET_WARNING(ERROR_MUTEX_LOCK_FAILED, "Mutex lock failed", 0x4455 );
+    SET_WARNING(ERROR_CREATE_FAILED, "Create failed", 0x5566 );
+    SET_WARNING(ERROR_TIME_OUT, "Time out error", 0x7788 );
+    SET_WARNING(ERROR_MUTEX_UNLOCK_FAILED, "Mutex unlock failed", 0x99AA );
+    SET_WARNING(ERROR_SEMAPHORE_UNLOCK_FAILED, "Semaphore unlock failed", 0xBBCC );
     
     MbedErrorStatus error = get_last_error();
     printf("\nlastError = 0x%08X", error );
@@ -131,7 +131,7 @@ void test_error_count_and_reset()
     
     //Log multiple errors and get the error count and make sure its 15
     for(int i=0; i<count; i++) {
-        SET_ERROR(ERROR_OUT_OF_MEMORY, "Out of memory", i);
+        SET_WARNING(ERROR_OUT_OF_MEMORY, "Out of memory", i);
     }
     
     TEST_ASSERT_EQUAL_INT(count, get_error_count());
@@ -148,48 +148,48 @@ void test_error_count_and_reset()
  */
 void test_error_encoding()
 {
-    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
+    SET_WARNING(ERROR_OUT_OF_RESOURCES, "System type error", 0x1100 );
     MbedErrorStatus lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_UNKNOWN, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_OUT_OF_RESOURCES, GET_MBED_ERROR_CODE(lastError));
     
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
-    SET_ERROR(error, "Custom Error Type", 0x2233);
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    SET_WARNING(error, "Custom Error Type", 0x2233);
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_CUSTOM, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_PLATFORM, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_PLATFORM, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_CREATE_FAILED, GET_MBED_ERROR_CODE(lastError));
     
-    SET_ERROR(ERROR_EACCES, "Posix Error 1", 0x3344 );
+    SET_WARNING(ERROR_EACCES, "Posix Error 1", 0x3344 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_POSIX, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_UNKNOWN, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_EACCES, GET_MBED_ERROR_CODE(lastError));
     
-    SET_ERROR(ERROR_ERANGE, "Posix Error 2", 0x3355 );
+    SET_WARNING(ERROR_ERANGE, "Posix Error 2", 0x3355 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_POSIX, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_UNKNOWN, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_ERANGE, GET_MBED_ERROR_CODE(lastError));
     
-    error = MAKE_ERROR(ENTITY_HAL, ERROR_CODE_UNKNOWN);
-    SET_ERROR(error, "HAL Entity error", 0x5566 );
+    error = MAKE_ERROR(MODULE_HAL, ERROR_CODE_UNKNOWN);
+    SET_WARNING(error, "HAL Entity error", 0x5566 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_HAL, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_HAL, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_UNKNOWN, GET_MBED_ERROR_CODE(lastError));
     
-    SET_ERROR(ERROR_UNKNOWN, "Unknown Entity error", 7788 );
+    SET_WARNING(ERROR_UNKNOWN, "Unknown Entity error", 7788 );
     lastError = get_last_error();
     printf("\nlastError = 0x%08X", lastError );
     TEST_ASSERT_EQUAL_UINT(ERROR_TYPE_SYSTEM, GET_MBED_ERROR_TYPE(lastError));
-    TEST_ASSERT_EQUAL_UINT(ENTITY_UNKNOWN, GET_MBED_ERROR_ENTITY(lastError));
+    TEST_ASSERT_EQUAL_UINT(MODULE_UNKNOWN, GET_MBED_ERROR_MODULE(lastError));
     TEST_ASSERT_EQUAL_UINT(ERROR_CODE_UNKNOWN, GET_MBED_ERROR_CODE(lastError));
     
 }
@@ -201,20 +201,20 @@ void test_error_value()
     uint32_t error_value = 0xAA11BB22;
     mbed_error_ctx error_ctx = {0};
     
-    SET_ERROR(ERROR_OUT_OF_RESOURCES, "System type error", error_value );
+    SET_WARNING(ERROR_OUT_OF_RESOURCES, "System type error", error_value );
     MbedErrorStatus status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
     
-    MbedErrorStatus error = MAKE_CUSTOM_ERROR(ENTITY_PLATFORM, ERROR_CODE_CREATE_FAILED);
+    MbedErrorStatus error = MAKE_CUSTOM_ERROR(MODULE_PLATFORM, ERROR_CODE_CREATE_FAILED);
     error_value = 0xABCD;
-    SET_ERROR(error, "Custom Error Type", error_value);
+    SET_WARNING(error, "Custom Error Type", error_value);
     status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
     
     error_value = 0x11223344;
-    SET_ERROR(ERROR_EACCES, "Posix Error 1", error_value );
+    SET_WARNING(ERROR_EACCES, "Posix Error 1", error_value );
     status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
@@ -227,7 +227,7 @@ void test_error_context_capture()
     uint32_t error_value = 0xABCD;
     mbed_error_ctx error_ctx = {0};
     
-    SET_ERROR(ERROR_INVALID_ARGUMENT, "System type error", error_value );
+    SET_WARNING(ERROR_INVALID_ARGUMENT, "System type error", error_value );
     MbedErrorStatus status = get_last_error_log_info( &error_ctx );
     TEST_ASSERT(status == ERROR_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
@@ -254,9 +254,9 @@ void test_error_logging()
     clear_all_errors();
     
     //log 3 errors and retrieve them to ensure they are correct
-    SET_ERROR(ERROR_INVALID_ARGUMENT, "Invalid argument error", 1 );
-    SET_ERROR(ERROR_INVALID_SIZE, "Invalid size error", 2 );
-    SET_ERROR(ERROR_INVALID_FORMAT, "Invalid format error", 3 );
+    SET_WARNING(ERROR_INVALID_ARGUMENT, "Invalid argument error", 1 );
+    SET_WARNING(ERROR_INVALID_SIZE, "Invalid size error", 2 );
+    SET_WARNING(ERROR_INVALID_FORMAT, "Invalid format error", 3 );
     
     MbedErrorStatus status = get_error_log_info( 0, &error_ctx );
     TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_ARGUMENT, error_ctx.error_status);
@@ -271,11 +271,11 @@ void test_error_logging()
     TEST_ASSERT_EQUAL_UINT(3, error_ctx.error_value);
     
     //log 2 more errors to fill the log and then read them out to ensure that its correct
-    SET_ERROR(ERROR_INVALID_DATA, "Invalid data", 4 );
-    SET_ERROR(ERROR_INVALID_OPERATION, "Invalid operation", 5 );
+    SET_WARNING(ERROR_INVALID_DATA_DETECTED, "Invalid data", 4 );
+    SET_WARNING(ERROR_INVALID_OPERATION, "Invalid operation", 5 );
     
     status = get_error_log_info( 3, &error_ctx );
-    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_DATA, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(ERROR_INVALID_DATA_DETECTED, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(4, error_ctx.error_value);
     
     status = get_error_log_info( 4, &error_ctx );
@@ -283,20 +283,20 @@ void test_error_logging()
     TEST_ASSERT_EQUAL_UINT(5, error_ctx.error_value);
     
     //Log a bunch of errors to overflow the error log and retrieve them
-    SET_ERROR(ERROR_INVALID_ARGUMENT, "Invalid argument error", 6 );
-    SET_ERROR(ERROR_INVALID_SIZE, "Invalid size error", 7 );
-    SET_ERROR(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
-    SET_ERROR(ERROR_NOT_READY, "Not ready error", 9 );
+    SET_WARNING(ERROR_INVALID_ARGUMENT, "Invalid argument error", 6 );
+    SET_WARNING(ERROR_INVALID_SIZE, "Invalid size error", 7 );
+    SET_WARNING(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
+    SET_WARNING(ERROR_NOT_READY, "Not ready error", 9 );
     
     //Last 5 entries
-    SET_ERROR(ERROR_TIMEOUT, "Timeout error", 10 );
-    SET_ERROR(ERROR_ALREADY_IN_USE, "Already in use error", 11 );
-    SET_ERROR(ERROR_NOT_SUPPORTED, "Not supported error", 12 );
-    SET_ERROR(ERROR_ACCESS_DENIED, "Access denied error", 13 );
-    SET_ERROR(ERROR_NOT_FOUND, "Not found error", 14 );
+    SET_WARNING(ERROR_TIME_OUT, "Timeout error", 10 );
+    SET_WARNING(ERROR_ALREADY_IN_USE, "Already in use error", 11 );
+    SET_WARNING(ERROR_UNSUPPORTED, "Not supported error", 12 );
+    SET_WARNING(ERROR_ACCESS_DENIED, "Access denied error", 13 );
+    SET_WARNING(ERROR_ITEM_NOT_FOUND, "Not found error", 14 );
     
     status = get_error_log_info( 0, &error_ctx );
-    TEST_ASSERT_EQUAL_UINT(ERROR_TIMEOUT, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(ERROR_TIME_OUT, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(10, error_ctx.error_value);
     
     status = get_error_log_info( 1, &error_ctx );
@@ -304,7 +304,7 @@ void test_error_logging()
     TEST_ASSERT_EQUAL_UINT(11, error_ctx.error_value);
     
     status = get_error_log_info( 2, &error_ctx );
-    TEST_ASSERT_EQUAL_UINT(ERROR_NOT_SUPPORTED, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(ERROR_UNSUPPORTED, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(12, error_ctx.error_value);
     
     status = get_error_log_info( 3, &error_ctx );
@@ -312,7 +312,7 @@ void test_error_logging()
     TEST_ASSERT_EQUAL_UINT(13, error_ctx.error_value);
     
     status = get_error_log_info( 4, &error_ctx );
-    TEST_ASSERT_EQUAL_UINT(ERROR_NOT_FOUND, error_ctx.error_status);
+    TEST_ASSERT_EQUAL_UINT(ERROR_ITEM_NOT_FOUND, error_ctx.error_status);
     TEST_ASSERT_EQUAL_UINT(14, error_ctx.error_value);
     
     //Try an index which is invalid, we should get ERROR_INVALID_ARGUMENT back
@@ -326,8 +326,8 @@ void test_error_logging()
 //Error logger threads
 void err_thread_func(MbedErrorStatus *error_status)
 {
-    printf("\nError Status = 0x%08X\n",*error_status);
-    SET_ERROR(*error_status, "Error from Multi-Threaded error logging test", *error_status );
+    //printf("\nError Status = 0x%08X\n",*error_status);
+    SET_WARNING(*error_status, "Error from Multi-Threaded error logging test", *error_status );
 }
 
 
@@ -339,8 +339,8 @@ void test_error_logging_multithread()
     int i=0;
     Thread errThread[NUM_TEST_THREADS];
     MbedErrorStatus error_status[NUM_TEST_THREADS] = { 
-                                        ERROR_INVALID_ARGUMENT, ERROR_INVALID_DATA, ERROR_INVALID_FORMAT, ERROR_INVALID_SIZE, ERROR_INVALID_OPERATION, 
-                                        ERROR_NOT_FOUND, ERROR_ACCESS_DENIED, ERROR_FAILED_OPERATION, ERROR_OPERATION_PROHIBITED, ERROR_OPERATION_ABORTED
+                                        ERROR_INVALID_ARGUMENT, ERROR_INVALID_DATA_DETECTED, ERROR_INVALID_FORMAT, ERROR_INVALID_SIZE, ERROR_INVALID_OPERATION, 
+                                        ERROR_ITEM_NOT_FOUND, ERROR_ACCESS_DENIED, ERROR_FAILED_OPERATION, ERROR_OPERATION_PROHIBITED, ERROR_OPERATION_ABORTED
     };
     
         
@@ -353,14 +353,14 @@ void test_error_logging_multithread()
     }
     
     i = get_error_log_count()-1;
-    printf("\nError log count = %d\n", i+1);
+    //printf("\nError log count = %d\n", i+1);
     for(;i>=0;--i) {
         MbedErrorStatus status = get_error_log_info( i, &error_ctx );
         if(status != ERROR_SUCCESS) {
             TEST_FAIL();
         }
             
-        printf("\nError Status[%d] = 0x%08X Value = 0x%08X\n", i, (unsigned int)error_ctx.error_status, (unsigned int)error_ctx.error_value);
+        //printf("\nError Status[%d] = 0x%08X Value = 0x%08X\n", i, (unsigned int)error_ctx.error_status, (unsigned int)error_ctx.error_value);
         TEST_ASSERT_EQUAL_UINT((unsigned int)error_ctx.error_value, (unsigned int)error_ctx.error_status);
     }
 }
@@ -380,7 +380,7 @@ void test_error_hook()
         TEST_FAIL();
     }
     
-    SET_ERROR(ERROR_INVALID_ARGUMENT, "Test for error hook", 1234);
+    SET_WARNING(ERROR_INVALID_ARGUMENT, "Test for error hook", 1234);
     int32_t sem_status = callback_sem.wait(5000);
     
     TEST_ASSERT(sem_status > 0);
@@ -421,16 +421,16 @@ MBED_TEST_SIM_BLOCKDEVICE_DECL;
 void test_save_error_log()
 {
     //Log some errors
-    SET_ERROR(ERROR_TIMEOUT, "Timeout error", 1 );
-    SET_ERROR(ERROR_ALREADY_IN_USE, "Already in use error", 2 );
-    SET_ERROR(ERROR_NOT_SUPPORTED, "Not supported error", 3 );
-    SET_ERROR(ERROR_ACCESS_DENIED, "Access denied error", 4 );
-    SET_ERROR(ERROR_NOT_FOUND, "Not found error", 5 );
-    SET_ERROR(ERROR_INVALID_ARGUMENT, "Invalid argument error", 6 );
-    SET_ERROR(ERROR_INVALID_SIZE, "Invalid size error", 7 );
-    SET_ERROR(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
-    SET_ERROR(ERROR_INVALID_OPERATION, "Invalid operation", 9 );
-    SET_ERROR(ERROR_NOT_READY, "Not ready error", 10 );
+    SET_WARNING(ERROR_TIME_OUT, "Timeout error", 1 );
+    SET_WARNING(ERROR_ALREADY_IN_USE, "Already in use error", 2 );
+    SET_WARNING(ERROR_UNSUPPORTED, "Not supported error", 3 );
+    SET_WARNING(ERROR_ACCESS_DENIED, "Access denied error", 4 );
+    SET_WARNING(ERROR_ITEM_NOT_FOUND, "Not found error", 5 );
+    SET_WARNING(ERROR_INVALID_ARGUMENT, "Invalid argument error", 6 );
+    SET_WARNING(ERROR_INVALID_SIZE, "Invalid size error", 7 );
+    SET_WARNING(ERROR_INVALID_FORMAT, "Invalid format error", 8 );
+    SET_WARNING(ERROR_INVALID_OPERATION, "Invalid operation", 9 );
+    SET_WARNING(ERROR_NOT_READY, "Not ready error", 10 );
     
     int error = 0;
     

--- a/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
@@ -53,9 +53,9 @@ void error(const char* format, ...) {
 }
 
 //Override the set_error function to trap the errors 
-mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 #endif
 

--- a/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
@@ -51,6 +51,12 @@ Semaphore sync_sem(0, 1);
 void error(const char* format, ...) {
     (void) format;
 }
+
+//Override the set_error function to trap the errors 
+mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+{
+    return ERROR_SUCCESS;
+}
 #endif
 
 template<uint32_t flags, uint32_t wait_ms>

--- a/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
@@ -85,6 +85,11 @@ void error(const char* format, ...)
 {
     (void) format;
 }
+
+mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+{
+    return ERROR_SUCCESS;
+}
 #endif
 
 /** Test one-shot not restarted when elapsed

--- a/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
@@ -86,9 +86,9 @@ void error(const char* format, ...)
     (void) format;
 }
 
-mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 #endif
 

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -55,6 +55,11 @@ struct Sync {
 void error(const char* format, ...) {
     (void) format;
 }
+
+mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+{
+    return ERROR_SUCCESS;
+}
 #endif
 
 

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -56,9 +56,9 @@ void error(const char* format, ...) {
     (void) format;
 }
 
-mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 #endif
 

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -123,7 +123,7 @@ u32_t sys_now(void) {
  *---------------------------------------------------------------------------*/
 err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     if (queue_sz > MB_SIZE)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_INVALID_SIZE), "sys_mbox_new size error\n", queue_sz);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_INVALID_SIZE), "sys_mbox_new size error\n", queue_sz);
 
     memset(mbox, 0, sizeof(*mbox));
 
@@ -131,7 +131,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     mbox->attr.cb_size = sizeof(mbox->data);
     mbox->id = osEventFlagsNew(&mbox->attr);
     if (mbox->id == NULL)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_mbox_new create error\n", mbox->id);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_mbox_new create error\n", mbox->id);
 
     osEventFlagsSet(mbox->id, SYS_MBOX_POST_EVENT);
 
@@ -150,7 +150,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
  *---------------------------------------------------------------------------*/
 void sys_mbox_free(sys_mbox_t *mbox) {
     if (mbox->post_idx != mbox->fetch_idx)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_FREE_FAILED), "sys_mbox_free error\n", mbox->post_idx);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_FREE_FAILED), "sys_mbox_free error\n", mbox->post_idx);
 }
 
 /*---------------------------------------------------------------------------*
@@ -309,7 +309,7 @@ err_t sys_sem_new(sys_sem_t *sem, u8_t count) {
     sem->attr.cb_size = sizeof(sem->data);
     sem->id = osSemaphoreNew(UINT16_MAX, count, &sem->attr);
     if (sem->id == NULL)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_sem_new create error\n", sem->id);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_sem_new create error\n", sem->id);
     
     return ERR_OK;
 }
@@ -388,14 +388,14 @@ err_t sys_mutex_new(sys_mutex_t *mutex) {
  * @param mutex the mutex to lock */
 void sys_mutex_lock(sys_mutex_t *mutex) {
     if (osMutexAcquire(mutex->id, osWaitForever) != osOK)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_mutex_lock error\n", mutex->id);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_mutex_lock error\n", mutex->id);
 }
 
 /** Unlock a mutex
  * @param mutex the mutex to unlock */
 void sys_mutex_unlock(sys_mutex_t *mutex) {
     if (osMutexRelease(mutex->id) != osOK)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_UNLOCK_FAILED), "sys_mutex_unlock error\n", mutex->id);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_UNLOCK_FAILED), "sys_mutex_unlock error\n", mutex->id);
 }
 
 /** Delete a mutex
@@ -418,7 +418,7 @@ void sys_init(void) {
     lwip_sys_mutex_attr.cb_size = sizeof(lwip_sys_mutex_data);
     lwip_sys_mutex = osMutexNew(&lwip_sys_mutex_attr);
     if (lwip_sys_mutex == NULL)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_INITIALIZATION_FAILED), "sys_init error\n", lwip_sys_mutex);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_INITIALIZATION_FAILED), "sys_init error\n", lwip_sys_mutex);
 }
 
 /*---------------------------------------------------------------------------*
@@ -452,7 +452,7 @@ u32_t sys_jiffies(void) {
  *---------------------------------------------------------------------------*/
 sys_prot_t sys_arch_protect(void) {
     if (osMutexAcquire(lwip_sys_mutex, osWaitForever) != osOK)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_protect error\n", lwip_sys_mutex);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_protect error\n", lwip_sys_mutex);
     return (sys_prot_t) 1;
 }
 
@@ -469,7 +469,7 @@ sys_prot_t sys_arch_protect(void) {
  *---------------------------------------------------------------------------*/
 void sys_arch_unprotect(sys_prot_t p) {
     if (osMutexRelease(lwip_sys_mutex) != osOK)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_unprotect error\n", lwip_sys_mutex);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_unprotect error\n", lwip_sys_mutex);
 }
 
 u32_t sys_now(void) {
@@ -508,7 +508,7 @@ sys_thread_t sys_thread_new(const char *pcName,
     LWIP_DEBUGF(SYS_DEBUG, ("New Thread: %s\n", pcName));
 
     if (thread_pool_index >= SYS_THREAD_POOL_N)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new number error\n", thread_pool_index);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new number error\n", thread_pool_index);
     sys_thread_t t = (sys_thread_t)&thread_pool[thread_pool_index];
     thread_pool_index++;
 
@@ -520,11 +520,11 @@ sys_thread_t sys_thread_new(const char *pcName,
     t->attr.stack_size = stacksize;
     t->attr.stack_mem = malloc(stacksize);
     if (t->attr.stack_mem == NULL) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory", t);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory", t);
     }
     t->id = osThreadNew((osThreadFunc_t)thread, arg, &t->attr);
     if (t->id == NULL)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new create error\n", t->id);
+        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new create error\n", t->id);
     
     return t;
 }

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -123,7 +123,7 @@ u32_t sys_now(void) {
  *---------------------------------------------------------------------------*/
 err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     if (queue_sz > MB_SIZE)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_INVALID_SIZE), "sys_mbox_new size error\n", queue_sz);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_INVALID_SIZE), "sys_mbox_new size error\n", queue_sz);
 
     memset(mbox, 0, sizeof(*mbox));
 
@@ -131,7 +131,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     mbox->attr.cb_size = sizeof(mbox->data);
     mbox->id = osEventFlagsNew(&mbox->attr);
     if (mbox->id == NULL)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_mbox_new create error\n", mbox->id);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_CREATE_FAILED), "sys_mbox_new create error\n", mbox->id);
 
     osEventFlagsSet(mbox->id, SYS_MBOX_POST_EVENT);
 
@@ -150,7 +150,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
  *---------------------------------------------------------------------------*/
 void sys_mbox_free(sys_mbox_t *mbox) {
     if (mbox->post_idx != mbox->fetch_idx)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_FREE_FAILED), "sys_mbox_free error\n", mbox->post_idx);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_FREE_FAILED), "sys_mbox_free error\n", mbox->post_idx);
 }
 
 /*---------------------------------------------------------------------------*
@@ -309,7 +309,7 @@ err_t sys_sem_new(sys_sem_t *sem, u8_t count) {
     sem->attr.cb_size = sizeof(sem->data);
     sem->id = osSemaphoreNew(UINT16_MAX, count, &sem->attr);
     if (sem->id == NULL)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_sem_new create error\n", sem->id);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_CREATE_FAILED), "sys_sem_new create error\n", sem->id);
     
     return ERR_OK;
 }
@@ -388,14 +388,14 @@ err_t sys_mutex_new(sys_mutex_t *mutex) {
  * @param mutex the mutex to lock */
 void sys_mutex_lock(sys_mutex_t *mutex) {
     if (osMutexAcquire(mutex->id, osWaitForever) != osOK)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_mutex_lock error\n", mutex->id);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "sys_mutex_lock error\n", mutex->id);
 }
 
 /** Unlock a mutex
  * @param mutex the mutex to unlock */
 void sys_mutex_unlock(sys_mutex_t *mutex) {
     if (osMutexRelease(mutex->id) != osOK)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_UNLOCK_FAILED), "sys_mutex_unlock error\n", mutex->id);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_MUTEX_UNLOCK_FAILED), "sys_mutex_unlock error\n", mutex->id);
 }
 
 /** Delete a mutex
@@ -418,7 +418,7 @@ void sys_init(void) {
     lwip_sys_mutex_attr.cb_size = sizeof(lwip_sys_mutex_data);
     lwip_sys_mutex = osMutexNew(&lwip_sys_mutex_attr);
     if (lwip_sys_mutex == NULL)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_INITIALIZATION_FAILED), "sys_init error\n", lwip_sys_mutex);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_INITIALIZATION_FAILED), "sys_init error\n", lwip_sys_mutex);
 }
 
 /*---------------------------------------------------------------------------*
@@ -452,7 +452,7 @@ u32_t sys_jiffies(void) {
  *---------------------------------------------------------------------------*/
 sys_prot_t sys_arch_protect(void) {
     if (osMutexAcquire(lwip_sys_mutex, osWaitForever) != osOK)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_protect error\n", lwip_sys_mutex);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_protect error\n", lwip_sys_mutex);
     return (sys_prot_t) 1;
 }
 
@@ -469,7 +469,7 @@ sys_prot_t sys_arch_protect(void) {
  *---------------------------------------------------------------------------*/
 void sys_arch_unprotect(sys_prot_t p) {
     if (osMutexRelease(lwip_sys_mutex) != osOK)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_unprotect error\n", lwip_sys_mutex);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_unprotect error\n", lwip_sys_mutex);
 }
 
 u32_t sys_now(void) {
@@ -508,7 +508,7 @@ sys_thread_t sys_thread_new(const char *pcName,
     LWIP_DEBUGF(SYS_DEBUG, ("New Thread: %s\n", pcName));
 
     if (thread_pool_index >= SYS_THREAD_POOL_N)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new number error\n", thread_pool_index);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new number error\n", thread_pool_index);
     sys_thread_t t = (sys_thread_t)&thread_pool[thread_pool_index];
     thread_pool_index++;
 
@@ -520,11 +520,11 @@ sys_thread_t sys_thread_new(const char *pcName,
     t->attr.stack_size = stacksize;
     t->attr.stack_mem = malloc(stacksize);
     if (t->attr.stack_mem == NULL) {
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory", t);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory", t);
     }
     t->id = osThreadNew((osThreadFunc_t)thread, arg, &t->attr);
     if (t->id == NULL)
-        SET_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new create error\n", t->id);
+        MBED_ERROR(MAKE_ERROR(MODULE_NETWORK_STACK, MBED_ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new create error\n", t->id);
     
     return t;
 }

--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -123,7 +123,7 @@ u32_t sys_now(void) {
  *---------------------------------------------------------------------------*/
 err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     if (queue_sz > MB_SIZE)
-        error("sys_mbox_new size error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_INVALID_SIZE), "sys_mbox_new size error\n", queue_sz);
 
     memset(mbox, 0, sizeof(*mbox));
 
@@ -131,7 +131,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
     mbox->attr.cb_size = sizeof(mbox->data);
     mbox->id = osEventFlagsNew(&mbox->attr);
     if (mbox->id == NULL)
-        error("sys_mbox_new create error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_mbox_new create error\n", mbox->id);
 
     osEventFlagsSet(mbox->id, SYS_MBOX_POST_EVENT);
 
@@ -150,7 +150,7 @@ err_t sys_mbox_new(sys_mbox_t *mbox, int queue_sz) {
  *---------------------------------------------------------------------------*/
 void sys_mbox_free(sys_mbox_t *mbox) {
     if (mbox->post_idx != mbox->fetch_idx)
-        error("sys_mbox_free error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_FREE_FAILED), "sys_mbox_free error\n", mbox->post_idx);
 }
 
 /*---------------------------------------------------------------------------*
@@ -309,7 +309,7 @@ err_t sys_sem_new(sys_sem_t *sem, u8_t count) {
     sem->attr.cb_size = sizeof(sem->data);
     sem->id = osSemaphoreNew(UINT16_MAX, count, &sem->attr);
     if (sem->id == NULL)
-        error("sys_sem_new create error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_CREATE_FAILED), "sys_sem_new create error\n", sem->id);
     
     return ERR_OK;
 }
@@ -388,14 +388,14 @@ err_t sys_mutex_new(sys_mutex_t *mutex) {
  * @param mutex the mutex to lock */
 void sys_mutex_lock(sys_mutex_t *mutex) {
     if (osMutexAcquire(mutex->id, osWaitForever) != osOK)
-        error("sys_mutex_lock error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_mutex_lock error\n", mutex->id);
 }
 
 /** Unlock a mutex
  * @param mutex the mutex to unlock */
 void sys_mutex_unlock(sys_mutex_t *mutex) {
     if (osMutexRelease(mutex->id) != osOK)
-        error("sys_mutex_unlock error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_UNLOCK_FAILED), "sys_mutex_unlock error\n", mutex->id);
 }
 
 /** Delete a mutex
@@ -418,7 +418,7 @@ void sys_init(void) {
     lwip_sys_mutex_attr.cb_size = sizeof(lwip_sys_mutex_data);
     lwip_sys_mutex = osMutexNew(&lwip_sys_mutex_attr);
     if (lwip_sys_mutex == NULL)
-        error("sys_init error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_INITIALIZATION_FAILED), "sys_init error\n", lwip_sys_mutex);
 }
 
 /*---------------------------------------------------------------------------*
@@ -452,7 +452,7 @@ u32_t sys_jiffies(void) {
  *---------------------------------------------------------------------------*/
 sys_prot_t sys_arch_protect(void) {
     if (osMutexAcquire(lwip_sys_mutex, osWaitForever) != osOK)
-        error("sys_arch_protect error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_protect error\n", lwip_sys_mutex);
     return (sys_prot_t) 1;
 }
 
@@ -469,7 +469,7 @@ sys_prot_t sys_arch_protect(void) {
  *---------------------------------------------------------------------------*/
 void sys_arch_unprotect(sys_prot_t p) {
     if (osMutexRelease(lwip_sys_mutex) != osOK)
-        error("sys_arch_unprotect error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_MUTEX_LOCK_FAILED), "sys_arch_unprotect error\n", lwip_sys_mutex);
 }
 
 u32_t sys_now(void) {
@@ -508,7 +508,7 @@ sys_thread_t sys_thread_new(const char *pcName,
     LWIP_DEBUGF(SYS_DEBUG, ("New Thread: %s\n", pcName));
 
     if (thread_pool_index >= SYS_THREAD_POOL_N)
-        error("sys_thread_new number error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new number error\n", thread_pool_index);
     sys_thread_t t = (sys_thread_t)&thread_pool[thread_pool_index];
     thread_pool_index++;
 
@@ -520,11 +520,11 @@ sys_thread_t sys_thread_new(const char *pcName,
     t->attr.stack_size = stacksize;
     t->attr.stack_mem = malloc(stacksize);
     if (t->attr.stack_mem == NULL) {
-      error("Error allocating the stack memory");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory", t);
     }
     t->id = osThreadNew((osThreadFunc_t)thread, arg, &t->attr);
     if (t->id == NULL)
-        error("sys_thread_new create error\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_NETWORK_STACK, ERROR_CODE_THREAD_CREATE_FAILED), "sys_thread_new create error\n", t->id);
     
     return t;
 }

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -57,13 +57,13 @@ int ReadOnlyBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
 int ReadOnlyBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::program() not allowed", addr);
+    SET_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::program() not allowed", addr);
     return ERROR_WRITE_PROTECTED;
 }
 
 int ReadOnlyBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::erase() not allowed", addr);
+    SET_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::erase() not allowed", addr);
     return ERROR_WRITE_PROTECTED;
 }
 

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -57,14 +57,14 @@ int ReadOnlyBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
 int ReadOnlyBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::program() not allowed", addr);
-    return ERROR_WRITE_PROTECTED;
+    MBED_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, MBED_ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::program() not allowed", addr);
+    return MBED_ERROR_WRITE_PROTECTED;
 }
 
 int ReadOnlyBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::erase() not allowed", addr);
-    return ERROR_WRITE_PROTECTED;
+    MBED_ERROR(MAKE_ERROR(MODULE_BLOCK_DEVICE, MBED_ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::erase() not allowed", addr);
+    return MBED_ERROR_WRITE_PROTECTED;
 }
 
 bd_size_t ReadOnlyBlockDevice::get_read_size() const

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -57,14 +57,14 @@ int ReadOnlyBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
 int ReadOnlyBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
 {
-    error("ReadOnlyBlockDevice::program() not allowed");
-    return 0;
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::program() not allowed", addr);
+    return ERROR_WRITE_PROTECTED;
 }
 
 int ReadOnlyBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 {
-    error("ReadOnlyBlockDevice::erase() not allowed");
-    return 0;
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_BLOCK_DEVICE, ERROR_CODE_WRITE_PROTECTED), "ReadOnlyBlockDevice::erase() not allowed", addr);
+    return ERROR_WRITE_PROTECTED;
 }
 
 bd_size_t ReadOnlyBlockDevice::get_read_size() const

--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -29,7 +29,7 @@ void pinmap_pinout(PinName pin, const PinMap *map) {
         }
         map++;
     }
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "could not pinout", pin);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "could not pinout", pin);
 }
 
 uint32_t pinmap_merge(uint32_t a, uint32_t b) {
@@ -44,7 +44,7 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b) {
         return a;
 
     // mis-match error case
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
     return (uint32_t)NC;
 }
 
@@ -64,7 +64,7 @@ uint32_t pinmap_peripheral(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     peripheral = pinmap_find_peripheral(pin, map);
     if ((uint32_t)NC == peripheral) // no mapping available
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
     return peripheral;
 }
 
@@ -84,6 +84,6 @@ uint32_t pinmap_function(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     function = pinmap_find_function(pin, map);
     if ((uint32_t)NC == function) // no mapping available
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
     return function;
 }

--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -29,7 +29,7 @@ void pinmap_pinout(PinName pin, const PinMap *map) {
         }
         map++;
     }
-    error("could not pinout");
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "could not pinout", pin);
 }
 
 uint32_t pinmap_merge(uint32_t a, uint32_t b) {
@@ -44,7 +44,7 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b) {
         return a;
 
     // mis-match error case
-    error("pinmap mis-match");
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
     return (uint32_t)NC;
 }
 
@@ -64,7 +64,7 @@ uint32_t pinmap_peripheral(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     peripheral = pinmap_find_peripheral(pin, map);
     if ((uint32_t)NC == peripheral) // no mapping available
-        error("pinmap not found for peripheral");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
     return peripheral;
 }
 
@@ -84,6 +84,6 @@ uint32_t pinmap_function(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     function = pinmap_find_function(pin, map);
     if ((uint32_t)NC == function) // no mapping available
-        error("pinmap not found for function");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
     return function;
 }

--- a/hal/mbed_pinmap_common.c
+++ b/hal/mbed_pinmap_common.c
@@ -29,7 +29,7 @@ void pinmap_pinout(PinName pin, const PinMap *map) {
         }
         map++;
     }
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "could not pinout", pin);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "could not pinout", pin);
 }
 
 uint32_t pinmap_merge(uint32_t a, uint32_t b) {
@@ -44,7 +44,7 @@ uint32_t pinmap_merge(uint32_t a, uint32_t b) {
         return a;
 
     // mis-match error case
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap mis-match", a);
     return (uint32_t)NC;
 }
 
@@ -64,7 +64,7 @@ uint32_t pinmap_peripheral(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     peripheral = pinmap_find_peripheral(pin, map);
     if ((uint32_t)NC == peripheral) // no mapping available
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for peripheral", peripheral);
     return peripheral;
 }
 
@@ -84,6 +84,6 @@ uint32_t pinmap_function(PinName pin, const PinMap* map) {
         return (uint32_t)NC;
     function = pinmap_find_function(pin, map);
     if ((uint32_t)NC == function) // no mapping available
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PINMAP_INVALID), "pinmap not found for function", function);
     return function;
 }

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -119,7 +119,7 @@ void sleep_manager_lock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == USHRT_MAX) {
         core_util_critical_section_exit();
-        SET_ERROR(MAKE_ERROR(MODULE_HAL, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", deep_sleep_lock);
+        MBED_ERROR(MAKE_ERROR(MODULE_HAL, MBED_ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", deep_sleep_lock);
     }
     core_util_atomic_incr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();
@@ -130,7 +130,7 @@ void sleep_manager_unlock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == 0) {
         core_util_critical_section_exit();
-        SET_ERROR(MAKE_ERROR(MODULE_HAL, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", deep_sleep_lock);
+        MBED_ERROR(MAKE_ERROR(MODULE_HAL, MBED_ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", deep_sleep_lock);
     }
     core_util_atomic_decr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -119,7 +119,7 @@ void sleep_manager_lock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == USHRT_MAX) {
         core_util_critical_section_exit();
-        error("Deep sleep lock would overflow (> USHRT_MAX)");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_HAL, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", deep_sleep_lock);
     }
     core_util_atomic_incr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();
@@ -130,7 +130,7 @@ void sleep_manager_unlock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == 0) {
         core_util_critical_section_exit();
-        error("Deep sleep lock would underflow (< 0)");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_HAL, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", deep_sleep_lock);
     }
     core_util_atomic_decr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -119,7 +119,7 @@ void sleep_manager_lock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == USHRT_MAX) {
         core_util_critical_section_exit();
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_HAL, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", deep_sleep_lock);
+        SET_ERROR(MAKE_ERROR(MODULE_HAL, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", deep_sleep_lock);
     }
     core_util_atomic_incr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();
@@ -130,7 +130,7 @@ void sleep_manager_unlock_deep_sleep_internal(void)
     core_util_critical_section_enter();
     if (deep_sleep_lock == 0) {
         core_util_critical_section_exit();
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_HAL, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", deep_sleep_lock);
+        SET_ERROR(MAKE_ERROR(MODULE_HAL, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", deep_sleep_lock);
     }
     core_util_atomic_decr_u16(&deep_sleep_lock, 1);
     core_util_critical_section_exit();

--- a/platform/DeepSleepLock.h
+++ b/platform/DeepSleepLock.h
@@ -69,7 +69,7 @@ public:
             sleep_manager_lock_deep_sleep();
         }
         if (0 == count) {
-            error("DeepSleepLock overflow (> USHRT_MAX)");
+            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", count);
         }
     }
 
@@ -83,7 +83,7 @@ public:
         }
         if (count == USHRT_MAX) {
             core_util_critical_section_exit();
-            error("DeepSleepLock underflow (< 0)");
+            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", count);
         }
     }
 };

--- a/platform/DeepSleepLock.h
+++ b/platform/DeepSleepLock.h
@@ -69,7 +69,7 @@ public:
             sleep_manager_lock_deep_sleep();
         }
         if (0 == count) {
-            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", count);
+            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", count);
         }
     }
 
@@ -83,7 +83,7 @@ public:
         }
         if (count == USHRT_MAX) {
             core_util_critical_section_exit();
-            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", count);
+            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", count);
         }
     }
 };

--- a/platform/DeepSleepLock.h
+++ b/platform/DeepSleepLock.h
@@ -69,7 +69,7 @@ public:
             sleep_manager_lock_deep_sleep();
         }
         if (0 == count) {
-            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", count);
+            MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OVERFLOW), "DeepSleepLock overflow (> USHRT_MAX)", count);
         }
     }
 
@@ -83,7 +83,7 @@ public:
         }
         if (count == USHRT_MAX) {
             core_util_critical_section_exit();
-            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", count);
+            MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_UNDERFLOW), "DeepSleepLock underflow (< 0)", count);
         }
     }
 };

--- a/platform/Stream.cpp
+++ b/platform/Stream.cpp
@@ -29,7 +29,7 @@ Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
     if (_file) {
         mbed_set_unbuffered_stream(_file);
     } else {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OPEN_FAILED), "Stream obj failure", _file);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OPEN_FAILED), "Stream obj failure", _file);
     }
 }
 

--- a/platform/Stream.cpp
+++ b/platform/Stream.cpp
@@ -29,7 +29,7 @@ Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
     if (_file) {
         mbed_set_unbuffered_stream(_file);
     } else {
-        error("Stream obj failure, errno=%d\r\n", errno);
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OPEN_FAILED), "Stream obj failure", _file);
     }
 }
 

--- a/platform/Stream.cpp
+++ b/platform/Stream.cpp
@@ -29,7 +29,7 @@ Stream::Stream(const char *name) : FileLike(name), _file(NULL) {
     if (_file) {
         mbed_set_unbuffered_stream(_file);
     } else {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OPEN_FAILED), "Stream obj failure", _file);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OPEN_FAILED), "Stream obj failure", _file);
     }
 }
 

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -163,7 +163,7 @@ mbed_error_status_t set_warning(mbed_error_status_t error_status, const char *er
 }
 
 //Sets a fatal error 
-mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+WEAK mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
     //set the error reported and then halt the system
     if( ERROR_SUCCESS != handle_error(error_status, error_msg, error_value, filename, line_number) )

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -236,13 +236,17 @@ MbedErrorStatus clear_all_errors(void)
 {
     MbedErrorStatus status = ERROR_SUCCESS;
     
+    //Make sure we dont multiple clients resetting
+    core_util_critical_section_enter();
     //Clear the error and context capturing buffer
     memset(&last_error_ctx, sizeof(mbed_error_ctx), 0);
     //reset error count to 0
     error_count = 0;
 #ifndef MBED_CONF_ERROR_LOG_DISABLED    
     status = mbed_log_reset();
-#endif    
+#endif
+    core_util_critical_section_exit();
+    
     return status;
 }
 

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -30,7 +30,7 @@ static uint8_t error_in_progress = 0;
 static int error_count = 0;
 static mbed_error_ctx first_error_ctx = {0};
 static mbed_error_ctx last_error_ctx = {0};
-static MbedErrorHook error_hook = NULL;
+static mbed_error_hook_t error_hook = NULL;
 
 //Helper function to halt the system
 static void mbed_halt_system(void)
@@ -66,7 +66,7 @@ WEAK void error(const char* format, ...) {
 }
 
 //Set an error status with the error handling system
-MbedErrorStatus handle_error(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t handle_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
     mbed_error_ctx current_error_ctx;
     
@@ -136,14 +136,14 @@ MbedErrorStatus handle_error(MbedErrorStatus error_status, const char *error_msg
 }
 
 //Return the first error
-MbedErrorStatus get_first_error(void) 
+mbed_error_status_t get_first_error(void) 
 {
     //return the first error recorded
     return first_error_ctx.error_status;
 }
 
 //Return the last error
-MbedErrorStatus get_last_error(void) 
+mbed_error_status_t get_last_error(void) 
 {
     //return the last error recorded
     return last_error_ctx.error_status;
@@ -157,13 +157,13 @@ int get_error_count(void)
 }
 
 //Sets a fatal error 
-MbedErrorStatus set_warning(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t set_warning(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
     return handle_error(error_status, error_msg, error_value, filename, line_number);
 }
 
 //Sets a fatal error 
-MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
 {
     //set the error reported and then halt the system
     if( ERROR_SUCCESS != handle_error(error_status, error_msg, error_value, filename, line_number) )
@@ -174,7 +174,7 @@ MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, u
 }
 
 //Register an application defined callback with error handling
-MbedErrorStatus set_error_hook(MbedErrorHook error_hook_in) 
+mbed_error_status_t set_error_hook(mbed_error_hook_t error_hook_in) 
 {
     //register the new hook/callback
     if( error_hook_in != NULL )  {
@@ -186,21 +186,21 @@ MbedErrorStatus set_error_hook(MbedErrorHook error_hook_in)
 }
 
 //Retrieve the first error context from error log 
-MbedErrorStatus get_first_error_log_info (mbed_error_ctx *error_info) 
+mbed_error_status_t get_first_error_log_info (mbed_error_ctx *error_info) 
 {
     memcpy(error_info, &first_error_ctx, sizeof(first_error_ctx));
     return ERROR_SUCCESS;
 }
 
 //Retrieve the last error context from error log 
-MbedErrorStatus get_last_error_log_info (mbed_error_ctx *error_info) 
+mbed_error_status_t get_last_error_log_info (mbed_error_ctx *error_info) 
 {
     memcpy(error_info, &last_error_ctx, sizeof(mbed_error_ctx));
     return ERROR_SUCCESS;
 }
 
-//Makes an MbedErrorStatus value
-MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedModuleType entity, MbedErrorCode error_code) 
+//Makes an mbed_error_status_t value
+mbed_error_status_t make_mbed_error(mbed_error_type_t error_type, mbed_module_type_t entity, mbed_error_code_t error_code) 
 {
     switch(error_type)
     {
@@ -232,9 +232,9 @@ MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedModuleType entity,
  * @return                      0 or ERROR_SUCCESS on success.
  *
  */
-MbedErrorStatus clear_all_errors(void) 
+mbed_error_status_t clear_all_errors(void) 
 {
-    MbedErrorStatus status = ERROR_SUCCESS;
+    mbed_error_status_t status = ERROR_SUCCESS;
     
     //Make sure we dont multiple clients resetting
     core_util_critical_section_enter();
@@ -252,7 +252,7 @@ MbedErrorStatus clear_all_errors(void)
 
 #ifndef MBED_CONF_ERROR_LOG_DISABLED
 //Retrieve the error context from error log at the specified index
-MbedErrorStatus get_error_log_info (int index, mbed_error_ctx *error_info) 
+mbed_error_status_t get_error_log_info (int index, mbed_error_ctx *error_info) 
 {
     return mbed_log_get_error(index, error_info);
 }
@@ -263,9 +263,9 @@ int get_error_log_count(void)
     return mbed_log_get_error_log_count();
 }
 
-MbedErrorStatus save_error_log(const char *path)
+mbed_error_status_t save_error_log(const char *path)
 {
-    MbedErrorStatus ret = ERROR_SUCCESS;
+    mbed_error_status_t ret = ERROR_SUCCESS;
     mbed_error_ctx ctx = {0};
     int log_count = mbed_log_get_error_log_count();
     FILE *error_log_file = NULL;

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -15,15 +15,55 @@
  */
 #include <stdlib.h>
 #include <stdarg.h>
+#include "rtx_os.h"
+#include "mbed_rtx.h"
 #include "device.h"
-#include "platform/mbed_toolchain.h"
+#include "platform/mbed_critical.h"
 #include "platform/mbed_error.h"
+#include "platform/mbed_error_log.h"
+#include "platform/mbed_error_report.h"
 #include "platform/mbed_interface.h"
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif
 
 static uint8_t error_in_progress = 0;
+static int error_count = 0;
+static mbed_error_ctx first_error_ctx = {0};
+static mbed_error_ctx current_error_ctx = {0};
+static MbedErrorHook error_hook = NULL;
+
+//Helper function to get the current SP
+static unsigned int get_current_sp()
+{
+    //If in Handler mode we are always using MSP
+    if( __get_IPSR() != 0U ) {
+        return __get_MSP();
+    } else {
+        //Look into CONTROL.SPSEL value
+        if ((__get_CONTROL() & 2U) == 0U) {
+            return __get_PSP();//Read PSP
+        } else {
+            return __get_MSP();//Read MSP
+        }
+    }
+}
+
+//Helper function to halt the system
+static void mbed_halt_system(void)
+{
+    mbed_error_print("\nFATAL ERROR: Halting System...\n", NULL);
+    
+    //If not in ISR context exit, otherwise spin on WFI
+    if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
+        for(;;) {
+           __WFI();
+        }
+    } else {
+        //exit eventually calls mbed_die
+        exit(1);
+    }
+}
 
 WEAK void error(const char* format, ...) {
 
@@ -41,3 +81,190 @@ WEAK void error(const char* format, ...) {
 #endif
     exit(1);
 }
+
+//Set an error status with the error handling system
+MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+{
+    //Error status should always be < 0
+    if(error_status >= 0) {
+        return ERROR_INVALID_ARGUMENT;
+    }
+    
+    //Use critsect here, as we don't want processing more than one error at the same time
+    core_util_critical_section_enter();
+    
+    //Increment error count
+    error_count++;
+    
+    //Clear the context capturing buffer
+    memset(&current_error_ctx, sizeof(mbed_error_ctx), 0);
+    //Capture error information
+    current_error_ctx.error_status = error_status;
+    current_error_ctx.error_address = (uint32_t)MBED_CALLER_ADDR();
+    current_error_ctx.error_value = error_value;
+
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+    //Capture filename/linenumber if provided
+    //Index for tracking error_filename 
+    int idx = 0;
+    
+    if(NULL != filename) {
+        while(idx < MBED_CONF_MAX_ERROR_FILENAME_LEN && (filename[idx] != '\0')) {
+            current_error_ctx.error_filename[idx] = filename[idx];
+            idx++;
+        }
+        current_error_ctx.error_line_number = line_number;
+    }
+#endif
+    
+    //Capture thread info
+    osRtxThread_t *current_thread = osRtxInfo.thread.run.curr;
+    current_error_ctx.thread_id = (uint32_t)current_thread;
+    current_error_ctx.thread_entry_address = (uint32_t)current_thread->thread_addr;
+    current_error_ctx.thread_stack_size = current_thread->stack_size;
+    current_error_ctx.thread_stack_mem = (uint32_t)current_thread->stack_mem;
+    current_error_ctx.thread_current_sp = get_current_sp();
+    
+    //Call the error hook if available
+    if(error_hook != NULL) {
+        error_hook(&current_error_ctx);
+    }
+    
+#ifndef MBED_CONF_ERROR_LOG_DISABLED    
+    //Log the error with error log
+    mbed_log_put_error(&current_error_ctx);
+#endif
+    
+    //Report the error
+    mbed_report_error(&current_error_ctx, (char *)error_msg);
+    
+    //Capture the fist system error and store it
+    if(error_count == 1) { //first error
+        memcpy(&first_error_ctx, &current_error_ctx, sizeof(mbed_error_ctx));
+    }
+    
+    //Use critsect here, as we don't want processing more than one error at the same time
+    core_util_critical_section_exit();
+        
+    return ERROR_SUCCESS;
+}
+
+//Return the first error
+MbedErrorStatus get_first_error(void) 
+{
+    //return the first error recorded
+    return first_error_ctx.error_status;
+}
+
+//Return the last error
+MbedErrorStatus get_last_error(void) 
+{
+    //return the last error recorded
+    return current_error_ctx.error_status;
+}
+
+//Gets the current error count
+int get_error_count(void) 
+{
+    //return the current error count
+    return error_count;
+}
+
+//Sets a fatal error 
+MbedErrorStatus set_error_fatal(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number) 
+{
+    //set the error reported and then halt the system
+    if( ERROR_SUCCESS != set_error(error_status, error_msg, error_value, filename, line_number) )
+        return ERROR_FAILED_OPERATION;
+    mbed_halt_system();
+    
+    return ERROR_FAILED_OPERATION;
+}
+
+//Register an application defined callback with error handling
+MbedErrorStatus set_error_hook(MbedErrorHook error_hook_in) 
+{
+    //register the new hook/callback
+    if( error_hook_in != NULL )  {
+        error_hook = error_hook_in;
+        return ERROR_SUCCESS;
+    } 
+    
+    return ERROR_INVALID_ARGUMENT;
+}
+
+//Retrieve the first error context from error log 
+MbedErrorStatus get_first_error_log_info (mbed_error_ctx *error_info) 
+{
+    memcpy(error_info, &first_error_ctx, sizeof(first_error_ctx));
+    return ERROR_SUCCESS;
+}
+
+//Retrieve the last error context from error log 
+MbedErrorStatus get_last_error_log_info (mbed_error_ctx *error_info) 
+{
+    memcpy(error_info, &current_error_ctx, sizeof(mbed_error_ctx));
+    return ERROR_SUCCESS;
+}
+
+//Makes an MbedErrorStatus value
+MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedEntityType entity, MbedErrorCode error_code) 
+{
+    switch(error_type)
+    {
+        case ERROR_TYPE_POSIX:
+            if(error_code >= MBED_POSIX_ERROR_BASE && error_code <= MBED_SYSTEM_ERROR_BASE)
+                return -error_code;
+            break;
+            
+        case ERROR_TYPE_SYSTEM:
+            if(error_code >= MBED_SYSTEM_ERROR_BASE && error_code <= MBED_CUSTOM_ERROR_BASE)
+                return MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, entity, error_code);
+            break;
+            
+        case ERROR_TYPE_CUSTOM:
+            if(error_code >= MBED_CUSTOM_ERROR_BASE)
+                return MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, entity, error_code);
+            break;
+            
+        default:
+            break;
+    }
+    
+    //If we are passed incorrect values return a generic system error
+    return MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, ENTITY_UNKNOWN, ERROR_CODE_UNKNOWN);
+}
+
+/**
+ * Clears all the last error, error count and all entries in the error log.
+ * @return                      0 or ERROR_SUCCESS on success.
+ *
+ */
+MbedErrorStatus clear_all_errors(void) 
+{
+    MbedErrorStatus status = ERROR_SUCCESS;
+    
+    //Clear the error and context capturing buffer
+    memset(&current_error_ctx, sizeof(mbed_error_ctx), 0);
+    //reset error count to 0
+    error_count = 0;
+#ifndef MBED_CONF_ERROR_LOG_DISABLED    
+    status = mbed_log_reset();
+#endif    
+    return status;
+}
+
+#ifndef MBED_CONF_ERROR_LOG_DISABLED
+//Retrieve the error context from error log at the specified index
+MbedErrorStatus get_error_log_info (int index, mbed_error_ctx *error_info) 
+{
+    return mbed_log_get_error(index, error_info);
+}
+
+//Retrieve the error log count
+int get_error_log_count(void) 
+{
+    return mbed_log_get_error_log_count();
+}
+#endif
+

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -63,9 +63,9 @@ extern "C" {
                                                     (MBED_ERROR_STATUS_MODULE_MASK & (module << MBED_ERROR_STATUS_MODULE_POS)) |        \
                                                     (MBED_ERROR_STATUS_TYPE_MASK & (type << MBED_ERROR_STATUS_TYPE_POS)))    
 
-#define GET_MBED_ERROR_TYPE( error_status )         ((error_status & MBED_ERROR_STATUS_TYPE_MASK) >> MBED_ERROR_STATUS_TYPE_POS)
-#define GET_MBED_ERROR_MODULE( error_status )       ((error_status & MBED_ERROR_STATUS_MODULE_MASK) >> MBED_ERROR_STATUS_MODULE_POS)    
-#define GET_MBED_ERROR_CODE( error_status )         (int)((GET_MBED_ERROR_TYPE( error_status ) == ERROR_TYPE_POSIX)?(-error_status):((error_status & MBED_ERROR_STATUS_CODE_MASK) >> MBED_ERROR_STATUS_CODE_POS))
+#define MBED_GET_ERROR_TYPE( error_status )         ((error_status & MBED_ERROR_STATUS_TYPE_MASK) >> MBED_ERROR_STATUS_TYPE_POS)
+#define MBED_GET_ERROR_MODULE( error_status )       ((error_status & MBED_ERROR_STATUS_MODULE_MASK) >> MBED_ERROR_STATUS_MODULE_POS)    
+#define MBED_GET_ERROR_CODE( error_status )         (int)((MBED_GET_ERROR_TYPE( error_status ) == MBED_ERROR_TYPE_POSIX)?(-error_status):((error_status & MBED_ERROR_STATUS_CODE_MASK) >> MBED_ERROR_STATUS_CODE_POS))
 
 /** mbed_error_status_t description
  *
@@ -102,8 +102,8 @@ typedef int mbed_error_status_t;
  *
  */
 #define MBED_DEFINE_POSIX_ERROR( error_name, error_code )   \
-                     ERROR_CODE_##error_name = error_code,  \
-                     ERROR_##error_name = -(MBED_POSIX_ERROR_BASE + error_code)
+                     MBED_ERROR_CODE_##error_name = error_code,  \
+                     MBED_ERROR_##error_name = -(MBED_POSIX_ERROR_BASE + error_code)
 
 /**
  * Macro for defining a System error status. This macro is used to define System error values in mbed_error_code_t enumeration.
@@ -112,8 +112,8 @@ typedef int mbed_error_status_t;
  *
  */
 #define MBED_DEFINE_SYSTEM_ERROR( error_name, error_code )   \
-                      ERROR_CODE_##error_name = MBED_SYSTEM_ERROR_BASE + error_code,  \
-                      ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, MODULE_UNKNOWN, ERROR_CODE_##error_name)
+                      MBED_ERROR_CODE_##error_name = MBED_SYSTEM_ERROR_BASE + error_code,  \
+                      MBED_ERROR_##error_name = MAKE_MBED_ERROR(MBED_ERROR_TYPE_SYSTEM, MODULE_UNKNOWN, MBED_ERROR_CODE_##error_name)
 
 /**
  * Macro for defining a Custom error status. This macro is used to define custom error values in mbed_error_code_t enumeration.
@@ -122,52 +122,52 @@ typedef int mbed_error_status_t;
  *
  */
 #define MBED_DEFINE_CUSTOM_ERROR( error_name, error_code )   \
-                      ERROR_CODE_##error_name = MBED_CUSTOM_ERROR_BASE + error_code,  \
-                      ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, MODULE_UNKNOWN, ERROR_CODE_##error_name)
+                      MBED_ERROR_CODE_##error_name = MBED_CUSTOM_ERROR_BASE + error_code,  \
+                      MBED_ERROR_##error_name = MAKE_MBED_ERROR(MBED_ERROR_TYPE_CUSTOM, MODULE_UNKNOWN, MBED_ERROR_CODE_##error_name)
 
 
 /**
- * Macro for setting a system error. This macro will log the error, prints the error report and return to the caller. Its a wrapper for calling set_error API.
+ * Macro for setting a system error. This macro will log the error, prints the error report and return to the caller. Its a wrapper for calling mbed_error API.
  * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  *
  * @code
  * 
- * SET_ERROR( ERROR_INVALID_SIZE, "MyDriver: Invalid size in read", size_val )
+ * MBED_ERROR( ERROR_INVALID_SIZE, "MyDriver: Invalid size in read", size_val )
  *
  * @endcode
- * @note The macro calls set_error API with filename and line number info without caller explicitly passing them.
- *        Since this macro is a wrapper for set_error API callers should process the return value from this macro which is the return value from calling set_error API.
+ * @note The macro calls mbed_error API with filename and line number info without caller explicitly passing them.
+ *        Since this macro is a wrapper for mbed_error API callers should process the return value from this macro which is the return value from calling mbed_error API.
  *
  */
 #ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
-    #define SET_WARNING( error_status, error_msg, error_value )             set_warning( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
+    #define MBED_WARNING( error_status, error_msg, error_value )             mbed_warning( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
 #else
-    #define SET_WARNING( error_status, error_msg, error_value )             set_warning( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
+    #define MBED_WARNING( error_status, error_msg, error_value )             mbed_warning( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
 #endif
 
 /**
- * Macro for setting a fatal system error. This macro will log the error, prints the error report and halts the system. Its a wrapper for calling set_error API
+ * Macro for setting a fatal system error. This macro will log the error, prints the error report and halts the system. Its a wrapper for calling mbed_error API
  * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
- * @return                  0 or ERROR_SUCCESS.
- *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes
+ * @return                  0 or MBED_SUCCESS.
+ *                          MBED_ERROR_INVALID_ARGUMENT if called with invalid error status/codes
  *
  * @code
  * 
- * SET_ERROR( ERROR_MUTEX_LOCK_FAILED, "MyDriver: Can't lock driver Mutex", &my_mutex )
+ * MBED_ERROR( MBED_ERROR_MUTEX_LOCK_FAILED, "MyDriver: Can't lock driver Mutex", &my_mutex )
  *
  * @endcode
- * @note The macro calls set_error API with filename and line number info without caller explicitly passing them.
-*        Since this macro is a wrapper for set_error API callers should process the return value from this macro which is the return value from calling set_error API. 
+ * @note The macro calls mbed_error API with filename and line number info without caller explicitly passing them.
+*        Since this macro is a wrapper for mbed_error API callers should process the return value from this macro which is the return value from calling mbed_error API. 
  *
  */
 #ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
-    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
+    #define MBED_ERROR( error_status, error_msg, error_value )       mbed_error( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
 #else
-    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
+    #define MBED_ERROR( error_status, error_msg, error_value )       mbed_error( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
 #endif         
 
 //Error Type definition
@@ -175,19 +175,19 @@ typedef int mbed_error_status_t;
  *  @note
  *  This enumeration defines the Error types supported. The value of these enum values will be encoded into mbed_error_status_t TYPE field.\n
  *      See mbed_error_status_t description for more info.\n
- *         ERROR_TYPE_SYSTEM - Used to indicate that the error status is of System defined Error type.\n
- *         ERROR_TYPE_CUSTOM - Used to indicate that the error status is of Custom defined Error type.\n 
- *         ERROR_TYPE_POSIX  - Used to indicate that the error status is of Posix error type.\n 
+ *         MBED_ERROR_TYPE_SYSTEM - Used to indicate that the error status is of System defined Error type.\n
+ *         MBED_ERROR_TYPE_CUSTOM - Used to indicate that the error status is of Custom defined Error type.\n 
+ *         MBED_ERROR_TYPE_POSIX  - Used to indicate that the error status is of Posix error type.\n 
  *
  */
 typedef enum _mbed_error_type_t
 {
-    ERROR_TYPE_SYSTEM = 0,
-    ERROR_TYPE_CUSTOM = 1,
+    MBED_ERROR_TYPE_SYSTEM = 0,
+    MBED_ERROR_TYPE_CUSTOM = 1,
     //2 is reserved
     //Use 3 for POSIX because we are mapping -1 to -255 to POSIX error codes
     //and thus we must use 3 to match the type bits in error status representation which are from 0xFFFFFFFF to 0xFFFFFF00
-    ERROR_TYPE_POSIX = 3
+    MBED_ERROR_TYPE_POSIX = 3
 } mbed_error_type_t;        
 
 //Module type/id definitions
@@ -195,13 +195,13 @@ typedef enum _mbed_error_type_t
  * @note
  * This enumeration defines the module types. The value of these enum values will be encoded into mbed_error_status_t MODULE field.\n\n
  *      See mbed_error_status_t description for more info.\n
- *          MODULE_UNKNOWN - This module type can be used if caller of the set_error/set_warning doesn't know who is the actual originator of the error.\n
+ *          MODULE_UNKNOWN - This module type can be used if caller of the mbed_error/mbed_warning doesn't know who is the actual originator of the error.\n
  *                       Other module values can be used to provide more info on who/where the error originated from.\n\n
  *                       For example, if I2C driver is the component originating the error you can use MODULE_DRIVER_I2C to provide more info.\n
  *                       Its used in call to MAKE_ERROR/MAKE_SYSTEM_ERROR/MAKE_CUSTOM_ERROR macros.\n
  *
  * @code
- *      Example: mbed_error_status_t i2c_driver_error = MAKE_ERROR( MODULE_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
+ *      Example: mbed_error_status_t i2c_driver_error = MAKE_ERROR( MODULE_DRIVER_I2C, MBED_ERROR_CONFIG_UNSUPPORTED );
  * @endcode
  * 
  * @note
@@ -266,8 +266,8 @@ typedef enum _mbed_module_type
     MODULE_MAX = MODULE_UNKNOWN
 } mbed_module_type_t;
 
-//Use ERROR_SUCCESS(=0) or any postive number for successful returns
-#define ERROR_SUCCESS           0
+//Use MBED_SUCCESS(=0) or any postive number for successful returns
+#define MBED_SUCCESS           0
 
 #define MBED_POSIX_ERROR_BASE   0
 #define MBED_SYSTEM_ERROR_BASE  256
@@ -806,8 +806,8 @@ typedef struct _mbed_error_ctx {
  *                  Code snippets below show valid format.
  *
  * @deprecated
- * This function has been deprecated, please use one of SET_WARNING/SET_ERROR macros 
- * or one of set_error/set_warning functions.
+ * This function has been deprecated, please use one of MBED_WARNING/MBED_ERROR macros 
+ * or one of mbed_error/mbed_warning functions.
  *
  * @code
  * #error "That shouldn't have happened!"
@@ -846,7 +846,7 @@ typedef struct _mbed_error_ctx {
  *
  */
     
-MBED_DEPRECATED_SINCE("mbed-os-5.9", "This function has been deprecated, please use one of SET_WARNING/SET_ERROR macros or one of set_warning/set_error functions" )
+MBED_DEPRECATED_SINCE("mbed-os-5.9", "This function has been deprecated, please use one of MBED_WARNING/MBED_ERROR macros or one of mbed_warning/mbed_error functions" )
 
 void error(const char* format, ...);
 
@@ -857,13 +857,13 @@ void error(const char* format, ...);
  *
  * @code
  * 
- * mbed_error_status_t driver_error = MAKE_SYSTEM_ERROR( MODULE_DRIVER_USB, ERROR_CODE_INITIALIZATION_FAILED )
+ * mbed_error_status_t driver_error = MAKE_SYSTEM_ERROR( MODULE_DRIVER_USB, MBED_ERROR_CODE_INITIALIZATION_FAILED )
  *
  * @endcode
- * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_SYSTEM
+ * @note This macro generate mbed_error_status_t-es with error type set to MBED_ERROR_TYPE_SYSTEM
  *
  */
-#define MAKE_SYSTEM_ERROR(module, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, module, error_code)
+#define MAKE_SYSTEM_ERROR(module, error_code)                   MAKE_MBED_ERROR(MBED_ERROR_TYPE_SYSTEM, module, error_code)
 
 /**
  * Call this Macro to generate a mbed_error_status_t value for a Custom error
@@ -875,10 +875,10 @@ void error(const char* format, ...);
  * mbed_error_status_t custom_error = MAKE_CUSTOM_ERROR( MODULE_APPLICATION, 0xDEAD//16-bit custom error code )
  *
  * @endcode
- * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_CUSTOM
+ * @note This macro generate mbed_error_status_t-es with error type set to MBED_ERROR_TYPE_CUSTOM
  *
  */
-#define MAKE_CUSTOM_ERROR(module, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, module, error_code)
+#define MAKE_CUSTOM_ERROR(module, error_code)                   MAKE_MBED_ERROR(MBED_ERROR_TYPE_CUSTOM, module, error_code)
 
 /**
  * Call this Macro to generate a mbed_error_status_t value for a System error
@@ -887,10 +887,10 @@ void error(const char* format, ...);
  *
  * @code
  * 
- * mbed_error_status_t new_error = MAKE_ERROR( MODULE_DRIVER_USB, ERROR_INITIALIZATION_FAILED )
+ * mbed_error_status_t new_error = MAKE_ERROR( MODULE_DRIVER_USB, MBED_ERROR_INITIALIZATION_FAILED )
  *
  * @endcode
- * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_SYSTEM
+ * @note This macro generate mbed_error_status_t-es with error type set to MBED_ERROR_TYPE_SYSTEM
  *
  */
 #define MAKE_ERROR(module, error_code)                          MAKE_SYSTEM_ERROR(module, error_code)
@@ -914,29 +914,29 @@ typedef void (*mbed_error_hook_t)(const mbed_error_ctx *error_ctx);
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
  * @param  line_number      The line number of the source file originating the error( Most callers can pass __LINE__ here ) .
- * @return                  0 or ERROR_SUCCESS.
- *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
+ * @return                  0 or MBED_SUCCESS.
+ *                          MBED_ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
  *
  * @code
  * 
- * set_error( ERROR_OUT_OF_MEMORY, "Out of memory error", 0, __FILE__, __LINE__ )
+ * mbed_error( ERROR_OUT_OF_MEMORY, "Out of memory error", 0, __FILE__, __LINE__ )
  *
  * @endcode
  *
- * @note See SET_WARNING/SET_ERROR macros which provides a wrapper on this API
+ * @note See MBED_WARNING/MBED_ERROR macros which provides a wrapper on this API
  */
-mbed_error_status_t set_warning(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+mbed_error_status_t mbed_warning(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
 
 /**
  * Returns the first system error reported.
- * @return                  mbed_error_status_t code logged for the first error or ERROR_SUCCESS if no errors are logged.
+ * @return                  mbed_error_status_t code logged for the first error or MBED_SUCCESS if no errors are logged.
  *
  */
 mbed_error_status_t get_first_error(void);
 
 /**
  * Returns the most recent system error reported.
- * @return                  mbed_error_status_t code logged for the last error or ERROR_SUCCESS if no errors are logged.
+ * @return                  mbed_error_status_t code logged for the last error or MBED_SUCCESS if no errors are logged.
  *
  */
 mbed_error_status_t get_last_error(void);
@@ -956,26 +956,26 @@ int get_error_count(void);
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
  * @param  line_number      The line number of the source file originating the error( Most callers can pass __LINE__ here ) .
- * @return                  0 or ERROR_SUCCESS.
- *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
+ * @return                  0 or MBED_SUCCESS.
+ *                          MBED_ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
  *
  * @code
  * 
- * set_error( ERROR_PROHIBITED_OPERATION, "Prohibited operation tried", 0, __FILE__, __LINE__ )
+ * mbed_error( MBED_ERROR_PROHIBITED_OPERATION, "Prohibited operation tried", 0, __FILE__, __LINE__ )
  *
  * @endcode
  *
- * @note See SET_WARNING/SET_ERROR macros which provides a wrapper on this API
+ * @note See MBED_WARNING/MBED_ERROR macros which provides a wrapper on this API
  */
-mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
 
 /**
  * Registers an application defined error callback with the error handling system. 
- * This function will be called with error context info whenever system handles a set_error/set_warning call
- * NOTE: This function should be implemented for re-entrancy as multiple threads may invoke set_error which may cause error hook to be called.
+ * This function will be called with error context info whenever system handles a mbed_error/mbed_warning call
+ * NOTE: This function should be implemented for re-entrancy as multiple threads may invoke mbed_error which may cause error hook to be called.
  * @param  custom_error_hook    mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
- * @return                      0 or ERROR_SUCCESS on success.
- *                              ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
+ * @return                      0 or MBED_SUCCESS on success.
+ *                              MBED_ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
  *
  * @code
  * 
@@ -993,25 +993,25 @@ mbed_error_status_t set_error_hook(mbed_error_hook_t custom_error_hook);
 
 /**
  * Reads the first error context information logged.
- * @param  error_info           This is the mbed_error_context info captured as part of the first set_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
- * @return                      0 or ERROR_SUCCESS on success.
- *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ * @param  error_info           This is the mbed_error_context info captured as part of the first mbed_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
+ * @return                      0 or MBED_SUCCESS on success.
+ *                              MBED_ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
 mbed_error_status_t get_first_error_log_info(mbed_error_ctx *error_info);
 
 /**
  * Reads the last error context information logged.
- * @param  error_info           This is the mbed_error_context info captured as part of the last set_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
- * @return                      0 or ERROR_SUCCESS on success.
- *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ * @param  error_info           This is the mbed_error_context info captured as part of the last mbed_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
+ * @return                      0 or MBED_ERROR_SUCCESS on success.
+ *                              MBED_ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
 mbed_error_status_t get_last_error_log_info(mbed_error_ctx *error_info);
 
 /**
  * Clears all the last error, error count and all entries in the error log.
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *
  */
 mbed_error_status_t clear_all_errors(void);
@@ -1021,7 +1021,7 @@ mbed_error_status_t clear_all_errors(void);
  * @param  error_type           Error type based on mbed_error_type_t enum.
  * @param  module               Module type based on mbed_module_type_t enum.
  * @param  error_code           Error codes defined by mbed_error_code_t enum
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_ERROR_SUCCESS on success.
  *
  */
 mbed_error_status_t make_mbed_error(mbed_error_type_t error_type, mbed_module_type_t module, mbed_error_code_t error_code);
@@ -1040,8 +1040,8 @@ int get_error_log_count(void);
  *                              The number of entries in the error log depth is configured during build and the max index depends on max depth of error log.\n
  *                              index = 0 points to the oldest entry in the log, and index = (max log depth - 1) points to the latest entry in the error log.\n
  * @param  error_info           This is the mbed_error_context info captured as part of the log. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
- * @return                      0 or ERROR_SUCCESS on success.
- *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ * @return                      0 or MBED_SUCCESS on success.
+ *                              MBED_ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
 mbed_error_status_t get_error_log_info(int index, mbed_error_ctx *error_info);
@@ -1050,9 +1050,9 @@ mbed_error_status_t get_error_log_info(int index, mbed_error_ctx *error_info);
  * Saves the error log information to a file
  * 
  * @param  path                 path to the file in the filesystem
- * @return                      0 or ERROR_SUCCESS on success.
- *                              ERROR_WRITE_FAILED if writing to file failed
- *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ * @return                      0 or MBED_ERROR_SUCCESS on success.
+ *                              MBED_ERROR_WRITE_FAILED if writing to file failed
+ *                              MBED_ERROR_INVALID_ARGUMENT if path is not valid 
  *
  * @note                        Filesystem support is required in order for this function to work.
  *

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -190,16 +190,48 @@ typedef enum _MbedErrorType
 
 //Entity type/id definitions
 /** MbedEntityType definition
- *  @note
- *  This enumeration defines the Entity types. The value of these enum values will be encoded into MbedErrorStatus ENTITY field.\n\n
+ * @note
+ * This enumeration defines the Entity types. The value of these enum values will be encoded into MbedErrorStatus ENTITY field.\n\n
  *      See MbedErrorStatus description for more info.\n
  *          ENTITY_UNKNOWN - This entity type can be used if caller of the set_error/set_error_fatal doesn't know who is the actual originator of the error.\n
  *                       Other entity values can be used to provide more info on who/where the error originated from.\n\n
  *                       For example, if I2C driver is the component originating the error you can use ENTITY_DRIVER_I2C to provide more info.\n
  *                       Its used in call to MAKE_ERROR/MAKE_SYSTEM_ERROR/MAKE_CUSTOM_ERROR macros.\n
+ *
  * @code
- *      MbedErrorStatus i2c_driver_error = MAKE_ERROR( ENTITY_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
+ *      Example: MbedErrorStatus i2c_driver_error = MAKE_ERROR( ENTITY_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
  * @endcode
+ * 
+ * @note
+ *  \n Below are the entity code mappings:\n
+    \verbatim
+    ENTITY_APPLICATION              0       Application     
+    ENTITY_PLATFORM                 1       Platform
+    ENTITY_KERNEL                   2       RTX Kernel
+    ENTITY_NETWORK_STACK            3       Network stack
+    ENTITY_HAL                      4       HAL - Hardware Abstraction Layer
+    ENTITY_MEMORY_SUBSYSTEM         5       Memory Subsystem    
+    ENTITY_FILESYSTEM               6       Filesystem
+    ENTITY_BLOCK_DEVICE             7       Block device
+    ENTITY_DRIVER                   8       Driver
+    ENTITY_DRIVER_SERIAL            9       Serial Driver
+    ENTITY_DRIVER_RTC               10      RTC Driver
+    ENTITY_DRIVER_I2C               11      I2C Driver
+    ENTITY_DRIVER_SPI               12      SPI Driver
+    ENTITY_DRIVER_GPIO              13      GPIO Driver
+    ENTITY_DRIVER_ANALOG            14      Analog Driver
+    ENTITY_DRIVER_DIGITAL           15      DigitalIO Driver
+    ENTITY_DRIVER_CAN               16      CAN Driver
+    ENTITY_DRIVER_ETHERNET          17      Ethernet Driver
+    ENTITY_DRIVER_CRC               18      CRC Module
+    ENTITY_DRIVER_PWM               19      PWM Driver
+    ENTITY_DRIVER_QSPI              20      QSPI Driver
+    ENTITY_DRIVER_USB               21      USB Driver
+    ENTITY_TARGET_SDK               22      SDK 
+    
+    ENTITY_UNKNOWN                  255     Unknown entity
+    \endverbatim
+ *       
  */
 typedef enum _MbedEntityType
 {
@@ -485,18 +517,22 @@ typedef enum _MbedEntityType
  *
  *  
  *  @note
- *  Searching for error codes in mbed-os source tree. \n
- *  If you get an error report as below which you want to search for mbed-os source tree first take note of "Error Code" number. \n
+ *  **Searching for error codes in mbed-os source tree:** \n
+ *  If you get an error report as below which you want to search for in mbed-os source tree, first take note of "Error Code" number. \n
  *  For example, the below error report has an error code of \b 259. Find the error name associated with the error code and in this case its \b INVALID_FORMAT. \n
  *  Use that error name(\b INVALID_FORMAT) to search the source tree for code locations setting that specific error code. \n 
-    \verbatim
+ *  If the Error Entity reported is not 255(which indicates unknown entity), you can also use that to narrow down to the specific component reporting the error.
+ *  See MbedEntityType enum above for entity mapping. \n
+ *  
+ *  \verbatim
     ++ MbedOS Error Info ++
-    Error Status: 0x80FF0103
-    Error Code:    259
-    Error Message: Invalid format error
-    Error Location: 0x00002CFF
-    Error Value: 0x00000008
-    Current Thread: Id: 0x200025AC EntryFn: 0x00009681 StackSize: 0x00001000 StackMem: 0x200025F8 SP: 0x2002FFD8
+    Error Status: 0x80040103
+    Error Code: 259
+    Error Entity: 04
+    Error Message: HAL Entity error
+    Error Location: 0x000067C7
+    Error Value: 0x00005566
+    Current Thread: Id: 0x200024A8 EntryFn: 0x0000FB0D StackSize: 0x00001000 StackMem: 0x200014A8 SP: 0x2002FFD8
     -- MbedOS Error Info --
     \endverbatim
  */

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -1,4 +1,3 @@
-
 /** \addtogroup platform */
 /** @{*/
 /**
@@ -23,12 +22,521 @@
 #ifndef MBED_ERROR_H
 #define MBED_ERROR_H
 
+#include "platform/mbed_retarget.h"
+#include "platform/mbed_toolchain.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//Define this macro to include filenames in error context, this can save memory. For release builds, do not include filename    
+//#define MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED 1    
+    
+//Define this macro to disable error logging, note that the first and last error capture will still be active by default
+//#define MBED_CONF_ERROR_LOG_DISABLED    1
+
+#ifndef MBED_CONF_MAX_ERROR_FILENAME_LEN
+#define MBED_CONF_MAX_ERROR_FILENAME_LEN            16
+#endif    
+    
+#define MBED_ERROR_STATUS_CODE_MASK                 (0x0000FFFF)
+#define MBED_ERROR_STATUS_CODE_POS                  (0)
+#define MBED_ERROR_STATUS_CODE_FIELD_SIZE           (16)
+
+#define MBED_ERROR_STATUS_ENTITY_MASK               (0x00FF0000)
+#define MBED_ERROR_STATUS_ENTITY_POS                (16)
+#define MBED_ERROR_STATUS_ENTITY_FIELD_SIZE         (8)
+
+#define MBED_ERROR_STATUS_TYPE_MASK                 (0x60000000)
+#define MBED_ERROR_STATUS_TYPE_POS                  (29)
+#define MBED_ERROR_STATUS_TYPE_FIELD_SIZE           (2)
+
+/* MbedErrorStatus Status Encoding */
+//|31(1 bit) Always Negative|30-29(2 bits)  |28-24	            | 23-16(8 bits)	|  15-0(16 bits) |
+//|-1	                    |TYPE	        |(unused/reserved)	| ENTITY TYPE	|  ERROR CODE    |
+
+#define MAKE_MBED_ERROR(type, entity, error_code)   (MbedErrorStatus)                                                                   \
+                                                    ((0x80000000) |                                                                     \
+                                                    (MBED_ERROR_STATUS_CODE_MASK & (error_code << MBED_ERROR_STATUS_CODE_POS)) |        \
+                                                    (MBED_ERROR_STATUS_ENTITY_MASK & (entity << MBED_ERROR_STATUS_ENTITY_POS)) |        \
+                                                    (MBED_ERROR_STATUS_TYPE_MASK & (type << MBED_ERROR_STATUS_TYPE_POS)))    
+
+#define GET_MBED_ERROR_TYPE( error_status )         ((error_status & MBED_ERROR_STATUS_TYPE_MASK) >> MBED_ERROR_STATUS_TYPE_POS)
+#define GET_MBED_ERROR_ENTITY( error_status )       ((error_status & MBED_ERROR_STATUS_ENTITY_MASK) >> MBED_ERROR_STATUS_ENTITY_POS)    
+#define GET_MBED_ERROR_CODE( error_status )         (int)((GET_MBED_ERROR_TYPE( error_status ) == ERROR_TYPE_POSIX)?(-error_status):((error_status & MBED_ERROR_STATUS_CODE_MASK) >> MBED_ERROR_STATUS_CODE_POS))
+
+/** MbedErrorStatus description
+ *
+ * MbedErrorStatus type represents the error status values under MbedOS. MbedErrorStatus values are signed integers and always be negative.\n
+ * Internally its encoded as below with bit-fields representing error type, entity and error code:\n\n
+ * MbedErrorStatus Status Encoding:\n
+ *
+ \verbatim
+ | 31 Always Negative | 30-29(2 bits)  | 28-24              | 23-16(8 bits)	| 15-0(16 bits) |
+ | -1                 | TYPE           | (unused/reserved)  | ENTITY TYPE    | ERROR CODE    |
+ \endverbatim
+ * 
+ * The error status value range for each error type is as follows:\n
+ *   Posix Error Status-es  - 0xFFFFFFFF to 0xFFFFFF01(-1 -255) - This corresponds to Posix error codes represented as negative.\n
+ *   System Error Status-es - 0x80XX0100 to 0x80XX0FFF - This corresponds to System error codes range(all values are negative). Bits 23-16 will be entity type(marked with XX)\n
+ *   Custom Error Status-es - 0xA0XX1000 to 0xA0XXFFFF - This corresponds to Custom error codes range(all values are negative). Bits 23-16 will be entity type(marked with XX)\n\n
+ *
+ * The ERROR CODE(values encoded into ERROR CODE bit-field in MbedErrorStatus) value range for each error type is also seperated as below:\n
+ *   Posix Error Codes  - 1 to 255.\n
+ *   System Error Codes - 256 to 4095.\n
+ *   Custom Error Codes - 4096 to 65535.\n
+ *
+ * @note Posix error codes are always encoded as negative of their actual value. For example, EPERM is encoded as -EPERM.
+ *       And, the ENTITY TYPE for Posix error codes are always encoded as ENTITY_UNKNOWN.\n
+ *       This is to enable easy injection of Posix error codes into MbedOS error handling system without altering the actual Posix error values.\n
+ *       Accordingly, Posix error codes are represented as -1 to -255 under MbedOS error status representation.
+ */
+typedef int MbedErrorStatus;
+
+/**
+ * Macro for defining a Posix error status. This macro is mainly used to define Posix error values in MbedErrorCode enumeration.
+ * @param  error_name       Name of the error without the ERROR_ prefix
+ * @param  error_code       Error code value to be used, must be between 1 and 255(inclusive).
+ *
+ */
+#define DEFINE_POSIX_ERROR( error_name, error_code )   \
+                     ERROR_CODE_##error_name = error_code,  \
+                     ERROR_##error_name = -(MBED_POSIX_ERROR_BASE + error_code)
+
+/**
+ * Macro for defining a System error status. This macro is used to define System error values in MbedErrorCode enumeration.
+ * @param  error_name       Name of the error without the ERROR_ prefix
+ * @param  error_code       Error code value to be used, must be between 256 and 4096(inclusive).
+ *
+ */
+#define DEFINE_SYSTEM_ERROR( error_name, error_code )   \
+                      ERROR_CODE_##error_name = MBED_SYSTEM_ERROR_BASE + error_code,  \
+                      ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, ENTITY_UNKNOWN, ERROR_CODE_##error_name)
+
+/**
+ * Macro for defining a Custom error status. This macro is used to define custom error values in MbedErrorCode enumeration.
+ * @param  error_name       Name of the error without the ERROR_ prefix
+ * @param  error_code       Error code value to be used, must be between 4097 and 65535(inclusive).
+ *
+ */
+#define DEFINE_CUSTOM_ERROR( error_name, error_code )   \
+                      ERROR_CODE_##error_name = MBED_CUSTOM_ERROR_BASE + error_code,  \
+                      ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, ENTITY_UNKNOWN, ERROR_CODE_##error_name)
+
+
+/**
+ * Macro for setting a system error. This macro will log the error, prints the error report and return to the caller. Its a wrapper for calling set_error API.
+ * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_msg        The error message to be printed out to STDIO/Serial.
+ * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
+ *
+ * @code
+ * 
+ * SET_ERROR( ERROR_INVALID_SIZE, "MyDriver: Invalid size in read", size_val )
+ *
+ * @endcode
+ * @note The macro calls set_error API with filename and line number info without caller explicitly passing them.
+ *        Since this macro is a wrapper for set_error API callers should process the return value from this macro which is the return value from calling set_error API.
+ *
+ */
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
+#else
+    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
+#endif
+
+/**
+ * Macro for setting a fatal system error. This macro will log the error, prints the error report and halts the system. Its a wrapper for calling set_error_fatal API
+ * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_msg        The error message to be printed out to STDIO/Serial.
+ * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
+ * @return                  0 or ERROR_SUCCESS.
+ *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes
+ *
+ * @code
+ * 
+ * SET_ERROR_FATAL( ERROR_MUTEX_LOCK_FAILED, "MyDriver: Can't lock driver Mutex", &my_mutex )
+ *
+ * @endcode
+ * @note The macro calls set_error_fatal API with filename and line number info without caller explicitly passing them.
+*        Since this macro is a wrapper for set_error_fatal API callers should process the return value from this macro which is the return value from calling set_error_fatal API. 
+ *
+ */
+#define SET_ERROR_FATAL( error_status, error_msg, error_value ) set_error_fatal( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )           
+
+//Error Type definition
+/** MbedErrorType definition
+ *  @note
+ *  This enumeration defines the Error types supported. The value of these enum values will be encoded into MbedErrorStatus TYPE field.\n
+ *      See MbedErrorStatus description for more info.\n
+ *         ERROR_TYPE_SYSTEM - Used to indicate that the error status is of System defined Error type.\n
+ *         ERROR_TYPE_CUSTOM - Used to indicate that the error status is of Custom defined Error type.\n 
+ *         ERROR_TYPE_POSIX  - Used to indicate that the error status is of Posix error type.\n 
+ *
+ */
+typedef enum _MbedErrorType
+{
+    ERROR_TYPE_SYSTEM = 0,
+    ERROR_TYPE_CUSTOM = 1,
+    //2 is reserved
+    //Use 3 for POSIX because we are mapping -1 to -255 to POSIX error codes
+    //and thus we must use 3 to match the type bits in error status representation which are from 0xFFFFFFFF to 0xFFFFFF00
+    ERROR_TYPE_POSIX = 3
+} MbedErrorType;		
+
+//Entity type/id definitions
+/** MbedEntityType definition
+ *  @note
+ *  This enumeration defines the Entity types. The value of these enum values will be encoded into MbedErrorStatus ENTITY field.\n\n
+ *      See MbedErrorStatus description for more info.\n
+ *          ENTITY_UNKNOWN - This entity type can be used if caller of the set_error/set_error_fatal doesn't know who is the actual originator of the error.\n
+ *                       Other entity values can be used to provide more info on who/where the error originated from.\n\n
+ *                       For example, if I2C driver is the component originating the error you can use ENTITY_DRIVER_I2C to provide more info.\n
+ *                       Its used in call to MAKE_ERROR/MAKE_SYSTEM_ERROR/MAKE_CUSTOM_ERROR macros.\n
+ * @code
+ *      MbedErrorStatus i2c_driver_error = MAKE_ERROR( ENTITY_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
+ * @endcode
+ */
+typedef enum _MbedEntityType
+{
+	ENTITY_APPLICATION = 0,
+	ENTITY_PLATFORM,
+	ENTITY_KERNEL,
+	ENTITY_NETWORK_STACK,
+	ENTITY_HAL,
+	ENTITY_MEMORY_SUBSYSTEM,
+    ENTITY_FILESYSTEM,
+    ENTITY_BLOCK_DEVICE,
+	ENTITY_DRIVER,
+	ENTITY_DRIVER_SERIAL,
+	ENTITY_DRIVER_RTC,
+	ENTITY_DRIVER_I2C,
+	ENTITY_DRIVER_SPI,
+	ENTITY_DRIVER_GPIO,
+	ENTITY_DRIVER_ANALOG,
+	ENTITY_DRIVER_DIGITAL,
+	ENTITY_DRIVER_CAN,
+    ENTITY_DRIVER_ETHERNET,
+	ENTITY_DRIVER_CRC,
+	ENTITY_DRIVER_PWM,
+	ENTITY_DRIVER_QSPI,
+	ENTITY_DRIVER_USB,
+    ENTITY_TARGET_SDK,
+    /* Add More entities here as required */
+    
+    ENTITY_UNKNOWN = 255,
+    ENTITY_MAX = ENTITY_UNKNOWN
+} MbedEntityType;
+
+//Use ERROR_SUCCESS(=0) or any postive number for successful returns
+#define ERROR_SUCCESS           0
+
+#define MBED_POSIX_ERROR_BASE   0
+#define MBED_SYSTEM_ERROR_BASE  256
+#define MBED_CUSTOM_ERROR_BASE  4096
+
+//Error Code definitions
+/** MbedErrorCode definition
+ *
+ *  MbedErrorCode enumeration defines the Error codes and Error status values for ENTITY_UNKNOWN.\n
+ *  It defines all of Posix Error Codes/Statuses and Mbed System Error Codes/Statuses.\n\n
+ *
+ *  @note
+ *  Posix Error codes are defined using the macro DEFINE_POSIX_ERROR\n
+ *  For example DEFINE_POSIX_ERROR( EPERM, EPERM ). This effectively defines the following values:\n
+ *      ERROR_CODE_EPERM = EPERM\n
+ *      ERROR_EPERM = -EPERM\n
+ *
+ *  Posix Error codes are defined using the macro DEFINE_POSIX_ERROR\n
+ *  For example DEFINE_POSIX_ERROR( EPERM, EPERM ). This macro defines the following values:\n
+ *      ERROR_CODE_EPERM = MBED_POSIX_ERROR_BASE+EPERM\n
+ *      ERROR_EPERM = -(MBED_POSIX_ERROR_BASE+EPERM)\n
+ *  Its effectively equivalent to:\n
+ *      ERROR_CODE_EPERM = 1\n
+ *      ERROR_EPERM = -1\n 
+ *  All Posix error codes currently supported by MbedOS(defined in mbed_retarget.h) are defined using the DEFINE_POSIX_ERROR macro.\n\n
+ *
+ *  MbedOS System Error codes are defined using the macro DEFINE_SYSTEM_ERROR\n
+ *  For example DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT ,1 ) macro defines the following values:\n
+ *      ERROR_CODE_INVALID_ARGUMENT = MBED_SYSTEM_ERROR_BASE+1\n
+ *      ERROR_INVALID_ARGUMENT = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, ENTITY_UNKNOWN, ERROR_CODE_INVALID_ARGUMENT)\n
+ *  Its effectively equivalent to:\n
+ *      ERROR_CODE_INVALID_ARGUMENT = 1\n
+ *      ERROR_INVALID_ARGUMENT = 0x80FF0001\n (Note that ENTITY field is set to ENTITY_UNKNOWN) 
+ *  New System Error codes should be defined using DEFINE_SYSTEM_ERROR macro and must have an unique error code value\n
+ *  passed as the second argument in the DEFINE_SYSTEM_ERROR macro.\n\n
+ *
+ *  Custom Error codes can be defined using the macro DEFINE_CUSTOM_ERROR\n
+ *  This is mainly meant to capture non-generic error codes specific to a device.
+ *  For example DEFINE_CUSTOM_ERROR( MY_CUSTOM_ERROR ,1 ) macro defines the following values:\n
+ *      ERROR_CODE_MY_CUSTOM_ERROR = MBED_CUSTOM_ERROR_BASE+1\n
+ *      ERROR_MY_CUSTOM_ERROR = MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, ENTITY_UNKNOWN, ERROR_CODE_MY_CUSTOM_ERROR)\n
+ *  Its effectively equivalent to:\n
+ *      ERROR_CODE_MY_CUSTOM_ERROR = 4097\n
+ *      ERROR_MY_CUSTOM_ERROR = 0xA0FF1001\n (Note that ENTITY field is set to ENTITY_UNKNOWN) 
+ *
+ */
+ 
+typedef enum _MbedErrorCode
+{
+    //Below are POSIX ERROR CODE definitions, which starts at MBED_POSIX_ERROR_BASE(=0)
+    //POSIX ERROR CODE definitions starts at offset 0(MBED_POSIX_ERROR_BASE) to align them with actual Posix Error Code
+    //defintions in mbed_retarget.h
+    //                  Error Name             Error Code  
+    DEFINE_POSIX_ERROR( EPERM                 ,EPERM           ),  /* 1       Operation not permitted */
+    DEFINE_POSIX_ERROR( ENOENT                ,ENOENT          ),  /* 2       No such file or directory */
+    DEFINE_POSIX_ERROR( ESRCH                 ,ESRCH           ),  /* 3       No such process */
+    DEFINE_POSIX_ERROR( EINTR                 ,EINTR           ),  /* 4       Interrupted system call */
+    DEFINE_POSIX_ERROR( EIO                   ,EIO             ),  /* 5       I/O error */
+    DEFINE_POSIX_ERROR( ENXIO                 ,ENXIO           ),  /* 6       No such device or address */
+    DEFINE_POSIX_ERROR( E2BIG                 ,E2BIG           ),  /* 7       Argument list too long */
+    DEFINE_POSIX_ERROR( ENOEXEC               ,ENOEXEC         ),  /* 8       Exec format error */
+    DEFINE_POSIX_ERROR( EBADF                 ,EBADF           ),  /* 9       Bad file number */
+    DEFINE_POSIX_ERROR( ECHILD                ,ECHILD          ),  /* 10      No child processes */
+    DEFINE_POSIX_ERROR( EAGAIN                ,EAGAIN          ),  /* 11      Try again */
+    DEFINE_POSIX_ERROR( ENOMEM                ,ENOMEM          ),  /* 12      Out of memory */
+    DEFINE_POSIX_ERROR( EACCES                ,EACCES          ),  /* 13      Permission denied */
+    DEFINE_POSIX_ERROR( EFAULT                ,EFAULT          ),  /* 14      Bad address */
+    DEFINE_POSIX_ERROR( ENOTBLK               ,ENOTBLK         ),  /* 15      Block device required */
+    DEFINE_POSIX_ERROR( EBUSY                 ,EBUSY           ),  /* 16      Device or resource busy */
+    DEFINE_POSIX_ERROR( EEXIST                ,EEXIST          ),  /* 17      File exists */
+    DEFINE_POSIX_ERROR( EXDEV                 ,EXDEV           ),  /* 18      Cross-device link */
+    DEFINE_POSIX_ERROR( ENODEV                ,ENODEV          ),  /* 19      No such device */
+    DEFINE_POSIX_ERROR( ENOTDIR               ,ENOTDIR         ),  /* 20      Not a directory */
+    DEFINE_POSIX_ERROR( EISDIR                ,EISDIR          ),  /* 21      Is a directory */
+    DEFINE_POSIX_ERROR( EINVAL                ,EINVAL          ),  /* 22      Invalid argument */
+    DEFINE_POSIX_ERROR( ENFILE                ,ENFILE          ),  /* 23      File table overflow */
+    DEFINE_POSIX_ERROR( EMFILE                ,EMFILE          ),  /* 24      Too many open files */
+    DEFINE_POSIX_ERROR( ENOTTY                ,ENOTTY          ),  /* 25      Not a typewriter */
+    DEFINE_POSIX_ERROR( ETXTBSY               ,ETXTBSY         ),  /* 26      Text file busy */
+    DEFINE_POSIX_ERROR( EFBIG                 ,EFBIG           ),  /* 27      File too large */
+    DEFINE_POSIX_ERROR( ENOSPC                ,ENOSPC          ),  /* 28      No space left on device */
+    DEFINE_POSIX_ERROR( ESPIPE                ,ESPIPE          ),  /* 29      Illegal seek */
+    DEFINE_POSIX_ERROR( EROFS                 ,EROFS           ),  /* 30      Read-only file system */
+    DEFINE_POSIX_ERROR( EMLINK                ,EMLINK          ),  /* 31      Too many links */
+    DEFINE_POSIX_ERROR( EPIPE                 ,EPIPE           ),  /* 32      Broken pipe */
+    DEFINE_POSIX_ERROR( EDOM                  ,EDOM            ),  /* 33      Math argument out of domain of func */
+    DEFINE_POSIX_ERROR( ERANGE                ,ERANGE          ),  /* 34      Math result not representable */
+    DEFINE_POSIX_ERROR( EDEADLK               ,EDEADLK         ),  /* 35      Resource deadlock would occur */
+    DEFINE_POSIX_ERROR( ENAMETOOLONG          ,ENAMETOOLONG    ),  /* 36      File name too long */
+    DEFINE_POSIX_ERROR( ENOLCK                ,ENOLCK          ),  /* 37      No record locks available */
+    DEFINE_POSIX_ERROR( ENOSYS                ,ENOSYS          ),  /* 38      Function not implemented */
+    DEFINE_POSIX_ERROR( ENOTEMPTY             ,ENOTEMPTY       ),  /* 39      Directory not empty */
+    DEFINE_POSIX_ERROR( ELOOP                 ,ELOOP           ),  /* 40      Too many symbolic links encountered */
+    DEFINE_POSIX_ERROR( EWOULDBLOCK           ,EAGAIN          ),  /* EAGAIN  Operation would block */
+    DEFINE_POSIX_ERROR( ENOMSG                ,ENOMSG          ),  /* 42      No message of desired type */
+    DEFINE_POSIX_ERROR( EIDRM                 ,EIDRM           ),  /* 43      Identifier removed */
+    DEFINE_POSIX_ERROR( ECHRNG                ,ECHRNG          ),  /* 44      Channel number out of range */
+    DEFINE_POSIX_ERROR( EL2NSYNC              ,EL2NSYNC        ),  /* 45      Level 2 not synchronized */
+    DEFINE_POSIX_ERROR( EL3HLT                ,EL3HLT          ),  /* 46      Level 3 halted */
+    DEFINE_POSIX_ERROR( EL3RST                ,EL3RST          ),  /* 47      Level 3 reset */
+    DEFINE_POSIX_ERROR( ELNRNG                ,ELNRNG          ),  /* 48      Link number out of range */
+    DEFINE_POSIX_ERROR( EUNATCH               ,EUNATCH         ),  /* 49      Protocol driver not attached */
+    DEFINE_POSIX_ERROR( ENOCSI                ,ENOCSI          ),  /* 50      No CSI structure available */
+    DEFINE_POSIX_ERROR( EL2HLT                ,EL2HLT          ),  /* 51      Level 2 halted */
+    DEFINE_POSIX_ERROR( EBADE                 ,EBADE           ),  /* 52      Invalid exchange */
+    DEFINE_POSIX_ERROR( EBADR                 ,EBADR           ),  /* 53      Invalid request descriptor */
+    DEFINE_POSIX_ERROR( EXFULL                ,EXFULL          ),  /* 54      Exchange full */
+    DEFINE_POSIX_ERROR( ENOANO                ,ENOANO          ),  /* 55      No anode */
+    DEFINE_POSIX_ERROR( EBADRQC               ,EBADRQC         ),  /* 56      Invalid request code */
+    DEFINE_POSIX_ERROR( EBADSLT               ,EBADSLT         ),  /* 57      Invalid slot */
+    DEFINE_POSIX_ERROR( EDEADLOCK             ,EDEADLK         ),  /* EDEADLK Resource deadlock would occur */
+    DEFINE_POSIX_ERROR( EBFONT                ,EBFONT          ),  /* 59      Bad font file format */
+    DEFINE_POSIX_ERROR( ENOSTR                ,ENOSTR          ),  /* 60      Device not a stream */
+    DEFINE_POSIX_ERROR( ENODATA               ,ENODATA         ),  /* 61      No data available */
+    DEFINE_POSIX_ERROR( ETIME                 ,ETIME           ),  /* 62      Timer expired */
+    DEFINE_POSIX_ERROR( ENOSR                 ,ENOSR           ),  /* 63      Out of streams resources */
+    DEFINE_POSIX_ERROR( ENONET                ,ENONET          ),  /* 64      Machine is not on the network */
+    DEFINE_POSIX_ERROR( ENOPKG                ,ENOPKG          ),  /* 65      Package not installed */
+    DEFINE_POSIX_ERROR( EREMOTE               ,EREMOTE         ),  /* 66      Object is remote */
+    DEFINE_POSIX_ERROR( ENOLINK               ,ENOLINK         ),  /* 67      Link has been severed */
+    DEFINE_POSIX_ERROR( EADV                  ,EADV            ),  /* 68      Advertise error */
+    DEFINE_POSIX_ERROR( ESRMNT                ,ESRMNT          ),  /* 69      Srmount error */
+    DEFINE_POSIX_ERROR( ECOMM                 ,ECOMM           ),  /* 70      Communication error on send */
+    DEFINE_POSIX_ERROR( EPROTO                ,EPROTO          ),  /* 71      Protocol error */
+    DEFINE_POSIX_ERROR( EMULTIHOP             ,EMULTIHOP       ),  /* 72      Multihop attempted */
+    DEFINE_POSIX_ERROR( EDOTDOT               ,EDOTDOT         ),  /* 73      RFS specific error */
+    DEFINE_POSIX_ERROR( EBADMSG               ,EBADMSG         ),  /* 74      Not a data message */
+    DEFINE_POSIX_ERROR( EOVERFLOW             ,EOVERFLOW       ),  /* 75      Value too large for defined data type */
+    DEFINE_POSIX_ERROR( ENOTUNIQ              ,ENOTUNIQ        ),  /* 76      Name not unique on network */
+    DEFINE_POSIX_ERROR( EBADFD                ,EBADFD          ),  /* 77      File descriptor in bad state */
+    DEFINE_POSIX_ERROR( EREMCHG               ,EREMCHG         ),  /* 78      Remote address changed */
+    DEFINE_POSIX_ERROR( ELIBACC               ,ELIBACC         ),  /* 79      Can not access a needed shared library */
+    DEFINE_POSIX_ERROR( ELIBBAD               ,ELIBBAD         ),  /* 80      Accessing a corrupted shared library */
+    DEFINE_POSIX_ERROR( ELIBSCN               ,ELIBSCN         ),  /* 81      .lib section in a.out corrupted */
+    DEFINE_POSIX_ERROR( ELIBMAX               ,ELIBMAX         ),  /* 82      Attempting to link in too many shared libraries */
+    DEFINE_POSIX_ERROR( ELIBEXEC              ,ELIBEXEC        ),  /* 83      Cannot exec a shared library directly */
+    DEFINE_POSIX_ERROR( EILSEQ                ,EILSEQ          ),  /* 84      Illegal byte sequence */
+    DEFINE_POSIX_ERROR( ERESTART              ,ERESTART        ),  /* 85      Interrupted system call should be restarted */
+    DEFINE_POSIX_ERROR( ESTRPIPE              ,ESTRPIPE        ),  /* 86      Streams pipe error */
+    DEFINE_POSIX_ERROR( EUSERS                ,EUSERS          ),  /* 87      Too many users */
+    DEFINE_POSIX_ERROR( ENOTSOCK              ,ENOTSOCK        ),  /* 88      Socket operation on non-socket */
+    DEFINE_POSIX_ERROR( EDESTADDRREQ          ,EDESTADDRREQ    ),  /* 89      Destination address required */
+    DEFINE_POSIX_ERROR( EMSGSIZE              ,EMSGSIZE        ),  /* 90      Message too long */
+    DEFINE_POSIX_ERROR( EPROTOTYPE            ,EPROTOTYPE      ),  /* 91      Protocol wrong type for socket */
+    DEFINE_POSIX_ERROR( ENOPROTOOPT           ,ENOPROTOOPT     ),  /* 92      Protocol not available */
+    DEFINE_POSIX_ERROR( EPROTONOSUPPORT       ,EPROTONOSUPPORT ),  /* 93      Protocol not supported */
+    DEFINE_POSIX_ERROR( ESOCKTNOSUPPORT       ,ESOCKTNOSUPPORT ),  /* 94      Socket type not supported */
+    DEFINE_POSIX_ERROR( EOPNOTSUPP            ,EOPNOTSUPP      ),  /* 95      Operation not supported on transport endpoint */
+    DEFINE_POSIX_ERROR( EPFNOSUPPORT          ,EPFNOSUPPORT    ),  /* 96      Protocol family not supported */
+    DEFINE_POSIX_ERROR( EAFNOSUPPORT          ,EAFNOSUPPORT    ),  /* 97      Address family not supported by protocol */
+    DEFINE_POSIX_ERROR( EADDRINUSE            ,EADDRINUSE      ),  /* 98      Address already in use */
+    DEFINE_POSIX_ERROR( EADDRNOTAVAIL         ,EADDRNOTAVAIL   ),  /* 99      Cannot assign requested address */
+    DEFINE_POSIX_ERROR( ENETDOWN              ,ENETDOWN        ),  /* 100     Network is down */
+    DEFINE_POSIX_ERROR( ENETUNREACH           ,ENETUNREACH     ),  /* 101     Network is unreachable */
+    DEFINE_POSIX_ERROR( ENETRESET             ,ENETRESET       ),  /* 102     Network dropped connection because of reset */
+    DEFINE_POSIX_ERROR( ECONNABORTED          ,ECONNABORTED    ),  /* 103     Software caused connection abort */
+    DEFINE_POSIX_ERROR( ECONNRESET            ,ECONNRESET      ),  /* 104     Connection reset by peer */
+    DEFINE_POSIX_ERROR( ENOBUFS               ,ENOBUFS         ),  /* 105     No buffer space available */
+    DEFINE_POSIX_ERROR( EISCONN               ,EISCONN         ),  /* 106     Transport endpoint is already connected */
+    DEFINE_POSIX_ERROR( ENOTCONN              ,ENOTCONN        ),  /* 107     Transport endpoint is not connected */
+    DEFINE_POSIX_ERROR( ESHUTDOWN             ,ESHUTDOWN       ),  /* 108     Cannot send after transport endpoint shutdown */
+    DEFINE_POSIX_ERROR( ETOOMANYREFS          ,ETOOMANYREFS    ),  /* 109     Too many references: cannot splice */
+    DEFINE_POSIX_ERROR( ETIMEDOUT             ,ETIMEDOUT       ),  /* 110     Connection timed out */
+    DEFINE_POSIX_ERROR( ECONNREFUSED          ,ECONNREFUSED    ),  /* 111     Connection refused */
+    DEFINE_POSIX_ERROR( EHOSTDOWN             ,EHOSTDOWN       ),  /* 112     Host is down */
+    DEFINE_POSIX_ERROR( EHOSTUNREACH          ,EHOSTUNREACH    ),  /* 113     No route to host */
+    DEFINE_POSIX_ERROR( EALREADY              ,EALREADY        ),  /* 114     Operation already in progress */
+    DEFINE_POSIX_ERROR( EINPROGRESS           ,EINPROGRESS     ),  /* 115     Operation now in progress */
+    DEFINE_POSIX_ERROR( ESTALE                ,ESTALE          ),  /* 116     Stale NFS file handle */
+    DEFINE_POSIX_ERROR( EUCLEAN               ,EUCLEAN         ),  /* 117     Structure needs cleaning */
+    DEFINE_POSIX_ERROR( ENOTNAM               ,ENOTNAM         ),  /* 118     Not a XENIX named type file */
+    DEFINE_POSIX_ERROR( ENAVAIL               ,ENAVAIL         ),  /* 119     No XENIX semaphores available */
+    DEFINE_POSIX_ERROR( EISNAM                ,EISNAM          ),  /* 120     Is a named type file */
+    DEFINE_POSIX_ERROR( EREMOTEIO             ,EREMOTEIO       ),  /* 121     Remote I/O error */
+    DEFINE_POSIX_ERROR( EDQUOT                ,EDQUOT          ),  /* 122     Quota exceeded */
+    DEFINE_POSIX_ERROR( ENOMEDIUM             ,ENOMEDIUM       ),  /* 123     No medium found */
+    DEFINE_POSIX_ERROR( EMEDIUMTYPE           ,EMEDIUMTYPE     ),  /* 124     Wrong medium type */
+    DEFINE_POSIX_ERROR( ECANCELED             ,ECANCELED       ),  /* 125     Operation Canceled */
+    DEFINE_POSIX_ERROR( ENOKEY                ,ENOKEY          ),  /* 126     Required key not available */
+    DEFINE_POSIX_ERROR( EKEYEXPIRED           ,EKEYEXPIRED     ),  /* 127     Key has expired */
+    DEFINE_POSIX_ERROR( EKEYREVOKED           ,EKEYREVOKED     ),  /* 128     Key has been revoked */
+    DEFINE_POSIX_ERROR( EKEYREJECTED          ,EKEYREJECTED    ),  /* 129     Key was rejected by service */
+    DEFINE_POSIX_ERROR( EOWNERDEAD            ,EOWNERDEAD      ),  /* 130     Owner died */
+    DEFINE_POSIX_ERROR( ENOTRECOVERABLE       ,ENOTRECOVERABLE ),  /* 131     State not recoverable */
+    
+    //Below are MBED SYSTEM ERROR CODE definitions
+    //MBED SYSTEM ERROR CODE definitions starts at offset MBED_SYSTEM_ERROR_BASE, see above.
+    //                   Error Name                 Error Code  
+	DEFINE_SYSTEM_ERROR( UNKNOWN                    ,0 ),
+    DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT           ,1 ),
+	DEFINE_SYSTEM_ERROR( INVALID_DATA               ,2 ),
+	DEFINE_SYSTEM_ERROR( INVALID_FORMAT             ,3 ),
+	DEFINE_SYSTEM_ERROR( INVALID_INDEX              ,4 ),
+    DEFINE_SYSTEM_ERROR( INVALID_SIZE               ,5 ),
+    DEFINE_SYSTEM_ERROR( INVALID_OPERATION          ,6 ),
+	DEFINE_SYSTEM_ERROR( NOT_FOUND                  ,7 ),
+	DEFINE_SYSTEM_ERROR( ACCESS_DENIED              ,8 ),
+	DEFINE_SYSTEM_ERROR( NOT_SUPPORTED              ,9 ),
+	DEFINE_SYSTEM_ERROR( BUFFER_FULL                ,10 ),
+	DEFINE_SYSTEM_ERROR( MEDIA_FULL                 ,11 ),
+	DEFINE_SYSTEM_ERROR( ALREADY_IN_USE             ,12 ),
+	DEFINE_SYSTEM_ERROR( TIMEOUT                    ,13 ),
+	DEFINE_SYSTEM_ERROR( NOT_READY                  ,14 ),
+	DEFINE_SYSTEM_ERROR( FAILED_OPERATION           ,15 ),
+    DEFINE_SYSTEM_ERROR( OPERATION_PROHIBITED       ,16 ),
+	DEFINE_SYSTEM_ERROR( OPERATION_ABORTED          ,17 ),
+	DEFINE_SYSTEM_ERROR( WRITE_PROTECTED            ,18 ),
+	DEFINE_SYSTEM_ERROR( NO_RESPONSE                ,19 ),
+	DEFINE_SYSTEM_ERROR( SEMAPHORE_LOCK_FAILED      ,20 ),
+	DEFINE_SYSTEM_ERROR( MUTEX_LOCK_FAILED          ,21 ),
+    DEFINE_SYSTEM_ERROR( SEMAPHORE_UNLOCK_FAILED    ,22 ),
+	DEFINE_SYSTEM_ERROR( MUTEX_UNLOCK_FAILED        ,23 ),
+	DEFINE_SYSTEM_ERROR( CRC_ERROR                  ,24 ),
+    DEFINE_SYSTEM_ERROR( OPEN_FAILED                ,25 ),
+    DEFINE_SYSTEM_ERROR( CLOSE_FAILED               ,26 ),
+    DEFINE_SYSTEM_ERROR( READ_FAILED                ,27 ),
+    DEFINE_SYSTEM_ERROR( WRITE_FAILED               ,28 ),
+	DEFINE_SYSTEM_ERROR( INITIALIZATION_FAILED      ,29 ),
+	DEFINE_SYSTEM_ERROR( BOOT_FAILURE               ,30 ),
+    DEFINE_SYSTEM_ERROR( OUT_OF_MEMORY              ,31 ),
+    DEFINE_SYSTEM_ERROR( OUT_OF_RESOURCES           ,32 ),
+    DEFINE_SYSTEM_ERROR( ALLOC_FAILED               ,33 ),
+    DEFINE_SYSTEM_ERROR( FREE_FAILED                ,34 ),
+    DEFINE_SYSTEM_ERROR( OVERFLOW                   ,35 ),
+    DEFINE_SYSTEM_ERROR( UNDERFLOW                  ,36 ),
+    DEFINE_SYSTEM_ERROR( STACK_OVERFLOW             ,37 ),
+    DEFINE_SYSTEM_ERROR( ISR_QUEUE_OVERFLOW         ,38 ),
+    DEFINE_SYSTEM_ERROR( TIMER_QUEUE_OVERFLOW       ,39 ),
+    DEFINE_SYSTEM_ERROR( CLIB_SPACE_UNAVAILABLE     ,40 ),
+    DEFINE_SYSTEM_ERROR( CLIB_EXCEPTION             ,41 ),
+    DEFINE_SYSTEM_ERROR( CLIB_MUTEX_INIT_FAILURE    ,42 ),
+    DEFINE_SYSTEM_ERROR( CREATE_FAILED              ,43 ),
+    DEFINE_SYSTEM_ERROR( DELETE_FAILED              ,44 ),
+    DEFINE_SYSTEM_ERROR( THREAD_CREATE_FAILED       ,45 ),
+    DEFINE_SYSTEM_ERROR( THREAD_DELETE_FAILED       ,46 ),
+    DEFINE_SYSTEM_ERROR( PROHIBITED_IN_ISR_CONTEXT  ,47 ),
+    DEFINE_SYSTEM_ERROR( PINMAP_INVALID             ,48 ),
+    DEFINE_SYSTEM_ERROR( RTOS_EVENT                 ,49 ),
+    DEFINE_SYSTEM_ERROR( RTOS_THREAD_EVENT          ,50 ),
+    DEFINE_SYSTEM_ERROR( RTOS_MUTEX_EVENT           ,51 ),
+    DEFINE_SYSTEM_ERROR( RTOS_SEMAPHORE_EVENT       ,52 ),
+    DEFINE_SYSTEM_ERROR( RTOS_MEMORY_POOL_EVENT     ,53 ),
+    DEFINE_SYSTEM_ERROR( RTOS_TIMER_EVENT           ,54 ),
+    DEFINE_SYSTEM_ERROR( RTOS_EVENT_FLAGS_EVENT     ,55 ),
+    DEFINE_SYSTEM_ERROR( RTOS_MESSAGE_QUEUE_EVENT   ,56 ),
+    DEFINE_SYSTEM_ERROR( DEVICE_BUSY                ,57 ),
+    DEFINE_SYSTEM_ERROR( CONFIG_UNSUPPORTED         ,58 ),
+    DEFINE_SYSTEM_ERROR( CONFIG_MISMATCH            ,59 ),
+    DEFINE_SYSTEM_ERROR( ALREADY_INITIALIZED        ,60 ),
+    DEFINE_SYSTEM_ERROR( HARDFAULT_EXCEPTION        ,61 ),
+	DEFINE_SYSTEM_ERROR( MEMMANAGE_EXCEPTION        ,62 ),
+	DEFINE_SYSTEM_ERROR( BUSFAULT_EXCEPTION         ,63 ),
+	DEFINE_SYSTEM_ERROR( USAGEFAULT_EXCEPTION       ,64 ),
+        
+    //Everytime you add a new system error code, you must update
+    //Error documentation under Handbook to capture the info on
+    //the new error status/codes
+    
+    //MBED CUSTOM ERROR CODE definitions starts at offset MBED_CUSTOM_ERROR_BASE, see above.
+    /* Add More/Custom Error Codes here, See example below */
+    //DEFINE_CUSTOM_ERROR( MY_CUSTOM_ERROR     , 1 ),    
+    
+} MbedErrorCode;
+
+/** mbed_error_ctx struct
+ *
+ *  This struct captures the context information at the time of error.\n
+ *  It primarily contains information about the thread where the error originated,\n
+ *  filename/line number of the source file where the error occurred, a context specific error value(error_value)\n
+ *  and the address where the error originated.\n
+ *
+ *  @note
+ *  Below are the members of mbed_error_ctx struct\n
+ *      error_status              MbedErrorStatus value for this error\n
+ *      error_function_address    Address where the error occurred\n
+ *      thread_id                 ID of the thread which generated the error\n
+ *      thread_entry_address      Entry function of the thread which generated the error\n
+ *      thread_stack_size         Stack Size of the thread which generated the error\n
+ *      thread_stack_mem          Stack Top of the thread which generated the error\n
+ *      thread_current_sp         Current Stack Pointer of the thread which generated the error\n
+ *      error_value               A context/error specific value associated with this error\n
+ *      error_filename            Filename where the error originated\n
+ *      error_line_number         Line number in error_filename where the error originated\n
+ */
+typedef struct _mbed_error_ctx {
+    MbedErrorStatus error_status;
+    uint32_t error_address;
+    uint32_t error_value;
+    uint32_t thread_id;
+    uint32_t thread_entry_address;
+    uint32_t thread_stack_size;
+    uint32_t thread_stack_mem;
+    uint32_t thread_current_sp;
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+    char error_filename[MBED_CONF_MAX_ERROR_FILENAME_LEN];
+    uint32_t error_line_number;
+#endif    
+} mbed_error_ctx;
 
 /** To generate a fatal compile-time error, you can use the pre-processor #error directive.
  *
  * @param format    C string that contains data stream to be printed.
  *                  Code snippets below show valid format.
+ *
+ * @deprecated
+ * This function has been deprecated, please use one of SET_ERROR/SET_ERROR_FATAL macros 
+ * or one of set_error/set_error_fatal functions.
  *
  * @code
  * #error "That shouldn't have happened!"
@@ -66,11 +574,206 @@
  *
  *
  */
+    
+MBED_DEPRECATED_SINCE("mbed-os-5.9", "This function has been deprecated, please use one of SET_ERROR/SET_ERROR_FATAL macros or one of set_error/set_error_fatal functions" )
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 void error(const char* format, ...);
+
+/**
+ * Call this Macro to generate a MbedErrorStatus value for a System error
+ * @param  entity           Entity generating the error code. If its unknown, pass ENTITY_UNKNOWN. See MbedEntityType for entity types.
+ * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ *
+ * @code
+ * 
+ * MbedErrorStatus driver_error = MAKE_SYSTEM_ERROR( ENTITY_DRIVER_USB, ERROR_CODE_INITIALIZATION_FAILED )
+ *
+ * @endcode
+ * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_SYSTEM
+ *
+ */
+#define MAKE_SYSTEM_ERROR(entity, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, entity, error_code)
+
+/**
+ * Call this Macro to generate a MbedErrorStatus value for a Custom error
+ * @param  entity           Entity generating the error code. If its unknown, pass ENTITY_UNKNOWN. See MbedEntityType for entity types.
+ * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ *
+ * @code
+ * 
+ * MbedErrorStatus custom_error = MAKE_CUSTOM_ERROR( ENTITY_APPLICATION, 0xDEAD//16-bit custom error code )
+ *
+ * @endcode
+ * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_CUSTOM
+ *
+ */
+#define MAKE_CUSTOM_ERROR(entity, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, entity, error_code)
+
+/**
+ * Call this Macro to generate a MbedErrorStatus value for a System error
+ * @param  entity           Entity generating the error code. If its unknown, pass ENTITY_UNKNOWN. See MbedEntityType for entity types.
+ * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ *
+ * @code
+ * 
+ * MbedErrorStatus new_error = MAKE_ERROR( ENTITY_DRIVER_USB, ERROR_INITIALIZATION_FAILED )
+ *
+ * @endcode
+ * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_SYSTEM
+ *
+ */
+#define MAKE_ERROR(entity, error_code)                          MAKE_SYSTEM_ERROR(entity, error_code)
+
+/**
+ * Callback/Error hook function prototype. Applications needing a callback when an error is reported can use set_error_hook function
+ * to register a callback/error hook function using the following prototype. When an error happens in the system error handling
+ * implementation will invoke this callback with the MbedErrorStatus reported and the error context at the time of error.
+ * @param  error_status     MbedErrorStatus status being reported.
+ * @param  error_ctx        Error context structure associated with this error.
+ * @return                  void
+ *
+ */
+typedef void (*MbedErrorHook)(const mbed_error_ctx *error_ctx);
+
+/**
+ * Call this function to set a system error. This function will log the error status with the context info, prints the error report and return to caller.
+ *
+ * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_msg        The error message to be printed out to STDIO/Serial.
+ * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
+ * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
+ * @param  line_number      The line number of the source file originating the error( Most callers can pass __LINE__ here ) .
+ * @return                  0 or ERROR_SUCCESS.
+ *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
+ *
+ * @code
+ * 
+ * set_error( ERROR_OUT_OF_MEMORY, "Out of memory error", 0, __FILE__, __LINE__ )
+ *
+ * @endcode
+ *
+ * @note See SET_ERROR/SET_ERROR_FATAL macros which provides a wrapper on this API
+ */
+MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+
+/**
+ * Returns the first system error reported.
+ * @return                  MbedErrorStatus code logged for the first error or ERROR_SUCCESS if no errors are logged.
+ *
+ */
+MbedErrorStatus get_first_error(void);
+
+/**
+ * Returns the most recent system error reported.
+ * @return                  MbedErrorStatus code logged for the last error or ERROR_SUCCESS if no errors are logged.
+ *
+ */
+MbedErrorStatus get_last_error(void);
+
+/**
+ * Returns the number of system errors reported after boot.
+ * @return                  int Number of errors reported.
+ *
+ */
+int get_error_count(void);
+
+/**
+ * Call this function to set a fatal system error and halt the system. This function will log the fatal error with the context info and prints the error report.
+ * 
+ * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_msg        The error message to be printed out to STDIO/Serial.
+ * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
+ * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
+ * @param  line_number      The line number of the source file originating the error( Most callers can pass __LINE__ here ) .
+ * @return                  0 or ERROR_SUCCESS.
+ *                          ERROR_INVALID_ARGUMENT if called with invalid error status/codes 
+ *
+ * @code
+ * 
+ * set_error_fatal( ERROR_PROHIBITED_OPERATION, "Prohibited operation tried", 0, __FILE__, __LINE__ )
+ *
+ * @endcode
+ *
+ * @note See SET_ERROR/SET_ERROR_FATAL macros which provides a wrapper on this API
+ */
+MbedErrorStatus set_error_fatal(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+
+/**
+ * Registers an application defined error callback with the error handling system. 
+ * This function will be called with error context info whenever system handles a set_error/set_error_fatal call
+ * @param  custom_error_hook    MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
+ *
+ * @code
+ * 
+ * MbedErrorStatus my_custom_error_hook(MbedErrorStatus error_status, const mbed_error_ctx *error_ctx) {
+ *    //Do something with the error_status or error_ctx
+ * }
+ *
+ * set_error_hook( my_custom_error_hook )
+ *
+ * @endcode
+ *
+ */
+MbedErrorStatus set_error_hook(MbedErrorHook custom_error_hook);
+
+/**
+ * Reads the first error context information logged.
+ * @param  error_info           This is the mbed_error_context info captured as part of the first set_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ *
+ */
+MbedErrorStatus get_first_error_log_info(mbed_error_ctx *error_info);
+
+/**
+ * Reads the last error context information logged.
+ * @param  error_info           This is the mbed_error_context info captured as part of the last set_error call. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ *
+ */
+MbedErrorStatus get_last_error_log_info(mbed_error_ctx *error_info);
+
+/**
+ * Clears all the last error, error count and all entries in the error log.
+ * @return                      0 or ERROR_SUCCESS on success.
+ *
+ */
+MbedErrorStatus clear_all_errors(void);
+
+/**
+ * Generates a MbedErrorStatus value based on passed in values for type, entity and error code.
+ * @param  error_type           Error type based on MbedErrorType enum.
+ * @param  entity               Entity type based on MbedEntityType enum.
+ * @param  error_code           Error codes defined by MbedErrorCode enum
+ * @return                      0 or ERROR_SUCCESS on success.
+ *
+ */
+MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedEntityType entity, MbedErrorCode error_code);
+
+#ifndef MBED_CONF_ERROR_LOG_DISABLED
+/**
+ * Returns the current number of entries in the error log, if there has been more than max number of errors logged the number returned will be max depth of error log.
+ * @return                      Current number of entries in the error log.
+ *
+ */
+int get_error_log_count(void);
+
+/**
+ * Reads the error context information for a specific error log specified by the index.
+ * 
+ * @param  index                index of the error context entry in the log to be retrieved.\n
+ *                              The number of entries in the error log depth is configured during build and the max index depends on max depth of error log.\n
+ *                              index = 0 points to the oldest entry in the log, and index = (max log depth - 1) points to the latest entry in the error log.\n
+ * @param  error_info           This is the mbed_error_context info captured as part of the log. The caller should pass a pointer to mbed_error_context struct allocated by the caller.
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_INVALID_ARGUMENT in case of invalid index
+ *
+ */
+MbedErrorStatus get_error_log_info(int index, mbed_error_ctx *error_info);
+#endif
 
 #ifdef __cplusplus
 }
@@ -80,3 +783,5 @@ void error(const char* format, ...);
 
 /** @}*/
 /** @}*/
+
+

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -52,8 +52,8 @@ extern "C" {
 #define MBED_ERROR_STATUS_TYPE_FIELD_SIZE           (2)
 
 /* MbedErrorStatus Status Encoding */
-//|31(1 bit) Always Negative|30-29(2 bits)  |28-24	            | 23-16(8 bits)	|  15-0(16 bits) |
-//|-1	                    |TYPE	        |(unused/reserved)	| ENTITY TYPE	|  ERROR CODE    |
+//|31(1 bit) Always Negative|30-29(2 bits)  |28-24              | 23-16(8 bits) |  15-0(16 bits) |
+//|-1                       |TYPE           |(unused/reserved)  | ENTITY TYPE   |  ERROR CODE    |
 
 #define MAKE_MBED_ERROR(type, entity, error_code)   (MbedErrorStatus)                                                                   \
                                                     ((0x80000000) |                                                                     \
@@ -72,7 +72,7 @@ extern "C" {
  * MbedErrorStatus Status Encoding:\n
  *
  \verbatim
- | 31 Always Negative | 30-29(2 bits)  | 28-24              | 23-16(8 bits)	| 15-0(16 bits) |
+ | 31 Always Negative | 30-29(2 bits)  | 28-24              | 23-16(8 bits) | 15-0(16 bits) |
  | -1                 | TYPE           | (unused/reserved)  | ENTITY TYPE    | ERROR CODE    |
  \endverbatim
  * 
@@ -140,9 +140,9 @@ typedef int MbedErrorStatus;
  *
  */
 #ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
-    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
+    #define SET_ERROR( error_status, error_msg, error_value )             set_error( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
 #else
-    #define SET_ERROR( error_status, error_msg, error_value )       set_error( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
+    #define SET_ERROR( error_status, error_msg, error_value )             set_error( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
 #endif
 
 /**
@@ -162,7 +162,11 @@ typedef int MbedErrorStatus;
 *        Since this macro is a wrapper for set_error_fatal API callers should process the return value from this macro which is the return value from calling set_error_fatal API. 
  *
  */
-#define SET_ERROR_FATAL( error_status, error_msg, error_value ) set_error_fatal( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )           
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+    #define SET_ERROR_FATAL( error_status, error_msg, error_value )       set_error_fatal( error_status, (const char *)error_msg, (uint32_t)error_value, (const char *)MBED_FILENAME, __LINE__ )
+#else
+    #define SET_ERROR_FATAL( error_status, error_msg, error_value )       set_error_fatal( error_status, (const char *)error_msg, (uint32_t)error_value, NULL, 0 )
+#endif         
 
 //Error Type definition
 /** MbedErrorType definition
@@ -182,7 +186,7 @@ typedef enum _MbedErrorType
     //Use 3 for POSIX because we are mapping -1 to -255 to POSIX error codes
     //and thus we must use 3 to match the type bits in error status representation which are from 0xFFFFFFFF to 0xFFFFFF00
     ERROR_TYPE_POSIX = 3
-} MbedErrorType;		
+} MbedErrorType;        
 
 //Entity type/id definitions
 /** MbedEntityType definition
@@ -199,28 +203,28 @@ typedef enum _MbedErrorType
  */
 typedef enum _MbedEntityType
 {
-	ENTITY_APPLICATION = 0,
-	ENTITY_PLATFORM,
-	ENTITY_KERNEL,
-	ENTITY_NETWORK_STACK,
-	ENTITY_HAL,
-	ENTITY_MEMORY_SUBSYSTEM,
+    ENTITY_APPLICATION = 0,
+    ENTITY_PLATFORM,
+    ENTITY_KERNEL,
+    ENTITY_NETWORK_STACK,
+    ENTITY_HAL,
+    ENTITY_MEMORY_SUBSYSTEM,
     ENTITY_FILESYSTEM,
     ENTITY_BLOCK_DEVICE,
-	ENTITY_DRIVER,
-	ENTITY_DRIVER_SERIAL,
-	ENTITY_DRIVER_RTC,
-	ENTITY_DRIVER_I2C,
-	ENTITY_DRIVER_SPI,
-	ENTITY_DRIVER_GPIO,
-	ENTITY_DRIVER_ANALOG,
-	ENTITY_DRIVER_DIGITAL,
-	ENTITY_DRIVER_CAN,
+    ENTITY_DRIVER,
+    ENTITY_DRIVER_SERIAL,
+    ENTITY_DRIVER_RTC,
+    ENTITY_DRIVER_I2C,
+    ENTITY_DRIVER_SPI,
+    ENTITY_DRIVER_GPIO,
+    ENTITY_DRIVER_ANALOG,
+    ENTITY_DRIVER_DIGITAL,
+    ENTITY_DRIVER_CAN,
     ENTITY_DRIVER_ETHERNET,
-	ENTITY_DRIVER_CRC,
-	ENTITY_DRIVER_PWM,
-	ENTITY_DRIVER_QSPI,
-	ENTITY_DRIVER_USB,
+    ENTITY_DRIVER_CRC,
+    ENTITY_DRIVER_PWM,
+    ENTITY_DRIVER_QSPI,
+    ENTITY_DRIVER_USB,
     ENTITY_TARGET_SDK,
     /* Add More entities here as required */
     
@@ -255,7 +259,142 @@ typedef enum _MbedEntityType
  *      ERROR_CODE_EPERM = 1\n
  *      ERROR_EPERM = -1\n 
  *  All Posix error codes currently supported by MbedOS(defined in mbed_retarget.h) are defined using the DEFINE_POSIX_ERROR macro.\n\n
+ *  Below are the Posic error codes and the description:\n
+ *  \verbatim
+    EPERM                      1        Operation not permitted 
+    ENOENT                     2        No such file or directory 
+    ESRCH                      3        No such process 
+    EINTR                      4        Interrupted system call 
+    EIO                        5        I/O error 
+    ENXIO                      6        No such device or address 
+    E2BIG                      7        Argument list too long 
+    ENOEXEC                    8        Exec format error 
+    EBADF                      9        Bad file number 
+    ECHILD                     10       No child processes 
+    EAGAIN                     11       Try again 
+    ENOMEM                     12       Out of memory 
+    EACCES                     13       Permission denied 
+    EFAULT                     14       Bad address 
+    ENOTBLK                    15       Block device required 
+    EBUSY                      16       Device or resource busy 
+    EEXIST                     17       File exists 
+    EXDEV                      18       Cross-device link 
+    ENODEV                     19       No such device 
+    ENOTDIR                    20       Not a directory 
+    EISDIR                     21       Is a directory 
+    EINVAL                     22       Invalid argument 
+    ENFILE                     23       File table overflow 
+    EMFILE                     24       Too many open files 
+    ENOTTY                     25       Not a typewriter 
+    ETXTBSY                    26       Text file busy 
+    EFBIG                      27       File too large 
+    ENOSPC                     28       No space left on device 
+    ESPIPE                     29       Illegal seek 
+    EROFS                      30       Read-only file system 
+    EMLINK                     31       Too many links 
+    EPIPE                      32       Broken pipe 
+    EDOM                       33       Math argument out of domain of func 
+    ERANGE                     34       Math result not representable 
+    EDEADLK                    35       Resource deadlock would occur 
+    ENAMETOOLONG               36       File name too long 
+    ENOLCK                     37       No record locks available 
+    ENOSYS                     38       Function not implemented 
+    ENOTEMPTY                  39       Directory not empty 
+    ELOOP                      40       Too many symbolic links encountered 
+    EWOULDBLOCK                EAGAIN   Operation would block 
+    ENOMSG                     42       No message of desired type 
+    EIDRM                      43       Identifier removed 
+    ECHRNG                     44       Channel number out of range 
+    EL2NSYNC                   45       Level 2 not synchronized 
+    EL3HLT                     46       Level 3 halted 
+    EL3RST                     47       Level 3 reset 
+    ELNRNG                     48       Link number out of range 
+    EUNATCH                    49       Protocol driver not attached 
+    ENOCSI                     50       No CSI structure available 
+    EL2HLT                     51       Level 2 halted 
+    EBADE                      52       Invalid exchange 
+    EBADR                      53       Invalid request descriptor 
+    EXFULL                     54       Exchange full 
+    ENOANO                     55       No anode 
+    EBADRQC                    56       Invalid request code 
+    EBADSLT                    57       Invalid slot 
+    EDEADLOCK                  EDEADLK  Resource deadlock would occur 
+    EBFONT                     59       Bad font file format 
+    ENOSTR                     60       Device not a stream 
+    ENODATA                    61       No data available 
+    ETIME                      62       Timer expired 
+    ENOSR                      63       Out of streams resources 
+    ENONET                     64       Machine is not on the network 
+    ENOPKG                     65       Package not installed 
+    EREMOTE                    66       Object is remote 
+    ENOLINK                    67       Link has been severed 
+    EADV                       68       Advertise error 
+    ESRMNT                     69       Srmount error 
+    ECOMM                      70       Communication error on send 
+    EPROTO                     71       Protocol error 
+    EMULTIHOP                  72       Multihop attempted 
+    EDOTDOT                    73       RFS specific error 
+    EBADMSG                    74       Not a data message 
+    EOVERFLOW                  75       Value too large for defined data type 
+    ENOTUNIQ                   76       Name not unique on network 
+    EBADFD                     77       File descriptor in bad state 
+    EREMCHG                    78       Remote address changed 
+    ELIBACC                    79       Can not access a needed shared library 
+    ELIBBAD                    80       Accessing a corrupted shared library 
+    ELIBSCN                    81       .lib section in a.out corrupted 
+    ELIBMAX                    82       Attempting to link in too many shared libraries 
+    ELIBEXEC                   83       Cannot exec a shared library directly 
+    EILSEQ                     84       Illegal byte sequence 
+    ERESTART                   85       Interrupted system call should be restarted 
+    ESTRPIPE                   86       Streams pipe error 
+    EUSERS                     87       Too many users 
+    ENOTSOCK                   88       Socket operation on non-socket 
+    EDESTADDRREQ               89       Destination address required 
+    EMSGSIZE                   90       Message too long 
+    EPROTOTYPE                 91       Protocol wrong type for socket 
+    ENOPROTOOPT                92       Protocol not available 
+    EPROTONOSUPPORT            93       Protocol not supported 
+    ESOCKTNOSUPPORT            94       Socket type not supported 
+    EOPNOTSUPP                 95       Operation not supported on transport endpoint 
+    EPFNOSUPPORT               96       Protocol family not supported 
+    EAFNOSUPPORT               97       Address family not supported by protocol 
+    EADDRINUSE                 98       Address already in use 
+    EADDRNOTAVAIL              99       Cannot assign requested address 
+    ENETDOWN                   100      Network is down 
+    ENETUNREACH                101      Network is unreachable 
+    ENETRESET                  102      Network dropped connection because of reset 
+    ECONNABORTED               103      Software caused connection abort 
+    ECONNRESET                 104      Connection reset by peer 
+    ENOBUFS                    105      No buffer space available 
+    EISCONN                    106      Transport endpoint is already connected 
+    ENOTCONN                   107      Transport endpoint is not connected 
+    ESHUTDOWN                  108      Cannot send after transport endpoint shutdown 
+    ETOOMANYREFS               109      Too many references: cannot splice 
+    ETIMEDOUT                  110      Connection timed out 
+    ECONNREFUSED               111      Connection refused 
+    EHOSTDOWN                  112      Host is down 
+    EHOSTUNREACH               113      No route to host 
+    EALREADY                   114      Operation already in progress 
+    EINPROGRESS                115      Operation now in progress 
+    ESTALE                     116      Stale NFS file handle 
+    EUCLEAN                    117      Structure needs cleaning 
+    ENOTNAM                    118      Not a XENIX named type file 
+    ENAVAIL                    119      No XENIX semaphores available 
+    EISNAM                     120      Is a named type file 
+    EREMOTEIO                  121      Remote I/O error 
+    EDQUOT                     122      Quota exceeded 
+    ENOMEDIUM                  123      No medium found 
+    EMEDIUMTYPE                124      Wrong medium type 
+    ECANCELED                  125      Operation Canceled 
+    ENOKEY                     126      Required key not available 
+    EKEYEXPIRED                127      Key has expired 
+    EKEYREVOKED                128      Key has been revoked 
+    EKEYREJECTED               129      Key was rejected by service 
+    EOWNERDEAD                 130      Owner died 
+    ENOTRECOVERABLE            131      State not recoverable 
+    \endverbatim
  *
+ *  @note
  *  MbedOS System Error codes are defined using the macro DEFINE_SYSTEM_ERROR\n
  *  For example DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT ,1 ) macro defines the following values:\n
  *      ERROR_CODE_INVALID_ARGUMENT = MBED_SYSTEM_ERROR_BASE+1\n
@@ -265,7 +404,76 @@ typedef enum _MbedEntityType
  *      ERROR_INVALID_ARGUMENT = 0x80FF0001\n (Note that ENTITY field is set to ENTITY_UNKNOWN) 
  *  New System Error codes should be defined using DEFINE_SYSTEM_ERROR macro and must have an unique error code value\n
  *  passed as the second argument in the DEFINE_SYSTEM_ERROR macro.\n\n
+ *  Below are the Mbed System error codes and the description:
+ *  \verbatim 
+    UNKNOWN                    256      Unknown error 
+    INVALID_ARGUMENT           257      Invalid Argument 
+    INVALID_DATA               258      Invalid data 
+    INVALID_FORMAT             259      Invalid format 
+    INVALID_INDEX              260      Invalid Index 
+    INVALID_SIZE               261      Inavlid Size 
+    INVALID_OPERATION          262      Invalid Operation 
+    NOT_FOUND                  263      Not Found 
+    ACCESS_DENIED              264      Access Denied 
+    NOT_SUPPORTED              265      Not supported 
+    BUFFER_FULL                266      Buffer Full 
+    MEDIA_FULL                 267      Media/Disk Full 
+    ALREADY_IN_USE             268      Already in use 
+    TIMEOUT                    269      Timeout error 
+    NOT_READY                  270      Not Ready 
+    FAILED_OPERATION           271      Requested Operation failed 
+    OPERATION_PROHIBITED       272      Operation prohibited 
+    OPERATION_ABORTED          273      Operation failed 
+    WRITE_PROTECTED            274      Attempt to write to write-protected resource 
+    NO_RESPONSE                275      No response 
+    SEMAPHORE_LOCK_FAILED      276      Sempahore lock failed 
+    MUTEX_LOCK_FAILED          277      Mutex lock failed 
+    SEMAPHORE_UNLOCK_FAILED    278      Sempahore unlock failed 
+    MUTEX_UNLOCK_FAILED        279      Mutex unlock failed 
+    CRC_ERROR                  280      CRC error or mismatch 
+    OPEN_FAILED                281      Open failed 
+    CLOSE_FAILED               282      Close failed 
+    READ_FAILED                283      Read failed 
+    WRITE_FAILED               284      Write failed 
+    INITIALIZATION_FAILED      285      Initialization failed 
+    BOOT_FAILURE               286      Boot failure 
+    OUT_OF_MEMORY              287      Out of memory 
+    OUT_OF_RESOURCES           288      Out of resources 
+    ALLOC_FAILED               289      Alloc failed 
+    FREE_FAILED                290      Free failed 
+    OVERFLOW                   291      Overflow error 
+    UNDERFLOW                  292      Underflow error 
+    STACK_OVERFLOW             293      Stack overflow error 
+    ISR_QUEUE_OVERFLOW         294      ISR queue overflow 
+    TIMER_QUEUE_OVERFLOW       295      Timer Queue overflow 
+    CLIB_SPACE_UNAVAILABLE     296      Standard library error - Space unavailable 
+    CLIB_EXCEPTION             297      Standard library error - Exception 
+    CLIB_MUTEX_INIT_FAILURE    298      Standard library error - Mutex Init failure 
+    CREATE_FAILED              299      Create failed 
+    DELETE_FAILED              300      Delete failed 
+    THREAD_CREATE_FAILED       301      Thread Create failed 
+    THREAD_DELETE_FAILED       302      Thread Delete failed 
+    PROHIBITED_IN_ISR_CONTEXT  303      Operation Prohibited in ISR context 
+    PINMAP_INVALID             304      Pinmap Invalid 
+    RTOS_EVENT                 305      Unknown Rtos Error 
+    RTOS_THREAD_EVENT          306      Rtos Thread Error 
+    RTOS_MUTEX_EVENT           307      Rtos Mutex Error 
+    RTOS_SEMAPHORE_EVENT       308      Rtos Semaphore Error 
+    RTOS_MEMORY_POOL_EVENT     309      Rtos Memory Pool Error 
+    RTOS_TIMER_EVENT           310      Rtos Timer Error 
+    RTOS_EVENT_FLAGS_EVENT     311      Rtos Event flags Error 
+    RTOS_MESSAGE_QUEUE_EVENT   312      Rtos Message queue Error 
+    DEVICE_BUSY                313      Device Busy 
+    CONFIG_UNSUPPORTED         314      Configuration not supported 
+    CONFIG_MISMATCH            315      Configuration mismatch 
+    ALREADY_INITIALIZED        316      Already initialzied 
+    HARDFAULT_EXCEPTION        317      HardFault exception 
+    MEMMANAGE_EXCEPTION        318      MemManage exception 
+    BUSFAULT_EXCEPTION         319      BusFault exception 
+    USAGEFAULT_EXCEPTION       320      UsageFault exception
+    \endverbatim
  *
+ *  @note
  *  Custom Error codes can be defined using the macro DEFINE_CUSTOM_ERROR\n
  *  This is mainly meant to capture non-generic error codes specific to a device.
  *  For example DEFINE_CUSTOM_ERROR( MY_CUSTOM_ERROR ,1 ) macro defines the following values:\n
@@ -273,8 +481,24 @@ typedef enum _MbedEntityType
  *      ERROR_MY_CUSTOM_ERROR = MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, ENTITY_UNKNOWN, ERROR_CODE_MY_CUSTOM_ERROR)\n
  *  Its effectively equivalent to:\n
  *      ERROR_CODE_MY_CUSTOM_ERROR = 4097\n
- *      ERROR_MY_CUSTOM_ERROR = 0xA0FF1001\n (Note that ENTITY field is set to ENTITY_UNKNOWN) 
+ *      ERROR_MY_CUSTOM_ERROR = 0xA0FF1001\n (Note that ENTITY field is set to ENTITY_UNKNOWN) \n\n
  *
+ *  
+ *  @note
+ *  Searching for error codes in mbed-os source tree. \n
+ *  If you get an error report as below which you want to search for mbed-os source tree first take note of "Error Code" number. \n
+ *  For example, the below error report has an error code of \b 259. Find the error name associated with the error code and in this case its \b INVALID_FORMAT. \n
+ *  Use that error name(\b INVALID_FORMAT) to search the source tree for code locations setting that specific error code. \n 
+    \verbatim
+    ++ MbedOS Error Info ++
+    Error Status: 0x80FF0103
+    Error Code:    259
+    Error Message: Invalid format error
+    Error Location: 0x00002CFF
+    Error Value: 0x00000008
+    Current Thread: Id: 0x200025AC EntryFn: 0x00009681 StackSize: 0x00001000 StackMem: 0x200025F8 SP: 0x2002FFD8
+    -- MbedOS Error Info --
+    \endverbatim
  */
  
 typedef enum _MbedErrorCode
@@ -282,7 +506,7 @@ typedef enum _MbedErrorCode
     //Below are POSIX ERROR CODE definitions, which starts at MBED_POSIX_ERROR_BASE(=0)
     //POSIX ERROR CODE definitions starts at offset 0(MBED_POSIX_ERROR_BASE) to align them with actual Posix Error Code
     //defintions in mbed_retarget.h
-    //                  Error Name             Error Code  
+    //                  Error Name                                    Error Code
     DEFINE_POSIX_ERROR( EPERM                 ,EPERM           ),  /* 1       Operation not permitted */
     DEFINE_POSIX_ERROR( ENOENT                ,ENOENT          ),  /* 2       No such file or directory */
     DEFINE_POSIX_ERROR( ESRCH                 ,ESRCH           ),  /* 3       No such process */
@@ -417,72 +641,72 @@ typedef enum _MbedErrorCode
     
     //Below are MBED SYSTEM ERROR CODE definitions
     //MBED SYSTEM ERROR CODE definitions starts at offset MBED_SYSTEM_ERROR_BASE, see above.
-    //                   Error Name                 Error Code  
-	DEFINE_SYSTEM_ERROR( UNKNOWN                    ,0 ),
-    DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT           ,1 ),
-	DEFINE_SYSTEM_ERROR( INVALID_DATA               ,2 ),
-	DEFINE_SYSTEM_ERROR( INVALID_FORMAT             ,3 ),
-	DEFINE_SYSTEM_ERROR( INVALID_INDEX              ,4 ),
-    DEFINE_SYSTEM_ERROR( INVALID_SIZE               ,5 ),
-    DEFINE_SYSTEM_ERROR( INVALID_OPERATION          ,6 ),
-	DEFINE_SYSTEM_ERROR( NOT_FOUND                  ,7 ),
-	DEFINE_SYSTEM_ERROR( ACCESS_DENIED              ,8 ),
-	DEFINE_SYSTEM_ERROR( NOT_SUPPORTED              ,9 ),
-	DEFINE_SYSTEM_ERROR( BUFFER_FULL                ,10 ),
-	DEFINE_SYSTEM_ERROR( MEDIA_FULL                 ,11 ),
-	DEFINE_SYSTEM_ERROR( ALREADY_IN_USE             ,12 ),
-	DEFINE_SYSTEM_ERROR( TIMEOUT                    ,13 ),
-	DEFINE_SYSTEM_ERROR( NOT_READY                  ,14 ),
-	DEFINE_SYSTEM_ERROR( FAILED_OPERATION           ,15 ),
-    DEFINE_SYSTEM_ERROR( OPERATION_PROHIBITED       ,16 ),
-	DEFINE_SYSTEM_ERROR( OPERATION_ABORTED          ,17 ),
-	DEFINE_SYSTEM_ERROR( WRITE_PROTECTED            ,18 ),
-	DEFINE_SYSTEM_ERROR( NO_RESPONSE                ,19 ),
-	DEFINE_SYSTEM_ERROR( SEMAPHORE_LOCK_FAILED      ,20 ),
-	DEFINE_SYSTEM_ERROR( MUTEX_LOCK_FAILED          ,21 ),
-    DEFINE_SYSTEM_ERROR( SEMAPHORE_UNLOCK_FAILED    ,22 ),
-	DEFINE_SYSTEM_ERROR( MUTEX_UNLOCK_FAILED        ,23 ),
-	DEFINE_SYSTEM_ERROR( CRC_ERROR                  ,24 ),
-    DEFINE_SYSTEM_ERROR( OPEN_FAILED                ,25 ),
-    DEFINE_SYSTEM_ERROR( CLOSE_FAILED               ,26 ),
-    DEFINE_SYSTEM_ERROR( READ_FAILED                ,27 ),
-    DEFINE_SYSTEM_ERROR( WRITE_FAILED               ,28 ),
-	DEFINE_SYSTEM_ERROR( INITIALIZATION_FAILED      ,29 ),
-	DEFINE_SYSTEM_ERROR( BOOT_FAILURE               ,30 ),
-    DEFINE_SYSTEM_ERROR( OUT_OF_MEMORY              ,31 ),
-    DEFINE_SYSTEM_ERROR( OUT_OF_RESOURCES           ,32 ),
-    DEFINE_SYSTEM_ERROR( ALLOC_FAILED               ,33 ),
-    DEFINE_SYSTEM_ERROR( FREE_FAILED                ,34 ),
-    DEFINE_SYSTEM_ERROR( OVERFLOW                   ,35 ),
-    DEFINE_SYSTEM_ERROR( UNDERFLOW                  ,36 ),
-    DEFINE_SYSTEM_ERROR( STACK_OVERFLOW             ,37 ),
-    DEFINE_SYSTEM_ERROR( ISR_QUEUE_OVERFLOW         ,38 ),
-    DEFINE_SYSTEM_ERROR( TIMER_QUEUE_OVERFLOW       ,39 ),
-    DEFINE_SYSTEM_ERROR( CLIB_SPACE_UNAVAILABLE     ,40 ),
-    DEFINE_SYSTEM_ERROR( CLIB_EXCEPTION             ,41 ),
-    DEFINE_SYSTEM_ERROR( CLIB_MUTEX_INIT_FAILURE    ,42 ),
-    DEFINE_SYSTEM_ERROR( CREATE_FAILED              ,43 ),
-    DEFINE_SYSTEM_ERROR( DELETE_FAILED              ,44 ),
-    DEFINE_SYSTEM_ERROR( THREAD_CREATE_FAILED       ,45 ),
-    DEFINE_SYSTEM_ERROR( THREAD_DELETE_FAILED       ,46 ),
-    DEFINE_SYSTEM_ERROR( PROHIBITED_IN_ISR_CONTEXT  ,47 ),
-    DEFINE_SYSTEM_ERROR( PINMAP_INVALID             ,48 ),
-    DEFINE_SYSTEM_ERROR( RTOS_EVENT                 ,49 ),
-    DEFINE_SYSTEM_ERROR( RTOS_THREAD_EVENT          ,50 ),
-    DEFINE_SYSTEM_ERROR( RTOS_MUTEX_EVENT           ,51 ),
-    DEFINE_SYSTEM_ERROR( RTOS_SEMAPHORE_EVENT       ,52 ),
-    DEFINE_SYSTEM_ERROR( RTOS_MEMORY_POOL_EVENT     ,53 ),
-    DEFINE_SYSTEM_ERROR( RTOS_TIMER_EVENT           ,54 ),
-    DEFINE_SYSTEM_ERROR( RTOS_EVENT_FLAGS_EVENT     ,55 ),
-    DEFINE_SYSTEM_ERROR( RTOS_MESSAGE_QUEUE_EVENT   ,56 ),
-    DEFINE_SYSTEM_ERROR( DEVICE_BUSY                ,57 ),
-    DEFINE_SYSTEM_ERROR( CONFIG_UNSUPPORTED         ,58 ),
-    DEFINE_SYSTEM_ERROR( CONFIG_MISMATCH            ,59 ),
-    DEFINE_SYSTEM_ERROR( ALREADY_INITIALIZED        ,60 ),
-    DEFINE_SYSTEM_ERROR( HARDFAULT_EXCEPTION        ,61 ),
-	DEFINE_SYSTEM_ERROR( MEMMANAGE_EXCEPTION        ,62 ),
-	DEFINE_SYSTEM_ERROR( BUSFAULT_EXCEPTION         ,63 ),
-	DEFINE_SYSTEM_ERROR( USAGEFAULT_EXCEPTION       ,64 ),
+    //                   Error Name                 Error Offset   Error Code
+    DEFINE_SYSTEM_ERROR( UNKNOWN                    ,0 ),          /* 256      Unknown error */
+    DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT           ,1 ),          /* 257      Invalid Argument */
+    DEFINE_SYSTEM_ERROR( INVALID_DATA               ,2 ),          /* 258      Invalid data */
+    DEFINE_SYSTEM_ERROR( INVALID_FORMAT             ,3 ),          /* 259      Invalid format */
+    DEFINE_SYSTEM_ERROR( INVALID_INDEX              ,4 ),          /* 260      Invalid Index */
+    DEFINE_SYSTEM_ERROR( INVALID_SIZE               ,5 ),          /* 261      Inavlid Size */
+    DEFINE_SYSTEM_ERROR( INVALID_OPERATION          ,6 ),          /* 262      Invalid Operation */
+    DEFINE_SYSTEM_ERROR( NOT_FOUND                  ,7 ),          /* 263      Not Found */
+    DEFINE_SYSTEM_ERROR( ACCESS_DENIED              ,8 ),          /* 264      Access Denied */
+    DEFINE_SYSTEM_ERROR( NOT_SUPPORTED              ,9 ),          /* 265      Not supported */
+    DEFINE_SYSTEM_ERROR( BUFFER_FULL                ,10 ),         /* 266      Buffer Full */
+    DEFINE_SYSTEM_ERROR( MEDIA_FULL                 ,11 ),         /* 267      Media/Disk Full */
+    DEFINE_SYSTEM_ERROR( ALREADY_IN_USE             ,12 ),         /* 268      Already in use */
+    DEFINE_SYSTEM_ERROR( TIMEOUT                    ,13 ),         /* 269      Timeout error */
+    DEFINE_SYSTEM_ERROR( NOT_READY                  ,14 ),         /* 270      Not Ready */
+    DEFINE_SYSTEM_ERROR( FAILED_OPERATION           ,15 ),         /* 271      Requested Operation failed */
+    DEFINE_SYSTEM_ERROR( OPERATION_PROHIBITED       ,16 ),         /* 272      Operation prohibited */
+    DEFINE_SYSTEM_ERROR( OPERATION_ABORTED          ,17 ),         /* 273      Operation failed */
+    DEFINE_SYSTEM_ERROR( WRITE_PROTECTED            ,18 ),         /* 274      Attempt to write to write-protected resource */
+    DEFINE_SYSTEM_ERROR( NO_RESPONSE                ,19 ),         /* 275      No response */
+    DEFINE_SYSTEM_ERROR( SEMAPHORE_LOCK_FAILED      ,20 ),         /* 276      Sempahore lock failed */
+    DEFINE_SYSTEM_ERROR( MUTEX_LOCK_FAILED          ,21 ),         /* 277      Mutex lock failed */
+    DEFINE_SYSTEM_ERROR( SEMAPHORE_UNLOCK_FAILED    ,22 ),         /* 278      Sempahore unlock failed */
+    DEFINE_SYSTEM_ERROR( MUTEX_UNLOCK_FAILED        ,23 ),         /* 279      Mutex unlock failed */
+    DEFINE_SYSTEM_ERROR( CRC_ERROR                  ,24 ),         /* 280      CRC error or mismatch */
+    DEFINE_SYSTEM_ERROR( OPEN_FAILED                ,25 ),         /* 281      Open failed */
+    DEFINE_SYSTEM_ERROR( CLOSE_FAILED               ,26 ),         /* 282      Close failed */
+    DEFINE_SYSTEM_ERROR( READ_FAILED                ,27 ),         /* 283      Read failed */
+    DEFINE_SYSTEM_ERROR( WRITE_FAILED               ,28 ),         /* 284      Write failed */
+    DEFINE_SYSTEM_ERROR( INITIALIZATION_FAILED      ,29 ),         /* 285      Initialization failed */
+    DEFINE_SYSTEM_ERROR( BOOT_FAILURE               ,30 ),         /* 286      Boot failure */
+    DEFINE_SYSTEM_ERROR( OUT_OF_MEMORY              ,31 ),         /* 287      Out of memory */
+    DEFINE_SYSTEM_ERROR( OUT_OF_RESOURCES           ,32 ),         /* 288      Out of resources */
+    DEFINE_SYSTEM_ERROR( ALLOC_FAILED               ,33 ),         /* 289      Alloc failed */
+    DEFINE_SYSTEM_ERROR( FREE_FAILED                ,34 ),         /* 290      Free failed */
+    DEFINE_SYSTEM_ERROR( OVERFLOW                   ,35 ),         /* 291      Overflow error */
+    DEFINE_SYSTEM_ERROR( UNDERFLOW                  ,36 ),         /* 292      Underflow error */
+    DEFINE_SYSTEM_ERROR( STACK_OVERFLOW             ,37 ),         /* 293      Stack overflow error */
+    DEFINE_SYSTEM_ERROR( ISR_QUEUE_OVERFLOW         ,38 ),         /* 294      ISR queue overflow */
+    DEFINE_SYSTEM_ERROR( TIMER_QUEUE_OVERFLOW       ,39 ),         /* 295      Timer Queue overflow */
+    DEFINE_SYSTEM_ERROR( CLIB_SPACE_UNAVAILABLE     ,40 ),         /* 296      Standard library error - Space unavailable */
+    DEFINE_SYSTEM_ERROR( CLIB_EXCEPTION             ,41 ),         /* 297      Standard library error - Exception */
+    DEFINE_SYSTEM_ERROR( CLIB_MUTEX_INIT_FAILURE    ,42 ),         /* 298      Standard library error - Mutex Init failure */
+    DEFINE_SYSTEM_ERROR( CREATE_FAILED              ,43 ),         /* 299      Create failed */
+    DEFINE_SYSTEM_ERROR( DELETE_FAILED              ,44 ),         /* 300      Delete failed */
+    DEFINE_SYSTEM_ERROR( THREAD_CREATE_FAILED       ,45 ),         /* 301      Thread Create failed */
+    DEFINE_SYSTEM_ERROR( THREAD_DELETE_FAILED       ,46 ),         /* 302      Thread Delete failed */
+    DEFINE_SYSTEM_ERROR( PROHIBITED_IN_ISR_CONTEXT  ,47 ),         /* 303      Operation Prohibited in ISR context */
+    DEFINE_SYSTEM_ERROR( PINMAP_INVALID             ,48 ),         /* 304      Pinmap Invalid */
+    DEFINE_SYSTEM_ERROR( RTOS_EVENT                 ,49 ),         /* 305      Unknown Rtos Error */
+    DEFINE_SYSTEM_ERROR( RTOS_THREAD_EVENT          ,50 ),         /* 306      Rtos Thread Error */
+    DEFINE_SYSTEM_ERROR( RTOS_MUTEX_EVENT           ,51 ),         /* 307      Rtos Mutex Error */
+    DEFINE_SYSTEM_ERROR( RTOS_SEMAPHORE_EVENT       ,52 ),         /* 308      Rtos Semaphore Error */
+    DEFINE_SYSTEM_ERROR( RTOS_MEMORY_POOL_EVENT     ,53 ),         /* 309      Rtos Memory Pool Error */
+    DEFINE_SYSTEM_ERROR( RTOS_TIMER_EVENT           ,54 ),         /* 310      Rtos Timer Error */
+    DEFINE_SYSTEM_ERROR( RTOS_EVENT_FLAGS_EVENT     ,55 ),         /* 311      Rtos Event flags Error */
+    DEFINE_SYSTEM_ERROR( RTOS_MESSAGE_QUEUE_EVENT   ,56 ),         /* 312      Rtos Message queue Error */
+    DEFINE_SYSTEM_ERROR( DEVICE_BUSY                ,57 ),         /* 313      Device Busy */
+    DEFINE_SYSTEM_ERROR( CONFIG_UNSUPPORTED         ,58 ),         /* 314      Configuration not supported */
+    DEFINE_SYSTEM_ERROR( CONFIG_MISMATCH            ,59 ),         /* 315      Configuration mismatch */
+    DEFINE_SYSTEM_ERROR( ALREADY_INITIALIZED        ,60 ),         /* 316      Already initialzied */
+    DEFINE_SYSTEM_ERROR( HARDFAULT_EXCEPTION        ,61 ),         /* 317      HardFault exception */
+    DEFINE_SYSTEM_ERROR( MEMMANAGE_EXCEPTION        ,62 ),         /* 318      MemManage exception */
+    DEFINE_SYSTEM_ERROR( BUSFAULT_EXCEPTION         ,63 ),         /* 319      BusFault exception */
+    DEFINE_SYSTEM_ERROR( USAGEFAULT_EXCEPTION       ,64 ),         /* 320      UsageFault exception*/
         
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on
@@ -753,7 +977,6 @@ MbedErrorStatus clear_all_errors(void);
  */
 MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedEntityType entity, MbedErrorCode error_code);
 
-#ifndef MBED_CONF_ERROR_LOG_DISABLED
 /**
  * Returns the current number of entries in the error log, if there has been more than max number of errors logged the number returned will be max depth of error log.
  * @return                      Current number of entries in the error log.
@@ -773,7 +996,19 @@ int get_error_log_count(void);
  *
  */
 MbedErrorStatus get_error_log_info(int index, mbed_error_ctx *error_info);
-#endif
+
+/**
+ * Saves the error log information to a file
+ * 
+ * @param  path                 path to the file in the filesystem
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ * @note                        Filesystem support is required in order for this function to work.
+ *
+ */
+MbedErrorStatus save_error_log(const char *path);
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -101,7 +101,7 @@ typedef int MbedErrorStatus;
  * @param  error_code       Error code value to be used, must be between 1 and 255(inclusive).
  *
  */
-#define DEFINE_POSIX_ERROR( error_name, error_code )   \
+#define MBED_DEFINE_POSIX_ERROR( error_name, error_code )   \
                      ERROR_CODE_##error_name = error_code,  \
                      ERROR_##error_name = -(MBED_POSIX_ERROR_BASE + error_code)
 
@@ -111,7 +111,7 @@ typedef int MbedErrorStatus;
  * @param  error_code       Error code value to be used, must be between 256 and 4096(inclusive).
  *
  */
-#define DEFINE_SYSTEM_ERROR( error_name, error_code )   \
+#define MBED_DEFINE_SYSTEM_ERROR( error_name, error_code )   \
                       ERROR_CODE_##error_name = MBED_SYSTEM_ERROR_BASE + error_code,  \
                       ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, MODULE_UNKNOWN, ERROR_CODE_##error_name)
 
@@ -121,7 +121,7 @@ typedef int MbedErrorStatus;
  * @param  error_code       Error code value to be used, must be between 4097 and 65535(inclusive).
  *
  */
-#define DEFINE_CUSTOM_ERROR( error_name, error_code )   \
+#define MBED_DEFINE_CUSTOM_ERROR( error_name, error_code )   \
                       ERROR_CODE_##error_name = MBED_CUSTOM_ERROR_BASE + error_code,  \
                       ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, MODULE_UNKNOWN, ERROR_CODE_##error_name)
 
@@ -280,19 +280,19 @@ typedef enum _MbedModuleType
  *  It defines all of Posix Error Codes/Statuses and Mbed System Error Codes/Statuses.\n\n
  *
  *  @note
- *  Posix Error codes are defined using the macro DEFINE_POSIX_ERROR\n
- *  For example DEFINE_POSIX_ERROR( EPERM, EPERM ). This effectively defines the following values:\n
+ *  Posix Error codes are defined using the macro MBED_DEFINE_POSIX_ERROR\n
+ *  For example MBED_DEFINE_POSIX_ERROR( EPERM, EPERM ). This effectively defines the following values:\n
  *      ERROR_CODE_EPERM = EPERM\n
  *      ERROR_EPERM = -EPERM\n
  *
- *  Posix Error codes are defined using the macro DEFINE_POSIX_ERROR\n
- *  For example DEFINE_POSIX_ERROR( EPERM, EPERM ). This macro defines the following values:\n
+ *  Posix Error codes are defined using the macro MBED_DEFINE_POSIX_ERROR\n
+ *  For example MBED_DEFINE_POSIX_ERROR( EPERM, EPERM ). This macro defines the following values:\n
  *      ERROR_CODE_EPERM = MBED_POSIX_ERROR_BASE+EPERM\n
  *      ERROR_EPERM = -(MBED_POSIX_ERROR_BASE+EPERM)\n
  *  Its effectively equivalent to:\n
  *      ERROR_CODE_EPERM = 1\n
  *      ERROR_EPERM = -1\n 
- *  All Posix error codes currently supported by MbedOS(defined in mbed_retarget.h) are defined using the DEFINE_POSIX_ERROR macro.\n\n
+ *  All Posix error codes currently supported by MbedOS(defined in mbed_retarget.h) are defined using the MBED_DEFINE_POSIX_ERROR macro.\n\n
  *  Below are the Posic error codes and the description:\n
  *  \verbatim
     EPERM                      1        Operation not permitted 
@@ -429,15 +429,15 @@ typedef enum _MbedModuleType
     \endverbatim
  *
  *  @note
- *  MbedOS System Error codes are defined using the macro DEFINE_SYSTEM_ERROR\n
- *  For example DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT ,1 ) macro defines the following values:\n
+ *  MbedOS System Error codes are defined using the macro MBED_DEFINE_SYSTEM_ERROR\n
+ *  For example MBED_DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT ,1 ) macro defines the following values:\n
  *      ERROR_CODE_INVALID_ARGUMENT = MBED_SYSTEM_ERROR_BASE+1\n
  *      ERROR_INVALID_ARGUMENT = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, MODULE_UNKNOWN, ERROR_CODE_INVALID_ARGUMENT)\n
  *  Its effectively equivalent to:\n
  *      ERROR_CODE_INVALID_ARGUMENT = 1\n
  *      ERROR_INVALID_ARGUMENT = 0x80FF0001\n (Note that MODULE field is set to MODULE_UNKNOWN) 
- *  New System Error codes should be defined using DEFINE_SYSTEM_ERROR macro and must have an unique error code value\n
- *  passed as the second argument in the DEFINE_SYSTEM_ERROR macro.\n\n
+ *  New System Error codes should be defined using MBED_DEFINE_SYSTEM_ERROR macro and must have an unique error code value\n
+ *  passed as the second argument in the MBED_DEFINE_SYSTEM_ERROR macro.\n\n
  *  Below are the Mbed System error codes and the description:
  *  \verbatim 
     UNKNOWN                    256      Unknown error 
@@ -554,206 +554,206 @@ typedef enum _MbedErrorCode
     //POSIX ERROR CODE definitions starts at offset 0(MBED_POSIX_ERROR_BASE) to align them with actual Posix Error Code
     //defintions in mbed_retarget.h
     //                  Error Name                                    Error Code
-    DEFINE_POSIX_ERROR( EPERM                 ,EPERM           ),  /* 1       Operation not permitted */
-    DEFINE_POSIX_ERROR( ENOENT                ,ENOENT          ),  /* 2       No such file or directory */
-    DEFINE_POSIX_ERROR( ESRCH                 ,ESRCH           ),  /* 3       No such process */
-    DEFINE_POSIX_ERROR( EINTR                 ,EINTR           ),  /* 4       Interrupted system call */
-    DEFINE_POSIX_ERROR( EIO                   ,EIO             ),  /* 5       I/O error */
-    DEFINE_POSIX_ERROR( ENXIO                 ,ENXIO           ),  /* 6       No such device or address */
-    DEFINE_POSIX_ERROR( E2BIG                 ,E2BIG           ),  /* 7       Argument list too long */
-    DEFINE_POSIX_ERROR( ENOEXEC               ,ENOEXEC         ),  /* 8       Exec format error */
-    DEFINE_POSIX_ERROR( EBADF                 ,EBADF           ),  /* 9       Bad file number */
-    DEFINE_POSIX_ERROR( ECHILD                ,ECHILD          ),  /* 10      No child processes */
-    DEFINE_POSIX_ERROR( EAGAIN                ,EAGAIN          ),  /* 11      Try again */
-    DEFINE_POSIX_ERROR( ENOMEM                ,ENOMEM          ),  /* 12      Out of memory */
-    DEFINE_POSIX_ERROR( EACCES                ,EACCES          ),  /* 13      Permission denied */
-    DEFINE_POSIX_ERROR( EFAULT                ,EFAULT          ),  /* 14      Bad address */
-    DEFINE_POSIX_ERROR( ENOTBLK               ,ENOTBLK         ),  /* 15      Block device required */
-    DEFINE_POSIX_ERROR( EBUSY                 ,EBUSY           ),  /* 16      Device or resource busy */
-    DEFINE_POSIX_ERROR( EEXIST                ,EEXIST          ),  /* 17      File exists */
-    DEFINE_POSIX_ERROR( EXDEV                 ,EXDEV           ),  /* 18      Cross-device link */
-    DEFINE_POSIX_ERROR( ENODEV                ,ENODEV          ),  /* 19      No such device */
-    DEFINE_POSIX_ERROR( ENOTDIR               ,ENOTDIR         ),  /* 20      Not a directory */
-    DEFINE_POSIX_ERROR( EISDIR                ,EISDIR          ),  /* 21      Is a directory */
-    DEFINE_POSIX_ERROR( EINVAL                ,EINVAL          ),  /* 22      Invalid argument */
-    DEFINE_POSIX_ERROR( ENFILE                ,ENFILE          ),  /* 23      File table overflow */
-    DEFINE_POSIX_ERROR( EMFILE                ,EMFILE          ),  /* 24      Too many open files */
-    DEFINE_POSIX_ERROR( ENOTTY                ,ENOTTY          ),  /* 25      Not a typewriter */
-    DEFINE_POSIX_ERROR( ETXTBSY               ,ETXTBSY         ),  /* 26      Text file busy */
-    DEFINE_POSIX_ERROR( EFBIG                 ,EFBIG           ),  /* 27      File too large */
-    DEFINE_POSIX_ERROR( ENOSPC                ,ENOSPC          ),  /* 28      No space left on device */
-    DEFINE_POSIX_ERROR( ESPIPE                ,ESPIPE          ),  /* 29      Illegal seek */
-    DEFINE_POSIX_ERROR( EROFS                 ,EROFS           ),  /* 30      Read-only file system */
-    DEFINE_POSIX_ERROR( EMLINK                ,EMLINK          ),  /* 31      Too many links */
-    DEFINE_POSIX_ERROR( EPIPE                 ,EPIPE           ),  /* 32      Broken pipe */
-    DEFINE_POSIX_ERROR( EDOM                  ,EDOM            ),  /* 33      Math argument out of domain of func */
-    DEFINE_POSIX_ERROR( ERANGE                ,ERANGE          ),  /* 34      Math result not representable */
-    DEFINE_POSIX_ERROR( EDEADLK               ,EDEADLK         ),  /* 35      Resource deadlock would occur */
-    DEFINE_POSIX_ERROR( ENAMETOOLONG          ,ENAMETOOLONG    ),  /* 36      File name too long */
-    DEFINE_POSIX_ERROR( ENOLCK                ,ENOLCK          ),  /* 37      No record locks available */
-    DEFINE_POSIX_ERROR( ENOSYS                ,ENOSYS          ),  /* 38      Function not implemented */
-    DEFINE_POSIX_ERROR( ENOTEMPTY             ,ENOTEMPTY       ),  /* 39      Directory not empty */
-    DEFINE_POSIX_ERROR( ELOOP                 ,ELOOP           ),  /* 40      Too many symbolic links encountered */
-    DEFINE_POSIX_ERROR( EWOULDBLOCK           ,EAGAIN          ),  /* EAGAIN  Operation would block */
-    DEFINE_POSIX_ERROR( ENOMSG                ,ENOMSG          ),  /* 42      No message of desired type */
-    DEFINE_POSIX_ERROR( EIDRM                 ,EIDRM           ),  /* 43      Identifier removed */
-    DEFINE_POSIX_ERROR( ECHRNG                ,ECHRNG          ),  /* 44      Channel number out of range */
-    DEFINE_POSIX_ERROR( EL2NSYNC              ,EL2NSYNC        ),  /* 45      Level 2 not synchronized */
-    DEFINE_POSIX_ERROR( EL3HLT                ,EL3HLT          ),  /* 46      Level 3 halted */
-    DEFINE_POSIX_ERROR( EL3RST                ,EL3RST          ),  /* 47      Level 3 reset */
-    DEFINE_POSIX_ERROR( ELNRNG                ,ELNRNG          ),  /* 48      Link number out of range */
-    DEFINE_POSIX_ERROR( EUNATCH               ,EUNATCH         ),  /* 49      Protocol driver not attached */
-    DEFINE_POSIX_ERROR( ENOCSI                ,ENOCSI          ),  /* 50      No CSI structure available */
-    DEFINE_POSIX_ERROR( EL2HLT                ,EL2HLT          ),  /* 51      Level 2 halted */
-    DEFINE_POSIX_ERROR( EBADE                 ,EBADE           ),  /* 52      Invalid exchange */
-    DEFINE_POSIX_ERROR( EBADR                 ,EBADR           ),  /* 53      Invalid request descriptor */
-    DEFINE_POSIX_ERROR( EXFULL                ,EXFULL          ),  /* 54      Exchange full */
-    DEFINE_POSIX_ERROR( ENOANO                ,ENOANO          ),  /* 55      No anode */
-    DEFINE_POSIX_ERROR( EBADRQC               ,EBADRQC         ),  /* 56      Invalid request code */
-    DEFINE_POSIX_ERROR( EBADSLT               ,EBADSLT         ),  /* 57      Invalid slot */
-    DEFINE_POSIX_ERROR( EDEADLOCK             ,EDEADLK         ),  /* EDEADLK Resource deadlock would occur */
-    DEFINE_POSIX_ERROR( EBFONT                ,EBFONT          ),  /* 59      Bad font file format */
-    DEFINE_POSIX_ERROR( ENOSTR                ,ENOSTR          ),  /* 60      Device not a stream */
-    DEFINE_POSIX_ERROR( ENODATA               ,ENODATA         ),  /* 61      No data available */
-    DEFINE_POSIX_ERROR( ETIME                 ,ETIME           ),  /* 62      Timer expired */
-    DEFINE_POSIX_ERROR( ENOSR                 ,ENOSR           ),  /* 63      Out of streams resources */
-    DEFINE_POSIX_ERROR( ENONET                ,ENONET          ),  /* 64      Machine is not on the network */
-    DEFINE_POSIX_ERROR( ENOPKG                ,ENOPKG          ),  /* 65      Package not installed */
-    DEFINE_POSIX_ERROR( EREMOTE               ,EREMOTE         ),  /* 66      Object is remote */
-    DEFINE_POSIX_ERROR( ENOLINK               ,ENOLINK         ),  /* 67      Link has been severed */
-    DEFINE_POSIX_ERROR( EADV                  ,EADV            ),  /* 68      Advertise error */
-    DEFINE_POSIX_ERROR( ESRMNT                ,ESRMNT          ),  /* 69      Srmount error */
-    DEFINE_POSIX_ERROR( ECOMM                 ,ECOMM           ),  /* 70      Communication error on send */
-    DEFINE_POSIX_ERROR( EPROTO                ,EPROTO          ),  /* 71      Protocol error */
-    DEFINE_POSIX_ERROR( EMULTIHOP             ,EMULTIHOP       ),  /* 72      Multihop attempted */
-    DEFINE_POSIX_ERROR( EDOTDOT               ,EDOTDOT         ),  /* 73      RFS specific error */
-    DEFINE_POSIX_ERROR( EBADMSG               ,EBADMSG         ),  /* 74      Not a data message */
-    DEFINE_POSIX_ERROR( EOVERFLOW             ,EOVERFLOW       ),  /* 75      Value too large for defined data type */
-    DEFINE_POSIX_ERROR( ENOTUNIQ              ,ENOTUNIQ        ),  /* 76      Name not unique on network */
-    DEFINE_POSIX_ERROR( EBADFD                ,EBADFD          ),  /* 77      File descriptor in bad state */
-    DEFINE_POSIX_ERROR( EREMCHG               ,EREMCHG         ),  /* 78      Remote address changed */
-    DEFINE_POSIX_ERROR( ELIBACC               ,ELIBACC         ),  /* 79      Can not access a needed shared library */
-    DEFINE_POSIX_ERROR( ELIBBAD               ,ELIBBAD         ),  /* 80      Accessing a corrupted shared library */
-    DEFINE_POSIX_ERROR( ELIBSCN               ,ELIBSCN         ),  /* 81      .lib section in a.out corrupted */
-    DEFINE_POSIX_ERROR( ELIBMAX               ,ELIBMAX         ),  /* 82      Attempting to link in too many shared libraries */
-    DEFINE_POSIX_ERROR( ELIBEXEC              ,ELIBEXEC        ),  /* 83      Cannot exec a shared library directly */
-    DEFINE_POSIX_ERROR( EILSEQ                ,EILSEQ          ),  /* 84      Illegal byte sequence */
-    DEFINE_POSIX_ERROR( ERESTART              ,ERESTART        ),  /* 85      Interrupted system call should be restarted */
-    DEFINE_POSIX_ERROR( ESTRPIPE              ,ESTRPIPE        ),  /* 86      Streams pipe error */
-    DEFINE_POSIX_ERROR( EUSERS                ,EUSERS          ),  /* 87      Too many users */
-    DEFINE_POSIX_ERROR( ENOTSOCK              ,ENOTSOCK        ),  /* 88      Socket operation on non-socket */
-    DEFINE_POSIX_ERROR( EDESTADDRREQ          ,EDESTADDRREQ    ),  /* 89      Destination address required */
-    DEFINE_POSIX_ERROR( EMSGSIZE              ,EMSGSIZE        ),  /* 90      Message too long */
-    DEFINE_POSIX_ERROR( EPROTOTYPE            ,EPROTOTYPE      ),  /* 91      Protocol wrong type for socket */
-    DEFINE_POSIX_ERROR( ENOPROTOOPT           ,ENOPROTOOPT     ),  /* 92      Protocol not available */
-    DEFINE_POSIX_ERROR( EPROTONOSUPPORT       ,EPROTONOSUPPORT ),  /* 93      Protocol not supported */
-    DEFINE_POSIX_ERROR( ESOCKTNOSUPPORT       ,ESOCKTNOSUPPORT ),  /* 94      Socket type not supported */
-    DEFINE_POSIX_ERROR( EOPNOTSUPP            ,EOPNOTSUPP      ),  /* 95      Operation not supported on transport endpoint */
-    DEFINE_POSIX_ERROR( EPFNOSUPPORT          ,EPFNOSUPPORT    ),  /* 96      Protocol family not supported */
-    DEFINE_POSIX_ERROR( EAFNOSUPPORT          ,EAFNOSUPPORT    ),  /* 97      Address family not supported by protocol */
-    DEFINE_POSIX_ERROR( EADDRINUSE            ,EADDRINUSE      ),  /* 98      Address already in use */
-    DEFINE_POSIX_ERROR( EADDRNOTAVAIL         ,EADDRNOTAVAIL   ),  /* 99      Cannot assign requested address */
-    DEFINE_POSIX_ERROR( ENETDOWN              ,ENETDOWN        ),  /* 100     Network is down */
-    DEFINE_POSIX_ERROR( ENETUNREACH           ,ENETUNREACH     ),  /* 101     Network is unreachable */
-    DEFINE_POSIX_ERROR( ENETRESET             ,ENETRESET       ),  /* 102     Network dropped connection because of reset */
-    DEFINE_POSIX_ERROR( ECONNABORTED          ,ECONNABORTED    ),  /* 103     Software caused connection abort */
-    DEFINE_POSIX_ERROR( ECONNRESET            ,ECONNRESET      ),  /* 104     Connection reset by peer */
-    DEFINE_POSIX_ERROR( ENOBUFS               ,ENOBUFS         ),  /* 105     No buffer space available */
-    DEFINE_POSIX_ERROR( EISCONN               ,EISCONN         ),  /* 106     Transport endpoint is already connected */
-    DEFINE_POSIX_ERROR( ENOTCONN              ,ENOTCONN        ),  /* 107     Transport endpoint is not connected */
-    DEFINE_POSIX_ERROR( ESHUTDOWN             ,ESHUTDOWN       ),  /* 108     Cannot send after transport endpoint shutdown */
-    DEFINE_POSIX_ERROR( ETOOMANYREFS          ,ETOOMANYREFS    ),  /* 109     Too many references: cannot splice */
-    DEFINE_POSIX_ERROR( ETIMEDOUT             ,ETIMEDOUT       ),  /* 110     Connection timed out */
-    DEFINE_POSIX_ERROR( ECONNREFUSED          ,ECONNREFUSED    ),  /* 111     Connection refused */
-    DEFINE_POSIX_ERROR( EHOSTDOWN             ,EHOSTDOWN       ),  /* 112     Host is down */
-    DEFINE_POSIX_ERROR( EHOSTUNREACH          ,EHOSTUNREACH    ),  /* 113     No route to host */
-    DEFINE_POSIX_ERROR( EALREADY              ,EALREADY        ),  /* 114     Operation already in progress */
-    DEFINE_POSIX_ERROR( EINPROGRESS           ,EINPROGRESS     ),  /* 115     Operation now in progress */
-    DEFINE_POSIX_ERROR( ESTALE                ,ESTALE          ),  /* 116     Stale NFS file handle */
-    DEFINE_POSIX_ERROR( EUCLEAN               ,EUCLEAN         ),  /* 117     Structure needs cleaning */
-    DEFINE_POSIX_ERROR( ENOTNAM               ,ENOTNAM         ),  /* 118     Not a XENIX named type file */
-    DEFINE_POSIX_ERROR( ENAVAIL               ,ENAVAIL         ),  /* 119     No XENIX semaphores available */
-    DEFINE_POSIX_ERROR( EISNAM                ,EISNAM          ),  /* 120     Is a named type file */
-    DEFINE_POSIX_ERROR( EREMOTEIO             ,EREMOTEIO       ),  /* 121     Remote I/O error */
-    DEFINE_POSIX_ERROR( EDQUOT                ,EDQUOT          ),  /* 122     Quota exceeded */
-    DEFINE_POSIX_ERROR( ENOMEDIUM             ,ENOMEDIUM       ),  /* 123     No medium found */
-    DEFINE_POSIX_ERROR( EMEDIUMTYPE           ,EMEDIUMTYPE     ),  /* 124     Wrong medium type */
-    DEFINE_POSIX_ERROR( ECANCELED             ,ECANCELED       ),  /* 125     Operation Canceled */
-    DEFINE_POSIX_ERROR( ENOKEY                ,ENOKEY          ),  /* 126     Required key not available */
-    DEFINE_POSIX_ERROR( EKEYEXPIRED           ,EKEYEXPIRED     ),  /* 127     Key has expired */
-    DEFINE_POSIX_ERROR( EKEYREVOKED           ,EKEYREVOKED     ),  /* 128     Key has been revoked */
-    DEFINE_POSIX_ERROR( EKEYREJECTED          ,EKEYREJECTED    ),  /* 129     Key was rejected by service */
-    DEFINE_POSIX_ERROR( EOWNERDEAD            ,EOWNERDEAD      ),  /* 130     Owner died */
-    DEFINE_POSIX_ERROR( ENOTRECOVERABLE       ,ENOTRECOVERABLE ),  /* 131     State not recoverable */
+    MBED_DEFINE_POSIX_ERROR( EPERM                 ,EPERM           ),  /* 1       Operation not permitted */
+    MBED_DEFINE_POSIX_ERROR( ENOENT                ,ENOENT          ),  /* 2       No such file or directory */
+    MBED_DEFINE_POSIX_ERROR( ESRCH                 ,ESRCH           ),  /* 3       No such process */
+    MBED_DEFINE_POSIX_ERROR( EINTR                 ,EINTR           ),  /* 4       Interrupted system call */
+    MBED_DEFINE_POSIX_ERROR( EIO                   ,EIO             ),  /* 5       I/O error */
+    MBED_DEFINE_POSIX_ERROR( ENXIO                 ,ENXIO           ),  /* 6       No such device or address */
+    MBED_DEFINE_POSIX_ERROR( E2BIG                 ,E2BIG           ),  /* 7       Argument list too long */
+    MBED_DEFINE_POSIX_ERROR( ENOEXEC               ,ENOEXEC         ),  /* 8       Exec format error */
+    MBED_DEFINE_POSIX_ERROR( EBADF                 ,EBADF           ),  /* 9       Bad file number */
+    MBED_DEFINE_POSIX_ERROR( ECHILD                ,ECHILD          ),  /* 10      No child processes */
+    MBED_DEFINE_POSIX_ERROR( EAGAIN                ,EAGAIN          ),  /* 11      Try again */
+    MBED_DEFINE_POSIX_ERROR( ENOMEM                ,ENOMEM          ),  /* 12      Out of memory */
+    MBED_DEFINE_POSIX_ERROR( EACCES                ,EACCES          ),  /* 13      Permission denied */
+    MBED_DEFINE_POSIX_ERROR( EFAULT                ,EFAULT          ),  /* 14      Bad address */
+    MBED_DEFINE_POSIX_ERROR( ENOTBLK               ,ENOTBLK         ),  /* 15      Block device required */
+    MBED_DEFINE_POSIX_ERROR( EBUSY                 ,EBUSY           ),  /* 16      Device or resource busy */
+    MBED_DEFINE_POSIX_ERROR( EEXIST                ,EEXIST          ),  /* 17      File exists */
+    MBED_DEFINE_POSIX_ERROR( EXDEV                 ,EXDEV           ),  /* 18      Cross-device link */
+    MBED_DEFINE_POSIX_ERROR( ENODEV                ,ENODEV          ),  /* 19      No such device */
+    MBED_DEFINE_POSIX_ERROR( ENOTDIR               ,ENOTDIR         ),  /* 20      Not a directory */
+    MBED_DEFINE_POSIX_ERROR( EISDIR                ,EISDIR          ),  /* 21      Is a directory */
+    MBED_DEFINE_POSIX_ERROR( EINVAL                ,EINVAL          ),  /* 22      Invalid argument */
+    MBED_DEFINE_POSIX_ERROR( ENFILE                ,ENFILE          ),  /* 23      File table overflow */
+    MBED_DEFINE_POSIX_ERROR( EMFILE                ,EMFILE          ),  /* 24      Too many open files */
+    MBED_DEFINE_POSIX_ERROR( ENOTTY                ,ENOTTY          ),  /* 25      Not a typewriter */
+    MBED_DEFINE_POSIX_ERROR( ETXTBSY               ,ETXTBSY         ),  /* 26      Text file busy */
+    MBED_DEFINE_POSIX_ERROR( EFBIG                 ,EFBIG           ),  /* 27      File too large */
+    MBED_DEFINE_POSIX_ERROR( ENOSPC                ,ENOSPC          ),  /* 28      No space left on device */
+    MBED_DEFINE_POSIX_ERROR( ESPIPE                ,ESPIPE          ),  /* 29      Illegal seek */
+    MBED_DEFINE_POSIX_ERROR( EROFS                 ,EROFS           ),  /* 30      Read-only file system */
+    MBED_DEFINE_POSIX_ERROR( EMLINK                ,EMLINK          ),  /* 31      Too many links */
+    MBED_DEFINE_POSIX_ERROR( EPIPE                 ,EPIPE           ),  /* 32      Broken pipe */
+    MBED_DEFINE_POSIX_ERROR( EDOM                  ,EDOM            ),  /* 33      Math argument out of domain of func */
+    MBED_DEFINE_POSIX_ERROR( ERANGE                ,ERANGE          ),  /* 34      Math result not representable */
+    MBED_DEFINE_POSIX_ERROR( EDEADLK               ,EDEADLK         ),  /* 35      Resource deadlock would occur */
+    MBED_DEFINE_POSIX_ERROR( ENAMETOOLONG          ,ENAMETOOLONG    ),  /* 36      File name too long */
+    MBED_DEFINE_POSIX_ERROR( ENOLCK                ,ENOLCK          ),  /* 37      No record locks available */
+    MBED_DEFINE_POSIX_ERROR( ENOSYS                ,ENOSYS          ),  /* 38      Function not implemented */
+    MBED_DEFINE_POSIX_ERROR( ENOTEMPTY             ,ENOTEMPTY       ),  /* 39      Directory not empty */
+    MBED_DEFINE_POSIX_ERROR( ELOOP                 ,ELOOP           ),  /* 40      Too many symbolic links encountered */
+    MBED_DEFINE_POSIX_ERROR( EWOULDBLOCK           ,EAGAIN          ),  /* EAGAIN  Operation would block */
+    MBED_DEFINE_POSIX_ERROR( ENOMSG                ,ENOMSG          ),  /* 42      No message of desired type */
+    MBED_DEFINE_POSIX_ERROR( EIDRM                 ,EIDRM           ),  /* 43      Identifier removed */
+    MBED_DEFINE_POSIX_ERROR( ECHRNG                ,ECHRNG          ),  /* 44      Channel number out of range */
+    MBED_DEFINE_POSIX_ERROR( EL2NSYNC              ,EL2NSYNC        ),  /* 45      Level 2 not synchronized */
+    MBED_DEFINE_POSIX_ERROR( EL3HLT                ,EL3HLT          ),  /* 46      Level 3 halted */
+    MBED_DEFINE_POSIX_ERROR( EL3RST                ,EL3RST          ),  /* 47      Level 3 reset */
+    MBED_DEFINE_POSIX_ERROR( ELNRNG                ,ELNRNG          ),  /* 48      Link number out of range */
+    MBED_DEFINE_POSIX_ERROR( EUNATCH               ,EUNATCH         ),  /* 49      Protocol driver not attached */
+    MBED_DEFINE_POSIX_ERROR( ENOCSI                ,ENOCSI          ),  /* 50      No CSI structure available */
+    MBED_DEFINE_POSIX_ERROR( EL2HLT                ,EL2HLT          ),  /* 51      Level 2 halted */
+    MBED_DEFINE_POSIX_ERROR( EBADE                 ,EBADE           ),  /* 52      Invalid exchange */
+    MBED_DEFINE_POSIX_ERROR( EBADR                 ,EBADR           ),  /* 53      Invalid request descriptor */
+    MBED_DEFINE_POSIX_ERROR( EXFULL                ,EXFULL          ),  /* 54      Exchange full */
+    MBED_DEFINE_POSIX_ERROR( ENOANO                ,ENOANO          ),  /* 55      No anode */
+    MBED_DEFINE_POSIX_ERROR( EBADRQC               ,EBADRQC         ),  /* 56      Invalid request code */
+    MBED_DEFINE_POSIX_ERROR( EBADSLT               ,EBADSLT         ),  /* 57      Invalid slot */
+    MBED_DEFINE_POSIX_ERROR( EDEADLOCK             ,EDEADLK         ),  /* EDEADLK Resource deadlock would occur */
+    MBED_DEFINE_POSIX_ERROR( EBFONT                ,EBFONT          ),  /* 59      Bad font file format */
+    MBED_DEFINE_POSIX_ERROR( ENOSTR                ,ENOSTR          ),  /* 60      Device not a stream */
+    MBED_DEFINE_POSIX_ERROR( ENODATA               ,ENODATA         ),  /* 61      No data available */
+    MBED_DEFINE_POSIX_ERROR( ETIME                 ,ETIME           ),  /* 62      Timer expired */
+    MBED_DEFINE_POSIX_ERROR( ENOSR                 ,ENOSR           ),  /* 63      Out of streams resources */
+    MBED_DEFINE_POSIX_ERROR( ENONET                ,ENONET          ),  /* 64      Machine is not on the network */
+    MBED_DEFINE_POSIX_ERROR( ENOPKG                ,ENOPKG          ),  /* 65      Package not installed */
+    MBED_DEFINE_POSIX_ERROR( EREMOTE               ,EREMOTE         ),  /* 66      Object is remote */
+    MBED_DEFINE_POSIX_ERROR( ENOLINK               ,ENOLINK         ),  /* 67      Link has been severed */
+    MBED_DEFINE_POSIX_ERROR( EADV                  ,EADV            ),  /* 68      Advertise error */
+    MBED_DEFINE_POSIX_ERROR( ESRMNT                ,ESRMNT          ),  /* 69      Srmount error */
+    MBED_DEFINE_POSIX_ERROR( ECOMM                 ,ECOMM           ),  /* 70      Communication error on send */
+    MBED_DEFINE_POSIX_ERROR( EPROTO                ,EPROTO          ),  /* 71      Protocol error */
+    MBED_DEFINE_POSIX_ERROR( EMULTIHOP             ,EMULTIHOP       ),  /* 72      Multihop attempted */
+    MBED_DEFINE_POSIX_ERROR( EDOTDOT               ,EDOTDOT         ),  /* 73      RFS specific error */
+    MBED_DEFINE_POSIX_ERROR( EBADMSG               ,EBADMSG         ),  /* 74      Not a data message */
+    MBED_DEFINE_POSIX_ERROR( EOVERFLOW             ,EOVERFLOW       ),  /* 75      Value too large for defined data type */
+    MBED_DEFINE_POSIX_ERROR( ENOTUNIQ              ,ENOTUNIQ        ),  /* 76      Name not unique on network */
+    MBED_DEFINE_POSIX_ERROR( EBADFD                ,EBADFD          ),  /* 77      File descriptor in bad state */
+    MBED_DEFINE_POSIX_ERROR( EREMCHG               ,EREMCHG         ),  /* 78      Remote address changed */
+    MBED_DEFINE_POSIX_ERROR( ELIBACC               ,ELIBACC         ),  /* 79      Can not access a needed shared library */
+    MBED_DEFINE_POSIX_ERROR( ELIBBAD               ,ELIBBAD         ),  /* 80      Accessing a corrupted shared library */
+    MBED_DEFINE_POSIX_ERROR( ELIBSCN               ,ELIBSCN         ),  /* 81      .lib section in a.out corrupted */
+    MBED_DEFINE_POSIX_ERROR( ELIBMAX               ,ELIBMAX         ),  /* 82      Attempting to link in too many shared libraries */
+    MBED_DEFINE_POSIX_ERROR( ELIBEXEC              ,ELIBEXEC        ),  /* 83      Cannot exec a shared library directly */
+    MBED_DEFINE_POSIX_ERROR( EILSEQ                ,EILSEQ          ),  /* 84      Illegal byte sequence */
+    MBED_DEFINE_POSIX_ERROR( ERESTART              ,ERESTART        ),  /* 85      Interrupted system call should be restarted */
+    MBED_DEFINE_POSIX_ERROR( ESTRPIPE              ,ESTRPIPE        ),  /* 86      Streams pipe error */
+    MBED_DEFINE_POSIX_ERROR( EUSERS                ,EUSERS          ),  /* 87      Too many users */
+    MBED_DEFINE_POSIX_ERROR( ENOTSOCK              ,ENOTSOCK        ),  /* 88      Socket operation on non-socket */
+    MBED_DEFINE_POSIX_ERROR( EDESTADDRREQ          ,EDESTADDRREQ    ),  /* 89      Destination address required */
+    MBED_DEFINE_POSIX_ERROR( EMSGSIZE              ,EMSGSIZE        ),  /* 90      Message too long */
+    MBED_DEFINE_POSIX_ERROR( EPROTOTYPE            ,EPROTOTYPE      ),  /* 91      Protocol wrong type for socket */
+    MBED_DEFINE_POSIX_ERROR( ENOPROTOOPT           ,ENOPROTOOPT     ),  /* 92      Protocol not available */
+    MBED_DEFINE_POSIX_ERROR( EPROTONOSUPPORT       ,EPROTONOSUPPORT ),  /* 93      Protocol not supported */
+    MBED_DEFINE_POSIX_ERROR( ESOCKTNOSUPPORT       ,ESOCKTNOSUPPORT ),  /* 94      Socket type not supported */
+    MBED_DEFINE_POSIX_ERROR( EOPNOTSUPP            ,EOPNOTSUPP      ),  /* 95      Operation not supported on transport endpoint */
+    MBED_DEFINE_POSIX_ERROR( EPFNOSUPPORT          ,EPFNOSUPPORT    ),  /* 96      Protocol family not supported */
+    MBED_DEFINE_POSIX_ERROR( EAFNOSUPPORT          ,EAFNOSUPPORT    ),  /* 97      Address family not supported by protocol */
+    MBED_DEFINE_POSIX_ERROR( EADDRINUSE            ,EADDRINUSE      ),  /* 98      Address already in use */
+    MBED_DEFINE_POSIX_ERROR( EADDRNOTAVAIL         ,EADDRNOTAVAIL   ),  /* 99      Cannot assign requested address */
+    MBED_DEFINE_POSIX_ERROR( ENETDOWN              ,ENETDOWN        ),  /* 100     Network is down */
+    MBED_DEFINE_POSIX_ERROR( ENETUNREACH           ,ENETUNREACH     ),  /* 101     Network is unreachable */
+    MBED_DEFINE_POSIX_ERROR( ENETRESET             ,ENETRESET       ),  /* 102     Network dropped connection because of reset */
+    MBED_DEFINE_POSIX_ERROR( ECONNABORTED          ,ECONNABORTED    ),  /* 103     Software caused connection abort */
+    MBED_DEFINE_POSIX_ERROR( ECONNRESET            ,ECONNRESET      ),  /* 104     Connection reset by peer */
+    MBED_DEFINE_POSIX_ERROR( ENOBUFS               ,ENOBUFS         ),  /* 105     No buffer space available */
+    MBED_DEFINE_POSIX_ERROR( EISCONN               ,EISCONN         ),  /* 106     Transport endpoint is already connected */
+    MBED_DEFINE_POSIX_ERROR( ENOTCONN              ,ENOTCONN        ),  /* 107     Transport endpoint is not connected */
+    MBED_DEFINE_POSIX_ERROR( ESHUTDOWN             ,ESHUTDOWN       ),  /* 108     Cannot send after transport endpoint shutdown */
+    MBED_DEFINE_POSIX_ERROR( ETOOMANYREFS          ,ETOOMANYREFS    ),  /* 109     Too many references: cannot splice */
+    MBED_DEFINE_POSIX_ERROR( ETIMEDOUT             ,ETIMEDOUT       ),  /* 110     Connection timed out */
+    MBED_DEFINE_POSIX_ERROR( ECONNREFUSED          ,ECONNREFUSED    ),  /* 111     Connection refused */
+    MBED_DEFINE_POSIX_ERROR( EHOSTDOWN             ,EHOSTDOWN       ),  /* 112     Host is down */
+    MBED_DEFINE_POSIX_ERROR( EHOSTUNREACH          ,EHOSTUNREACH    ),  /* 113     No route to host */
+    MBED_DEFINE_POSIX_ERROR( EALREADY              ,EALREADY        ),  /* 114     Operation already in progress */
+    MBED_DEFINE_POSIX_ERROR( EINPROGRESS           ,EINPROGRESS     ),  /* 115     Operation now in progress */
+    MBED_DEFINE_POSIX_ERROR( ESTALE                ,ESTALE          ),  /* 116     Stale NFS file handle */
+    MBED_DEFINE_POSIX_ERROR( EUCLEAN               ,EUCLEAN         ),  /* 117     Structure needs cleaning */
+    MBED_DEFINE_POSIX_ERROR( ENOTNAM               ,ENOTNAM         ),  /* 118     Not a XENIX named type file */
+    MBED_DEFINE_POSIX_ERROR( ENAVAIL               ,ENAVAIL         ),  /* 119     No XENIX semaphores available */
+    MBED_DEFINE_POSIX_ERROR( EISNAM                ,EISNAM          ),  /* 120     Is a named type file */
+    MBED_DEFINE_POSIX_ERROR( EREMOTEIO             ,EREMOTEIO       ),  /* 121     Remote I/O error */
+    MBED_DEFINE_POSIX_ERROR( EDQUOT                ,EDQUOT          ),  /* 122     Quota exceeded */
+    MBED_DEFINE_POSIX_ERROR( ENOMEDIUM             ,ENOMEDIUM       ),  /* 123     No medium found */
+    MBED_DEFINE_POSIX_ERROR( EMEDIUMTYPE           ,EMEDIUMTYPE     ),  /* 124     Wrong medium type */
+    MBED_DEFINE_POSIX_ERROR( ECANCELED             ,ECANCELED       ),  /* 125     Operation Canceled */
+    MBED_DEFINE_POSIX_ERROR( ENOKEY                ,ENOKEY          ),  /* 126     Required key not available */
+    MBED_DEFINE_POSIX_ERROR( EKEYEXPIRED           ,EKEYEXPIRED     ),  /* 127     Key has expired */
+    MBED_DEFINE_POSIX_ERROR( EKEYREVOKED           ,EKEYREVOKED     ),  /* 128     Key has been revoked */
+    MBED_DEFINE_POSIX_ERROR( EKEYREJECTED          ,EKEYREJECTED    ),  /* 129     Key was rejected by service */
+    MBED_DEFINE_POSIX_ERROR( EOWNERDEAD            ,EOWNERDEAD      ),  /* 130     Owner died */
+    MBED_DEFINE_POSIX_ERROR( ENOTRECOVERABLE       ,ENOTRECOVERABLE ),  /* 131     State not recoverable */
     
     //Below are MBED SYSTEM ERROR CODE definitions
     //MBED SYSTEM ERROR CODE definitions starts at offset MBED_SYSTEM_ERROR_BASE, see above.
     //                   Error Name                 Error Offset   Error Code
-    DEFINE_SYSTEM_ERROR( UNKNOWN                    ,0 ),          /* 256      Unknown error */
-    DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT           ,1 ),          /* 257      Invalid Argument */
-    DEFINE_SYSTEM_ERROR( INVALID_DATA_DETECTED      ,2 ),          /* 258      Invalid data detected */
-    DEFINE_SYSTEM_ERROR( INVALID_FORMAT             ,3 ),          /* 259      Invalid format */
-    DEFINE_SYSTEM_ERROR( INVALID_INDEX              ,4 ),          /* 260      Invalid Index */
-    DEFINE_SYSTEM_ERROR( INVALID_SIZE               ,5 ),          /* 261      Inavlid Size */
-    DEFINE_SYSTEM_ERROR( INVALID_OPERATION          ,6 ),          /* 262      Invalid Operation */
-    DEFINE_SYSTEM_ERROR( ITEM_NOT_FOUND             ,7 ),          /* 263      Item Not Found */
-    DEFINE_SYSTEM_ERROR( ACCESS_DENIED              ,8 ),          /* 264      Access Denied */
-    DEFINE_SYSTEM_ERROR( UNSUPPORTED                ,9 ),          /* 265      Unsupported */
-    DEFINE_SYSTEM_ERROR( BUFFER_FULL                ,10 ),         /* 266      Buffer Full */
-    DEFINE_SYSTEM_ERROR( MEDIA_FULL                 ,11 ),         /* 267      Media/Disk Full */
-    DEFINE_SYSTEM_ERROR( ALREADY_IN_USE             ,12 ),         /* 268      Already in use */
-    DEFINE_SYSTEM_ERROR( TIME_OUT                   ,13 ),         /* 269      Timeout error */
-    DEFINE_SYSTEM_ERROR( NOT_READY                  ,14 ),         /* 270      Not Ready */
-    DEFINE_SYSTEM_ERROR( FAILED_OPERATION           ,15 ),         /* 271      Requested Operation failed */
-    DEFINE_SYSTEM_ERROR( OPERATION_PROHIBITED       ,16 ),         /* 272      Operation prohibited */
-    DEFINE_SYSTEM_ERROR( OPERATION_ABORTED          ,17 ),         /* 273      Operation failed */
-    DEFINE_SYSTEM_ERROR( WRITE_PROTECTED            ,18 ),         /* 274      Attempt to write to write-protected resource */
-    DEFINE_SYSTEM_ERROR( NO_RESPONSE                ,19 ),         /* 275      No response */
-    DEFINE_SYSTEM_ERROR( SEMAPHORE_LOCK_FAILED      ,20 ),         /* 276      Sempahore lock failed */
-    DEFINE_SYSTEM_ERROR( MUTEX_LOCK_FAILED          ,21 ),         /* 277      Mutex lock failed */
-    DEFINE_SYSTEM_ERROR( SEMAPHORE_UNLOCK_FAILED    ,22 ),         /* 278      Sempahore unlock failed */
-    DEFINE_SYSTEM_ERROR( MUTEX_UNLOCK_FAILED        ,23 ),         /* 279      Mutex unlock failed */
-    DEFINE_SYSTEM_ERROR( CRC_ERROR                  ,24 ),         /* 280      CRC error or mismatch */
-    DEFINE_SYSTEM_ERROR( OPEN_FAILED                ,25 ),         /* 281      Open failed */
-    DEFINE_SYSTEM_ERROR( CLOSE_FAILED               ,26 ),         /* 282      Close failed */
-    DEFINE_SYSTEM_ERROR( READ_FAILED                ,27 ),         /* 283      Read failed */
-    DEFINE_SYSTEM_ERROR( WRITE_FAILED               ,28 ),         /* 284      Write failed */
-    DEFINE_SYSTEM_ERROR( INITIALIZATION_FAILED      ,29 ),         /* 285      Initialization failed */
-    DEFINE_SYSTEM_ERROR( BOOT_FAILURE               ,30 ),         /* 286      Boot failure */
-    DEFINE_SYSTEM_ERROR( OUT_OF_MEMORY              ,31 ),         /* 287      Out of memory */
-    DEFINE_SYSTEM_ERROR( OUT_OF_RESOURCES           ,32 ),         /* 288      Out of resources */
-    DEFINE_SYSTEM_ERROR( ALLOC_FAILED               ,33 ),         /* 289      Alloc failed */
-    DEFINE_SYSTEM_ERROR( FREE_FAILED                ,34 ),         /* 290      Free failed */
-    DEFINE_SYSTEM_ERROR( OVERFLOW                   ,35 ),         /* 291      Overflow error */
-    DEFINE_SYSTEM_ERROR( UNDERFLOW                  ,36 ),         /* 292      Underflow error */
-    DEFINE_SYSTEM_ERROR( STACK_OVERFLOW             ,37 ),         /* 293      Stack overflow error */
-    DEFINE_SYSTEM_ERROR( ISR_QUEUE_OVERFLOW         ,38 ),         /* 294      ISR queue overflow */
-    DEFINE_SYSTEM_ERROR( TIMER_QUEUE_OVERFLOW       ,39 ),         /* 295      Timer Queue overflow */
-    DEFINE_SYSTEM_ERROR( CLIB_SPACE_UNAVAILABLE     ,40 ),         /* 296      Standard library error - Space unavailable */
-    DEFINE_SYSTEM_ERROR( CLIB_EXCEPTION             ,41 ),         /* 297      Standard library error - Exception */
-    DEFINE_SYSTEM_ERROR( CLIB_MUTEX_INIT_FAILURE    ,42 ),         /* 298      Standard library error - Mutex Init failure */
-    DEFINE_SYSTEM_ERROR( CREATE_FAILED              ,43 ),         /* 299      Create failed */
-    DEFINE_SYSTEM_ERROR( DELETE_FAILED              ,44 ),         /* 300      Delete failed */
-    DEFINE_SYSTEM_ERROR( THREAD_CREATE_FAILED       ,45 ),         /* 301      Thread Create failed */
-    DEFINE_SYSTEM_ERROR( THREAD_DELETE_FAILED       ,46 ),         /* 302      Thread Delete failed */
-    DEFINE_SYSTEM_ERROR( PROHIBITED_IN_ISR_CONTEXT  ,47 ),         /* 303      Operation Prohibited in ISR context */
-    DEFINE_SYSTEM_ERROR( PINMAP_INVALID             ,48 ),         /* 304      Pinmap Invalid */
-    DEFINE_SYSTEM_ERROR( RTOS_EVENT                 ,49 ),         /* 305      Unknown Rtos Error */
-    DEFINE_SYSTEM_ERROR( RTOS_THREAD_EVENT          ,50 ),         /* 306      Rtos Thread Error */
-    DEFINE_SYSTEM_ERROR( RTOS_MUTEX_EVENT           ,51 ),         /* 307      Rtos Mutex Error */
-    DEFINE_SYSTEM_ERROR( RTOS_SEMAPHORE_EVENT       ,52 ),         /* 308      Rtos Semaphore Error */
-    DEFINE_SYSTEM_ERROR( RTOS_MEMORY_POOL_EVENT     ,53 ),         /* 309      Rtos Memory Pool Error */
-    DEFINE_SYSTEM_ERROR( RTOS_TIMER_EVENT           ,54 ),         /* 310      Rtos Timer Error */
-    DEFINE_SYSTEM_ERROR( RTOS_EVENT_FLAGS_EVENT     ,55 ),         /* 311      Rtos Event flags Error */
-    DEFINE_SYSTEM_ERROR( RTOS_MESSAGE_QUEUE_EVENT   ,56 ),         /* 312      Rtos Message queue Error */
-    DEFINE_SYSTEM_ERROR( DEVICE_BUSY                ,57 ),         /* 313      Device Busy */
-    DEFINE_SYSTEM_ERROR( CONFIG_UNSUPPORTED         ,58 ),         /* 314      Configuration not supported */
-    DEFINE_SYSTEM_ERROR( CONFIG_MISMATCH            ,59 ),         /* 315      Configuration mismatch */
-    DEFINE_SYSTEM_ERROR( ALREADY_INITIALIZED        ,60 ),         /* 316      Already initialzied */
-    DEFINE_SYSTEM_ERROR( HARDFAULT_EXCEPTION        ,61 ),         /* 317      HardFault exception */
-    DEFINE_SYSTEM_ERROR( MEMMANAGE_EXCEPTION        ,62 ),         /* 318      MemManage exception */
-    DEFINE_SYSTEM_ERROR( BUSFAULT_EXCEPTION         ,63 ),         /* 319      BusFault exception */
-    DEFINE_SYSTEM_ERROR( USAGEFAULT_EXCEPTION       ,64 ),         /* 320      UsageFault exception*/
+    MBED_DEFINE_SYSTEM_ERROR( UNKNOWN                    ,0 ),          /* 256      Unknown error */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_ARGUMENT           ,1 ),          /* 257      Invalid Argument */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_DATA_DETECTED      ,2 ),          /* 258      Invalid data detected */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_FORMAT             ,3 ),          /* 259      Invalid format */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_INDEX              ,4 ),          /* 260      Invalid Index */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_SIZE               ,5 ),          /* 261      Inavlid Size */
+    MBED_DEFINE_SYSTEM_ERROR( INVALID_OPERATION          ,6 ),          /* 262      Invalid Operation */
+    MBED_DEFINE_SYSTEM_ERROR( ITEM_NOT_FOUND             ,7 ),          /* 263      Item Not Found */
+    MBED_DEFINE_SYSTEM_ERROR( ACCESS_DENIED              ,8 ),          /* 264      Access Denied */
+    MBED_DEFINE_SYSTEM_ERROR( UNSUPPORTED                ,9 ),          /* 265      Unsupported */
+    MBED_DEFINE_SYSTEM_ERROR( BUFFER_FULL                ,10 ),         /* 266      Buffer Full */
+    MBED_DEFINE_SYSTEM_ERROR( MEDIA_FULL                 ,11 ),         /* 267      Media/Disk Full */
+    MBED_DEFINE_SYSTEM_ERROR( ALREADY_IN_USE             ,12 ),         /* 268      Already in use */
+    MBED_DEFINE_SYSTEM_ERROR( TIME_OUT                   ,13 ),         /* 269      Timeout error */
+    MBED_DEFINE_SYSTEM_ERROR( NOT_READY                  ,14 ),         /* 270      Not Ready */
+    MBED_DEFINE_SYSTEM_ERROR( FAILED_OPERATION           ,15 ),         /* 271      Requested Operation failed */
+    MBED_DEFINE_SYSTEM_ERROR( OPERATION_PROHIBITED       ,16 ),         /* 272      Operation prohibited */
+    MBED_DEFINE_SYSTEM_ERROR( OPERATION_ABORTED          ,17 ),         /* 273      Operation failed */
+    MBED_DEFINE_SYSTEM_ERROR( WRITE_PROTECTED            ,18 ),         /* 274      Attempt to write to write-protected resource */
+    MBED_DEFINE_SYSTEM_ERROR( NO_RESPONSE                ,19 ),         /* 275      No response */
+    MBED_DEFINE_SYSTEM_ERROR( SEMAPHORE_LOCK_FAILED      ,20 ),         /* 276      Sempahore lock failed */
+    MBED_DEFINE_SYSTEM_ERROR( MUTEX_LOCK_FAILED          ,21 ),         /* 277      Mutex lock failed */
+    MBED_DEFINE_SYSTEM_ERROR( SEMAPHORE_UNLOCK_FAILED    ,22 ),         /* 278      Sempahore unlock failed */
+    MBED_DEFINE_SYSTEM_ERROR( MUTEX_UNLOCK_FAILED        ,23 ),         /* 279      Mutex unlock failed */
+    MBED_DEFINE_SYSTEM_ERROR( CRC_ERROR                  ,24 ),         /* 280      CRC error or mismatch */
+    MBED_DEFINE_SYSTEM_ERROR( OPEN_FAILED                ,25 ),         /* 281      Open failed */
+    MBED_DEFINE_SYSTEM_ERROR( CLOSE_FAILED               ,26 ),         /* 282      Close failed */
+    MBED_DEFINE_SYSTEM_ERROR( READ_FAILED                ,27 ),         /* 283      Read failed */
+    MBED_DEFINE_SYSTEM_ERROR( WRITE_FAILED               ,28 ),         /* 284      Write failed */
+    MBED_DEFINE_SYSTEM_ERROR( INITIALIZATION_FAILED      ,29 ),         /* 285      Initialization failed */
+    MBED_DEFINE_SYSTEM_ERROR( BOOT_FAILURE               ,30 ),         /* 286      Boot failure */
+    MBED_DEFINE_SYSTEM_ERROR( OUT_OF_MEMORY              ,31 ),         /* 287      Out of memory */
+    MBED_DEFINE_SYSTEM_ERROR( OUT_OF_RESOURCES           ,32 ),         /* 288      Out of resources */
+    MBED_DEFINE_SYSTEM_ERROR( ALLOC_FAILED               ,33 ),         /* 289      Alloc failed */
+    MBED_DEFINE_SYSTEM_ERROR( FREE_FAILED                ,34 ),         /* 290      Free failed */
+    MBED_DEFINE_SYSTEM_ERROR( OVERFLOW                   ,35 ),         /* 291      Overflow error */
+    MBED_DEFINE_SYSTEM_ERROR( UNDERFLOW                  ,36 ),         /* 292      Underflow error */
+    MBED_DEFINE_SYSTEM_ERROR( STACK_OVERFLOW             ,37 ),         /* 293      Stack overflow error */
+    MBED_DEFINE_SYSTEM_ERROR( ISR_QUEUE_OVERFLOW         ,38 ),         /* 294      ISR queue overflow */
+    MBED_DEFINE_SYSTEM_ERROR( TIMER_QUEUE_OVERFLOW       ,39 ),         /* 295      Timer Queue overflow */
+    MBED_DEFINE_SYSTEM_ERROR( CLIB_SPACE_UNAVAILABLE     ,40 ),         /* 296      Standard library error - Space unavailable */
+    MBED_DEFINE_SYSTEM_ERROR( CLIB_EXCEPTION             ,41 ),         /* 297      Standard library error - Exception */
+    MBED_DEFINE_SYSTEM_ERROR( CLIB_MUTEX_INIT_FAILURE    ,42 ),         /* 298      Standard library error - Mutex Init failure */
+    MBED_DEFINE_SYSTEM_ERROR( CREATE_FAILED              ,43 ),         /* 299      Create failed */
+    MBED_DEFINE_SYSTEM_ERROR( DELETE_FAILED              ,44 ),         /* 300      Delete failed */
+    MBED_DEFINE_SYSTEM_ERROR( THREAD_CREATE_FAILED       ,45 ),         /* 301      Thread Create failed */
+    MBED_DEFINE_SYSTEM_ERROR( THREAD_DELETE_FAILED       ,46 ),         /* 302      Thread Delete failed */
+    MBED_DEFINE_SYSTEM_ERROR( PROHIBITED_IN_ISR_CONTEXT  ,47 ),         /* 303      Operation Prohibited in ISR context */
+    MBED_DEFINE_SYSTEM_ERROR( PINMAP_INVALID             ,48 ),         /* 304      Pinmap Invalid */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_EVENT                 ,49 ),         /* 305      Unknown Rtos Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_THREAD_EVENT          ,50 ),         /* 306      Rtos Thread Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_MUTEX_EVENT           ,51 ),         /* 307      Rtos Mutex Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_SEMAPHORE_EVENT       ,52 ),         /* 308      Rtos Semaphore Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_MEMORY_POOL_EVENT     ,53 ),         /* 309      Rtos Memory Pool Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_TIMER_EVENT           ,54 ),         /* 310      Rtos Timer Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_EVENT_FLAGS_EVENT     ,55 ),         /* 311      Rtos Event flags Error */
+    MBED_DEFINE_SYSTEM_ERROR( RTOS_MESSAGE_QUEUE_EVENT   ,56 ),         /* 312      Rtos Message queue Error */
+    MBED_DEFINE_SYSTEM_ERROR( DEVICE_BUSY                ,57 ),         /* 313      Device Busy */
+    MBED_DEFINE_SYSTEM_ERROR( CONFIG_UNSUPPORTED         ,58 ),         /* 314      Configuration not supported */
+    MBED_DEFINE_SYSTEM_ERROR( CONFIG_MISMATCH            ,59 ),         /* 315      Configuration mismatch */
+    MBED_DEFINE_SYSTEM_ERROR( ALREADY_INITIALIZED        ,60 ),         /* 316      Already initialzied */
+    MBED_DEFINE_SYSTEM_ERROR( HARDFAULT_EXCEPTION        ,61 ),         /* 317      HardFault exception */
+    MBED_DEFINE_SYSTEM_ERROR( MEMMANAGE_EXCEPTION        ,62 ),         /* 318      MemManage exception */
+    MBED_DEFINE_SYSTEM_ERROR( BUSFAULT_EXCEPTION         ,63 ),         /* 319      BusFault exception */
+    MBED_DEFINE_SYSTEM_ERROR( USAGEFAULT_EXCEPTION       ,64 ),         /* 320      UsageFault exception*/
         
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -53,11 +53,11 @@ extern "C" {
 #define MBED_ERROR_STATUS_TYPE_POS                  (29)
 #define MBED_ERROR_STATUS_TYPE_FIELD_SIZE           (2)
 
-/* MbedErrorStatus Status Encoding */
+/* mbed_error_status_t Status Encoding */
 //|31(1 bit) Always Negative|30-29(2 bits)  |28-24              | 23-16(8 bits) |  15-0(16 bits) |
 //|-1                       |TYPE           |(unused/reserved)  | MODULE TYPE   |  ERROR CODE    |
 
-#define MAKE_MBED_ERROR(type, module, error_code)   (MbedErrorStatus)                                                                   \
+#define MAKE_MBED_ERROR(type, module, error_code)   (mbed_error_status_t)                                                                   \
                                                     ((0x80000000) |                                                                     \
                                                     (MBED_ERROR_STATUS_CODE_MASK & (error_code << MBED_ERROR_STATUS_CODE_POS)) |        \
                                                     (MBED_ERROR_STATUS_MODULE_MASK & (module << MBED_ERROR_STATUS_MODULE_POS)) |        \
@@ -67,11 +67,11 @@ extern "C" {
 #define GET_MBED_ERROR_MODULE( error_status )       ((error_status & MBED_ERROR_STATUS_MODULE_MASK) >> MBED_ERROR_STATUS_MODULE_POS)    
 #define GET_MBED_ERROR_CODE( error_status )         (int)((GET_MBED_ERROR_TYPE( error_status ) == ERROR_TYPE_POSIX)?(-error_status):((error_status & MBED_ERROR_STATUS_CODE_MASK) >> MBED_ERROR_STATUS_CODE_POS))
 
-/** MbedErrorStatus description
+/** mbed_error_status_t description
  *
- * MbedErrorStatus type represents the error status values under MbedOS. MbedErrorStatus values are signed integers and always be negative.\n
+ * mbed_error_status_t type represents the error status values under MbedOS. mbed_error_status_t values are signed integers and always be negative.\n
  * Internally its encoded as below with bit-fields representing error type, module and error code:\n\n
- * MbedErrorStatus Status Encoding:\n
+ * mbed_error_status_t Status Encoding:\n
  *
  \verbatim
  | 31 Always Negative | 30-29(2 bits)  | 28-24              | 23-16(8 bits) | 15-0(16 bits) |
@@ -83,7 +83,7 @@ extern "C" {
  *   System Error Status-es - 0x80XX0100 to 0x80XX0FFF - This corresponds to System error codes range(all values are negative). Bits 23-16 will be module type(marked with XX)\n
  *   Custom Error Status-es - 0xA0XX1000 to 0xA0XXFFFF - This corresponds to Custom error codes range(all values are negative). Bits 23-16 will be module type(marked with XX)\n\n
  *
- * The ERROR CODE(values encoded into ERROR CODE bit-field in MbedErrorStatus) value range for each error type is also seperated as below:\n
+ * The ERROR CODE(values encoded into ERROR CODE bit-field in mbed_error_status_t) value range for each error type is also seperated as below:\n
  *   Posix Error Codes  - 1 to 255.\n
  *   System Error Codes - 256 to 4095.\n
  *   Custom Error Codes - 4096 to 65535.\n
@@ -93,10 +93,10 @@ extern "C" {
  *       This is to enable easy injection of Posix error codes into MbedOS error handling system without altering the actual Posix error values.\n
  *       Accordingly, Posix error codes are represented as -1 to -255 under MbedOS error status representation.
  */
-typedef int MbedErrorStatus;
+typedef int mbed_error_status_t;
 
 /**
- * Macro for defining a Posix error status. This macro is mainly used to define Posix error values in MbedErrorCode enumeration.
+ * Macro for defining a Posix error status. This macro is mainly used to define Posix error values in mbed_error_code_t enumeration.
  * @param  error_name       Name of the error without the ERROR_ prefix
  * @param  error_code       Error code value to be used, must be between 1 and 255(inclusive).
  *
@@ -106,7 +106,7 @@ typedef int MbedErrorStatus;
                      ERROR_##error_name = -(MBED_POSIX_ERROR_BASE + error_code)
 
 /**
- * Macro for defining a System error status. This macro is used to define System error values in MbedErrorCode enumeration.
+ * Macro for defining a System error status. This macro is used to define System error values in mbed_error_code_t enumeration.
  * @param  error_name       Name of the error without the ERROR_ prefix
  * @param  error_code       Error code value to be used, must be between 256 and 4096(inclusive).
  *
@@ -116,7 +116,7 @@ typedef int MbedErrorStatus;
                       ERROR_##error_name = MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, MODULE_UNKNOWN, ERROR_CODE_##error_name)
 
 /**
- * Macro for defining a Custom error status. This macro is used to define custom error values in MbedErrorCode enumeration.
+ * Macro for defining a Custom error status. This macro is used to define custom error values in mbed_error_code_t enumeration.
  * @param  error_name       Name of the error without the ERROR_ prefix
  * @param  error_code       Error code value to be used, must be between 4097 and 65535(inclusive).
  *
@@ -128,7 +128,7 @@ typedef int MbedErrorStatus;
 
 /**
  * Macro for setting a system error. This macro will log the error, prints the error report and return to the caller. Its a wrapper for calling set_error API.
- * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  *
@@ -149,7 +149,7 @@ typedef int MbedErrorStatus;
 
 /**
  * Macro for setting a fatal system error. This macro will log the error, prints the error report and halts the system. Its a wrapper for calling set_error API
- * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  * @return                  0 or ERROR_SUCCESS.
@@ -171,16 +171,16 @@ typedef int MbedErrorStatus;
 #endif         
 
 //Error Type definition
-/** MbedErrorType definition
+/** mbed_error_type_t definition
  *  @note
- *  This enumeration defines the Error types supported. The value of these enum values will be encoded into MbedErrorStatus TYPE field.\n
- *      See MbedErrorStatus description for more info.\n
+ *  This enumeration defines the Error types supported. The value of these enum values will be encoded into mbed_error_status_t TYPE field.\n
+ *      See mbed_error_status_t description for more info.\n
  *         ERROR_TYPE_SYSTEM - Used to indicate that the error status is of System defined Error type.\n
  *         ERROR_TYPE_CUSTOM - Used to indicate that the error status is of Custom defined Error type.\n 
  *         ERROR_TYPE_POSIX  - Used to indicate that the error status is of Posix error type.\n 
  *
  */
-typedef enum _MbedErrorType
+typedef enum _mbed_error_type_t
 {
     ERROR_TYPE_SYSTEM = 0,
     ERROR_TYPE_CUSTOM = 1,
@@ -188,20 +188,20 @@ typedef enum _MbedErrorType
     //Use 3 for POSIX because we are mapping -1 to -255 to POSIX error codes
     //and thus we must use 3 to match the type bits in error status representation which are from 0xFFFFFFFF to 0xFFFFFF00
     ERROR_TYPE_POSIX = 3
-} MbedErrorType;        
+} mbed_error_type_t;        
 
 //Module type/id definitions
-/** MbedModuleType definition
+/** mbed_module_type_t definition
  * @note
- * This enumeration defines the module types. The value of these enum values will be encoded into MbedErrorStatus MODULE field.\n\n
- *      See MbedErrorStatus description for more info.\n
+ * This enumeration defines the module types. The value of these enum values will be encoded into mbed_error_status_t MODULE field.\n\n
+ *      See mbed_error_status_t description for more info.\n
  *          MODULE_UNKNOWN - This module type can be used if caller of the set_error/set_warning doesn't know who is the actual originator of the error.\n
  *                       Other module values can be used to provide more info on who/where the error originated from.\n\n
  *                       For example, if I2C driver is the component originating the error you can use MODULE_DRIVER_I2C to provide more info.\n
  *                       Its used in call to MAKE_ERROR/MAKE_SYSTEM_ERROR/MAKE_CUSTOM_ERROR macros.\n
  *
  * @code
- *      Example: MbedErrorStatus i2c_driver_error = MAKE_ERROR( MODULE_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
+ *      Example: mbed_error_status_t i2c_driver_error = MAKE_ERROR( MODULE_DRIVER_I2C, ERROR_CONFIG_UNSUPPORTED );
  * @endcode
  * 
  * @note
@@ -235,7 +235,7 @@ typedef enum _MbedErrorType
     \endverbatim
  *       
  */
-typedef enum _MbedModuleType
+typedef enum _mbed_module_type
 {
     MODULE_APPLICATION = 0,
     MODULE_PLATFORM,
@@ -264,7 +264,7 @@ typedef enum _MbedModuleType
     
     MODULE_UNKNOWN = 255,
     MODULE_MAX = MODULE_UNKNOWN
-} MbedModuleType;
+} mbed_module_type_t;
 
 //Use ERROR_SUCCESS(=0) or any postive number for successful returns
 #define ERROR_SUCCESS           0
@@ -274,9 +274,9 @@ typedef enum _MbedModuleType
 #define MBED_CUSTOM_ERROR_BASE  4096
 
 //Error Code definitions
-/** MbedErrorCode definition
+/** mbed_error_code_t definition
  *
- *  MbedErrorCode enumeration defines the Error codes and Error status values for MODULE_UNKNOWN.\n
+ *  mbed_error_code_t enumeration defines the Error codes and Error status values for MODULE_UNKNOWN.\n
  *  It defines all of Posix Error Codes/Statuses and Mbed System Error Codes/Statuses.\n\n
  *
  *  @note
@@ -533,7 +533,7 @@ typedef enum _MbedModuleType
  *  For example, the below error report has an error code of \b 259. Find the error name associated with the error code and in this case its \b INVALID_FORMAT. \n
  *  Use that error name(\b INVALID_FORMAT) to search the source tree for code locations setting that specific error code. \n 
  *  If the Error module reported is not 255(which indicates unknown module), you can also use that to narrow down to the specific component reporting the error.
- *  See MbedModuleType enum above for module mapping. \n
+ *  See mbed_module_type_t enum above for module mapping. \n
  *  
  *  \verbatim
     ++ MbedOS Error Info ++
@@ -548,7 +548,7 @@ typedef enum _MbedModuleType
     \endverbatim
  */
  
-typedef enum _MbedErrorCode
+typedef enum _mbed_error_code
 {
     //Below are POSIX ERROR CODE definitions, which starts at MBED_POSIX_ERROR_BASE(=0)
     //POSIX ERROR CODE definitions starts at offset 0(MBED_POSIX_ERROR_BASE) to align them with actual Posix Error Code
@@ -763,7 +763,7 @@ typedef enum _MbedErrorCode
     /* Add More/Custom Error Codes here, See example below */
     //DEFINE_CUSTOM_ERROR( MY_CUSTOM_ERROR     , 1 ),    
     
-} MbedErrorCode;
+} mbed_error_code_t;
 
 /** mbed_error_ctx struct
  *
@@ -774,7 +774,7 @@ typedef enum _MbedErrorCode
  *
  *  @note
  *  Below are the members of mbed_error_ctx struct\n
- *      error_status              MbedErrorStatus value for this error\n
+ *      error_status              mbed_error_status_t value for this error\n
  *      error_function_address    Address where the error occurred\n
  *      thread_id                 ID of the thread which generated the error\n
  *      thread_entry_address      Entry function of the thread which generated the error\n
@@ -786,7 +786,7 @@ typedef enum _MbedErrorCode
  *      error_line_number         Line number in error_filename where the error originated\n
  */
 typedef struct _mbed_error_ctx {
-    MbedErrorStatus error_status;
+    mbed_error_status_t error_status;
     uint32_t error_address;
     uint32_t error_value;
     uint32_t thread_id;
@@ -851,46 +851,46 @@ MBED_DEPRECATED_SINCE("mbed-os-5.9", "This function has been deprecated, please 
 void error(const char* format, ...);
 
 /**
- * Call this Macro to generate a MbedErrorStatus value for a System error
- * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See MbedModuleType for module types.
- * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ * Call this Macro to generate a mbed_error_status_t value for a System error
+ * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See mbed_module_type_t for module types.
+ * @param  error_code       The mbed_error_code_t code to be used in generating the mbed_error_status_t. See mbed_error_code_t for error codes.
  *
  * @code
  * 
- * MbedErrorStatus driver_error = MAKE_SYSTEM_ERROR( MODULE_DRIVER_USB, ERROR_CODE_INITIALIZATION_FAILED )
+ * mbed_error_status_t driver_error = MAKE_SYSTEM_ERROR( MODULE_DRIVER_USB, ERROR_CODE_INITIALIZATION_FAILED )
  *
  * @endcode
- * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_SYSTEM
+ * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_SYSTEM
  *
  */
 #define MAKE_SYSTEM_ERROR(module, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_SYSTEM, module, error_code)
 
 /**
- * Call this Macro to generate a MbedErrorStatus value for a Custom error
- * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See MbedModuleType for module types.
- * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ * Call this Macro to generate a mbed_error_status_t value for a Custom error
+ * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See mbed_module_type_t for module types.
+ * @param  error_code       The mbed_error_code_t code to be used in generating the mbed_error_status_t. See mbed_error_code_t for error codes.
  *
  * @code
  * 
- * MbedErrorStatus custom_error = MAKE_CUSTOM_ERROR( MODULE_APPLICATION, 0xDEAD//16-bit custom error code )
+ * mbed_error_status_t custom_error = MAKE_CUSTOM_ERROR( MODULE_APPLICATION, 0xDEAD//16-bit custom error code )
  *
  * @endcode
- * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_CUSTOM
+ * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_CUSTOM
  *
  */
 #define MAKE_CUSTOM_ERROR(module, error_code)                   MAKE_MBED_ERROR(ERROR_TYPE_CUSTOM, module, error_code)
 
 /**
- * Call this Macro to generate a MbedErrorStatus value for a System error
- * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See MbedModuleType for module types.
- * @param  error_code       The MbedErrorCode code to be used in generating the MbedErrorStatus. See MbedErrorCode for error codes.
+ * Call this Macro to generate a mbed_error_status_t value for a System error
+ * @param  module           Module generating the error code. If its unknown, pass MODULE_UNKNOWN. See mbed_module_type_t for module types.
+ * @param  error_code       The mbed_error_code_t code to be used in generating the mbed_error_status_t. See mbed_error_code_t for error codes.
  *
  * @code
  * 
- * MbedErrorStatus new_error = MAKE_ERROR( MODULE_DRIVER_USB, ERROR_INITIALIZATION_FAILED )
+ * mbed_error_status_t new_error = MAKE_ERROR( MODULE_DRIVER_USB, ERROR_INITIALIZATION_FAILED )
  *
  * @endcode
- * @note This macro generate MbedErrorStatus-es with error type set to ERROR_TYPE_SYSTEM
+ * @note This macro generate mbed_error_status_t-es with error type set to ERROR_TYPE_SYSTEM
  *
  */
 #define MAKE_ERROR(module, error_code)                          MAKE_SYSTEM_ERROR(module, error_code)
@@ -898,18 +898,18 @@ void error(const char* format, ...);
 /**
  * Callback/Error hook function prototype. Applications needing a callback when an error is reported can use set_error_hook function
  * to register a callback/error hook function using the following prototype. When an error happens in the system error handling
- * implementation will invoke this callback with the MbedErrorStatus reported and the error context at the time of error.
- * @param  error_status     MbedErrorStatus status being reported.
+ * implementation will invoke this callback with the mbed_error_status_t reported and the error context at the time of error.
+ * @param  error_status     mbed_error_status_t status being reported.
  * @param  error_ctx        Error context structure associated with this error.
  * @return                  void
  *
  */
-typedef void (*MbedErrorHook)(const mbed_error_ctx *error_ctx);
+typedef void (*mbed_error_hook_t)(const mbed_error_ctx *error_ctx);
 
 /**
  * Call this function to set a system error/warning. This function will log the error status with the context info, prints the error report and return to caller.
  *
- * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
@@ -925,21 +925,21 @@ typedef void (*MbedErrorHook)(const mbed_error_ctx *error_ctx);
  *
  * @note See SET_WARNING/SET_ERROR macros which provides a wrapper on this API
  */
-MbedErrorStatus set_warning(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+mbed_error_status_t set_warning(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
 
 /**
  * Returns the first system error reported.
- * @return                  MbedErrorStatus code logged for the first error or ERROR_SUCCESS if no errors are logged.
+ * @return                  mbed_error_status_t code logged for the first error or ERROR_SUCCESS if no errors are logged.
  *
  */
-MbedErrorStatus get_first_error(void);
+mbed_error_status_t get_first_error(void);
 
 /**
  * Returns the most recent system error reported.
- * @return                  MbedErrorStatus code logged for the last error or ERROR_SUCCESS if no errors are logged.
+ * @return                  mbed_error_status_t code logged for the last error or ERROR_SUCCESS if no errors are logged.
  *
  */
-MbedErrorStatus get_last_error(void);
+mbed_error_status_t get_last_error(void);
 
 /**
  * Returns the number of system errors reported after boot.
@@ -951,7 +951,7 @@ int get_error_count(void);
 /**
  * Call this function to set a fatal system error and halt the system. This function will log the fatal error with the context info and prints the error report.
  * 
- * @param  error_status     MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  error_status     mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @param  error_msg        The error message to be printed out to STDIO/Serial.
  * @param  error_value      Value associated with the error status. This would depend on error code/error scenario.
  * @param  filename         Name of the source file originating the error( Most callers can pass __FILE__ here ).
@@ -967,19 +967,19 @@ int get_error_count(void);
  *
  * @note See SET_WARNING/SET_ERROR macros which provides a wrapper on this API
  */
-MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
+mbed_error_status_t set_error(mbed_error_status_t error_status, const char *error_msg, unsigned int error_value, const char *filename, int line_number);
 
 /**
  * Registers an application defined error callback with the error handling system. 
  * This function will be called with error context info whenever system handles a set_error/set_warning call
  * NOTE: This function should be implemented for re-entrancy as multiple threads may invoke set_error which may cause error hook to be called.
- * @param  custom_error_hook    MbedErrorStatus status to be set(See MbedErrorStatus enum above for available error status values).
+ * @param  custom_error_hook    mbed_error_status_t status to be set(See mbed_error_status_t enum above for available error status values).
  * @return                      0 or ERROR_SUCCESS on success.
  *                              ERROR_INVALID_ARGUMENT in case of NULL for custom_error_hook
  *
  * @code
  * 
- * MbedErrorStatus my_custom_error_hook(MbedErrorStatus error_status, const mbed_error_ctx *error_ctx) {
+ * mbed_error_status_t my_custom_error_hook(mbed_error_status_t error_status, const mbed_error_ctx *error_ctx) {
  *    //Do something with the error_status or error_ctx
  * }
  *
@@ -989,7 +989,7 @@ MbedErrorStatus set_error(MbedErrorStatus error_status, const char *error_msg, u
  * @note The erro hook function implementation should be re-entrant.
  *
  */
-MbedErrorStatus set_error_hook(MbedErrorHook custom_error_hook);
+mbed_error_status_t set_error_hook(mbed_error_hook_t custom_error_hook);
 
 /**
  * Reads the first error context information logged.
@@ -998,7 +998,7 @@ MbedErrorStatus set_error_hook(MbedErrorHook custom_error_hook);
  *                              ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
-MbedErrorStatus get_first_error_log_info(mbed_error_ctx *error_info);
+mbed_error_status_t get_first_error_log_info(mbed_error_ctx *error_info);
 
 /**
  * Reads the last error context information logged.
@@ -1007,24 +1007,24 @@ MbedErrorStatus get_first_error_log_info(mbed_error_ctx *error_info);
  *                              ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
-MbedErrorStatus get_last_error_log_info(mbed_error_ctx *error_info);
+mbed_error_status_t get_last_error_log_info(mbed_error_ctx *error_info);
 
 /**
  * Clears all the last error, error count and all entries in the error log.
  * @return                      0 or ERROR_SUCCESS on success.
  *
  */
-MbedErrorStatus clear_all_errors(void);
+mbed_error_status_t clear_all_errors(void);
 
 /**
- * Generates a MbedErrorStatus value based on passed in values for type, module and error code.
- * @param  error_type           Error type based on MbedErrorType enum.
- * @param  module               Module type based on MbedModuleType enum.
- * @param  error_code           Error codes defined by MbedErrorCode enum
+ * Generates a mbed_error_status_t value based on passed in values for type, module and error code.
+ * @param  error_type           Error type based on mbed_error_type_t enum.
+ * @param  module               Module type based on mbed_module_type_t enum.
+ * @param  error_code           Error codes defined by mbed_error_code_t enum
  * @return                      0 or ERROR_SUCCESS on success.
  *
  */
-MbedErrorStatus make_mbed_error(MbedErrorType error_type, MbedModuleType module, MbedErrorCode error_code);
+mbed_error_status_t make_mbed_error(mbed_error_type_t error_type, mbed_module_type_t module, mbed_error_code_t error_code);
 
 /**
  * Returns the current number of entries in the error log, if there has been more than max number of errors logged the number returned will be max depth of error log.
@@ -1044,7 +1044,7 @@ int get_error_log_count(void);
  *                              ERROR_INVALID_ARGUMENT in case of invalid index
  *
  */
-MbedErrorStatus get_error_log_info(int index, mbed_error_ctx *error_info);
+mbed_error_status_t get_error_log_info(int index, mbed_error_ctx *error_info);
 
 /**
  * Saves the error log information to a file
@@ -1057,7 +1057,7 @@ MbedErrorStatus get_error_log_info(int index, mbed_error_ctx *error_info);
  * @note                        Filesystem support is required in order for this function to work.
  *
  */
-MbedErrorStatus save_error_log(const char *path);
+mbed_error_status_t save_error_log(const char *path);
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_error_log.c
+++ b/platform/mbed_error_log.c
@@ -27,16 +27,6 @@
 static mbed_error_ctx mbed_error_ctx_log[MBED_CONF_ERROR_LOG_SIZE] = {0};
 static int error_log_count = -1;
 
-static void mbed_log_lock()
-{
-    core_util_critical_section_enter();
-}
-
-static void mbed_log_unlock()
-{
-    core_util_critical_section_exit(); 
-}
-
 MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx)
 {
     //Return error if error_ctx is NULL
@@ -44,10 +34,10 @@ MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx)
         return ERROR_INVALID_ARGUMENT;
     }
     
-    mbed_log_lock();
+    core_util_critical_section_enter();
     error_log_count++;
     memcpy(&mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], error_ctx, sizeof(mbed_error_ctx) );
-    mbed_log_unlock();
+    core_util_critical_section_exit(); 
     
     return ERROR_SUCCESS;
 }
@@ -59,12 +49,12 @@ MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
         return ERROR_INVALID_ARGUMENT;
     }
     
-    mbed_log_lock();
+    core_util_critical_section_enter();
     //calculate the index where we want to pick the ctx
     if(error_log_count >= MBED_CONF_ERROR_LOG_SIZE) {
         index = (error_log_count + index + 1) % MBED_CONF_ERROR_LOG_SIZE;
     }
-    mbed_log_unlock();
+    core_util_critical_section_exit(); 
     memcpy(error_ctx, &mbed_error_ctx_log[index % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
         
     return ERROR_SUCCESS;
@@ -72,10 +62,10 @@ MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
 
 mbed_error_ctx *mbed_log_get_entry(void)
 {
-    mbed_log_lock();
+    core_util_critical_section_enter();
     error_log_count++;
     mbed_error_ctx *ctx = &mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE];
-    mbed_log_unlock();
+    core_util_critical_section_exit(); 
     
     return ctx;
 }
@@ -83,11 +73,11 @@ mbed_error_ctx *mbed_log_get_entry(void)
 MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx)
 {
     if(-1 == error_log_count) {
-        return ERROR_NOT_FOUND;
+        return ERROR_ITEM_NOT_FOUND;
     }
-    mbed_log_lock();
+    core_util_critical_section_enter();
     memcpy(error_ctx, &mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
-    mbed_log_unlock();
+    core_util_critical_section_exit(); 
     
     return ERROR_SUCCESS;
 }
@@ -99,9 +89,9 @@ int mbed_log_get_error_log_count()
 
 MbedErrorStatus mbed_log_reset()
 {
-    mbed_log_lock();
+    core_util_critical_section_enter();
     error_log_count = -1;
-    mbed_log_unlock();
+    core_util_critical_section_exit(); 
     
     return ERROR_SUCCESS;
 }

--- a/platform/mbed_error_log.c
+++ b/platform/mbed_error_log.c
@@ -1,0 +1,148 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+#include <stdarg.h>
+#include "device.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_toolchain.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_interface.h"
+
+#ifndef MBED_CONF_ERROR_LOG_DISABLED
+#include "platform/mbed_error_log.h"
+
+static mbed_error_ctx mbed_error_ctx_log[MBED_CONF_ERROR_LOG_SIZE] = {0};
+static int error_log_count = -1;
+
+static void mbed_log_lock()
+{
+    core_util_critical_section_enter();
+}
+
+static void mbed_log_unlock()
+{
+    core_util_critical_section_exit(); 
+}
+
+MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx)
+{
+    //Return error if error_ctx is NULL
+    if(NULL == error_ctx) {
+        return ERROR_INVALID_ARGUMENT;
+    }
+    
+    mbed_log_lock();
+    error_log_count++;
+    memcpy(&mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], error_ctx, sizeof(mbed_error_ctx) );
+    mbed_log_unlock();
+    
+    return ERROR_SUCCESS;
+}
+
+MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
+{
+    //Return error if index is more than max log size
+    if(index >= MBED_CONF_ERROR_LOG_SIZE) {
+        return ERROR_INVALID_ARGUMENT;
+    }
+    
+    mbed_log_lock();
+    //calculate the index where we want to pick the ctx
+    if(error_log_count >= MBED_CONF_ERROR_LOG_SIZE) {
+        index = (error_log_count + index + 1) % MBED_CONF_ERROR_LOG_SIZE;
+    }
+    mbed_log_unlock();
+    memcpy(error_ctx, &mbed_error_ctx_log[index % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
+        
+    return ERROR_SUCCESS;
+}
+
+mbed_error_ctx *mbed_log_get_entry(void)
+{
+    mbed_log_lock();
+    error_log_count++;
+    mbed_error_ctx *ctx = &mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE];
+    mbed_log_unlock();
+    
+    return ctx;
+}
+
+MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx)
+{
+    if(-1 == error_log_count) {
+        return ERROR_NOT_FOUND;
+    }
+    mbed_log_lock();
+    memcpy(error_ctx, &mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
+    mbed_log_unlock();
+    
+    return ERROR_SUCCESS;
+}
+
+int mbed_log_get_error_log_count()
+{
+    return (error_log_count >= MBED_CONF_ERROR_LOG_SIZE? MBED_CONF_ERROR_LOG_SIZE:error_log_count+1);
+}
+
+MbedErrorStatus mbed_log_reset()
+{
+    mbed_log_lock();
+    error_log_count = -1;
+    mbed_log_unlock();
+    
+    return ERROR_SUCCESS;
+}
+
+#if DEVICE_LOCALFILESYSTEM
+MbedErrorStatus mbed_log_save_error_log(const char *path)
+{
+    MbedErrorStatus ret = ERROR_SUCCESS;
+    mbed_error_ctx ctx = {0};
+    int log_count = mbed_log_get_error_log_count();
+    FILE *error_log_file = NULL;
+    
+    //Open the file for saving the error log info
+    if((error_log_file = fopen( path, "w" ) ) == NULL){
+        ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OPEN_FAILED);
+        goto exit;
+    }
+
+    //first line of file will be error log count
+    if(fprintf(error_log_file, "\nError Log Count = %d\n", log_count)){
+        ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_WRITE_FAILED);
+        goto exit;
+    }
+    
+    //Update with error log info
+    while(log_count >= 0) {
+        mbed_log_get_error(log_count, &ctx);
+        //first line of file will be error log count
+        if(fprintf(error_log_file, "\n%d: Status:0x%x ThreadId:0x%x Address:0x%x File:%s+%d\n", log_count, ctx.error_status, ctx.thread_id, ctx.error_address)) {
+            ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_WRITE_FAILED);
+            goto exit;
+        }
+        log_count--;
+    }
+
+    ret = 0;
+
+exit:
+    fclose(error_log_file);
+        
+    return ret;
+}
+#endif
+#endif

--- a/platform/mbed_error_log.c
+++ b/platform/mbed_error_log.c
@@ -31,7 +31,7 @@ mbed_error_status_t mbed_log_put_error(mbed_error_ctx *error_ctx)
 {
     //Return error if error_ctx is NULL
     if(NULL == error_ctx) {
-        return ERROR_INVALID_ARGUMENT;
+        return MBED_ERROR_INVALID_ARGUMENT;
     }
     
     core_util_critical_section_enter();
@@ -39,14 +39,14 @@ mbed_error_status_t mbed_log_put_error(mbed_error_ctx *error_ctx)
     memcpy(&mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], error_ctx, sizeof(mbed_error_ctx) );
     core_util_critical_section_exit(); 
     
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 
 mbed_error_status_t mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
 {
     //Return error if index is more than max log size
     if(index >= MBED_CONF_ERROR_LOG_SIZE) {
-        return ERROR_INVALID_ARGUMENT;
+        return MBED_ERROR_INVALID_ARGUMENT;
     }
     
     core_util_critical_section_enter();
@@ -57,7 +57,7 @@ mbed_error_status_t mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
     core_util_critical_section_exit(); 
     memcpy(error_ctx, &mbed_error_ctx_log[index % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
         
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 
 mbed_error_ctx *mbed_log_get_entry(void)
@@ -73,13 +73,13 @@ mbed_error_ctx *mbed_log_get_entry(void)
 mbed_error_status_t mbed_log_get_last_error(mbed_error_ctx *error_ctx)
 {
     if(-1 == error_log_count) {
-        return ERROR_ITEM_NOT_FOUND;
+        return MBED_ERROR_ITEM_NOT_FOUND;
     }
     core_util_critical_section_enter();
     memcpy(error_ctx, &mbed_error_ctx_log[error_log_count % MBED_CONF_ERROR_LOG_SIZE], sizeof(mbed_error_ctx) );
     core_util_critical_section_exit(); 
     
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 
 int mbed_log_get_error_log_count()
@@ -93,7 +93,7 @@ mbed_error_status_t mbed_log_reset()
     error_log_count = -1;
     core_util_critical_section_exit(); 
     
-    return ERROR_SUCCESS;
+    return MBED_SUCCESS;
 }
 
 #endif

--- a/platform/mbed_error_log.c
+++ b/platform/mbed_error_log.c
@@ -106,43 +106,4 @@ MbedErrorStatus mbed_log_reset()
     return ERROR_SUCCESS;
 }
 
-#if DEVICE_LOCALFILESYSTEM
-MbedErrorStatus mbed_log_save_error_log(const char *path)
-{
-    MbedErrorStatus ret = ERROR_SUCCESS;
-    mbed_error_ctx ctx = {0};
-    int log_count = mbed_log_get_error_log_count();
-    FILE *error_log_file = NULL;
-    
-    //Open the file for saving the error log info
-    if((error_log_file = fopen( path, "w" ) ) == NULL){
-        ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OPEN_FAILED);
-        goto exit;
-    }
-
-    //first line of file will be error log count
-    if(fprintf(error_log_file, "\nError Log Count = %d\n", log_count)){
-        ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_WRITE_FAILED);
-        goto exit;
-    }
-    
-    //Update with error log info
-    while(log_count >= 0) {
-        mbed_log_get_error(log_count, &ctx);
-        //first line of file will be error log count
-        if(fprintf(error_log_file, "\n%d: Status:0x%x ThreadId:0x%x Address:0x%x File:%s+%d\n", log_count, ctx.error_status, ctx.thread_id, ctx.error_address)) {
-            ret = MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_WRITE_FAILED);
-            goto exit;
-        }
-        log_count--;
-    }
-
-    ret = 0;
-
-exit:
-    fclose(error_log_file);
-        
-    return ret;
-}
-#endif
 #endif

--- a/platform/mbed_error_log.c
+++ b/platform/mbed_error_log.c
@@ -27,7 +27,7 @@
 static mbed_error_ctx mbed_error_ctx_log[MBED_CONF_ERROR_LOG_SIZE] = {0};
 static int error_log_count = -1;
 
-MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx)
+mbed_error_status_t mbed_log_put_error(mbed_error_ctx *error_ctx)
 {
     //Return error if error_ctx is NULL
     if(NULL == error_ctx) {
@@ -42,7 +42,7 @@ MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx)
     return ERROR_SUCCESS;
 }
 
-MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
+mbed_error_status_t mbed_log_get_error(int index, mbed_error_ctx *error_ctx)
 {
     //Return error if index is more than max log size
     if(index >= MBED_CONF_ERROR_LOG_SIZE) {
@@ -70,7 +70,7 @@ mbed_error_ctx *mbed_log_get_entry(void)
     return ctx;
 }
 
-MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx)
+mbed_error_status_t mbed_log_get_last_error(mbed_error_ctx *error_ctx)
 {
     if(-1 == error_log_count) {
         return ERROR_ITEM_NOT_FOUND;
@@ -87,7 +87,7 @@ int mbed_log_get_error_log_count()
     return (error_log_count >= MBED_CONF_ERROR_LOG_SIZE? MBED_CONF_ERROR_LOG_SIZE:error_log_count+1);
 }
 
-MbedErrorStatus mbed_log_reset()
+mbed_error_status_t mbed_log_reset()
 {
     core_util_critical_section_enter();
     error_log_count = -1;

--- a/platform/mbed_error_log.h
+++ b/platform/mbed_error_log.h
@@ -31,7 +31,7 @@ extern "C" {
  * Puts/Adds an error entry into the error list
  * 
  * @param  error_ctx            pointer to the mbed_error_ctx struct with the error context
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *                              ERROR_WRITE_FAILED if writing to file failed
  *                              ERROR_INVALID_ARGUMENT if path is not valid 
  *
@@ -44,7 +44,7 @@ mbed_error_status_t mbed_log_put_error(mbed_error_ctx *error_ctx);
  * 
  * @param  index                Index of the error context to be retrieved. It starts from 0 and 0 is the oldest.
  * @param  error_ctx            pointer to the mbed_error_ctx struct where the error context will be filled, this should be allocated by the caller
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *                              ERROR_WRITE_FAILED if writing to file failed
  *                              ERROR_INVALID_ARGUMENT if path is not valid 
  *
@@ -66,7 +66,7 @@ mbed_error_ctx *mbed_log_get_entry(void);
  * Reads the last(latest) error entry from the error list
  * 
  * @param  error_ctx            pointer to the mbed_error_ctx struct where the error context will be filled, this should be allocated by the caller
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *                              ERROR_WRITE_FAILED if writing to file failed
  *                              ERROR_INVALID_ARGUMENT if path is not valid 
  *
@@ -86,7 +86,7 @@ int mbed_log_get_error_log_count(void);
 /*
  * Resets the error log by resetting the number of errors to 0 and clears all previous errors in the log
  * 
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *                              ERROR_WRITE_FAILED if writing to file failed
  *                              ERROR_INVALID_ARGUMENT if path is not valid 
  *
@@ -98,7 +98,7 @@ mbed_error_status_t mbed_log_reset(void);
  * Saves the error log information to a file
  * 
  * @param  path                 path to the file in the filesystem
- * @return                      0 or ERROR_SUCCESS on success.
+ * @return                      0 or MBED_SUCCESS on success.
  *                              ERROR_WRITE_FAILED if writing to file failed
  *                              ERROR_INVALID_ARGUMENT if path is not valid 
  *

--- a/platform/mbed_error_log.h
+++ b/platform/mbed_error_log.h
@@ -1,0 +1,44 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_ERROR_LOG_H
+#define MBED_ERROR_LOG_H
+
+#ifndef MBED_CONF_ERROR_LOG_SIZE
+    #define MBED_CONF_ERROR_LOG_SIZE  5
+#else
+    #if MBED_CONF_ERROR_LOG_SIZE == 0
+        #define MBED_CONF_ERROR_LOG_SIZE  1
+    #endif    
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx);
+MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx);
+mbed_error_ctx *mbed_log_get_entry(void);
+MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx);
+int mbed_log_get_error_log_count(void);
+MbedErrorStatus mbed_log_reset(void);
+MbedErrorStatus mbed_save_error_log(const char *path);    
+    
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+

--- a/platform/mbed_error_log.h
+++ b/platform/mbed_error_log.h
@@ -17,7 +17,7 @@
 #define MBED_ERROR_LOG_H
 
 #ifndef MBED_CONF_ERROR_LOG_SIZE
-    #define MBED_CONF_ERROR_LOG_SIZE  5
+    #define MBED_CONF_ERROR_LOG_SIZE  4
 #else
     #if MBED_CONF_ERROR_LOG_SIZE == 0
         #define MBED_CONF_ERROR_LOG_SIZE  1
@@ -27,12 +27,84 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+/*
+ * Puts/Adds an error entry into the error list
+ * 
+ * @param  error_ctx            pointer to the mbed_error_ctx struct with the error context
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ *
+ */
 MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx);
+    
+/*
+ * Reads the error entry from the error list with the specified index
+ * 
+ * @param  index                Index of the error context to be retrieved. It starts from 0 and 0 is the oldest.
+ * @param  error_ctx            pointer to the mbed_error_ctx struct where the error context will be filled, this should be allocated by the caller
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ *
+ */
 MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx);
+
+/*
+ * Gets a reference to the next error entry in the error log where in the error ctx can be filled in.
+ * Its like reserving the next error entry to fill in the error info
+ * 
+ * @return                      Returns the pointer to the next error ctx entry     
+ *
+ *
+ */
 mbed_error_ctx *mbed_log_get_entry(void);
+
+/*
+ * Reads the last(latest) error entry from the error list
+ * 
+ * @param  error_ctx            pointer to the mbed_error_ctx struct where the error context will be filled, this should be allocated by the caller
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ *
+ */
 MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx);
+
+/*
+ * Returns the number of error entries in the error list
+ * 
+ * @return                      Number of entries in the list 
+ *
+ *
+ */
 int mbed_log_get_error_log_count(void);
+
+/*
+ * Resets the error log by resetting the number of errors to 0 and clears all previous errors in the log
+ * 
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ *
+ */
 MbedErrorStatus mbed_log_reset(void);
+
+/*
+ * Saves the error log information to a file
+ * 
+ * @param  path                 path to the file in the filesystem
+ * @return                      0 or ERROR_SUCCESS on success.
+ *                              ERROR_WRITE_FAILED if writing to file failed
+ *                              ERROR_INVALID_ARGUMENT if path is not valid 
+ *
+ * @note                        Filesystem support is required in order for this function to work.
+ *
+ */
 MbedErrorStatus mbed_save_error_log(const char *path);    
     
 #ifdef __cplusplus

--- a/platform/mbed_error_log.h
+++ b/platform/mbed_error_log.h
@@ -37,7 +37,7 @@ extern "C" {
  *
  *
  */
-MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx);
+mbed_error_status_t mbed_log_put_error(mbed_error_ctx *error_ctx);
     
 /*
  * Reads the error entry from the error list with the specified index
@@ -50,7 +50,7 @@ MbedErrorStatus mbed_log_put_error(mbed_error_ctx *error_ctx);
  *
  *
  */
-MbedErrorStatus mbed_log_get_error(int index, mbed_error_ctx *error_ctx);
+mbed_error_status_t mbed_log_get_error(int index, mbed_error_ctx *error_ctx);
 
 /*
  * Gets a reference to the next error entry in the error log where in the error ctx can be filled in.
@@ -72,7 +72,7 @@ mbed_error_ctx *mbed_log_get_entry(void);
  *
  *
  */
-MbedErrorStatus mbed_log_get_last_error(mbed_error_ctx *error_ctx);
+mbed_error_status_t mbed_log_get_last_error(mbed_error_ctx *error_ctx);
 
 /*
  * Returns the number of error entries in the error list
@@ -92,7 +92,7 @@ int mbed_log_get_error_log_count(void);
  *
  *
  */
-MbedErrorStatus mbed_log_reset(void);
+mbed_error_status_t mbed_log_reset(void);
 
 /*
  * Saves the error log information to a file
@@ -105,7 +105,7 @@ MbedErrorStatus mbed_log_reset(void);
  * @note                        Filesystem support is required in order for this function to work.
  *
  */
-MbedErrorStatus mbed_save_error_log(const char *path);    
+mbed_error_status_t mbed_save_error_log(const char *path);    
     
 #ifdef __cplusplus
 }

--- a/platform/mbed_error_report.c
+++ b/platform/mbed_error_report.c
@@ -119,7 +119,7 @@ void mbed_error_print(char *fmtstr, uint32_t *values)
     while(fmtstr[i] != '\0') {
         if(fmtstr[i]=='%') {
             i++;
-            if(fmtstr[i]=='x' || fmtstr[i]=='d') {
+            if(fmtstr[i]=='x') {
                 //print the number in hex format
                 value_to_hex_str(values[vidx++],num_str);
                 for(idx=7; idx>=0; idx--) {

--- a/platform/mbed_error_report.c
+++ b/platform/mbed_error_report.c
@@ -81,6 +81,7 @@ void mbed_error_print(char *fmtstr, uint32_t *values)
         if(fmtstr[i]=='%') {
             i++;
             if(fmtstr[i]=='x') {
+                memset(num_str, '0', sizeof(num_str));
                 //print the number in hex format
                 value_to_hex_str(values[vidx++],num_str);
                 for(idx=7; idx>=0; idx--) {
@@ -88,9 +89,12 @@ void mbed_error_print(char *fmtstr, uint32_t *values)
                 }
             }
             else if(fmtstr[i]=='d') {
+                memset(num_str, '0', sizeof(num_str));
                 //print the number in dec format
                 value_to_dec_str(values[vidx++],num_str);
-                for(idx=5; idx>=0; idx--) {
+                idx=7;
+                while(num_str[idx--]=='0' && idx > 0);//Dont print zeros at front
+                for(idx++;idx>=0; idx--) {
                     serial_putc(&stdio_uart, num_str[idx]);
                 }
             }
@@ -140,9 +144,11 @@ void print_thread(osRtxThread_t *thread)
 void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg) 
 {
     int error_code = GET_MBED_ERROR_CODE(error_ctx->error_status);
+    int error_entity = GET_MBED_ERROR_ENTITY(error_ctx->error_status);
     
     mbed_error_print("\n\n++ MbedOS Error Info ++\nError Status: 0x%x", (uint32_t *)&error_ctx->error_status);
-    mbed_error_print("\nError Code: %d\nError Message: ", (uint32_t *)&error_code);
+    mbed_error_print("\nError Code: %d", (uint32_t *)&error_code);
+    mbed_error_print("\nError Entity: %d\nError Message: ", (uint32_t *)&error_entity);
     
     //Report error info based on error code, some errors require different info
     if(error_code == ERROR_CODE_HARDFAULT_EXCEPTION || 

--- a/platform/mbed_error_report.c
+++ b/platform/mbed_error_report.c
@@ -1,0 +1,187 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdlib.h>
+#include <stdarg.h>
+#include "rtx_os.h"
+#include "mbed_rtx.h"
+#include "hal/serial_api.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_error_report.h"
+
+#if DEVICE_SERIAL
+extern int stdio_uart_inited;
+extern serial_t stdio_uart;
+#endif
+
+
+/* Converts a uint32 to hex char string */
+static void value_to_hex_str(uint32_t value, char *hex_str)
+{
+    char hex_char_map[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    int i = 0;
+    
+    //Return without converting if hex_str is not provided
+    if(hex_str == NULL) return;
+        
+    for(i=7; i>=0; i--) {
+        hex_str[i] = hex_char_map[(value & (0xf << (i * 4))) >> (i * 4)];
+    }
+}
+
+/* Limited print functionality which prints the string out to 
+stdout/uart without using stdlib by directly calling serial-api 
+and also uses less resources 
+The fmtstr contains the format string for printing and for every %
+found in that it fetches a uint32 value from values buffer
+and prints it in hex format.
+*/
+void mbed_error_print(char *fmtstr, uint32_t *values)
+{
+#if DEVICE_SERIAL
+    int i = 0;
+    int idx = 0;
+    int vidx = 0;
+    char hex_str[9]={0};
+    char *str=NULL;
+    
+    /* Initializes std uart if not init-ed yet */
+    if (!stdio_uart_inited) {
+        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+    }
+        
+    while(fmtstr[i] != '\0') {
+        if(fmtstr[i]=='%') {
+            i++;
+            if(fmtstr[i]=='x') {
+                //print the number in hex format
+                value_to_hex_str(values[vidx++],hex_str);
+                for(idx=7; idx>=0; idx--) {
+                    serial_putc(&stdio_uart, hex_str[idx]);
+                }
+            }
+            else if(fmtstr[i]=='s') {
+                //print the string
+                str = (char *)((uint32_t)values[vidx++]);
+                while(*str != '\0') {
+                    serial_putc(&stdio_uart, *str);
+                    str++;
+                }
+                str = NULL;
+            } else {
+                //print the % and char without formatting and keep going
+                serial_putc(&stdio_uart, '%');
+                serial_putc(&stdio_uart, fmtstr[i]);
+            }
+        } else {
+            serial_putc(&stdio_uart, fmtstr[i]);
+        }
+        i++;
+    }
+#endif    
+}
+
+/* Prints thread info from a list */
+void print_threads_info(osRtxThread_t *threads)
+{
+    while(threads != NULL) {
+        print_thread( threads );
+        threads = threads->thread_next;
+    }
+}
+
+/* Prints info of a thread(using osRtxThread_t struct)*/
+void print_thread(osRtxThread_t *thread)
+{
+    uint32_t data[5];
+
+    data[0]=thread->state;
+    data[1]=thread->thread_addr;
+    data[2]=thread->stack_size;
+    data[3]=(uint32_t)thread->stack_mem;
+    data[4]=thread->sp;
+    mbed_error_print("\nState: 0x%x EntryFn: 0x%x Stack Size: 0x%x Mem: 0x%x SP: 0x%x", data);
+}
+
+void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg) 
+{
+    int error_code = GET_MBED_ERROR_CODE(error_ctx->error_status);
+    
+    mbed_error_print("\n\n++ MbedOS Error Info ++\nError Status: 0x%x", (uint32_t *)&error_ctx->error_status);
+    mbed_error_print("\nError Message: ", NULL);
+    
+    //Report error info based on error code, some errors require different info
+    if(error_code == ERROR_CODE_HARDFAULT_EXCEPTION || 
+       error_code == ERROR_CODE_MEMMANAGE_EXCEPTION || 
+       error_code == ERROR_CODE_BUSFAULT_EXCEPTION || 
+       error_code == ERROR_CODE_USAGEFAULT_EXCEPTION ) {
+        mbed_error_print(error_msg, NULL);
+        mbed_error_print("\nError Location: 0x%x\n", (uint32_t *)&error_ctx->error_value);
+    } else {
+        switch (error_code) {
+            //These are errors reported by kernel handled from mbed_rtx_handlers
+            case ERROR_CODE_RTOS_EVENT:
+                mbed_error_print("Kernel Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_THREAD_EVENT:
+                mbed_error_print("Thread Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_MUTEX_EVENT:
+                mbed_error_print("Mutex Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_SEMAPHORE_EVENT:
+                mbed_error_print("Semaphore Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_MEMORY_POOL_EVENT:
+                mbed_error_print("MemoryPool Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_EVENT_FLAGS_EVENT:
+                mbed_error_print("EventFlags Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_TIMER_EVENT:
+                mbed_error_print("Timer Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            case ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT:    
+                mbed_error_print("MessageQueue Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
+                break;
+            
+            default:
+                //Nothing to do here, just print the error info down
+                break;
+        }
+        mbed_error_print(error_msg, NULL);
+        mbed_error_print("\nError Location: 0x%x", (uint32_t *)&error_ctx->error_address);
+#ifdef MBED_CONF_ERROR_FILENAME_CAPTURE_ENABLED
+        if(NULL != error_ctx->error_filename) {
+            //for string, we must pass address of a ptr which has the address of the string 
+            uint32_t *file_name = (uint32_t *)&error_ctx->error_filename[0];
+            mbed_error_print("\nFile:%s", &file_name);
+            mbed_error_print("+0x%x", (uint32_t *)&error_ctx->error_line_number);
+        }
+#endif        
+        //Take advantage of the fact that the thread info in context struct is consecutively placed
+        mbed_error_print("\nError Value: 0x%x\nCurrent Thread: Id: 0x%x EntryFn: 0x%x StackSize: 0x%x StackMem: 0x%x SP: 0x%x ", 
+                            (uint32_t *)&error_ctx->error_value);
+    }
+    
+    mbed_error_print("\n-- MbedOS Error Info --", NULL);
+}

--- a/platform/mbed_error_report.c
+++ b/platform/mbed_error_report.c
@@ -41,6 +41,21 @@ static void value_to_hex_str(uint32_t value, char *hex_str)
     }
 }
 
+/* Converts a uint32 to dec char string */
+static void value_to_dec_str(uint32_t value, char *dec_str)
+{
+    char dec_char_map[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9'};
+    int i = 0;
+    
+    //Return without converting if hex_str is not provided
+    if(dec_str == NULL) return;
+        
+    while(value > 0) {
+        dec_str[i++] = dec_char_map[value % 10];
+        value = value / 10;
+    }
+}
+
 /* Limited print functionality which prints the string out to 
 stdout/uart without using stdlib by directly calling serial-api 
 and also uses less resources 
@@ -54,7 +69,7 @@ void mbed_error_print(char *fmtstr, uint32_t *values)
     int i = 0;
     int idx = 0;
     int vidx = 0;
-    char hex_str[9]={0};
+    char num_str[9]={0};
     char *str=NULL;
     
     /* Initializes std uart if not init-ed yet */
@@ -67,9 +82,16 @@ void mbed_error_print(char *fmtstr, uint32_t *values)
             i++;
             if(fmtstr[i]=='x') {
                 //print the number in hex format
-                value_to_hex_str(values[vidx++],hex_str);
+                value_to_hex_str(values[vidx++],num_str);
                 for(idx=7; idx>=0; idx--) {
-                    serial_putc(&stdio_uart, hex_str[idx]);
+                    serial_putc(&stdio_uart, num_str[idx]);
+                }
+            }
+            else if(fmtstr[i]=='d') {
+                //print the number in dec format
+                value_to_dec_str(values[vidx++],num_str);
+                for(idx=5; idx>=0; idx--) {
+                    serial_putc(&stdio_uart, num_str[idx]);
                 }
             }
             else if(fmtstr[i]=='s') {
@@ -120,7 +142,7 @@ void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg)
     int error_code = GET_MBED_ERROR_CODE(error_ctx->error_status);
     
     mbed_error_print("\n\n++ MbedOS Error Info ++\nError Status: 0x%x", (uint32_t *)&error_ctx->error_status);
-    mbed_error_print("\nError Message: ", NULL);
+    mbed_error_print("\nError Code: %d\nError Message: ", (uint32_t *)&error_code);
     
     //Report error info based on error code, some errors require different info
     if(error_code == ERROR_CODE_HARDFAULT_EXCEPTION || 

--- a/platform/mbed_error_report.c
+++ b/platform/mbed_error_report.c
@@ -188,51 +188,51 @@ void mbed_report_error(mbed_error_ctx *error_ctx, char *error_msg)
 {
     uint32_t error_vals[3] = {0};
     error_vals[0] = error_ctx->error_status;
-    error_vals[1] = GET_MBED_ERROR_CODE(error_ctx->error_status);
-    error_vals[2] = GET_MBED_ERROR_MODULE(error_ctx->error_status);
+    error_vals[1] = MBED_GET_ERROR_CODE(error_ctx->error_status);
+    error_vals[2] = MBED_GET_ERROR_MODULE(error_ctx->error_status);
     
     mbed_error_print("\n\n++ MbedOS Error Info ++\nError Status: 0x%x Code: %d Entity: %d\nError Message: ", error_vals);
     
     //Report error info based on error code, some errors require different 
     //error_vals[1] contains the error code
-    if(error_vals[1] == ERROR_CODE_HARDFAULT_EXCEPTION || 
-       error_vals[1] == ERROR_CODE_MEMMANAGE_EXCEPTION || 
-       error_vals[1] == ERROR_CODE_BUSFAULT_EXCEPTION || 
-       error_vals[1] == ERROR_CODE_USAGEFAULT_EXCEPTION ) {
+    if(error_vals[1] == MBED_ERROR_CODE_HARDFAULT_EXCEPTION || 
+       error_vals[1] == MBED_ERROR_CODE_MEMMANAGE_EXCEPTION || 
+       error_vals[1] == MBED_ERROR_CODE_BUSFAULT_EXCEPTION || 
+       error_vals[1] == MBED_ERROR_CODE_USAGEFAULT_EXCEPTION ) {
         mbed_error_print(error_msg, NULL);
         mbed_error_print("\nLocation: 0x%x\n", (uint32_t *)&error_ctx->error_value);
     } else {
         switch (error_vals[1]) {
             //These are errors reported by kernel handled from mbed_rtx_handlers
-            case ERROR_CODE_RTOS_EVENT:
+            case MBED_ERROR_CODE_RTOS_EVENT:
                 mbed_error_print("Kernel Error: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_THREAD_EVENT:
+            case MBED_ERROR_CODE_RTOS_THREAD_EVENT:
                 mbed_error_print("Thread: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_MUTEX_EVENT:
+            case MBED_ERROR_CODE_RTOS_MUTEX_EVENT:
                 mbed_error_print("Mutex: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_SEMAPHORE_EVENT:
+            case MBED_ERROR_CODE_RTOS_SEMAPHORE_EVENT:
                 mbed_error_print("Semaphore: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_MEMORY_POOL_EVENT:
+            case MBED_ERROR_CODE_RTOS_MEMORY_POOL_EVENT:
                 mbed_error_print("MemoryPool: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_EVENT_FLAGS_EVENT:
+            case MBED_ERROR_CODE_RTOS_EVENT_FLAGS_EVENT:
                 mbed_error_print("EventFlags: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_TIMER_EVENT:
+            case MBED_ERROR_CODE_RTOS_TIMER_EVENT:
                 mbed_error_print("Timer: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             
-            case ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT:    
+            case MBED_ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT:    
                 mbed_error_print("MessageQueue: 0x%x, ", (uint32_t *)&error_ctx->error_value);
                 break;
             

--- a/platform/mbed_error_report.h
+++ b/platform/mbed_error_report.h
@@ -22,8 +22,12 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+    
+#ifndef MBED_CONF_ERROR_REPORT_INTERFACE
+#define MBED_CONF_ERROR_REPORT_INTERFACE            DEVICE_SERIAL
+#endif       
 
-/* routine to report the error */
+/* Routine to report the error */
 void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg);
     
 /* Prints thread info from a list */
@@ -40,6 +44,12 @@ found in that it fetches a uint32 value from values buffer
 and prints it in hex format.
 */
 void mbed_error_print(char *fmtstr, uint32_t *values);
+    
+/*Initializes the data structures and interfaces for printing the error output*/
+void mbed_error_init(void);
+
+/*Routine which putc into serial/itm interface*/
+void mbed_error_putc(char ch);
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_error_report.h
+++ b/platform/mbed_error_report.h
@@ -29,29 +29,48 @@ extern "C" {
 
 #ifdef MBED_CONF_RTOS_PRESENT 
 #include "rtx_os.h"
-/* Prints thread info from a list */
+
+/* Prints thread info from a list
+ * @param  threads                    Pointer to the list of osRtxThread_t structs for which the thread info will be printed
+ *
+ */
 void print_threads_info(osRtxThread_t *threads);
 
-/* Prints info of a thread(using osRtxThread_t struct)*/
+/* Prints info of a thread(using osRtxThread_t struct)
+ * @param  thread                     Pointer to the osRtxThread_t struct for which the thread info will be printed
+ *
+ */
 void print_thread(osRtxThread_t *thread);
 #endif
 
-/* Routine to report the error */
+/* Routine to report the error 
+ * @param  error_ctx                   This is the error context struct containing the error info
+ * @param  error_msg                   Error message to be used when reporting the error   
+ *
+ */
 void mbed_report_error(mbed_error_ctx *error_ctx, char *error_msg);
     
 /* Limited print functionality which prints the string out to 
-stdout/uart without using stdlib by directly calling serial-api 
-and also uses less resources 
-The fmtstr contains the format string for printing and for every %
-found in that it fetches a uint32 value from values buffer
-and prints it in hex format.
-*/
+   stdout/uart without using stdlib by directly calling serial-api 
+   and also uses less resources 
+   The fmtstr contains the format string for printing and for every %
+   found in that it fetches a uint32 value from values buffer
+   and prints it in hex format.
+ * @param  fmstr                   format string to be used, currently we support %x(hex) %d(decimal) %s(string) formatters only.
+ * @param  values                  This should be a pointer to array of values used for printing corresponding to the format specifiers(%x,%d,%s)) mentioned          
+ *
+ */
 void mbed_error_print(char *fmtstr, uint32_t *values);
     
-/*Initializes the data structures and interfaces for printing the error output*/
+/* Initializes the data structures and interfaces for printing the error output
+ *
+ */
 void mbed_error_init(void);
 
-/*Routine which putc into serial/itm interface*/
+/* Routine which putc into serial/itm interface
+ * @param  ch                   character to print
+ *
+ */
 void mbed_error_putc(char ch);
 
 #ifdef __cplusplus

--- a/platform/mbed_error_report.h
+++ b/platform/mbed_error_report.h
@@ -1,0 +1,50 @@
+
+/** \addtogroup platform */
+/** @{*/
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_ERROR_REPORT_H
+#define MBED_ERROR_REPORT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* routine to report the error */
+void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg);
+    
+/* Prints thread info from a list */
+void print_threads_info(osRtxThread_t *threads);
+
+/* Prints info of a thread(using osRtxThread_t struct)*/
+void print_thread(osRtxThread_t *thread);
+
+/* Limited print functionality which prints the string out to 
+stdout/uart without using stdlib by directly calling serial-api 
+and also uses less resources 
+The fmtstr contains the format string for printing and for every %
+found in that it fetches a uint32 value from values buffer
+and prints it in hex format.
+*/
+void mbed_error_print(char *fmtstr, uint32_t *values);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+/** @}*/

--- a/platform/mbed_error_report.h
+++ b/platform/mbed_error_report.h
@@ -27,15 +27,18 @@ extern "C" {
 #define MBED_CONF_ERROR_REPORT_INTERFACE            DEVICE_SERIAL
 #endif       
 
-/* Routine to report the error */
-void mbed_report_error(const mbed_error_ctx *error_ctx, char *error_msg);
-    
+#ifdef MBED_CONF_RTOS_PRESENT 
+#include "rtx_os.h"
 /* Prints thread info from a list */
 void print_threads_info(osRtxThread_t *threads);
 
 /* Prints info of a thread(using osRtxThread_t struct)*/
 void print_thread(osRtxThread_t *thread);
+#endif
 
+/* Routine to report the error */
+void mbed_report_error(mbed_error_ctx *error_ctx, char *error_msg);
+    
 /* Limited print functionality which prints the string out to 
 stdout/uart without using stdlib by directly calling serial-api 
 and also uses less resources 

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -126,6 +126,7 @@ void remove_filehandle(FileHandle *file) {
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
+#endif
 
 /* Private FileHandle to implement backwards-compatible functionality of
  * direct HAL serial access for default stdin/stdout/stderr.
@@ -192,7 +193,6 @@ short DirectSerial::poll(short events) const {
     }
     return revents;
 }
-#endif
 
 class Sink : public FileHandle {
 public:
@@ -538,7 +538,7 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        error("Error - writing to a file in an ISR or critical section\r\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - writing to a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -646,7 +646,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        error("Error - reading from a file in an ISR or critical section\r\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - reading from a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -1053,7 +1053,7 @@ extern "C" int statvfs(const char *path, struct statvfs *buf) {
 #include "mbed_error.h"
 namespace __gnu_cxx {
     void __verbose_terminate_handler() {
-        error("Exception");
+        SET_ERROR_FATAL(MAKE_ERROR( ENTITY_PLATFORM, ERROR_CODE_CLIB_EXCEPTION),"Exception", 0);
     }
 }
 extern "C" WEAK void __cxa_pure_virtual(void);
@@ -1339,7 +1339,7 @@ extern "C" void __cxa_guard_abort(int *guard_object_p)
 
 #endif
 
-#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
+#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__))
 
 // If the memory tracing is enabled, the wrappers in mbed_alloc_wrappers.cpp
 // provide the implementation for these. Note: this needs to use the wrappers
@@ -1436,7 +1436,7 @@ void *operator new(std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        error("Operator new out of memory\r\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1445,7 +1445,7 @@ void *operator new[](std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        error("Operator new[] out of memory\r\n");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new[] out of memory\r\n", count);
     }
     return buffer;
 }

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -126,7 +126,6 @@ void remove_filehandle(FileHandle *file) {
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
-#endif
 
 /* Private FileHandle to implement backwards-compatible functionality of
  * direct HAL serial access for default stdin/stdout/stderr.
@@ -193,6 +192,7 @@ short DirectSerial::poll(short events) const {
     }
     return revents;
 }
+#endif
 
 class Sink : public FileHandle {
 public:
@@ -538,7 +538,7 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - writing to a file in an ISR or critical section\r\n", fh);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - writing to a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -646,7 +646,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - reading from a file in an ISR or critical section\r\n", fh);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - reading from a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -1053,7 +1053,7 @@ extern "C" int statvfs(const char *path, struct statvfs *buf) {
 #include "mbed_error.h"
 namespace __gnu_cxx {
     void __verbose_terminate_handler() {
-        SET_ERROR_FATAL(MAKE_ERROR( ENTITY_PLATFORM, ERROR_CODE_CLIB_EXCEPTION),"Exception", 0);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_CLIB_EXCEPTION),"Exception", 0);
     }
 }
 extern "C" WEAK void __cxa_pure_virtual(void);
@@ -1436,7 +1436,7 @@ void *operator new(std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1445,7 +1445,7 @@ void *operator new[](std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new[] out of memory\r\n", count);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new[] out of memory\r\n", count);
     }
     return buffer;
 }

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -538,7 +538,7 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - writing to a file in an ISR or critical section\r\n", fh);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - writing to a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -646,7 +646,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
 
 #if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED && defined(MBED_CONF_RTOS_PRESENT)
     if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - reading from a file in an ISR or critical section\r\n", fh);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_PROHIBITED_IN_ISR_CONTEXT), "Error - reading from a file in an ISR or critical section\r\n", fh);
     }
 #endif
 
@@ -1053,7 +1053,7 @@ extern "C" int statvfs(const char *path, struct statvfs *buf) {
 #include "mbed_error.h"
 namespace __gnu_cxx {
     void __verbose_terminate_handler() {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_CLIB_EXCEPTION),"Exception", 0);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_CLIB_EXCEPTION),"Exception", 0);
     }
 }
 extern "C" WEAK void __cxa_pure_virtual(void);
@@ -1352,7 +1352,7 @@ void *operator new(std::size_t count)
 {
     void *buffer = malloc_wrapper(count, MBED_CALLER_ADDR());
     if (NULL == buffer) {
-        error("Operator new out of memory\r\n");
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1396,7 +1396,7 @@ void *operator new(std::size_t count)
 {
     void *buffer = malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
     if (NULL == buffer) {
-        error("Operator new out of memory\r\n");
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1405,7 +1405,7 @@ void *operator new[](std::size_t count)
 {
     void *buffer = malloc_wrapper(_REENT, count, MBED_CALLER_ADDR());
     if (NULL == buffer) {
-        error("Operator new[] out of memory\r\n");
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1436,7 +1436,7 @@ void *operator new(std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Operator new out of memory\r\n", count);
     }
     return buffer;
 }
@@ -1445,7 +1445,7 @@ void *operator new[](std::size_t count)
 {
     void *buffer = malloc(count);
     if (NULL == buffer) {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Operator new[] out of memory\r\n", count);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Operator new[] out of memory\r\n", count);
     }
     return buffer;
 }

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -32,30 +32,30 @@ mbed_fault_context_t mbed_fault_context;
 //This runs in fault context and uses special functions(defined in mbed_rtx_fault_handler.c) to print the information without using C-lib support.
 __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_context_in, void *osRtxInfoIn)
 {
-    mbed_error_status_t faultStatus = ERROR_SUCCESS;
+    mbed_error_status_t faultStatus = MBED_SUCCESS;
     
     mbed_error_print("\n++ MbedOS Fault Handler ++\n\nFaultType: ",NULL);
         
     switch( fault_type ) {
       case HARD_FAULT_EXCEPTION: 
         mbed_error_print("HardFault",NULL);
-        faultStatus = ERROR_HARDFAULT_EXCEPTION;      
+        faultStatus = MBED_ERROR_HARDFAULT_EXCEPTION;      
         break;
       case MEMMANAGE_FAULT_EXCEPTION: 
         mbed_error_print("MemManageFault",NULL); 
-        faultStatus = ERROR_MEMMANAGE_EXCEPTION;
+        faultStatus = MBED_ERROR_MEMMANAGE_EXCEPTION;
         break;
       case BUS_FAULT_EXCEPTION: 
         mbed_error_print("BusFault",NULL); 
-        faultStatus = ERROR_BUSFAULT_EXCEPTION;
+        faultStatus = MBED_ERROR_BUSFAULT_EXCEPTION;
         break;
       case USAGE_FAULT_EXCEPTION: 
         mbed_error_print("UsageFault",NULL); 
-        faultStatus = ERROR_USAGEFAULT_EXCEPTION;
+        faultStatus = MBED_ERROR_USAGEFAULT_EXCEPTION;
         break;
       default: 
         mbed_error_print("Unknown Fault",NULL); 
-        faultStatus = ERROR_UNKNOWN;
+        faultStatus = MBED_ERROR_UNKNOWN;
         break;
     }
     mbed_error_print("\n\nContext:",NULL);
@@ -81,8 +81,8 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
     
     mbed_error_print("\n\n-- MbedOS Fault Handler --\n\n",NULL);
     
-    //Now call set_error, to log the error and halt the system
-    set_error( MAKE_ERROR( MODULE_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC_reg, NULL, 0 );
+    //Now call mbed_error, to log the error and halt the system
+    mbed_error( MAKE_ERROR( MODULE_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC_reg, NULL, 0 );
     
     /* In case we return, just spin here, we have already crashed */
     for (;;) { 

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -61,21 +61,21 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
     mbed_error_print("\n\nContext:",NULL);
     print_context_info();
         
-    mbed_error_print("\n\nThread Info:\nCurrent:",NULL);
+    mbed_error_print("\n\nThreads Info:\nCurrent:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.curr);
   
     mbed_error_print("\nNext:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.next);
     
-    mbed_error_print("\nWait Threads:",NULL);
+    mbed_error_print("\nWait:",NULL);
     osRtxThread_t *threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.wait_list;
     print_threads_info(threads);
     
-    mbed_error_print("\nDelay Threads:",NULL);
+    mbed_error_print("\nDelay:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.delay_list;
     print_threads_info(threads);
     
-    mbed_error_print("\nIdle Thread:",NULL);
+    mbed_error_print("\nIdle:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.idle;
     print_threads_info(threads);
     

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -32,7 +32,7 @@ mbed_fault_context_t mbed_fault_context;
 //This runs in fault context and uses special functions(defined in mbed_rtx_fault_handler.c) to print the information without using C-lib support.
 __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_context_in, void *osRtxInfoIn)
 {
-    MbedErrorStatus faultStatus = ERROR_SUCCESS;
+    mbed_error_status_t faultStatus = ERROR_SUCCESS;
     
     mbed_error_print("\n++ MbedOS Fault Handler ++\n\nFaultType: ",NULL);
         

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -15,104 +15,107 @@
  */
 
 #include "rtx_os.h"
+#include "device.h"
 #include "mbed_rtx.h"
-#include "mbed_rtx_fault_handler.h"
-#include "hal/serial_api.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_error_report.h"
 
 #ifndef MBED_FAULT_HANDLER_DISABLED
+#include "mbed_rtx_fault_handler.h"
+
+//Functions Prototypes
+void print_context_info(void);
+
 //Global for populating the context in exception handler
 mbed_fault_context_t mbed_fault_context;
-
-//Structure to capture the context
-void fault_print_init(void);
-void fault_print_str(char *fmtstr, uint32_t *values);
-void hex_to_str(uint32_t value, char *hex_star);
-void print_context_info(void);
-void print_threads_info(osRtxThread_t *);
-void print_thread(osRtxThread_t *thread);
-void print_register(char *regtag, uint32_t regval);
-
-#if DEVICE_SERIAL
-extern int stdio_uart_inited;
-extern serial_t stdio_uart;
-#endif
 
 //This is a handler function called from Fault handler to print the error information out.
 //This runs in fault context and uses special functions(defined in mbed_rtx_fault_handler.c) to print the information without using C-lib support.
 __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_context_in, void *osRtxInfoIn)
 {
-    fault_print_init();
-    fault_print_str("\n++ MbedOS Fault Handler ++\n\nFaultType: ",NULL);
+    MbedErrorStatus faultStatus = ERROR_SUCCESS;
+    
+    mbed_error_print("\n++ MbedOS Fault Handler ++\n\nFaultType: ",NULL);
         
     switch( fault_type ) {
       case HARD_FAULT_EXCEPTION: 
-        fault_print_str("HardFault",NULL); 
+        mbed_error_print("HardFault",NULL);
+        faultStatus = ERROR_HARDFAULT_EXCEPTION;      
         break;
       case MEMMANAGE_FAULT_EXCEPTION: 
-        fault_print_str("MemManageFault",NULL); 
+        mbed_error_print("MemManageFault",NULL); 
+        faultStatus = ERROR_MEMMANAGE_EXCEPTION;
         break;
       case BUS_FAULT_EXCEPTION: 
-        fault_print_str("BusFault",NULL); 
+        mbed_error_print("BusFault",NULL); 
+        faultStatus = ERROR_BUSFAULT_EXCEPTION;
         break;
       case USAGE_FAULT_EXCEPTION: 
-        fault_print_str("UsageFault",NULL); 
+        mbed_error_print("UsageFault",NULL); 
+        faultStatus = ERROR_USAGEFAULT_EXCEPTION;
         break;
       default: 
-        fault_print_str("Unknown Fault",NULL); 
+        mbed_error_print("Unknown Fault",NULL); 
+        faultStatus = ERROR_UNKNOWN;
         break;
     }
-    fault_print_str("\n\nContext:",NULL);
+    mbed_error_print("\n\nContext:",NULL);
     print_context_info();
         
-    fault_print_str("\n\nThread Info:\nCurrent:",NULL);
+    mbed_error_print("\n\nThread Info:\nCurrent:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.curr);
   
-    fault_print_str("\nNext:",NULL);
+    mbed_error_print("\nNext:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.next);
     
-    fault_print_str("\nWait Threads:",NULL);
+    mbed_error_print("\nWait Threads:",NULL);
     osRtxThread_t *threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.wait_list;
     print_threads_info(threads);
     
-    fault_print_str("\nDelay Threads:",NULL);
+    mbed_error_print("\nDelay Threads:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.delay_list;
     print_threads_info(threads);
     
-    fault_print_str("\nIdle Thread:",NULL);
+    mbed_error_print("\nIdle Thread:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.idle;
     print_threads_info(threads);
     
-    fault_print_str("\n\n-- MbedOS Fault Handler --\n\n",NULL);
-        
-    /* Just spin here, we have already crashed */
-    for (;;) {}
+    mbed_error_print("\n\n-- MbedOS Fault Handler --\n\n",NULL);
+    
+    //Now call set_error_fatal, to log the error and halt the system
+    set_error_fatal( MAKE_ERROR( ENTITY_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC, NULL, 0 );
+    
+    /* In case we return, just spin here, we have already crashed */
+    for (;;) { 
+        __WFI(); 
+    }
 }
 
-void print_context_info()
+void print_context_info(void)
 {
     //Context Regs
-    fault_print_str( "\nR0   : %" 
-                    "\nR1   : %" 
-                    "\nR2   : %" 
-                    "\nR3   : %" 
-                    "\nR4   : %" 
-                    "\nR5   : %" 
-                    "\nR6   : %" 
-                    "\nR7   : %" 
-                    "\nR8   : %" 
-                    "\nR9   : %" 
-                    "\nR10  : %" 
-                    "\nR11  : %" 
-                    "\nR12  : %" 
-                    "\nSP   : %" 
-                    "\nLR   : %" 
-                    "\nPC   : %" 
-                    "\nxPSR : %" 
-                    "\nPSP  : %" 
-                    "\nMSP  : %", (uint32_t *)&mbed_fault_context);
+    mbed_error_print("\nR0   : %x" 
+                    "\nR1   : %x" 
+                    "\nR2   : %x" 
+                    "\nR3   : %x" 
+                    "\nR4   : %x" 
+                    "\nR5   : %x" 
+                    "\nR6   : %x" 
+                    "\nR7   : %x" 
+                    "\nR8   : %x" 
+                    "\nR9   : %x" 
+                    "\nR10  : %x" 
+                    "\nR11  : %x" 
+                    "\nR12  : %x" 
+                    "\nSP   : %x" 
+                    "\nLR   : %x" 
+                    "\nPC   : %x" 
+                    "\nxPSR : %x" 
+                    "\nPSP  : %x" 
+                    "\nMSP  : %x", (uint32_t *)&mbed_fault_context);
                        
     //Capture CPUID to get core/cpu info
-    fault_print_str("\nCPUID: %",(uint32_t *)&SCB->CPUID);
+    mbed_error_print("\nCPUID: %x",(uint32_t *)&SCB->CPUID);
     
 #if !defined(TARGET_M0) && !defined(TARGET_M0P)
     //Capture fault information registers to infer the cause of exception
@@ -126,121 +129,43 @@ void print_context_info()
     FSR[4] = SCB->DFSR;
     FSR[5] = SCB->AFSR;
     FSR[6] = SCB->SHCSR;
-    fault_print_str("\nHFSR : %"
-                    "\nMMFSR: %"
-                    "\nBFSR : %"
-                    "\nUFSR : %"
-                    "\nDFSR : %"
-                    "\nAFSR : %"
-                    "\nSHCSR: %",FSR); 
+    mbed_error_print("\nHFSR : %x"
+                    "\nMMFSR: %x"
+                    "\nBFSR : %x"
+                    "\nUFSR : %x"
+                    "\nDFSR : %x"
+                    "\nAFSR : %x"
+                    "\nSHCSR: %x",FSR); 
     
     //Print MMFAR only if its valid as indicated by MMFSR
     if(FSR[1] & 0x80) {
-        fault_print_str("\nMMFAR: %",(uint32_t *)&SCB->MMFAR); 
+        mbed_error_print("\nMMFAR: %x",(uint32_t *)&SCB->MMFAR); 
     }
     //Print BFAR only if its valid as indicated by BFSR
     if(FSR[2] & 0x80) {
-        fault_print_str("\nBFAR : %",(uint32_t *)&SCB->BFAR); 
+        mbed_error_print("\nBFAR : %x",(uint32_t *)&SCB->BFAR); 
     }
 #endif
     //Print Mode
     if(mbed_fault_context.EXC_RETURN & 0x8) {
-        fault_print_str("\nMode : Thread", NULL);
+        mbed_error_print("\nMode : Thread", NULL);
         //Print Priv level in Thread mode - We capture CONTROL reg which reflects the privilege.
         //Note that the CONTROL register captured still reflects the privilege status of the 
         //thread mode eventhough we are in Handler mode by the time we capture it.
         if(mbed_fault_context.CONTROL & 0x1) {
-            fault_print_str("\nPriv : User", NULL); 
+            mbed_error_print("\nPriv : User", NULL); 
         } else {
-            fault_print_str("\nPriv : Privileged", NULL); 
+            mbed_error_print("\nPriv : Privileged", NULL); 
         }        
     } else {
-        fault_print_str("\nMode : Handler", NULL); 
-        fault_print_str("\nPriv : Privileged", NULL); 
+        mbed_error_print("\nMode : Handler", NULL); 
+        mbed_error_print("\nPriv : Privileged", NULL); 
     }
     //Print Return Stack
     if(mbed_fault_context.EXC_RETURN & 0x4) {
-        fault_print_str("\nStack: PSP", NULL); 
+        mbed_error_print("\nStack: PSP", NULL); 
     } else {
-        fault_print_str("\nStack: MSP", NULL); 
-    }
-}
-
-/* Prints thread info from a list */
-void print_threads_info(osRtxThread_t *threads)
-{
-    while(threads != NULL) {
-        print_thread( threads );
-        threads = threads->thread_next;
-    }
-}
-
-/* Prints info of a thread(using osRtxThread_t struct)*/
-void print_thread(osRtxThread_t *thread)
-{
-    uint32_t data[5];
-
-    data[0]=thread->state;
-    data[1]=thread->thread_addr;
-    data[2]=thread->stack_size;
-    data[3]=(uint32_t)thread->stack_mem;
-    data[4]=thread->sp;
-    fault_print_str("\nState: % EntryFn: % Stack Size: % Mem: % SP: %", data);
-}
-
-/* Initializes std uart for spitting the info out */
-void fault_print_init()
-{
-#if DEVICE_SERIAL
-    if (!stdio_uart_inited) {
-        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
-    }
-#endif    
-}
-
-/* Limited print functionality which prints the string out to 
-stdout/uart without using stdlib by directly calling serial-api 
-and also uses less resources 
-The fmtstr contains the format string for printing and for every %
-found in that it fetches a uint32 value from values buffer
-and prints it in hex format.
-*/
-void fault_print_str(char *fmtstr, uint32_t *values)
-{
-#if DEVICE_SERIAL
-    int i = 0;
-    int idx = 0;
-    int vidx = 0;
-    char hex_str[9]={0};
-        
-    while(fmtstr[i] != '\0') {
-        if(fmtstr[i]=='%') {
-            hex_to_str(values[vidx++],hex_str);
-            for(idx=7; idx>=0; idx--) {
-                serial_putc(&stdio_uart, hex_str[idx]);
-            }
-        } else {
-            if (fmtstr[i] == '\n') {
-                serial_putc(&stdio_uart, '\r');
-            }
-            serial_putc(&stdio_uart, fmtstr[i]);
-        }
-        i++;
-    }
-#endif    
-}
-
-/* Converts a uint32 to hex char string */
-void hex_to_str(uint32_t value, char *hex_str)
-{
-    char hex_char_map[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
-    int i = 0;
-    
-    //Return without converting if hex_str is not provided
-    if(hex_str == NULL) return;
-        
-    for(i=7; i>=0; i--) {
-        hex_str[i] = hex_char_map[(value & (0xf << (i * 4))) >> (i * 4)];
+        mbed_error_print("\nStack: MSP", NULL); 
     }
 }
 

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -82,8 +82,8 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
     
     mbed_error_print("\n\n-- MbedOS Fault Handler --\n\n",NULL);
     
-    //Now call set_error_fatal, to log the error and halt the system
-    set_error_fatal( MAKE_ERROR( ENTITY_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC, NULL, 0 );
+    //Now call set_error, to log the error and halt the system
+    set_error( MAKE_ERROR( MODULE_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC, NULL, 0 );
     
     /* In case we return, just spin here, we have already crashed */
     for (;;) { 

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -16,7 +16,6 @@
 
 #include "rtx_os.h"
 #include "device.h"
-#include "mbed_rtx.h"
 #include "platform/mbed_error.h"
 #include "platform/mbed_error_report.h"
 
@@ -83,7 +82,7 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
     mbed_error_print("\n\n-- MbedOS Fault Handler --\n\n",NULL);
     
     //Now call set_error, to log the error and halt the system
-    set_error( MAKE_ERROR( MODULE_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC, NULL, 0 );
+    set_error( MAKE_ERROR( MODULE_UNKNOWN, faultStatus ), "System encountered an unrecoverable fault excaption, halting system.", mbed_fault_context.PC_reg, NULL, 0 );
     
     /* In case we return, just spin here, we have already crashed */
     for (;;) { 

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+ 
+#ifndef MBED_RTX_FAULT_HANDLER_H
+#define MBED_RTX_FAULT_HANDLER_H 
 
 //Fault context struct
 //WARNING: DO NOT CHANGE THIS STRUCT WITHOUT MAKING CORRESPONDING CHANGES in except.S files.
@@ -52,3 +55,4 @@ typedef struct {
 //This runs in fault context and uses special functions(defined in mbed_rtx_fault_handler.c) to print the information without using C-lib support.
 __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_context_in, void *osRtxInfoIn);
 
+#endif

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.h
@@ -21,22 +21,22 @@
 //WARNING: DO NOT CHANGE THIS STRUCT WITHOUT MAKING CORRESPONDING CHANGES in except.S files.
 //Offset of these registers are used by fault handler in except.S
 typedef struct {
-  uint32_t R0;
-  uint32_t R1;
-  uint32_t R2;
-  uint32_t R3;
-  uint32_t R4;
-  uint32_t R5;
-  uint32_t R6;
-  uint32_t R7;
-  uint32_t R8;
-  uint32_t R9;
-  uint32_t R10;
-  uint32_t R11;
-  uint32_t R12;
-  uint32_t SP;
-  uint32_t LR;
-  uint32_t PC;
+  uint32_t R0_reg;
+  uint32_t R1_reg;
+  uint32_t R2_reg;
+  uint32_t R3_reg;
+  uint32_t R4_reg;
+  uint32_t R5_reg;
+  uint32_t R6_reg;
+  uint32_t R7_reg;
+  uint32_t R8_reg;
+  uint32_t R9_reg;
+  uint32_t R10_reg;
+  uint32_t R11_reg;
+  uint32_t R12_reg;
+  uint32_t SP_reg;
+  uint32_t LR_reg;
+  uint32_t PC_reg;
   uint32_t xPSR;
   uint32_t PSP;
   uint32_t MSP;

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -323,7 +323,7 @@ void mbed_start_main(void)
     _main_thread_attr.name = "main_thread";
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
-        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
+        MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
     }
 
     osKernelStart();

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -323,7 +323,7 @@ void mbed_start_main(void)
     _main_thread_attr.name = "main_thread";
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
-        error("Pre main thread not created");
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
     }
 
     osKernelStart();

--- a/rtos/TARGET_CORTEX/mbed_boot.c
+++ b/rtos/TARGET_CORTEX/mbed_boot.c
@@ -323,7 +323,7 @@ void mbed_start_main(void)
     _main_thread_attr.name = "main_thread";
     osThreadId_t result = osThreadNew((osThreadFunc_t)pre_main, NULL, &_main_thread_attr);
     if ((void *)result == NULL) {
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
+        SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_INITIALIZATION_FAILED), "Pre main thread not created", &_main_thread_attr);
     }
 
     osKernelStart();

--- a/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
+++ b/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
@@ -19,6 +19,7 @@
 #include "rtx_evr.h"
 #include "mbed_rtx.h"
 #include "mbed_error.h"
+#include "mbed_interface.h"
 #include "RTX_Config.h"
 
 #ifdef RTE_Compiler_EventRecorder
@@ -46,31 +47,27 @@ __NO_RETURN uint32_t osRtxErrorNotify (uint32_t code, void *object_id)
       case osRtxErrorStackUnderflow:
         // Stack underflow detected for thread (thread_id=object_id)
         // Note: "overflow" is printed instead of "underflow" due to end user familiarity with overflow errors
-        error("CMSIS-RTOS error: Stack overflow (status: 0x%X, task ID: 0x%X, task name: %s)\n\r",
-                code, object_id, osThreadGetName(object_id));
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_STACK_OVERFLOW), "CMSIS-RTOS error: Stack overflow", code);
         break;
       case osRtxErrorISRQueueOverflow:
         // ISR Queue overflow detected when inserting object (object_id)
-        error("CMSIS-RTOS error: ISR Queue overflow (status: 0x%X, task ID: 0x%X, object ID: 0x%X)\n\r",
-                code, tid, object_id);
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_ISR_QUEUE_OVERFLOW), "CMSIS-RTOS error: ISR Queue overflow", code);
         break;
       case osRtxErrorTimerQueueOverflow:
         // User Timer Callback Queue overflow detected for timer (timer_id=object_id)
-        error("CMSIS-RTOS error: User Timer Callback Queue overflow (status: 0x%X, task ID: 0x%X, timer ID: 0x%X)\n\r",
-                code, tid, object_id);
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_TIMER_QUEUE_OVERFLOW), "CMSIS-RTOS error: User Timer Callback Queue overflow", code);
         break;
       case osRtxErrorClibSpace:
         // Standard C/C++ library libspace not available: increase OS_THREAD_LIBSPACE_NUM
-        error("CMSIS-RTOS error: STD C/C++ library libspace not available (status: 0x%X, task ID: 0x%X)\n\r",
-                code, tid);
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_CLIB_SPACE_UNAVAILABLE), "CMSIS-RTOS error: STD C/C++ library libspace not available", code);
         break;
       case osRtxErrorClibMutex:
         // Standard C/C++ library mutex initialization failed
-        error("CMSIS-RTOS error: STD C/C++ library mutex initialization failed (status: 0x%X, task ID: 0x%X)\n\r",
-                code, tid);
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_CLIB_MUTEX_INIT_FAILURE), "CMSIS-RTOS error: STD C/C++ library mutex initialization failed", code);
         break;
       default:
-        error("CMSIS-RTOS error: Unknown (status: 0x%X, task ID: 0x%X)\n\r", code, tid);
+        //Unknown error flagged from kernel  
+        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
         break;
     }
 
@@ -102,27 +99,27 @@ static const char* error_msg(int32_t status)
 
 void EvrRtxKernelError (int32_t status)
 {
-    error("Kernel error %i: %s\r\n", status, error_msg(status));
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_EVENT), error_msg(status), status);
 }
 
 void EvrRtxThreadError (osThreadId_t thread_id, int32_t status)
 {
-    error("Thread %p error %i: %s\r\n", thread_id, status, error_msg(status));
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_THREAD_EVENT), error_msg(status), thread_id);
 }
 
 void EvrRtxTimerError (osTimerId_t timer_id, int32_t status)
 {
-    error("Timer %p error %i: %s\r\n", timer_id, status, error_msg(status));
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_TIMER_EVENT), error_msg(status), timer_id);
 }
 
 void EvrRtxEventFlagsError (osEventFlagsId_t ef_id, int32_t status)
 {
-    error("Event %p error %i: %s\r\n", ef_id, status, error_msg(status));
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_EVENT_FLAGS_EVENT), error_msg(status), ef_id);
 }
 
 void EvrRtxMutexError (osMutexId_t mutex_id, int32_t status)
 {
-    error("Mutex %p error %i: %s\r\n", mutex_id, status, error_msg(status));
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MUTEX_EVENT), error_msg(status), mutex_id);
 }
 
 void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
@@ -132,17 +129,17 @@ void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
         return;
     }
 
-    error("Semaphore %p error %i\r\n", semaphore_id, status);
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_SEMAPHORE_EVENT), error_msg(status), semaphore_id);
 }
 
 void EvrRtxMemoryPoolError (osMemoryPoolId_t mp_id, int32_t status)
 {
-    error("Memory Pool %p error %i\r\n", mp_id, status);
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MEMORY_POOL_EVENT), error_msg(status), mp_id);
 }
 
 void EvrRtxMessageQueueError (osMessageQueueId_t mq_id, int32_t status)
 {
-    error("Message Queue %p error %i\r\n", mq_id, status);
+    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT), error_msg(status), mq_id);
 }
 
 #endif

--- a/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
+++ b/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
@@ -47,27 +47,27 @@ __NO_RETURN uint32_t osRtxErrorNotify (uint32_t code, void *object_id)
       case osRtxErrorStackUnderflow:
         // Stack underflow detected for thread (thread_id=object_id)
         // Note: "overflow" is printed instead of "underflow" due to end user familiarity with overflow errors
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_STACK_OVERFLOW), "CMSIS-RTOS error: Stack overflow", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_STACK_OVERFLOW), "CMSIS-RTOS error: Stack overflow", code);
         break;
       case osRtxErrorISRQueueOverflow:
         // ISR Queue overflow detected when inserting object (object_id)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_ISR_QUEUE_OVERFLOW), "CMSIS-RTOS error: ISR Queue overflow", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_ISR_QUEUE_OVERFLOW), "CMSIS-RTOS error: ISR Queue overflow", code);
         break;
       case osRtxErrorTimerQueueOverflow:
         // User Timer Callback Queue overflow detected for timer (timer_id=object_id)
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_TIMER_QUEUE_OVERFLOW), "CMSIS-RTOS error: User Timer Callback Queue overflow", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_TIMER_QUEUE_OVERFLOW), "CMSIS-RTOS error: User Timer Callback Queue overflow", code);
         break;
       case osRtxErrorClibSpace:
         // Standard C/C++ library libspace not available: increase OS_THREAD_LIBSPACE_NUM
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_CLIB_SPACE_UNAVAILABLE), "CMSIS-RTOS error: STD C/C++ library libspace not available", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_CLIB_SPACE_UNAVAILABLE), "CMSIS-RTOS error: STD C/C++ library libspace not available", code);
         break;
       case osRtxErrorClibMutex:
         // Standard C/C++ library mutex initialization failed
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_CLIB_MUTEX_INIT_FAILURE), "CMSIS-RTOS error: STD C/C++ library mutex initialization failed", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_CLIB_MUTEX_INIT_FAILURE), "CMSIS-RTOS error: STD C/C++ library mutex initialization failed", code);
         break;
       default:
         //Unknown error flagged from kernel  
-        SET_ERROR_FATAL(MAKE_ERROR(ENTITY_KERNEL, ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
+        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
         break;
     }
 
@@ -99,27 +99,27 @@ static const char* error_msg(int32_t status)
 
 void EvrRtxKernelError (int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_EVENT), error_msg(status), status);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_EVENT), error_msg(status), status);
 }
 
 void EvrRtxThreadError (osThreadId_t thread_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_THREAD_EVENT), error_msg(status), thread_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_THREAD_EVENT), error_msg(status), thread_id);
 }
 
 void EvrRtxTimerError (osTimerId_t timer_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_TIMER_EVENT), error_msg(status), timer_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_TIMER_EVENT), error_msg(status), timer_id);
 }
 
 void EvrRtxEventFlagsError (osEventFlagsId_t ef_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_EVENT_FLAGS_EVENT), error_msg(status), ef_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_EVENT_FLAGS_EVENT), error_msg(status), ef_id);
 }
 
 void EvrRtxMutexError (osMutexId_t mutex_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MUTEX_EVENT), error_msg(status), mutex_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MUTEX_EVENT), error_msg(status), mutex_id);
 }
 
 void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
@@ -129,17 +129,17 @@ void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
         return;
     }
 
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_SEMAPHORE_EVENT), error_msg(status), semaphore_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_SEMAPHORE_EVENT), error_msg(status), semaphore_id);
 }
 
 void EvrRtxMemoryPoolError (osMemoryPoolId_t mp_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MEMORY_POOL_EVENT), error_msg(status), mp_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MEMORY_POOL_EVENT), error_msg(status), mp_id);
 }
 
 void EvrRtxMessageQueueError (osMessageQueueId_t mq_id, int32_t status)
 {
-    SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT), error_msg(status), mq_id);
+    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT), error_msg(status), mq_id);
 }
 
 #endif

--- a/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
+++ b/rtos/TARGET_CORTEX/mbed_rtx_handlers.c
@@ -47,27 +47,27 @@ __NO_RETURN uint32_t osRtxErrorNotify (uint32_t code, void *object_id)
       case osRtxErrorStackUnderflow:
         // Stack underflow detected for thread (thread_id=object_id)
         // Note: "overflow" is printed instead of "underflow" due to end user familiarity with overflow errors
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_STACK_OVERFLOW), "CMSIS-RTOS error: Stack overflow", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_STACK_OVERFLOW), "CMSIS-RTOS error: Stack overflow", code);
         break;
       case osRtxErrorISRQueueOverflow:
         // ISR Queue overflow detected when inserting object (object_id)
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_ISR_QUEUE_OVERFLOW), "CMSIS-RTOS error: ISR Queue overflow", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_ISR_QUEUE_OVERFLOW), "CMSIS-RTOS error: ISR Queue overflow", code);
         break;
       case osRtxErrorTimerQueueOverflow:
         // User Timer Callback Queue overflow detected for timer (timer_id=object_id)
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_TIMER_QUEUE_OVERFLOW), "CMSIS-RTOS error: User Timer Callback Queue overflow", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_TIMER_QUEUE_OVERFLOW), "CMSIS-RTOS error: User Timer Callback Queue overflow", code);
         break;
       case osRtxErrorClibSpace:
         // Standard C/C++ library libspace not available: increase OS_THREAD_LIBSPACE_NUM
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_CLIB_SPACE_UNAVAILABLE), "CMSIS-RTOS error: STD C/C++ library libspace not available", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_CLIB_SPACE_UNAVAILABLE), "CMSIS-RTOS error: STD C/C++ library libspace not available", code);
         break;
       case osRtxErrorClibMutex:
         // Standard C/C++ library mutex initialization failed
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_CLIB_MUTEX_INIT_FAILURE), "CMSIS-RTOS error: STD C/C++ library mutex initialization failed", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_CLIB_MUTEX_INIT_FAILURE), "CMSIS-RTOS error: STD C/C++ library mutex initialization failed", code);
         break;
       default:
         //Unknown error flagged from kernel  
-        SET_ERROR(MAKE_ERROR(MODULE_KERNEL, ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
+        MBED_ERROR(MAKE_ERROR(MODULE_KERNEL, MBED_ERROR_CODE_UNKNOWN), "CMSIS-RTOS error: Unknown", code);
         break;
     }
 
@@ -99,27 +99,27 @@ static const char* error_msg(int32_t status)
 
 void EvrRtxKernelError (int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_EVENT), error_msg(status), status);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_EVENT), error_msg(status), status);
 }
 
 void EvrRtxThreadError (osThreadId_t thread_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_THREAD_EVENT), error_msg(status), thread_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_THREAD_EVENT), error_msg(status), thread_id);
 }
 
 void EvrRtxTimerError (osTimerId_t timer_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_TIMER_EVENT), error_msg(status), timer_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_TIMER_EVENT), error_msg(status), timer_id);
 }
 
 void EvrRtxEventFlagsError (osEventFlagsId_t ef_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_EVENT_FLAGS_EVENT), error_msg(status), ef_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_EVENT_FLAGS_EVENT), error_msg(status), ef_id);
 }
 
 void EvrRtxMutexError (osMutexId_t mutex_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MUTEX_EVENT), error_msg(status), mutex_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_MUTEX_EVENT), error_msg(status), mutex_id);
 }
 
 void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
@@ -129,17 +129,17 @@ void EvrRtxSemaphoreError (osSemaphoreId_t semaphore_id, int32_t status)
         return;
     }
 
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_SEMAPHORE_EVENT), error_msg(status), semaphore_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_SEMAPHORE_EVENT), error_msg(status), semaphore_id);
 }
 
 void EvrRtxMemoryPoolError (osMemoryPoolId_t mp_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MEMORY_POOL_EVENT), error_msg(status), mp_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_MEMORY_POOL_EVENT), error_msg(status), mp_id);
 }
 
 void EvrRtxMessageQueueError (osMessageQueueId_t mq_id, int32_t status)
 {
-    SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT), error_msg(status), mq_id);
+    MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT), error_msg(status), mq_id);
 }
 
 #endif

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -78,13 +78,13 @@ void Thread::constructor(Callback<void()> task,
 
     switch (start(task)) {
         case osErrorResource:
-            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_RESOURCES), "OS ran out of threads!\n", task);
+            MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_RESOURCES), "OS ran out of threads!\n", task);
             break;
         case osErrorParameter:
-            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_ALREADY_IN_USE), "Thread already running!\n", task);
+            MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_ALREADY_IN_USE), "Thread already running!\n", task);
             break;
         case osErrorNoMemory:
-            SET_ERROR(MAKE_ERROR(MODULE_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory\n", task);
+            MBED_ERROR(MAKE_ERROR(MODULE_PLATFORM, MBED_ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory\n", task);
         default:
             break;
     }

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -43,11 +43,7 @@ extern "C" void thread_terminate_hook(osThreadId_t id)
 
 namespace rtos {
 
-#ifndef MBED_TZ_DEFAULT_ACCESS
-#define MBED_TZ_DEFAULT_ACCESS   0
-#endif
-
-void Thread::constructor(uint32_t tz_module, osPriority priority,
+void Thread::constructor(osPriority priority,
         uint32_t stack_size, unsigned char *stack_mem, const char *name) {
 
     const uintptr_t unaligned_mem = reinterpret_cast<uintptr_t>(stack_mem);
@@ -64,27 +60,21 @@ void Thread::constructor(uint32_t tz_module, osPriority priority,
     _attr.stack_size = aligned_size;
     _attr.name = name ? name : "application_unnamed_thread";
     _attr.stack_mem = reinterpret_cast<uint32_t*>(aligned_mem);
-    _attr.tz_module = tz_module;
-}
-
-void Thread::constructor(osPriority priority,
-        uint32_t stack_size, unsigned char *stack_mem, const char *name) {
-    constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
 }
 
 void Thread::constructor(Callback<void()> task,
         osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name) {
-    constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
+    constructor(priority, stack_size, stack_mem, name);
 
     switch (start(task)) {
         case osErrorResource:
-            error("OS ran out of threads!\n");
+            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_RESOURCES), "OS ran out of threads!\n", task);
             break;
         case osErrorParameter:
-            error("Thread already running!\n");
+            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_ALREADY_IN_USE), "Thread already running!\n", task);
             break;
         case osErrorNoMemory:
-            error("Error allocating the stack memory\n");
+            SET_ERROR_FATAL(MAKE_ERROR(ENTITY_PLATFORM, ERROR_CODE_OUT_OF_MEMORY), "Error allocating the stack memory\n", task);
         default:
             break;
     }


### PR DESCRIPTION
This is the implementation for Standardized error coding and handling for mbed-os.
The changes with this pull request implements standardized error code handling and error code definitions/encoding. With this, error handling is implemented as a Core-os service which captures and
logs the errors with context information. Each error code is captured with error location, error message, 
error file(this is configurable as this can cause increase in binary size), calling thread info, module generating the error etc. Relevant APIs are provided to log and retrieve errors from error logging system.
A build time flag has been provided to switch off error logging system on memory constrained platforms.  
Error reporting itself is logically separated and implemented in mbed_error_reporting.c/h. By doing this both exception handling and error handling can use the same reporting infrastructure. A sample error report is as below. Note that error status value captures error type, entity and error code. Error reporting prints these values separately as well to enable developers to search the source tree with error code.
Error handling service also provides an API to save the error log in file system if required. 

    ++ MbedOS Error Info ++
    Error Status: 0x80040103
    Error Code: 259
    Error Entity: 04
    Error Message: HAL Entity error
    Error Location: 0x000067C7
    Error Value: 0x00005566
    Current Thread: Id: 0x200024A8 EntryFn: 0x0000FB0D StackSize: 0x00001000 StackMem: 0x200014A8 SP: 0x2002FFD8
    -- MbedOS Error Info --

The implementation is tested using the Greentea tests under TESTS/mbed_platform/error_handling.
Note that exception handling and reporting testing cannot be done using Greentea and was manually tested.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

The APIs/data structures/macros are all documented using Doxygen. In addition handbook documentation will also be generated for release. 

Overall impact of this feature is ~1K(ROM) including logging. Logging can be disabled and if disabled 
the overall impact would be around 0.75K.
  
