### PR TITLE
Update mbed-coap to version 4.4.4

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.4.4](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.4.4) 
+**Closed issues:**
+ - IOTCLT-2638 [GitHub] hardfault during reconnection retry with Thread
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.4.3...v4.4.4)
+
 ## [v4.4.3](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.4.3) 
 **Closed issues:**
  - IOTCLT-2506 [GitHub] Cannot set registration time if server does not use max age option

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.4.3",
+  "version": "4.4.4",
   "description": "COAP library",
   "keywords": [
     "coap",


### PR DESCRIPTION
### Description

Fixes one error: IOTCLT-2638 Hardfault during reconnection retry with Thread

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

