### PR TITLE
lwIP: Enable TCP out-of-order processing

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwipopts.h
+++ b/features/FEATURE_LWIP/lwip-interface/lwipopts.h
@@ -210,7 +210,6 @@
 
 #if MBED_CONF_LWIP_TCP_ENABLED
 #define LWIP_TCP                    1
-#define TCP_QUEUE_OOSEQ             0
 #define TCP_OVERSIZE                0
 #define LWIP_TCP_KEEPALIVE          1
 #else


### PR DESCRIPTION
### Description

Our config file for lwIP had TCP_QUEUE_OOSEQ disabled - this can
cause significant performance problems, as observed during testing.

One lost packet can lock an input stream into a mode where the
transmitter keeps thinking packets are being lost, so keeps slowing
down. This caused test failures - a transfer that would normally
take 10s hit a 60s timeout.

Turning this on increases code size, but doesn't significantly increase
static memory use. The memory used for out-of-order packets comes from
the same pbuf pool as for outgoing TCP segments, so there is contention
when running bidirectionally.

Out-of-order processing is on by default for lwIP - this seems to be
another example of us excessively paring it back.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

