### PR TITLE
Travis: Quick name-fix for warnings reported by Astyle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -123,13 +123,13 @@ matrix:
           PREV=$(curl https://api.github.com/repos/$TRAVIS_REPO_SLUG/status/master \
               | jq -re "select(.sha != \"$TRAVIS_COMMIT\")
                   | .statuses[] | select(.context == \"travis-ci/$NAME\").description
-                  | capture(\", (?<warnings>[0-9]+) warnings\").warnings" \
+                  | capture(\", (?<files>[0-9]+) files\").warnings" \
               || echo 0)
 
-          STATUSM="Passed, ${CURR} warnings"
+          STATUSM="Passed, ${CURR} files"
           if [ "$PREV" -ne 0 ]
           then
-              STATUSM="$STATUSM ($(python -c "print '%+d' % ($CURR-$PREV)") warnings)"
+              STATUSM="$STATUSM ($(python -c "print '%+d' % ($CURR-$PREV)") files)"
           fi
         - bash -c "$STATUS" success "$STATUSM"
 


### PR DESCRIPTION


### Description


Currently Astyle is reporting files with warnings, not the actual count of warnings. This is a bug, but fixing right now will cause incorrect results (and we're in the middle of preparing a release!). At least for the short-term we can change the name to avoid as much confusion as possible.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


cc @0xc0170 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

