### PR TITLE
Cellular: Added power and sim greentea and unit tests.

### DIFF
--- a/features/cellular/TESTS/api/cellular_power/main.cpp
+++ b/features/cellular/TESTS/api/cellular_power/main.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if !defined(MBED_CONF_NSAPI_PRESENT)
+#error [NOT_SUPPORTED] A json configuration file is needed. Skipping this build.
+#endif
+
+#include "CellularUtil.h" // for CELLULAR_ helper macros
+#include "CellularTargets.h"
+
+#ifndef CELLULAR_DEVICE
+#error [NOT_SUPPORTED] CELLULAR_DEVICE must be defined
+#endif
+
+#ifndef MBED_CONF_APP_CELLULAR_SIM_PIN
+#error [NOT_SUPPORTED] SIM pin code is needed. Skipping this build.
+#endif
+
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+#include "mbed.h"
+
+#include "CellularDevice.h"
+#include "../../cellular_tests_common.h"
+#include CELLULAR_STRINGIFY(CELLULAR_DEVICE.h)
+
+#define NETWORK_TIMEOUT (180*1000)
+
+static UARTSerial cellular_serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
+static CELLULAR_DEVICE* cellular_device;
+static EventQueue queue(2 * EVENTS_EVENT_SIZE);
+
+static void urc_callback()
+{
+}
+
+static void wait_for_power(CellularPower* pwr)
+{
+    nsapi_error_t err = pwr->set_device_ready_urc_cb(&urc_callback);
+    MBED_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_UNSUPPORTED);
+
+    int sanity_count = 0;
+    while (pwr->is_device_ready() != NSAPI_ERROR_OK) {
+        sanity_count++;
+        wait(1);
+        MBED_ASSERT(sanity_count < 20);
+    }
+
+    err = pwr->set_at_mode();
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+
+    pwr->remove_device_ready_urc_cb(&urc_callback);
+}
+
+static void test_power_interface()
+{
+    cellular_device = new CELLULAR_DEVICE(queue);
+    CellularPower* pwr = cellular_device->open_power(&cellular_serial);
+
+    nsapi_error_t err = pwr->on();
+    MBED_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_UNSUPPORTED);
+    wait_for_power(pwr);
+
+    MBED_ASSERT(pwr->set_power_level(1,0) == NSAPI_ERROR_OK);
+
+    err = pwr->reset();
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+    wait_for_power(pwr);
+
+    err = pwr->off();
+    MBED_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_UNSUPPORTED);
+}
+
+using namespace utest::v1;
+
+static utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
+{
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_ABORT;
+}
+
+static Case cases[] = {
+    Case("CellularPower test interface", test_power_interface, greentea_failure_handler)
+};
+
+static utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10*60, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+static Specification specification(test_setup, cases);
+
+int main()
+{
+#if MBED_CONF_MBED_TRACE_ENABLE
+    trace_open();
+#endif
+    int ret = Harness::run(specification);
+#if MBED_CONF_MBED_TRACE_ENABLE
+    trace_close();
+#endif
+    return ret;
+}

