### PR TITLE
Use RTOS wait primitive where possible

### DIFF
--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -29,7 +29,14 @@ void wait(float s) {
 }
 
 void wait_ms(int ms) {
-    Thread::wait((uint32_t)ms);
+    // Shouldn't be calling a wait function from a critical section,
+    // but in case someone does...
+    if (core_util_are_interrupts_enabled()) {
+        Thread::wait((uint32_t)ms);
+    } else {
+        wait_us(ms * 1000);
+    }
+
 }
 
 void wait_us(int us) {

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -25,11 +25,11 @@
 #include "platform/mbed_power_mgmt.h"
 
 void wait(float s) {
-    wait_us(s * 1000000.0f);
+    wait_ms(s * 1000.0f);
 }
 
 void wait_ms(int ms) {
-    wait_us(ms * 1000);
+    Thread::wait((uint32_t)ms);
 }
 
 void wait_us(int us) {


### PR DESCRIPTION
### Description

When an RTOS is present, use the thread wait primitive for millisecond resolution and above. This will lead to vastly improved power consumption on targets with tickless support.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

