### PR TITLE
Fixed ppp_lwip_disconnect hangs when connection failure.

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -374,11 +374,9 @@ nsapi_error_t AT_CellularNetwork::disconnect()
     nsapi_error_t err = nsapi_ppp_disconnect(_at.get_file_handle());
     // after ppp disconnect if we wan't to use same at handler we need to set filehandle again to athandler so it
     // will set the correct sigio and nonblocking
-    if (err == NSAPI_ERROR_OK) {
-        _at.lock();
-        _at.set_file_handle(_at.get_file_handle());
-        _at.unlock();
-    }
+    _at.lock();
+    _at.set_file_handle(_at.get_file_handle());
+    _at.unlock();
     return err;
 #else
     _at.lock();


### PR DESCRIPTION
### Description
- fixed ppp_lwip_disconnect hangs when connection failure.
- improved nsapi_ppp_connect error handling
- fixing issue https://github.com/ARMmbed/mbed-os/issues/6979

@AriParkkila @kjbracey-arm please review.

Internal ref to defect: IOTCELL-1028

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

