### PR TITLE
Cellular: Semaphore wasn't released in easycellular release build.

### DIFF
--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -42,7 +42,7 @@ bool EasyCellularConnection::cellular_status(int state, int next_state)
 
     if (_target_state == state) {
         tr_info("Target state reached: %s", _cellularConnectionFSM->get_state_string(_target_state));
-        MBED_ASSERT(_cellularSemaphore.release() == osOK);
+        (void)_cellularSemaphore.release();
         return false; // return false -> state machine is halted
     }
     return true;


### PR DESCRIPTION
### Description

Semaphore was released inside of MBED_ASSERT in EasyCellularConnection and so it was not released in release build.

@juhoeskeli please review.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

