### PR TITLE
FlashIAP: Fix problem of programming source buffer not aligned to 4

### DIFF
--- a/TESTS/mbed_drivers/flashiap/main.cpp
+++ b/TESTS/mbed_drivers/flashiap/main.cpp
@@ -22,6 +22,7 @@
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
+#include <algorithm>
 
 #include "mbed.h"
 
@@ -48,10 +49,10 @@ void flashiap_program_test()
     TEST_ASSERT_NOT_EQUAL(0, sector_size);
     TEST_ASSERT_NOT_EQUAL(0, page_size);
     TEST_ASSERT_TRUE(sector_size % page_size == 0);
-    const uint8_t test_value = 0xCE;
-    uint8_t *data = new uint8_t[page_size];
-    for (uint32_t i = 0; i < page_size; i++) {
-        data[i] = test_value;
+    uint32_t prog_size = std::max(page_size, (uint32_t)8);
+    uint8_t *data = new uint8_t[prog_size + 2];
+    for (uint32_t i = 0; i < prog_size + 2; i++) {
+        data[i] = i;
     }
 
     // the one before the last sector in the system
@@ -61,19 +62,29 @@ void flashiap_program_test()
     TEST_ASSERT_EQUAL_INT32(0, ret);
 
 
-    for (uint32_t i = 0; i < sector_size / page_size; i++) {
-        uint32_t page_addr = address + i * page_size;
-        ret = flash_device.program(data, page_addr, page_size);
+    for (uint32_t i = 0; i < sector_size / prog_size; i++) {
+        uint32_t prog_addr = address + i * prog_size;
+        ret = flash_device.program(data, prog_addr, prog_size);
         TEST_ASSERT_EQUAL_INT32(0, ret);
     }
 
-    uint8_t *data_flashed = new uint8_t[page_size];
-    for (uint32_t i = 0; i < sector_size / page_size; i++) {
-        uint32_t page_addr = address + i * page_size;
-        ret = flash_device.read(data_flashed, page_addr, page_size);
+    uint8_t *data_flashed = new uint8_t[prog_size];
+    for (uint32_t i = 0; i < sector_size / prog_size; i++) {
+        uint32_t page_addr = address + i * prog_size;
+        ret = flash_device.read(data_flashed, page_addr, prog_size);
         TEST_ASSERT_EQUAL_INT32(0, ret);
-        TEST_ASSERT_EQUAL_UINT8_ARRAY(data, data_flashed, page_size);
+        TEST_ASSERT_EQUAL_UINT8_ARRAY(data, data_flashed, prog_size);
     }
+
+    // check programming of unaligned buffer and size
+    ret = flash_device.erase(address, sector_size);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    ret = flash_device.program(data + 2, address, prog_size);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    ret = flash_device.read(data_flashed, address, prog_size - 1);
+    TEST_ASSERT_EQUAL_INT32(0, ret);
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(data + 2, data_flashed, prog_size - 1);
+
     delete[] data;
     delete[] data_flashed;
 


### PR DESCRIPTION

### Description
This PR resolves a problem (found by @yossi2le) when programming the internal flash via FlashIAP:  The `program`  API receives a `const void *buffer` parameter as the source buffer to program. As such, the program buffer can point to data of any kind, without alignment restrictions. However, many of the target specific flash drivers assume this buffer is aligned to `uint32_t` and thus cast it to `uint32_t*`.
Freescale's `flash_api` module shows a [typical example](https://github.com/ARMmbed/mbed-os/blob/master/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/flash_api.c#L85) for that. Other targets do the same as well.
Solution is by using an aligned buffer for this case in FlashIAP. This was already implemented for unaligned program sizes. Same code is now used for the unaligned source buffer case.
This PR also modifies the FlashIAP programming test code, as the previous one was quite trivial and didn't check this scenario as well.
This fix also resolves issue [#6706](https://github.com/ARMmbed/mbed-os/issues/6706).

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