--- a/features/cellular/TESTS/api/cellular_sim/main.cpp
+++ b/features/cellular/TESTS/api/cellular_sim/main.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#if !defined(MBED_CONF_NSAPI_PRESENT)
+#error [NOT_SUPPORTED] A json configuration file is needed. Skipping this build.
+#endif
+
+#include "CellularUtil.h" // for CELLULAR_ helper macros
+#include "CellularTargets.h"
+
+#ifndef CELLULAR_DEVICE
+#error [NOT_SUPPORTED] CELLULAR_DEVICE must be defined
+#endif
+
+#ifndef MBED_CONF_APP_CELLULAR_SIM_PIN
+#error [NOT_SUPPORTED] SIM pin code is needed. Skipping this build.
+#endif
+
+#include "greentea-client/test_env.h"
+#include "unity.h"
+#include "utest.h"
+
+#include "mbed.h"
+
+#include "CellularConnectionFSM.h"
+#include "CellularDevice.h"
+#include "../../cellular_tests_common.h"
+#include CELLULAR_STRINGIFY(CELLULAR_DEVICE.h)
+
+#define NETWORK_TIMEOUT (180*1000)
+
+static UARTSerial cellular_serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SERIAL_BAUD_RATE);
+static EventQueue queue(8 * EVENTS_EVENT_SIZE);
+static rtos::Semaphore network_semaphore(0);
+static CellularConnectionFSM cellular;
+static CellularConnectionFSM::CellularState cellular_target_state;
+
+static char *get_rand_string(char *str, size_t size)
+{
+    const char charset[] = "0123456789";
+    if (size) {
+        --size;
+        for (size_t n = 0; n < size; n++) {
+            int key = rand() % (int) (sizeof charset - 1);
+            str[n] = charset[key];
+        }
+        str[size] = '\0';
+    }
+    return str;
+}
+
+static bool fsm_callback(int state, int next_state)
+{
+    if (next_state == CellularConnectionFSM::STATE_SIM_PIN) {
+        MBED_ASSERT(network_semaphore.release() == osOK);
+        return false;
+    }
+    return true;
+}
+
+static void init_to_sim_state()
+{
+    cellular.set_serial(&cellular_serial);
+    TEST_ASSERT(cellular.init() == NSAPI_ERROR_OK);
+#if defined (MDMRTS) && defined (MDMCTS)
+    cellular_serial.set_flow_control(SerialBase::RTSCTS, MDMRTS, MDMCTS);
+#endif
+    cellular.set_callback(&fsm_callback);
+    TEST_ASSERT(cellular.start_dispatch() == NSAPI_ERROR_OK);
+    cellular_target_state = CellularConnectionFSM::STATE_SIM_PIN;
+    TEST_ASSERT(cellular.continue_to_state(cellular_target_state) == NSAPI_ERROR_OK);
+    TEST_ASSERT(network_semaphore.wait(NETWORK_TIMEOUT) == 1);
+}
+
+static void test_sim_interface()
+{
+    CellularSIM *sim = cellular.get_sim();
+    TEST_ASSERT(sim != NULL);
+
+    // 1. test set_pin
+    nsapi_error_t err = sim->set_pin(MBED_CONF_APP_CELLULAR_SIM_PIN);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+
+    // 2. test change pin
+    char pin[5];
+    int sanity_count = 0;
+    while (strcmp(get_rand_string(pin, 5), MBED_CONF_APP_CELLULAR_SIM_PIN) == 0) {
+        sanity_count++;
+        TEST_ASSERT(sanity_count < 50);
+    };
+
+    // change pin and change it back
+    err = sim->change_pin(MBED_CONF_APP_CELLULAR_SIM_PIN, pin);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+    err = sim->change_pin(pin, MBED_CONF_APP_CELLULAR_SIM_PIN);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+
+    // 3. test set_pin_query
+    err = sim->set_pin_query(MBED_CONF_APP_CELLULAR_SIM_PIN, false);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+    err = sim->set_pin_query(MBED_CONF_APP_CELLULAR_SIM_PIN, true);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+
+    // 4. test get_sim_state
+    CellularSIM::SimState state;
+    err = sim->get_sim_state(state);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+    MBED_ASSERT(state == CellularSIM::SimStateReady);
+
+    // 5. test get_imsi
+    char imsi[16] = {0};
+    err = sim->get_imsi(imsi);
+    MBED_ASSERT(err == NSAPI_ERROR_OK);
+    MBED_ASSERT(strlen(imsi) > 0);
+}
+
+using namespace utest::v1;
+
+static utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
+{
+    greentea_case_failure_abort_handler(source, reason);
+    return STATUS_ABORT;
+}
+
+static Case cases[] = {
+    Case("CellularSIM init", init_to_sim_state, greentea_failure_handler),
+    Case("CellularSIM test interface", test_sim_interface, greentea_failure_handler)
+};
+
+static utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10*60, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+static Specification specification(test_setup, cases);
+
+int main()
+{
+#if MBED_CONF_MBED_TRACE_ENABLE
+    trace_open();
+#endif
+    int ret = Harness::run(specification);
+#if MBED_CONF_MBED_TRACE_ENABLE
+    trace_close();
+#endif
+    return ret;
+}

