### PR TITLE
Fix USB on Kinetis devices

### DIFF
--- a/usb/device/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
+++ b/usb/device/targets/TARGET_Freescale/USBPhy_Kinetis.cpp
@@ -125,6 +125,10 @@ void USBPhyHw::init(USBPhyEvents *events)
     MPU->CESR=0;
 #endif
 
+#if (defined(FSL_FEATURE_SOC_SYSMPU_COUNT) && (FSL_FEATURE_SOC_SYSMPU_COUNT > 0U))
+    SYSMPU->CESR=0;
+#endif
+
 #if defined(TARGET_KL43Z) || defined(TARGET_K22F) || defined(TARGET_K64F)
     // enable USBFS clock
     CLOCK_EnableUsbfs0Clock(kCLOCK_UsbSrcIrc48M, 48000000U);


### PR DESCRIPTION
### Description

Set correct SYSMPU register for proper USB operation.  This bug was
introduced when the SYSMPU register names and defines were updated
in the commit:
"K64F: Updated the SYSMPU SDK driver"
93f8cfed058174b2de468353c173c0d7b9335ea4

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

