### PR TITLE
Build mbed-os-example-lora only for lora targets

### DIFF
--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -232,7 +232,7 @@
         "mbed": [],
         "test-repo-source": "github",
         "features" : [],
-        "targets" : [],
+        "targets" : ["DISCO_L072CZ_LRWAN1", "MTB_MTS_XDOT", "MTS_MDOT_F411RE"],
         "toolchains" : [],
         "exporters": [],
         "compile" : true,


### PR DESCRIPTION


### Description
mbed-os-example-lora should be only compiled for targets which support lora.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

