### PR TITLE
Add USB endpoint tests

### DIFF
--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -1,0 +1,767 @@
+/*
+ * Copyright (c) 2018-2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stdint.h"
+#include "USBEndpointTester.h"
+#include "mbed_shared_queues.h"
+#include "EndpointResolver.h"
+
+#define DEFAULT_CONFIGURATION       (1)
+
+#define NUM_PACKETS_UNTIL_ABORT     2
+#define NUM_PACKETS_AFTER_ABORT     8
+
+#define VENDOR_TEST_CTRL_IN         1
+#define VENDOR_TEST_CTRL_OUT        2
+#define VENDOR_TEST_CTRL_IN_SIZES   9
+#define VENDOR_TEST_CTRL_OUT_SIZES  10
+
+#define EVENT_READY (1 << 0)
+
+#define TEST_SIZE_EP_BULK_MAX   (64)
+#define TEST_SIZE_EP_BULK_MIN   (8)
+#define TEST_SIZE_EP_BULK_0     (16)
+#define TEST_SIZE_EP_BULK_1     TEST_SIZE_EP_BULK_MAX
+#define TEST_SIZE_EP_BULK_2     (32)
+#define TEST_SIZE_EP_BULK_3     (16)
+#define TEST_SIZE_EP_BULK_4     TEST_SIZE_EP_BULK_MIN
+
+#define TEST_SIZE_EP_INT_MAX    (64)
+#define TEST_SIZE_EP_INT_MIN    (1)
+#define TEST_SIZE_EP_INT_0      (16)
+#define TEST_SIZE_EP_INT_1      TEST_SIZE_EP_INT_MAX
+#define TEST_SIZE_EP_INT_2      (32)
+#define TEST_SIZE_EP_INT_3      (16)
+#define TEST_SIZE_EP_INT_4      TEST_SIZE_EP_INT_MIN
+
+#define TEST_SIZE_EP_ISO_MAX    (1023)
+#define TEST_SIZE_EP_ISO_MIN    (1)
+#define TEST_SIZE_EP_ISO_0      (0)
+#define TEST_SIZE_EP_ISO_1      (0)
+#define TEST_SIZE_EP_ISO_2      (0)
+#define TEST_SIZE_EP_ISO_3      (0)
+#define TEST_SIZE_EP_ISO_4      (0)
+
+#define EP_BULK_OUT 0
+#define EP_BULK_IN  1
+#define EP_INT_OUT  2
+#define EP_INT_IN   3
+#define EP_ISO_OUT  4
+#define EP_ISO_IN   5
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config_max[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_out) },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_in) },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_out) },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_in) },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_out) },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_MAX, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_in) },
+};
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config0[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_0, NULL },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_0, NULL },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_0, NULL },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_0, NULL },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_0, NULL },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_0, NULL },
+};
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config1[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_out) },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_in) },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_out) },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_in) },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_out) },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_1, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_in) },
+};
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config2[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_out) },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_in) },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_out) },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_in) },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_out) },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_2, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_in) },
+};
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config3[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_out) },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_in) },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_out) },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_in) },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_out) },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_3, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_in) },
+};
+
+USBEndpointTester::ep_config_t USBEndpointTester::_intf_config4[NUM_ENDPOINTS] = {
+    { false, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_out) },
+    { true, USB_EP_TYPE_BULK, TEST_SIZE_EP_BULK_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_bulk_in) },
+    { false, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_out) },
+    { true, USB_EP_TYPE_INT, TEST_SIZE_EP_INT_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_int_in) },
+    { false, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_out) },
+    { true, USB_EP_TYPE_ISO, TEST_SIZE_EP_ISO_4, static_cast<ep_cb_t>(&USBEndpointTester::_cb_iso_in) },
+};
+
+USBEndpointTester::USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
+        bool abort_transfer_test) :
+        USBDevice(phy, vendor_id, product_id, product_release), _abort_transfer_test(abort_transfer_test), _endpoint_configs(
+                &_intf_config_max)
+{
+    _cnt_cb_set_conf = 0;
+    _cnt_cb_set_intf = 0;
+    _cnt_cb_bulk_out = 0;
+    _cnt_cb_bulk_in = 0;
+    _cnt_cb_int_out = 0;
+    _cnt_cb_int_in = 0;
+    _cnt_cb_iso_out = 0;
+    _cnt_cb_iso_in = 0;
+
+    EndpointResolver resolver(endpoint_table());
+    resolver.endpoint_ctrl(64);
+    ep_config_t *epc = NULL;
+    for (size_t i = 0; i < NUM_ENDPOINTS; i++) {
+        epc = &((*_endpoint_configs)[i]);
+        _endpoints[i] = resolver.next_free_endpoint(epc->dir_in, epc->type, epc->max_packet);
+        _endpoint_buffs[i] = (uint8_t *) calloc(epc->max_packet, sizeof(uint8_t));
+        MBED_ASSERT(_endpoint_buffs[i] != NULL);
+    }
+    MBED_ASSERT(resolver.valid());
+
+    queue = mbed_highprio_event_queue();
+    configuration_desc(0);
+    init();
+    USBDevice::connect();
+    flags.wait_any(EVENT_READY, osWaitForever, false);
+
+}
+
+USBEndpointTester::~USBEndpointTester()
+{
+    for (size_t i = 0; i < NUM_ENDPOINTS; i++) {
+        if (_endpoint_buffs[i] != NULL) {
+            free(_endpoint_buffs[i]);
+        }
+    }
+    deinit();
+}
+
+const char *USBEndpointTester::get_desc_string(const uint8_t *desc)
+{
+    static char ret_string[128] = { };
+    const uint8_t desc_size = desc[0] - 2;
+    const uint8_t *desc_str = &desc[2];
+    uint32_t j = 0;
+    for (uint32_t i = 0; i < desc_size; i += 2, j++) {
+        ret_string[j] = desc_str[i];
+    }
+    ret_string[j] = '\0';
+    return ret_string;
+}
+
+const char *USBEndpointTester::get_serial_desc_string()
+{
+    return get_desc_string(string_iserial_desc());
+}
+
+void USBEndpointTester::callback_state_change(DeviceState new_state)
+{
+    if (new_state == Configured) {
+        flags.set(EVENT_READY);
+    } else {
+        flags.clear(EVENT_READY);
+    }
+}
+
+void USBEndpointTester::callback_request(const setup_packet_t *setup)
+{
+    /* Called in ISR context */
+    RequestResult result = PassThrough;
+    uint8_t *data = NULL;
+    uint32_t size = 0;
+
+    /* Process vendor-specific requests */
+    if (setup->bmRequestType.Type == VENDOR_TYPE) {
+        switch (setup->bRequest) {
+            case VENDOR_TEST_CTRL_IN:
+                result = Send;
+                data = ctrl_buf;
+                size = setup->wValue < sizeof(ctrl_buf) ? setup->wValue : sizeof(ctrl_buf);
+                break;
+            case VENDOR_TEST_CTRL_OUT:
+                result = Receive;
+                data = ctrl_buf;
+                size = setup->wValue < 8 ? setup->wValue : 8;
+                break;
+            case VENDOR_TEST_CTRL_IN_SIZES:
+                result = Send;
+                data = ctrl_buf;
+                size = setup->wLength;
+                break;
+            case VENDOR_TEST_CTRL_OUT_SIZES:
+                result = Receive;
+                data = ctrl_buf;
+                size = setup->wValue;
+                break;
+            default:
+                result = PassThrough;
+                break;
+        }
+    }
+    complete_request(result, data, size);
+}
+
+void USBEndpointTester::callback_request_xfer_done(const setup_packet_t *setup, bool aborted)
+{
+    if (aborted) {
+        complete_request_xfer_done(false);
+        return;
+    }
+
+    bool result = false;
+    if (setup->bmRequestType.Type == VENDOR_TYPE) {
+        switch (setup->bRequest) {
+            case VENDOR_TEST_CTRL_IN:
+                result = true;
+                break;
+            case VENDOR_TEST_CTRL_OUT:
+                result = true;
+                break;
+            case VENDOR_TEST_CTRL_OUT_SIZES:
+                result = true;
+                break;
+            case VENDOR_TEST_CTRL_IN_SIZES:
+                result = true;
+                break;
+            default:
+                result = false;
+                break;
+        }
+    }
+    complete_request_xfer_done(result);
+}
+
+void USBEndpointTester::callback_set_configuration(uint8_t configuration)
+{
+    _cnt_cb_set_conf++;
+    if (configuration != DEFAULT_CONFIGURATION) {
+        complete_set_configuration(false);
+        return;
+    }
+
+    // Configure endpoints > 0
+    bool status = _setup_interface(0, 0);
+    complete_set_configuration(status);
+}
+
+bool USBEndpointTester::_setup_interface(uint16_t interface, uint8_t alternate)
+{
+    if (interface != 0) {
+        return false;
+    }
+
+    switch (alternate) {
+        case 0:
+            _endpoint_configs = &_intf_config0;
+            break;
+        case 1:
+            _endpoint_configs = &_intf_config1;
+            break;
+        case 2:
+            _endpoint_configs = &_intf_config2;
+            break;
+        case 3:
+            _endpoint_configs = &_intf_config3;
+            break;
+        case 4:
+            _endpoint_configs = &_intf_config4;
+            break;
+        default:
+            return false;
+    }
+
+    _setup_non_zero_endpoints();
+
+    if (_abort_transfer_test && alternate >= 1) {
+        _cnt_cb_bulk_out_abort = _cnt_cb_bulk_out;
+        _cnt_cb_bulk_in_abort = _cnt_cb_bulk_in;
+        _cnt_cb_int_out_abort = _cnt_cb_int_out;
+        _cnt_cb_int_in_abort = _cnt_cb_int_in;
+        start_ep_in_abort_test();
+    }
+    return true;
+}
+
+void USBEndpointTester::_setup_non_zero_endpoints()
+{
+    ep_config_t *epc = NULL;
+    for (size_t i = 0; i < NUM_ENDPOINTS; i++) {
+        epc = &((*_endpoint_configs)[i]);
+        endpoint_add(_endpoints[i], epc->max_packet, epc->type, epc->callback);
+        if (epc->callback == NULL) {
+            continue;
+        }
+        if (epc->dir_in == true) {
+//            write_start(_endpoints[i], _endpoint_buffs[i], epc->max_packet);
+        } else {
+            read_start(_endpoints[i], _endpoint_buffs[i], epc->max_packet);
+        }
+    }
+}
+
+void USBEndpointTester::callback_set_interface(uint16_t interface, uint8_t alternate)
+{
+    _cnt_cb_set_intf++;
+    if (interface != 0 || alternate > 4) {
+        complete_set_interface(false);
+        return;
+    }
+    for (size_t i = 0; i < NUM_ENDPOINTS; i++) {
+        endpoint_abort(_endpoints[i]);
+        endpoint_remove(_endpoints[i]);
+    }
+    bool status = _setup_interface(interface, alternate);
+    complete_set_interface(status);
+}
+
+#define CONFIG1_DESC_SIZE (CONFIGURATION_DESCRIPTOR_LENGTH \
+        + 5 * (INTERFACE_DESCRIPTOR_LENGTH + NUM_ENDPOINTS * ENDPOINT_DESCRIPTOR_LENGTH) )
+
+const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
+{
+    static const uint8_t config_1_descriptor[] = {
+        // configuration descriptor
+        CONFIGURATION_DESCRIPTOR_LENGTH,    // bLength
+        CONFIGURATION_DESCRIPTOR,           // bDescriptorType
+        LSB(CONFIG1_DESC_SIZE),             // wTotalLength (LSB)
+        MSB(CONFIG1_DESC_SIZE),             // wTotalLength (MSB)
+        1,                                  // bNumInterfaces
+        1,                                  // bConfigurationValue
+        0,                                  // iConfiguration
+        0x80,                               // bmAttributes
+        50,                                 // bMaxPower
+
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        INTERFACE_DESCRIPTOR_LENGTH,// bLength
+        INTERFACE_DESCRIPTOR,       // bDescriptorType
+        0,                          // bInterfaceNumber
+        0,                          // bAlternateSetting
+        NUM_ENDPOINTS,              // bNumEndpoints
+        0xFF,                       // bInterfaceClass
+        0xFF,                       // bInterfaceSubClass
+        0xFF,                       // bInterfaceProtocol
+        0,                          // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_OUT],    // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_IN],     // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_OUT],     // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_IN],      // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_OUT],     // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_IN],      // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config0[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config0[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        INTERFACE_DESCRIPTOR_LENGTH,// bLength
+        INTERFACE_DESCRIPTOR,       // bDescriptorType
+        0,                          // bInterfaceNumber
+        1,                          // bAlternateSetting
+        NUM_ENDPOINTS,              // bNumEndpoints
+        0xFF,                       // bInterfaceClass
+        0xFF,                       // bInterfaceSubClass
+        0xFF,                       // bInterfaceProtocol
+        0,                          // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_OUT],    // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_IN],     // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_OUT],     // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_IN],      // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_OUT],     // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_IN],      // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config1[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config1[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        INTERFACE_DESCRIPTOR_LENGTH,// bLength
+        INTERFACE_DESCRIPTOR,       // bDescriptorType
+        0,                          // bInterfaceNumber
+        2,                          // bAlternateSetting
+        NUM_ENDPOINTS,              // bNumEndpoints
+        0xFF,                       // bInterfaceClass
+        0xFF,                       // bInterfaceSubClass
+        0xFF,                       // bInterfaceProtocol
+        0,                          // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_OUT],    // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_IN],     // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_OUT],     // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_IN],      // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_OUT],     // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_IN],      // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config2[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config2[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        INTERFACE_DESCRIPTOR_LENGTH,// bLength
+        INTERFACE_DESCRIPTOR,       // bDescriptorType
+        0,                          // bInterfaceNumber
+        3,                          // bAlternateSetting
+        NUM_ENDPOINTS,              // bNumEndpoints
+        0xFF,                       // bInterfaceClass
+        0xFF,                       // bInterfaceSubClass
+        0xFF,                       // bInterfaceProtocol
+        0,                          // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_OUT],    // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_IN],     // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_OUT],     // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_IN],      // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_OUT],     // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_IN],      // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config3[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config3[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+
+        // interface descriptor, USB spec 9.6.5, page 267-269, Table 9-12
+        INTERFACE_DESCRIPTOR_LENGTH,// bLength
+        INTERFACE_DESCRIPTOR,       // bDescriptorType
+        0,                          // bInterfaceNumber
+        4,                          // bAlternateSetting
+        NUM_ENDPOINTS,              // bNumEndpoints
+        0xFF,                       // bInterfaceClass
+        0xFF,                       // bInterfaceSubClass
+        0xFF,                       // bInterfaceProtocol
+        0,                          // iInterface
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_OUT],    // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_BULK_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_BULK_OUT].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_BULK_IN],     // bEndpointAddress
+        E_BULK,                     // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_BULK_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_BULK_IN].max_packet)), // wMaxPacketSize (MSB)
+        0,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_OUT],     // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_INT_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_INT_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_INT_IN],      // bEndpointAddress
+        E_INTERRUPT,                // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_INT_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_INT_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_OUT],     // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_ISO_OUT].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_ISO_OUT].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        ENDPOINT_DESCRIPTOR_LENGTH, // bLength
+        ENDPOINT_DESCRIPTOR,        // bDescriptorType
+        _endpoints[EP_ISO_IN],      // bEndpointAddress
+        E_ISOCHRONOUS,              // bmAttributes
+        (uint8_t) (LSB(_intf_config4[EP_ISO_IN].max_packet)), // wMaxPacketSize (LSB)
+        (uint8_t) (MSB(_intf_config4[EP_ISO_IN].max_packet)), // wMaxPacketSize (MSB)
+        1,                          // bInterval
+    };
+    if (index == 0) {
+        return config_1_descriptor;
+    } else {
+        return NULL;
+    }
+}
+
+void USBEndpointTester::_cb_bulk_out(usb_ep_t endpoint)
+{
+    _cnt_cb_bulk_out++;
+    uint32_t rx_size = read_finish(endpoint);
+
+    if (_abort_transfer_test == false) {
+        // Send data back to host using the IN endpoint.
+        memset(_endpoint_buffs[EP_BULK_IN], 0, (*_endpoint_configs)[EP_BULK_IN].max_packet);
+        memcpy(_endpoint_buffs[EP_BULK_IN], _endpoint_buffs[EP_BULK_OUT], rx_size);
+        write_start(_endpoints[EP_BULK_IN], _endpoint_buffs[EP_BULK_IN], rx_size);
+    } else {
+        // Abort the transfer if enough data was received.
+        uint32_t num_packets_received = _cnt_cb_bulk_out - _cnt_cb_bulk_out_abort;
+        read_start(_endpoints[EP_BULK_OUT], _endpoint_buffs[EP_BULK_OUT], (*_endpoint_configs)[EP_BULK_OUT].max_packet);
+        if (num_packets_received >= NUM_PACKETS_UNTIL_ABORT) {
+            endpoint_abort(endpoint);
+        }
+    }
+}
+
+void USBEndpointTester::_cb_bulk_in(usb_ep_t endpoint)
+{
+    _cnt_cb_bulk_in++;
+    write_finish(endpoint);
+
+    if (_abort_transfer_test == false) {
+        // Receive more data from the host using the OUT endpoint.
+        read_start(_endpoints[EP_BULK_OUT], _endpoint_buffs[EP_BULK_OUT], (*_endpoint_configs)[EP_BULK_OUT].max_packet);
+    } else {
+        uint32_t num_packets_sent = _cnt_cb_bulk_in - _cnt_cb_bulk_in_abort;
+        if (num_packets_sent >= NUM_PACKETS_UNTIL_ABORT + NUM_PACKETS_AFTER_ABORT) {
+            return;
+        }
+        // Abort the transfer if enough data was sent.
+        memset(_endpoint_buffs[EP_BULK_IN], num_packets_sent, (*_endpoint_configs)[EP_BULK_IN].max_packet);
+        write_start(_endpoints[EP_BULK_IN], _endpoint_buffs[EP_BULK_IN], (*_endpoint_configs)[EP_BULK_IN].max_packet);
+        if (num_packets_sent >= NUM_PACKETS_UNTIL_ABORT) {
+            endpoint_abort(endpoint);
+        }
+    }
+}
+
+void USBEndpointTester::_cb_int_out(usb_ep_t endpoint)
+{
+    _cnt_cb_int_out++;
+    uint32_t rx_size = read_finish(endpoint);
+    if (_abort_transfer_test == false) {
+        // Send data back to host using the IN endpoint.
+        memset(_endpoint_buffs[EP_INT_IN], 0, (*_endpoint_configs)[EP_INT_IN].max_packet);
+        memcpy(_endpoint_buffs[EP_INT_IN], _endpoint_buffs[EP_INT_OUT], rx_size);
+        write_start(_endpoints[EP_INT_IN], _endpoint_buffs[EP_INT_IN], rx_size);
+    } else {
+        // Abort the transfer if enough data was received.
+        uint32_t num_packets_received = _cnt_cb_int_out - _cnt_cb_int_out_abort;
+        read_start(_endpoints[EP_INT_OUT], _endpoint_buffs[EP_INT_OUT], (*_endpoint_configs)[EP_INT_OUT].max_packet);
+        if (num_packets_received >= NUM_PACKETS_UNTIL_ABORT) {
+            endpoint_abort(endpoint);
+        }
+    }
+}
+
+void USBEndpointTester::_cb_int_in(usb_ep_t endpoint)
+{
+    _cnt_cb_int_in++;
+    write_finish(endpoint);
+    if (_abort_transfer_test == false) {
+        // Receive more data from the host using the OUT endpoint.
+        read_start(_endpoints[EP_INT_OUT], _endpoint_buffs[EP_INT_OUT], (*_endpoint_configs)[EP_INT_OUT].max_packet);
+    } else {
+        uint32_t num_packets_sent = _cnt_cb_int_in - _cnt_cb_int_in_abort;
+        if (num_packets_sent >= NUM_PACKETS_UNTIL_ABORT + NUM_PACKETS_AFTER_ABORT) {
+            return;
+        }
+        // Abort the transfer if enough data was sent.
+        memset(_endpoint_buffs[EP_INT_IN], num_packets_sent, (*_endpoint_configs)[EP_INT_IN].max_packet);
+        write_start(_endpoints[EP_INT_IN], _endpoint_buffs[EP_INT_IN], (*_endpoint_configs)[EP_INT_IN].max_packet);
+        if (num_packets_sent >= NUM_PACKETS_UNTIL_ABORT) {
+            endpoint_abort(endpoint);
+        }
+    }
+}
+
+void USBEndpointTester::_cb_iso_out(usb_ep_t endpoint)
+{
+    _cnt_cb_iso_out++;
+    uint32_t rx_size = read_finish(endpoint);
+    // Send data back to host using the IN endpoint.
+    memset(_endpoint_buffs[EP_ISO_IN], 0, (*_endpoint_configs)[EP_ISO_IN].max_packet);
+    memcpy(_endpoint_buffs[EP_ISO_IN], _endpoint_buffs[EP_ISO_OUT], rx_size);
+    write_start(_endpoints[EP_ISO_IN], _endpoint_buffs[EP_ISO_IN], rx_size);
+}
+
+void USBEndpointTester::_cb_iso_in(usb_ep_t endpoint)
+{
+    _cnt_cb_iso_in++;
+    write_finish(endpoint);
+    // Receive more data from the host using the OUT endpoint.
+    read_start(_endpoints[EP_ISO_OUT], _endpoint_buffs[EP_ISO_OUT], (*_endpoint_configs)[EP_ISO_OUT].max_packet);
+}
+
+void USBEndpointTester::start_ep_in_abort_test()
+{
+    memset(_endpoint_buffs[EP_BULK_IN], 0, (*_endpoint_configs)[EP_BULK_IN].max_packet);
+    memset(_endpoint_buffs[EP_INT_IN], 0, (*_endpoint_configs)[EP_INT_IN].max_packet);
+
+    write_start(_endpoints[EP_BULK_IN], _endpoint_buffs[EP_BULK_IN], (*_endpoint_configs)[EP_BULK_IN].max_packet);
+    write_start(_endpoints[EP_INT_IN], _endpoint_buffs[EP_INT_IN], (*_endpoint_configs)[EP_INT_IN].max_packet);
+}

