### PR TITLE
Test build: Reduce include command length

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -228,18 +228,23 @@ if __name__ == '__main__':
             else:
                 # Build all the tests
                 notify = TerminalNotifier(options.verbose)
-                test_build_success, test_build = build_tests(tests, [options.build_dir], options.build_dir, mcu, toolchain,
-                        clean=options.clean,
-                        report=build_report,
-                        properties=build_properties,
-                        macros=options.macros,
-                        notify=notify,
-                        jobs=options.jobs,
-                        continue_on_build_fail=options.continue_on_build_fail,
-                        app_config=config,
-                        build_profile=profile,
-                        stats_depth=options.stats_depth,
-                        ignore=options.ignore)
+                test_build_success, test_build = build_tests(
+                    tests,
+                    [os.path.relpath(options.build_dir)],
+                    options.build_dir,
+                    mcu,
+                    toolchain,
+                    clean=options.clean,
+                    report=build_report,
+                    properties=build_properties,
+                    macros=options.macros,
+                    notify=notify,
+                    jobs=options.jobs,
+                    continue_on_build_fail=options.continue_on_build_fail,
+                    app_config=config,
+                    build_profile=profile,
+                    stats_depth=options.stats_depth,
+                    ignore=options.ignore)
 
                 # If a path to a test spec is provided, write it to a file
                 if options.test_spec:


### PR DESCRIPTION
### Description

Resolves #6577

Tests are built in two passes:
 * Mbed OS as a lib (just `.o` files)
 * Each test is built and linked with the Mbed OS `.o`
 
The second pass involves scanning the build directory creating in the first 
pass. This is where the bug lies: the second pass takes an _absolute_ path to
the artifacts create by the first. This adds the directory containing mbed-os
to the _each_ include path, and these extra characters exceed the maximum
command line length on windows.

This patch uses a relate path, eliminating the problem

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change