### PR TITLE
Add support for USBMSD

### DIFF
--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -331,13 +331,11 @@ void USBDevice::_complete_request_xfer_done()
     _transfer.user_callback = None;
     if (_abort_control) {
         _control_abort();
-        unlock();
         return;
     }
 
     if (!success) {
         _phy->ep0_stall();
-        unlock();
         return;
     }
 
@@ -405,7 +403,6 @@ void USBDevice::_complete_set_configuration()
     _transfer.user_callback = None;
     if (_abort_control) {
         _control_abort();
-        unlock();
         return;
     }
 
@@ -478,7 +475,6 @@ void USBDevice::_complete_set_interface()
     _transfer.user_callback = None;
     if (_abort_control) {
         _control_abort();
-        unlock();
         return;
     }
 
@@ -716,7 +712,6 @@ void USBDevice::_complete_request()
         } else {
             _control_abort();
         }
-        unlock();
         return;
     }
 
@@ -1563,8 +1558,6 @@ void USBDevice::lock()
 
 void USBDevice::unlock()
 {
-    MBED_ASSERT(_locked > 0);
-
     if (_locked == 1) {
         // Perform post processing before fully unlocking
         while (_post_process != NULL) {
@@ -1574,6 +1567,7 @@ void USBDevice::unlock()
         }
     }
 
+    MBED_ASSERT(_locked > 0);
     _locked--;
     core_util_critical_section_exit();
 }

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -595,6 +595,7 @@ private:
     USBPhy *_phy;
     bool _initialized;
     bool _connected;
+    bool _endpoint_add_remove_allowed;
     control_transfer_t _transfer;
     usb_device_t _device;
     uint32_t _max_packet_size_ep0;

