### PR TITLE
STM32F76x: Add support of dual bank flash mode

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/flash_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/flash_data.h
@@ -35,26 +35,65 @@
 
 #if DEVICE_FLASH
 
-/* Exported types ------------------------------------------------------------*/
-/* Exported constants --------------------------------------------------------*/
-/* Exported macro ------------------------------------------------------------*/
-/* FLASH SIZE */
-#define FLASH_SIZE      (uint32_t) 0x200000
+#define FLASH_SIZE      ((uint32_t)0x200000)
 
-/*  We're considering the default reset SINGLE BANK CONFIGURATION ONLY */
-/* Base address of the Flash sectors Bank 1 */
-#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base @ of Sector 0, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08008000) /* Base @ of Sector 1, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08010000) /* Base @ of Sector 2, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x08018000) /* Base @ of Sector 3, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08020000) /* Base @ of Sector 4, 128 Kbytes */
-#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08040000) /* Base @ of Sector 5, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08080000) /* Base @ of Sector 6, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x080C0000) /* Base @ of Sector 7, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08100000) /* Base @ of Sector 8, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x08140000) /* Base @ of Sector 9, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x08180000) /* Base @ of Sector 10, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x081C0000) /* Base @ of Sector 11, 256 Kbytes */
+//=====================================================================
+// The Single Bank mode is selected by default.
+// To enable the Dual Bank mode you have to:
+//   1) enable the FLASH_DUAL_BANK configuration using a json file
+//   2) enable the nDBANK option byte using STLink-Utility software
+//=====================================================================
+#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
 
-#endif
+#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08004000) /* Base address of Sector 1, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08008000) /* Base address of Sector 2, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x0800C000) /* Base address of Sector 3, 16 Kbytes */
+
+#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08010000) /* Base address of Sector 4, 64 Kbytes */
+
+#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08020000) /* Base address of Sector 5, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08040000) /* Base address of Sector 6, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x08060000) /* Base address of Sector 7, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08080000) /* Base address of Sector 8, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x080A0000) /* Base address of Sector 9, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x080C0000) /* Base address of Sector 10, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x080E0000) /* Base address of Sector 11, 128 Kbytes */
+
+#define ADDR_FLASH_SECTOR_12    ((uint32_t)0x08100000) /* Base address of Sector 12, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_13    ((uint32_t)0x08104000) /* Base address of Sector 13, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_14    ((uint32_t)0x08108000) /* Base address of Sector 14, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_15    ((uint32_t)0x0810C000) /* Base address of Sector 15, 16 Kbytes */
+
+#define ADDR_FLASH_SECTOR_16    ((uint32_t)0x08110000) /* Base address of Sector 16, 64 Kbytes */
+
+#define ADDR_FLASH_SECTOR_17    ((uint32_t)0x08120000) /* Base address of Sector 17, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_18    ((uint32_t)0x08140000) /* Base address of Sector 18, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_19    ((uint32_t)0x08160000) /* Base address of Sector 19, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_20    ((uint32_t)0x08180000) /* Base address of Sector 20, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_21    ((uint32_t)0x081A0000) /* Base address of Sector 21, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_22    ((uint32_t)0x081C0000) /* Base address of Sector 22, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_23    ((uint32_t)0x081E0000) /* Base address of Sector 23, 128 Kbytes */
+
+#else // SINGLE BANK
+
+#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08008000) /* Base address of Sector 1, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08010000) /* Base address of Sector 2, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x08018000) /* Base address of Sector 3, 32 Kbytes */
+
+#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08020000) /* Base address of Sector 4, 128 Kbytes */
+
+#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08040000) /* Base address of Sector 5, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08080000) /* Base address of Sector 6, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x080C0000) /* Base address of Sector 7, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08100000) /* Base address of Sector 8, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x08140000) /* Base address of Sector 9, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x08180000) /* Base address of Sector 10, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x081C0000) /* Base address of Sector 11, 256 Kbytes */
+
+#endif // MBED_CONF_TARGET_FLASH_DUAL_BANK
+
+#endif // DEVICE_FLASH
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/flash_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/flash_data.h
@@ -43,7 +43,7 @@
 //   1) enable the FLASH_DUAL_BANK configuration using a json file
 //   2) enable the nDBANK option byte using STLink-Utility software
 //=====================================================================
