### PR TITLE
Add non-blocking write function for USBCDC

### DIFF
--- a/features/unsupported/USBDevice/USBSerial/USBCDC.cpp
+++ b/features/unsupported/USBDevice/USBSerial/USBCDC.cpp
@@ -127,6 +127,10 @@ bool USBCDC::send(uint8_t * buffer, uint32_t size) {
     return USBDevice::write(EPBULK_IN, buffer, size, MAX_CDC_REPORT_SIZE);
 }
 
+bool USBCDC::send_NB(uint8_t * buffer, uint32_t size) {
+    return USBDevice::writeNB(EPBULK_IN, buffer, size, MAX_CDC_REPORT_SIZE);
+}
+
 bool USBCDC::readEP(uint8_t * buffer, uint32_t * size) {
     if (!USBDevice::readEP(EPBULK_OUT, buffer, size, MAX_CDC_REPORT_SIZE))
         return false;

--- a/features/unsupported/USBDevice/USBSerial/USBCDC.h
+++ b/features/unsupported/USBDevice/USBSerial/USBCDC.h
@@ -70,7 +70,7 @@ protected:
     virtual const uint8_t * configurationDesc();
 
     /*
-    * Send a buffer
+    * Send a buffer. Warning: blocking
     *
     * @param endpoint endpoint which will be sent the buffer
     * @param buffer buffer to be sent
@@ -78,6 +78,16 @@ protected:
     * @returns true if successful
     */
     bool send(uint8_t * buffer, uint32_t size);
+
+    /*
+    * Send a buffer. Warning: non blocking
+    *
+    * @param endpoint endpoint which will be sent the buffer
+    * @param buffer buffer to be sent
+    * @param size length of the buffer
+    * @returns true if successful
+    */
+    bool send_NB(uint8_t * buffer, uint32_t size);
 
     /*
     * Read a buffer from a certain endpoint. Warning: blocking


### PR DESCRIPTION
### Description
For certain applications it is desirable to do a non-blocking write when sending larger blocks of data over USBSerial. I am proposing to add a second function to USBCDC to support this. Does anyone have suggestions on how to implement this in the API?

```
bool USBSerial::writeBlock(uint8_t * buf, uint16_t size) {
    if(size > MAX_PACKET_SIZE_EPBULK) {
        return false;
    }
    if(!send(buf, size)) {
        return false;
    }
    return true;
}
```

There could be an optional argument bool blocking=true, or a second function writeBlockNB, or make it always non-blocking?

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

