### PR TITLE
Make Nanostack C++ constructor initialise Nanostack

### DIFF
--- a/features/nanostack/nanostack-interface/Nanostack.cpp
+++ b/features/nanostack/nanostack-interface/Nanostack.cpp
@@ -449,7 +449,7 @@ void NanostackSocket::event_connection_reset(socket_callback_t *sock_cb)
 Nanostack::Nanostack()
     : call_event_tasklet(-1)
 {
-
+    mesh_system_init();
 }
 
 void Nanostack::call_event_tasklet_main(arm_event_s *event)


### PR DESCRIPTION

### Description

Nanostack object constructor didn't actually initialise Nanostack. Nanostack initialisation was deferred until an interface was actually attached to the stack, which generally happened at first interface connect.

Not normally a problem, unless you're trying to make direct Nanostack setup calls prior to connect - some applications do this, and were relying on ThreadInterface::initialise to do Nanostack initialisation.

Unfortunately in 5.9 ThreadInterface::initialise no longer does initialise Nanostack immediately, because the mesh interfaces were aligned and integrated with the Ethernet interfaces, which did initialisation on connect().

Make the Nanostack object constructor initialise Nanostack (as the LWIP constructor does for lwIP), so calling Nanostack::get_instance() is the 5.9 API for Nanostack initialisation.

For future work, APIs like ns_file_system_set_root_path should be exposed as methods of Nanostack, so everything happens with a single Nanostack::get_instance().file_system_set_root_path().

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

