### PR TITLE
Clean prints from MbedOS Fault Handler.

### DIFF
--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -43,47 +43,47 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
 {
     fault_print_init();
     fault_print_str("\r\n++ MbedOS Fault Handler ++\r\n\r\nFaultType: ",NULL);
-        
+
     switch( fault_type ) {
-      case HARD_FAULT_EXCEPTION: 
-        fault_print_str("HardFault",NULL); 
+      case HARD_FAULT_EXCEPTION:
+        fault_print_str("HardFault",NULL);
         break;
-      case MEMMANAGE_FAULT_EXCEPTION: 
-        fault_print_str("MemManageFault",NULL); 
+      case MEMMANAGE_FAULT_EXCEPTION:
+        fault_print_str("MemManageFault",NULL);
         break;
-      case BUS_FAULT_EXCEPTION: 
-        fault_print_str("BusFault",NULL); 
+      case BUS_FAULT_EXCEPTION:
+        fault_print_str("BusFault",NULL);
         break;
-      case USAGE_FAULT_EXCEPTION: 
-        fault_print_str("UsageFault",NULL); 
+      case USAGE_FAULT_EXCEPTION:
+        fault_print_str("UsageFault",NULL);
         break;
-      default: 
-        fault_print_str("Unknown Fault",NULL); 
+      default:
+        fault_print_str("Unknown Fault",NULL);
         break;
     }
     fault_print_str("\r\n\r\nContext:",NULL);
     print_context_info();
-        
+
     fault_print_str("\r\n\r\nThread Info:\r\nCurrent:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.curr);
-  
+
     fault_print_str("\r\nNext:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.next);
-    
+
     fault_print_str("\r\nWait Threads:",NULL);
     osRtxThread_t *threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.wait_list;
     print_threads_info(threads);
-    
+
     fault_print_str("\r\nDelay Threads:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.delay_list;
     print_threads_info(threads);
-    
+
     fault_print_str("\r\nIdle Thread:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.idle;
     print_threads_info(threads);
-    
+
     fault_print_str("\r\n\r\n-- MbedOS Fault Handler --\r\n\r\n",NULL);
-        
+
     /* Just spin here, we have already crashed */
     for (;;) {}
 }
@@ -110,14 +110,14 @@ void print_context_info()
                      "\r\nxPSR : %"
                      "\r\nPSP  : %"
                      "\r\nMSP  : %", (uint32_t *)&mbed_fault_context);
-                       
+
     //Capture CPUID to get core/cpu info
     fault_print_str("\r\nCPUID: %",(uint32_t *)&SCB->CPUID);
-    
+
 #if !defined(TARGET_M0) && !defined(TARGET_M0P)
     //Capture fault information registers to infer the cause of exception
     uint32_t FSR[7] = {0};
-    
+
     FSR[0] = SCB->HFSR;
     //Split/Capture CFSR into MMFSR, BFSR, UFSR
     FSR[1] = 0xFF & SCB->CFSR;//MMFSR
@@ -133,7 +133,7 @@ void print_context_info()
                     "\r\nDFSR : %"
                     "\r\nAFSR : %"
                     "\r\nSHCSR: %",FSR);
-    
+
     //Print MMFAR only if its valid as indicated by MMFSR
     if(FSR[1] & 0x80) {
         fault_print_str("\r\nMMFAR: %",(uint32_t *)&SCB->MMFAR);
@@ -147,13 +147,13 @@ void print_context_info()
     if(mbed_fault_context.EXC_RETURN & 0x8) {
         fault_print_str("\r\nMode : Thread", NULL);
         //Print Priv level in Thread mode - We capture CONTROL reg which reflects the privilege.
-        //Note that the CONTROL register captured still reflects the privilege status of the 
+        //Note that the CONTROL register captured still reflects the privilege status of the
         //thread mode eventhough we are in Handler mode by the time we capture it.
         if(mbed_fault_context.CONTROL & 0x1) {
             fault_print_str("\r\nPriv : User", NULL);
         } else {
             fault_print_str("\r\nPriv : Privileged", NULL);
-        }        
+        }
     } else {
         fault_print_str("\r\nMode : Handler", NULL);
         fault_print_str("\r\nPriv : Privileged", NULL);
@@ -195,12 +195,12 @@ void fault_print_init()
     if (!stdio_uart_inited) {
         serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
     }
-#endif    
+#endif
 }
 
-/* Limited print functionality which prints the string out to 
-stdout/uart without using stdlib by directly calling serial-api 
-and also uses less resources 
+/* Limited print functionality which prints the string out to
+stdout/uart without using stdlib by directly calling serial-api
+and also uses less resources
 The fmtstr contains the format string for printing and for every %
 found in that it fetches a uint32 value from values buffer
 and prints it in hex format.
@@ -212,7 +212,7 @@ void fault_print_str(char *fmtstr, uint32_t *values)
     int idx = 0;
     int vidx = 0;
     char hex_str[9]={0};
-        
+
     while(fmtstr[i] != '\0') {
         if(fmtstr[i]=='%') {
             hex_to_str(values[vidx++],hex_str);
@@ -227,7 +227,7 @@ void fault_print_str(char *fmtstr, uint32_t *values)
         }
         i++;
     }
-#endif    
+#endif
 }
 
 /* Converts a uint32 to hex char string */
@@ -235,10 +235,10 @@ void hex_to_str(uint32_t value, char *hex_str)
 {
     char hex_char_map[] = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
     int i = 0;
-    
+
     //Return without converting if hex_str is not provided
     if(hex_str == NULL) return;
-        
+
     for(i=7; i>=0; i--) {
         hex_str[i] = hex_char_map[(value & (0xf << (i * 4))) >> (i * 4)];
     }

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -42,7 +42,7 @@ extern serial_t stdio_uart;
 __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_context_in, void *osRtxInfoIn)
 {
     fault_print_init();
-    fault_print_str("\n++ MbedOS Fault Handler ++\n\nFaultType: ",NULL);
+    fault_print_str("\r\n++ MbedOS Fault Handler ++\r\n\r\nFaultType: ",NULL);
         
     switch( fault_type ) {
       case HARD_FAULT_EXCEPTION: 
@@ -61,28 +61,28 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
         fault_print_str("Unknown Fault",NULL); 
         break;
     }
-    fault_print_str("\n\nContext:",NULL);
+    fault_print_str("\r\n\r\nContext:",NULL);
     print_context_info();
         
-    fault_print_str("\n\nThread Info:\nCurrent:",NULL);
+    fault_print_str("\r\n\r\nThread Info:\r\nCurrent:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.curr);
   
-    fault_print_str("\nNext:",NULL);
+    fault_print_str("\r\nNext:",NULL);
     print_thread(((osRtxInfo_t *)osRtxInfoIn)->thread.run.next);
     
-    fault_print_str("\nWait Threads:",NULL);
+    fault_print_str("\r\nWait Threads:",NULL);
     osRtxThread_t *threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.wait_list;
     print_threads_info(threads);
     
-    fault_print_str("\nDelay Threads:",NULL);
+    fault_print_str("\r\nDelay Threads:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.delay_list;
     print_threads_info(threads);
     
-    fault_print_str("\nIdle Thread:",NULL);
+    fault_print_str("\r\nIdle Thread:",NULL);
     threads = ((osRtxInfo_t *)osRtxInfoIn)->thread.idle;
     print_threads_info(threads);
     
-    fault_print_str("\n\n-- MbedOS Fault Handler --\n\n",NULL);
+    fault_print_str("\r\n\r\n-- MbedOS Fault Handler --\r\n\r\n",NULL);
         
     /* Just spin here, we have already crashed */
     for (;;) {}
@@ -91,28 +91,28 @@ __NO_RETURN void mbed_fault_handler (uint32_t fault_type, void *mbed_fault_conte
 void print_context_info()
 {
     //Context Regs
-    fault_print_str( "\nR0   : %" 
-                    "\nR1   : %" 
-                    "\nR2   : %" 
-                    "\nR3   : %" 
-                    "\nR4   : %" 
-                    "\nR5   : %" 
-                    "\nR6   : %" 
-                    "\nR7   : %" 
-                    "\nR8   : %" 
-                    "\nR9   : %" 
-                    "\nR10  : %" 
-                    "\nR11  : %" 
-                    "\nR12  : %" 
-                    "\nSP   : %" 
-                    "\nLR   : %" 
-                    "\nPC   : %" 
-                    "\nxPSR : %" 
-                    "\nPSP  : %" 
-                    "\nMSP  : %", (uint32_t *)&mbed_fault_context);
+    fault_print_str( "\r\nR0   : %"
+                     "\r\nR1   : %"
+                     "\r\nR2   : %"
+                     "\r\nR3   : %"
+                     "\r\nR4   : %"
+                     "\r\nR5   : %"
+                     "\r\nR6   : %"
+                     "\r\nR7   : %"
+                     "\r\nR8   : %"
+                     "\r\nR9   : %"
+                     "\r\nR10  : %"
+                     "\r\nR11  : %"
+                     "\r\nR12  : %"
+                     "\r\nSP   : %"
+                     "\r\nLR   : %"
+                     "\r\nPC   : %"
+                     "\r\nxPSR : %"
+                     "\r\nPSP  : %"
+                     "\r\nMSP  : %", (uint32_t *)&mbed_fault_context);
                        
     //Capture CPUID to get core/cpu info
-    fault_print_str("\nCPUID: %",(uint32_t *)&SCB->CPUID);
+    fault_print_str("\r\nCPUID: %",(uint32_t *)&SCB->CPUID);
     
 #if !defined(TARGET_M0) && !defined(TARGET_M0P)
     //Capture fault information registers to infer the cause of exception
@@ -126,43 +126,43 @@ void print_context_info()
     FSR[4] = SCB->DFSR;
     FSR[5] = SCB->AFSR;
     FSR[6] = SCB->SHCSR;
-    fault_print_str("\nHFSR : %"
-                    "\nMMFSR: %"
-                    "\nBFSR : %"
-                    "\nUFSR : %"
-                    "\nDFSR : %"
-                    "\nAFSR : %"
-                    "\nSHCSR: %",FSR); 
+    fault_print_str("\r\nHFSR : %"
+                    "\r\nMMFSR: %"
+                    "\r\nBFSR : %"
+                    "\r\nUFSR : %"
+                    "\r\nDFSR : %"
+                    "\r\nAFSR : %"
+                    "\r\nSHCSR: %",FSR);
     
     //Print MMFAR only if its valid as indicated by MMFSR
     if(FSR[1] & 0x80) {
-        fault_print_str("\nMMFAR: %",(uint32_t *)&SCB->MMFAR); 
+        fault_print_str("\r\nMMFAR: %",(uint32_t *)&SCB->MMFAR);
     }
     //Print BFAR only if its valid as indicated by BFSR
     if(FSR[2] & 0x80) {
-        fault_print_str("\nBFAR : %",(uint32_t *)&SCB->BFAR); 
+        fault_print_str("\r\nBFAR : %",(uint32_t *)&SCB->BFAR);
     }
 #endif
     //Print Mode
     if(mbed_fault_context.EXC_RETURN & 0x8) {
-        fault_print_str("\nMode : Thread", NULL);
+        fault_print_str("\r\nMode : Thread", NULL);
         //Print Priv level in Thread mode - We capture CONTROL reg which reflects the privilege.
         //Note that the CONTROL register captured still reflects the privilege status of the 
         //thread mode eventhough we are in Handler mode by the time we capture it.
         if(mbed_fault_context.CONTROL & 0x1) {
-            fault_print_str("\nPriv : User", NULL); 
+            fault_print_str("\r\nPriv : User", NULL);
         } else {
-            fault_print_str("\nPriv : Privileged", NULL); 
+            fault_print_str("\r\nPriv : Privileged", NULL);
         }        
     } else {
-        fault_print_str("\nMode : Handler", NULL); 
-        fault_print_str("\nPriv : Privileged", NULL); 
+        fault_print_str("\r\nMode : Handler", NULL);
+        fault_print_str("\r\nPriv : Privileged", NULL);
     }
     //Print Return Stack
     if(mbed_fault_context.EXC_RETURN & 0x4) {
-        fault_print_str("\nStack: PSP", NULL); 
+        fault_print_str("\r\nStack: PSP", NULL);
     } else {
-        fault_print_str("\nStack: MSP", NULL); 
+        fault_print_str("\r\nStack: MSP", NULL);
     }
 }
 
@@ -185,7 +185,7 @@ void print_thread(osRtxThread_t *thread)
     data[2]=thread->stack_size;
     data[3]=(uint32_t)thread->stack_mem;
     data[4]=thread->sp;
-    fault_print_str("\nState: % EntryFn: % Stack Size: % Mem: % SP: %", data);
+    fault_print_str("\r\nState: % EntryFn: % Stack Size: % Mem: % SP: %", data);
 }
 
 /* Initializes std uart for spitting the info out */


### PR DESCRIPTION
### Description
MbedOS Fault Handler uses C-style '\n' newlines when it directly writes to serial port. I think the line ending should be '\r\n' which is commonly expected as a default by popular serial programs (putty, minicom).

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