--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -49,7 +49,19 @@
 #define TEST_SIZE_EP_INT_3      (16)
 #define TEST_SIZE_EP_INT_4      TEST_SIZE_EP_INT_MIN
 
-#define TEST_SIZE_EP_ISO_MAX    (1023)
+
+/* According to USB spec, the wMaxPacketSize for FS isochronous endpoints
+ * is 1023 B. There are a couple of reasons this value is not used in tests:
+ * - some of the boards supported by Mbed OS have too little RAM dedicated
+ *   for USB, making EndpointResolve::valid() fail when all the endpoints (2x
+ *   bulk, 2x interrupt, 2x isochronous, 2x control) are configured to use
+ *   the max value of wMaxPacketSize
+ *   (e.g. NUCLEO_F207ZG has 1.25K of endpoint RAM),
+ * - given a test host with other USB devices on the bus, it is unlikely
+ *   for the test device to be able to reserve the bandwidth associated with
+ *   high wMaxPacketSize for iso endpoints.
+ */
+#define TEST_SIZE_EP_ISO_MAX    (256)
 #define TEST_SIZE_EP_ISO_MIN    (1)
 #define TEST_SIZE_EP_ISO_0      (0)
 #define TEST_SIZE_EP_ISO_1      (0)

--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -684,10 +684,10 @@ const uint8_t *USBEndpointTester::configuration_desc(uint8_t index)
     }
 }
 
