### PR TITLE
USB: Device: Fix IN and OUT callbacks

### DIFF
--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -932,7 +932,9 @@ void USBDevice::out(usb_ep_t endpoint)
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
 
-    MBED_ASSERT(info->pending >= 1);
+    if (info->pending < 1) {
+        return;
+    }
     info->pending -= 1;
     if (info->callback) {
         (this->*(info->callback))(endpoint);
@@ -950,7 +952,9 @@ void USBDevice::in(usb_ep_t endpoint)
 
     endpoint_info_t *info = &_endpoint_info[EP_TO_INDEX(endpoint)];
 
-    MBED_ASSERT(info->pending >= 1);
+    if (info->pending < 1) {
+        return;
+    }
     info->pending -= 1;
     if (info->callback) {
         (this->*(info->callback))(endpoint);


### PR DESCRIPTION
Do not fail the assertion if no endpoints are pending when IN or OUT
transmission takes place.

The condition `info->pending >= 1` may be false if `endpoint_abort()` is
called after the `read_start()` or `write_start()` and before the
`out()` or `in()` callback.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @c1728p9 @maciejbocianski @jamesbeyond