### PR TITLE
NRF52: add a separate .nvictable section and allow .noinit to be used…

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -35,7 +35,7 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE {
    .ANY (+RO)
   }
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section
-        *(*noinit)
+        *(*nvictable)
   }
   RW_IRAM1 MBED_RAM1_START MBED_RAM1_SIZE {
    .ANY (+RW +ZI)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -199,13 +199,20 @@ SECTIONS
 
     __edata = .;
 
+    .nvictable (NOLOAD) :
+    {
+      PROVIDE(__start_nvictable = .);
+      KEEP(*(.nvictable))
+      PROVIDE(__stop_nvictable = .);
+    } > RAM_NVIC
+
     .noinit (NOLOAD) :
     {
       PROVIDE(__start_noinit = .);
       KEEP(*(.noinit))
       PROVIDE(__stop_noinit = .);
-    } > RAM_NVIC
-    
+    } > RAM
+
     .bss :
     {
         . = ALIGN(4);

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -54,8 +54,12 @@ define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
 initialize by copy { readwrite };
+do not initialize  { section .nvictable };
+place at address mem:__ICFEDIT_region_RAM_NVIC_start__ { section .nvictable };
+
 do not initialize  { section .noinit };
-place at address mem:__ICFEDIT_region_RAM_NVIC_start__ { section .noinit };
+place in RAM_region { section .noinit };
+
 
 keep { section .intvec };
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -198,12 +198,19 @@ SECTIONS
 
     __edata = .;
 
+    .nvictable (NOLOAD) :
+    {
+      PROVIDE(__start_nvictable = .);
+      KEEP(*(.nvictable))
+      PROVIDE(__stop_nvictable = .);
+    } > RAM_NVIC
+
     .noinit (NOLOAD) :
     {
       PROVIDE(__start_noinit = .);
       KEEP(*(.noinit))
       PROVIDE(__stop_noinit = .);
-    } > RAM_NVIC
+    } > RAM
 
     .bss :
     {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -46,13 +46,13 @@
 #endif
 
 #if defined(__CC_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
-    __attribute__ ((section(".bss.noinit"),zero_init))
+    __attribute__ ((section(".bss.nvictable"),zero_init))
     uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
 #elif defined(__GNUC__)
-    __attribute__ ((section(".noinit")))
+    __attribute__ ((section(".nvictable")))
     uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS];
 #elif defined(__ICCARM__)
-    uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS] @ ".noinit";
+    uint32_t nrf_dispatch_vector[NVIC_NUM_VECTORS] @ ".nvictable";
 #endif
 
 extern uint32_t __Vectors[];


### PR DESCRIPTION
### Description

Creates a separate section for the NVIC relocated vector table.
Yields the common .noinit for application use cases.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [X] Breaking change

This could be potentially breaking if an app does some dynamic vector table modifcation or similiar.
