### PR TITLE
Fix USB on Kinetis devices

### DIFF
--- a/features/unsupported/USBDevice/targets/TARGET_Freescale/USBHAL_KL25Z.cpp
+++ b/features/unsupported/USBDevice/targets/TARGET_Freescale/USBHAL_KL25Z.cpp
@@ -100,6 +100,11 @@ USBHAL::USBHAL(void) {
 #if (defined(FSL_FEATURE_SOC_MPU_COUNT) && (FSL_FEATURE_SOC_MPU_COUNT > 0U))
     MPU->CESR=0;
 #endif
+
+#if (defined(FSL_FEATURE_SOC_SYSMPU_COUNT) && (FSL_FEATURE_SOC_SYSMPU_COUNT > 0U))
+    SYSMPU->CESR=0;
+#endif
+
     // fill in callback array
     epCallback[0] = &USBHAL::EP1_OUT_callback;
     epCallback[1] = &USBHAL::EP1_IN_callback;


### PR DESCRIPTION
### Description

Set correct SYSMPU register for proper USB operation.  This bug was
introduced when the SYSMPU register names and defines were updated
in the commit:
"K64F: Updated the SYSMPU SDK driver"
93f8cfed058174b2de468353c173c0d7b9335ea4

This is the same fix as #7178 but for the USB code in features/unsupported.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