-void USBEndpointTester::_cb_bulk_out(usb_ep_t endpoint)
+void USBEndpointTester::_cb_bulk_out()
 {
     _cnt_cb_bulk_out++;
-    uint32_t rx_size = read_finish(endpoint);
+    uint32_t rx_size = read_finish(_endpoints[EP_BULK_OUT]);
 
     if (_abort_transfer_test == false) {
         // Send data back to host using the IN endpoint.
@@ -699,15 +699,15 @@ void USBEndpointTester::_cb_bulk_out(usb_ep_t endpoint)
         _num_packets_bulk_out_abort++;
         read_start(_endpoints[EP_BULK_OUT], _endpoint_buffs[EP_BULK_OUT], (*_endpoint_configs)[EP_BULK_OUT].max_packet);
         if (_num_packets_bulk_out_abort == NUM_PACKETS_UNTIL_ABORT) {
-            endpoint_abort(endpoint);
+            endpoint_abort(_endpoints[EP_BULK_OUT]);
         }
     }
 }
 
-void USBEndpointTester::_cb_bulk_in(usb_ep_t endpoint)
+void USBEndpointTester::_cb_bulk_in()
 {
     _cnt_cb_bulk_in++;
-    write_finish(endpoint);
+    write_finish(_endpoints[EP_BULK_IN]);
 
     if (_abort_transfer_test == false) {
         // Receive more data from the host using the OUT endpoint.
@@ -721,15 +721,15 @@ void USBEndpointTester::_cb_bulk_in(usb_ep_t endpoint)
         memset(_endpoint_buffs[EP_BULK_IN], _num_packets_bulk_in_abort, (*_endpoint_configs)[EP_BULK_IN].max_packet);
         write_start(_endpoints[EP_BULK_IN], _endpoint_buffs[EP_BULK_IN], (*_endpoint_configs)[EP_BULK_IN].max_packet);
         if (_num_packets_bulk_in_abort == NUM_PACKETS_UNTIL_ABORT) {
-            endpoint_abort(endpoint);
+            endpoint_abort(_endpoints[EP_BULK_IN]);
         }
     }
 }
 
