### PR TITLE
Fix build error with secure/non-secure ROM address on Cortex-M23/M33

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -575,6 +575,13 @@ class Config(object):
             except KeyError:
                 raise ConfigException("Not enough information in CMSIS packs to "
                                       "build a bootloader project")
+        
+        # Fix TrustZone secure/non-secure ROM address
+        if (self.target.core == "Cortex-M23" or self.target.core == "Cortex-M33"):
+            rom_start = rom_start + int(getattr(self.target, "tz_offset", "0x0"), 0)
+        elif (self.target.core == "Cortex-M23-NS" or self.target.core == "Cortex-M33-NS"):
+            rom_start = rom_start + int(getattr(self.target, "tz_offset_ns", "0x0"), 0)
+        
         if self.target.bootloader_img or self.target.restrict_size:
             return self._generate_bootloader_build(rom_start, rom_size)
         elif self.target.mbed_app_start or self.target.mbed_app_size:


### PR DESCRIPTION
### Description

This PR tries to fix secure/non-secure ROM address error in bootloader-related build on Cortex-M23/M33. Take our on-going **NUMAKER_PFM_M2351** as an example. Its ROM address is `0x0` from CMSIS pack. By introducing `tz_offset`/`tz_offset_ns`, we can correct secure/non-secure ROM address to `0x0`/`0x10000000` in build tool.
<pre>
"NUMAKER_PFM_M2351": {
        "core": "Cortex-M23-NS",
        "default_toolchain": "GCC_ARM",
        "extra_labels": ["NUVOTON", "M2351", "M2351KIAAEES", "FLASH_CMSIS_ALGO"],
        "OUTPUT_EXT": "hex",
        "macros": ["MBED_FAULT_HANDLER_DISABLED", "MBED_TZ_DEFAULT_ACCESS=1"],
        "is_disk_virtual": true,
        "supported_toolchains": ["GCC_ARM", "IAR", "ARMC6"],
        "config": {
            "gpio-irq-debounce-enable": {
                "help": "Enable GPIO IRQ debounce",
                "value": 0
            },
            "gpio-irq-debounce-enable-list": {
                "help": "Comma separated pin list to enable GPIO IRQ debounce",
                "value": "NC"
            },
            "gpio-irq-debounce-clock-source": {
                "help": "Select GPIO IRQ debounce clock source: GPIO_DBCTL_DBCLKSRC_HCLK or GPIO_DBCTL_DBCLKSRC_LIRC",
                "value": "GPIO_DBCTL_DBCLKSRC_LIRC"
            },
            "gpio-irq-debounce-sample-rate": {
                "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCTL_DBCLKSEL_1, GPIO_DBCTL_DBCLKSEL_2, GPIO_DBCTL_DBCLKSEL_4, ..., or GPIO_DBCTL_DBCLKSEL_32768",
                "value": "GPIO_DBCTL_DBCLKSEL_16"
            }
        },
        "inherits": ["Target"],
        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "LOWPOWERTIMER", "RTC", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG", "FLASH"],
        "detect_code": ["1305"],
        "release_versions": ["5"],
        "device_name": "M2351KIAAEES",
        "bootloader_supported": true,
        <b>
        "tz_offset": "0x0",
        "tz_offset_ns": "0x10000000"
        </b>
    },
    "NUMAKER_PFM_M2351_S": {
        "core": "Cortex-M23",
        "inherits": ["NUMAKER_PFM_M2351"],
        "device_has_remove": ["TRNG"]
    },
    "NUMAKER_PFM_M2351_NS": {
        "core": "Cortex-M23-NS",
        "inherits": ["NUMAKER_PFM_M2351"]
    }
</pre>

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

