### PR TITLE
STM32 SPI: fix NSS pin configuration

### DIFF
--- a/targets/TARGET_STM/stm_spi_api.c
+++ b/targets/TARGET_STM/stm_spi_api.c
@@ -163,6 +163,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     spiobj->pin_ssel = ssel;
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
+        handle->Init.NSS = SPI_NSS_HARD_OUTPUT;
     } else {
         handle->Init.NSS = SPI_NSS_SOFT;
     }


### PR DESCRIPTION
### Description

The NSS pin initialization was not done when the NSS pin was not NC. This fixes issue #6888 

### Pull request type

```
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
```

