### PR TITLE
LoRaWAN: Adding acquisition of metadata, backoff and a cancel_send() API

### DIFF
--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -389,6 +389,19 @@ public:
      *
      */
     virtual lorawan_status_t get_backoff_metadata(int& backoff) = 0;
+
+    /** Cancel outgoing transmission
+     *
+     * This API is used to cancel any outstanding transmission in the TX pipe.
+     * If an event for transmission is not already queued at the end of backoff timer,
+     * the system can cancel the outstanding outgoing packet. Otherwise, the system is
+     * busy sending and can't be held back.
+     *
+     * @return              LORAWAN_STATUS_OK if the sending is cancelled.
+     *                      LORAWAN_STATUS_BUSY otherwise.
+     *
+     */
+    virtual lorawan_status_t cancel_sending(void) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */

--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -352,7 +352,7 @@ public:
      * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
-    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata) = 0;
+    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata &metadata) = 0;
 
     /** Get hold of RX meta-data
      *
@@ -368,7 +368,7 @@ public:
      * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
-    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata) = 0;
+    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata &metadata) = 0;
 
     /** Get hold of backoff time
      *
@@ -388,7 +388,7 @@ public:
      *                      otherwise LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      *
      */
-    virtual lorawan_status_t get_backoff_metadata(int& backoff) = 0;
+    virtual lorawan_status_t get_backoff_metadata(int &backoff) = 0;
 
     /** Cancel outgoing transmission
      *

--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -353,6 +353,22 @@ public:
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
     virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata) = 0;
+
+    /** Get hold of RX meta-data
+     *
+     * Use this method to acquire any RX meta-data related to current
+     * reception.
+     * RX meta-data is only available right after the reception is completed.
+     * In other words, you can check for RX meta-data right after receiving the
+     * RX_DONE event.
+     *
+     * @param    metadata    the inbound structure that will be filled if the meta-data
+     *                       is available.
+     *
+     * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     */
+    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */

--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -369,6 +369,26 @@ public:
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
     virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata) = 0;
+
+    /** Get hold of backoff time
+     *
+     * In the TX path, because of automatic duty cycling, the transmission is delayed
+     * by a certain amount of time which is the backoff time. While the system schedules
+     * application data to be sent, the application can inquire about how much time is
+     * left in the actual transmission to happen.
+     *
+     * The system will provide you with a backoff time only if the application data is
+     * in the TX pipe. If however, the event is already queued for the transmission, this
+     * API returns a LORAWAN_STATUS_METADATA_NOT_AVAILABLE error code.
+     *
+     * @param    backoff    the inbound integer that will be carry the backoff time if it
+     *                      is available.
+     *
+     * @return              LORAWAN_STATUS_OK if the meta-data regarding backoff is available,
+     *                      otherwise LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     *
+     */
+    virtual lorawan_status_t get_backoff_metadata(int& backoff) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */

--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -337,6 +337,22 @@ public:
      *                          or other negative error code if request failed.
      */
     virtual lorawan_status_t set_device_class(device_class_t device_class) = 0;
+
+    /** Get hold of TX meta-data
+     *
+     * Use this method to acquire any TX meta-data related to previous
+     * transmission.
+     * TX meta-data is only available right after the transmission is completed.
+     * In other words, you can check for TX meta-data right after receiving the
+     * TX_DONE event.
+     *
+     * @param    metadata    the inbound structure that will be filled if the meta-data
+     *                       is available.
+     *
+     * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     */
+    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata) = 0;
 };
 
 #endif /* LORAWAN_BASE_H_ */

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -122,6 +122,12 @@ int16_t LoRaWANInterface::send(uint8_t port, const uint8_t* data, uint16_t lengt
     return _lw_stack.handle_tx(port, data, length, flags);
 }
 
