### PR TITLE
BLE: check flags to make sure the IRK has been stored before retrieving it

### DIFF
--- a/features/FEATURE_BLE/ble/generic/SecurityDb.h
+++ b/features/FEATURE_BLE/ble/generic/SecurityDb.h
@@ -588,7 +588,7 @@ public:
             entry_handle_t db_handle = get_entry_handle_by_index(i);
             SecurityDistributionFlags_t* flags = get_distribution_flags(db_handle);
 
-            if (!flags) {
+            if (!flags || !flags->irk_stored) {
                 continue;
             }
 


### PR DESCRIPTION
### Description

Fix for IRK and BDADDR being read in without checking the storage is valid. Found through a new clitest [SM_whitelist_generation_test_01](https://github.com/ARMmbed/ble-tests/pull/42).

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

