### PR TITLE
Maxim Ticker update for mbed-os 5.9.0

### DIFF
--- a/targets/TARGET_Maxim/TARGET_MAX32620C/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620C/rtc_api.c
@@ -147,14 +147,23 @@ time_t rtc_read(void)
 //******************************************************************************
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
-        return;
-    }
-
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
     NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
     init_rtc();
-    lp_ticker_inited = 1;
+}
+
+//******************************************************************************
+void lp_ticker_free(void)
+{
+    // Disable interrupt associated with LPTICKER API
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
+
+    // RTC hardware is shared by LPTICKER and RTC APIs.
+    // Prior initialization of the RTC API gates disabling the RTC hardware.
+    if (!(MXC_RTCTMR->inten & MXC_F_RTC_INTEN_OVERFLOW)) {
+        RTC_Stop();
+    }
 }
 
 //******************************************************************************
@@ -167,13 +176,13 @@ uint32_t lp_ticker_read(void)
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
     MXC_RTCTMR->comp[0] = timestamp;
-    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS;
-    MXC_RTCTMR->inten |= MXC_F_RTC_INTEN_COMP0;
+    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_COMP0;
+    RTC_EnableINT(MXC_F_RTC_INTEN_COMP0);
 
-    // Enable wakeup from RTC compare 0
-    LP_ConfigRTCWakeUp(1, 0, 0, rtc_inited);
+    // Enable as LP wakeup source
+    MXC_PWRSEQ->msk_flags |= MXC_F_PWRSEQ_FLAGS_RTC_CMPR0;
 
-    // Wait for pending transactions
+    // Postponed write pending wait for comp0 and flags
     while (MXC_RTCTMR->ctrl & MXC_F_RTC_CTRL_PENDING);
 }
 
@@ -186,7 +195,7 @@ void lp_ticker_disable_interrupt(void)
 //******************************************************************************
 void lp_ticker_clear_interrupt(void)
 {
-    RTC_ClearFlags(MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS);
+    RTC_ClearFlags(MXC_F_RTC_FLAGS_COMP0);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32625/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32625/rtc_api.c
@@ -147,14 +147,23 @@ time_t rtc_read(void)
 //******************************************************************************
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
-        return;
-    }
-
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
     NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
     init_rtc();
-    lp_ticker_inited = 1;
+}
+
+//******************************************************************************
+void lp_ticker_free(void)
+{
+    // Disable interrupt associated with LPTICKER API
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
+
+    // RTC hardware is shared by LPTICKER and RTC APIs.
+    // Prior initialization of the RTC API gates disabling the RTC hardware.
+    if (!(MXC_RTCTMR->inten & MXC_F_RTC_INTEN_OVERFLOW)) {
+        RTC_Stop();
+    }
 }
 
 //******************************************************************************
@@ -167,13 +176,13 @@ uint32_t lp_ticker_read(void)
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
     MXC_RTCTMR->comp[0] = timestamp;
-    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS;
-    MXC_RTCTMR->inten |= MXC_F_RTC_INTEN_COMP0;
+    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_COMP0;
+    RTC_EnableINT(MXC_F_RTC_INTEN_COMP0);
 
-    // Enable wakeup from RTC compare 0
-    LP_ConfigRTCWakeUp(1, 0, 0, rtc_inited);
+    // Enable as LP wakeup source
+    MXC_PWRSEQ->msk_flags |= MXC_F_PWRSEQ_FLAGS_RTC_CMPR0;
 
-    // Wait for pending transactions
+    // Postponed write pending wait for comp0 and flags
     while (MXC_RTCTMR->ctrl & MXC_F_RTC_CTRL_PENDING);
 }
 
@@ -186,7 +195,7 @@ void lp_ticker_disable_interrupt(void)
 //******************************************************************************
 void lp_ticker_clear_interrupt(void)
 {
-    RTC_ClearFlags(MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS);
+    RTC_ClearFlags(MXC_F_RTC_FLAGS_COMP0);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/rtc_api.c
@@ -109,8 +109,8 @@ void rtc_free(void)
         if (lp_ticker_inited) {
             RTC_DisableINT(MXC_F_RTC_FLAGS_OVERFLOW);
         } else {
-        MXC_RTCTMR->ctrl |= MXC_F_RTC_CTRL_CLEAR;
-        RTC_Stop();
+            MXC_RTCTMR->ctrl |= MXC_F_RTC_CTRL_CLEAR;
+            RTC_Stop();
         }
     }
 }
