### PR TITLE
Corrected iteritems py2/3 compatability in test_api.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ fuzzywuzzy>=0.11
 pyelftools>=0.24
 jsonschema>=2.6
 future>=0.16.0
+six>=1.11.0

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -17,6 +17,7 @@ limitations under the License.
 Author: Przemyslaw Wirkus <Przemyslaw.wirkus@arm.com>
 """
 from __future__ import print_function
+import six
 
 import os
 import re
@@ -2126,12 +2127,12 @@ def find_tests(base_dir, target_name, toolchain_name, app_config=None):
 
     # Apply common directories
     for pred, path in commons:
-        for test_identity, test_paths in tests.iteritems():
+        for test_identity, test_paths in six.iteritems(tests):
             if pred(test_identity):
                 test_paths.append(path)
 
     # Drop identity besides name
-    return {name: paths for (name, _, _, _), paths in tests.iteritems()}
+    return {name: paths for (name, _, _, _), paths in six.iteritems(tests)}
 
 def print_tests(tests, format="list", sort=True):
     """Given a dictionary of tests (as returned from "find_tests"), print them


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Fixes an iteritems compatibility between py2 and py3.

Discovered whilst finalizing py3 support for mbed-cli circleci tests.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

