### PR TITLE
Fix redeclaration of type name "bool_t" for Renesas

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/common/r_typedefs.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/common/r_typedefs.h
@@ -51,7 +51,9 @@ typedef double              float64_t;
 Typedef definitions
 ******************************************************************************/
 typedef char                char_t;
-typedef int                 bool_t;
+#ifndef bool_t
+typedef bool                bool_t;
+#endif
 typedef int                 int_t;
 typedef long double         float128_t;
 typedef signed long         long_t;


### PR DESCRIPTION
### Description
I fixed redeclaration of type name "bool_t" for target Renesas because this typedef has been defined in rtx_core_ca.h by #6273.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