@@ -147,14 +147,23 @@ time_t rtc_read(void)
 //******************************************************************************
 void lp_ticker_init(void)
 {
-    if (lp_ticker_inited) {
-        return;
-    }
-
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
     NVIC_SetVector(RTC0_IRQn, (uint32_t)lp_ticker_irq_handler);
     NVIC_EnableIRQ(RTC0_IRQn);
     init_rtc();
-    lp_ticker_inited = 1;
+}
+
+//******************************************************************************
+void lp_ticker_free(void)
+{
+    // Disable interrupt associated with LPTICKER API
+    RTC_DisableINT(MXC_F_RTC_INTEN_COMP0);
+
+    // RTC hardware is shared by LPTICKER and RTC APIs.
+    // Prior initialization of the RTC API gates disabling the RTC hardware.
+    if (!(MXC_RTCTMR->inten & MXC_F_RTC_INTEN_OVERFLOW)) {
+        RTC_Stop();
+    }
 }
 
 //******************************************************************************
@@ -167,13 +176,13 @@ uint32_t lp_ticker_read(void)
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
     MXC_RTCTMR->comp[0] = timestamp;
-    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS;
-    MXC_RTCTMR->inten |= MXC_F_RTC_INTEN_COMP0;
+    MXC_RTCTMR->flags = MXC_F_RTC_FLAGS_COMP0;
+    RTC_EnableINT(MXC_F_RTC_INTEN_COMP0);
 
-    // Enable wakeup from RTC compare 0
-    LP_ConfigRTCWakeUp(1, 0, 0, rtc_inited);
+    // Enable as LP wakeup source
+    MXC_PWRSEQ->msk_flags |= MXC_F_PWRSEQ_FLAGS_RTC_CMPR0;
 
-    // Wait for pending transactions
+    // Postponed write pending wait for comp0 and flags
     while (MXC_RTCTMR->ctrl & MXC_F_RTC_CTRL_PENDING);
 }
 
@@ -186,7 +195,7 @@ void lp_ticker_disable_interrupt(void)
 //******************************************************************************
 void lp_ticker_clear_interrupt(void)
 {
-    RTC_ClearFlags(MXC_F_RTC_FLAGS_ASYNC_CLR_FLAGS);
+    RTC_ClearFlags(MXC_F_RTC_FLAGS_COMP0);
 }
 
 //******************************************************************************

--- a/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32630/us_ticker.c
@@ -35,42 +35,39 @@
 #include "us_ticker_api.h"
 #include "tmr.h"
 
-#define US_TIMER            MXC_TMR0
-#define US_TIMER_IRQn       TMR0_0_IRQn
-#define US_TIMER_PRESCALE   TMR_PRESCALE_DIV_2_5
-#define US_TIMER_MODE       TMR32_MODE_COMPARE
-#define US_TIMER_WIDTH      32
-
-static volatile int us_ticker_inited = 0;
+#define US_TIMER          MXC_TMR0
+#define US_TIMER_IRQn     TMR0_0_IRQn
+#define US_TIMER_PRESCALE TMR_PRESCALE_DIV_2_5
+#define US_TIMER_MODE     TMR32_MODE_COMPARE
+#define US_TIMER_WIDTH    32
 
 //******************************************************************************
 void us_ticker_init(void)
 {
-    tmr32_cfg_t cfg;
+    // Disable and deconfigure
+    US_TIMER->ctrl = 0;
+    US_TIMER->term_cnt32 = 0;
+    US_TIMER->inten = 0;
+    US_TIMER->intfl = MXC_F_TMR_INTFL_TIMER0;
 
-    if (us_ticker_inited) {
-        return;
-    }
-    us_ticker_inited = 1;
+    // Configure and enable
+    US_TIMER->ctrl = MXC_F_TMR_CTRL_ENABLE0 |
+                     (US_TIMER_MODE << MXC_F_TMR_CTRL_MODE_POS) |
+                     (US_TIMER_PRESCALE << MXC_F_TMR_CTRL_PRESCALE_POS);
 
-    cfg.mode = US_TIMER_MODE;
-    cfg.polarity = TMR_POLARITY_UNUSED;
-    cfg.compareCount = UINT32_MAX;
-
-    TMR_Init(US_TIMER, US_TIMER_PRESCALE, NULL);
-    TMR32_Config(US_TIMER, &cfg);
     NVIC_SetVector(US_TIMER_IRQn, (uint32_t)us_ticker_irq_handler);
     NVIC_EnableIRQ(US_TIMER_IRQn);
-    TMR32_Start(US_TIMER);
+}
+
+//******************************************************************************
+void us_ticker_free(void)
+{
+    US_TIMER->ctrl = 0;
 }
 
 //******************************************************************************
 uint32_t us_ticker_read(void)
 {
-    if (!us_ticker_inited) {
-        us_ticker_init();
-    }
-
     return US_TIMER->count32;
 }
 
