### PR TITLE
Override ROM/RAM start/size for TrustZone targets

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -575,6 +575,19 @@ class Config(object):
             except KeyError:
                 raise ConfigException("Not enough information in CMSIS packs to "
                                       "build a bootloader project")
+            
+        # Override rom_start/rom_size
+        #
+        # This is usually done for a target which:
+        # 1. Doesn't support CMSIS pack, or
+        # 2. Supports TrustZone and user needs to change its flash partition
+        rom_start_override = getattr(self.target, "mbed_rom_start", False)
+        if rom_start_override:
+            rom_start = int(rom_start_override, 0)
+        rom_size_override = getattr(self.target, "mbed_rom_size", False)
+        if rom_size_override:
+            rom_size = int(rom_size_override, 0)
+
         if self.target.bootloader_img or self.target.restrict_size:
             return self._generate_bootloader_build(rom_start, rom_size)
         elif self.target.mbed_app_start or self.target.mbed_app_size:

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -41,10 +41,25 @@ try:
 except NameError:
     unicode = str
 PATH_OVERRIDES = set(["target.bootloader_img"])
-BOOTLOADER_OVERRIDES = set(["target.bootloader_img", "target.restrict_size",
-                            "target.header_format", "target.header_offset",
-                            "target.app_offset",
-                            "target.mbed_app_start", "target.mbed_app_size"])
+ROM_OVERRIDES = set([
+    # managed BL
+    "target.bootloader_img", "target.restrict_size",
+    "target.header_format", "target.header_offset",
+    "target.app_offset",
+
+    # unmanaged BL
+    "target.mbed_app_start", "target.mbed_app_size",
+
+    # both
+    "target.mbed_rom_start", "target.mbed_rom_size",
+])
+RAM_OVERRIDES = set([
+    # both
+    "target.mbed_ram_start", "target.mbed_ram_size",
+])
+
+BOOTLOADER_OVERRIDES = ROM_OVERRIDES | RAM_OVERRIDES
+
 
 
 # Base class for all configuration exceptions
@@ -355,6 +370,7 @@ def _process_macros(mlist, macros, unit_name, unit_kind):
 
 
 Region = namedtuple("Region", "name start size active filename")
+RamRegion = namedtuple("RamRegion", "name start size active")
 
 class Config(object):
     """'Config' implements the mbed configuration mechanism"""
@@ -525,7 +541,16 @@ class Config(object):
     @property
     def has_regions(self):
         """Does this config have regions defined?"""
-        for override in BOOTLOADER_OVERRIDES:
+        for override in ROM_OVERRIDES:
+            _, attr = override.split(".")
+            if getattr(self.target, attr, None):
+                return True
+        return False
+
+    @property
+    def has_ram_regions(self):
+        """Does this config have regions defined?"""
+        for override in RAM_OVERRIDES:
             _, attr = override.split(".")
             if getattr(self.target, attr, None):
                 return True
@@ -545,9 +570,7 @@ class Config(object):
             return sectors
         raise ConfigException("No sector info available")
 
-    @property
-    def regions(self):
-        """Generate a list of regions from the config"""
+    def _get_cmsis_part(self):
         if not self.target.bootloader_supported:
             raise ConfigException("Bootloader not supported on this target.")
         if not hasattr(self.target, "device_name"):
@@ -558,43 +581,63 @@ class Config(object):
             raise ConfigException("Bootloader not supported on this target: "
                                   "targets.json `device_name` not found in "
                                   "arm_pack_manager index.")
-        cmsis_part = cache.index[self.target.device_name]
+        return cache.index[self.target.device_name]
+
+    def _get_mem_specs(self, memories, cmsis_part, exception_text):
+        for memory in memories:
+            try:
+                size = cmsis_part['memory']['IRAM1']['size']
+                start = cmsis_part['memory']['IRAM1']['start']
+                return (start, size)
+            except KeyError:
+                continue
+        raise ConfigException(exception_text)
+
+    @property
+    def ram_regions(self):
+        """Generate a list of ram regions from the config"""
+        cmsis_part = self._get_cmsis_part()
+        ram_start, ram_size = self._get_mem_specs(
+            ["IRAM1", "SRAM0"],
+            cmsis_part,
+            "Not enough information in CMSIS packs to build a ram sharing project"
+        )
+        # Override ram_start/ram_size
+        #
+        # This is usually done for a target which:
+        # 1. Doesn't support CMSIS pack, or
+        # 2. Supports TrustZone and user needs to change its flash partition
+        ram_start = getattr(self.target, "mbed_ram_start", False) or ram_start
+        ram_size = getattr(self.target, "mbed_ram_size", False) or ram_size
+        return [RamRegion("application_ram", int(ram_start, 0), int(ram_size, 0), True)]
+
+    @property
+    def regions(self):
+        """Generate a list of regions from the config"""
+        cmsis_part = self._get_cmsis_part()
         if  ((self.target.bootloader_img or self.target.restrict_size) and
              (self.target.mbed_app_start or self.target.mbed_app_size)):
             raise ConfigException(
                 "target.bootloader_img and target.restirct_size are "
                 "incompatible with target.mbed_app_start and "
                 "target.mbed_app_size")
