### PR TITLE
Add warning about FEATURE_UVISOR being deprecated

### DIFF
--- a/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_deprecation.h
+++ b/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_deprecation.h
@@ -18,7 +18,7 @@
 #define __UVISOR_DEPRECATION_H__
 
 #if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
-#warning "---- WARNING: You are using FEATURE_UVISOR which is deprecated since mbed-os-5.9!! ----"
+#warning "Warning: You are using FEATURE_UVISOR, which is unsupported as of Mbed OS 5.9."
 #endif
 
 #endif  // __UVISOR_DEPRECATION_H__

--- a/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_deprecation.h
+++ b/features/FEATURE_UVISOR/includes/uvisor/api/inc/uvisor_deprecation.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __UVISOR_DEPRECATION_H__
+#define __UVISOR_DEPRECATION_H__
+
+#if defined(UVISOR_PRESENT) && UVISOR_PRESENT == 1
+#warning "---- WARNING: You are using FEATURE_UVISOR which is deprecated since mbed-os-5.9!! ----"
+#endif
+
+#endif  // __UVISOR_DEPRECATION_H__

--- a/features/FEATURE_UVISOR/source/rtx/box_init.c
+++ b/features/FEATURE_UVISOR/source/rtx/box_init.c
@@ -19,6 +19,7 @@
 #include "api/inc/rpc_exports.h"
 #include "api/inc/uvisor_semaphore.h"
 #include "api/inc/box_config.h"
+#include "api/inc/uvisor_deprecation.h"
 #include "mbed_interface.h"
 #include "cmsis_os2.h"
 #include <stdint.h>


### PR DESCRIPTION
### Description

Add warning about FEATURE_UVISOR being deprecated.
If FEATURE_UVISOR is being used (compiled), then a compilation warning  is issued.

### Pull request type

    [ ] Fix
    [ x ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