-void USBEndpointTester::_cb_int_out(usb_ep_t endpoint)
+void USBEndpointTester::_cb_int_out()
 {
     _cnt_cb_int_out++;
-    uint32_t rx_size = read_finish(endpoint);
+    uint32_t rx_size = read_finish(_endpoints[EP_INT_OUT]);
     if (_abort_transfer_test == false) {
         // Send data back to host using the IN endpoint.
         memset(_endpoint_buffs[EP_INT_IN], 0, (*_endpoint_configs)[EP_INT_IN].max_packet);
@@ -740,15 +740,15 @@ void USBEndpointTester::_cb_int_out(usb_ep_t endpoint)
         _num_packets_int_out_abort++;
         read_start(_endpoints[EP_INT_OUT], _endpoint_buffs[EP_INT_OUT], (*_endpoint_configs)[EP_INT_OUT].max_packet);
         if (_num_packets_int_out_abort == NUM_PACKETS_UNTIL_ABORT) {
-            endpoint_abort(endpoint);
+            endpoint_abort(_endpoints[EP_INT_OUT]);
         }
     }
 }
 
-void USBEndpointTester::_cb_int_in(usb_ep_t endpoint)
+void USBEndpointTester::_cb_int_in()
 {
     _cnt_cb_int_in++;
-    write_finish(endpoint);
+    write_finish(_endpoints[EP_INT_IN]);
     if (_abort_transfer_test == false) {
         // Receive more data from the host using the OUT endpoint.
         read_start(_endpoints[EP_INT_OUT], _endpoint_buffs[EP_INT_OUT], (*_endpoint_configs)[EP_INT_OUT].max_packet);
@@ -761,25 +761,25 @@ void USBEndpointTester::_cb_int_in(usb_ep_t endpoint)
         memset(_endpoint_buffs[EP_INT_IN], _num_packets_int_in_abort, (*_endpoint_configs)[EP_INT_IN].max_packet);
         write_start(_endpoints[EP_INT_IN], _endpoint_buffs[EP_INT_IN], (*_endpoint_configs)[EP_INT_IN].max_packet);
         if (_num_packets_int_in_abort == NUM_PACKETS_UNTIL_ABORT) {
-            endpoint_abort(endpoint);
+            endpoint_abort(_endpoints[EP_INT_IN]);
         }
     }
 }
 
