### PR TITLE
Kinetis EMAC: Make number of buffers configurable 

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
@@ -55,7 +55,7 @@ uint8_t *rx_desc_start_addr;
 // RX packet buffer pointers
 emac_mem_buf_t *rx_buff[ENET_RX_RING_LEN];
 // TX packet buffer pointers
-emac_mem_buf_t *tx_buff[ENET_RX_RING_LEN];
+emac_mem_buf_t *tx_buff[ENET_TX_RING_LEN];
 // RX packet payload pointers
 uint32_t *rx_ptr[ENET_RX_RING_LEN];
 

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac_config.h
@@ -32,8 +32,8 @@
 
 #include "fsl_enet.h"
 
-#define ENET_RX_RING_LEN              (16)
-#define ENET_TX_RING_LEN              (8)
+#define ENET_RX_RING_LEN              MBED_CONF_KINETIS_EMAC_RX_RING_LEN
+#define ENET_TX_RING_LEN              MBED_CONF_KINETIS_EMAC_TX_RING_LEN
 
 #define ENET_ETH_MAX_FLEN             (1522) // recommended size for a VLAN frame
 

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/mbed_lib.json
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/mbed_lib.json
@@ -1,0 +1,7 @@
+{
+    "name": "kinetis-emac",
+    "config": {
+        "rx-ring-len": 16,
+        "tx-ring-len": 8
+    }
+}


### PR DESCRIPTION
### Description

16 RX buffers and 8 TX buffers is probably excessive. Nanostack version of driver ( https://github.com/ARMmbed/sal-nanostack-driver-k64f-eth ) successfully used 4+4, and data pump should be broadly equivalent.

This means that switching K64F devices from Nanostack to EMAC for 5.9 increases base heap usage by 18K - observed in Nanostack border router builds.

Add a config option to make it possible for border router and others  to lower the number of buffers.  

Defer consideration of lowering the default to later - leaving it as 16+8 for now.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

