### PR TITLE
EFM32 - Revert IRQ Handling to 5.8.0

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_irq_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/gpio_irq_api.c
@@ -61,11 +61,15 @@ static void handle_interrupt_in(uint8_t pin)
         return;
     }
 
+    // we are storing two ports in each uint8, so we must acquire the one we want.	
+    // If pin is odd, the port is encoded in the 4 most significant bits. If pin is even, the port is encoded in the 4 least significant bits	
+    uint8_t isRise = GPIO_PinInGet((pin & 0x1) ? channel_ports[(pin>>1) & 0x7] >> 4 & 0xF : channel_ports[(pin>>1) & 0x7] & 0xF, pin);
+
     // Get trigger event
     gpio_irq_event event = IRQ_NONE;
-    if (GPIO->EXTIFALL & (1 << pin)) {
+    if ((GPIO->EXTIFALL & (1 << pin)) && !isRise) {
         event = IRQ_FALL;
-    } else if (GPIO->EXTIRISE & (1 << pin)) {
+    } else if ((GPIO->EXTIRISE & (1 << pin)) && isRise) {
         event = IRQ_RISE;
     }
     GPIO_IntClear(pin);


### PR DESCRIPTION
### Description

Referring to issue [#6783](https://github.com/ARMmbed/mbed-os/issues/6738) the pull request/commit  [#2a3d6d4](https://github.com/ARMmbed/mbed-os/commit/2a3d6d4349a5a32693edf92223ee008b5b9e8a4b) must be reverted. This commit causes the problem that the rise callback will never be called.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

