### PR TITLE
Cellular: reduced stack size in cellular state machine thread.

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -107,7 +107,8 @@ public:
      */
     CellularDevice* get_device();
 
-    /** Get cellular sim interface
+    /** Get cellular sim interface. After SIM is open and ready (move from state STATE_SIM_PIN) SIM interface is closed to save resources.
+     *  After SIM interface is closed this method will return NULL and any instances got via this method before this are invalid.
      *  @return sim interface, NULL on failure
      */
     CellularSIM* get_sim();
@@ -144,7 +145,6 @@ private:
     NetworkStack *get_stack();
 
 private:
-    void device_ready();
     void report_failure(const char* msg);
     void event();
 


### PR DESCRIPTION
### Description

- reduced stack size in cellular state machine thread to save memory
- release resources that are not needed anymore in state machine to save memory
- fixes cellular example application to work when compiled with IAR
- this is fix for mbed-os patch release 5.8.6

@AnttiKauppila @AriParkkila  please review

Internal ref to defect: IOTCELL-997

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

