### PR TITLE
Update watchdog timing test

### DIFF
--- a/TESTS/mbed_hal/watchdog_timing/main.cpp
+++ b/TESTS/mbed_hal/watchdog_timing/main.cpp
@@ -48,6 +48,12 @@ testcase_data current_case;
 template<uint32_t timeout_ms, uint32_t delta_ms>
 void test_timing()
 {
+    watchdog_features_t features = hal_watchdog_get_platform_features();
+    if (timeout_ms > features.max_timeout) {
+        TEST_IGNORE_MESSAGE("Requested timeout value not supported for this target -- ignoring test case.");
+        return;
+    }
+
     // Phase 2. -- verify the test results.
     // Verify the heartbeat time span sent by host is within given delta.
     if (current_case.received_data != CASE_DATA_INVALID) {


### PR DESCRIPTION
### Description
Skip test cases with unsupported timeout values in `tests-mbed_hal-watchdog_timing`.

The arbitrary timeout values used in this test may be too long for some of the partners' boards. Some of them only support timeout values up to 150 ms.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @scartmell-arm @jamesbeyond

