### PR TITLE
Cordio driver hook

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCIDriver.h
@@ -58,6 +58,10 @@ struct buf_pool_desc_t {
  *   - Access to the write function of the underlying HCITransport driver.
  */
 class CordioHCIDriver {
+
+    // hook for internal tests and passthrough driver
+    friend class CordioHCIHook;
+
 public:
     /**
      * Construct a new instance of an HCI driver.

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.cpp
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#include <algorithm>
+#include <limits>
+
 #include "CordioHCITransportDriver.h"
 #include "CordioHCIDriver.h"
 
@@ -23,9 +26,22 @@ namespace ble {
 namespace vendor {
 namespace cordio {
 
+CordioHCITransportDriver::data_received_handler_t
+    CordioHCITransportDriver::data_received_handler = hciTrSerialRxIncoming;
+
 void CordioHCITransportDriver::on_data_received(uint8_t* data, uint16_t len)
 {
-    hciTrSerialRxIncoming(data, len);
+    while (len) {
+        uint8_t chunk_length = std::min(len, (uint16_t) std::numeric_limits<uint8_t>::max());
+        data_received_handler(data, chunk_length);
+        len = len - chunk_length;
+        data = data + chunk_length;
+    }
+}
+
+void CordioHCITransportDriver::set_data_received_handler(data_received_handler_t handler)
+{
+    data_received_handler = handler;
 }
 
 } // namespace cordio

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.h
@@ -68,6 +68,13 @@ public:
      * @param len Number of bytes received.
      */
     static void on_data_received(uint8_t* data, uint16_t len);
+
+private:
+    typedef void (*data_received_handler_t)(uint8_t* data, uint8_t len);
+
+    static data_received_handler_t data_received_handler;
+
+    static void set_data_received_handler(data_received_handler_t handler);
 };
 
 } // namespace cordio

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/driver/CordioHCITransportDriver.h
@@ -28,6 +28,10 @@ namespace cordio {
  * It allow the stack to write data in the HCI channel.
  */
 class CordioHCITransportDriver {
+
+    // hook for internal tests and passthrough driver
+    friend class CordioHCIHook;
+
 public:
     /**
      * Driver destructor.


### PR DESCRIPTION
### Description

This patch adds the necessary mechanisms to get access to the internals of the classes `CordioHCIDriver` and `CordioHCITransportDriver`. With this change a class living in the namespace `ble::vendor::cordio` and named `CordioHCIHook` can get access to the internal of both classes mentioned above. 

This patch also allows dynamic override of the RX handler. 

Note: It is not meant to be used by application; it will be used in internals tests. 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

