### PR TITLE
Add reference counter for platform context

### DIFF
--- a/features/cryptocell/FEATURE_CRYPTOCELL310/Readme.md
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/Readme.md
@@ -16,6 +16,6 @@ To port your CC 310 driver to Mbed OS on your specific target, do the following:
 1. In `objects.h`, include `objects_cryptocell.h`. You can use the `FEATURE_CRYPTOCELL310` precompilation check as defined above.
 1. In `features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_<target name>`, add your platform-specific libraries for all toolchains in `TOOLCHAIN_ARM`, `TOOLCHAIN_GCC_ARM` and `TOOLCHAIN_IAR` respectively.
 1. Add your CC setup code:
-	* Implement `cc_platform_setup()` and `cc_platform_terminate()` to enable CC on your platform, in case you have board-specific setup functionality, required for CC setup. These functions can be empty.
-	* Define `cc_platform_ctx` in `cc_platform.h` in a way that suits your implementation.
+	* Implement `crypto_platform_setup()` and `crypto_platform_terminate()` to enable CC on your platform, in case you have board-specific setup functionality, required for CC setup. You MUST call 'SaSi_LibInit()` and 'SaSi_LibFini()' respectively in these functions.
+	* Define `crypto_platform_ctx` in `crypto_platform.h` in a way that suits your implementation.
  

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
@@ -34,7 +34,7 @@ int crypto_platform_setup( crypto_platform_ctx *ctx )
     NRF_CRYPTOCELL->ENABLE = 1;
 
     if( SaSi_LibInit( &rndState, &rndWorkBuff ) != 0 )
-          return ( -1 );
+          return ( MBEDTLS_PLATFORM_HW_FAILED );
 
     return ( 0 );
 }

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
@@ -1,5 +1,5 @@
  /*
-  *  cc_platform_nrf52840.c
+  *  crypto_platform.c
   *
   *  Copyright (C) 2018, Arm Limited, All Rights Reserved
   *  SPDX-License-Identifier: Apache-2.0
@@ -20,14 +20,29 @@
 
 #include "platform_alt.h"
 #include "nrf52840.h"
+#include "sns_silib.h"
+#if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
+/* once https://github.com/ARMmbed/mbedtls/issues/1200 will be supported,
+ * rndState should be part of mbedtls_platform_context
+ * Until then, we should keep it global and extern */
 
-int cc_platform_setup( cc_platform_ctx *ctx )
+CRYS_RND_State_t     rndState = { { 0 } } ;
+CRYS_RND_WorkBuff_t  rndWorkBuff = { { 0 } } ;
+
+int crypto_platform_setup( crypto_platform_ctx *ctx )
 {
     NRF_CRYPTOCELL->ENABLE = 1;
+
+    if( SaSi_LibInit( &rndState, &rndWorkBuff ) != 0 )
+          return ( -1 );
+
     return ( 0 );
 }
 
-void cc_platform_terminate( cc_platform_ctx *ctx )
+void crypto_platform_terminate( crypto_platform_ctx *ctx )
 {
+    SaSi_LibFini( &rndState );
     NRF_CRYPTOCELL->ENABLE = 0;
 }
+
+#endif /* MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
@@ -30,7 +30,7 @@ int crypto_platform_setup( crypto_platform_ctx *ctx )
     NRF_CRYPTOCELL->ENABLE = 1;
 
     if( SaSi_LibInit( &ctx->rndState, &rndWorkBuff ) != 0 )
-          return ( MBEDTLS_PLATFORM_HW_FAILED );
+          return ( MBEDTLS_ERR_PLATFORM_HW_FAILED );
 
     return ( 0 );
 }

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
@@ -22,18 +22,14 @@
 #include "nrf52840.h"
 #include "sns_silib.h"
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
-/* once https://github.com/ARMmbed/mbedtls/issues/1200 will be supported,
- * rndState should be part of mbedtls_platform_context
- * Until then, we should keep it global and extern */
 