-void USBEndpointTester::_cb_iso_out(usb_ep_t endpoint)
+void USBEndpointTester::_cb_iso_out()
 {
     _cnt_cb_iso_out++;
-    uint32_t rx_size = read_finish(endpoint);
+    uint32_t rx_size = read_finish(_endpoints[EP_ISO_OUT]);
     // Send data back to host using the IN endpoint.
     memset(_endpoint_buffs[EP_ISO_IN], 0, (*_endpoint_configs)[EP_ISO_IN].max_packet);
     memcpy(_endpoint_buffs[EP_ISO_IN], _endpoint_buffs[EP_ISO_OUT], rx_size);
     write_start(_endpoints[EP_ISO_IN], _endpoint_buffs[EP_ISO_IN], rx_size);
 }
 
-void USBEndpointTester::_cb_iso_in(usb_ep_t endpoint)
+void USBEndpointTester::_cb_iso_in()
 {
     _cnt_cb_iso_in++;
-    write_finish(endpoint);
+    write_finish(_endpoints[EP_ISO_IN]);
     // Receive more data from the host using the OUT endpoint.
     read_start(_endpoints[EP_ISO_OUT], _endpoint_buffs[EP_ISO_OUT], (*_endpoint_configs)[EP_ISO_OUT].max_packet);
 }

--- a/TESTS/usb_device/basic/USBEndpointTester.cpp
+++ b/TESTS/usb_device/basic/USBEndpointTester.cpp
@@ -228,6 +228,29 @@ void USBEndpointTester::callback_request(const setup_packet_t *setup)
                 result = PassThrough;
                 break;
         }
