### PR TITLE
BLE: fix pairing for misconfigured devices (deny pairing correctly)

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -1144,6 +1144,7 @@ void GenericSecurityManager::on_pairing_request(
     /* cancel pairing if secure connection paring is not possible */
     if (!_legacy_pairing_allowed && !authentication.get_secure_connections()) {
         cancelPairingRequest(connection);
+        return;
     }
 
     ControlBlock_t *cb = get_control_block(connection);


### PR DESCRIPTION
### Description

Under certain circumstances when SC is not supported but required when pairing is requested this would send a reject (correctly) but also potentially accept at the same time because the function is missing a return that was intended to be there. The pairing would still fail but incorrect events and messages would be sent. This stops it.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

