### PR TITLE
OS version not update in mbed_stats

### DIFF
--- a/TESTS/mbed_platform/stats_sys/main.cpp
+++ b/TESTS/mbed_platform/stats_sys/main.cpp
@@ -32,10 +32,6 @@ void test_sys_info()
     mbed_stats_sys_t stats;
     mbed_stats_sys_get(&stats);
 
-#if defined(MBED_VERSION)
-    TEST_ASSERT_NOT_EQUAL(0, stats.os_version);
-#endif
-
 #if defined(__CORTEX_M)
     TEST_ASSERT_NOT_EQUAL(0, stats.cpu_id);
 #endif

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -123,9 +123,6 @@ void mbed_stats_sys_get(mbed_stats_sys_t *stats)
     memset(stats, 0, sizeof(mbed_stats_sys_t));
 
 #if defined(MBED_SYS_STATS_ENABLED)
-#if defined(MBED_VERSION)
-    stats->os_version = MBED_VERSION;
-#endif
 #if defined(__CORTEX_M)
     stats->cpu_id = SCB->CPUID;
 #endif


### PR DESCRIPTION
### Description
Temporary fix to remove OS version update, it will be always zero (even in release versions)

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @0xc0170 