### PR TITLE
Cellular: added device reset to cellular state machine start.

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -218,6 +218,9 @@ private:
     const char* _plmn;
     bool _command_success;
     bool _plmn_network_found;
+#if MBED_CONF_CELLULAR_RESET_DEVICE_IN_START != 0
+    bool _device_restarted;
+#endif
 };
 
 } // namespace

--- a/features/cellular/mbed_lib.json
+++ b/features/cellular/mbed_lib.json
@@ -8,6 +8,10 @@
         "random_max_start_delay": {
             "help": "Maximum random delay value used in start-up sequence in milliseconds",
             "value": 0
+        },
+        "reset_device_in_start": {
+            "help": "Reset the device after power",
+            "value": 0
         }
     }
 }


### PR DESCRIPTION


### Description

Added device reset to cellular state machine start.
Some devices need possibility to reset device when starting cellular state machine. Added configurable possibility and by default reset is not done.

Internal ref to defect: IOTCELL-993

@TeemuKultala 
@AriParkkila 
please review.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