-#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+#if MBED_CONF_TARGET_FLASH_DUAL_BANK
 
 #define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 16 Kbytes */
 #define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08004000) /* Base address of Sector 1, 16 Kbytes */

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/flash_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/flash_data.h
@@ -35,26 +35,65 @@
 
 #if DEVICE_FLASH
 
-/* Exported types ------------------------------------------------------------*/
-/* Exported constants --------------------------------------------------------*/
-/* Exported macro ------------------------------------------------------------*/
-/* FLASH SIZE */
-#define FLASH_SIZE      (uint32_t) 0x200000
+#define FLASH_SIZE      ((uint32_t)0x200000)
 
-/*  We're considering the default reset SINGLE BANK CONFIGURATION ONLY */
-/* Base address of the Flash sectors Bank 1 */
-#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base @ of Sector 0, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08008000) /* Base @ of Sector 1, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08010000) /* Base @ of Sector 2, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x08018000) /* Base @ of Sector 3, 32 Kbytes */
-#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08020000) /* Base @ of Sector 4, 128 Kbytes */
-#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08040000) /* Base @ of Sector 5, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08080000) /* Base @ of Sector 6, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x080C0000) /* Base @ of Sector 7, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08100000) /* Base @ of Sector 8, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x08140000) /* Base @ of Sector 9, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x08180000) /* Base @ of Sector 10, 256 Kbytes */
-#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x081C0000) /* Base @ of Sector 11, 256 Kbytes */
+//=====================================================================
+// The Single Bank mode is selected by default.
+// To enable the Dual Bank mode you have to:
+//   1) enable the FLASH_DUAL_BANK configuration using a json file
+//   2) enable the nDBANK option byte using STLink-Utility software
+//=====================================================================
+#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
 
-#endif
+#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08004000) /* Base address of Sector 1, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08008000) /* Base address of Sector 2, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x0800C000) /* Base address of Sector 3, 16 Kbytes */
+
+#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08010000) /* Base address of Sector 4, 64 Kbytes */
+
+#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08020000) /* Base address of Sector 5, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08040000) /* Base address of Sector 6, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x08060000) /* Base address of Sector 7, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08080000) /* Base address of Sector 8, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x080A0000) /* Base address of Sector 9, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x080C0000) /* Base address of Sector 10, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x080E0000) /* Base address of Sector 11, 128 Kbytes */
+
+#define ADDR_FLASH_SECTOR_12    ((uint32_t)0x08100000) /* Base address of Sector 12, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_13    ((uint32_t)0x08104000) /* Base address of Sector 13, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_14    ((uint32_t)0x08108000) /* Base address of Sector 14, 16 Kbytes */
+#define ADDR_FLASH_SECTOR_15    ((uint32_t)0x0810C000) /* Base address of Sector 15, 16 Kbytes */
+
+#define ADDR_FLASH_SECTOR_16    ((uint32_t)0x08110000) /* Base address of Sector 16, 64 Kbytes */
+
+#define ADDR_FLASH_SECTOR_17    ((uint32_t)0x08120000) /* Base address of Sector 17, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_18    ((uint32_t)0x08140000) /* Base address of Sector 18, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_19    ((uint32_t)0x08160000) /* Base address of Sector 19, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_20    ((uint32_t)0x08180000) /* Base address of Sector 20, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_21    ((uint32_t)0x081A0000) /* Base address of Sector 21, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_22    ((uint32_t)0x081C0000) /* Base address of Sector 22, 128 Kbytes */
+#define ADDR_FLASH_SECTOR_23    ((uint32_t)0x081E0000) /* Base address of Sector 23, 128 Kbytes */
+
+#else // SINGLE BANK
+
+#define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08008000) /* Base address of Sector 1, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_2     ((uint32_t)0x08010000) /* Base address of Sector 2, 32 Kbytes */
+#define ADDR_FLASH_SECTOR_3     ((uint32_t)0x08018000) /* Base address of Sector 3, 32 Kbytes */
+
+#define ADDR_FLASH_SECTOR_4     ((uint32_t)0x08020000) /* Base address of Sector 4, 128 Kbytes */
+
+#define ADDR_FLASH_SECTOR_5     ((uint32_t)0x08040000) /* Base address of Sector 5, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_6     ((uint32_t)0x08080000) /* Base address of Sector 6, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_7     ((uint32_t)0x080C0000) /* Base address of Sector 7, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_8     ((uint32_t)0x08100000) /* Base address of Sector 8, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_9     ((uint32_t)0x08140000) /* Base address of Sector 9, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_10    ((uint32_t)0x08180000) /* Base address of Sector 10, 256 Kbytes */
+#define ADDR_FLASH_SECTOR_11    ((uint32_t)0x081C0000) /* Base address of Sector 11, 256 Kbytes */
+
+#endif // MBED_CONF_TARGET_FLASH_DUAL_BANK
+
+#endif // DEVICE_FLASH
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/flash_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/flash_data.h
@@ -43,7 +43,7 @@
 //   1) enable the FLASH_DUAL_BANK configuration using a json file
 //   2) enable the nDBANK option byte using STLink-Utility software
 //=====================================================================
