### PR TITLE
Updated ublox odin greentea test configuration file connect statement

### DIFF
--- a/tools/test_configs/OdinInterface.json
+++ b/tools/test_configs/OdinInterface.json
@@ -8,8 +8,8 @@
             "value" : "new OdinWiFiInterface()"
         },
         "connect-statement" : {
-            "help" : "Disabled until EMAC updated",
-            "value" : null
+            "help" : "Must use 'net' variable name",
+            "value" : "net->wifiInterface()->connect(WIFI_SSID, WIFI_PASSWORD)"
         },
         "echo-server-addr" : {
             "help" : "IP address of echo server",


### PR DESCRIPTION
### Description

Updated ublox odin greentea test configuration file connect statement to use network interface wifiInterface() method to get wifi interface instead of casting.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

