### PR TITLE
Fix possible bug with SysTimer

### DIFF
--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -74,6 +74,7 @@ void SysTimer::suspend(uint32_t ticks)
 {
     core_util_critical_section_enter();
 
+    remove();
     schedule_tick(ticks);
     _suspend_time_passed = false;
     _suspended = true;


### PR DESCRIPTION
Ensure the SysTimer isn't added to the timer list twice by adding an extra call to remove() inside suspend().

### Description

@stevew817 has reported [a problem with SysTimer](https://github.com/ARMmbed/mbed-os/pull/6534/files/ec59cbb6f83c4349f33c1981760a62115d2d838b#r190895667) which this PR fixes.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