-        try:
-            rom_size = int(cmsis_part['memory']['IROM1']['size'], 0)
-            rom_start = int(cmsis_part['memory']['IROM1']['start'], 0)
-        except KeyError:
-            try:
-                rom_size = int(cmsis_part['memory']['PROGRAM_FLASH']['size'], 0)
-                rom_start = int(cmsis_part['memory']['PROGRAM_FLASH']['start'], 0)
-            except KeyError:
-                raise ConfigException("Not enough information in CMSIS packs to "
-                                      "build a bootloader project")
-            
+        rom_start, rom_size = self._get_mem_specs(
+            ["IROM1", "PROMGRAM_FLASH"],
+            cmsis_part,
+            "Not enough information in CMSIS packs to build a bootloader project"
+        )
         # Override rom_start/rom_size
         #
         # This is usually done for a target which:
         # 1. Doesn't support CMSIS pack, or
         # 2. Supports TrustZone and user needs to change its flash partition
-        rom_start_override = getattr(self.target, "mbed_rom_start", False)
-        if rom_start_override:
-            rom_start = int(rom_start_override, 0)
-        rom_size_override = getattr(self.target, "mbed_rom_size", False)
-        if rom_size_override:
-            rom_size = int(rom_size_override, 0)
+        rom_start = int(getattr(self.target, "mbed_rom_start", False) or rom_start, 0)
+        rom_size = int(getattr(self.target, "mbed_rom_size", False) or rom_size, 0)
 
         if self.target.bootloader_img or self.target.restrict_size:
             return self._generate_bootloader_build(rom_start, rom_size)
-        elif self.target.mbed_app_start or self.target.mbed_app_size:
-            return self._generate_linker_overrides(rom_start, rom_size)
         else:
-            raise ConfigException(
-                "Bootloader build requested but no bootlader configuration")
+            return self._generate_linker_overrides(rom_start, rom_size)
 
     @staticmethod
     def header_member_size(member):

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -586,8 +586,8 @@ class Config(object):
     def _get_mem_specs(self, memories, cmsis_part, exception_text):
         for memory in memories:
             try:
-                size = cmsis_part['memory']['IRAM1']['size']
-                start = cmsis_part['memory']['IRAM1']['start']
+                size = cmsis_part['memory'][memory]['size']
+                start = cmsis_part['memory'][memory]['start']
                 return (start, size)
             except KeyError:
                 continue

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -462,6 +462,17 @@ class mbedToolchain:
         if 'UVISOR' in self.target.features and 'UVISOR_SUPPORTED' in self.target.extra_labels:
             self.target.core = re.sub(r"F$", '', self.target.core)
 
+        # Pass flash information (MBED_ROM_START/MBED_ROM_SIZE) to compiler/linker
+        # if target configuration options (mbed_rom_start/mbed_rom_size) are defined.
+        rom_start_override = getattr(self.target, "mbed_rom_start", False)
+        if rom_start_override:
+            self.macros.append("MBED_ROM_START=0x%x" % int(rom_start_override, 0))
+            self.make_ld_define("MBED_ROM_START", int(rom_start_override, 0))
+        rom_size_override = getattr(self.target, "mbed_rom_size", False)
+        if rom_size_override:
+            self.macros.append("MBED_ROM_SIZE=0x%x" % int(rom_size_override, 0))
+            self.make_ld_define("MBED_ROM_SIZE", int(rom_size_override, 0))
+
         # Stats cache is used to reduce the amount of IO requests to stat
         # header files during dependency change. See need_update()
         self.stat_cache = {}

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -467,22 +467,26 @@ class mbedToolchain:
         rom_start_override = getattr(self.target, "mbed_rom_start", False)
         if rom_start_override:
             self.macros.append("MBED_ROM_START=0x%x" % int(rom_start_override, 0))
-            self.make_ld_define("MBED_ROM_START", int(rom_start_override, 0))
+            _ = self.make_ld_define("MBED_ROM_START", int(rom_start_override, 0))
+            self.flags["ld"].append(_)
         rom_size_override = getattr(self.target, "mbed_rom_size", False)
         if rom_size_override:
             self.macros.append("MBED_ROM_SIZE=0x%x" % int(rom_size_override, 0))