+lorawan_status_t LoRaWANInterface::cancel_sending(void)
+{
+    Lock lock(*this);
+    return _lw_stack.stop_sending();
+}
+
 lorawan_status_t LoRaWANInterface::get_tx_metadata(lorawan_tx_metadata& metadata)
 {
     Lock lock(*this);

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -128,6 +128,12 @@ lorawan_status_t LoRaWANInterface::get_tx_metadata(lorawan_tx_metadata& metadata
     return _lw_stack.acquire_tx_metadata(metadata);
 }
 
+lorawan_status_t LoRaWANInterface::get_rx_metadata(lorawan_rx_metadata& metadata)
+{
+    Lock lock(*this);
+    return _lw_stack.acquire_rx_metadata(metadata);
+}
+
 int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length, int flags)
 {
     Lock lock(*this);

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -134,6 +134,12 @@ lorawan_status_t LoRaWANInterface::get_rx_metadata(lorawan_rx_metadata& metadata
     return _lw_stack.acquire_rx_metadata(metadata);
 }
 
+lorawan_status_t LoRaWANInterface::get_backoff_metadata(int& backoff)
+{
+    Lock lock(*this);
+    return _lw_stack.acquire_backoff_metadata(backoff);
+}
+
 int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length, int flags)
 {
     Lock lock(*this);

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -122,6 +122,12 @@ int16_t LoRaWANInterface::send(uint8_t port, const uint8_t* data, uint16_t lengt
     return _lw_stack.handle_tx(port, data, length, flags);
 }
 
+lorawan_status_t LoRaWANInterface::get_tx_metadata(lorawan_tx_metadata& metadata)
+{
+    Lock lock(*this);
+    return _lw_stack.acquire_tx_metadata(metadata);
+}
+
 int16_t LoRaWANInterface::receive(uint8_t port, uint8_t* data, uint16_t length, int flags)
 {
     Lock lock(*this);

--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -128,19 +128,19 @@ lorawan_status_t LoRaWANInterface::cancel_sending(void)
     return _lw_stack.stop_sending();
 }
 
-lorawan_status_t LoRaWANInterface::get_tx_metadata(lorawan_tx_metadata& metadata)
+lorawan_status_t LoRaWANInterface::get_tx_metadata(lorawan_tx_metadata &metadata)
 {
     Lock lock(*this);
     return _lw_stack.acquire_tx_metadata(metadata);
 }
 
-lorawan_status_t LoRaWANInterface::get_rx_metadata(lorawan_rx_metadata& metadata)
+lorawan_status_t LoRaWANInterface::get_rx_metadata(lorawan_rx_metadata &metadata)
 {
     Lock lock(*this);
     return _lw_stack.acquire_rx_metadata(metadata);
 }
 
-lorawan_status_t LoRaWANInterface::get_backoff_metadata(int& backoff)
+lorawan_status_t LoRaWANInterface::get_backoff_metadata(int &backoff)
 {
     Lock lock(*this);
     return _lw_stack.acquire_backoff_metadata(backoff);

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -488,6 +488,20 @@ public:
      */
     virtual lorawan_status_t get_backoff_metadata(int& backoff);
 
+    /** Cancel outgoing transmission
+     *
+     * This API is used to cancel any outstanding transmission in the TX pipe.
+     * If an event for transmission is not already queued at the end of backoff timer,
+     * the system can cancel the outstanding outgoing packet. Otherwise, the system is
+     * busy sending and can't be held back. The system will not try to re-send if the
+     * outgoing message was a CONFIRMED message even if the ack is not received.
+     *
+     * @return              LORAWAN_STATUS_OK if the sending is cancelled.
+     *                      LORAWAN_STATUS_BUSY otherwise.
+     *
+     */
+    virtual lorawan_status_t cancel_sending(void);
+
     void lock(void) { _lw_stack.lock(); }
     void unlock(void) { _lw_stack.unlock(); }
 

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -452,6 +452,22 @@ public:
      */
     virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata);
 
+    /** Get hold of RX meta-data
+     *
+     * Use this method to acquire any RX meta-data related to current
+     * reception.
+     * RX meta-data is only available right after the reception is completed.
+     * In other words, you can check for RX meta-data right after receiving the
+     * RX_DONE event.
+     *
+     * @param    metadata    the inbound structure that will be filled if the meta-data
+     *                       is available.
+     *
+     * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     */
+    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata);
+
     void lock(void) { _lw_stack.lock(); }
     void unlock(void) { _lw_stack.unlock(); }
 

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -436,6 +436,22 @@ public:
      */
     virtual lorawan_status_t set_device_class(const device_class_t device_class);
 
