### PR TITLE
Fix Greentea test failed with device_key and CRC

### DIFF
--- a/drivers/MbedCRC.cpp
+++ b/drivers/MbedCRC.cpp
@@ -53,6 +53,7 @@ MbedCRC<POLY_16BIT_CCITT, 16>::MbedCRC(uint32_t initial_xor, uint32_t final_xor,
         _initial_value(initial_xor), _final_xor(final_xor), _reflect_data(reflect_data), _reflect_remainder(reflect_remainder),
         _crc_table((uint32_t *)Table_CRC_16bit_CCITT)
 {
+    mbed_crc_ctor();
 }
 
 template<>

--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -434,7 +434,7 @@ void generate_derived_key_wrong_key_type_test()
     ret = inject_dummy_rot_key();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    memset(output, 0, DEVICE_KEY_32BYTE);
+    memset(output, 0, DEVICE_KEY_16BYTE);
     ret = devkey.generate_derived_key(salt, salt_size, output, 12);//96 bit key type is not supported
     TEST_ASSERT_EQUAL_INT32(DEVICEKEY_INVALID_KEY_TYPE, ret);
 


### PR DESCRIPTION
### Description

This PR fixes Greentea test failed with device_key and CRC
1. mbed-os-tests-mbed_drivers-crc
1. mbed-os-features-device_key-tests-device_key-functionality

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

