### PR TITLE
USB tests -- add device config files for Zadig

### DIFF
--- a/TESTS/usb_device/basic/zadig_conf/README.md
+++ b/TESTS/usb_device/basic/zadig_conf/README.md
@@ -1,0 +1,18 @@
+# Generic USB driver installation on Windows machines
+
+In order to run the Mbed OS USB device test suite (`tests-usb_device-*`)
+on Windows hosts you need to install generic USB drivers for two test devices.
+
+1. Download *Zadig* application from https://zadig.akeo.ie/.
+1. Unplug the Mbed device.
+1. Open *Zadig*.
+1. Select *Device -> Load Preset Device*.
+1. Open `mbed_os-usb_test_device1.cfg`.
+1. Choose `libusb-win32 (v1.2.6.0)` driver.
+1. Select `Install Driver` and click it.
+1. Select *Device -> Load Preset Device*.
+1. Open `mbed_os-usb_test_device2.cfg`.
+1. Choose `libusb-win32 (v1.2.6.0)` driver.
+1. Select `Install Driver` and click it.
+1. Close *Zadig*.
+1. Plug both device USB interfaces (*DAPLink* and *USB device*).

--- a/TESTS/usb_device/basic/zadig_conf/mbed_os-usb_test_device1.cfg
+++ b/TESTS/usb_device/basic/zadig_conf/mbed_os-usb_test_device1.cfg
@@ -1,0 +1,6 @@
+# Zadig device configuration
+# Mbed OS USB test device -- basic tests
+[device]
+Description = "MBED TEST DEVICE"
+VID = 0x0D28
+PID = 0x0205

--- a/TESTS/usb_device/basic/zadig_conf/mbed_os-usb_test_device2.cfg
+++ b/TESTS/usb_device/basic/zadig_conf/mbed_os-usb_test_device2.cfg
@@ -1,0 +1,6 @@
+# Zadig device configuration
+# Mbed OS USB test device -- endpoint tests
+[device]
+Description = "USB DEVICE"
+VID = 0x0D28
+PID = 0x0206


### PR DESCRIPTION
### Description
Zadig is a tool used to install generic USB drivers on Windows machines.
These drivers are necessary to run USB device test suite on Windows
hosts.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change
