### PR TITLE
Add FileHandle::truncate and ftruncate

### DIFF
--- a/TESTS/mbed_platform/FileHandle/TestFile.h
+++ b/TESTS/mbed_platform/FileHandle/TestFile.h
@@ -30,7 +30,7 @@ public:
     ~TestFile() {}
 
     enum FunctionName {
-        fnNone, fnRead, fnWrite, fnSeek, fnClose, fnIsatty
+        fnNone, fnRead, fnWrite, fnSeek, fnClose, fnIsatty, fnTruncate
     };
 
     virtual ssize_t read(void *buffer, size_t size)
@@ -104,6 +104,24 @@ public:
     virtual int close()
     {
         _fnCalled = fnClose;
+        return 0;
+    }
+
+    virtual off_t size()
+    {
+        return _end;
+    }
+
+    virtual int truncate(off_t length)
+    {
+        _fnCalled = fnTruncate;
+        if (!NEW_POS_IS_VALID(length)) {
+            return -EINVAL;
+        }
+        while (_end < length) {
+            _data[_end++] = 0;
+        }
+        _end = length;
         return 0;
     }
 

--- a/features/storage/filesystem/File.cpp
+++ b/features/storage/filesystem/File.cpp
@@ -110,4 +110,10 @@ off_t File::size()
     return _fs->file_size(_file);
 }
 
+int File::truncate(off_t length)
+{
+    MBED_ASSERT(_fs);
+    return _fs->file_truncate(_file, length);
+}
+
 } // namespace mbed

--- a/features/storage/filesystem/File.h
+++ b/features/storage/filesystem/File.h
@@ -126,6 +126,18 @@ public:
      */
     virtual off_t size();
 
+    /** Truncate or extend a file.
+     *
+     * The file's length is set to the specified value. The seek pointer is
+     * not changed. If the file is extended, the extended area appears as if
+     * it were zero-filled.
+     *
+     *  @param length   The requested new length for the file
+     *
+     *  @return         Zero on success, negative error code on failure
+     */
+    virtual int truncate(off_t length);
+
 private:
     FileSystem *_fs;
     fs_file_t _file;

--- a/features/storage/filesystem/FileSystem.cpp
+++ b/features/storage/filesystem/FileSystem.cpp
@@ -84,6 +84,11 @@ off_t FileSystem::file_size(fs_file_t file)
     return size;
 }
 
