### PR TITLE
Tools: Remove second header when every bl config param is used

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -650,7 +650,7 @@ class Config(object):
             new_size = Config._align_floor(start + new_size, self.sectors) - start
             yield Region("application", start, new_size, True, None)
             start += new_size
-            if self.target.header_format:
+            if self.target.header_format and not self.target.bootloader_img:
                 if self.target.header_offset:
                     start = self._assign_new_offset(
                         rom_start, start, self.target.header_offset, "header")


### PR DESCRIPTION
### Description

Resolves #7190

The issue is simple: the managed bootloader mode will accept both 
`target.bootloader_img` and `target.restrict_size` at the same time.
When combined with `target.header_format` though, you end up with
two application headers, one before the application and one after.

This PR removes the second one; the after-application header.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change