### PR TITLE
set the tolerance to 5% if NO_SYSTICK is enabled

### DIFF
--- a/TESTS/mbed_drivers/timer/main.cpp
+++ b/TESTS/mbed_drivers/timer/main.cpp
@@ -45,9 +45,15 @@ extern uint32_t SystemCoreClock;
  * 1000 ms delay: tolerance = 20500 us
  *
  *  */
-#define DELTA_US(delay_ms) (500 + (delay_ms) * US_PER_MSEC / 50)
-#define DELTA_MS(delay_ms) (1 + ((delay_ms) * US_PER_MSEC / 50 / US_PER_MSEC))
-#define DELTA_S(delay_ms) (0.000500f + (((float)(delay_ms)) / MSEC_PER_SEC / 50))
+#ifdef NO_SYSTICK
+#define TOLERANCE 5
+#else
+#define TOLERANCE 2
+#endif
+
+#define DELTA_US(delay_ms) (500 + (delay_ms) * US_PER_MSEC  * TOLERANCE / 100)
+#define DELTA_MS(delay_ms) (1 + (delay_ms) * TOLERANCE / 100)
+#define DELTA_S(delay_ms) (0.000500f + ((float)(delay_ms)) * ((float)(TOLERANCE) / 100.f) / MSEC_PER_SEC)
 
 #define TICKER_FREQ_1MHZ 1000000
 #define TICKER_BITS 32


### PR DESCRIPTION
### Description

Fixes the issue raised on CI on the NRF 51 device.
The value of **5%** is chosen to match the tolerance applied to `lp_ticker`s that are also often RTC-backed.

### Related PR

- #7063

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