--- a/features/cellular/TESTS/cellular_tests_common.h
+++ b/features/cellular/TESTS/cellular_tests_common.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef CELLULAR_TESTS_COMMON_H_
+#define CELLULAR_TESTS_COMMON_H_
+
+#include "CellularLog.h"
+
+#if MBED_CONF_MBED_TRACE_ENABLE
+
+static rtos::Mutex trace_mutex;
+
+void trace_wait()
+{
+    trace_mutex.lock();
+}
+
+void trace_release()
+{
+    trace_mutex.unlock();
+}
+
+static char time_st[sizeof("[12345678]") + 1];
+
+static char *trace_time(size_t ss)
+{
+    snprintf(time_st, sizeof("[12345678]"), "[%08llu]", rtos::Kernel::get_ms_count());
+    return time_st;
+}
+
+static void trace_open()
+{
+    mbed_trace_init();
+    mbed_trace_prefix_function_set(&trace_time);
+    mbed_trace_mutex_wait_function_set(trace_wait);
+    mbed_trace_mutex_release_function_set(trace_release);
+
+    mbed_cellular_trace::mutex_wait_function_set(trace_wait);
+    mbed_cellular_trace::mutex_release_function_set(trace_release);
+}
+
+static void trace_close()
+{
+    mbed_cellular_trace::mutex_wait_function_set(NULL);
+    mbed_cellular_trace::mutex_release_function_set(NULL);
+
+    mbed_trace_free();
+}
+
+#endif // MBED_CONF_MBED_TRACE_ENABLE
+
+
+#endif /* CELLULAR_TESTS_COMMON_H_ */

--- a/features/cellular/TESTS/socket/udp/main.cpp
+++ b/features/cellular/TESTS/socket/udp/main.cpp
@@ -42,7 +42,7 @@
 #include "APN_db.h"
 #endif //MBED_CONF_CELLULAR_USE_APN_LOOKUP || MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP
 
-#include "CellularLog.h"
+#include "../../cellular_tests_common.h"
 
 #define NETWORK_TIMEOUT (180*1000)
 #define SOCKET_TIMEOUT (30*1000)
@@ -55,51 +55,7 @@ static UARTSerial cellular_serial(MDMTXD, MDMRXD, MBED_CONF_PLATFORM_DEFAULT_SER
 static rtos::Semaphore network_semaphore(0);
 static CellularConnectionFSM cellular;
 
-#if MBED_CONF_MBED_TRACE_ENABLE
-
-static rtos::Mutex trace_mutex;
-
-void trace_wait()
-{
-    trace_mutex.lock();
-}
-
-void trace_release()
-{
-    trace_mutex.unlock();
-}
-
-static char time_st[sizeof("[12345678]") + 1];
-
-static char *trace_time(size_t ss)
-{
-    snprintf(time_st, sizeof("[12345678]"), "[%08llu]", rtos::Kernel::get_ms_count());
-    return time_st;
-}
-
-static void trace_open()
-{
-    mbed_trace_init();
-    mbed_trace_prefix_function_set(&trace_time);
-    mbed_trace_mutex_wait_function_set(trace_wait);
-    mbed_trace_mutex_release_function_set(trace_release);
-
-    mbed_cellular_trace::mutex_wait_function_set(trace_wait);
-    mbed_cellular_trace::mutex_release_function_set(trace_release);
-}
-
-static void trace_close()
-{
-    mbed_cellular_trace::mutex_wait_function_set(NULL);
-    mbed_cellular_trace::mutex_release_function_set(NULL);
-
-    mbed_trace_free();
-}
-
-#endif // MBED_CONF_MBED_TRACE_ENABLE
-
 static SocketAddress echo_server_addr;
-
 static rtos::EventFlags eventFlags;
 
 class EchoSocket : public UDPSocket {

--- a/features/cellular/UNITTESTS/at/at_cellularpower/at_cellularpowertest.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularpower/at_cellularpowertest.cpp
@@ -77,3 +77,17 @@ TEST(AT_CellularPower, test_AT_CellularPower_opt_receive_period)
     unit->test_AT_CellularPower_opt_receive_period();
 }
 
+TEST(AT_CellularPower, test_AT_CellularPower_is_device_ready)
+{
+    unit->test_AT_CellularPower_is_device_ready();
+}
+
+TEST(AT_CellularPower, test_AT_CellularPower_set_device_ready_urc_cb)
+{
+    unit->test_AT_CellularPower_set_device_ready_urc_cb();
+}
+
+TEST(AT_CellularPower, test_AT_CellularPower_remove_device_ready_urc_cb)
+{
+    unit->test_AT_CellularPower_remove_device_ready_urc_cb();
+}

--- a/features/cellular/UNITTESTS/at/at_cellularpower/test_at_cellularpower.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularpower/test_at_cellularpower.cpp
@@ -54,7 +54,7 @@ void Test_AT_CellularPower::test_AT_CellularPower_on()
     ATHandler at(&fh1, que, 0, ",");
 
     AT_CellularPower pow(at);
-    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.on())
+    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.on());
 }
 
 void Test_AT_CellularPower::test_AT_CellularPower_off()
