### PR TITLE
Nordic: Fix nrf sections on ARMCC

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -26,14 +26,10 @@
 LR_IROM1 MBED_APP_START MBED_APP_SIZE {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE {
    *.o (RESET, +First)
-   *(InRoot$$Sections)
-   __start_sdh_soc_observers *(sdh_soc_observers) __stop_sdh_soc_observers
-   __start_sdh_stack_observers *(sdh_stack_observers) __stop_sdh_stack_observers
-   __start_sdh_req_observers *(sdh_req_observers) __stop_sdh_req_observers
-   __start_sdh_state_observers *(sdh_state_observers) __stop_sdh_state_observers
-   __start_sdh_ble_observers *(sdh_ble_observers) __stop_sdh_ble_observers
-   .ANY (+RO)
+   *(InRoot$$Sections)    
+    .ANY (+RO)
   }
+
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section
         *(*noinit)
   }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
@@ -27,11 +27,6 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE {
   ER_IROM1 MBED_APP_START MBED_APP_SIZE {
    *.o (RESET, +First)
    *(InRoot$$Sections)
-   __start_sdh_soc_observers *(sdh_soc_observers) __stop_sdh_soc_observers
-   __start_sdh_stack_observers *(sdh_stack_observers) __stop_sdh_stack_observers
-   __start_sdh_req_observers *(sdh_req_observers) __stop_sdh_req_observers
-   __start_sdh_state_observers *(sdh_state_observers) __stop_sdh_state_observers
-   __start_sdh_ble_observers *(sdh_ble_observers) __stop_sdh_ble_observers   
    .ANY (+RO)
   }
   RW_IRAM0 MBED_RAM0_START UNINIT MBED_RAM0_SIZE { ;no init section

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.c
@@ -45,7 +45,7 @@
 #include "nrf_section_iter.h"
 
 
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__CC_ARM)
 static void nrf_section_iter_item_set(nrf_section_iter_t * p_iter)
 {
     ASSERT(p_iter            != NULL);
@@ -82,7 +82,7 @@ void nrf_section_iter_init(nrf_section_iter_t * p_iter, nrf_section_set_t const 
 
     p_iter->p_set = p_set;
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     p_iter->p_item = p_iter->p_set->section.p_start;
     if (p_iter->p_item == p_iter->p_set->section.p_end)
     {
@@ -106,7 +106,7 @@ void nrf_section_iter_next(nrf_section_iter_t * p_iter)
 
     p_iter->p_item = (void *)((size_t)(p_iter->p_item) + p_iter->p_set->item_size);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     if (p_iter->p_item == p_iter->p_set->section.p_end)
     {
         p_iter->p_item = NULL;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section_iter.h
@@ -68,7 +68,7 @@ typedef struct
 /**@brief Set of the sections description structure. */
 typedef struct
 {
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     nrf_section_t           section;    //!< Description of the set of sections.
                                         /**<
                                          * In case of GCC all sections in the set are sorted and
@@ -87,7 +87,7 @@ typedef struct
 typedef struct
 {
     nrf_section_set_t const * p_set;        //!< Pointer to the appropriate section set.
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__CC_ARM)
     nrf_section_t const     * p_section;    //!< Pointer to the selected section.
                                             /**<
                                              * In case of GCC all sections in the set are sorted and
@@ -110,7 +110,7 @@ typedef struct
  * @param[in]   _count  Number of the sections in the set. This parameter is ignored in case of GCC.
  * @hideinitializer
  */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
 
 #define NRF_SECTION_SET_DEF(_name, _type, _count)                                                   \
                                                                                                     \


### PR DESCRIPTION
### Description

The nrf section features has different implementations for each compilers supported by mbed-os. The header guard was ruling out compiler other than GCC by checking if __GNUC__ is defined. This check is not applicable on mbed os as the ARM compiler compile sources with gnu compatibility.

This patch makes sure that the right implementation is selected for the right compiler . The previous patch has been reverted as it is not reliable.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

