### PR TITLE
Fix USB problems on the LPC1768

### DIFF
--- a/usb/device/targets/TARGET_NXP/USBHAL_LPC17.cpp
+++ b/usb/device/targets/TARGET_NXP/USBHAL_LPC17.cpp
@@ -583,6 +583,9 @@ void USBPhyHw::endpoint_remove(usb_ep_t endpoint)
 
     disableEndpointEvent(endpoint);
 
+    // reset this endpoint, including data toggle
+    SIEsetEndpointStatus(endpoint, 0);
+
     LPC_USB->USBDevIntClr = EP_RLZED;
     LPC_USB->USBReEp &= ~EP(endpoint);
 


### PR DESCRIPTION
### Description

Implement the missing abort function and fix an error caused by not resetting data toggle.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