+    /** Get hold of TX meta-data
+     *
+     * Use this method to acquire any TX meta-data related to previous
+     * transmission.
+     * TX meta-data is only available right after the transmission is completed.
+     * In other words, you can check for TX meta-data right after receiving the
+     * TX_DONE event.
+     *
+     * @param    metadata    the inbound structure that will be filled if the meta-data
+     *                       is available.
+     *
+     * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     */
+    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata);
+
     void lock(void) { _lw_stack.lock(); }
     void unlock(void) { _lw_stack.unlock(); }
 

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -468,6 +468,26 @@ public:
      */
     virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata);
 
+    /** Get hold of backoff time
+     *
+     * In the TX path, because of automatic duty cycling, the transmission is delayed
+     * by a certain amount of time which is the backoff time. While the system schedules
+     * application data to be sent, the application can inquire about how much time is
+     * left in the actual transmission to happen.
+     *
+     * The system will provide you with a backoff time only if the application data is
+     * in the TX pipe. If however, the event is already queued for the transmission, this
+     * API returns a LORAWAN_STATUS_METADATA_NOT_AVAILABLE error code.
+     *
+     * @param    backoff    the inbound integer that will be carry the backoff time if it
+     *                      is available.
+     *
+     * @return              LORAWAN_STATUS_OK if the meta-data regarding backoff is available,
+     *                      otherwise LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
+     *
+     */
+    virtual lorawan_status_t get_backoff_metadata(int& backoff);
+
     void lock(void) { _lw_stack.lock(); }
     void unlock(void) { _lw_stack.unlock(); }
 

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -450,7 +450,7 @@ public:
      * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
-    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata& metadata);
+    virtual lorawan_status_t get_tx_metadata(lorawan_tx_metadata &metadata);
 
     /** Get hold of RX meta-data
      *
@@ -466,7 +466,7 @@ public:
      * @return               LORAWAN_STATUS_OK if the meta-data is available, otherwise
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      */
-    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata& metadata);
+    virtual lorawan_status_t get_rx_metadata(lorawan_rx_metadata &metadata);
 
     /** Get hold of backoff time
      *
@@ -486,7 +486,7 @@ public:
      *                      otherwise LORAWAN_STATUS_METADATA_NOT_AVAILABLE is returned.
      *
      */