@@ -64,7 +64,7 @@ void Test_AT_CellularPower::test_AT_CellularPower_off()
     ATHandler at(&fh1, que, 0, ",");
 
     AT_CellularPower pow(at);
-    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.off())
+    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.off());
 }
 
 void Test_AT_CellularPower::test_AT_CellularPower_set_at_mode()
@@ -75,7 +75,7 @@ void Test_AT_CellularPower::test_AT_CellularPower_set_at_mode()
 
     AT_CellularPower pow(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
-    CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.set_at_mode())
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.set_at_mode());
 }
 
 void Test_AT_CellularPower::test_AT_CellularPower_set_power_level()
@@ -87,6 +87,8 @@ void Test_AT_CellularPower::test_AT_CellularPower_set_power_level()
     AT_CellularPower pow(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.set_power_level(6));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.set_power_level(1,1));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.set_power_level(1,0));
 }
 
 void Test_AT_CellularPower::test_AT_CellularPower_reset()
@@ -135,4 +137,42 @@ void Test_AT_CellularPower::test_AT_CellularPower_opt_receive_period()
     AT_CellularPower pow(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.opt_receive_period(1, CellularPower::EDRXUTRAN_Iu_mode, 3));
+}
+
+void Test_AT_CellularPower::test_AT_CellularPower_is_device_ready()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularPower pow(at);
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == pow.is_device_ready());
+}
+
+static void device_ready_cb()
+{
+}
+
+void Test_AT_CellularPower::test_AT_CellularPower_set_device_ready_urc_cb()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularPower pow(at);
+    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.set_device_ready_urc_cb(&device_ready_cb));
+}
+
+void Test_AT_CellularPower::test_AT_CellularPower_remove_device_ready_urc_cb()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    AT_CellularPower pow(at);
+    CHECK(NSAPI_ERROR_UNSUPPORTED == pow.set_device_ready_urc_cb(&device_ready_cb));
+
+    pow.remove_device_ready_urc_cb(NULL);
+    pow.remove_device_ready_urc_cb(&device_ready_cb);
 }

--- a/features/cellular/UNITTESTS/at/at_cellularpower/test_at_cellularpower.h
+++ b/features/cellular/UNITTESTS/at/at_cellularpower/test_at_cellularpower.h
@@ -39,6 +39,12 @@ public:
     void test_AT_CellularPower_opt_power_save_mode();
 
     void test_AT_CellularPower_opt_receive_period();
+
+    void test_AT_CellularPower_is_device_ready();
+
+    void test_AT_CellularPower_set_device_ready_urc_cb();
+
+    void test_AT_CellularPower_remove_device_ready_urc_cb();
 };
 
 #endif // TEST_AT_CELLULARPOWER_H

--- a/features/cellular/UNITTESTS/at/at_cellularsim/at_cellularsimtest.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularsim/at_cellularsimtest.cpp
@@ -62,3 +62,8 @@ TEST(AT_CellularSIM, test_AT_CellularSIM_get_sim_state)
     unit->test_AT_CellularSIM_get_sim_state();
 }
 
