### PR TITLE
Enabled Travis CI tests for Python 3.5 and 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -98,13 +98,13 @@ matrix:
         # Report success since we have overridden default behaviour
         - bash -c "$STATUS" success "Local $NAME testing has passed"
 
-#    - <<: *tools-pytest
-#      env: NAME=tools-py3.5
-#      python: 3.5
-#
-#    - <<: *tools-pytest
-#      env: NAME=tools-py3.6
-#      python: 3.6
+    - <<: *tools-pytest
+      env: NAME=tools-py3.5
+      python: 3.5
+
+    - <<: *tools-pytest
+      env: NAME=tools-py3.6
+      python: 3.6
 
     - env:
         - NAME=astyle


### PR DESCRIPTION
### Description

Enables Travis CI tests for testing against python 3.5 and 3.6.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

