### PR TITLE
Adding Sleep and usticker to MTB_ODIN_W2

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2138,6 +2138,7 @@
     },
     "MTB_UBLOX_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
+        "device_has_add": ["SLEEP", "USTICKER"],
         "release_versions": ["5"]
      },
     "UBLOX_C030": {


### PR DESCRIPTION
### Description
Adding Sleep and usticker to MTB_ODIN.
Greentea logs attached below for all 3 toolchains.
[MTB_ODIN_sleep_usticker_GT_all_3_compilers_Pass_log.txt](https://github.com/ARMmbed/mbed-os/files/2022716/MTB_ODIN_sleep_usticker_GT_all_3_compilers_Pass_log.txt)



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

