### PR TITLE
Add API to read Thread EUI-64

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
@@ -30,12 +30,12 @@ public:
      *
      *  Must initialize to initialize the mesh on a phy.
      */
-    ThreadInterface() : user_set_eui64(false) { }
+    ThreadInterface() { }
 
     /** Create an initialized ThreadInterface
      *
      */
-    ThreadInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy), user_set_eui64(false) { }
+    ThreadInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy) { }
 
     /**
      * \brief Sets the eui64 for the device configuration.
@@ -43,6 +43,13 @@ public:
      * The value must be set before calling the connect function.
      * */
     void device_eui64_set(const uint8_t *eui64);
+
+    /**
+     * \brief Reads the eui64 from the device configuration.
+     * By default this value is read from the radio driver, but it may have
+     * been set by device_eui64_set().
+     * */
+    void device_eui64_get(uint8_t *eui64);
 
     /**
      * \brief sets the PSKd for the device configuration.
@@ -59,9 +66,6 @@ public:
     virtual int disconnect();
 protected:
     Nanostack::ThreadInterface *get_interface() const;
-
-private:
-    bool user_set_eui64;
 };
 
 #endif // THREADINTERFACE_H

--- a/features/nanostack/mbed-mesh-api/source/include/thread_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/thread_tasklet.h
@@ -59,9 +59,14 @@ int8_t thread_tasklet_network_init(int8_t device_id);
 /*
  * \brief Sets eui64 for the device configuration
  * \param eui64 eui64 to be set
- * \param pskd private shared key
  */
 void thread_tasklet_device_eui64_set(const uint8_t *eui64);
+
+/*
+ * \brief Gets eui64 from the device configuration
+ * \param eui64 buffer for output eui64
+ */
+void thread_tasklet_device_eui64_get(uint8_t *eui64);
 
 /*
  * \brief Sets PSKd for the device configuration

--- a/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
@@ -474,6 +474,11 @@ void thread_tasklet_device_eui64_set(const uint8_t *eui64)
     memcpy(device_configuration.eui64, eui64, 8);
 }
 
+void thread_tasklet_device_eui64_get(uint8_t *eui64)
+{
+    memcpy(eui64, device_configuration.eui64, 8);
+}
+
 uint8_t thread_tasklet_device_pskd_set(const char *pskd)
 {
     int len = strlen(pskd);


### PR DESCRIPTION
### Description

Previously get_mac_address on a ThreadInterface returned the EUI-64
reported by the radio driver. This was required for commissioning, but
was inconsistent with other interfaces, and the API concept.

5.9.0 inadvertently changed this so that get_mac_address returned the
actual MAC address used by the radio, which is a hash result of the
EUI-64 for Thread.

The original "return the EUI-64" form was somewhat faulty, as
get_mac_address would not return the EUI-64 set by set_device_eui64() or
another mechanism before connect() was called.

Rather than revert to old behaviour, add a new API to get the device
EUI-64 to ThreadInterface, alongside the existing set API.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

New API, but required to get commissioning working properly in 5.9 due to an inadvertent (but desirable) behaviour change.
