### PR TITLE
Stats - Update ticker read mechanism

### DIFF
--- a/TESTS/mbed_hal/sleep/main.cpp
+++ b/TESTS/mbed_hal/sleep/main.cpp
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#if 1 || !DEVICE_SLEEP
+#if !DEVICE_SLEEP
 #error [NOT_SUPPORTED] sleep not supported for this target
 #endif
 
@@ -25,6 +25,7 @@
 #include "greentea-client/test_env.h"
 
 #include "sleep_api_tests.h"
+#include "mbed_power_mgmt.h"
 
 #define US_PER_S 1000000
 
@@ -98,7 +99,6 @@ void lp_ticker_isr(const ticker_data_t *const ticker_data)
  * high frequency ticker interrupt can wake-up target from sleep. */
 void sleep_usticker_test()
 {
-#if 0
     const ticker_data_t * ticker = get_us_ticker_data();
     const unsigned int ticker_freq = ticker->interface->get_info()->frequency;
     const unsigned int ticker_width = ticker->interface->get_info()->bits;
@@ -130,7 +130,6 @@ void sleep_usticker_test()
 
     sleep_manager_unlock_deep_sleep();
     TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep());
-#endif
 }
 
 #ifdef DEVICE_LPTICKER
@@ -218,6 +217,11 @@ utest::v1::status_t greentea_failure_handler(const Case * const source, const fa
     return STATUS_CONTINUE;
 }
 
+us_timestamp_t disable_stats_read(void)
+{
+    return 0;
+}
+
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(60, "default_auto");
@@ -225,6 +229,7 @@ utest::v1::status_t greentea_test_setup(const size_t number_of_cases)
 #if DEVICE_LPTICKER
     lp_ticker_init();
 #endif
+    mbed_stats_ticker_read = disable_stats_read;
     /* Suspend RTOS Kernel to enable sleep modes. */
     osKernelSuspend();
     return greentea_test_setup_handler(number_of_cases);

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -38,7 +38,7 @@ static us_timestamp_t deep_sleep_time = 0;
 static ticker_data_t *sleep_ticker = NULL;
 #endif
 
-static inline us_timestamp_t read_us(void)
+static inline us_timestamp_t default_stats_ticker_read(void)
 {
 #if defined(MBED_CPU_STATS_ENABLED) && defined(DEVICE_LPTICKER)
     if (NULL == sleep_ticker) {
@@ -50,6 +50,8 @@ static inline us_timestamp_t read_us(void)
 #endif
 }
 
+us_timestamp_t (*mbed_stats_ticker_read)(void) = default_stats_ticker_read;
+
 us_timestamp_t mbed_time_idle(void)
 {
     return (sleep_time + deep_sleep_time);
@@ -57,7 +59,7 @@ us_timestamp_t mbed_time_idle(void)
 
 us_timestamp_t mbed_uptime(void)
 {
-    return read_us();
+    return mbed_stats_ticker_read();
 }
 
 us_timestamp_t mbed_time_sleep(void)
@@ -189,7 +191,7 @@ void sleep_manager_sleep_auto(void)
     sleep_tracker_print_stats();
 #endif
     core_util_critical_section_enter();
-    us_timestamp_t start = read_us();
+    us_timestamp_t start = mbed_stats_ticker_read();
     bool deep = false;
 
 // debug profile should keep debuggers attached, no deep sleep allowed
@@ -204,7 +206,7 @@ void sleep_manager_sleep_auto(void)
     }
 #endif
 
-    us_timestamp_t end = read_us();
+    us_timestamp_t end = mbed_stats_ticker_read();
     if (true == deep) {
         deep_sleep_time += end - start;
     } else {

--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -235,6 +235,13 @@ us_timestamp_t mbed_time_idle(void);
  */
 us_timestamp_t mbed_uptime(void);
 
+/* Set ticker read function.
+ * Default lpticker is used to read timer data for stats collection.
+ * User can disable stats collection by setting empty - zero return
+ * function.
+ */
+extern us_timestamp_t (*mbed_stats_ticker_read)(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description

Stats collection in sleep affected other time critical tests, resulting into failures. Mechanism is added to  disable stats collection, if required for sleep tests.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

https://github.com/ARMmbed/mbed-os/pull/7036