+    } else if ((setup->bmRequestType.Type == STANDARD_TYPE) && (setup->bmRequestType.Recipient == ENDPOINT_RECIPIENT)) {
+        if (setup->bRequest == CLEAR_FEATURE) {
+            usb_ep_t ep = setup->wIndex;
+            bool valid = false;
+            uint32_t ep_index = 0;
+            if (ep == _endpoints[EP_BULK_OUT]) {
+                valid = true;
+                ep_index = EP_BULK_OUT;
+            } else if (ep == _endpoints[EP_INT_OUT]) {
+                valid = true;
+                ep_index = EP_INT_OUT;
+            } else if (ep == _endpoints[EP_ISO_OUT]) {
+                valid = true;
+                ep_index = EP_ISO_OUT;
+            }
+
+            if (valid) {
+                // Restart reads when an OUT endpoint is unstalled
+                result = Success;
+                endpoint_unstall(ep);
+                read_start(_endpoints[ep_index], _endpoint_buffs[ep_index], (*_endpoint_configs)[ep_index].max_packet);
+            }
+        }
     }
     complete_request(result, data, size);
 }

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -33,7 +33,7 @@ class USBEndpointTester: public USBDevice {
 public:
     USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
             bool abort_transfer_test);
-    ~USBEndpointTester();
+    virtual ~USBEndpointTester();
     const char *get_serial_desc_string();
     void start_ep_in_abort_test();
 
@@ -94,12 +94,12 @@ protected:
     void _setup_non_zero_endpoints();
     bool _setup_interface(uint16_t interface, uint8_t alternate);
 
-    virtual void _cb_bulk_out(usb_ep_t endpoint);
-    virtual void _cb_bulk_in(usb_ep_t endpoint);
-    virtual void _cb_int_out(usb_ep_t endpoint);
-    virtual void _cb_int_in(usb_ep_t endpoint);
-    virtual void _cb_iso_out(usb_ep_t endpoint);
-    virtual void _cb_iso_in(usb_ep_t endpoint);
+    virtual void _cb_bulk_out();
+    virtual void _cb_bulk_in();
+    virtual void _cb_int_out();
+    virtual void _cb_int_in();
+    virtual void _cb_iso_out();
+    virtual void _cb_iso_in();
 
 private:
     const char *get_desc_string(const uint8_t *desc);

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -104,6 +104,7 @@ protected:
 private:
     const char *get_desc_string(const uint8_t *desc);
     bool _request_read_start(const setup_packet_t *setup);
+    bool _request_abort_buff_check(const setup_packet_t *setup);
 };
 
 #endif

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -79,10 +79,10 @@ protected:
     volatile uint32_t _cnt_cb_iso_out;
     volatile uint32_t _cnt_cb_iso_in;
 
-    volatile uint32_t _cnt_cb_bulk_out_abort;
-    volatile uint32_t _cnt_cb_bulk_in_abort;
-    volatile uint32_t _cnt_cb_int_out_abort;
-    volatile uint32_t _cnt_cb_int_in_abort;
+    volatile uint32_t _num_packets_bulk_out_abort;
+    volatile uint32_t _num_packets_bulk_in_abort;
+    volatile uint32_t _num_packets_int_out_abort;
+    volatile uint32_t _num_packets_int_in_abort;
 
     virtual const uint8_t *configuration_desc(uint8_t index);
     virtual void callback_state_change(DeviceState new_state);
@@ -103,6 +103,7 @@ protected:
 
 private:
     const char *get_desc_string(const uint8_t *desc);
+    bool _request_read_start(const setup_packet_t *setup);
 };
 
 #endif

--- a/TESTS/usb_device/basic/USBEndpointTester.h
+++ b/TESTS/usb_device/basic/USBEndpointTester.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2018-2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef USB_ENDPOINT_TESTER_H
+#define USB_ENDPOINT_TESTER_H
+
+/* These headers are included for child class. */
+#include "USBDescriptor.h"
+#include "USBDevice_Types.h"
+#include "EventQueue.h"
+#include "EventFlags.h"
+
+#include "USBDevice.h"
+
+#define NUM_ENDPOINTS 6 // Not including CTRL OUT/IN
+
+class USBEndpointTester: public USBDevice {
+
+public:
+    USBEndpointTester(USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release,
+            bool abort_transfer_test);
+    ~USBEndpointTester();
+    const char *get_serial_desc_string();
+    void start_ep_in_abort_test();
+
+    uint32_t get_cnt_cb_set_conf() const { return _cnt_cb_set_conf; }
+    uint32_t get_cnt_cb_set_intf() const { return _cnt_cb_set_intf; }
+    uint32_t get_cnt_cb_bulk_out() const { return _cnt_cb_bulk_out; }
+    uint32_t get_cnt_cb_bulk_in() const { return _cnt_cb_bulk_in; }
+    uint32_t get_cnt_cb_int_out() const { return _cnt_cb_int_out; }
+    uint32_t get_cnt_cb_int_in() const { return _cnt_cb_int_in; }
+    uint32_t get_cnt_cb_iso_out() const { return _cnt_cb_iso_out; }
+    uint32_t get_cnt_cb_iso_in() const { return _cnt_cb_iso_in; }
+
+    struct ep_config_t {
+        bool dir_in;
+        usb_ep_type_t type;
+        uint32_t max_packet;
+        ep_cb_t callback;
+    };
+
+protected:
+    EventQueue *queue;
+    rtos::EventFlags flags;
+    uint8_t ctrl_buf[2048];
+
+    bool _abort_transfer_test;
+    usb_ep_t _endpoints[NUM_ENDPOINTS];
+    uint8_t *_endpoint_buffs[NUM_ENDPOINTS];
+    ep_config_t (*_endpoint_configs)[NUM_ENDPOINTS];
+
+    static ep_config_t _intf_config_max[NUM_ENDPOINTS];
+    static ep_config_t _intf_config0[NUM_ENDPOINTS];
+    static ep_config_t _intf_config1[NUM_ENDPOINTS];
+    static ep_config_t _intf_config2[NUM_ENDPOINTS];
+    static ep_config_t _intf_config3[NUM_ENDPOINTS];
+    static ep_config_t _intf_config4[NUM_ENDPOINTS];
+
+    volatile uint32_t _cnt_cb_set_conf;
+    volatile uint32_t _cnt_cb_set_intf;
+    volatile uint32_t _cnt_cb_bulk_out;
+    volatile uint32_t _cnt_cb_bulk_in;
+    volatile uint32_t _cnt_cb_int_out;
+    volatile uint32_t _cnt_cb_int_in;
+    volatile uint32_t _cnt_cb_iso_out;
+    volatile uint32_t _cnt_cb_iso_in;
+
+    volatile uint32_t _cnt_cb_bulk_out_abort;
+    volatile uint32_t _cnt_cb_bulk_in_abort;
+    volatile uint32_t _cnt_cb_int_out_abort;
+    volatile uint32_t _cnt_cb_int_in_abort;
+
+    virtual const uint8_t *configuration_desc(uint8_t index);
+    virtual void callback_state_change(DeviceState new_state);
+    virtual void callback_request(const setup_packet_t *setup);
+    virtual void callback_request_xfer_done(const setup_packet_t *setup, bool aborted);
+    virtual void callback_set_configuration(uint8_t configuration);
+    virtual void callback_set_interface(uint16_t interface, uint8_t alternate);
+
+    void _setup_non_zero_endpoints();
+    bool _setup_interface(uint16_t interface, uint8_t alternate);
+
+    virtual void _cb_bulk_out(usb_ep_t endpoint);
+    virtual void _cb_bulk_in(usb_ep_t endpoint);
+    virtual void _cb_int_out(usb_ep_t endpoint);
+    virtual void _cb_int_in(usb_ep_t endpoint);
+    virtual void _cb_iso_out(usb_ep_t endpoint);
+    virtual void _cb_iso_in(usb_ep_t endpoint);
+
+private:
+    const char *get_desc_string(const uint8_t *desc);
+};
+
+#endif

