### PR TITLE
NOT_SUPPORTED error was not supported any more in test_api.py script

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -528,7 +528,7 @@ class SingleTestRunner(object):
                             project_name_str))
                         test_result = self.TEST_RESULT_BUILD_FAILED
                     elif isinstance(e, NotSupportedException):
-                        print(elf.logger.log_line(
+                        print(self.logger.log_line(
                             self.logger.LogType.INFO,
                             'Project %s is not supported' % project_name_str))
                         test_result = self.TEST_RESULT_NOT_SUPPORTED


### PR DESCRIPTION
### Description

If OS2 test contains the NOT_SUPPORTED error directive, script was crashing:

[Error] :  #35: #error directive: [NOT_SUPPORTED]
Traceback (most recent call last):
  File "tools/singletest.py", line 262, in <module>
    if (singletest_in_cli_mode(single_test)):
  File "C:\github\mbed\tools\test_api.py", line 1545, in singletest_in_cli_mode
    test_summary, shuffle_seed, test_summary_ext, test_suite_properties_ext, build_report, build_properties = single_test.execute()
  File "C:\github\mbed\tools\test_api.py", line 649, in execute
    self.execute_thread_slice(q, target, toolchains, clean, test_ids, self.build_report, self.build_properties)
  File "C:\github\mbed\tools\test_api.py", line 529, in execute_thread_slice
    print(elf.logger.log_line(
NameError: global name 'elf' is not defined


@theotherjimmy 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
