### PR TITLE
Support default tz_module in event loop thread for M23/M33

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
+++ b/features/FEATURE_LWIP/lwip-interface/lwip-sys/arch/lwip_sys_arch.c
@@ -502,7 +502,11 @@ static sys_thread_data_t thread_pool[SYS_THREAD_POOL_N];
  * Outputs:
  *      sys_thread_t              -- Pointer to thread handle.
  *---------------------------------------------------------------------------*/
-sys_thread_t sys_thread_new(const char *pcName,
+#ifndef MBED_TZ_DEFAULT_ACCESS
+#define MBED_TZ_DEFAULT_ACCESS   0
+#endif    
+
+ sys_thread_t sys_thread_new(const char *pcName,
                             void (*thread)(void *arg),
                             void *arg, int stacksize, int priority) {
     LWIP_DEBUGF(SYS_DEBUG, ("New Thread: %s\n", pcName));
@@ -519,6 +523,7 @@ sys_thread_t sys_thread_new(const char *pcName,
     t->attr.cb_mem = &t->data;
     t->attr.stack_size = stacksize;
     t->attr.stack_mem = malloc(stacksize);
+    t->attr.tz_module = MBED_TZ_DEFAULT_ACCESS;
     if (t->attr.stack_mem == NULL) {
       error("Error allocating the stack memory");
     }

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/ns_event_loop.c
@@ -27,6 +27,10 @@ static osEventFlagsId_t event_flag_id;
 
 #else
 
+#ifndef MBED_TZ_DEFAULT_ACCESS
+#define MBED_TZ_DEFAULT_ACCESS   0
+#endif    
+    
 static void event_loop_thread(void *arg);
 
 static uint64_t event_thread_stk[MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_THREAD_STACK_SIZE/8];
@@ -38,6 +42,7 @@ static const osThreadAttr_t event_thread_attr = {
     .stack_size = sizeof event_thread_stk,
     .cb_mem = &event_thread_tcb,
     .cb_size = sizeof event_thread_tcb,
+    .tz_module = MBED_TZ_DEFAULT_ACCESS,
 };
 #endif
 


### PR DESCRIPTION
### Description

 Thread class could support default tz_module of Thread attribute for M23/M33 in #6486  , however event loop & lwip will create new thread by osThreadNew(...) directly. So, to apply the same mechanism of #6486 on these 2 features. To allow event-queue's non-secure task to access secure functions.  


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

@deepikabhavnani 

