### PR TITLE
Cellular: Unit tests fixes

### DIFF
--- a/features/cellular/UNITTESTS/at/athandler/Makefile
+++ b/features/cellular/UNITTESTS/at/athandler/Makefile
@@ -21,6 +21,7 @@ TEST_SRC_FILES = \
         ../../stubs/Timer_stub.cpp \
         ../../stubs/equeue_stub.cpp \
         ../../stubs/Kernel.cpp \
+        ../../stubs/Thread_stub.cpp \
 
 include ../../MakefileWorker.mk
 

--- a/features/cellular/UNITTESTS/at/athandler/test_athandler.cpp
+++ b/features/cellular/UNITTESTS/at/athandler/test_athandler.cpp
@@ -479,6 +479,9 @@ void Test_ATHandler::test_ATHandler_read_bytes()
     char table[] = "ssssssssssssssssssssssssssssOK\r\n\0";
     filehandle_stub_table = table;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
+
 
     at.clear_error();
     CHECK(5 == at.read_bytes(buf, 5));
@@ -491,57 +494,66 @@ void Test_ATHandler::test_ATHandler_read_string()
 
     ATHandler at(&fh1, que, 0, ",");
 
+    at.clear_error();
     char table[] = "\"s,\"OK\r\n\0";
     filehandle_stub_table = table;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
 
     char buf[5];
     uint8_t buf2[5];
-    at.flush();
-    at.clear_error();
     at.resp_start();
     at.read_bytes(buf2, 5);
     CHECK(-1 == at.read_string(buf, 15));
+    at.flush();
+    at.clear_error();
 
     filehandle_stub_table = table;
     filehandle_stub_table_pos = 0;
 
-    at.flush();
-    at.clear_error();
     at.resp_start();
     at.read_bytes(buf2, 1);
     CHECK(1 == at.read_string(buf, 5, true));
+    at.flush();
+    at.clear_error();
 
     char table2[] = "\"s\"OK\r\n\0";
     filehandle_stub_table = table2;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table2);
 
-    at.flush();
-    at.clear_error();
     at.resp_start();
     at.read_bytes(buf2, 1);
     CHECK(1 == at.read_string(buf, 5, true));
+    at.flush();
+    at.clear_error();
 
     char table3[] = "sss\rsss\0";
     filehandle_stub_table = table3;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
 
-    at.flush();
-    at.clear_error();
     at.resp_start("s");
     at.read_string(buf, 5, true);
+    at.flush();
+    at.clear_error();
 
     char table4[] = "\"s\"\0";
     filehandle_stub_table = table4;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
 
-    at.flush();
-    at.clear_error();
     at.resp_start("s");
     at.read_string(buf, 5, true);
 
     filehandle_stub_table = NULL;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLOUT;
+    mbed_poll_stub::int_value = 0;
 }
 
 void Test_ATHandler::test_ATHandler_read_int()
@@ -553,24 +565,27 @@ void Test_ATHandler::test_ATHandler_read_int()
 
     int32_t ret= at.read_int();
     CHECK(-1 == ret);
+    at.clear_error();
 
     char table[] = "\",\"OK\r\n\0";
     filehandle_stub_table = table;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
 
-    at.flush();
-    at.clear_error();
     at.resp_start();
 
     ret= at.read_int();
     CHECK(-1 == ret);
+    at.flush();
+    at.clear_error();
 
     char table2[] = "\"2,\"OK\r\n\0";
     filehandle_stub_table = table2;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table2);
 
-    at.flush();
-    at.clear_error();
     at.resp_start();
 
     ret= at.read_int();
@@ -694,23 +709,29 @@ void Test_ATHandler::test_ATHandler_info_resp()
     at.resp_start();
     CHECK(!at.info_resp());
 
+    at.flush();
+    at.clear_error();
+
     char table2[] = "21 OK\r\n\0";
     filehandle_stub_table = table2;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table2);
 
-    at.flush();
-    at.clear_error();
     at.resp_start("21");
     CHECK(at.info_resp());
 
     CHECK(!at.info_resp());
 
+    at.flush();
+    at.clear_error();
+
     char table3[] = "21 OK\r\n\0";
     filehandle_stub_table = table3;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table3);
 
-    at.flush();
-    at.clear_error();
     CHECK(at.info_resp());
 }
 
@@ -722,25 +743,27 @@ void Test_ATHandler::test_ATHandler_info_elem()
     char table[] = "21 OK\r\n\0";
     filehandle_stub_table = table;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table);
 
     ATHandler at(&fh1, que, 0, ",");
-    CHECK(!at.info_elem(char(79)));
+    CHECK(!at.info_elem('O'));
+    at.flush();
 
     char table2[] = "21 OK\r\n\0";
     filehandle_stub_table = table2;
     filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = strlen(table2);
 
