### PR TITLE
Greentea test updated for NXP lpc17xx

### DIFF
--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -34,6 +34,9 @@ namespace
     NetworkInterface* net;
 }
 
+char tcp_global::rx_buffer[RX_BUFF_SIZE];
+char tcp_global::tx_buffer[TX_BUFF_SIZE];
+
 NetworkInterface* get_interface()
 {
     return net;

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -24,6 +24,17 @@ void fill_tx_buffer_ascii(char *buff, size_t len);
 void tcpsocket_connect_to_echo_srv(TCPSocket& sock);
 void tcpsocket_connect_to_discard_srv(TCPSocket& sock);
 
+namespace tcp_global
+{
+static const int TCP_OS_STACK_SIZE = 1024;
+
+static const int RX_BUFF_SIZE = 1220;
+static const int TX_BUFF_SIZE = 1220;
+
+extern char rx_buffer[RX_BUFF_SIZE];
+extern char tx_buffer[TX_BUFF_SIZE];
+}
+
 /*
  * Test cases
  */

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -32,8 +32,6 @@ namespace
 
     static const int BURST_CNT = 100;
     static const int BURST_SIZE = 1220;
-    char rx_buffer[BURST_SIZE] = {0};
-    char tx_buffer[BURST_SIZE] = {0};
 }
 
 static void _sigio_handler(osThreadId id) {
@@ -47,7 +45,7 @@ void TCPSOCKET_ECHOTEST_BURST()
     sock.sigio(callback(_sigio_handler, Thread::gettid()));
 
     // TX buffer to be preserved for comparison
-    fill_tx_buffer_ascii(tx_buffer, BURST_SIZE);
+    fill_tx_buffer_ascii(tcp_global::tx_buffer, BURST_SIZE);
 
     int recvd;
     int bt_left;
@@ -55,7 +53,7 @@ void TCPSOCKET_ECHOTEST_BURST()
     for (int i = 0; i < BURST_CNT; i++) {
         bt_left = BURST_SIZE;
         while (bt_left > 0) {
-            sent = sock.send(&(tx_buffer[BURST_SIZE-bt_left]), bt_left);
+            sent = sock.send(&(tcp_global::tx_buffer[BURST_SIZE-bt_left]), bt_left);
             if (sent == NSAPI_ERROR_WOULD_BLOCK) {
                 if(osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
                     TEST_FAIL();
@@ -70,7 +68,7 @@ void TCPSOCKET_ECHOTEST_BURST()
 
         bt_left = BURST_SIZE;
         while (bt_left > 0) {
-            recvd = sock.recv(&(rx_buffer[BURST_SIZE-bt_left]), BURST_SIZE);
+            recvd = sock.recv(&(tcp_global::rx_buffer[BURST_SIZE-bt_left]), BURST_SIZE);
             if (recvd < 0) {
                 printf("[%02d] network error %d\n", i, recvd);
                 break;
@@ -83,7 +81,7 @@ void TCPSOCKET_ECHOTEST_BURST()
             TEST_FAIL();
         }
 
-        TEST_ASSERT_EQUAL(0, memcmp(tx_buffer, rx_buffer, BURST_SIZE));
+        TEST_ASSERT_EQUAL(0, memcmp(tcp_global::tx_buffer, tcp_global::rx_buffer, BURST_SIZE));
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
@@ -96,7 +94,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
     sock.sigio(callback(_sigio_handler, Thread::gettid()));
 
     // TX buffer to be preserved for comparison
-    fill_tx_buffer_ascii(tx_buffer, BURST_SIZE);
+    fill_tx_buffer_ascii(tcp_global::tx_buffer, BURST_SIZE);
 
     int sent;
     int recvd;
@@ -104,7 +102,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
     for (int i = 0; i < BURST_CNT; i++) {
         bt_left = BURST_SIZE;
         while (bt_left > 0) {
-            sent = sock.send(&(tx_buffer[BURST_SIZE-bt_left]), bt_left);
+            sent = sock.send(&(tcp_global::tx_buffer[BURST_SIZE-bt_left]), bt_left);
             if (sent == NSAPI_ERROR_WOULD_BLOCK) {
                 if(osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
                     TEST_FAIL();
@@ -120,7 +118,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
 
         bt_left = BURST_SIZE;
         while (bt_left > 0) {
-            recvd = sock.recv(&(rx_buffer[BURST_SIZE-bt_left]), BURST_SIZE);
+            recvd = sock.recv(&(tcp_global::rx_buffer[BURST_SIZE-bt_left]), BURST_SIZE);
             if (recvd == NSAPI_ERROR_WOULD_BLOCK) {
                 if(osSignalWait(SIGNAL_SIGIO, SIGIO_TIMEOUT).status == osEventTimeout) {
                     printf("[bt#%02d] packet timeout...", i);
@@ -140,7 +138,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
             TEST_FAIL();
         }
 
-        TEST_ASSERT_EQUAL(0, memcmp(tx_buffer, rx_buffer, BURST_SIZE));
+        TEST_ASSERT_EQUAL(0, memcmp(tcp_global::tx_buffer, tcp_global::rx_buffer, BURST_SIZE));
     }
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }

--- a/TESTS/network/emac/emac_TestNetworkStack.cpp
+++ b/TESTS/network/emac/emac_TestNetworkStack.cpp
@@ -39,6 +39,18 @@ nsapi_error_t EmacTestNetworkStack::add_dns_server(const SocketAddress &address)
     return NSAPI_ERROR_OK;
 }
 
+nsapi_error_t EmacTestNetworkStack::call_in(int delay, mbed::Callback<void()> func)
+{
+    // Implemented as empty to save memory
+    return NSAPI_ERROR_DEVICE_ERROR;
+}
+
+EmacTestNetworkStack::call_in_callback_cb_t EmacTestNetworkStack::get_call_in_callback()
+{
+    call_in_callback_cb_t cb(this, &EmacTestNetworkStack::call_in);
+    return cb;
+}
+
 nsapi_error_t EmacTestNetworkStack::socket_open(nsapi_socket_t *handle, nsapi_protocol_t proto)
 {
     return NSAPI_ERROR_OK;

--- a/TESTS/network/emac/emac_TestNetworkStack.h
+++ b/TESTS/network/emac/emac_TestNetworkStack.h
@@ -356,6 +356,38 @@ protected:
                                      int optname, void *optval, unsigned *optlen);
 
 private:
+
+    /** Call in callback
+      *
+      *  Callback is used to call the call in method of the network stack.
+      */
+    typedef mbed::Callback<nsapi_error_t (int delay_ms, mbed::Callback<void()> user_cb)> call_in_callback_cb_t;
+
+    /** Get a call in callback
+     *
+     *  Get a call in callback from the network stack context.
+     *
+     *  Callback should not take more than 10ms to execute, otherwise it might
+     *  prevent underlying thread processing. A portable user of the callback
+     *  should not make calls to network operations due to stack size limitations.
+     *  The callback should not perform expensive operations such as socket recv/send
+     *  calls or blocking operations.
+     *
+     *  @return         Call in callback
+     */
+    virtual call_in_callback_cb_t get_call_in_callback();
+
+    /** Call a callback after a delay
+     *
+     *  Call a callback from the network stack context after a delay. If function
+     *  returns error callback will not be called.
+     *
+     *  @param delay    Delay in milliseconds
+     *  @param func     Callback to be called
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t call_in(int delay, mbed::Callback<void()> func);
+
     Interface *m_interface;
 };
 

--- a/TESTS/network/emac/emac_util.h
+++ b/TESTS/network/emac/emac_util.h
@@ -58,7 +58,7 @@ extern const unsigned char eth_mac_broadcast_addr[];
 #define RESET_ERROR_FLAGS(flags) emac_if_reset_error_flags(flags)
 
 #define ETH_FRAME_HEADER_LEN    28
-#define ETH_FRAME_MIN_LEN       60
+#define ETH_FRAME_MIN_LEN       60 + 4
 #define ETH_MAC_ADDR_LEN        6
 
 #define TIMEOUT                 1


### PR DESCRIPTION
### Description

Added support for NXP lpc17xx EMAC driver to greentea EMAC tests and optimized netsocket TCP tests memory usage by combining TX/RX buffers.

Related NXP lpc17xx driver changes are in this pull request: https://github.com/ARMmbed/mbed-os/pull/7086

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