--- a/usb/device/USBMSD/USBMSD.cpp
+++ b/usb/device/USBMSD/USBMSD.cpp
@@ -1,0 +1,887 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "stdint.h"
+#include "USBMSD.h"
+#include "EndpointResolver.h"
+
+#define DISK_OK         0x00
+#define NO_INIT         0x01
+#define NO_DISK         0x02
+#define WRITE_PROTECT   0x04
+
+#define CBW_Signature   0x43425355
+#define CSW_Signature   0x53425355
+
+// SCSI Commands
+#define TEST_UNIT_READY            0x00
+#define REQUEST_SENSE              0x03
+#define FORMAT_UNIT                0x04
+#define INQUIRY                    0x12
+#define MODE_SELECT6               0x15
+#define MODE_SENSE6                0x1A
+#define START_STOP_UNIT            0x1B
+#define MEDIA_REMOVAL              0x1E
+#define READ_FORMAT_CAPACITIES     0x23
+#define READ_CAPACITY              0x25
+#define READ10                     0x28
+#define WRITE10                    0x2A
+#define VERIFY10                   0x2F
+#define READ12                     0xA8
+#define WRITE12                    0xAA
+#define MODE_SELECT10              0x55
+#define MODE_SENSE10               0x5A
+
+// MSC class specific requests
+#define MSC_REQUEST_RESET          0xFF
+#define MSC_REQUEST_GET_MAX_LUN    0xFE
+
+#define DEFAULT_CONFIGURATION (1)
+
+// max packet size
+#define MAX_PACKET  64
+
+// CSW Status
+enum Status {
+    CSW_PASSED,
+    CSW_FAILED,
+    CSW_ERROR,
+};
+
+USBMSD::USBMSD(BlockDevice *bd, USBPhy *phy, uint16_t vendor_id, uint16_t product_id, uint16_t product_release)
+    : USBDevice(phy, vendor_id, product_id, product_release),
+      _in_task(&_queue), _out_task(&_queue), _reset_task(&_queue), _control_task(&_queue), _configure_task(&_queue)
+{
+    _bd = bd;
+    _bd->init();
+
+    _in_task = callback(this, &USBMSD::_in);
+    _out_task = callback(this, &USBMSD::_out);
+    _reset_task = callback(this, &USBMSD::_reset);
+    _control_task = callback(this, &USBMSD::_control);
+    _configure_task = callback(this, &USBMSD::_configure);
+
+    EndpointResolver resolver(endpoint_table());
+
+    resolver.endpoint_ctrl(64);
+    _bulk_in = resolver.endpoint_in(USB_EP_TYPE_BULK, MAX_PACKET);
+    _bulk_out = resolver.endpoint_out(USB_EP_TYPE_BULK, MAX_PACKET);
+    MBED_ASSERT(resolver.valid());
+
+    _stage = READ_CBW;
+    memset((void *)&_cbw, 0, sizeof(CBW));
+    memset((void *)&_csw, 0, sizeof(CSW));
+    _page = NULL;
+}
+
+USBMSD::~USBMSD()
+{
+    disconnect();
+    _bd->deinit();
+}
+
+bool USBMSD::connect()
+{
+    _mutex.lock();
+
+    //disk initialization
+    if (disk_status() & NO_INIT) {
+        if (disk_initialize()) {
+            _mutex.unlock();
+            return false;
+        }
+    }
+
+    // get number of blocks
+    _block_count = disk_sectors();
+
+    // get memory size
+    _memory_size = disk_size();
+
+    if (_block_count > 0) {
+        _block_size = _memory_size / _block_count;
+        if (_block_size != 0) {
+            free(_page);
+            _page = (uint8_t *)malloc(_block_size * sizeof(uint8_t));
+            if (_page == NULL) {
+                _mutex.unlock();
+                return false;
+            }
+        }
+    } else {
+        _mutex.unlock();
+        return false;
+    }
+
+    //connect the device
+    USBDevice::connect();
+    _mutex.unlock();
+    return true;
+}
+
+void USBMSD::disconnect()
+{
+    _mutex.lock();
+
+    USBDevice::disconnect();
+
+    _in_task.cancel();
+    _out_task.cancel();
+    _reset_task.cancel();
+    _control_task.cancel();
+    _configure_task.cancel();
+
+    _in_task.wait();
+    _out_task.wait();
+    _reset_task.wait();
+    _control_task.wait();
+    _configure_task.wait();
+
+    //De-allocate MSD page size:
+    free(_page);
+    _page = NULL;
+
+    _mutex.unlock();
+}
+
+bool USBMSD::ready()
+{
+    return configured();
+}
+
+void USBMSD::process()
+{
+    _queue.dispatch();
+}
+
+void USBMSD::attach(mbed::Callback<void()> cb)
+{
+    lock();
+
+    _queue.attach(cb);
+
+    unlock();
+}
+
+int USBMSD::disk_read(uint8_t* data, uint64_t block, uint8_t count)
+{
+    bd_addr_t addr =  block * _bd->get_erase_size();
+    bd_size_t size = count * _bd->get_erase_size();
+    return _bd->read(data, addr, size);
+}
+
+int USBMSD::disk_write(const uint8_t* data, uint64_t block, uint8_t count)
+{
+    bd_addr_t addr =  block * _bd->get_erase_size();
+    bd_size_t size = count * _bd->get_erase_size();
+    int ret = _bd->erase(addr, size);
+    if (ret != 0) {
+        return ret;
+    }
+
+    return _bd->program(data, addr, size);
+}
+
+int USBMSD::disk_initialize()
+{
+    return 0;
+}
+
+uint64_t USBMSD::disk_sectors()
+{
+    return _bd->size() / _bd->get_erase_size();
+}
+
+uint64_t USBMSD::disk_size()
+{
+    return _bd->size();
+}
+
+
+int USBMSD::disk_status()
+{
+    return 0;
+}
+
+void USBMSD::_isr_out(usb_ep_t endpoint)
+{
+    _out_task.call();
+}
+
+void USBMSD::_isr_in(usb_ep_t endpoint)
+{
+    _in_task.call();
+}
+
+void USBMSD::callback_state_change(DeviceState new_state)
+{
+    // called in ISR context
+
+    if (new_state != Configured) {
+        _reset_task.call();
+    }
+}
+
+void USBMSD::callback_request(const setup_packet_t *setup)
+{
+    // called in ISR context
+
+    if (setup->bmRequestType.Type == CLASS_TYPE) {
+        _control_task.call(setup);
+    } else {
+        complete_request(PassThrough, NULL, 0);
+    }
+}
+
+void USBMSD::callback_request_xfer_done(const setup_packet_t *setup, bool aborted)
+{
+    // called in ISR context
+
+    bool success = setup->bRequest == MSC_REQUEST_GET_MAX_LUN;
+    complete_request_xfer_done(success);
+}
+
+void USBMSD::callback_set_configuration(uint8_t configuration)
+{
+    // called in ISR context
+
+    if (configuration != DEFAULT_CONFIGURATION) {
+        complete_set_configuration(false);
+        return;
+    }
+    _configure_task.call();
+}
+
+void USBMSD::callback_set_interface(uint16_t interface, uint8_t alternate)
+{
+    // called in ISR context
+
+    bool success = (interface == 0) && (alternate == 0);
+    complete_set_interface(success);
+}
+
+
+const uint8_t *USBMSD::string_iinterface_desc()
+{
+    static const uint8_t string_iinterface_descriptor[] = {
+        0x08,                           //bLength
+        STRING_DESCRIPTOR,              //bDescriptorType 0x03
+        'M', 0, 'S', 0, 'D', 0          //bString iInterface - MSD
+    };
+    return string_iinterface_descriptor;
+}
+
+const uint8_t *USBMSD::string_iproduct_desc()
+{
+    static const uint8_t string_iproduct_descriptor[] = {
+        0x12,                                           //bLength
+        STRING_DESCRIPTOR,                              //bDescriptorType 0x03
+        'M', 0, 'b', 0, 'e', 0, 'd', 0, ' ', 0, 'M', 0, 'S', 0, 'D', 0 //bString iProduct - Mbed Audio
+    };
+    return string_iproduct_descriptor;
+}
+
+
+const uint8_t *USBMSD::configuration_desc(uint8_t index)
+{
+    if (index != 0) {
+        return NULL;
+    }
+
+    uint8_t config_descriptor_temp[] = {
+
+        // Configuration 1
+        9,      // bLength
+        2,      // bDescriptorType
+        LSB(9 + 9 + 7 + 7), // wTotalLength
+        MSB(9 + 9 + 7 + 7),
+        0x01,   // bNumInterfaces
+        0x01,   // bConfigurationValue: 0x01 is used to select this configuration
+        0x00,   // iConfiguration: no string to describe this configuration
+        0xC0,   // bmAttributes
+        100,    // bMaxPower, device power consumption is 100 mA
+
+        // Interface 0, Alternate Setting 0, MSC Class
+        9,      // bLength
+        4,      // bDescriptorType
+        0x00,   // bInterfaceNumber
+        0x00,   // bAlternateSetting
+        0x02,   // bNumEndpoints
+        0x08,   // bInterfaceClass
+        0x06,   // bInterfaceSubClass
+        0x50,   // bInterfaceProtocol
+        0x04,   // iInterface
+
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                          // bLength
+        5,                          // bDescriptorType
+        _bulk_in,                   // bEndpointAddress
+        0x02,                       // bmAttributes (0x02=bulk)
+        LSB(MAX_PACKET),            // wMaxPacketSize (LSB)
+        MSB(MAX_PACKET),            // wMaxPacketSize (MSB)
+        0,                          // bInterval
+
+        // endpoint descriptor, USB spec 9.6.6, page 269-271, Table 9-13
+        7,                          // bLength
+        5,                          // bDescriptorType
+        _bulk_out,                  // bEndpointAddress
+        0x02,                       // bmAttributes (0x02=bulk)
+        LSB(MAX_PACKET),            // wMaxPacketSize (LSB)
+        MSB(MAX_PACKET),            // wMaxPacketSize (MSB)
+        0                           // bInterval
+    };
+    MBED_ASSERT(sizeof(config_descriptor_temp) == sizeof(_configuration_descriptor));
+    memcpy(_configuration_descriptor, config_descriptor_temp, sizeof(_configuration_descriptor));
+    return _configuration_descriptor;
+}
+
+void USBMSD::_out()
+{
+    _mutex.lock();
+
+    _bulk_out_size = read_finish(_bulk_out);
+    _out_ready = true;
+    _process();
+
+    _mutex.unlock();
+}
+
+void USBMSD::_in()
+{
+    _mutex.lock();
+
+    write_finish(_bulk_in);
+    _in_ready = true;
+    _process();
+
+    _mutex.unlock();
+}
+
+void USBMSD::_reset()
+{
+    _mutex.lock();
+
+    msd_reset();
+
+    _mutex.unlock();
+}
+
+void USBMSD::_control(const setup_packet_t *setup)
+{
+    _mutex.lock();
+
+    static const uint8_t maxLUN[1] = {0};
+
+    RequestResult result = PassThrough;
+    uint8_t *data = NULL;
+    uint32_t size = 0;
+
+    if (setup->bmRequestType.Type == CLASS_TYPE) {
+        switch (setup->bRequest) {
+            case MSC_REQUEST_RESET:
+                result = Success;
+                msd_reset();
+                break;
+            case MSC_REQUEST_GET_MAX_LUN:
+                result = Send;
+                data = (uint8_t*)maxLUN;
+                size = 1;
+                break;
+            default:
+                break;
+        }
+    }
+
+    complete_request(result, data, size);
+
+    _mutex.unlock();
+}
+
+void USBMSD::_configure()
+{
+    _mutex.lock();
+
+    // Configure endpoints > 0
+    endpoint_add(_bulk_in, MAX_PACKET, USB_EP_TYPE_BULK, &USBMSD::_isr_in);
+    endpoint_add(_bulk_out, MAX_PACKET, USB_EP_TYPE_BULK, &USBMSD::_isr_out);
+    MBED_ASSERT(sizeof(_bulk_out_buf) == MAX_PACKET);
+    MBED_ASSERT(sizeof(_bulk_in_buf) == MAX_PACKET);
+
+    _out_ready = false;
+    _in_ready = true;
+
+    //activate readings
+    read_start(_bulk_out, _bulk_out_buf, sizeof(_bulk_out_buf));
+    complete_set_configuration(true);
+
+    _mutex.unlock();
+}
+
+void USBMSD::_process()
+{
+    // Mutex must be locked by caller
+
+    switch (_stage) {
+        // the device has to decode the CBW received
+        case READ_CBW:
+            if (!_out_ready) {
+                break;
+            }
+            CBWDecode(_bulk_out_buf, _bulk_out_size);
+            _read_next();
+            break;
+
+
+        case PROCESS_CBW:
+            switch (_cbw.CB[0]) {
+                // the device has to receive data from the host
+                case WRITE10:
+                case WRITE12:
+                    if (!_out_ready) {
+                        break;
+                    }
+                    memoryWrite(_bulk_out_buf, _bulk_out_size);
+                    _read_next();
+                    break;
+                case VERIFY10:
+                    if (!_out_ready) {
+                        break;
+                    }
+                    memoryVerify(_bulk_out_buf, _bulk_out_size);
+                    _read_next();
+                    break;
+                // the device has to send data to the host
+                case READ10:
+                case READ12:
+                    if (!_in_ready) {
+                        break;
+                    }
+                    memoryRead();
+                    break;
+            }
+            break;
+
+        //the device has to send a CSW
+        case SEND_CSW:
+            if (!_in_ready) {
+                break;
+            }
+            sendCSW();
+            break;
+
+        // an error has occurred: stall endpoint and send CSW
+        default:
+            endpoint_stall(_bulk_out);
+            endpoint_stall(_bulk_in);
+            _csw.Status = CSW_ERROR;
+            sendCSW();
+            break;
+    }
+}
+
+void USBMSD::_write_next(uint8_t *data, uint32_t size)
+{
+    lock();
+
+    MBED_ASSERT(size <= MAX_PACKET);
+    MBED_ASSERT(_in_ready);
+    uint32_t send_size = MAX_PACKET > size ? size : MAX_PACKET;
+    memcpy(_bulk_in_buf, data, send_size);
+    write_start(_bulk_in, _bulk_in_buf, send_size);
+    _in_ready = false;
+
+    unlock();
+}
+
+void USBMSD::_read_next()
+{
+    lock();
+
+    MBED_ASSERT(_out_ready);
+    read_start(_bulk_out, _bulk_out_buf, sizeof(_bulk_out_buf));
+    _out_ready = false;
+
+    unlock();
+}
+
+void USBMSD::memoryWrite(uint8_t *buf, uint16_t size)
+{
+    if ((_addr + size) > _memory_size) {
+        size = _memory_size - _addr;
+        _stage = ERROR;
+        endpoint_stall(_bulk_out);
+    }
+
+    // we fill an array in RAM of 1 block before writing it in memory
+    for (int i = 0; i < size; i++) {
+        _page[_addr % _block_size + i] = buf[i];
+    }
+
+    // if the array is filled, write it in memory
+    if (!((_addr + size) % _block_size)) {
+        if (!(disk_status() & WRITE_PROTECT)) {
+            disk_write(_page, _addr / _block_size, 1);
+        }
+    }
+
+    _addr += size;
+    _length -= size;
+    _csw.DataResidue -= size;
+
+    if ((!_length) || (_stage != PROCESS_CBW)) {
+        _csw.Status = (_stage == ERROR) ? CSW_FAILED : CSW_PASSED;
+        sendCSW();
+    }
+}
+
+void USBMSD::memoryVerify(uint8_t *buf, uint16_t size)
+{
+    uint32_t n;
+
+    if ((_addr + size) > _memory_size) {
+        size = _memory_size - _addr;
+        _stage = ERROR;
+        endpoint_stall(_bulk_out);
+    }
+
+    // beginning of a new block -> load a whole block in RAM
+    if (!(_addr % _block_size)) {
+        disk_read(_page, _addr / _block_size, 1);
+    }
+
+    // info are in RAM -> no need to re-read memory
+    for (n = 0; n < size; n++) {
+        if (_page[_addr % _block_size + n] != buf[n]) {
+            _mem_ok = false;
+            break;
+        }
+    }
+
+    _addr += size;
+    _length -= size;
+    _csw.DataResidue -= size;
+
+    if (!_length || (_stage != PROCESS_CBW)) {
+        _csw.Status = (_mem_ok && (_stage == PROCESS_CBW)) ? CSW_PASSED : CSW_FAILED;
+        sendCSW();
+    }
+}
+
+
+bool USBMSD::inquiryRequest(void)
+{
+    uint8_t inquiry[] = { 0x00, 0x80, 0x00, 0x01,
+                          36 - 4, 0x80, 0x00, 0x00,
+                          'M', 'B', 'E', 'D', '.', 'O', 'R', 'G',
+                          'M', 'B', 'E', 'D', ' ', 'U', 'S', 'B', ' ', 'D', 'I', 'S', 'K', ' ', ' ', ' ',
+                          '1', '.', '0', ' ',
+                        };
+    if (!write(inquiry, sizeof(inquiry))) {
+        return false;
+    }
+    return true;
+}
+
+
+bool USBMSD::readFormatCapacity()
+{
+    uint8_t capacity[] = { 0x00, 0x00, 0x00, 0x08,
+                           (uint8_t)((_block_count >> 24) & 0xff),
+                           (uint8_t)((_block_count >> 16) & 0xff),
+                           (uint8_t)((_block_count >> 8) & 0xff),
+                           (uint8_t)((_block_count >> 0) & 0xff),
+
+                           0x02,
+                           (uint8_t)((_block_size >> 16) & 0xff),
+                           (uint8_t)((_block_size >> 8) & 0xff),
+                           (uint8_t)((_block_size >> 0) & 0xff),
+                         };
+    if (!write(capacity, sizeof(capacity))) {
+        return false;
+    }
+    return true;
+}
+
+
+bool USBMSD::readCapacity(void)
+{
+    uint8_t capacity[] = {
+        (uint8_t)(((_block_count - 1) >> 24) & 0xff),
+        (uint8_t)(((_block_count - 1) >> 16) & 0xff),
+        (uint8_t)(((_block_count - 1) >> 8) & 0xff),
+        (uint8_t)(((_block_count - 1) >> 0) & 0xff),
+
+        (uint8_t)((_block_size >> 24) & 0xff),
+        (uint8_t)((_block_size >> 16) & 0xff),
+        (uint8_t)((_block_size >> 8) & 0xff),
+        (uint8_t)((_block_size >> 0) & 0xff),
+    };
+    if (!write(capacity, sizeof(capacity))) {
+        return false;
+    }
+    return true;
+}
+
+bool USBMSD::write(uint8_t *buf, uint16_t size)
+{
+
+    if (size >= _cbw.DataLength) {
+        size = _cbw.DataLength;
+    }
+    _stage = SEND_CSW;
+
+    _write_next(buf, size);
+
+    _csw.DataResidue -= size;
+    _csw.Status = CSW_PASSED;
+    return true;
+}
+
+
+bool USBMSD::modeSense6(void)
+{
+    uint8_t sense6[] = { 0x03, 0x00, 0x00, 0x00 };
+    if (!write(sense6, sizeof(sense6))) {
+        return false;
+    }
+    return true;
+}
+
+void USBMSD::sendCSW()
+{
+    _csw.Signature = CSW_Signature;
+    _write_next((uint8_t *)&_csw, sizeof(CSW));
+    _stage = READ_CBW;
+}
+
+bool USBMSD::requestSense(void)
+{
+    uint8_t request_sense[] = {
+        0x70,
+        0x00,
+        0x05,   // Sense Key: illegal request
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x0A,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x30,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+    };
+
+    if (!write(request_sense, sizeof(request_sense))) {
+        return false;
+    }
+
+    return true;
+}
+
+void USBMSD::fail()
+{
+    _csw.Status = CSW_FAILED;
+    sendCSW();
+}
+
+
+void USBMSD::CBWDecode(uint8_t *buf, uint16_t size)
+{
+    if (size == sizeof(_cbw)) {
+        memcpy((uint8_t *)&_cbw, buf, size);
+        if (_cbw.Signature == CBW_Signature) {
+            _csw.Tag = _cbw.Tag;
+            _csw.DataResidue = _cbw.DataLength;
+            if ((_cbw.CBLength <  1) || (_cbw.CBLength > 16)) {
+                fail();
+            } else {
+                switch (_cbw.CB[0]) {
+                    case TEST_UNIT_READY:
+                        testUnitReady();
+                        break;
+                    case REQUEST_SENSE:
+                        requestSense();
+                        break;
+                    case INQUIRY:
+                        inquiryRequest();
+                        break;
+                    case MODE_SENSE6:
+                        modeSense6();
+                        break;
+                    case READ_FORMAT_CAPACITIES:
+                        readFormatCapacity();
+                        break;
+                    case READ_CAPACITY:
+                        readCapacity();
+                        break;
+                    case READ10:
+                    case READ12:
+                        if (infoTransfer()) {
+                            if ((_cbw.Flags & 0x80)) {
+                                _stage = PROCESS_CBW;
+                                memoryRead();
+                            } else {
+                                endpoint_stall(_bulk_out);
+                                _csw.Status = CSW_ERROR;
+                                sendCSW();
+                            }
+                        }
+                        break;
+                    case WRITE10:
+                    case WRITE12:
+                        if (infoTransfer()) {
+                            if (!(_cbw.Flags & 0x80)) {
+                                _stage = PROCESS_CBW;
+                            } else {
+                                endpoint_stall(_bulk_in);
+                                _csw.Status = CSW_ERROR;
+                                sendCSW();
+                            }
+                        }
+                        break;
+                    case VERIFY10:
+                        if (!(_cbw.CB[1] & 0x02)) {
+                            _csw.Status = CSW_PASSED;
+                            sendCSW();
+                            break;
+                        }
+                        if (infoTransfer()) {
+                            if (!(_cbw.Flags & 0x80)) {
+                                _stage = PROCESS_CBW;
+                                _mem_ok = true;
+                            } else {
+                                endpoint_stall(_bulk_in);
+                                _csw.Status = CSW_ERROR;
+                                sendCSW();
+                            }
+                        }
+                        break;
+                    case MEDIA_REMOVAL:
+                        _csw.Status = CSW_PASSED;
+                        sendCSW();
+                        break;
+                    default:
+                        fail();
+                        break;
+                }
+            }
+        }
+    }
+}
+
+void USBMSD::testUnitReady(void)
+{
+
+    if (_cbw.DataLength != 0) {
+        if ((_cbw.Flags & 0x80) != 0) {
+            endpoint_stall(_bulk_in);
+        } else {
+            endpoint_stall(_bulk_out);
+        }
+    }
+
+    _csw.Status = CSW_PASSED;
+    sendCSW();
+}
+
+
+void USBMSD::memoryRead(void)
+{
+    uint32_t n;
+
+    n = (_length > MAX_PACKET) ? MAX_PACKET : _length;
+
+    if ((_addr + n) > _memory_size) {
+        n = _memory_size - _addr;
+        _stage = ERROR;
+    }
+
+    // we read an entire block
+    if (!(_addr % _block_size)) {
+        disk_read(_page, _addr / _block_size, 1);
+    }
+
+    // write data which are in RAM
+    _write_next(&_page[_addr % _block_size], MAX_PACKET);
+
+    _addr += n;
+    _length -= n;
+
+    _csw.DataResidue -= n;
+
+    if (!_length || (_stage != PROCESS_CBW)) {
+        _csw.Status = (_stage == PROCESS_CBW) ? CSW_PASSED : CSW_FAILED;
+        _stage = (_stage == PROCESS_CBW) ? SEND_CSW : _stage;
+    }
+}
+
+
+bool USBMSD::infoTransfer(void)
+{
+    uint32_t n;
+
+    // Logical Block Address of First Block
+    n = (_cbw.CB[2] << 24) | (_cbw.CB[3] << 16) | (_cbw.CB[4] <<  8) | (_cbw.CB[5] <<  0);
+
+    _addr = n * _block_size;
+
+    // Number of Blocks to transfer
+    switch (_cbw.CB[0]) {
+        case READ10:
+        case WRITE10:
+        case VERIFY10:
+            n = (_cbw.CB[7] <<  8) | (_cbw.CB[8] <<  0);
+            break;
+
+        case READ12:
+        case WRITE12:
+            n = (_cbw.CB[6] << 24) | (_cbw.CB[7] << 16) | (_cbw.CB[8] <<  8) | (_cbw.CB[9] <<  0);
+            break;
+    }
+
+    _length = n * _block_size;
+
+    if (!_cbw.DataLength) {              // host requests no data
+        _csw.Status = CSW_FAILED;
+        sendCSW();
+        return false;
+    }
+
+    if (_cbw.DataLength != _length) {
+        if ((_cbw.Flags & 0x80) != 0) {
+            endpoint_stall(_bulk_in);
+        } else {
+            endpoint_stall(_bulk_out);
+        }
+
+        _csw.Status = CSW_FAILED;
+        sendCSW();
+        return false;
+    }
+
+    return true;
+}
+
+void USBMSD::msd_reset()
+{
+    _stage = READ_CBW;
+}