+int FileSystem::file_truncate(fs_file_t file, off_t length)
+{
+    return -ENOSYS;
+}
+
 int FileSystem::dir_open(fs_dir_t *dir, const char *path)
 {
     return -ENOSYS;

--- a/features/storage/filesystem/FileSystem.h
+++ b/features/storage/filesystem/FileSystem.h
@@ -220,6 +220,19 @@ protected:
      */
     virtual off_t file_size(fs_file_t file);
 
+    /** Truncate or extend a file.
+     *
+     * The file's length is set to the specified value. The seek pointer is
+     * not changed. If the file is extended, the extended area appears as if
+     * it were zero-filled.
+     *
+     *  @param file     File handle
+     *  @param length   The requested new length for the file
+     *
+     *  @return         Zero on success, negative error code on failure
+     */
+    virtual int file_truncate(fs_file_t file, off_t length);
+
     /** Open a directory on the filesystem
      *
      *  @param dir      Destination for the handle to the directory

--- a/features/storage/filesystem/fat/FATFileSystem.h
+++ b/features/storage/filesystem/fat/FATFileSystem.h
@@ -217,6 +217,19 @@ protected:
      */
     virtual off_t file_size(mbed::fs_file_t file);
 
+    /** Truncate or extend a file.
+     *
+     * The file's length is set to the specified value. The seek pointer is
+     * not changed. If the file is extended, the extended area appears as if
+     * it were zero-filled.
+     *
+     *  @param file     File handle
+     *  @param length   The requested new length for the file
+     *
+     *  @return         Zero on success, negative error code on failure
+     */
+    virtual int file_truncate(mbed::fs_file_t file, off_t length);
+
     /** Open a directory on the filesystem
      *
      *  @param dir      Destination for the handle to the directory

--- a/features/storage/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.cpp
@@ -474,6 +474,17 @@ off_t LittleFileSystem::file_size(fs_file_t file)
     return lfs_toerror(res);
 }
 
+int LittleFileSystem::file_truncate(fs_file_t file, off_t length)
+{
+    lfs_file_t *f = (lfs_file_t *)file;
+    _mutex.lock();
+    LFS_INFO("file_truncate(%p)", file);
+    int err = lfs_file_truncate(&_lfs, f, length);
+    LFS_INFO("file_truncate -> %d", lfs_toerror(err));
+    _mutex.unlock();
+    return lfs_toerror(err);
+}
+
 
 ////// Dir operations //////
 int LittleFileSystem::dir_open(fs_dir_t *dir, const char *path)

--- a/features/storage/filesystem/littlefs/LittleFileSystem.h
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.h
@@ -220,6 +220,19 @@ protected:
      */
     virtual off_t file_size(mbed::fs_file_t file);
 
+    /** Truncate or extend a file.
+     *
+     * The file's length is set to the specified value. The seek pointer is
+     * not changed. If the file is extended, the extended area appears as if
+     * it were zero-filled.
+     *
+     *  @param file     File handle
+     *  @param length   The requested new length for the file
+     *
+     *  @return         Zero on success, negative error code on failure
+     */
+    virtual int file_truncate(mbed::fs_file_t file, off_t length);
+
     /** Open a directory on the filesystem
      *
      *  @param dir      Destination for the handle to the directory

--- a/platform/FileHandle.h
+++ b/platform/FileHandle.h
@@ -137,6 +137,21 @@ public:
      */
     virtual off_t size();
 
+    /** Truncate or extend a file.
+     *
+     * The file's length is set to the specified value. The seek pointer is
+     * not changed. If the file is extended, the extended area appears as if
+     * it were zero-filled.
+     *
+     *  @param length   The requested new length for the file
+     *
+     *  @return         Zero on success, negative error code on failure
+     */
+    virtual int truncate(off_t length)
+    {
+        return -EINVAL;
+    }
+
     /** Move the file position to a given offset from a given location.
      *
      *  @param offset The offset from whence to move to

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -841,6 +841,23 @@ extern "C" off_t lseek(int fildes, off_t offset, int whence)
     return off;
 }
 
+extern "C" int ftruncate(int fildes, off_t length)
+{
+    FileHandle* fhc = get_fhc(fildes);
+    if (fhc == NULL) {
+        errno = EBADF;
+        return -1;
+    }
+
+    int err = fhc->truncate(length);
+    if (err < 0) {
+        errno = -err;
+        return -1;
+    } else {
+        return 0;
+    }
+}
+
 #ifdef __ARMCC_VERSION
 extern "C" int PREFIX(_ensure)(FILEHANDLE fh)
 {

--- a/platform/mbed_retarget.h
+++ b/platform/mbed_retarget.h
@@ -523,6 +523,7 @@ extern "C" {
     ssize_t write(int fildes, const void *buf, size_t nbyte);
     ssize_t read(int fildes, void *buf, size_t nbyte);
     off_t lseek(int fildes, off_t offset, int whence);
+    int ftruncate(int fildes, off_t length);
     int isatty(int fildes);
     int fsync(int fildes);
     int fstat(int fildes, struct stat *st);


### PR DESCRIPTION
### Description

Add support for file truncation (or extension) to the abstract API.

Unit tests added.

Implementation added for:

- `File::truncate`
- `FileSystem::file_truncate`
- `FATFileSystem::file_truncate`
- `LittleFileSystem::file_truncate`

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