-#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+#if MBED_CONF_TARGET_FLASH_DUAL_BANK
 
 #define ADDR_FLASH_SECTOR_0     ((uint32_t)0x08000000) /* Base address of Sector 0, 16 Kbytes */
 #define ADDR_FLASH_SECTOR_1     ((uint32_t)0x08004000) /* Base address of Sector 1, 16 Kbytes */

--- a/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
@@ -32,14 +32,43 @@
 #include "flash_api.h"
 #include "flash_data.h"
 #include "platform/mbed_critical.h"
+#include "mbed_error.h"
 
 static uint32_t GetSector(uint32_t Address);
 static uint32_t GetSectorSize(uint32_t Sector);
 
 int32_t flash_init(flash_t *obj)
 {
+    // Check Dual Bank option byte (nDBANK) on devices supporting both single and dual bank configurations
+#ifdef FLASH_OPTCR_nDBANK
+    FLASH_OBProgramInitTypeDef OBInit;
+    /* Allow Access to option bytes sector */
+    HAL_FLASH_OB_Unlock();
+    /* Get the Dual bank configuration status */
+    HAL_FLASHEx_OBGetConfig(&OBInit);
+    /* Allow Access to option bytes sector */
+    HAL_FLASH_OB_Lock();
+#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+    if ((OBInit.USERConfig & OB_NDBANK_SINGLE_BANK) == OB_NDBANK_SINGLE_BANK)
+    {
+        error("The Dual Bank mode option byte (nDBANK) must be enabled (box unchecked)\n");
+        return -1;
+    }
+#else // SINGLE BANK
+    if ((OBInit.USERConfig & OB_NDBANK_SINGLE_BANK) == OB_NDBANK_DUAL_BANK)
+    {
+        error("The Dual Bank mode option byte (nDBANK) must be disabled (box checked)\n");
+        return -1;
+    }
+#endif
+#else // Devices supporting Single Bank only
+#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+#error "The Dual Bank configuration is not supported on this device."
+#endif
+#endif
     return 0;
 }