--- a/usb/device/USBMSD/USBMSD.h
+++ b/usb/device/USBMSD/USBMSD.h
@@ -1,0 +1,279 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef USBMSD_H
+#define USBMSD_H
+
+/* These headers are included for child class. */
+#include "USBDescriptor.h"
+#include "USBDevice_Types.h"
+#include "platform/Callback.h"
+#include "events/PolledQueue.h"
+#include "events/Task.h"
+#include "BlockDevice.h"
+#include "Mutex.h"
+#include "usb_phy_api.h"
+
+#include "USBDevice.h"
+
+/**
+ * USBMSD class: generic class in order to use all kinds of blocks storage chip
+ *
+ * Introduction
+ *
+ * USBMSD implements the MSD protocol. It permits to access a block device (flash, sdcard,...)
+ * from a computer over USB.
+ *
+ * @code
+ * #include "mbed.h"
+ * #include "SDBlockDevice.h"
+ * #include "USBMSD.h"
+ *
+ * SDBlockDevice sd(PTE3, PTE1, PTE2, PTE4);
+ * USBMSD usb(&sd);
+ *
+ * int main() {
+ *     usb.connect();
+ *
+ *     while(true) {
+ *         usb.process();
+ *     }
+ *
+ *     return 0;
+ * }
+ * @endcode
+ */
+class USBMSD: public USBDevice {
+public:
+
+    /**
+    * Constructor
+    *
+    * This creates a new USBMSD object with the given block device. Connect must be called
+    * for the block device to connect.
+    *
+    * @param bd BlockDevice to mount as a USB drive
+    * @param phy USB phy to use
+    * @param vendor_id Your vendor_id
+    * @param product_id Your product_id
+    * @param product_release Your preoduct_release
+    */
+    USBMSD(BlockDevice *bd, USBPhy *phy=get_usb_phy(), uint16_t vendor_id = 0x0703, uint16_t product_id = 0x0104, uint16_t product_release = 0x0001);
+
+    /**
+     * Destroy this object
+     *
+     * Any classes which inherit from this class must call disconnect
+     * before this destructor runs.
+     */
+    virtual ~USBMSD();
+
+    /**
+    * Connect the USB MSD device. Establish disk initialization before really connect the device.
+    *
+    * @returns true if successful
+    */
+    bool connect();
+
+    /**
+    * Disconnect the USB MSD device.
+    */
+    void disconnect();
+
+    /**
+     * Check if USB is connected
+     *
+     * @return true if a USB is connected, false otherwise
+     */
+    bool ready();
+
+    /**
+    * Perform USB processing
+    */
+    void process();
+
+    /**
+     * Called when USBMSD needs to perform processing
+     *
+     * @param cb Callback called when USBMSD needs process() to be called
+     */
+    void attach(mbed::Callback<void()> cb);
+
+protected:
+
+    /*
+    * read one or more blocks on a storage chip
+    *
+    * @param data pointer where will be stored read data
+    * @param block starting block number
+    * @param count number of blocks to read
+    * @returns 0 if successful
+    */
+    virtual int disk_read(uint8_t *data, uint64_t block, uint8_t count);
+
+    /*
+    * write one or more blocks on a storage chip
+    *
+    * @param data data to write
+    * @param block starting block number
+    * @param count number of blocks to write
+    * @returns 0 if successful
+    */
+    virtual int disk_write(const uint8_t *data, uint64_t block, uint8_t count);
+
+    /*
+    * Disk initilization
+    */
+    virtual int disk_initialize();
+
+    /*
+    * Return the number of blocks
+    *
+    * @returns number of blocks
+    */
+    virtual uint64_t disk_sectors();
+
+    /*
+    * Return memory size
+    *
+    * @returns memory size
+    */
+    virtual uint64_t disk_size();
+
+    /*
+    * To check the status of the storage chip
+    *
+    * @returns status: 0: OK, 1: disk not initialized, 2: no medium in the drive, 4: write protected
+    */
+    virtual int disk_status();
+
+private:
+
+    // MSC Bulk-only Stage
+    enum Stage {
+        READ_CBW,     // wait a CBW
+        ERROR,        // error
+        PROCESS_CBW,  // process a CBW request
+        SEND_CSW,     // send a CSW
+    };
+
+    // Bulk-only CBW
+    typedef MBED_PACKED(struct) {
+        uint32_t Signature;
+        uint32_t Tag;
+        uint32_t DataLength;
+        uint8_t  Flags;
+        uint8_t  LUN;
+        uint8_t  CBLength;
+        uint8_t  CB[16];
+    } CBW;
+
+    // Bulk-only CSW
+    typedef MBED_PACKED(struct) {
+        uint32_t Signature;
+        uint32_t Tag;
+        uint32_t DataResidue;
+        uint8_t  Status;
+    } CSW;
+
+    //state of the bulk-only state machine
+    Stage _stage;
+
+    // current CBW
+    CBW _cbw;
+
+    // CSW which will be sent
+    CSW _csw;
+
+    // addr where will be read or written data
+    uint32_t _addr;
+
+    // length of a reading or writing
+    uint32_t _length;
+
+    // memory OK (after a memoryVerify)
+    bool _mem_ok;
+
+    // cache in RAM before writing in memory. Useful also to read a block.
+    uint8_t *_page;
+
+    int _block_size;
+    uint64_t _memory_size;
+    uint64_t _block_count;
+
+    // endpoints
+    usb_ep_t _bulk_in;
+    usb_ep_t _bulk_out;
+    uint8_t _bulk_in_buf[64];
+    uint8_t _bulk_out_buf[64];
+    bool _out_ready;
+    bool _in_ready;
+    uint32_t _bulk_out_size;
+
+    // Interrupt to thread deferral
+    PolledQueue _queue;
+    Task<void()> _in_task;
+    Task<void()> _out_task;
+    Task<void()> _reset_task;
+    Task<void(const setup_packet_t *)> _control_task;
+    Task<void()> _configure_task;
+
+    BlockDevice *_bd;
+    rtos::Mutex _mutex;
+
+    // space for config descriptor
+    uint8_t _configuration_descriptor[32];
+
+    virtual const uint8_t *string_iproduct_desc();
+    virtual const uint8_t *string_iinterface_desc();
+    virtual const uint8_t *configuration_desc(uint8_t index);
+    virtual void callback_set_configuration(uint8_t configuration);
+    virtual void callback_set_interface(uint16_t interface, uint8_t alternate);
+    virtual void callback_state_change(DeviceState new_state);
+    virtual void callback_request(const setup_packet_t *setup);
+    virtual void callback_request_xfer_done(const setup_packet_t *setup, bool aborted);
+
+    void _isr_out(usb_ep_t endpoint);
+    void _isr_in(usb_ep_t endpoint);
+
+    void _out();
+    void _in();
+    void _reset();
+    void _control(const setup_packet_t *request);
+    void _configure();
+
+    void _process();
+    void _write_next(uint8_t *data, uint32_t size);
+    void _read_next();
+
+    void CBWDecode(uint8_t *buf, uint16_t size);
+    void sendCSW(void);
+    bool inquiryRequest(void);
+    bool write(uint8_t *buf, uint16_t size);
+    bool readFormatCapacity();
+    bool readCapacity(void);
+    bool infoTransfer(void);
+    void memoryRead(void);
+    bool modeSense6(void);
+    void testUnitReady(void);
+    bool requestSense(void);
+    void memoryVerify(uint8_t *buf, uint16_t size);
+    void memoryWrite(uint8_t *buf, uint16_t size);
+    void msd_reset();
+    void fail();
+};
+
+#endif

