### PR TITLE
BL mode: Prevent jump address conflicts

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -434,6 +434,7 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
         if region.filename:
             notify.info("  Filling region %s with %s" % (region.name, region.filename))
             part = intelhex_offset(region.filename, offset=region.start)
+            part.start_addr = None
             part_size = (part.maxaddr() - part.minaddr()) + 1
             if part_size > region.size:
                 raise ToolException("Contents of region %s does not fit"


### PR DESCRIPTION
### Description

The Intel hex file format contains enough information to load a program
into memory and _begin it's execution_. This includes a jump address,
which is generally set to main, that is generated by most compilers. When
merging two Intel hex files, there is no way to know a priori which one
is the true jump address. Therefore, IntelHex (the python package) has
opted to raise an exception: `Starting addresses are different`. This can 
happen when jump address is set in a boot loader and an application; when 
both are built as Intel hex. This patch removes jump addresses before 
merging the boot loader with the application.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change