### PR TITLE
KW41Z: Enable SLEEP feature

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -585,7 +585,7 @@
         "macros": ["CPU_MKW41Z512VHT4", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0201"],
-        "device_has": ["USTICKER", "ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "TRNG", "STDIO_MESSAGES"],
+        "device_has": ["USTICKER", "ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "TRNG", "STDIO_MESSAGES"],
         "release_versions": ["2", "5"],
         "device_name": "MKW41Z512xxx4"
     },


### PR DESCRIPTION
Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>

### Description
The changes as part of https://github.com/ARMmbed/mbed-os/pull/6956 should allow us to turn on SLEEP on KW41Z. All tests pass.

Do we need to turn it on in this branch as well? This patch enables SLEEP on KW41Z, but requires changes from PR 6956.

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