--- a/usb/device/utilities/events/PolledQueue.cpp
+++ b/usb/device/utilities/events/PolledQueue.cpp
@@ -1,0 +1,91 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "events/PolledQueue.h"
+
+#include "events/mbed_events.h"
+#include "platform/Callback.h"
+
+
+PolledQueue::PolledQueue(mbed::Callback<void()> cb): _cb(cb)
+{
+
+}
+
+PolledQueue::~PolledQueue()
+{
+
+}
+
+void PolledQueue::dispatch()
+{
+    core_util_critical_section_enter();
+    uint64_t buf[MBED_MAX_TASK_SIZE / sizeof(uint64_t)];
+
+    while (true) {
+
+        // Atomically dequeue the task and copy the callback
+        TaskBase *task = _list.dequeue();
+        if (!task) {
+            break;
+        }
+        MBED_ASSERT(sizeof(buf) >= task_size(task));
+        TaskBase::run_callback_t callback = task_start(task, (uint8_t*)buf, sizeof(buf));
+
+        // Run the callback outside the critical section
+        core_util_critical_section_exit();
+        callback((uint8_t*)buf);
+        core_util_critical_section_enter();
+
+        // Finish
+        task_finish(task);
+        task = NULL;
+
+    }
+
+    core_util_critical_section_exit();
+}
+
+void PolledQueue::attach(mbed::Callback<void()> cb)
+{
+    core_util_critical_section_enter();
+
+    _cb = cb;
+
+    core_util_critical_section_exit();
+}
+
+void PolledQueue::post(TaskBase *task)
+{
+    core_util_critical_section_enter();
+
+    bool empty = _list.head() == NULL;
+    _list.remove(task);
+    _list.enqueue(task);
+    if (empty && _cb) {
+        _cb();
+    }
+
+    core_util_critical_section_exit();
+}
+
+void PolledQueue::cancel(TaskBase *task)
+{
+    core_util_critical_section_enter();
+
+    _list.remove(task);
+
+    core_util_critical_section_exit();
+}