-            self.make_ld_define("MBED_ROM_SIZE", int(rom_size_override, 0))
+            _ = self.make_ld_define("MBED_ROM_SIZE", int(rom_size_override, 0))
+            self.flags["ld"].append(_)
 
         # Pass SRAM information (MBED_RAM_START/MBED_RAM_SIZE) to compiler/linker
         # if target configuration options (mbed_ram_start/mbed_ram_size) are defined.
         ram_start_override = getattr(self.target, "mbed_ram_start", False)
         if ram_start_override:
             self.macros.append("MBED_RAM_START=0x%x" % int(ram_start_override, 0))
-            self.make_ld_define("MBED_RAM_START", int(ram_start_override, 0))
+            _ = self.make_ld_define("MBED_RAM_START", int(ram_start_override, 0))
+            self.flags["ld"].append(_)
         ram_size_override = getattr(self.target, "mbed_ram_size", False)
         if ram_size_override:
             self.macros.append("MBED_RAM_SIZE=0x%x" % int(ram_size_override, 0))
-            self.make_ld_define("MBED_RAM_SIZE", int(ram_size_override, 0))
+            _ = self.make_ld_define("MBED_RAM_SIZE", int(ram_size_override, 0))
+            self.flags["ld"].append(_)
 
         # Stats cache is used to reduce the amount of IO requests to stat
         # header files during dependency change. See need_update()

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -473,6 +473,17 @@ class mbedToolchain:
             self.macros.append("MBED_ROM_SIZE=0x%x" % int(rom_size_override, 0))
             self.make_ld_define("MBED_ROM_SIZE", int(rom_size_override, 0))
 
+        # Pass SRAM information (MBED_RAM_START/MBED_RAM_SIZE) to compiler/linker
+        # if target configuration options (mbed_ram_start/mbed_ram_size) are defined.
+        ram_start_override = getattr(self.target, "mbed_ram_start", False)
+        if ram_start_override:
+            self.macros.append("MBED_RAM_START=0x%x" % int(ram_start_override, 0))
+            self.make_ld_define("MBED_RAM_START", int(ram_start_override, 0))
+        ram_size_override = getattr(self.target, "mbed_ram_size", False)
+        if ram_size_override:
+            self.macros.append("MBED_RAM_SIZE=0x%x" % int(ram_size_override, 0))
+            self.make_ld_define("MBED_RAM_SIZE", int(ram_size_override, 0))
+
         # Stats cache is used to reduce the amount of IO requests to stat
         # header files during dependency change. See need_update()
         self.stat_cache = {}


### PR DESCRIPTION
### Description

On TrustZone targets, ROM/RAM start/size are not so fixed and can be changed by external tool or other means. This PR introduces new target configuration options for user to override ROM/RAM start/size dependent on its real case.
1. Introduce new target configuration options (`mbed_rom_start`/`mbed_rom_size`)
    1. Override `rom_start`/`rom_size` pulled from CMSIS pack or no CMSIS pack
    1. Pass overridden flash information (`MBED_ROM_START`/`MBED_ROM_SIZE`) to compiler
    1. Pass overridden flash information (`MBED_ROM_START`/`MBED_ROM_SIZE`) to linker
1. Introduce new target configuration options (`mbed_ram_start`/`mbed_ram_size`)
    1. Override `ram_start`/`ram_size` pulled from CMSIS pack or no CMSIS pack
    1. Pass overridden SRAM information (`MBED_RAM_START`/`MBED_RAM_SIZE`) to compiler
    1. Pass overridden SRAM information (`MBED_RAM_START`/`MBED_RAM_SIZE`) to linker

Take our on-going **NUMAKER_PFM_M2351** as an example. We have partitioned 512 KB flash/96KB SRAM to:

**Secure flash**: 64KB
**Non-secure flash**: 448KB
**Secure SRAM**: 8KB
**Non-secure SRAM**: 88KB

For build for **NUMAKER_PFM_M2351** secure target, we must have `mbed_app.json`:

<pre>
"target_overrides": {

    "NUMAKER_PFM_M2351_S": {
        <b>
        "target.mbed_rom_start": "0x0",
        "target.mbed_rom_size": "0x10000",
        "target.mbed_ram_start": "0x20000000",
        "target.mbed_ram_size": "0x2000",
        </b>
    }
},
</pre>

For build for **NUMAKER_PFM_M2351** non-secure target, we must have `mbed_app.json`:

<pre>
"target_overrides": {

    "NUMAKER_PFM_M2351_NS": {
        <b>
        "target.mbed_rom_start": "0x10010000",
        "target.mbed_rom_size": "0x70000",
        "target.mbed_ram_start": "0x30002000",
        "target.mbed_ram_size": "0x16000",
        </b>
    }
},
</pre>

#### Related PR
#6890 

### Pull request type


    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

