### PR TITLE
Add ISM43362 driver support for STM32 wifi DISCO boards

### DIFF
--- a/tools/test_configs/ISM43362Interface.json
+++ b/tools/test_configs/ISM43362Interface.json
@@ -67,24 +67,6 @@
     "target_overrides": {
         "*": {
             "platform.stdio-convert-newlines": true
-        },
-        "DISCO_F413ZH": {
-            "ism43362.wifi-miso": "PB_4",
-            "ism43362.wifi-mosi": "PB_5",
-            "ism43362.wifi-sclk": "PB_12",
-            "ism43362.wifi-nss": "PG_11",
-            "ism43362.wifi-reset": "PH_1",
-            "ism43362.wifi-dataready": "PG_12",
-            "ism43362.wifi-wakeup": "PB_15"
-        },
-        "DISCO_L475VG_IOT01A": {
-            "ism43362.wifi-miso": "PC_11",
-            "ism43362.wifi-mosi": "PC_12",
-            "ism43362.wifi-sclk": "PC_10",
-            "ism43362.wifi-nss": "PE_0",
-            "ism43362.wifi-reset": "PE_8",
-            "ism43362.wifi-dataready": "PE_1",
-            "ism43362.wifi-wakeup": "PB_13"
         }
     }
 }

--- a/tools/test_configs/ISM43362Interface.json
+++ b/tools/test_configs/ISM43362Interface.json
@@ -1,0 +1,90 @@
+{
+    "config": {
+        "header-file": {
+            "help" : "String for including your driver header file",
+            "value" : "\"ISM43362Interface.h\""
+        },
+        "object-construction" : {
+            "value" : "new ISM43362Interface()"
+        },
+        "connect-statement" : {
+            "help" : "Must use 'net' variable name",
+            "value" : "net->wifiInterface()->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2)"
+        },
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        },
+        "tcp-echo-prefix" : {
+            "help" : "Some servers send a prefix before echoed message",
+            "value" : null
+        },
+        "tcp-client-echo-buffer-size" : {
+            "help" : "Number of bytes to be send to echo server",
+            "value" : "200"
+        },
+        "wifi-secure-ssid": {
+            "help": "WiFi SSID for WPA2 secured network",
+            "value": "\"SSID-SECURE\""
+        },
+        "wifi-unsecure-ssid": {
+            "help": "WiFi SSID for unsecure network",
+            "value": "\"SSID-UNSECURE\""
+        },
+        "wifi-password": {
+            "help": "WiFi Password",
+            "value": "\"PASSWORD\""
+        },
+        "wifi-secure-protocol": {
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2",
+            "value": "\"WPA2\""
+        },
+        "wifi-ch-secure": {
+            "help": "Channel number of secure SSID",
+            "value": 1
+        },
+        "wifi-ch-unsecure": {
+            "help": "Channel number of unsecure SSID",
+            "value": 2
+        },
+        "ap-mac-secure": {
+            "help": "BSSID of secure AP in form of AA:BB:CC:DD:EE:FF",
+            "value": "\"AA:AA:AA:AA:AA:AA\""
+        },
+        "ap-mac-unsecure": {
+            "help": "BSSID of unsecure AP in form of \"AA:BB:CC:DD:EE:FF\"",
+            "value": "\"BB:BB:BB:BB:BB:BB\""
+        },
+        "max-scan-size": {
+            "help": "How many networks may appear in Wifi scan result",
+            "value": 10
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "platform.stdio-convert-newlines": true
+        },
+        "DISCO_F413ZH": {
+            "ism43362.wifi-miso": "PB_4",
+            "ism43362.wifi-mosi": "PB_5",
+            "ism43362.wifi-sclk": "PB_12",
+            "ism43362.wifi-nss": "PG_11",
+            "ism43362.wifi-reset": "PH_1",
+            "ism43362.wifi-dataready": "PG_12",
+            "ism43362.wifi-wakeup": "PB_15"
+        },
+        "DISCO_L475VG_IOT01A": {
+            "ism43362.wifi-miso": "PC_11",
+            "ism43362.wifi-mosi": "PC_12",
+            "ism43362.wifi-sclk": "PC_10",
+            "ism43362.wifi-nss": "PE_0",
+            "ism43362.wifi-reset": "PE_8",
+            "ism43362.wifi-dataready": "PE_1",
+            "ism43362.wifi-wakeup": "PB_13"
+        }
+    }
+}

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -7,5 +7,6 @@
     "REALTEK_WIFI" : "RealtekInterface.json",	
     "ESP8266_WIFI" : "ESP8266Interface.json",
     "WICED_WIFI" : "WicedInterface.json",
+    "ISM43362_WIFI" : "ISM43362Interface.json",
     "IDW0XX1_WIFI" : "SpwfSAInterface.json"
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -15,6 +15,14 @@
         "default_test_configuration": "HEAPBLOCKDEVICE_AND_ETHERNET",
         "test_configurations": ["HEAPBLOCKDEVICE_AND_ETHERNET"]
     },
