### PR TITLE
Support mbed_start_application for Cortex-M23

### DIFF
--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -125,8 +125,9 @@ __asm static void start_new_application(void *sp, void *pc)
 void start_new_application(void *sp, void *pc)
 {
     __asm volatile (
-        "movw   r2, #0      \n" // Fail to compile "mov r2, #0" with ARMC6. Replace with movw/movt.
-        "movt   r2, #0      \n"
+        "movw   r2, #0      \n" // Fail to compile "mov r2, #0" with ARMC6. Replace with MOVW.
+                                // We needn't "movt r2, #0" immediately following because MOVW
+                                // will zero-extend the 16-bit immediate.
         "msr    control, r2 \n" // Switch to main stack
         "mov    sp, %0      \n"
         "msr    primask, r2 \n" // Enable interrupts

--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -117,20 +117,13 @@ __asm static void start_new_application(void *sp, void *pc)
 
 void start_new_application(void *sp, void *pc)
 {
+    __asm volatile (
 #if defined(__CORTEX_M23)
-    __asm volatile (
-        "ldr    r2, =0      \n"
-        "msr    control, r2 \n" // Switch to main stack
-        "mov    sp, %0      \n"
-        "msr    primask, r2 \n" // Enable interrupts
-        "bx     %1          \n"
-        :
-        : "l" (sp), "l" (pc)
-        : "r2", "cc", "memory"
-    );
+        "movw   r2, #0      \n"
+        "movt   r2, #0      \n"
 #else
-    __asm volatile (
         "mov    r2, #0      \n"
+#endif
         "msr    control, r2 \n" // Switch to main stack
         "mov    sp, %0      \n"
         "msr    primask, r2 \n" // Enable interrupts
@@ -139,7 +132,6 @@ void start_new_application(void *sp, void *pc)
         : "l" (sp), "l" (pc)
         : "r2", "cc", "memory"
     );
-#endif
 }
 
 #else

--- a/platform/mbed_application.h
+++ b/platform/mbed_application.h
@@ -19,7 +19,8 @@
 
 #include<stdint.h>
 
-#if defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7)
+#if defined(__CORTEX_M3) || defined(__CORTEX_M4) || defined(__CORTEX_M7)\
+    || defined(__CORTEX_M23)
 #define MBED_APPLICATION_SUPPORT 1
 #else
 #define MBED_APPLICATION_SUPPORT 0


### PR DESCRIPTION
### Description
This PR implements `mbed_start_application` on Cortex-M23 for bootloader related application.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] New target
    [ ] Feature
    [ ] Breaking change

