### PR TITLE
CPU Stats test - Increased wait time to allow device to sleep

### DIFF
--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -65,7 +65,7 @@ void test_cpu_info(void)
     mbed_stats_cpu_t stats;
     // Additional read to make sure timer is initialized
     mbed_stats_cpu_get(&stats);
-    Thread::wait(1);
+    Thread::wait(3);
     mbed_stats_cpu_get(&stats);
     TEST_ASSERT_NOT_EQUAL(0, stats.uptime);
     TEST_ASSERT_NOT_EQUAL(0, stats.idle_time);


### PR DESCRIPTION
### Description
With small wait time at the start, chances are that device does not enter sleep and idle time is zero. Increasing wait time to make sure device goes to sleep.

Issue seen in CI testing for NRF51_DK https://github.com/ARMmbed/mbed-os/pull/6910#issuecomment-391469548

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @cmonr 
