### PR TITLE
fix greentea-client, require a character input between K-V pairs

### DIFF
--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -728,6 +728,7 @@ static int gettok(char *out_str, const int str_size) {
 	if (LastChar == '}') {
 		LastChar = greentea_getc();
 		if (LastChar == '}') {
+			LastChar = '!';
 			return tok_close;
 		}
 	}


### PR DESCRIPTION


### Description
Currently, greentea-client require a character input in between 2 K-V pair sync commands.
e.g. between {{__sync;1234}} and {{base_time;0}} in a time drifting test.

This is becasue greentea-client didn't reset the LastChar after it receives "tok_close".
The problem didn't got expose before, becasue in mbedhtrun side, it always insert a line feed "\n" in between any 2 K-V pairs.

in the serial connection, that works fine, cancel out the issue.
However, working with Fast Models, specially in windows enviroment, which use telnet as UART. It which use "\r\n" to flush the buffer, this is causing a problem.
  
So the fix is to reset "LastChar" after  received "tok_close"

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