-    at.flush();
     at.clear_error();
     at.resp_start("21");
-    CHECK(at.info_elem(char(79)));
-
-    CHECK(at.info_elem('2'));
+    CHECK(at.info_elem('O'));
+    at.flush();
 
     filehandle_stub_table = NULL;
     filehandle_stub_table_pos = 0;
 
-    at.flush();
     at.clear_error();
     at.resp_start("21");
     CHECK(!at.info_elem('2'));

--- a/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -85,6 +85,10 @@ nsapi_error_t ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()>
     return NSAPI_ERROR_OK;
 }
 
+void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> callback)
+{
+}
+
 nsapi_error_t ATHandler::get_last_error() const
 {
     if (ATHandler_stub::nsapi_error_ok_counter) {

--- a/features/cellular/UNITTESTS/stubs/SocketAddress_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/SocketAddress_stub.cpp
@@ -102,13 +102,14 @@ const void *SocketAddress::get_ip_bytes() const
 
 nsapi_version_t SocketAddress::get_ip_version() const
 {
-    nsapi_version_t ver;
+    nsapi_version_t ver = NSAPI_IPv6;
     return ver;
 }
 
 nsapi_addr_t SocketAddress::get_addr() const
 {
     nsapi_addr_t addr;
+    addr.version = NSAPI_IPv6;
     return _addr;
 }
 

--- a/features/cellular/UNITTESTS/stubs/Thread_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/Thread_stub.cpp
@@ -15,4 +15,12 @@
  * limitations under the License.
  */
 
-#define EAGAIN 11
+#include "Thread.h"
+
+namespace rtos {
+
+osStatus Thread::wait_until(uint64_t millisec) {
+    return 0;
+}
+
+}

--- a/features/cellular/UNITTESTS/target_h/cmsis_os.h
+++ b/features/cellular/UNITTESTS/target_h/cmsis_os.h
@@ -1,0 +1,13 @@
+#ifndef CMSIS_OS_H_
+#define CMSIS_OS_H_
+
+#include "cmsis_os2.h"
+
+#define osPriority osPriority_t
+
+#define osThreadId osThreadId_t
+
+typedef struct {
+} osEvent;
+
+#endif

--- a/features/cellular/UNITTESTS/target_h/cmsis_os.h
+++ b/features/cellular/UNITTESTS/target_h/cmsis_os.h
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #ifndef CMSIS_OS_H_
 #define CMSIS_OS_H_
 

--- a/features/cellular/UNITTESTS/target_h/cmsis_os2.h
+++ b/features/cellular/UNITTESTS/target_h/cmsis_os2.h
@@ -35,6 +35,17 @@ typedef struct {
   uint32_t                   cb_size;   ///< size of provided memory for control block
 } osSemaphoreAttr_t;
 
+//Thread
+typedef enum {
+  osPriorityNormal        = 24       ///< Priority: normal
+} osPriority_t;
+
+typedef void *osThreadId_t;
+
+/// Attributes structure for thread.
+typedef struct {
+} osThreadAttr_t;
+
 #define osWaitForever         0xFFFFFFFFU
 
 

--- a/features/cellular/UNITTESTS/target_h/mbed_rtos1_types.h
+++ b/features/cellular/UNITTESTS/target_h/mbed_rtos1_types.h
@@ -14,3 +14,5 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#include "cmsis_os.h"

--- a/features/cellular/UNITTESTS/target_h/mbed_rtos_storage.h
+++ b/features/cellular/UNITTESTS/target_h/mbed_rtos_storage.h
@@ -18,5 +18,7 @@
 #include "cmsis_os2.h"
 #include "rtx_os.h"
 #include "rtx_lib.h"
+#include "mbed_rtx_conf.h"
 
 typedef os_semaphore_t mbed_rtos_storage_semaphore_t;
+typedef os_thread_t mbed_rtos_storage_thread_t;

--- a/features/cellular/UNITTESTS/target_h/mbed_rtx_conf.h
+++ b/features/cellular/UNITTESTS/target_h/mbed_rtx_conf.h
@@ -1,0 +1,1 @@
+#define OS_STACK_SIZE 0

--- a/features/cellular/UNITTESTS/target_h/mbed_rtx_conf.h
+++ b/features/cellular/UNITTESTS/target_h/mbed_rtx_conf.h
@@ -1,1 +1,18 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 #define OS_STACK_SIZE 0

--- a/features/cellular/UNITTESTS/target_h/platform/mbed_retarget.h
+++ b/features/cellular/UNITTESTS/target_h/platform/mbed_retarget.h
@@ -15,4 +15,5 @@
  * limitations under the License.
  */
 
+#include <sys/types.h>
 #define EAGAIN 11

--- a/features/cellular/UNITTESTS/target_h/platform/mbed_retarget.h
+++ b/features/cellular/UNITTESTS/target_h/platform/mbed_retarget.h
@@ -17,3 +17,4 @@
 
 #include <sys/types.h>
 #define EAGAIN 11
+#define ENOTTY 25

--- a/features/cellular/UNITTESTS/target_h/rtos/Mutex.h
+++ b/features/cellular/UNITTESTS/target_h/rtos/Mutex.h
@@ -1,1 +1,18 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 typedef void* Mutex;

--- a/features/cellular/UNITTESTS/target_h/rtos/Mutex.h
+++ b/features/cellular/UNITTESTS/target_h/rtos/Mutex.h
@@ -1,0 +1,1 @@
+typedef void* Mutex;

--- a/features/cellular/UNITTESTS/target_h/rtos/Semaphore.h
+++ b/features/cellular/UNITTESTS/target_h/rtos/Semaphore.h
@@ -1,1 +1,18 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 typedef void* Semaphore;

--- a/features/cellular/UNITTESTS/target_h/rtos/Semaphore.h
+++ b/features/cellular/UNITTESTS/target_h/rtos/Semaphore.h
@@ -1,0 +1,1 @@
+typedef void* Semaphore;

--- a/features/cellular/UNITTESTS/target_h/rtx_lib.h
+++ b/features/cellular/UNITTESTS/target_h/rtx_lib.h
@@ -20,5 +20,6 @@
 #include "rtx_os.h"
 
 #define os_semaphore_t      osRtxSemaphore_t
+#define os_thread_t         osRtxThread_t
 
 #endif

--- a/features/cellular/UNITTESTS/target_h/rtx_os.h
+++ b/features/cellular/UNITTESTS/target_h/rtx_os.h
@@ -30,4 +30,31 @@ typedef struct osRtxSemaphore_s {
   uint16_t                 max_tokens;  ///< Maximum number of tokens
 } osRtxSemaphore_t;
 
+typedef struct osRtxThread_s {
+  uint8_t                          id;  ///< Object Identifier
+  uint8_t                       state;  ///< Object State
+  uint8_t                       flags;  ///< Object Flags
+  uint8_t                        attr;  ///< Object Attributes
+  const char                    *name;  ///< Object Name
+  struct osRtxThread_s   *thread_next;  ///< Link pointer to next Thread in Object list
+  struct osRtxThread_s   *thread_prev;  ///< Link pointer to previous Thread in Object list
+  struct osRtxThread_s    *delay_next;  ///< Link pointer to next Thread in Delay list
+  struct osRtxThread_s    *delay_prev;  ///< Link pointer to previous Thread in Delay list
+  struct osRtxThread_s   *thread_join;  ///< Thread waiting to Join
+  uint32_t                      delay;  ///< Delay Time
+  int8_t                     priority;  ///< Thread Priority
+  int8_t                priority_base;  ///< Base Priority
+  uint8_t                 stack_frame;  ///< Stack Frame (EXC_RETURN[7..0])
+  uint8_t               flags_options;  ///< Thread/Event Flags Options
+  uint32_t                 wait_flags;  ///< Waiting Thread/Event Flags
+  uint32_t               thread_flags;  ///< Thread Flags
+  struct osRtxMutex_s     *mutex_list;  ///< Link pointer to list of owned Mutexes
+  void                     *stack_mem;  ///< Stack Memory
+  uint32_t                 stack_size;  ///< Stack Size
+  uint32_t                         sp;  ///< Current Stack Pointer
+  uint32_t                thread_addr;  ///< Thread entry address
+  uint32_t                  tz_memory;  ///< TrustZone Memory Identifier
+  void                       *context;  ///< Context for OsEventObserver objects
+} osRtxThread_t;
+
 #endif 

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -23,9 +23,7 @@
 #include "FileHandle.h"
 #include "mbed_wait_api.h"
 #include "mbed_debug.h"
-#ifdef MBED_CONF_RTOS_PRESENT
 #include "rtos/Thread.h"
-#endif
 #include "Kernel.h"
 #include "CellularUtil.h"
 

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -17,6 +17,7 @@
 
 #include <time.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include "mbed_wait_api.h"
 #include "AT_CellularSMS.h"
 #include "CellularUtil.h"


### PR DESCRIPTION
### Description

Fixes for following issues:
- missing rtos::Thread::wait_until stub after such call was introduced to ATHandler
- missing poll_stub setting for reading routines after poll(...) replaced the filehandle read loop in ATHandler
- wrong location for unit test's mbed_retarget.h and missing sys/types.h include for ssize_t type

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