--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -200,6 +200,14 @@ void control_stress_test()
     }
 }
 
+/** Test data correctness for every OUT/IN endpoint pair
+ *
+ * Given a USB device with multiple OUT/IN endpoint pairs
+ * When the host sends random payloads up to wMaxPacketSize in size
+ *     to an OUT endpoint of the device,
+ *     and then the device sends data back to host using an IN endpoint
+ * Then data sent and received by host is equal for every endpoint pair
+ */
 void ep_test_data_correctness()
 {
     uint16_t vendor_id = 0x0d28;
@@ -230,6 +238,13 @@ void ep_test_data_correctness()
     }
 }
 
+/** Test endpoint halt for every OUT/IN endpoint pair
+ *
+ * Given a USB device with multiple OUT/IN endpoint pairs
+ * When the host issues an endpoint halt control request at a random point
+ *     of OUT or IN transfer
+ * Then the endpoint is stalled and all further transfers fail
+ */
 void ep_test_halt()
 {
     uint16_t vendor_id = 0x0d28;
@@ -260,6 +275,13 @@ void ep_test_halt()
     }
 }
 
+/** Test simultaneous data transfers for multiple OUT/IN endpoint pairs
+ *
+ * Given a USB device with multiple OUT/IN endpoint pairs
+ * When multiple OUT and IN endpoints are used to transfer random data in parallel
+ * Then all transfers succeed
+ *     and for every endpoint pair, data received by host equals data sent by host
+ */
 void ep_test_parallel_transfers()
 {
     uint16_t vendor_id = 0x0d28;
@@ -290,6 +312,14 @@ void ep_test_parallel_transfers()
     }
 }
 
+/** Test simultaneous data transfers in parallel with control transfers
+ *
+ * Given a USB device with multiple OUT/IN endpoint pairs
+ * When multiple OUT and IN endpoints are used to transfer random data
+ *     and control requests are processed in parallel
+ * Then all transfers succeed
+ *     and for every endpoint pair, data received by host equals data sent by host
+ */
 void ep_test_parallel_transfers_ctrl()
 {
     uint16_t vendor_id = 0x0d28;
@@ -320,6 +350,12 @@ void ep_test_parallel_transfers_ctrl()
     }
 }
 
+/** Test aborting data transfer for every OUT/IN endpoint pair
+ *
+ * Given a USB device with multiple OUT/IN endpoint pairs
+ * When a device aborts an in progress data transfer
+ * Then no more data is transmitted
+ */
 void ep_test_abort()
 {
     uint16_t vendor_id = 0x0d28;

--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -385,6 +385,45 @@ void ep_test_abort()
     }
 }
 
+/** Test data toggle reset for bulk OUT/IN endpoint pairs
+ *
+ * Given a USB device
+ * When an interface is set
+ * Then the data toggle bits for all endpoints are reset to DATA0
+ * When clear feature is called for an endpoint that *IS NOT* stalled
+ * Then the data toggle is reset to DATA0 for that endpoint
+ * When clear halt is called for an endpoint that *IS* stalled
+ * Then the data toggle is reset to DATA0 for that endpoint
+ */
+void ep_test_data_toggle()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, false);
+        greentea_send_kv("ep_test_data_toggle", serial.get_serial_desc_string());
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
+
 /** Test USB implementation against repeated reset
 
     Given an initialized USB (HOST <---> DUT connection established)
@@ -602,7 +641,8 @@ Case cases[] = {
     Case("endpoint test halt", ep_test_halt),
     Case("endpoint test parallel transfers", ep_test_parallel_transfers),
     Case("endpoint test parallel transfers ctrl", ep_test_parallel_transfers_ctrl),
-    Case("endpoint test abort", ep_test_abort)
+    Case("endpoint test abort", ep_test_abort),
+    Case("endpoint test data toggle reset", ep_test_data_toggle)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -355,6 +355,7 @@ void ep_test_parallel_transfers_ctrl()
  * Given a USB device with multiple OUT/IN endpoint pairs
  * When a device aborts an in progress data transfer
  * Then no more data is transmitted
+ *     and endpoint buffer is correctly released on the device end
  */
 void ep_test_abort()
 {

--- a/TESTS/usb_device/basic/main.cpp
+++ b/TESTS/usb_device/basic/main.cpp
@@ -22,6 +22,7 @@
 #include "utest/utest.h"
 
 #include "USBTester.h"
+#include "USBEndpointTester.h"
 #include "usb_phy_api.h"
 
 // TODO
@@ -43,6 +44,9 @@
 
 
 using namespace utest::v1;
+
+// Print callback counters for endpoint tests
+#define EP_DBG 0
 
 static USBPhy *get_phy()
 {
@@ -196,6 +200,154 @@ void control_stress_test()
     }
 }
 