+
 int32_t flash_free(flash_t *obj)
 {
     return 0;
@@ -70,7 +99,6 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
 {
     /* Variable used for Erase procedure */
     FLASH_EraseInitTypeDef EraseInitStruct;
-    FLASH_OBProgramInitTypeDef OBInit;
     uint32_t SectorId;
     uint32_t SectorError = 0;
     int32_t status = 0;
@@ -94,24 +122,7 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
     /* Get the 1st sector to erase */
     SectorId = GetSector(address);
 
-    /* Allow Access to option bytes sector */
-    HAL_FLASH_OB_Unlock();
-    /* Get the Dual bank configuration status */
-    HAL_FLASHEx_OBGetConfig(&OBInit);
-    /* Allow Access to option bytes sector */
-    HAL_FLASH_OB_Lock();
-
-#if defined (FLASH_OPTCR_nDBANK)
-    /* On targets that support dynamic single or dual bank configuration
-     * Check that we're in SINGLE Bank mode, only supported mode now.
-     */
-    if((OBInit.USERConfig & OB_NDBANK_SINGLE_BANK) != OB_NDBANK_SINGLE_BANK) {
-        /*  We don't support the DUAL BANK MODE for now, so return error */
-        return -1;
-    }
-#endif
-
-    /* Fill EraseInit structure*/
+    /* Fill EraseInit structure */
     EraseInitStruct.TypeErase = FLASH_TYPEERASE_SECTORS;
     EraseInitStruct.VoltageRange = FLASH_VOLTAGE_RANGE_3;
     EraseInitStruct.Sector = SectorId;
@@ -196,17 +207,32 @@ static uint32_t GetSector(uint32_t address)
 {
     uint32_t sector = 0;
     uint32_t tmp = address - ADDR_FLASH_SECTOR_0;
-
-    if (address < ADDR_FLASH_SECTOR_4) {
-        // 32k sectorsize
-        sector += tmp >>15;
-    } else if (address < ADDR_FLASH_SECTOR_5) {
-        //64k sector size
+#if defined(MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
+    if (address < ADDR_FLASH_SECTOR_4) { // Sectors 0 to 3
+        sector += tmp >> 14;
+    } else if (address < ADDR_FLASH_SECTOR_5) { // Sector 4
         sector += FLASH_SECTOR_4;
-    } else {
-        sector += 4 + (tmp >>18);
+    } else if (address < ADDR_FLASH_SECTOR_12) { // Sectors 5 to 11
+        sector += 4 + (tmp >> 17);
+    } else if (address < ADDR_FLASH_SECTOR_16) { // Sectors 12 to 15
+        tmp = address - ADDR_FLASH_SECTOR_12;
+        sector += 12 + (tmp >> 14);
+    } else if (address < ADDR_FLASH_SECTOR_17) { // Sector 16
+        sector += FLASH_SECTOR_16;
     }
-
+    else { // Sectors 17 to 23
+        tmp = address - ADDR_FLASH_SECTOR_12;
+        sector += 16 + (tmp >> 17);
+    }
+#else // SINGLE BANK
+    if (address < ADDR_FLASH_SECTOR_4) { // Sectors 0 to 3
+        sector += tmp >> 15;
+    } else if (address < ADDR_FLASH_SECTOR_5) { // Sector 4
+        sector += FLASH_SECTOR_4;
+    } else { // Sectors 5 to 11
+        sector += 4 + (tmp >> 18);
+    }
+#endif
     return sector;
 }
 
@@ -218,6 +244,18 @@ static uint32_t GetSector(uint32_t address)
 static uint32_t GetSectorSize(uint32_t Sector)
 {
     uint32_t sectorsize = 0x00;
+#if defined(MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
+    if ((Sector == FLASH_SECTOR_0) || (Sector == FLASH_SECTOR_1) ||\
+        (Sector == FLASH_SECTOR_2) || (Sector == FLASH_SECTOR_3) ||\
+        (Sector == FLASH_SECTOR_12) || (Sector == FLASH_SECTOR_13) ||\
+        (Sector == FLASH_SECTOR_14) || (Sector == FLASH_SECTOR_15)) {
+            sectorsize = 16 * 1024;
+    } else if ((Sector == FLASH_SECTOR_4) || (Sector == FLASH_SECTOR_16)) {
+            sectorsize = 64 * 1024;
+    } else {
+            sectorsize = 128 * 1024;
+    }
+#else // SINGLE BANK
     if ((Sector == FLASH_SECTOR_0) || (Sector == FLASH_SECTOR_1) ||\
         (Sector == FLASH_SECTOR_2) || (Sector == FLASH_SECTOR_3)) {
             sectorsize = 32 * 1024;
@@ -226,7 +264,7 @@ static uint32_t GetSectorSize(uint32_t Sector)
     } else {
             sectorsize = 256 * 1024;
     }
-
+#endif
     return sectorsize;
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
@@ -48,7 +48,7 @@ int32_t flash_init(flash_t *obj)
     HAL_FLASHEx_OBGetConfig(&OBInit);
     /* Allow Access to option bytes sector */
     HAL_FLASH_OB_Lock();
-#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+#if MBED_CONF_TARGET_FLASH_DUAL_BANK
     if ((OBInit.USERConfig & OB_NDBANK_SINGLE_BANK) == OB_NDBANK_SINGLE_BANK)
     {
         error("The Dual Bank mode option byte (nDBANK) must be enabled (box unchecked)\n");
@@ -62,7 +62,7 @@ int32_t flash_init(flash_t *obj)
     }
 #endif
 #else // Devices supporting Single Bank only
-#ifdef MBED_CONF_TARGET_FLASH_DUAL_BANK
+#if MBED_CONF_TARGET_FLASH_DUAL_BANK
 #error "The Dual Bank configuration is not supported on this device."
 #endif
 #endif
@@ -207,7 +207,7 @@ static uint32_t GetSector(uint32_t address)
 {
     uint32_t sector = 0;
     uint32_t tmp = address - ADDR_FLASH_SECTOR_0;
-#if defined(MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
+#if (MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
     if (address < ADDR_FLASH_SECTOR_4) { // Sectors 0 to 3
         sector += tmp >> 14;
     } else if (address < ADDR_FLASH_SECTOR_5) { // Sector 4
@@ -244,7 +244,7 @@ static uint32_t GetSector(uint32_t address)
 static uint32_t GetSectorSize(uint32_t Sector)
 {
     uint32_t sectorsize = 0x00;
-#if defined(MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
+#if (MBED_CONF_TARGET_FLASH_DUAL_BANK) && defined(FLASH_OPTCR_nDBANK)
     if ((Sector == FLASH_SECTOR_0) || (Sector == FLASH_SECTOR_1) ||\
         (Sector == FLASH_SECTOR_2) || (Sector == FLASH_SECTOR_3) ||\
         (Sector == FLASH_SECTOR_12) || (Sector == FLASH_SECTOR_13) ||\

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1432,6 +1432,10 @@
         "core": "Cortex-M7FD",
         "extra_labels_add": ["STM32F7", "STM32F767", "STM32F767xI", "STM32F767ZI", "STM_EMAC"],
         "config": {
+            "flash_dual_bank": {
+                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
+                "value": "0"
+            },
             "d11_configuration": {
                 "help": "Value: PA_7 for the default board configuration, PB_5 in case of solder bridge update (SB121 off/ SB122 on)",
                 "value": "PA_7",
@@ -1932,6 +1936,10 @@
         "extra_labels_add": ["STM32F7", "STM32F769", "STM32F769xI", "STM32F769NI", "STM_EMAC"],
         "supported_form_factors": ["ARDUINO"],
         "config": {
+            "flash_dual_bank": {
+                "help": "Default board configuration is Single Bank Flash. If you enable Dual Bank with ST Link Utility, set value to 1",
+                "value": "0"
+            },
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",


### PR DESCRIPTION
### Description

This PR adds support of Dual Bank flash mode on NUCLEO_F767ZI and DISCO_F769NI platforms.

Fixes Issue #6955 

Tested OK using tests-mbed_drivers-flashiap and tests-mbed_hal-flash tests.

Note
The Single Bank mode is selected by default on these 2 boards.
To enable the Dual Bank mode you have to:
- enable the FLASH_DUAL_BANK configuration using a json file
- enable the Dual Bank in the option bytes using STLink-Utility software (uncheck the nDBANK box)
- upgrade the STLink fw on the board to the latest version (V2.J30.M21 as of today)

Wiki page:
https://os.mbed.com/teams/ST/wiki/How-to-enable-flash-dual-bank

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

