### PR TITLE
Fix Greentea test code with device_key

### DIFF
--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -434,7 +434,7 @@ void generate_derived_key_wrong_key_type_test()
     ret = inject_dummy_rot_key();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    memset(output, 0, DEVICE_KEY_32BYTE);
+    memset(output, 0, DEVICE_KEY_16BYTE);
     ret = devkey.generate_derived_key(salt, salt_size, output, 12);//96 bit key type is not supported
     TEST_ASSERT_EQUAL_INT32(DEVICEKEY_INVALID_KEY_TYPE, ret);
 


### PR DESCRIPTION
### Description

This PR fixes stack corrupted in `mbed-os-features-device_key-tests-device_key-functionality`/`Device Key - derived key wrong key type`.

#### Related PR
#7066 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

