### PR TITLE
Fix RTOS-less build failed with cmsis/RTE_Components.h

### DIFF
--- a/cmsis/RTE_Components.h
+++ b/cmsis/RTE_Components.h
@@ -18,7 +18,9 @@
 
 #define CMSIS_device_header <cmsis.h>
 
+#if defined(MBED_CONF_RTOS_PRESENT)
 #include "mbed_rtx_conf.h"
+#endif
 #include "mbed_cmsis_conf.h"
 
 #endif


### PR DESCRIPTION
### Description

This PR just fixes RTOS-less build failed with `cmsis/RTE_Components.h`.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

