### PR TITLE
Update mbed-coap to version 4.4.3

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v4.4.3](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.4.3) 
+**Closed issues:**
+ - IOTCLT-2506 [GitHub] Cannot set registration time if server does not use max age option
+
+Extend blockwise message transfer status to have states for sending as well.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.4.2...v4.4.3)
+
 ## [v4.4.2](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.4.2) 
 **Closed issues:**
  - IOTCLT-2469 CoAP UDP retransmission does not work for blocks after first one for requests (Eg. registration POST)

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_header.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_header.h
@@ -158,8 +158,16 @@ typedef enum sn_coap_status_ {
     COAP_STATUS_PARSER_BLOCKWISE_MSG_REJECTED  = 5, /**< Blockwise message received but not supported by compiling switch */
     COAP_STATUS_PARSER_BLOCKWISE_MSG_RECEIVED  = 6, /**< Blockwise message fully received and returned to app.
                                                          User must take care of releasing whole payload of the blockwise messages */
-    COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED = 7  /**< When re-transmissions have been done and ACK not received, CoAP library calls
+    COAP_STATUS_BUILDER_MESSAGE_SENDING_FAILED = 7, /**< When re-transmissions have been done and ACK not received, CoAP library calls
                                                          RX callback with this status */
+
+    COAP_STATUS_BUILDER_BLOCK_SENDING_FAILED   = 8, /**< Blockwise message sending timeout.
+                                                         The msg_id in sn_coap_hdr_s* parameter of RX callback is set to the same value
+                                                         as in the first block sent, and parameter sn_nsdl_addr_s* is set as NULL.  */
+    COAP_STATUS_BUILDER_BLOCK_SENDING_DONE     = 9  /**< Blockwise message sending, last block sent.
+                                                         The msg_id in sn_coap_hdr_s* parameter of RX callback is set to the same value
+                                                         as in the first block sent, and parameter sn_nsdl_addr_s* is set as NULL. */
+
 } sn_coap_status_e;
 
 

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
+++ b/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
@@ -185,7 +185,10 @@ typedef struct coap_blockwise_msg_ {
     sn_coap_hdr_s       *coap_msg_ptr;
     struct coap_s       *coap;      /* CoAP library handle */
 
-    ns_list_link_t     link;
+    void                *param;
+    uint16_t            msg_id;
+
+    ns_list_link_t      link;
 } coap_blockwise_msg_s;
 
 typedef NS_LIST_HEAD(coap_blockwise_msg_s, link) coap_blockwise_msg_list_t;

--- a/features/frameworks/mbed-coap/source/sn_coap_parser.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_parser.c
@@ -102,7 +102,7 @@ sn_coap_options_list_s *sn_coap_parser_alloc_options(struct coap_s *handle, sn_c
     /* XXX not technically legal to memset pointers to 0 */
     memset(coap_msg_ptr->options_list_ptr, 0x00, sizeof(sn_coap_options_list_s));
 
-    coap_msg_ptr->options_list_ptr->max_age = COAP_OPTION_MAX_AGE_DEFAULT;
+    coap_msg_ptr->options_list_ptr->max_age = 0;
     coap_msg_ptr->options_list_ptr->uri_port = COAP_OPTION_URI_PORT_NONE;
     coap_msg_ptr->options_list_ptr->observe = COAP_OBSERVE_NONE;
     coap_msg_ptr->options_list_ptr->accept = COAP_CT_NONE;


### PR DESCRIPTION
### Description

Fixes error: IOTCLT-2506 [GitHub] Cannot set registration time if server does not use max age option
Improvements; Extend blockwise message transfer status to have states for sending as well.

NOTE! These are internal changes required for cloud client. This has no direct relevance to any mbed-os functionality.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

