### PR TITLE
Add show full path option to armc6 linker

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -24,7 +24,7 @@
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
         "ld": ["--verbose", "--remove", "--legacyalign", "--no_strict_wchar_size",
-               "--no_strict_enum_size"]
+               "--no_strict_enum_size", "--show_full_path"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -22,7 +22,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--legacyalign", "--no_strict_wchar_size", "--no_strict_enum_size"]
+        "ld": ["--legacyalign", "--no_strict_wchar_size", "--no_strict_enum_size", "--show_full_path"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -22,7 +22,8 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--legacyalign", "--no_strict_wchar_size", "--no_strict_enum_size"]
+        "ld": ["--legacyalign", "--no_strict_wchar_size", "--no_strict_enum_size",
+               "--show_full_path"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
### Description
Full paths in the map file are required to have correct memap parsing.
This PR adds the option `--show_full_path` to ARMC6 in every profile.
This option only affects the map file output, so it's safe to add.

 ### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change