### PR TITLE
Cellular: Added CellularBase::get_default_instance default implementation

### DIFF
--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -336,6 +336,11 @@ NetworkStack *EasyCellularConnection::get_stack()
     }
 }
 
+CellularBase *EasyCellularConnection::get_default_instance()
+{
+    return new EasyCellularConnection();
+}
+
 } // namespace
 
 #endif // CELLULAR_DEVICE

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -137,6 +137,12 @@ public:
      *  @param plmn operator in numeric format. See more from 3GPP TS 27.007 chapter 7.3.
      */
     void set_plmn(const char* plmn);
+
+    /** Create a new default cellular network interface.
+     *  @return a network instance which application must free, NULL on failure
+	 */
+    static CellularBase *get_default_instance();
+
 protected:
 
     /** Provide access to the NetworkStack object

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -64,7 +64,7 @@ public:
      *
      * * ETHERNET: EthernetInterface, using default EMAC and OnboardNetworkStack
      * * MESH: ThreadInterface or LoWPANNDInterface, using default NanostackRfPhy
-     * * CELLULAR: OnboardModemInterface
+     * * CELLULAR: CellularBase
      * * WIFI: None - always provided by a specific class
      *
      * Specific drivers may be activated by other settings of the


### PR DESCRIPTION
### Description

Added `CellularBase::get_default_instance()`  in `EasyCellularConnection`.

This is an implementation for previously existing API, which used to return NULL as default implementation.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

