### PR TITLE
Add targets to Greentea EMAC tests

### DIFF
--- a/TESTS/network/emac/emac_test_initialize.cpp
+++ b/TESTS/network/emac/emac_test_initialize.cpp
@@ -32,11 +32,16 @@
 
 #if MBED_CONF_APP_TEST_WIFI
 
-#ifdef TARGET_UBLOX_EVK_ODIN_W2
+#if defined(TARGET_UBLOX_EVK_ODIN_W2) || defined(TARGET_MTB_UBLOX_ODIN_W2)
 #include "OdinWiFiInterface.h"
 #endif
 #ifdef TARGET_REALTEK_RTL8195AM
 #include "RTWInterface.h"
+#endif
+#if defined(TARGET_MTB_ADV_WISE_1530)   || \
+    defined(TARGET_MTB_USI_WM_BN_BM_22) || \
+    defined(TARGET_MTB_MXCHIP_EMW3166)
+#include "WicedInterface.h"
 #endif
 
 #endif
@@ -61,10 +66,14 @@ void test_emac_initialize()
 #elif MBED_CONF_APP_TEST_WIFI
 
     // Add wifi classes here
-#ifdef TARGET_UBLOX_EVK_ODIN_W2
+#if defined(TARGET_UBLOX_EVK_ODIN_W2) || defined(TARGET_MTB_UBLOX_ODIN_W2)
     static WiFiInterface *network_interface = new OdinWiFiInterface;
-#elif TARGET_REALTEK_RTL8195AM
+#elif defined(TARGET_REALTEK_RTL8195AM)
     static WiFiInterface *network_interface = new RTWInterface;
+#elif defined(TARGET_MTB_ADV_WISE_1530)   || \
+      defined(TARGET_MTB_USI_WM_BN_BM_22) || \
+      defined(TARGET_MTB_MXCHIP_EMW3166)
+    static WiFiInterface *network_interface = new WicedInterface;
 #else
     static WiFiInterface *network_interface = new WiFiInterface;
 #endif

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -33,8 +33,13 @@
 #error [NOT_SUPPORTED] Both wifi and ethernet testing cannot be enabled
 #endif
 #if MBED_CONF_APP_TEST_WIFI
-#if !defined(TARGET_UBLOX_EVK_ODIN_W2) && !defined(TARGET_REALTEK_RTL8195AM)
-#error [NOT_SUPPORTED] Tests are valid only for UBLOX_EVK_ODIN_W2 and REALTEK_RTL8195AM
+#if !defined(TARGET_UBLOX_EVK_ODIN_W2)      && \
+    !defined(TARGET_REALTEK_RTL8195AM)      && \
+    !defined(TARGET_MTB_ADV_WISE_1530)      && \
+    !defined(TARGET_MTB_USI_WM_BN_BM_22)    && \
+    !defined(TARGET_MTB_MXCHIP_EMW3166)     && \
+    !defined(TARGET_MTB_UBLOX_ODIN_W2)
+#error [NOT_SUPPORTED] Wifi tests are not valid for the target
 #endif
 #endif
 

--- a/tools/test_configs/WicedInterface.json
+++ b/tools/test_configs/WicedInterface.json
@@ -9,7 +9,7 @@
         },
         "connect-statement" : {
             "help" : "Must use 'net' variable name, replace WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY with your WiFi settings",
-            "value" : "((WicedInterface *)net)->connect(WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY)"
+            "value" : "net->wifiInterface()->connect(WIFI_SSID, WIFI_PASSWORD, WIFI_SECURITY)"
         },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
@@ -30,6 +30,9 @@
         }
     },
     "target_overrides": {
+        "*": {
+            "nsapi.default-stack": "LWIP"
+        },
         "MTB_ADV_WISE_1530": {
             "target.extra_labels_add": ["WICED"],
             "target.features_add": ["BLE", "LWIP"]


### PR DESCRIPTION
### Description

Add Greentea EMAC test support for below targets
- MTB_ADV_WISE_1530
- MTB_USI_WM_BN_BM_22
- MTB_MXCHIP_EMW3166
- MTB_UBLOX_ODIN_W2

Update test configuration file for WicedInterface

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

