### PR TITLE
Add memory manager set to add_ethernet_interface() of test stack

### DIFF
--- a/TESTS/network/emac/emac_TestNetworkStack.cpp
+++ b/TESTS/network/emac/emac_TestNetworkStack.cpp
@@ -114,6 +114,9 @@ nsapi_error_t EmacTestNetworkStack::add_ethernet_interface(EMAC &emac, bool defa
 
     m_interface->m_emac = &emac;
 
+    EmacTestMemoryManager *memory_manager = &EmacTestMemoryManager::get_instance();
+    emac.set_memory_manager(*memory_manager);
+
     *interface_out = m_interface;
 
     return NSAPI_ERROR_OK;

--- a/TESTS/network/emac/emac_test_initialize.cpp
+++ b/TESTS/network/emac/emac_test_initialize.cpp
@@ -115,8 +115,6 @@ EmacTestMemoryManager *emac_m_mngr_get(void)
 bool emac_if_init(void)
 {
     static EMAC *emac = &EMAC::get_default_instance();
-    static EmacTestMemoryManager *memory_manager = &EmacTestMemoryManager::get_instance();
-    emac->set_memory_manager(*memory_manager);
 
     emac->set_link_input_cb(emac_if_link_input_cb);
     emac->set_link_state_cb(emac_if_link_state_change_cb);

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -124,7 +124,8 @@ public:
     /** Register a network interface with the IP stack
      *
      * Connects EMAC layer with the IP stack and initializes all the required infrastructure.
-     * This function should be called only once for each available interface.
+     * This function should be called only once for each available interface. EMAC memory
+     * manager is available to EMAC after this function call.
      *
      * @param      emac             EMAC HAL implementation for this network interface
      * @param      default_if       true if the interface should be treated as the default one


### PR DESCRIPTION
### Description

Added memory manager set to add_ethernet_interface() of test stack. This allows that EMAC memory manager can be used to allocate EMAC driver memory already after the add_ethernet_interface() call.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

