### PR TITLE
Fix greentea test failure on Renesas Cortex-A9 targets

### DIFF
--- a/cmsis/TARGET_CORTEX_A/cmsis_armcc.h
+++ b/cmsis/TARGET_CORTEX_A/cmsis_armcc.h
@@ -451,8 +451,8 @@ __STATIC_INLINE void __set_FPEXC(uint32_t fpexc)
  * Include common core functions to access Coprocessor 15 registers
  */
 
-#define __get_CP(cp, op1, Rt, CRn, CRm, op2) do { register uint32_t tmp __ASM("cp" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2); (Rt) = tmp; } while(0)
-#define __set_CP(cp, op1, Rt, CRn, CRm, op2) do { register uint32_t tmp __ASM("cp" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2); tmp = (Rt); } while(0)
+#define __get_CP(cp, op1, Rt, CRn, CRm, op2) do { register volatile uint32_t tmp __ASM("cp" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2); (Rt) = tmp; } while(0)
+#define __set_CP(cp, op1, Rt, CRn, CRm, op2) do { register volatile uint32_t tmp __ASM("cp" # cp ":" # op1 ":c" # CRn ":c" # CRm ":" # op2); tmp = (Rt); } while(0)
 #define __get_CP64(cp, op1, Rt, CRm) \
   do { \
     uint32_t ltmp, htmp; \


### PR DESCRIPTION
### Description

This fix is to prevent optimization code removal (only ARM build) for Renesas Cortex-A9 targets (GR-PEACH and GR-LYCHEE).
The problem ~~was accidentally introduced~~ potentially existed and was surfaced with this PR https://github.com/ARMmbed/mbed-os/pull/6273

https://github.com/ARMmbed/mbed-os/commit/d8cb72a0a2c440edb66d3954a064f17dabd9746a#diff-bf05db1901365d4d793784baf718227eR953

The ARM compiler removed `__set_CP` inlined functions (`__set_DCISW`, `__set_DCCSW` and `__set_DCCISW`) by optimization and target startup in the `SystemInit()` does not work properly.  i.e. just hangs at startup
This fix prevents unnecessary compiler optimization and startup code initialize cache memory as expected.

You can see codegen difference by armcc here.
[codegen_diff.txt](https://github.com/ARMmbed/mbed-os/files/2078988/codegen_diff.txt)

It should fix https://github.com/ARMmbed/mbed-os/issues/7065 and https://github.com/ARMmbed/mbed-os-example-blinky/issues/124

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

### Test result

[mbed-test_gr_lychee_arm.txt](https://github.com/ARMmbed/mbed-os/files/2075605/mbed-test_gr_lychee_arm.txt)
[mbed-test_rz_a1h_arm.txt](https://github.com/ARMmbed/mbed-os/files/2075608/mbed-test_rz_a1h_arm.txt)


