### PR TITLE
Cellular: Fix AT URC handler not to dismiss incoming chars

### DIFF
--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -282,21 +282,19 @@ void ATHandler::process_oob()
                 if (!(_fileHandle->readable() || (_recv_pos < _recv_len))) {
                     break; // we have nothing to read anymore
                 }
-                _start_time = rtos::Kernel::get_ms_count(); // time to process next (potential) URC
             } else if (mem_str(_recv_buff, _recv_len, CRLF, CRLF_LENGTH)) { // If no match found, look for CRLF and consume everything up to CRLF
                 consume_to_tag(CRLF, true);
             } else {
                 if (!fill_buffer()) {
+                    reset_buffer(); // consume anything that could not be handled
                     break;
                 }
+                _start_time = rtos::Kernel::get_ms_count();
             }
         }
         _at_timeout = timeout;
     }
     tr_debug("process_oob exit");
-
-    flush(); // consume anything that could not be handled
-
     unlock();
 }
 


### PR DESCRIPTION
### Description

Fixes AT URC handler to not miss URC in a case when a part of that was received just before URC timeout expired, for example:

I------------I-------------I
          NO CARRIER

This fix depends on PR #7030.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

