### PR TITLE
Adding usticker to MTB_ODIN

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2147,6 +2147,7 @@
     },
     "MTB_UBLOX_ODIN_W2": {
         "inherits": ["MODULE_UBLOX_ODIN_W2"],
+        "device_has_add": ["USTICKER"],
         "release_versions": ["5"]
      },
     "UBLOX_C030": {


### PR DESCRIPTION
### Description

Adding USTICKER for MTB_ODIN to appropriate branch.

GT logs are already attached in PR https://github.com/ARMmbed/mbed-os/pull/6964
@0xc0170 : This PR addresses [this comment in 6964 ](https://github.com/ARMmbed/mbed-os/pull/6964#issuecomment-390898907) to add USTICKER to the appropriate feature branch

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

cc: @bulislaw 