### PR TITLE
BLE fixes (SM whitelist creation, Nordic scatter file fix, missing TLS initialisation)

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -142,6 +142,9 @@ ble_error_t GenericSecurityManager::purgeAllBondingState(void) {
 ble_error_t GenericSecurityManager::generateWhitelistFromBondTable(Gap::Whitelist_t *whitelist) const {
     if (!_db) return BLE_ERROR_INITIALIZATION_INCOMPLETE;
     if (eventHandler) {
+        if (!whitelist) {
+            return BLE_ERROR_INVALID_PARAM;
+        }
         _db->generate_whitelist_from_bond_table(
             mbed::callback(eventHandler, &::SecurityManager::EventHandler::whitelistFromBondTable),
             whitelist

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/nRF5xGap.cpp
@@ -1266,7 +1266,7 @@ void nRF5xGap::on_connection(Gap::Handle_t handle, const ble_gap_evt_connected_t
         const resolving_list_entry_t* entry = get_sm().resolve_address(
             evt.peer_addr.addr
         );
-        MBED_ASSERT(entry == NULL);
+        MBED_ASSERT(entry != NULL);
 
         peer_addr_type = convert_identity_address(entry->peer_identity_address_type);
         peer_address = entry->peer_identity_address.data();

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.cpp
@@ -47,6 +47,7 @@ namespace vendor {
 namespace nordic {
 
 CryptoToolbox::CryptoToolbox() : _initialized(false) {
+    mbedtls_platform_setup(&_platform_context);
     mbedtls_entropy_init(&_entropy_context);
     mbedtls_ecp_group_init(&_group);
     int err = mbedtls_ecp_group_load(
@@ -59,6 +60,7 @@ CryptoToolbox::CryptoToolbox() : _initialized(false) {
 CryptoToolbox::~CryptoToolbox() {
     mbedtls_ecp_group_free(&_group);
     mbedtls_entropy_free(&_entropy_context);
+    mbedtls_platform_teardown(&_platform_context);
 }
 
 bool CryptoToolbox::generate_keys(

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.h
@@ -132,6 +132,7 @@ private:
     void swap_endian(uint8_t* buf, size_t len);
 
     bool _initialized;
+    mbedtls_platform_context _platform_context;
     mbedtls_entropy_context _entropy_context;
     mbedtls_ecp_group _group;
 };

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -27,6 +27,11 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE {
    *.o (RESET, +First)
    *(InRoot$$Sections)
+   __start_sdh_soc_observers *(sdh_soc_observers) __stop_sdh_soc_observers
+   __start_sdh_stack_observers *(sdh_stack_observers) __stop_sdh_stack_observers
+   __start_sdh_req_observers *(sdh_req_observers) __stop_sdh_req_observers
+   __start_sdh_state_observers *(sdh_state_observers) __stop_sdh_state_observers
+   __start_sdh_ble_observers *(sdh_ble_observers) __stop_sdh_ble_observers
    .ANY (+RO)
   }
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
@@ -27,6 +27,11 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE {
    *.o (RESET, +First)
    *(InRoot$$Sections)
+   __start_sdh_soc_observers *(sdh_soc_observers) __stop_sdh_soc_observers
+   __start_sdh_stack_observers *(sdh_stack_observers) __stop_sdh_stack_observers
+   __start_sdh_req_observers *(sdh_req_observers) __stop_sdh_req_observers
+   __start_sdh_state_observers *(sdh_state_observers) __stop_sdh_state_observers
+   __start_sdh_ble_observers *(sdh_ble_observers) __stop_sdh_ble_observers   
    .ANY (+RO)
   }
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section


### PR DESCRIPTION
### Description

Whitelist creation did not update the size making the consumer think no items where created (original PR: https://github.com/paul-szczepanek-arm/mbed-os/pull/54).

Place observers sequentially in flash in the scatter file for Nordic (original PR: https://github.com/paul-szczepanek-arm/mbed-os/pull/57).

Missing TLS initialisation (original PR: https://github.com/paul-szczepanek-arm/mbed-os/pull/56).

MBED_ASSERT had the wrong condition, creating a false assert when ran in debug.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

