### PR TITLE
AStyle: Fix astyle indentation

### DIFF
--- a/.astylerc
+++ b/.astylerc
@@ -31,3 +31,7 @@ align-reference=name
 # Attach { for classes and namespaces
 attach-namespaces
 attach-classes
+
+# Extend longer lines, define maximum 120 value. This results in aligned code,
+# otherwise the lines are broken and not consistent 
+max-continuation-indent=120

--- a/.astylerc
+++ b/.astylerc
@@ -16,7 +16,6 @@ convert-tabs
 
 # Indent switches and cases
 indent-switches
-indent-cases
 
 # Remove spaces in and around parentheses
 unpad-paren


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This PR fixes the indentation we identified (thanks @kjbracey-arm @hasnainvirk) in Lorawan PR - lorawan codebase tested astyle to the point where we found that the code astyle was fixing was not correct (see the commit messages with examples how it was and with this config how is it). You will spot the differences.

This PR is vital for astyle applying to our bigger codebase.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