+TEST(AT_CellularSIM, test_AT_CellularSIM_get_imsi)
+{
+    unit->test_AT_CellularSIM_get_imsi();
+}
+

--- a/features/cellular/UNITTESTS/at/at_cellularsim/test_at_cellularsim.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularsim/test_at_cellularsim.cpp
@@ -65,6 +65,8 @@ void Test_AT_CellularSIM::test_AT_CellularSIM_set_pin()
     ATHandler_stub::read_string_value = table2;
     ATHandler_stub::ssize_value = 5;
     CHECK(NSAPI_ERROR_OK == sim.set_pin("12"));
+
+    CHECK(NSAPI_ERROR_OK == sim.set_pin(NULL));
 }
 
 void Test_AT_CellularSIM::test_AT_CellularSIM_change_pin()
@@ -76,6 +78,10 @@ void Test_AT_CellularSIM::test_AT_CellularSIM_change_pin()
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.change_pin("12", "34"));
+
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.change_pin(NULL, "34"));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.change_pin("12", NULL));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.change_pin(NULL, NULL));
 }
 
 void Test_AT_CellularSIM::test_AT_CellularSIM_set_pin_query()
@@ -87,9 +93,11 @@ void Test_AT_CellularSIM::test_AT_CellularSIM_set_pin_query()
     AT_CellularSIM sim(at);
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.set_pin_query("12", true));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.set_pin_query(NULL, true));
 
     ATHandler_stub::nsapi_error_value = NSAPI_ERROR_AUTH_FAILURE;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.set_pin_query("12", false));
+    CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.set_pin_query(NULL, false));
 }
 
 void Test_AT_CellularSIM::test_AT_CellularSIM_get_sim_state()
@@ -128,4 +136,26 @@ void Test_AT_CellularSIM::test_AT_CellularSIM_get_sim_state()
     ATHandler_stub::ssize_value = 9;
     CHECK(NSAPI_ERROR_AUTH_FAILURE == sim.get_sim_state(state));
     CHECK(CellularSIM::SimStateUnknown == state);
+}
+
+void Test_AT_CellularSIM::test_AT_CellularSIM_get_imsi()
+{
+    EventQueue que;
+    FileHandle_stub fh1;
+    ATHandler at(&fh1, que, 0, ",");
+
+    char imsi[16];
+    AT_CellularSIM sim(at);
+    ATHandler_stub::nsapi_error_value = NSAPI_ERROR_OK;
+    ATHandler_stub::read_string_value = "123456789012345";
+    ATHandler_stub::ssize_value = 15;
+    CHECK(NSAPI_ERROR_OK == sim.get_imsi(imsi));
+    CHECK(strcmp(ATHandler_stub::read_string_value, imsi) == 0);
+
+    CHECK(NSAPI_ERROR_PARAMETER == sim.get_imsi(NULL));
+
+    // this would fail as get_imsi should take another param which is the size of the buffer which we could use for validation.
+    // Now we have improved documentation that that the given imsi buffer size must be over 15.
+    //char imsi2[5];
+    //CHECK(NSAPI_ERROR_PARAMETER == sim.get_imsi(imsi2));
 }

--- a/features/cellular/UNITTESTS/at/at_cellularsim/test_at_cellularsim.h
+++ b/features/cellular/UNITTESTS/at/at_cellularsim/test_at_cellularsim.h
@@ -33,6 +33,8 @@ public:
     void test_AT_CellularSIM_set_pin_query();
 
     void test_AT_CellularSIM_get_sim_state();
+
+    void test_AT_CellularSIM_get_imsi();
 };
 
 #endif // TEST_AT_CELLULARSIM_H

--- a/features/cellular/UNITTESTS/common/util/Makefile
+++ b/features/cellular/UNITTESTS/common/util/Makefile
@@ -10,6 +10,7 @@ TEST_SRC_FILES = \
 	main.cpp \
         utiltest.cpp \
         test_util.cpp \
+        ../../stubs/randLIB_stub.cpp \
 
 include ../../MakefileWorker.mk
 