-CRYS_RND_State_t     rndState = { { 0 } } ;
-CRYS_RND_WorkBuff_t  rndWorkBuff = { { 0 } } ;
+static CRYS_RND_WorkBuff_t  rndWorkBuff = { { 0 } } ;
 
 int crypto_platform_setup( crypto_platform_ctx *ctx )
 {
     NRF_CRYPTOCELL->ENABLE = 1;
 
-    if( SaSi_LibInit( &rndState, &rndWorkBuff ) != 0 )
+    if( SaSi_LibInit( &ctx->rndState, &rndWorkBuff ) != 0 )
           return ( MBEDTLS_PLATFORM_HW_FAILED );
 
     return ( 0 );
@@ -41,7 +37,7 @@ int crypto_platform_setup( crypto_platform_ctx *ctx )
 
 void crypto_platform_terminate( crypto_platform_ctx *ctx )
 {
-    SaSi_LibFini( &rndState );
+    SaSi_LibFini( &ctx->rndState );
     NRF_CRYPTOCELL->ENABLE = 0;
 }
 

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.h
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.h
@@ -19,6 +19,7 @@
   */
 #ifndef __CC_PLATFORM_H_
 #define __CC_PLATFORM_H_
+#if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
 /**
  * \brief   The CC platform context structure.
  *
@@ -27,7 +28,10 @@
  */
 typedef struct {
     char dummy; /**< Placeholder member, as empty structs are not portable. */
+    /*
+     * Add CRYS_RND_State_t rndState; when https://github.com/ARMmbed/mbedtls/issues/1200 is supported
+     */
 }
-cc_platform_ctx;
-
+crypto_platform_ctx;
+#endif /* MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
 #endif /* __CC_PLATFORM_H_ */

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.h
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.h
@@ -1,5 +1,5 @@
 /*
-  *  cc_platform.h
+  *  crypto_platform.h
   *
   *  Copyright (C) 2018, Arm Limited, All Rights Reserved
   *  SPDX-License-Identifier: Apache-2.0
@@ -17,9 +17,10 @@
   *  limitations under the License.
   *
   */
-#ifndef __CC_PLATFORM_H_
-#define __CC_PLATFORM_H_
+#ifndef __CRYPTO_PLATFORM_H_
+#define __CRYPTO_PLATFORM_H_
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
+#include "crys_rnd.h"
 /**
  * \brief   The CC platform context structure.
  *
@@ -27,11 +28,8 @@
  *          setup or teardown operations.
  */
 typedef struct {
-    char dummy; /**< Placeholder member, as empty structs are not portable. */
-    /*
-     * Add CRYS_RND_State_t rndState; when https://github.com/ARMmbed/mbedtls/issues/1200 is supported
-     */
+     CRYS_RND_State_t rndState;
 }
 crypto_platform_ctx;
 #endif /* MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT */
-#endif /* __CC_PLATFORM_H_ */
+#endif /* __CRYPTO_PLATFORM_H_ */

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
@@ -25,7 +25,7 @@
 #include "mbedtls/platform.h"
 
 extern mbedtls_platform_context  ctx;
-static CRYS_RND_WorkBuff_t  rndWorkBuff;
+static CRYS_RND_WorkBuff_t  rndWorkBuff = { { 0 } };
 
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/trng.c
@@ -22,9 +22,10 @@
 
 #include <string.h>
 #include "trng_api.h"
+#include "mbedtls/platform.h"
 
-extern CRYS_RND_State_t     rndState;
-extern CRYS_RND_WorkBuff_t  rndWorkBuff;
+extern mbedtls_platform_context  ctx;
+static CRYS_RND_WorkBuff_t  rndWorkBuff;
 
 /* Implementation that should never be optimized out by the compiler */
 static void mbedtls_zeroize( void *v, size_t n ) {
@@ -48,7 +49,7 @@ CRYSError_t LLF_RND_GetTrngSource(
 
 void trng_init(trng_t *obj)
 {
-    RNG_PLAT_SetUserRngParameters(&rndState, obj);
+    RNG_PLAT_SetUserRngParameters(&ctx.platform_impl_ctx.rndState, obj);
 }
 
 void trng_free(trng_t *obj)
@@ -66,7 +67,7 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *outputLe
     uint32_t actualLength;
 
     ret = LLF_RND_GetTrngSource(
-                &rndState ,    /*in/out*/
+                &ctx.platform_impl_ctx.rndState ,    /*in/out*/
                 obj,       /*in/out*/
                 0,       /*in*/
                 &entropySizeBits,  /*in/out*/

--- a/features/mbedtls/platform/inc/platform_alt.h
+++ b/features/mbedtls/platform/inc/platform_alt.h
@@ -20,8 +20,9 @@
 
 #ifndef __PLATFORM_ALT__
 #define __PLATFORM_ALT__
-#include "cc_platform.h"
-#include "crys_rnd.h"
+#include "platform_mbed.h"
+#if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
+#include "crypto_platform.h"
 
 /**
  * \brief   The platform context structure.
@@ -30,40 +31,37 @@
  *          setup or teardown operations.
  */
 typedef struct {
-    cc_platform_ctx platform_impl_ctx; /** A context holding all the partner's platform specific context */
-    /*
-     * Add CRYS_RND_State_t rndState; when https://github.com/ARMmbed/mbedtls/issues/1200 is supported
-     * */
+    crypto_platform_ctx platform_impl_ctx; /* A context holding all the platform specific context for cryptography. Should be defined in crypto_platform.h */
 }
 mbedtls_platform_context;
 
 
+void mbedtls_platform_init( mbedtls_platform_context* ctx);
 /**
- * \brief   This function performs any partner platform initialization operations,
- *          needed top enable CryptoCell.
+ * \brief   This function performs any platform initialization operations,
+ *          needed for setting up cryptographic modules.
  *
  * \param   ctx     The platform specific context.
  *
  * \return          \c 0 on success.
  *
- * \note    This function is intended to allow platform-specific initialization for CryptoCell,
- *          and is called before initializing the CC library(SaSi_LibInit). Its
+ * \note    This function is intended to allow platform-specific initialization for Mbed TLS,
+ *          and is called before initializing the Mbed TLS functions. Its
  *          implementation is platform-specific, and its implementation MUST be provided.
  *
  */
-int cc_platform_setup( cc_platform_ctx *ctx );
+int crypto_platform_setup( crypto_platform_ctx *ctx );
 
 /**
- * \brief   This function performs any partner platform teardown operations, to disable CryptoCell.
+ * \brief   This function performs any  platform teardown operations, to disable cryptographic operations.
  *
  * \param   ctx     The platform specific context.
  *
- * \note    This function is called after terminating CC library(SaSi_LibFini)
- *          and intended to free any resource used for CryptoCell by the platform.
+ * \note    This function is intended to free any resource used Mbed TLS by the platform.
  *          Its implementation is platform-specific,and its implementation MUST be provided.
  *
  */
-void cc_platform_terminate( cc_platform_ctx *ctx );
-
+void crypto_platform_terminate( crypto_platform_ctx *ctx );
+#endif
 #endif /* __PLATFORM_ALT__ */
 

--- a/features/mbedtls/platform/inc/platform_alt.h
+++ b/features/mbedtls/platform/inc/platform_alt.h
@@ -23,7 +23,6 @@
 #include "platform_mbed.h"
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
 #include "crypto_platform.h"
-
 /**
  * \brief   The platform context structure.
  *
@@ -32,6 +31,7 @@
  */
 typedef struct {
     crypto_platform_ctx platform_impl_ctx; /* A context holding all the platform specific context for cryptography. Should be defined in crypto_platform.h */
+    int reference_count;
 }
 mbedtls_platform_context;
 

--- a/features/mbedtls/platform/inc/platform_alt.h
+++ b/features/mbedtls/platform/inc/platform_alt.h
@@ -36,7 +36,6 @@ typedef struct {
 mbedtls_platform_context;
 
 
-void mbedtls_platform_init( mbedtls_platform_context* ctx);
 /**
  * \brief   This function performs any platform initialization operations,
  *          needed for setting up cryptographic modules.

--- a/features/mbedtls/platform/inc/platform_alt.h
+++ b/features/mbedtls/platform/inc/platform_alt.h
@@ -49,7 +49,7 @@ mbedtls_platform_context;
  *          implementation is platform-specific, and its implementation MUST be provided.
  *
  */
-int crypto_platform_setup( crypto_platform_ctx *ctx );
+int crypto_platform_setup( crypto_platform_ctx *unused_ctx );
 
 /**
  * \brief   This function performs any  platform teardown operations, to disable cryptographic operations.
@@ -60,7 +60,7 @@ int crypto_platform_setup( crypto_platform_ctx *ctx );
  *          Its implementation is platform-specific,and its implementation MUST be provided.
  *
  */
-void crypto_platform_terminate( crypto_platform_ctx *ctx );
+void crypto_platform_terminate( crypto_platform_ctx *unused_ctx );
 #endif
 #endif /* __PLATFORM_ALT__ */
 

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -24,3 +24,6 @@
 #if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif
+
+#define MBEDTLS_PLATFORM_INVALID_DATA    -0x0080
+#define MBEDTLS_PLATFORM_HW_FAILED       -0x0082

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -25,5 +25,4 @@
 #include "mbedtls_device.h"
 #endif
 
-#define MBEDTLS_PLATFORM_INVALID_DATA    -0x0080
-#define MBEDTLS_PLATFORM_HW_FAILED       -0x0082
+#define MBEDTLS_ERR_PLATFORM_HW_FAILED       -0x0080

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -27,7 +27,7 @@ int mbedtls_platform_setup( mbedtls_platform_context *ctx )
 {
     int ret = 0;
     if( ctx == NULL )
-        return ( -1 );
+        return ( MBEDTLS_PLATFORM_INVALID_DATA );
 
     reference_count++;
 
@@ -44,15 +44,13 @@ void mbedtls_platform_teardown( mbedtls_platform_context *ctx )
     if( ctx == NULL )
         return;
 
-    if( reference_count == 0 )
-        return;
-
     reference_count--;
 
-    if( reference_count == 0 )
+    if( reference_count <= 0 )
     {
         /* call platform specific code to terminate crypto driver*/
         crypto_platform_terminate( &ctx->platform_impl_ctx );
+        reference_count = 0;
     }
 }
 

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -20,15 +20,8 @@
 
 #include "mbedtls/platform.h"
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
-#include "sns_silib.h"
 
-/* once https://github.com/ARMmbed/mbedtls/issues/1200 will be supported,
- * rndState should be part of mbedtls_platform_context
- * Until then, we should keep it global and extern */
-
-CRYS_RND_State_t     rndState = { { 0 } } ;
-CRYS_RND_WorkBuff_t  rndWorkBuff = { { 0 } } ;
-
+static int reference_count = 0;
 
 int mbedtls_platform_setup( mbedtls_platform_context *ctx )
 {
@@ -36,13 +29,14 @@ int mbedtls_platform_setup( mbedtls_platform_context *ctx )
     if( ctx == NULL )
         return ( -1 );
 
-    /* call platform specific code to setup CC driver*/
-    if( ( ret = cc_platform_setup( &ctx->platform_impl_ctx ) ) != 0 )
-        return ( ret );
+    reference_count++;
 
-    if( SaSi_LibInit( &rndState, &rndWorkBuff ) != 0 )
-        return ( -1 );
-    return ( 0 );
+    if( reference_count == 1 )
+    {
+        /* call platform specific code to setup crypto driver*/
+        ret = crypto_platform_setup( &ctx->platform_impl_ctx );
+    }
+    return ( ret );
 }
 
 void mbedtls_platform_teardown( mbedtls_platform_context *ctx )
@@ -50,8 +44,16 @@ void mbedtls_platform_teardown( mbedtls_platform_context *ctx )
     if( ctx == NULL )
         return;
 
-    SaSi_LibFini( &rndState );
-    cc_platform_terminate( &ctx->platform_impl_ctx );
+    if( reference_count == 0 )
+        return;
+
+    reference_count--;
+
+    if( reference_count == 0 )
+    {
+        /* call platform specific code to terminate crypto driver*/
+        crypto_platform_terminate( &ctx->platform_impl_ctx );
+    }
 }
 
 #endif /* MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT*/

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -22,7 +22,7 @@
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
 #include "mbed_critical.h"
 
-mbedtls_platform_context ctx = { };
+mbedtls_platform_context ctx = { { 0 } };
 
 int mbedtls_platform_setup( mbedtls_platform_context *unused_ctx )
 {

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -24,7 +24,7 @@
 
 mbedtls_platform_context ctx = { };
 
-int mbedtls_platform_setup( mbedtls_platform_context *obsolete_ctx )
+int mbedtls_platform_setup( mbedtls_platform_context *unused_ctx )
 {
     int ret = 0;
 
@@ -38,9 +38,8 @@ int mbedtls_platform_setup( mbedtls_platform_context *obsolete_ctx )
     return ( ret );
 }
 
-void mbedtls_platform_teardown( mbedtls_platform_context *obsolete_ctx )
+void mbedtls_platform_teardown( mbedtls_platform_context *unused_ctx )
 {
-
     core_util_atomic_decr_u32( ( volatile uint32_t * )&ctx.reference_count, 1 );
     if( ctx.reference_count < 1 )
     {

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -20,37 +20,32 @@
 
 #include "mbedtls/platform.h"
 #if defined(MBEDTLS_PLATFORM_SETUP_TEARDOWN_ALT)
+mbedtls_platform_context ctx = {0};
 
-static int reference_count = 0;
-
-int mbedtls_platform_setup( mbedtls_platform_context *ctx )
+int mbedtls_platform_setup( mbedtls_platform_context *obsolete_ctx )
 {
     int ret = 0;
-    if( ctx == NULL )
-        return ( MBEDTLS_PLATFORM_INVALID_DATA );
 
-    reference_count++;
+    ctx.reference_count++;
 
-    if( reference_count == 1 )
+    if( ctx.reference_count == 1 )
     {
         /* call platform specific code to setup crypto driver*/
-        ret = crypto_platform_setup( &ctx->platform_impl_ctx );
+        ret = crypto_platform_setup( &ctx.platform_impl_ctx );
     }
     return ( ret );
 }
 
-void mbedtls_platform_teardown( mbedtls_platform_context *ctx )
+void mbedtls_platform_teardown( mbedtls_platform_context *obsolete_ctx )
 {
-    if( ctx == NULL )
-        return;
 
-    reference_count--;
+    ctx.reference_count--;
 
-    if( reference_count <= 0 )
+    if( ctx.reference_count <= 0 )
     {
         /* call platform specific code to terminate crypto driver*/
-        crypto_platform_terminate( &ctx->platform_impl_ctx );
-        reference_count = 0;
+        crypto_platform_terminate( &ctx.platform_impl_ctx );
+        ctx.reference_count = 0;
     }
 }
 

--- a/features/mbedtls/platform/src/platform_alt.c
+++ b/features/mbedtls/platform/src/platform_alt.c
@@ -42,7 +42,7 @@ void mbedtls_platform_teardown( mbedtls_platform_context *obsolete_ctx )
 {
 
     core_util_atomic_decr_u32( ( volatile uint32_t * )&ctx.reference_count, 1 );
-    if( ctx.reference_count <= 0 )
+    if( ctx.reference_count < 1 )
     {
         /* call platform specific code to terminate crypto driver */
         crypto_platform_terminate( &ctx.platform_impl_ctx );


### PR DESCRIPTION

### Description
1. Move the `mbedtls_platform_context` to be platform code, in `features/mbedtls/platfrom/`.
2. Add static refernce counter, to setup and teardown the platform code only once.
3. Adjust Cryptocell porting accordingly.

Should work with system modules using Mbed TLS, such as BLE, that wouldn't terminate the cryptographic driver for the application, in the middle of operation.
Adresses first part of #7069 

CC @sbutcher-arm @Patater @pan- 

Question: Should we protect the reference counter with a mutex?

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

