### PR TITLE
error: fix undeclared memcpy

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -15,6 +15,7 @@
  */
 #include <stdlib.h>
 #include <stdarg.h>
+#include <string.h>
 #include "device.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_error.h"


### PR DESCRIPTION
### Description

Some targets do not get string header file in, results in the warning:
`implicit declaration of function 'memcpy'`

I discovered this while compiling mbed 2 for `RZ_A1H` target

```
Compile [ 84.7%]: mbed_error.c
[Warning] mbed_error.c@117,5: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
[Warning] mbed_error.c@145,9: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
```

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

