### PR TITLE
Made lwip memory configuration more specific for NXP targets

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
+++ b/features/FEATURE_LWIP/lwip-interface/mbed_lib.json
@@ -107,7 +107,16 @@
         "Freescale": {
             "mem-size": 36560
         },
-        "NXP": {
+        "LPC1768": {
+            "mem-size": 16362
+        },
+        "LPC4088": {
+            "mem-size": 15360
+        },
+        "LPC4088_DM": {
+            "mem-size": 15360
+        },
+        "LPC546XX": {
             "mem-size": 36496
         }
     }


### PR DESCRIPTION
### Description

There is a configuration problem with UBLOX_C027 cellular because of missing
LWIP memory configuration for the target.
    
Added configuration for LPC1768, LPC4088, LPC4088_DM targets and changed
NXP to more specific LPC546XX.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

