### PR TITLE
Make CPU stats test conditional on new LP ticker 

### DIFF
--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -21,7 +21,7 @@
 
 #include "mbed.h"
 
-#if !defined(MBED_CPU_STATS_ENABLED) || !defined(DEVICE_LOWPOWERTIMER) || !defined(DEVICE_SLEEP)
+#if !defined(MBED_CPU_STATS_ENABLED) || !DEVICE_LPTICKER || !defined(DEVICE_SLEEP)
 #error [NOT_SUPPORTED] test not supported
 #endif
 


### PR DESCRIPTION
### Description

Pending the new LP ticker HAL changes, we're still seeing test issues on
the NRF51.

On the assumption that the LP ticker PR will fix it, and knowing that it
is currently lacking the necessary change to DEVICE_LPTICKER for this
test, change the test now.

This deactivates the test, and it will be reenabled when the LP ticker
PR lands, rather than being deactivated by it.



### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

