### PR TITLE
Fixing some coverity issues.

### DIFF
--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -100,6 +100,7 @@ void generate_derived_key_consistency_16_byte_key_long_consistency_test(char *ke
         TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
         memset(output1, 0, sizeof(output1));
+        memset(empty_buffer, 0, sizeof(empty_buffer));
         ret = devkey.generate_derived_key(salt, salt_size, output1, key_type);
         TEST_ASSERT_EQUAL_INT32(0, ret);
         bool is_empty = !memcmp(empty_buffer, output1, sizeof(output1));
@@ -158,6 +159,7 @@ void generate_derived_key_consistency_32_byte_key_long_consistency_test(char *ke
         TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
         memset(output1, 0, sizeof(output1));
+        memset(empty_buffer, 0, sizeof(empty_buffer));
         ret = devkey.generate_derived_key(salt, salt_size, output1, key_type);
         TEST_ASSERT_EQUAL_INT32(0, ret);
         bool is_empty = !memcmp(empty_buffer, output1, sizeof(output1));
@@ -307,6 +309,7 @@ void generate_derived_key_consistency_16_byte_key_test()
 
     size_t salt_size = sizeof(salt);
     memset(output1, 0, sizeof(output1));
+    memset(empty_buffer, 0, sizeof(empty_buffer));
     ret = devkey.generate_derived_key(salt, salt_size, output1, key_type);
     TEST_ASSERT_EQUAL_INT32(0, ret);
     bool is_empty = !memcmp(empty_buffer, output1, sizeof(output1));
@@ -341,6 +344,7 @@ void generate_derived_key_consistency_32_byte_key_test()
 
     size_t salt_size = sizeof(salt);
     memset(output1, 0, sizeof(output1));
+    memset(empty_buffer, 0, sizeof(empty_buffer));
     ret = devkey.generate_derived_key(salt, salt_size, output1, key_type);
     TEST_ASSERT_EQUAL_INT32(0, ret);
     bool is_empty = !memcmp(empty_buffer, output1, sizeof(output1));
@@ -434,7 +438,7 @@ void generate_derived_key_wrong_key_type_test()
     ret = inject_dummy_rot_key();
     TEST_ASSERT_EQUAL_INT(DEVICEKEY_SUCCESS, ret);
 
-    memset(output, 0, DEVICE_KEY_32BYTE);
+    memset(output, 0, DEVICE_KEY_16BYTE);
     ret = devkey.generate_derived_key(salt, salt_size, output, 12);//96 bit key type is not supported
     TEST_ASSERT_EQUAL_INT32(DEVICEKEY_INVALID_KEY_TYPE, ret);
 


### PR DESCRIPTION
### Description

This PR fix some errors discovered by Coverity.
4 uninitialized memory use errors.

#### Related PR
Fix Greentea test code with device_key #7080 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

