### PR TITLE
FPGAIO: Add MISC IO initialization support

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/arm_mps2_io_drv.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/arm_mps2_io_drv.c
@@ -46,6 +46,16 @@ struct arm_mps2_io_reg_map_t {
                                           *         [31:2] : Reserved
                                           *         [1:0]  : Buttons */
     } button_reg;
+    volatile uint32_t reserved1[16];
+    volatile uint32_t misc;              /* Offset: 0x04C (R/W)  Misc control
+                                          *              [31:7] : Reserved
+                                          *              [6] : CLCD_BL_CTRL
+                                          *              [5] : CLCD_RD
+                                          *              [4] : CLCD_RS
+                                          *              [3] : CLCD_RESET
+                                          *              [2] : Reserved
+                                          *              [1] : SPI_nSS
+                                          *              [0] : CLCD_CS */
 };
 
 void arm_mps2_io_write_leds(struct arm_mps2_io_dev_t* dev,
@@ -110,6 +120,25 @@ void arm_mps2_io_write_leds(struct arm_mps2_io_dev_t* dev,
 
         break;
     /* default: explicitely not used to force to cover all enumeration cases */
+    }
+}
+
+void arm_mps2_io_write_misc(struct arm_mps2_io_dev_t* dev,
+                            enum arm_mps2_io_access_t access,
+                            uint8_t pin_num,
+                            uint32_t value)
+{
+    struct arm_mps2_io_reg_map_t* p_mps2_io_port =
+                                  (struct arm_mps2_io_reg_map_t*)dev->cfg->base;
+
+    /* The MISC write is for FPGAIO only */
+    if (dev->cfg->type != ARM_MPS2_IO_TYPE_FPGAIO)
+        return;
+
+    if (value) {
+        p_mps2_io_port->misc |= (1UL << pin_num);
+    } else {
+        p_mps2_io_port->misc &= ~(1UL << pin_num);
     }
 }
 

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/arm_mps2_io_drv.h
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/device/drivers/arm_mps2_io_drv.h
@@ -66,6 +66,21 @@ void arm_mps2_io_write_leds(struct arm_mps2_io_dev_t* dev,
                             uint32_t value);
 
 /**
+ * \brief  Writes corresponding pin in FPGA IO MISC register.
+ *
+ * \param[in] dev      MPS2 IO device where to write \ref arm_mps2_io_dev_t
+ * \param[in] pin_num  Pin number.
+ * \param[in] value    Value to set.
+ *
+ * \note This function doesn't check if dev is NULL.
+ * \note This function doesn't support port access.
+ */
+void arm_mps2_io_write_misc(struct arm_mps2_io_dev_t* dev,
+                            enum arm_mps2_io_access_t access,
+                            uint8_t pin_num,
+                            uint32_t value);
+
+/**
  * \brief Reads the buttons status.
  *
  * \param[in] dev      MPS2 IO device where to read \ref arm_mps2_io_dev_t

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/objects.h
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/objects.h
@@ -30,6 +30,10 @@ extern "C" {
 typedef struct gpio_s {
     struct arm_gpio_dev_t *gpio_dev;
     struct arm_mps2_io_dev_t *mps2_io_dev;
+    void (*arm_mps2_io_write)(struct arm_mps2_io_dev_t* dev,
+                            enum arm_mps2_io_access_t access,
+                            uint8_t pin_num,
+                            uint32_t value);
     uint32_t pin_number;
     PinDirection direction;
 } gpio_t;


### PR DESCRIPTION
### Description

Enable MISC FPGA IO support on CM3DS, it will be needed by several peripherals. We are going to enable SPI SD card in the future, and SPI_nSS pin is requied.

Tested locally with CM3DS on MPS2+.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