--- a/usb/device/utilities/events/PolledQueue.h
+++ b/usb/device/utilities/events/PolledQueue.h
@@ -1,0 +1,71 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef POLLED_QUEUE_H
+#define POLLED_QUEUE_H
+
+#include "events/TaskQueue.h"
+#include "platform/Callback.h"
+#include "LinkedList.h"
+namespace events {
+/** \addtogroup events */
+
+
+/** PolledQueue
+ *
+ * This class is an implementation of TaskQueue which is
+ * processed synchronously by calls to dispatch.
+ * @ingroup events
+ */
+class PolledQueue: public TaskQueue {
+public:
+
+    /** Create a PolledQueue
+     *
+     *  Create an event queue.
+     *
+     *  @param cb Callback called when dispatch needs to be called
+     */
+    PolledQueue(mbed::Callback<void()> cb=NULL);
+
+    virtual ~PolledQueue();
+
+    virtual void post(TaskBase *event);
+
+    virtual void cancel(TaskBase *event);
+
+    /**
+     * Process all the events in this queue
+     */
+    void dispatch();
+
+    /**
+     * Attach a callback indicating that this queue needs to be processed
+     *
+     * @param cb Callback called when dispatch needs to be called
+     */
+    void attach(mbed::Callback<void()> cb);
+
+protected:
+
+    mbed::Callback<void()> _cb;
+    LinkedList<TaskBase> _list;
+
+};
+
+}
+#endif
+

