### PR TITLE
UBLOX_C027: init us_ticker in the target initialization

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_UBLOX_C027/ublox_low_level_api.c
@@ -42,6 +42,7 @@ void ublox_mdm_init(void)
     // Can't use wait_ms() as RTOS isn't initialised yet
     //wait_ms(50); // when USB cable is inserted the interface chip issues
     // Here's the code from the non-RTOS version
+    us_ticker_init();
     uint32_t start = us_ticker_read();
     while ((us_ticker_read() - start) < 50000);
 }


### PR DESCRIPTION
### Description

A hardfault for this target has been reported.
```
Crash Info:
	Crash location = us_ticker_read [0x0001BAFA] (based on PC value)
	Caller location = ublox_mdm_init [0x0001B0AD] (based on LR value)
	Stack Pointer at the time of crash = [10007FB0]
	Target and Fault Info:
		Processor Arch: ARM-V7M or above
		Processor Variant: C23
		Forced exception, a fault with configurable priority has been escalated to HardFault
		A precise data access error has occurred. Faulting address: 40094008
```

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

