### PR TITLE
Corrected asynchronous DNS functionality

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/LWIPStack.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/LWIPStack.cpp
@@ -209,7 +209,7 @@ void LWIP::tcpip_thread_callback(void *ptr)
 
 nsapi_error_t LWIP::call_in(int delay, mbed::Callback<void()> func)
 {
-    lwip_callback *cb = new lwip_callback;
+    lwip_callback *cb = new (std::nothrow) lwip_callback;
     if (!cb) {
         return NSAPI_ERROR_NO_MEMORY;
     }

--- a/features/netsocket/NetworkStack.cpp
+++ b/features/netsocket/NetworkStack.cpp
@@ -114,7 +114,7 @@ nsapi_error_t NetworkStack::getsockopt(void *handle, int level, int optname, voi
 
 nsapi_error_t NetworkStack::call_in(int delay, mbed::Callback<void()> func)
 {
-    events::EventQueue *event_queue = mbed::mbed_event_queue();
+    static events::EventQueue *event_queue = mbed::mbed_event_queue();
 
     if (!event_queue) {
         return NSAPI_ERROR_NO_MEMORY;

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -54,6 +54,7 @@ enum nsapi_error {
     NSAPI_ERROR_CONNECTION_LOST     = -3016,     /*!< connection lost */
     NSAPI_ERROR_CONNECTION_TIMEOUT  = -3017,     /*!< connection timed out */
     NSAPI_ERROR_ADDRESS_IN_USE      = -3018,     /*!< Address already in use */
+    NSAPI_ERROR_TIMEOUT             = -3019,     /*!< operation timed out */
 };
 
 


### PR DESCRIPTION
### Description

Made fixes to asynchronous DNS. These are fixes to PR: https://github.com/ARMmbed/mbed-os/pull/6847

List of changes:
- Set network stack to store event queue so that mbed::mbed_event_queue() call
  is not needed every time call_in() is called
- Added dns state variables and enum (states are: created, initiated and cancelled)
- Corrected DNS response handling so that if DNS server returns that host name is
  unknown the DNS query is not tried again
- Reorder mutexes in nsapi_dns_query_multiple_async()
- Created nsapi_dns_query_async_initiate_next() function to initiate the next
  DNS query from the queue after delete of previous query
- Added dsn_timer_running variable to supervise DNS timer start/stop
- Changed cancel function to only mark query as deleted and moved deletion
  to timer function. This allows to run socket close on DNS thread
- Added new nsapi error NSAPI_ERROR_TIMEOUT for DNS (and other) timeouts

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

