### PR TITLE
Cellular: Disable Greentea tracing to consume less memory

### DIFF
--- a/features/cellular/TESTS/socket/udp/template_mbed_app.json.txt
+++ b/features/cellular/TESTS/socket/udp/template_mbed_app.json.txt
@@ -27,7 +27,7 @@
             "ppp-cell-iface.apn-lookup": false,
             "cellular.use-apn-lookup": false,
             "target.features_add": ["LWIP"],
-            "mbed-trace.enable": true,
+            "mbed-trace.enable": false,
             "lwip.ipv4-enabled": true,
             "lwip.ipv6-enabled": true,
             "lwip.tcp-enabled": false,


### PR DESCRIPTION
### Description

Cellular Greentea tests were failing with UBLOX_C027 target + IAR toolchain due to out-of-memory. This change disables tracing while running Greentea tests to consume less memory.

Fixes ARM internal ref IOTCELL-1082.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

