### PR TITLE
EFM32: make mbed_rtx.h depend of families instead of targets

### DIFF
--- a/targets/TARGET_Silicon_Labs/mbed_rtx.h
+++ b/targets/TARGET_Silicon_Labs/mbed_rtx.h
@@ -20,31 +20,31 @@
 #include <stdint.h>
 #include "clocking.h"
 
-#if defined(TARGET_EFM32GG_STK3700)
+#if defined(TARGET_EFM32GG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20020000UL)
 #endif
 
-#elif defined(TARGET_EFM32HG_STK3400)
+#elif defined(TARGET_EFM32HG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20002000UL)
 #endif
 
-#elif defined(TARGET_EFM32LG_STK3600)
+#elif defined(TARGET_EFM32LG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
-#elif defined(TARGET_EFM32PG_STK3401)
+#elif defined(TARGET_EFM32PG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)
 #endif
 
-#elif defined(TARGET_EFM32WG_STK3800)
+#elif defined(TARGET_EFM32WG)
 
 #ifndef INITIAL_SP
 #define INITIAL_SP              (0x20008000UL)


### PR DESCRIPTION
### Description

Currently, custom targets based on these families would require a fork of mbed-os, otherwise the build would fail on an undefined `INITIAL_SP`:

- EFM32GG
- EFM32HG
- EFM32LG
- EFM32PG
- EFM32WG

This is due to specific targets like `EFM32GG_STK3700` being used in `mbed_rtx.h`, instead of families such as `EFM32GG`.

The newest families `EFR32MG12` and `EFM32PG12` do not have this issue. This PR aligns `mbed_rtx.h` with the approach of these new families.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