+void ep_test_data_correctness()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, false);
+        greentea_send_kv("ep_test_data_correctness", serial.get_serial_desc_string());
+        // Wait for host before terminating
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
+
+void ep_test_halt()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, false);
+        greentea_send_kv("ep_test_halt", serial.get_serial_desc_string());
+        // Wait for host before terminating
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
+
+void ep_test_parallel_transfers()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, false);
+        greentea_send_kv("ep_test_parallel_transfers", serial.get_serial_desc_string());
+        // Wait for host before terminating
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
+
+void ep_test_parallel_transfers_ctrl()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, false);
+        greentea_send_kv("ep_test_parallel_transfers_ctrl", serial.get_serial_desc_string());
+        // Wait for host before terminating
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
+
+void ep_test_abort()
+{
+    uint16_t vendor_id = 0x0d28;
+    // Use a product ID different than that used in other tests,
+    // to help Windows hosts use the correct configuration descriptor.
+    uint16_t product_id = 0x0206;
+    uint16_t product_release = 0x0001;
+    char _key[11] = { };
+    char _value[128] = { };
+
+    {
+        USBEndpointTester serial(get_phy(), vendor_id, product_id, product_release, true);
+        greentea_send_kv("ep_test_abort", serial.get_serial_desc_string());
+        greentea_parse_kv(_key, _value, sizeof(_key), sizeof(_value));
+#if EP_DBG
+        wait_ms(100);
+        printf("cnt_cb_set_conf = %lu\r\n", serial.get_cnt_cb_set_conf());
+        printf("cnt_cb_set_intf = %lu\r\n", serial.get_cnt_cb_set_intf());
+        printf("cnt_cb_bulk_out = %lu\r\n", serial.get_cnt_cb_bulk_out());
+        printf("cnt_cb_bulk_in  = %lu\r\n", serial.get_cnt_cb_bulk_in());
+        printf("cnt_cb_int_out  = %lu\r\n", serial.get_cnt_cb_int_out());
+        printf("cnt_cb_int_in   = %lu\r\n", serial.get_cnt_cb_int_in());
+        printf("cnt_cb_iso_out  = %lu\r\n", serial.get_cnt_cb_iso_out());
+        printf("cnt_cb_iso_in   = %lu\r\n", serial.get_cnt_cb_iso_in());
+#endif
+        TEST_ASSERT_EQUAL_STRING("pass", _key);
+    }
+}
 
 /** Test USB implementation against repeated reset
 
@@ -409,12 +561,17 @@ Case cases[] = {
 #if SUSPEND_RESUME_TEST_SUPPORTED
     Case("usb device suspend/resume test", device_suspend_resume_test),
 #endif
-    Case("usb repeated construction destruction test", repeated_construction_destruction_test)
+    Case("usb repeated construction destruction test", repeated_construction_destruction_test),
+    Case("endpoint test data correctness", ep_test_data_correctness),
+    Case("endpoint test halt", ep_test_halt),
+    Case("endpoint test parallel transfers", ep_test_parallel_transfers),
+    Case("endpoint test parallel transfers ctrl", ep_test_parallel_transfers_ctrl),
+    Case("endpoint test abort", ep_test_abort)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(120, "pyusb_basic");
+    GREENTEA_SETUP(180, "pyusb_basic");
     return greentea_test_setup_handler(number_of_cases);
 }
 

--- a/usb/device/USBDevice/EndpointResolver.cpp
+++ b/usb/device/USBDevice/EndpointResolver.cpp
@@ -44,9 +44,9 @@ void EndpointResolver::endpoint_ctrl(uint32_t size)
     endpoint_out(USB_EP_TYPE_CTRL, size);
 }
 
-usb_ep_t EndpointResolver::endpoint_in(usb_ep_type_t type, uint32_t size)
+usb_ep_t EndpointResolver::next_free_endpoint(bool in_not_out, usb_ep_type_t type, uint32_t size)
 {
-    int index = next_index(type, true);
+    int index = next_index(type, in_not_out);
     if (index < 0) {
         _valid = false;
         return 0;
@@ -57,21 +57,16 @@ usb_ep_t EndpointResolver::endpoint_in(usb_ep_type_t type, uint32_t size)
     _used |= 1 << index;
 
     return index_to_endpoint(index);
+
+}
+usb_ep_t EndpointResolver::endpoint_in(usb_ep_type_t type, uint32_t size)
+{
+    return next_free_endpoint(true, type, size);
 }
 
 usb_ep_t EndpointResolver::endpoint_out(usb_ep_type_t type, uint32_t size)
 {
-    int index = next_index(type, false);
-    if (index < 0) {
-        _valid = false;
-        return 0;
-    }
-
-    const usb_ep_entry_t &entry = _table->table[index_to_logical(index)];
-    _cost += entry.base_cost + entry.byte_cost * size;
-    _used |= 1 << index;
-
-    return index_to_endpoint(index);
+    return next_free_endpoint(false, type, size);
 }
 
 bool EndpointResolver::valid()

--- a/usb/device/USBDevice/EndpointResolver.h
+++ b/usb/device/USBDevice/EndpointResolver.h
@@ -63,6 +63,11 @@ public:
     usb_ep_t endpoint_out(usb_ep_type_t type, uint32_t size);
 
     /**
+     * Get next free endpoint
+     */
+    usb_ep_t next_free_endpoint(bool in_not_out, usb_ep_type_t type, uint32_t size);
+
+    /**
      * Check if the endpoint configuration created so far is valid
      *
      * @return true if all endpoint sizes are available and fit, false otherwise


### PR DESCRIPTION
### Description

Extend `tests-usb_device-basic` with:
* `endpoint test abort`,
* `endpoint test data correctness`,
* `endpoint test data toggle reset`,
* `endpoint test halt`,
* `endpoint test parallel transfers`,
* `endpoint test parallel transfers ctrl`.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

CC @c1728p9 @maciejbocianski @jamesbeyond 

