### PR TITLE
Removed EMAC get default instance from EMAC tests

### DIFF
--- a/TESTS/network/emac/emac_TestNetworkStack.cpp
+++ b/TESTS/network/emac/emac_TestNetworkStack.cpp
@@ -114,6 +114,9 @@ nsapi_error_t EmacTestNetworkStack::add_ethernet_interface(EMAC &emac, bool defa
 
     m_interface->m_emac = &emac;
 
+    EmacTestMemoryManager *memory_manager = &EmacTestMemoryManager::get_instance();
+    emac.set_memory_manager(*memory_manager);
+
     *interface_out = m_interface;
 
     return NSAPI_ERROR_OK;

--- a/TESTS/network/emac/emac_TestNetworkStack.cpp
+++ b/TESTS/network/emac/emac_TestNetworkStack.cpp
@@ -161,7 +161,7 @@ char *EmacTestNetworkStack::Interface::get_gateway(char *buf, nsapi_size_t bufle
 
 nsapi_error_t EmacTestNetworkStack::Interface::bringup(bool dhcp, const char *ip, const char *netmask, const char *gw, const nsapi_ip_stack_t stack, bool blocking)
 {
-    if (!emac_if_init()) {
+    if (!emac_if_init(m_emac)) {
         TEST_ASSERT_MESSAGE(0, "emac initialization failed!");
     }
 

--- a/TESTS/network/emac/emac_initialize.h
+++ b/TESTS/network/emac/emac_initialize.h
@@ -19,7 +19,7 @@
 #define EMAC_INITIALIZE_H
 
 unsigned char *emac_if_get_hw_addr(void);
-bool emac_if_init(void);
+bool emac_if_init(EMAC *emac);
 EMAC *emac_if_get(void);
 EmacTestMemoryManager *emac_m_mngr_get(void);
 

--- a/TESTS/network/emac/emac_test_initialize.cpp
+++ b/TESTS/network/emac/emac_test_initialize.cpp
@@ -115,8 +115,6 @@ EmacTestMemoryManager *emac_m_mngr_get(void)
 bool emac_if_init(void)
 {
     static EMAC *emac = &EMAC::get_default_instance();
-    static EmacTestMemoryManager *memory_manager = &EmacTestMemoryManager::get_instance();
-    emac->set_memory_manager(*memory_manager);
 
     emac->set_link_input_cb(emac_if_link_input_cb);
     emac->set_link_state_cb(emac_if_link_state_change_cb);

--- a/TESTS/network/emac/emac_test_initialize.cpp
+++ b/TESTS/network/emac/emac_test_initialize.cpp
@@ -48,6 +48,7 @@
 using namespace utest::v1;
 
 static unsigned char eth_mac_addr[ETH_MAC_ADDR_LEN];
+EMAC *emac_handle = NULL;
 
 void test_emac_initialize()
 {
@@ -104,7 +105,7 @@ unsigned char *emac_if_get_hw_addr(void)
 
 EMAC *emac_if_get(void)
 {
-    return &EMAC::get_default_instance();
+    return emac_handle;
 }
 
 EmacTestMemoryManager *emac_m_mngr_get(void)
@@ -112,9 +113,9 @@ EmacTestMemoryManager *emac_m_mngr_get(void)
     return &EmacTestMemoryManager::get_instance();
 }
 
-bool emac_if_init(void)
+bool emac_if_init(EMAC *emac)
 {
-    static EMAC *emac = &EMAC::get_default_instance();
+    emac_handle = emac;
 
     emac->set_link_input_cb(emac_if_link_input_cb);
     emac->set_link_state_cb(emac_if_link_state_change_cb);

--- a/features/netsocket/OnboardNetworkStack.h
+++ b/features/netsocket/OnboardNetworkStack.h
@@ -124,7 +124,8 @@ public:
     /** Register a network interface with the IP stack
      *
      * Connects EMAC layer with the IP stack and initializes all the required infrastructure.
-     * This function should be called only once for each available interface.
+     * This function should be called only once for each available interface. EMAC memory
+     * manager is available to EMAC after this function call.
      *
      * @param      emac             EMAC HAL implementation for this network interface
      * @param      default_if       true if the interface should be treated as the default one


### PR DESCRIPTION
### Description

Removed EMAC get default instance from EMAC tests.
    
Test environment now uses the EMAC defined by add ethernet interface.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

