### PR TITLE
Fixes for RZ_A1H issue 6543

### DIFF
--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -25,9 +25,16 @@
 
 #include "hal/lp_ticker_api.h"
 #include "mbed_critical.h"
+#if defined(TARGET_CORTEX_A)
+#include "rtx_core_ca.h"
+#else//Cortex-M
 #include "rtx_core_cm.h"
+#endif
 extern "C" {
 #include "rtx_lib.h"
+#if defined(TARGET_CORTEX_A)
+#include "irq_ctrl.h"
+#endif
 }
 
 #if (defined(NO_SYSTICK))
@@ -58,7 +65,7 @@ SysTimer::SysTimer(const ticker_data_t *data) :
 
 void SysTimer::setup_irq()
 {
-#if (defined(NO_SYSTICK))
+#if (defined(NO_SYSTICK) && !defined (TARGET_CORTEX_A))
     NVIC_SetVector(mbed_get_m0_tick_irqn(), (uint32_t)SysTick_Handler);
     NVIC_SetPriority(mbed_get_m0_tick_irqn(), 0xFF); /* RTOS requires lowest priority */
     NVIC_EnableIRQ(mbed_get_m0_tick_irqn());
@@ -148,6 +155,8 @@ void SysTimer::_set_irq_pending()
 
 #if (defined(NO_SYSTICK))
     NVIC_SetPendingIRQ(mbed_get_m0_tick_irqn());
+#elif (TARGET_CORTEX_A)
+    IRQ_SetPending(mbed_get_a9_tick_irqn());
 #else
     SCB->ICSR = SCB_ICSR_PENDSTSET_Msk;
 #endif

--- a/rtos/TARGET_CORTEX/rtx5/Include/os_tick.h
+++ b/rtos/TARGET_CORTEX/rtx5/Include/os_tick.h
@@ -26,6 +26,9 @@
 #define OS_TICK_H
 
 #include <stdint.h>
+#if defined(TARGET_CORTEX_A)
+#include "irq_ctrl.h"
+#endif
 
 /// IRQ Handler.
 #ifndef IRQHANDLER_T
@@ -68,4 +71,9 @@ uint32_t OS_Tick_GetCount (void);
 /// \return OS Tick overflow status (1 - overflow, 0 - no overflow).
 uint32_t OS_Tick_GetOverflow (void);
 
+/// Get Cortex-A9 OS Timer interrupt number
+/// \returns Cortex-A9 OS Timer interrupt number (134)
+#if defined(TARGET_CORTEX_A)
+IRQn_ID_t mbed_get_a9_tick_irqn(void);
+#endif
 #endif  /* OS_TICK_H */

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -193,5 +193,9 @@ uint32_t OS_Tick_GetOverflow (void)
   return (IRQ_GetPending(OSTM_IRQn));
 }
 
+// Get Cortex-A9 OS Timer interrupt number
+IRQn_ID_t mbed_get_a9_tick_irqn(){
+  return OSTMI0TINT_IRQn;
+}
 #endif
 


### PR DESCRIPTION
### Description
Code to fix build errors in issue 6543. 
I have put debugging code in my remote https://github.com/mrcoulter45/mbed-os in the issue6543_debug branch. That code will build Blinky for the RZ_A1H with GCC_ARM and should be a good starting point for those who are implementing the low power ticker. In the debug code, the us ticker is being used as a substitute for the lp ticker. 
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

