### PR TITLE
build: fix notifier typo and passing to builds API

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -184,7 +184,7 @@ if __name__ == '__main__':
                 skipped.append(tt_id)
             else:
                 try:
-                    notify = TerminalNotifer(options.verbose, options.silent)
+                    notifier = TerminalNotifier(options.verbose, options.silent)
                     mcu = TARGET_MAP[target]
                     profile = extract_profile(parser, options, toolchain)
                     if options.source_dir:
@@ -197,6 +197,7 @@ if __name__ == '__main__':
                             name=options.artifact_name,
                             build_profile=profile,
                             ignore=options.ignore,
+                            notify = notifier,
                         )
                     else:
                         lib_build_res = build_mbed_libs(
@@ -206,6 +207,7 @@ if __name__ == '__main__':
                             macros=options.macros,
                             build_profile=profile,
                             ignore=options.ignore,
+                            notify=notifier,
                         )
 
                     for lib_id in libraries:

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -383,7 +383,6 @@ class SingleTestRunner(object):
                 build_mbed_libs_result = build_mbed_libs(
                     T, toolchain,
                     clean=clean_mbed_libs_options,
-                    verbose=self.opts_verbose,
                     jobs=self.opts_jobs,
                     report=build_report,
                     properties=build_properties,
@@ -463,7 +462,6 @@ class SingleTestRunner(object):
                     build_lib(lib_id,
                               T,
                               toolchain,
-                              verbose=self.opts_verbose,
                               clean=clean_mbed_libs_options,
                               jobs=self.opts_jobs,
                               report=build_report,
@@ -509,7 +507,7 @@ class SingleTestRunner(object):
                 try:
                     path = build_project(test.source_dir, join(build_dir, test_id), T,
                         toolchain, test.dependencies, clean=clean_project_options,
-                        verbose=self.opts_verbose, name=project_name, macros=MACROS,
+                        name=project_name, macros=MACROS,
                         inc_dirs=INC_DIRS, jobs=self.opts_jobs, report=build_report,
                         properties=build_properties, project_id=test_id,
                         project_description=test.get_description(),

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -733,7 +733,7 @@ class mbedToolchain:
 
         elif ext == self.LINKER_EXT:
             if resources.linker_script is not None:
-                self.info("Warning: Multiple linker scripts detected: %s -> %s" % (resources.linker_script, file_path))
+                self.notify.info("Warning: Multiple linker scripts detected: %s -> %s" % (resources.linker_script, file_path))
             resources.linker_script = file_path
 
         elif ext == '.lib':
@@ -1085,7 +1085,7 @@ class mbedToolchain:
         lib = self.STD_LIB_NAME % name
         fout = join(dir, lib)
         if self.need_update(fout, objects):
-            self.info("Library: %s" % lib)
+            self.notify.info("Library: %s" % lib)
             self.archive(objects, fout)
             needed_update = True
 
@@ -1175,7 +1175,7 @@ class mbedToolchain:
 
         # Parse and decode a map file
         if memap.parse(abspath(map), toolchain) is False:
-            self.info("Unknown toolchain for memory statistics %s" % toolchain)
+            self.notify.info("Unknown toolchain for memory statistics %s" % toolchain)
             return None
 
         # Store the memap instance for later use


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Notifier should be passed to build libs functions, otherwise it's none and fails. To get this in, I would like first to have tests failing for mbed 2 builds to confirm this is fixing it (tested locally, it does build now).

@jeromecoutant This should fix the issue you reported few minutes ago.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

