### PR TITLE
Fixed float-abi linker option for CCES exporter.

### DIFF
--- a/tools/export/cces/__init__.py
+++ b/tools/export/cces/__init__.py
@@ -108,14 +108,14 @@ class CCES(Exporter):
         return CCES.format_path(path, "PARENT-1-PROJECT_LOC/")
 
     @staticmethod
-    def clean_flags(container, flags):
+    def clean_flags(container, flags_to_remove):
         """
         Some flags are handled by CCES already, so there's no need
         to include them twice.
         """
-        for flag in container:
-            if flag in flags:
-                flags.remove(flag)
+        for flag in flags_to_remove:
+            if flag in container:
+                container.remove(flag)
 
     @staticmethod
     def parse_flags(flags, options, booleans):

--- a/tools/export/cces/cces.json.tmpl
+++ b/tools/export/cces/cces.json.tmpl
@@ -91,9 +91,9 @@
                      ]
                   },
                   {% if float_abi %}
-                  "-mfloat-abi=${value}" : {
-                     "type" : "command",
-                     "value" : "{{ float_abi }}"
+                  "arm.toolchain.gcc.cpp.linker.option.fpu.abi" : {
+                     "type" : "baseId",
+                     "value" : "arm.toolchain.gcc.c.linker.option.fpu.abi.{{ float_abi }}"
                   },
                   {% endif %}
                   "-T" : {


### PR DESCRIPTION


### Description
This pull request fixes issue #6977. The CCES exporter was incorrectly specifying the float-abi linker option in the .json file. There was also an issue with handling the toolchain cpu options. The CCES exporter was supposed to remove the toolchain cpu options from the linker and compiler flags, but there was a bug preventing it from removing them.


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

