### PR TITLE
Cellular: BC95 socket creation to fail on missing socket id in the re…

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -250,7 +250,10 @@ nsapi_size_or_error_t AT_CellularStack::socket_sendto(nsapi_socket_t handle, con
 
         _at.unlock();
         if (ret_val != NSAPI_ERROR_OK) {
+            tr_error("Error creating socket to send to: %s error code: %d", addr.get_ip_address(), ret_val);
             return ret_val;
+        } else {
+            tr_info("Success creating socket to send to: %s", addr.get_ip_address());
         }
     }
 
@@ -265,6 +268,12 @@ nsapi_size_or_error_t AT_CellularStack::socket_sendto(nsapi_socket_t handle, con
     _at.lock();
 
     ret_val = socket_sendto_impl(socket, addr, data, size);
+    
+    if (ret_val <= 0) {
+        tr_error("Error sending to: %s error code: %d", addr.get_ip_address(), ret_val);
+    } else {
+        tr_info("Success sending %d Bytes to: %s", ret_val, addr.get_ip_address());
+    }
 
     _at.unlock();
 

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -119,7 +119,7 @@ nsapi_error_t QUECTEL_BC95_CellularStack::create_socket_impl(CellularSocket *soc
         }
     }
 
-    if (!socketOpenWorking) {
+    if (!socketOpenWorking || (sock_id == -1)) {
         tr_error("Socket create failed!");
         return NSAPI_ERROR_NO_SOCKET;
     }


### PR DESCRIPTION
…sponse

### Description
For BC95 modem, socket creation AT command is found to return OK without the socket id. In this case socket id returned by at handler on read_int() is -1 which is invalid id to be used so socket creation should report failure in this case. 
"OK without socket id" is an abnormal response and will need to be investigated further. In case the socket id part of the response is not lost on our side(serial/athandler) issue has to be raised to manufacturer.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