--- a/usb/device/utilities/events/Task.h
+++ b/usb/device/utilities/events/Task.h
@@ -1,0 +1,597 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_TASK_H
+#define MBED_TASK_H
+
+#include "events/EventQueue.h"
+#include "events/TaskBase.h"
+#include "platform/mbed_assert.h"
+#include "platform/Callback.h"
+
+namespace events {
+/** \addtogroup events */
+
+
+template<typename F, typename A1=void, typename A2=void, typename A3=void, typename A4=void, typename A5=void>
+struct AllArgs;
+
+template<typename B0>
+struct AllArgs<B0> {
+    typedef AllArgs<B0> Self;
+    B0 b0;
+
+    AllArgs(B0 b0=B0()): b0(b0) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0();
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, void> ops;
+};
+
+template<typename B0, typename B1>
+struct AllArgs<B0, B1> {
+    typedef AllArgs<B0, B1> Self;
+    B0 b0; B1 b1;
+
+    AllArgs(B0 b0=B0(), B1 b1=B1()): b0(b0), b1(b1) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0(s->b1);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T*, R (U::*)()> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))();
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)() const> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))();
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)() volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))();
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)() const volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))();
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, B1> ops;
+};
+
+template<typename B0, typename B1, typename B2>
+struct AllArgs<B0, B1, B2> {
+    typedef AllArgs<B0, B1, B2> Self;
+    B0 b0; B1 b1; B2 b2;
+
+
+    AllArgs(B0 b0=B0(), B1 b1=B1(), B2 b2=B2()): b0(b0), b1(b1), b2(b2) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0(s->b1, s->b2);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T*, R (U::*)(B2)> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2) const> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2) volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2) const volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2);
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, B1> ops;
+};
+
+template<typename B0, typename B1, typename B2, typename B3>
+struct AllArgs<B0, B1, B2, B3> {
+    typedef AllArgs<B0, B1, B2, B3> Self;
+    B0 b0; B1 b1; B2 b2; B3 b3;
+
+
+    AllArgs(B0 b0=B0(), B1 b1=B1(), B2 b2=B2(), B3 b3=B3()): b0(b0), b1(b1), b2(b2), b3(b3) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0(s->b1, s->b2, s->b3);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T*, R (U::*)(B2, B3)> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3) const> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3) volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3) const volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3);
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, B1> ops;
+};
+
+template<typename B0, typename B1, typename B2, typename B3, typename B4>
+struct AllArgs<B0, B1, B2, B3, B4> {
+    typedef AllArgs<B0, B1, B2, B3, B4> Self;
+    B0 b0; B1 b1; B2 b2; B3 b3; B4 b4;
+
+
+    AllArgs(B0 b0=B0(), B1 b1=B1(), B2 b2=B2(), B3 b3=B3(), B4 b4=B4()): b0(b0), b1(b1), b2(b2), b3(b3), b4(b4) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0(s->b1, s->b2, s->b3, s->b4);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T*, R (U::*)(B2, B3, B4)> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4) const> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4) volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4) const volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4);
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, B1> ops;
+};
+
+template<typename B0, typename B1, typename B2, typename B3, typename B4, typename B5>
+struct AllArgs {
+    typedef AllArgs<B0, B1, B2, B3, B4, B5> Self;
+    B0 b0; B1 b1; B2 b2; B3 b3; B4 b4; B5 b5;
+
+
+    AllArgs(B0 b0=B0(), B1 b1=B1(), B2 b2=B2(), B3 b3=B3(), B4 b4=B4(), B5 b5=B5()): b0(b0), b1(b1), b2(b2), b3(b3), b4(b4), b5(b5) {}
+
+    template <typename T, typename _>
+    struct Operations {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            s->b0(s->b1, s->b2, s->b3, s->b4, s->b5);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T*, R (U::*)(B2, B3, B4, B5)> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4, s->b5);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4, B5) const> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4, s->b5);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4, B5) volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4, s->b5);
+            s->~Self();
+        }
+    };
+
+    template <typename T, typename R, typename U>
+    struct Operations<T, R (U::*)(B2, B3, B4, B5) const volatile> {
+        static void copy(void *_dest, void *_src)
+        {
+            new (_dest) Self(*(Self*)_src);
+        }
+
+        static void call(void *data) {
+            Self *s = static_cast<Self*>(data);
+            ((s->b0)->*(s->b1))(s->b2, s->b3, s->b4, s->b5);
+            s->~Self();
+        }
+    };
+
+    typedef Operations<B0, B1> ops;
+};
+
+
+template <typename F>
+class Task;
+
+template <typename R>
+class Task<R()>: public TaskBase {
+public:
+
+    Task(TaskQueue *q=NULL, mbed::Callback<R()> cb=mbed::Callback<R()>())
+        : TaskBase(q), _args(cb) {
+    }
+
+    Task& operator=( mbed::Callback<R()> cb) {
+        _args.b0 = cb;
+        return *this;
+    }
+
+    void call() {
+        post();
+    }
+
+protected:
+
+    virtual uint32_t size() {
+        return sizeof(_args);
+    }
+
+    virtual run_callback_t start(void *data, uint32_t max_size) {
+        All::ops::copy(data, (void*)&_args);
+        return &All::ops::call;
+    }
+
+private:
+    typedef AllArgs<mbed::Callback<R()> > All;
+    All _args;
+};
+
+template <typename R, typename A0>
+class Task<R(A0)>: public TaskBase {
+public:
+
+    Task(TaskQueue *q=NULL, mbed::Callback<R(A0)> cb=mbed::Callback<R(A0)>())
+        : TaskBase(q), _args(cb) {
+    }
+
+    Task& operator=( mbed::Callback<R(A0)> cb) {
+        _args.b0 = cb;
+        return *this;
+    }
+
+    void call(A0 a0) {
+        _args.b1 = a0;
+        post();
+    }
+
+protected:
+
+    virtual uint32_t size() {
+        return sizeof(_args);
+    }
+
+    virtual run_callback_t start(void *data, uint32_t max_size) {
+        All::ops::copy(data, (void*)&_args);
+        return &All::ops::call;
+    }
+
+private:
+    typedef AllArgs<mbed::Callback<R(A0)>, A0> All;
+    All _args;
+};
+
+/** Task
+ *
+ *  Representation of a postable task
+ * @ingroup events
+ */
+template <typename R, typename A0, typename A1>
+class Task<R(A0, A1)>: public TaskBase {
+public:
+
+    /**
+     * Construct a new task
+     *
+     * @param q TaskQueue to post to
+     * @param cb Callback to run
+     */
+    Task(TaskQueue *q=NULL, mbed::Callback<R(A0, A1)> cb=mbed::Callback<R(A0, A1)>())
+        : TaskBase(q), _args(cb) {
+    }
+
+    /**
+     * Set the callback of this task
+     *
+     * @param cb Callback to run
+     */
+    Task& operator=(mbed::Callback<R(A0, A1)> cb) {
+        _args.b0 = cb;
+        return *this;
+    }
+
+    /**
+     * Post this task for execution
+     *
+     * The number of arguments to call should match
+     * the type of the callback. For example Task<void(int, int)>
+     * expects two integers as arguments to call, while Task<void()>
+     * expects no arguments.
+     *
+     * @param a0 First callback parameter
+     * @param a1 Second callback parameter
+     */
+    void call(A0 a0, A1 a1) {
+        _args.b1 = a0;
+        _args.b2 = a1;
+        post();
+    }
+
+protected:
+
+    virtual uint32_t size() {
+        return sizeof(_args);
+    }
+
+    virtual run_callback_t start(void *data, uint32_t max_size) {
+        All::ops::copy(data, (void*)&_args);
+        return &All::ops::call;
+    }
+
+private:
+    typedef AllArgs<mbed::Callback<R(A0, A1)>, A0, A1> All;
+    All _args;
+};
+
+}
+
+/** @}*/
+
+#endif

