### PR TITLE
ticker test improvement

### DIFF
--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -80,9 +80,14 @@ void test_multi_ticker(void)
     }
 
     Thread::wait(MULTI_TICKER_TIME_MS + extra_wait);
+    TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
+
     for (int i = 0; i < TICKER_COUNT; i++) {
             ticker[i].detach();
     }
+    // Because detach calls schedule_interrupt in some circumstances
+    // (e.g. when head event is removed), it's good to check if
+    // no more callbacks were triggered during detaching.
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     multi_counter = 0;
@@ -91,9 +96,14 @@ void test_multi_ticker(void)
     }
 
     Thread::wait(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
+    TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
+
     for (int i = 0; i < TICKER_COUNT; i++) {
         ticker[i].detach();
     }
+    // Because detach calls schedule_interrupt in some circumstances
+    // (e.g. when head event is removed), it's good to check if
+    // no more callbacks were triggered during detaching.
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 }
 

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -196,9 +196,14 @@ void test_multi_ticker(void)
     }
 
     Thread::wait(MULTI_TICKER_TIME_MS + extra_wait);
+    TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
+
     for (int i = 0; i < TICKER_COUNT; i++) {
             ticker[i].detach();
     }
+    // Because detach calls schedule_interrupt in some circumstances
+    // (e.g. when head event is removed), it's good to check if
+    // no more callbacks were triggered during detaching.
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     multi_counter = 0;
@@ -207,9 +212,14 @@ void test_multi_ticker(void)
     }
 
     Thread::wait(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
+    TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
+
     for (int i = 0; i < TICKER_COUNT; i++) {
         ticker[i].detach();
     }
+    // Because detach calls schedule_interrupt in some circumstances
+    // (e.g. when head event is removed), it's good to check if
+    // no more callbacks were triggered during detaching.
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 }
 


### PR DESCRIPTION
### Description

Make multiticker test more reliable when scheduling very early interrupts.

When very early interrupt is scheduled (e.g now + 2[ticks]) then it's likely that it won't be fired in some circumstances and as a result there is overdue event in queue. That overdue event can be mistakenly scheduled again by `Ticker::detach` (detach calls schedule if head was removed). That's why we should check interrupts counter immediately after wait period and before detach loop

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
