### PR TITLE
Change LPTICKER spec to allow clock freq starting at 4kHz

### DIFF
--- a/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
+++ b/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
@@ -32,7 +32,7 @@ extern "C" {
  *
  * Given ticker is available.
  * When ticker information data is obtained.
- * Then collected data indicates that ticker frequency is between 8KHz and 64KHz and the counter is at least 12 bits wide.
+ * Then collected data indicates that ticker frequency is between 4KHz and 64KHz and the counter is at least 12 bits wide.
  */
 void lp_ticker_info_test(void);
 

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -82,7 +82,7 @@ void lp_ticker_info_test()
 {
     const ticker_info_t* p_ticker_info = lp_ticker_get_info();
 
-    TEST_ASSERT(p_ticker_info->frequency >= 8000);
+    TEST_ASSERT(p_ticker_info->frequency >= 4000);
     TEST_ASSERT(p_ticker_info->frequency <= 64000);
     TEST_ASSERT(p_ticker_info->bits >= 12);
 }

--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -34,7 +34,7 @@ extern "C" {
  * Low level interface to the low power ticker of a target
  *
  * # Defined behavior
- * * Has a reported frequency between 8KHz and 64KHz - verified by ::lp_ticker_info_test
+ * * Has a reported frequency between 4KHz and 64KHz - verified by ::lp_ticker_info_test
  * * Has a counter that is at least 12 bits wide - verified by ::lp_ticker_info_test
  * * Continues operating in deep sleep mode - verified by ::lp_ticker_deepsleep_test
  * * All behavior defined by the @ref hal_ticker_shared "ticker specification"


### PR DESCRIPTION
### Description

Some HW supports 4kHz low power clock, that allows to achieve 1ms accuracy which should be allowed in our spec.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

@c1728p9 Please review