-    virtual lorawan_status_t get_backoff_metadata(int& backoff);
+    virtual lorawan_status_t get_backoff_metadata(int &backoff);
 
     /** Cancel outgoing transmission
      *

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -553,6 +553,7 @@ void LoRaWANStack::process_transmission(void)
         if (_loramac.get_mcps_confirmation()->req_type == MCPS_CONFIRMED) {
             _ctrl_flags |= TX_ONGOING_FLAG;
             _ctrl_flags &= ~TX_DONE_FLAG;
+            tr_debug("Awaiting ACK");
             _device_current_state = DEVICE_STATE_AWAITING_ACK;
             return;
         }

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -446,6 +446,19 @@ lorawan_status_t LoRaWANStack::acquire_rx_metadata(lorawan_rx_metadata& metadata
     return LORAWAN_STATUS_METADATA_NOT_AVAILABLE;
 }
 
+lorawan_status_t LoRaWANStack::acquire_backoff_metadata(int& backoff)
+{
+    int id = _loramac.get_backoff_timer_event_id();
+
+    if (_loramac.get_backoff_timer_event_id() > 0) {
+        backoff = _queue->time_left(id);
+        return LORAWAN_STATUS_OK;
+    }
+
+    backoff = -1;
+    return LORAWAN_STATUS_METADATA_NOT_AVAILABLE;
+}
+
 /*****************************************************************************
  * Interrupt handlers                                                        *
  ****************************************************************************/

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -540,8 +540,8 @@ void LoRaWANStack::process_transmission_timeout()
 
 void LoRaWANStack::process_transmission(void)
 {
-    _loramac.on_radio_tx_done();
     tr_debug("Transmission completed");
+    _loramac.on_radio_tx_done();
 
     make_tx_metadata_available();
 

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -259,17 +259,17 @@ lorawan_status_t LoRaWANStack::enable_adaptive_datarate(bool adr_enabled)
 
 lorawan_status_t LoRaWANStack::stop_sending(void)
 {
-     if (_loramac.clear_tx_pipe() == LORAWAN_STATUS_OK) {
-         if (_device_current_state == DEVICE_STATE_SENDING) {
-             _ctrl_flags &= ~TX_DONE_FLAG;
-             _ctrl_flags &= ~TX_ONGOING_FLAG;
-             _loramac.set_tx_ongoing(false);
-             _device_current_state = DEVICE_STATE_IDLE;
-             return LORAWAN_STATUS_OK;
-         }
-     }
+    if (_loramac.clear_tx_pipe() == LORAWAN_STATUS_OK) {
+        if (_device_current_state == DEVICE_STATE_SENDING) {
+            _ctrl_flags &= ~TX_DONE_FLAG;
+            _ctrl_flags &= ~TX_ONGOING_FLAG;
+            _loramac.set_tx_ongoing(false);
+            _device_current_state = DEVICE_STATE_IDLE;
+            return LORAWAN_STATUS_OK;
+        }
+    }
 
-     return LORAWAN_STATUS_BUSY;
+    return LORAWAN_STATUS_BUSY;
 }
 
 int16_t LoRaWANStack::handle_tx(const uint8_t port, const uint8_t* data,
@@ -439,7 +439,7 @@ lorawan_status_t LoRaWANStack::set_device_class(const device_class_t& device_cla
     return LORAWAN_STATUS_OK;
 }
 
-lorawan_status_t  LoRaWANStack::acquire_tx_metadata(lorawan_tx_metadata& tx_metadata)
+lorawan_status_t  LoRaWANStack::acquire_tx_metadata(lorawan_tx_metadata &tx_metadata)
 {
     if (!_tx_metadata.stale) {
         tx_metadata = _tx_metadata;
@@ -450,7 +450,7 @@ lorawan_status_t  LoRaWANStack::acquire_tx_metadata(lorawan_tx_metadata& tx_meta
     return LORAWAN_STATUS_METADATA_NOT_AVAILABLE;
 }
 
-lorawan_status_t LoRaWANStack::acquire_rx_metadata(lorawan_rx_metadata& metadata)
+lorawan_status_t LoRaWANStack::acquire_rx_metadata(lorawan_rx_metadata &metadata)
 {
     if (!_rx_metadata.stale) {
         metadata = _rx_metadata;

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -441,6 +441,10 @@ lorawan_status_t LoRaWANStack::set_device_class(const device_class_t& device_cla
 
 lorawan_status_t  LoRaWANStack::acquire_tx_metadata(lorawan_tx_metadata &tx_metadata)
 {
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state) {
+        return LORAWAN_STATUS_NOT_INITIALIZED;
+    }
+
     if (!_tx_metadata.stale) {
         tx_metadata = _tx_metadata;
         _tx_metadata.stale = true;
@@ -452,6 +456,10 @@ lorawan_status_t  LoRaWANStack::acquire_tx_metadata(lorawan_tx_metadata &tx_meta
 
 lorawan_status_t LoRaWANStack::acquire_rx_metadata(lorawan_rx_metadata &metadata)
 {
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state) {
+        return LORAWAN_STATUS_NOT_INITIALIZED;
+    }
+
     if (!_rx_metadata.stale) {
         metadata = _rx_metadata;
         _rx_metadata.stale = true;
@@ -463,6 +471,10 @@ lorawan_status_t LoRaWANStack::acquire_rx_metadata(lorawan_rx_metadata &metadata
 
 lorawan_status_t LoRaWANStack::acquire_backoff_metadata(int& backoff)
 {
+    if (DEVICE_STATE_NOT_INITIALIZED == _device_current_state) {
+        return LORAWAN_STATUS_NOT_INITIALIZED;
+    }
+
     int id = _loramac.get_backoff_timer_event_id();
 
     if (_loramac.get_backoff_timer_event_id() > 0) {

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -391,6 +391,18 @@ public:
      */
     lorawan_status_t acquire_tx_metadata(lorawan_tx_metadata& metadata);
 
+    /** Acquire RX meta-data
+     *
+     * Upon successful reception, RX meta-data will be made available
+     *
+     * @param    metadata    A reference to the inbound structure which will be
+     *                       filled with any RX meta-data if available.
+     *
+     * @return               LORAWAN_STATUS_OK if successful,
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
+     */
+    lorawan_status_t acquire_rx_metadata(lorawan_rx_metadata& metadata);
+
     void lock(void) { _loramac.lock(); }
     void unlock(void) { _loramac.unlock(); }
 
@@ -486,6 +498,7 @@ private:
     int convert_to_msg_flag(const mcps_type_t type);
 
     void make_tx_metadata_available(void);
+    void make_rx_metadata_available(void);
 
 private:
     LoRaMac _loramac;
@@ -496,6 +509,7 @@ private:
     loramac_tx_message_t _tx_msg;
     loramac_rx_message_t _rx_msg;
     lorawan_tx_metadata _tx_metadata;
+    lorawan_rx_metadata _rx_metadata;
     uint8_t _num_retry;
     uint32_t _ctrl_flags;
     uint8_t _app_port;

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -389,7 +389,7 @@ public:
      * @return               LORAWAN_STATUS_OK if successful,
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
      */
-    lorawan_status_t acquire_tx_metadata(lorawan_tx_metadata& metadata);
+    lorawan_status_t acquire_tx_metadata(lorawan_tx_metadata &metadata);
 
     /** Acquire RX meta-data
      *
@@ -401,7 +401,7 @@ public:
      * @return               LORAWAN_STATUS_OK if successful,
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
      */
-    lorawan_status_t acquire_rx_metadata(lorawan_rx_metadata& metadata);
+    lorawan_status_t acquire_rx_metadata(lorawan_rx_metadata &metadata);
 
     /** Acquire backoff meta-data
      *
@@ -413,7 +413,7 @@ public:
      * @return               LORAWAN_STATUS_OK if successful,
      *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
      */
-    lorawan_status_t acquire_backoff_metadata(int& backoff);
+    lorawan_status_t acquire_backoff_metadata(int &backoff);
 
     /** Stops sending
      *

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -522,6 +522,8 @@ private:
     void make_tx_metadata_available(void);
     void make_rx_metadata_available(void);
 
+    void handle_ack_expiry_for_class_c(void);
+
 private:
     LoRaMac _loramac;
     radio_events_t radio_events;

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -415,6 +415,16 @@ public:
      */
     lorawan_status_t acquire_backoff_metadata(int& backoff);
 
+    /** Stops sending
+     *
+     * Stop sending any outstanding messages if they are not yet queued for
+     * transmission, i.e., if the backoff timer is nhot elapsed yet.
+     *
+     * @return               LORAWAN_STATUS_OK if the transmission is cancelled.
+     *                       LORAWAN_STATUS_BUSY otherwise.
+     */
+    lorawan_status_t stop_sending(void);
+
     void lock(void) { _loramac.lock(); }
     void unlock(void) { _loramac.unlock(); }
 

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -379,6 +379,18 @@ public:
      */
     lorawan_status_t set_device_class(const device_class_t& device_class);
 
+    /** Acquire TX meta-data
+     *
+     * Upon successful transmission, TX meta-data will be made available
+     *
+     * @param    metadata    A reference to the inbound structure which will be
+     *                       filled with any TX meta-data if available.
+     *
+     * @return               LORAWAN_STATUS_OK if successful,
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
+     */
+    lorawan_status_t acquire_tx_metadata(lorawan_tx_metadata& metadata);
+
     void lock(void) { _loramac.lock(); }
     void unlock(void) { _loramac.unlock(); }
 
@@ -473,6 +485,8 @@ private:
 
     int convert_to_msg_flag(const mcps_type_t type);
 
+    void make_tx_metadata_available(void);
+
 private:
     LoRaMac _loramac;
     radio_events_t radio_events;
@@ -481,6 +495,7 @@ private:
     lorawan_session_t _lw_session;
     loramac_tx_message_t _tx_msg;
     loramac_rx_message_t _rx_msg;
+    lorawan_tx_metadata _tx_metadata;
     uint8_t _num_retry;
     uint32_t _ctrl_flags;
     uint8_t _app_port;

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -403,6 +403,18 @@ public:
      */
     lorawan_status_t acquire_rx_metadata(lorawan_rx_metadata& metadata);
 
+    /** Acquire backoff meta-data
+     *
+     * Get hold of backoff time after which the transmission will take place.
+     *
+     * @param    backoff     A reference to the inbound integer which will be
+     *                       filled with any backoff meta-data if available.
+     *
+     * @return               LORAWAN_STATUS_OK if successful,
+     *                       LORAWAN_STATUS_METADATA_NOT_AVAILABLE otherwise
+     */
+    lorawan_status_t acquire_backoff_metadata(int& backoff);
+
     void lock(void) { _loramac.lock(); }
     void unlock(void) { _loramac.unlock(); }
 

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1008,6 +1008,11 @@ lorawan_status_t LoRaMac::send(loramac_mhdr_t *machdr, const uint8_t fport,
     return status;
 }
 
+int LoRaMac::get_backoff_timer_event_id(void)
+{
+    return _params.timers.backoff_timer.timer_id;
+}
+
 lorawan_status_t LoRaMac::schedule_tx()
 {
     channel_selection_params_t next_channel;

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -351,8 +351,10 @@ public:
     /**
      * @brief set_device_class Sets active device class.
      * @param device_class Device class to use.
+     * @param ack_expiry_handler callback function to inform about ack expiry
      */
-    void set_device_class(const device_class_t& device_class);
+    void set_device_class(const device_class_t& device_class,
+                          mbed::Callback<void(void)>ack_expiry_handler);
 
     /**
      * @brief opens a continuous RX2 window for Class C devices
@@ -641,6 +643,13 @@ private:
      * EventQueue object storage
      */
     events::EventQueue *_ev_queue;
+
+    /**
+     * Class C doesn't timeout in RX2 window as it is a continuous window.
+     * We use this callback to inform the LoRaWANStack controller that the
+     * system cannot do more retries.
+     */
+    mbed::Callback<void(void)> _ack_expiry_handler_for_class_c;
 
     /**
      * Structure to hold MCPS indication data.

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -448,6 +448,12 @@ public:
     int get_backoff_timer_event_id(void);
 
     /**
+     * Clears out the TX pipe by discarding any outgoing message if the backoff
+     * timer is still running.
+     */
+    lorawan_status_t clear_tx_pipe(void);
+
+    /**
      * These locks trample through to the upper layers and make
      * the stack thread safe.
      */

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -675,6 +675,8 @@ private:
 
     bool _is_nwk_joined;
 
+    bool _continuous_rx2_window_open;
+
     device_class_t _device_class;
 
 #if defined(LORAWAN_COMPLIANCE_TEST)

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -472,11 +472,6 @@ private:
 #endif
 
     /**
-     * Aborts reception
-     */
-    void abort_rx(void);
-
-    /**
      * Handles a Join Accept frame
      */
     void handle_join_accept_frame(const uint8_t *payload, uint16_t size);

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -443,6 +443,11 @@ public:
     void set_batterylevel_callback(mbed::Callback<uint8_t(void)> battery_level);
 
     /**
+     * Returns the event ID of backoff timer.
+     */
+    int get_backoff_timer_event_id(void);
+
+    /**
      * These locks trample through to the upper layers and make
      * the stack thread safe.
      */

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -350,29 +350,29 @@ typedef struct lora_channelplan {
  */
 typedef struct {
     /**
-     * A boolean to mark if the meta data is stale
+     * The transmission time on air of the frame.
      */
-    bool stale;
+    uint32_t tx_toa;
     /**
      * The uplink channel used for transmission.
      */
     uint32_t channel;
     /**
-     * The uplink datarate.
-     */
-    uint8_t data_rate;
-    /**
      * The transmission power.
      */
     int8_t tx_power;
+    /**
+     * The uplink datarate.
+     */
+    uint8_t data_rate;
     /**
      * Provides the number of retransmissions.
      */
     uint8_t nb_retries;
     /**
-     * The transmission time on air of the frame.
+     * A boolean to mark if the meta data is stale
      */
-    uint32_t tx_toa;
+    bool stale;
 } lorawan_tx_metadata;
 
 /**
@@ -380,25 +380,21 @@ typedef struct {
  */
 typedef struct {
     /**
-     * A boolean to mark if the meta data is stale
+     * The RSSI for the received packet.
      */
-    bool stale;
+    int16_t rssi;
     /**
      * Data rate of reception
      */
     uint8_t rx_datarate;
     /**
-     * Frame pending status.
-     */
-    uint8_t fpending_status;
-    /**
-     * The RSSI for the received packet.
-     */
-    int16_t rssi;
-    /**
      * The SNR for the received packet.
      */
     uint8_t snr;
+    /**
+     * A boolean to mark if the meta data is stale
+     */
+    bool stale;
 } lorawan_rx_metadata;
 
 #endif /* MBED_LORAWAN_TYPES_H_ */

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -192,7 +192,7 @@ typedef struct lorawan_connect {
  * TX_DONE              - When a packet is sent
  * TX_TIMEOUT,          - When stack was unable to send packet in TX window
  * TX_ERROR,            - A general TX error
- * TX_CRYPTO_ERROR,     - If MIC fails, or any other crypto relted error
+ * CRYPTO_ERROR,        - A crypto error indicating wrong keys
  * TX_SCHEDULING_ERROR, - When stack is unable to schedule packet
  * RX_DONE,             - When there is something to receive
  * RX_TIMEOUT,          - Not yet mapped
@@ -209,7 +209,8 @@ typedef enum lora_events {
     TX_DONE,
     TX_TIMEOUT,
     TX_ERROR,
-    TX_CRYPTO_ERROR,
+    CRYPTO_ERROR,
+    TX_CRYPTO_ERROR = CRYPTO_ERROR, //keeping this for backward compatibility
     TX_SCHEDULING_ERROR,
     RX_DONE,
     RX_TIMEOUT,

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -101,6 +101,7 @@ typedef enum lorawan_status {
     LORAWAN_STATUS_DUTYCYCLE_RESTRICTED = -1020,
     LORAWAN_STATUS_NO_CHANNEL_FOUND = -1021,
     LORAWAN_STATUS_NO_FREE_CHANNEL_FOUND = -1022,
+    LORAWAN_STATUS_METADATA_NOT_AVAILABLE = -1023
 } lorawan_status_t;
 
 /** The lorawan_connect_otaa structure.
@@ -343,5 +344,60 @@ typedef struct lora_channelplan {
     uint8_t nb_channels;    // number of channels
     loramac_channel_t *channels;
 } lorawan_channelplan_t;
+
+/**
+ * Meta-data collection for a transmission
+ */
+typedef struct {
+    /**
+     * A boolean to mark if the meta data is stale
+     */
+    bool stale;
+    /**
+     * The uplink channel used for transmission.
+     */
+    uint32_t channel;
+    /**
+     * The uplink datarate.
+     */
+    uint8_t data_rate;
+    /**
+     * The transmission power.
+     */
+    int8_t tx_power;
+    /**
+     * Provides the number of retransmissions.
+     */
+    uint8_t nb_retries;
+    /**
+     * The transmission time on air of the frame.
+     */
+    uint32_t tx_toa;
+} lorawan_tx_metadata;
+
+ * Meta-data collection for the received packet
+ */
+typedef struct {
+    /**
+     * A boolean to mark if the meta data is stale
+     */
+    bool stale;
+    /**
+     * Data rate of reception
+     */
+    uint8_t rx_datarate;
+    /**
+     * Frame pending status.
+     */
+    uint8_t fpending_status;
+    /**
+     * The RSSI for the received packet.
+     */
+    int16_t rssi;
+    /**
+     * The SNR for the received packet.
+     */
+    uint8_t snr;
+} lorawan_rx_metadata;
 
 #endif /* MBED_LORAWAN_TYPES_H_ */

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -375,6 +375,7 @@ typedef struct {
     uint32_t tx_toa;
 } lorawan_tx_metadata;
 
+/**
  * Meta-data collection for the received packet
  */
 typedef struct {

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -1305,6 +1305,7 @@ typedef struct {
 
 } loramac_protocol_params;
 
+
 #if defined(LORAWAN_COMPLIANCE_TEST)
 
 typedef struct {


### PR DESCRIPTION
### Description

This PR adds new APIs to our Mbed LoRaWAN stack which facilitate the application
in acquiring metadata relating to transmission or reception as well as an API to cancel
an outstanding outgoing message.  

Dependency: https://github.com/ARMmbed/mbed-os/pull/6901

Target: Mbed OS 5.9

Internal ref: IOTCELL-575

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

