### PR TITLE
Correct PPPCellularInterface::get_gateway()

### DIFF
--- a/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
+++ b/features/FEATURE_LWIP/lwip-interface/ppp_lwip.cpp
@@ -434,7 +434,7 @@ const char *nsapi_ppp_get_gw_addr(FileHandle *stream)
 
     static char gwaddr[IPADDR_STRLEN_MAX];
     if (stream == my_stream) {
-        if (my_interface->get_netmask(gwaddr, IPADDR_STRLEN_MAX)) {
+        if (my_interface->get_gateway(gwaddr, IPADDR_STRLEN_MAX)) {
             return gwaddr;
         }
     }

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.cpp
@@ -749,7 +749,7 @@ const char *PPPCellularInterface::get_netmask()
 
 const char *PPPCellularInterface::get_gateway()
 {
-    return nsapi_ppp_get_ip_addr(_fh);
+    return nsapi_ppp_get_gw_addr(_fh);
 }
 
 /** Power down modem


### PR DESCRIPTION

### Description

Two cascading copy-paste errors stopped this working:

  * PPPCellularInterface::get_gateway() called nsapi_ppp_get_ip_address();
  * nsapi_ppp_get_gateway() called the interface's get_netmask().

First bug has always been there - second one was introduced in 5.9.

AT_CellularNetwork currently lacks calls to get both netmask and gateway - this patch would be needed for that when added.


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

