### PR TITLE
BLE: Replace Serial with RawSerial in Cordio H4 Transport Driver

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
@@ -69,7 +69,7 @@ public:
 private:
     void on_controller_irq();
 
-    Serial uart;
+    RawSerial uart;
     PinName cts;
     PinName rts;
 };

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/H4TransportDriver.h
@@ -69,6 +69,10 @@ public:
 private:
     void on_controller_irq();
 
+    // Use RawSerial as opposed to Serial as we don't require the locking primitives
+    // provided by the Serial class (access to the UART should be exclusive to this driver)
+    // Furthermore, we access the peripheral in interrupt context which would clash
+    // with Serial's locking facilities
     RawSerial uart;
     PinName cts;
     PinName rts;


### PR DESCRIPTION
### Description

This PR should fix #7043. This replaces the use of the Serial class with RawSerial as the driver needs access to the serial port in interrupt context.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
