### PR TITLE
LoRaWAN: Message flags correction

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -64,6 +64,12 @@ using namespace events;
     #endif
 #endif
 
+/**
+ * Bit mask for message flags
+ */
+
+#define MSG_FLAG_MASK                         0x0F
+
 /*****************************************************************************
  * Constructor                                                               *
  ****************************************************************************/
@@ -292,10 +298,17 @@ int16_t LoRaWANStack::handle_tx(const uint8_t port, const uint8_t* data,
         return status;
     }
 
-    if (flags == 0 ||
-        (flags & MSG_FLAG_MASK) == (MSG_CONFIRMED_FLAG|MSG_UNCONFIRMED_FLAG)) {
-        tr_error("CONFIRMED and UNCONFIRMED are mutually exclusive for send()");
-        return LORAWAN_STATUS_PARAMETER_INVALID;
+    // All the flags mutually exclusive. In addition to that MSG_MULTICAST_FLAG cannot be
+    // used for uplink.
+    switch (flags & MSG_FLAG_MASK) {
+        case MSG_UNCONFIRMED_FLAG:
+        case MSG_CONFIRMED_FLAG:
+        case MSG_PROPRIETARY_FLAG:
+            break;
+
+        default:
+            tr_error("Invalid send flags");
+            return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
     int16_t len = _loramac.prepare_ongoing_tx(port, data, length, flags, _num_retry);
@@ -533,8 +546,8 @@ void LoRaWANStack::process_reception(const uint8_t* const payload, uint16_t size
                 state_controller(DEVICE_STATE_STATUS_CHECK);
             }
         } else {
-            // handle UNCONFIRMED case here, RX slots were turned off due to
-            // valid packet reception
+            // handle UNCONFIRMED, PROPRIETARY case here, RX slots were turned off due to
+            // valid packet reception, so we generate a TX_DONE event
             _loramac.post_process_mcps_req();
             _ctrl_flags |= TX_DONE_FLAG;
             state_controller(DEVICE_STATE_STATUS_CHECK);

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -36,37 +36,15 @@
 
 /**
  * Option Flags for send(), receive() APIs
+ *
+ * Special Notes for UPLINK:
+ *  i)  All of the flags are mutually exclusive.
+ *  ii) MSG_MULTICAST_FLAG cannot be used.
  */
 #define MSG_UNCONFIRMED_FLAG                  0x01
 #define MSG_CONFIRMED_FLAG                    0x02
 #define MSG_MULTICAST_FLAG                    0x04
 #define MSG_PROPRIETARY_FLAG                  0x08
-
-/**
- * Bit mask for message flags
- */
-
-#define MSG_FLAG_MASK                         0x0F
-
-/**
- * Mask for unconfirmed multicast message
- */
-#define MSG_UNCONFIRMED_MULTICAST              0x05
-
-/**
- * Mask for confirmed multicast message
- */
-#define MSG_CONFIRMED_MULTICAST                0x06
-
-/**
- * Mask for unconfirmed message proprietary message
- */
-#define MSG_UNCONFIRMED_PROPRIETARY            0x09
-
-/**
- * Mask for confirmed proprietary message
- */
-#define MSG_CONFIRMED_PROPRIETARY              0x0A
 
 /**
  * LoRaWAN device classes definition.


### PR DESCRIPTION
### Description

Uplink multicast is not allowed. Proprietary messages cannot be
of type unconfirmed and unconfirmed.

Some error flags are introduced which check in the UP direction
if the user have used the flags wrongly.

#### Target version
Mbed OS-5.9-rc1


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

