### PR TITLE
Extend feature which displays errors/warnings as Link

### DIFF
--- a/tools/notifier/term.py
+++ b/tools/notifier/term.py
@@ -86,7 +86,7 @@ class TerminalNotifier(Notifier):
             event['severity'] = event['severity'].title()
 
             if PRINT_COMPILER_OUTPUT_AS_LINK:
-                event['file'] = getcwd() + event['file'].strip('.')
+                event['file'] = abspath(event['file'])
                 return '[{severity}] {file}:{line}:{col}: {message}'.format(
                     **event)
             else:

--- a/tools/notifier/term.py
+++ b/tools/notifier/term.py
@@ -18,7 +18,7 @@ from __future__ import print_function, division, absolute_import
 import re
 import sys
 from os import getcwd
-from os.path import basename
+from os.path import (basename, abspath)
 
 from . import Notifier
 from ..settings import (PRINT_COMPILER_OUTPUT_AS_LINK,

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -18,7 +18,7 @@ from __future__ import print_function, division, absolute_import
 
 import re
 import sys
-from os import stat, walk, getcwd, sep, remove, path
+from os import stat, walk, getcwd, sep, remove
 from copy import copy
 from time import time, sleep
 from shutil import copyfile
@@ -987,7 +987,7 @@ class mbedToolchain:
         # Check dependencies
         _, ext = splitext(source)
         ext = ext.lower()
-        
+
         source = abspath(source) if PRINT_COMPILER_OUTPUT_AS_LINK else source
 
         if ext == '.c' or  ext == '.cpp':

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -18,7 +18,7 @@ from __future__ import print_function, division, absolute_import
 
 import re
 import sys
-from os import stat, walk, getcwd, sep, remove
+from os import stat, walk, getcwd, sep, remove, path
 from copy import copy
 from time import time, sleep
 from shutil import copyfile
@@ -433,7 +433,7 @@ class mbedToolchain:
         self.build_all = False
 
         # Build output dir
-        self.build_dir = build_dir
+        self.build_dir = path.abspath(build_dir) if PRINT_COMPILER_OUTPUT_AS_LINK else build_dir
         self.timestamp = time()
 
         # Number of concurrent build jobs. 0 means auto (based on host system cores)
@@ -987,6 +987,8 @@ class mbedToolchain:
         # Check dependencies
         _, ext = splitext(source)
         ext = ext.lower()
+        
+        source = abspath(source) if PRINT_COMPILER_OUTPUT_AS_LINK else source
 
         if ext == '.c' or  ext == '.cpp':
             base, _ = splitext(object)

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -433,7 +433,7 @@ class mbedToolchain:
         self.build_all = False
 
         # Build output dir
-        self.build_dir = path.abspath(build_dir) if PRINT_COMPILER_OUTPUT_AS_LINK else build_dir
+        self.build_dir = abspath(build_dir) if PRINT_COMPILER_OUTPUT_AS_LINK else build_dir
         self.timestamp = time()
 
         # Number of concurrent build jobs. 0 means auto (based on host system cores)


### PR DESCRIPTION
### Description
I already made a PR #6270 which offers a flag to displays  errors/warnings as a Link to file and line.
I extended this feature to display, in case of an error, also the GCC output as a clickable link.
See here [GCC Output](https://www.screencast.com/t/ls3HxoJx).
The feature will be activated by setting `PRINT_COMPILER_OUTPUT_AS_LINK = True` in the application specific `mbed_settings.py`.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

