### PR TITLE
Remove ns_event_loop_thread_start() from NDInterface and ThreadInterface connect()

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
@@ -398,7 +398,6 @@ int8_t nd_tasklet_connect(mesh_interface_cb callback, int8_t nwk_interface_id)
             // -2 memory allocation failure
             return tasklet_data_ptr->tasklet;
         }
-        ns_event_loop_thread_start();
     } else {
         tasklet_data_ptr->tasklet = tasklet_id;
         mesh_system_send_connect_event(tasklet_data_ptr->tasklet);

--- a/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
@@ -431,9 +431,7 @@ int8_t thread_tasklet_connect(mesh_interface_cb callback, int8_t nwk_interface_i
             // -1 handler already used by other tasklet
             // -2 memory allocation failure
             return thread_tasklet_data_ptr->tasklet;
-        }
-
-        ns_event_loop_thread_start();
+        }        
     } else {
         thread_tasklet_data_ptr->tasklet = tasklet;
         mesh_system_send_connect_event(thread_tasklet_data_ptr->tasklet);


### PR DESCRIPTION
### Description

ns_event_loop_thread_start() is incorrectly used at connect() phase, the initial
setup is already done at init() phase and the eventloop thread is correctly initialized.

Also, the usage of ns_event_loop_thread_start() API should be behind MBED_CONF_NANOSTACK_HAL_EVENT_LOOP_DISPATCH_FROM_APPLICATION
flag as application can decide to use main thread for event loop, which will result in linker error for this API call in
case of ARMCC compiler.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