--- a/usb/device/utilities/events/TaskBase.cpp
+++ b/usb/device/utilities/events/TaskBase.cpp
@@ -1,0 +1,151 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "events/TaskBase.h"
+#include "events/TaskQueue.h"
+#include "events/mbed_events.h"
+#include "rtos/Semaphore.h"
+#include "mbed.h"
+
+TaskBase::TaskBase(TaskQueue *q)
+    : _queue(q), _posted(false), _start_count(0), _flush_sem(NULL)
+{
+
+}
+
+TaskBase::~TaskBase()
+{
+    cancel();
+    wait();
+}
+
+void TaskBase::set(TaskQueue *q)
+{
+    core_util_critical_section_enter();
+
+    // Cannot set the queue when it has been posted but has not been finished
+    MBED_ASSERT(!_posted);
+    _queue = q;
+
+    core_util_critical_section_exit();
+}
+
+void TaskBase::cancel()
+{
+    core_util_critical_section_enter();
+
+    if (_posted) {
+        _queue->cancel(this);
+        _posted = false;
+        _wake_check();
+    }
+
+    core_util_critical_section_exit();
+}
+
+void TaskBase::wait()
+{
+    // Fast path check for finished
+    core_util_critical_section_enter();
+    if (finished()) {
+        core_util_critical_section_exit();
+        return;
+    }
+    core_util_critical_section_exit();
+
+    rtos::Semaphore sem;
+
+    // If the event is in-flight then wait for it to complete
+    core_util_critical_section_enter();
+    if (finished()) {
+        // This element has been flushed from the queue
+        core_util_critical_section_exit();
+        return;
+    }
+    _flush_sem = &sem;
+    core_util_critical_section_exit();
+
+    sem.wait();
+}
+
+bool TaskBase::ready()
+{
+    core_util_critical_section_enter();
+
+    bool is_ready = !_posted;
+
+    core_util_critical_section_exit();
+    return is_ready;
+}
+
+bool TaskBase::finished()
+{
+    core_util_critical_section_enter();
+
+    bool is_finished = !_posted && (_start_count == 0);
+
+    core_util_critical_section_exit();
+    return is_finished;
+}
+
+void TaskBase::finish()
+{
+    // Nothing to do
+}
+
+void TaskBase::post()
+{
+    core_util_critical_section_enter();
+
+    MBED_ASSERT(_queue);
+    if (_queue) {
+        MBED_ASSERT(!_posted);
+        _queue->post(this);
+        _posted = true;
+    }
+
+    core_util_critical_section_exit();
+}
+
+TaskBase::run_callback_t TaskBase::_start(void *buffer, uint32_t size)
+{
+    // Each call to _start must result in a call to _finish
+    MBED_ASSERT(_start_count < 0xFFFF);
+    _start_count++;
+    _posted = false;
+
+    return start(buffer, size);
+}
+
+void TaskBase::_finish()
+{
+    // Each call to _finish must be preceded by a call to _start
+    MBED_ASSERT(_start_count > 0);
+    _start_count--;
+    _wake_check();
+    finish();
+}
+
+void TaskBase::_wake_check()
+{
+    if (!finished()) {
+        return;
+    }
+    if (_flush_sem) {
+        _flush_sem->release();
+        _flush_sem = NULL;
+    }
+}