--- a/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -90,21 +90,6 @@ nsapi_error_t AT_CellularNetwork::set_blocking(bool blocking)
     return NSAPI_ERROR_OK;;
 }
 
-nsapi_error_t AT_CellularNetwork::set_context_to_be_activated()
-{
-    return NSAPI_ERROR_OK;
-}
-
-//bool AT_CellularNetwork::set_new_context(nsapi_ip_stack_t stack, int cid)
-//{
-//  return false;
-//}
-
-//bool AT_CellularNetwork::get_context(nsapi_ip_stack_t requested_stack)
-//{
-//    return false;
-//}
-
 nsapi_ip_stack_t AT_CellularNetwork::string_to_stack_type(const char* pdp_type)
 {
     return IPV4_STACK;
@@ -261,3 +246,11 @@ nsapi_error_t AT_CellularNetwork::get_operator_names(operator_names_list &op_nam
 {
     return NSAPI_ERROR_OK;
 }
+
+nsapi_error_t AT_CellularNetwork::do_user_authentication()
+{
+    return NSAPI_ERROR_OK;
+}
+
+
+

--- a/features/cellular/UNITTESTS/stubs/AT_CellularPower_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/AT_CellularPower_stub.cpp
@@ -45,7 +45,7 @@ nsapi_error_t AT_CellularPower::set_at_mode()
     return NSAPI_ERROR_OK;
 }
 
-nsapi_error_t AT_CellularPower::set_power_level(int func_level)
+nsapi_error_t AT_CellularPower::set_power_level(int func_level, int do_reset)
 {
     return NSAPI_ERROR_OK;
 }

--- a/features/cellular/UNITTESTS/stubs/randLIB_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/randLIB_stub.cpp
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "randLIB.h"
+
+void randLIB_seed_random(void)
+{
+}
+
+uint16_t randLIB_get_random_in_range(uint16_t min, uint16_t max)
+{
+    return min;
+}
+

--- a/features/cellular/UNITTESTS/target_h/mbed-trace/mbed_trace.h
+++ b/features/cellular/UNITTESTS/target_h/mbed-trace/mbed_trace.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,11 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_OS_FEATURES_CELLULAR_MBED_TRACE_H_
-#define MBED_OS_FEATURES_CELLULAR_MBED_TRACE_H_
+#ifndef CELLULAR_UNITTESTS_MBED_TRACE_H_
+#define CELLULAR_UNITTESTS_MBED_TRACE_H_
 
-
-//usage macros:
 #define tr_debug(...)
 #define tr_info(...)
 #define tr_warning(...)
@@ -26,5 +24,4 @@
 #define tr_error(...)
 #define tr_err(...)
 
-
-#endif /* MBED_OS_FEATURES_CELLULAR_MBED_TRACE_H_ */
+#endif /* CELLULAR_UNITTESTS_MBED_TRACE_H_ */

--- a/features/cellular/UNITTESTS/target_h/randLIB.h
+++ b/features/cellular/UNITTESTS/target_h/randLIB.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2017, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef FEATURES_CELLULAR_UNITTESTS_TARGET_H_RANDLIB_H_
+#define FEATURES_CELLULAR_UNITTESTS_TARGET_H_RANDLIB_H_
+
+#include <stdint.h>
+
+extern void randLIB_seed_random(void);
+
+uint16_t randLIB_get_random_in_range(uint16_t min, uint16_t max);
+
+
+#endif /* FEATURES_CELLULAR_UNITTESTS_TARGET_H_RANDLIB_H_ */

--- a/features/cellular/framework/API/CellularPower.h
+++ b/features/cellular/framework/API/CellularPower.h
@@ -86,12 +86,13 @@ public:
      *  2   disable (turn off) MT transmit RF circuits only
      *  3   disable (turn off) MT receive RF circuits only
      *  4   disable (turn off) both MT transmit and receive RF circuits
+     *  @param do_reset     0 for do not reset, 1 for reset the device when changing the functionality
      *
      *  @remark See 3GPP TS 27.007 CFUN for more details
      *
      *  @return zero on success
      */
-    virtual nsapi_error_t set_power_level(int func_level) = 0;
+    virtual nsapi_error_t set_power_level(int func_level, int do_reset = 1) = 0;
 
     /** Reset and wake-up cellular device.
      *

--- a/features/cellular/framework/API/CellularSIM.h
+++ b/features/cellular/framework/API/CellularSIM.h
@@ -56,7 +56,7 @@ public:
      */
     virtual nsapi_error_t set_pin(const char *sim_pin) = 0;
 
-    /**Change sim pin code.
+    /** Change sim pin code.
      *
      *  @param sim_pin  Current PIN for sim
      *  @param new_pin  New PIN for sim
@@ -80,6 +80,7 @@ public:
     virtual nsapi_error_t get_sim_state(SimState &state) = 0;
 
     /** Get IMSI from the sim card
+     *  @remark         Given imsi buffer length must be 16 or more as imsi max length is 15!
      *
      *  @param imsi     preallocated char* which after successful request contains imsi
      *  @return         zero on success

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -142,6 +142,7 @@ protected:
      */
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology op_rat);
 