@@ -78,12 +75,12 @@ uint32_t us_ticker_read(void)
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
     US_TIMER->ctrl = 0;
-    US_TIMER->term_cnt32 = timestamp;
+    US_TIMER->term_cnt32 = (timestamp) ? timestamp : 1;
     US_TIMER->inten = MXC_F_TMR_INTEN_TIMER0;
     US_TIMER->ctrl = MXC_F_TMR_CTRL_ENABLE0 |
                      (US_TIMER_MODE << MXC_F_TMR_CTRL_MODE_POS) |
                      (US_TIMER_PRESCALE << MXC_F_TMR_CTRL_PRESCALE_POS);
-    }
+}
 
 //******************************************************************************
 void us_ticker_fire_interrupt(void)

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2795,7 +2795,7 @@
         "macros": ["TARGET=MAX32625","TARGET_REV=0x4132", "OPEN_DRAIN_LEDS"],
         "extra_labels": ["Maxim", "MAX32625"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
-        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
         "release_versions": ["2", "5"],
         "public": false
     },
@@ -2830,9 +2830,9 @@
         "macros": ["__SYSTEM_HFX=96000000", "TARGET=MAX32630", "TARGET_REV=0x4132", "BLE_HCI_UART", "OPEN_DRAIN_LEDS"],
         "extra_labels": ["Maxim", "MAX32630"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
-        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
         "features": ["BLE"],
-        "release_versions": []
+        "release_versions": ["2", "5"]
     },
     "EFM32": {
         "inherits": ["Target"],

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2786,8 +2786,8 @@
         "macros": ["__SYSTEM_HFX=96000000","TARGET=MAX32620","TARGET_REV=0x4332","OPEN_DRAIN_LEDS"],
         "extra_labels": ["Maxim", "MAX32620C"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
-        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release_versions": ["2"]
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
+        "release_versions": ["2", "5"]
     },
     "MAX32625_BASE": {
         "inherits": ["Target"],
@@ -2795,8 +2795,8 @@
         "macros": ["TARGET=MAX32625","TARGET_REV=0x4132", "OPEN_DRAIN_LEDS"],
         "extra_labels": ["Maxim", "MAX32625"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
-        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release_versions": ["2"],
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
+        "release_versions": ["2", "5"],
         "public": false
     },
     "MAX32625_BOOT": {
@@ -2830,7 +2830,7 @@
         "macros": ["__SYSTEM_HFX=96000000", "TARGET=MAX32630", "TARGET_REV=0x4132", "BLE_HCI_UART", "OPEN_DRAIN_LEDS"],
         "extra_labels": ["Maxim", "MAX32630"],
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
-        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES", "USTICKER"],
         "features": ["BLE"],
         "release_versions": []
     },


### PR DESCRIPTION
### Description
Depends on PR #6972 

Note: LP ticker has a maximum frequency of 4kHz. 

Tested on MAX32620FTHR, MAX32625MBED, MAX32630FTHR
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