+    "DISCO_L475VG_IOT01A": {
+        "default_test_configuration": "NONE",
+        "test_configurations": ["ISM43362_WIFI"]
+    },
+    "DISCO_F413ZH": {
+        "default_test_configuration": "NONE",
+        "test_configurations": ["ISM43362_WIFI"]
+    },
     "MTB_UBLOX_ODIN_W2": {
         "default_test_configuration": "NONE",
         "test_configurations": ["ODIN_WIFI"]


### PR DESCRIPTION
### Description

I would like to make wifi tests enable for STM32.

ISM 43362 Wifi drivers : https://github.com/ARMmbed/wifi-ism43362

This WiFi Inventek module is currenlty available with 2 ST DISCO boards:

- DISCO_L475VG_IOT01A : https://os.mbed.com/platforms/ST-Discovery-L475E-IOT01A/
- DISCO_F413ZH : https://os.mbed.com/platforms/ST-Discovery-F413H/

3 tests supported:
- tests-netsocket-tcp
- tests-netsocket-udp
- tests-network-wifi

### Test status
```
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST                 | 1      | 0      | OK     | 5.4                |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 7.95               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.14               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.59               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-tcp | TCPSOCKET_THREAD_PER_SOCKET_SAFETY | 1      | 0      | OK     | 5.26               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-udp | UDPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 11.26              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-udp | UDPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.14               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-udp | UDPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.59               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-netsocket-udp | UDPSOCKET_SENDTO_TIMEOUT           | 1      | 0      | OK     | 0.2                |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT                       | 1      | 0      | OK     | 1.57               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-DISCONNECT-REPEAT     | 1      | 0      | OK     | 15.09              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-NOCREDENTIALS         | 1      | 0      | OK     | 0.06               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-PARAMS-CHANNEL        | 1      | 0      | OK     | 0.09               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-PARAMS-CHANNEL-FAIL   | 1      | 0      | OK     | 0.11               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-PARAMS-NULL           | 1      | 0      | OK     | 0.04               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-PARAMS-VALID-SECURE   | 1      | 0      | OK     | 3.89               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-PARAMS-VALID-UNSECURE | 1      | 0      | OK     | 2.96               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-SECURE                | 1      | 0      | OK     | 3.75               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONNECT-SECURE-FAIL           | 1      | 0      | OK     | 21.46              |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-CONSTRUCTOR                   | 1      | 0      | OK     | 0.55               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-GET-RSSI                      | 1      | 0      | OK     | 2.2                |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-SCAN                          | 1      | 0      | OK     | 2.79               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-SCAN-NULL                     | 1      | 0      | OK     | 2.78               |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-SET-CHANNEL                   | 1      | 0      | OK     | 0.1                |
| DISCO_F413ZH-ARM | DISCO_F413ZH  | tests-network-wifi  | WIFI-SET-CREDENTIAL                | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST                 | 1      | 0      | OK     | 5.36               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 7.91               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.14               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.59               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-tcp | TCPSOCKET_THREAD_PER_SOCKET_SAFETY | 1      | 0      | OK     | 5.28               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp | UDPSOCKET_ECHOTEST_NONBLOCK        | 1      | 0      | OK     | 11.34              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp | UDPSOCKET_OPEN_CLOSE_REPEAT        | 1      | 0      | OK     | 0.14               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp | UDPSOCKET_OPEN_LIMIT               | 1      | 0      | OK     | 0.59               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-netsocket-udp | UDPSOCKET_SENDTO_TIMEOUT           | 1      | 0      | OK     | 0.23               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT                       | 1      | 0      | OK     | 1.55               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-DISCONNECT-REPEAT     | 1      | 0      | OK     | 15.01              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-NOCREDENTIALS         | 1      | 0      | OK     | 0.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-PARAMS-CHANNEL        | 1      | 0      | OK     | 0.11               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-PARAMS-CHANNEL-FAIL   | 1      | 0      | OK     | 0.11               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-PARAMS-NULL           | 1      | 0      | OK     | 0.06               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-PARAMS-VALID-SECURE   | 1      | 0      | OK     | 3.92               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-PARAMS-VALID-UNSECURE | 1      | 0      | OK     | 2.95               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-SECURE                | 1      | 0      | OK     | 6.07               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONNECT-SECURE-FAIL           | 1      | 0      | OK     | 21.51              |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-CONSTRUCTOR                   | 1      | 0      | OK     | 0.56               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-GET-RSSI                      | 1      | 0      | OK     | 2.23               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-SCAN                          | 1      | 0      | OK     | 2.8                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-SCAN-NULL                     | 1      | 0      | OK     | 2.78               |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-SET-CHANNEL                   | 1      | 0      | OK     | 0.1                |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-network-wifi  | WIFI-SET-CREDENTIAL                | 1      | 0      | OK     | 0.05               |
```

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