+    virtual nsapi_error_t do_user_authentication();
 private:
     //  "NO CARRIER" urc
     void urc_no_carrier();
@@ -179,7 +180,6 @@ protected:
     AuthenticationType _authentication_type;
     int _cell_id;
     nsapi_connection_status_t _connect_status;
-    virtual nsapi_error_t do_user_authentication();
     bool _new_context_set;
     bool _is_context_active;
     RegistrationStatus _reg_status;

--- a/features/cellular/framework/AT/AT_CellularPower.cpp
+++ b/features/cellular/framework/AT/AT_CellularPower.cpp
@@ -60,11 +60,12 @@ nsapi_error_t AT_CellularPower::set_at_mode()
     return _at.unlock_return_error();
 }
 
-nsapi_error_t AT_CellularPower::set_power_level(int func_level)
+nsapi_error_t AT_CellularPower::set_power_level(int func_level, int do_reset)
 {
     _at.lock();
     _at.cmd_start("AT+CFUN=");
     _at.write_int(func_level);
+    _at.write_int(do_reset);
     _at.cmd_stop();
     _at.resp_start();
     _at.resp_stop();

--- a/features/cellular/framework/AT/AT_CellularPower.h
+++ b/features/cellular/framework/AT/AT_CellularPower.h
@@ -41,7 +41,7 @@ public:
 
     virtual nsapi_error_t set_at_mode();
 
-    virtual nsapi_error_t set_power_level(int func_level);
+    virtual nsapi_error_t set_power_level(int func_level, int do_reset = 1);
 
     virtual nsapi_error_t reset();
 

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -136,6 +136,9 @@ nsapi_error_t AT_CellularSIM::set_pin_query(const char *sim_pin, bool query_pin)
 
 nsapi_error_t AT_CellularSIM::get_imsi(char *imsi)
 {
+    if (imsi == NULL) {
+        return NSAPI_ERROR_PARAMETER;
+    }
     _at.lock();
     _at.cmd_start("AT+CIMI");
     _at.cmd_stop();

--- a/features/cellular/framework/common/CellularUtil.cpp
+++ b/features/cellular/framework/common/CellularUtil.cpp
@@ -334,7 +334,7 @@ uint16_t get_dynamic_ip_port()
     if (port_counter >= RANDOM_PORT_NUMBER_COUNT) {
         port_counter -= RANDOM_PORT_NUMBER_COUNT;
     }
- 
+
     return (RANDOM_PORT_NUMBER_START + port_counter);
 }
 


### PR DESCRIPTION
### Description
- created power and sim greentea tests
- added more power and sim unit tests.
- added 'int do_reset' param to API CellularPower method "virtual nsapi_error_t set_power_level(int func_level, int do_reset = 1);"
  This does not affect to current behaviour as default value is 1 and then it behaves in the old way.
- AT_CellularSIM::get_imsi(char *imsi) now returns with NSAPI_ERROR_PARAMETER if the given imsi is null. This changes how method behaves but it fixes a crash (and invalid usage of method) so should not make a difference if one thinks this as a API change.

Internal ref to defect: IOTCELL-903-916

@mirelachirica @AnttiKauppila  please review.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change