### PR TITLE
Lora: Remove obsolete FEATURE_COMMON_PAL flags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -150,7 +150,7 @@ matrix:
         - python tools/make.py -t GCC_ARM -m K64F --source=. --build=BUILD/K64F/GCC_ARM -j0
         # Check that example compiles without rtos
         - sed -n '/``` cpp/,/```/{/```$/Q;/```/d;p;}' $EVENTS/README.md > main.cpp
-        - rm -r rtos features/cellular features/netsocket features/nanostack features/frameworks BUILD
+        - rm -r rtos features/cellular features/netsocket features/nanostack features/frameworks/greentea-client features/frameworks/utest features/frameworks/unity BUILD
         - python tools/make.py -t GCC_ARM -m DISCO_F401VC --source=. --build=BUILD/DISCO_F401VC/GCC_ARM -j0
         # Run local equeue tests
         - make -C $EVENTS/equeue test

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -29,15 +29,9 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "events/EventQueue.h"
 
 #include "LoRaWANStack.h"
-#if defined(FEATURE_COMMON_PAL)
-#include "mbed_trace.h"
+
+#include "mbed-trace/mbed_trace.h"
 #define TRACE_GROUP "LSTK"
-#else
-#define tr_debug(...) (void(0)) //dummies if feature common pal is not added
-#define tr_info(...)  (void(0)) //dummies if feature common pal is not added
-#define tr_error(...) (void(0)) //dummies if feature common pal is not added
-#define tr_warn(...) (void(0)) //dummies if feature common pal is not added
-#endif //defined(FEATURE_COMMON_PAL)
 
 #define INVALID_PORT                0xFF
 #define MAX_CONFIRMED_MSG_RETRIES   255

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -22,17 +22,10 @@ Copyright (c) 2017, Arm Limited and affiliates.
 SPDX-License-Identifier: BSD-3-Clause
 */
 #include <stdlib.h>
-
 #include "LoRaMac.h"
 
-#if defined(FEATURE_COMMON_PAL)
-#include "mbed_trace.h"
+#include "mbed-trace/mbed_trace.h"
 #define TRACE_GROUP "LMAC"
-#else
-#define tr_debug(...) (void(0)) //dummies if feature common pal is not added
-#define tr_info(...)  (void(0)) //dummies if feature common pal is not added
-#define tr_error(...) (void(0)) //dummies if feature common pal is not added
-#endif //defined(FEATURE_COMMON_PAL)
 
 using namespace events;
 using namespace mbed;

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -25,14 +25,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #include "LoRaMacCommand.h"
 #include "LoRaMac.h"
 
-#if defined(FEATURE_COMMON_PAL)
-#include "mbed_trace.h"
+#include "mbed-trace/mbed_trace.h"
 #define TRACE_GROUP "LMACC"
-#else
-#define tr_debug(...) (void(0)) //dummies if feature common pal is not added
-#define tr_info(...)  (void(0)) //dummies if feature common pal is not added
-#define tr_error(...) (void(0)) //dummies if feature common pal is not added
-#endif //defined(FEATURE_COMMON_PAL)
 
 /**
  * LoRaMAC max EIRP (dBm) table.


### PR DESCRIPTION
### Description

mbed-trace no longer requires `COMMON_PAL` to be enabled.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