--- a/usb/device/utilities/events/TaskBase.h
+++ b/usb/device/utilities/events/TaskBase.h
@@ -1,0 +1,163 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef TASK_BASE_H
+#define TASK_BASE_H
+
+#include "platform/Callback.h"
+#include "platform/mbed_assert.h"
+#include "LinkEntry.h"
+
+namespace rtos {
+class Semaphore;
+}
+
+namespace events {
+/** \addtogroup events */
+
+
+class TaskQueue;
+
+/** TaskBase
+ *
+ *  Representation of a caller allocated task
+ * @ingroup events
+ */
+class TaskBase : public LinkEntry {
+public:
+
+    typedef void (*run_callback_t)(void *data);
+
+    /**
+     * Construct a new TaskBase object
+     *
+     * @param q Queue for posting to
+     */
+    TaskBase(TaskQueue *q);
+
+    /**
+     * Destroy this TaskBase
+     */
+    virtual ~TaskBase();
+
+    /**
+     * Set the queue of this task
+     *
+     * @param q TaskQueue to post to
+     */
+    void set(TaskQueue *q);
+
+    /**
+     * Cancel the execution of this task
+     *
+     * Once cancelled the task can be posted again. Previous
+     * calls to post may still run. If you need to ensure the
+     * callback has finished the function wait() can be used.
+     *
+     * @note This function is interrupt safe
+     */
+    void cancel();
+
+    /**
+     * Return true if this task is ready to be posted
+     *
+     * Check if this task is on a queue waiting to be run.
+     *
+     * @return true if it is safe to call post
+     */
+    bool ready();
+
+    /**
+     * Wait for this task to finish execution
+     *
+     * When this function returns then this task is in the finished state.
+     */
+    void wait();
+
+    /**
+     * Check if the callback has run to completion or been fully canceled
+     *
+     * When an task is finished the queue is completely done with it and the
+     * callback is either fully complete or has been canceled and will not run.
+     *
+     * @return true if this task has been flushed from the queue, false otherwise
+     */
+    bool finished();
+
+protected:
+
+    /**
+     * Size of buffer required for TaskBase::start
+     *
+     * @return requested buffer size
+     */
+    virtual uint32_t size() = 0;
+
+    /**
+     * Copy any callback data and return a callback to run
+     *
+     * @param data Buffer to copy data to. Do not copy more than TaskBase::size() data.
+     * @param size Maximum size to copy
+     */
+    virtual run_callback_t start(void *data, uint32_t size) = 0;
+
+    /**
+     * Inform this task that execution has finished.
+     *
+     */
+    virtual void finish();
+
+    /**
+     * Post this task to the set TaskQueue for execution
+     */
+    void post();
+
+private:
+
+    TaskQueue *_queue;
+    bool _posted;
+    uint16_t _start_count;
+    rtos::Semaphore *_flush_sem;
+
+    friend class TaskQueue;
+
+    /*
+     * Must be called in a critical section
+     *
+     * This function should not be called directly. Instead
+     * TaskQueue::task_start should be used instead.
+     */
+    run_callback_t _start(void *buffer, uint32_t size);
+
+    /*
+     * Must be called in a critical section
+     *
+     * This function should not be called directly. Instead
+     * TaskQueue::task_finish should be used instead.
+     *
+     */
+    void _finish();
+
+    /*
+     * Unblock wait if this task is finished
+     */
+    void _wake_check();
+};
+
+}
+
+#endif
+
+/** @}*/

--- a/usb/device/utilities/events/TaskQueue.h
+++ b/usb/device/utilities/events/TaskQueue.h
@@ -1,0 +1,138 @@
+/* events
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef TASK_QUEUE_H
+#define TASK_QUEUE_H
+
+#include "events/TaskBase.h"
+#include "platform/Callback.h"
+#include "mbed_critical.h"
+
+#define MBED_MAX_TASK_SIZE  32
+
+namespace events {
+/** \addtogroup events */
+
+
+
+/** TaskQueue
+ *
+ *  Flexible task queue for dispatching tasks
+ * @ingroup events
+ */
+class TaskQueue {
+public:
+
+    /** Create a TaskQueue
+     *
+     *  Create an event queue.
+     */
+    TaskQueue()
+    {
+
+    }
+
+    /** Destroy a TaskQueue
+     */
+    virtual ~TaskQueue()
+    {
+
+    }
+
+    /**
+     * Add this event to the queue for execution
+     *
+     * If the event is already in the queue then it is canceled and
+     * added to the end of the queue.
+     *
+     *  @param event    Pointer to the event
+     */
+    virtual void post(TaskBase *event) = 0;
+
+    /** Cancel an in-flight event
+     *
+     *  Cancels the given event so the event's memory can be reused.
+     *
+     *  The cancel function is irq safe.
+     *
+     *  If called while the event queue's dispatch loop is active, the cancel
+     *  function does not guarantee that the event will not execute after it
+     *  returns, as the event may have already begun executing. It does
+     *  guarantee that the event queue is no longer using event data so
+     *  the event can be freed or reused.
+     *
+     *  @param event    Pointer to the event
+     */
+    virtual void cancel(TaskBase *event) = 0;
+
+protected:
+
+    /**
+     * Get the size required to run this task
+     *
+     * Get the minimum size required for TaskQueue::task_start
+     *
+     * @param task The task to check size on
+     * @return required size
+     * @note This call must be made in a critical section
+     */
+    static uint32_t task_size(TaskBase *task)
+    {
+
+        return task->size();
+    }
+
+    /**
+     * Start processing this event by copying out its data
+     *
+     * Inform this event both that callback execution has started
+     * and that the event is free to be posted again.
+     *
+     * @param task The task to start processing
+     * @param dest The buffer to copy the callback arguments to
+     * @param size maximum size to copy
+     * @return Pointer to function run
+     *
+     * @note event_start must not be called on a canceled event as the
+     *                   memory may have been freed already
+     * @note Every call to event_start must be paired with event_finish
+     * @note This call must be made in a critical section
+     */
+    static TaskBase::run_callback_t task_start(TaskBase *task, uint8_t *dest, uint32_t size)
+    {
+
+        return task->_start(dest, size);
+    }
+
+    /**
+     * Finish processing this event
+     *
+     * Inform this event that the callback has run to completion.
+     *
+     * @param task The task to finish processing
+     *
+     * @note Every call to event_finish must be preceded by a call to event_start
+     * @note This call must be made in a critical section
+     */
+    static void task_finish(TaskBase *task)
+    {
+        task->_finish();
+    }
+};
+
+}
+#endif
+


### PR DESCRIPTION
### Description

Update USBMSD from unsupported to match the new USB API. USBMSD now takes in a block device in its constructor. Because block devices cant be used for interrupt context, this change also adds code to allow deferral to threads by calling USBMSD::process(). Internally USBMSD uses a new experimental class, TaskQueue, to manage this deferral. Finally, this PR fixes a couple USB bugs which surfaced when USBMSD was added.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] New target
    [ ] Feature
    [ ] Breaking change

