### PR TITLE
Tools: Allow exporting of uARM-only targets to uvision

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -133,9 +133,16 @@ class Uvision(Exporter):
     @classmethod
     def is_target_supported(cls, target_name):
         target = TARGET_MAP[target_name]
-        return apply_supported_whitelist(
-            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target) and\
-            DeviceCMSIS.check_supported(target_name)
+        if not (set(target.supported_toolchains) and set(["ARM", "uARM"])):
+            return False
+        if not DeviceCMSIS.check_supported(target_name):
+            return False
+        if not hasattr(target, "post_binary_hook"):
+            return True
+        if target.post_binary_hook['function'] in cls.POST_BINARY_WHITELIST:
+            return True
+        else:
+            return False
 
     #File associations within .uvprojx file
     file_types = {'.cpp': 8, '.c': 1, '.s': 2,

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -532,8 +532,7 @@ class mbedToolchain:
 
     def get_labels(self):
         if self.labels is None:
-            toolchain_labels = [c.__name__ for c in getmro(self.__class__)]
-            toolchain_labels.remove('mbedToolchain')
+            toolchain_labels = self._get_toolchain_labels()
             self.labels = {
                 'TARGET': self.target.labels,
                 'FEATURE': self.target.features,
@@ -550,6 +549,12 @@ class mbedToolchain:
             else:
                 self.labels['TARGET'].append("RELEASE")
         return self.labels
+
+    def _get_toolchain_labels(self):
+        toolchain_labels = [c.__name__ for c in getmro(self.__class__)]
+        toolchain_labels.remove('mbedToolchain')
+        toolchain_labels.remove('object')
+        return toolchain_labels
 
 
     # Determine whether a source file needs updating/compiling

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -91,6 +91,12 @@ class ARM(mbedToolchain):
 
         self.SHEBANG += " --cpu=%s" % cpu
 
+    def _get_toolchain_labels(self):
+        if getattr(self.target, "defalut_lib", "std") == "small":
+            return ["ARM", "ARM_MICRO"]
+        else:
+            return ["ARM", "ARM_STD"]
+
     def parse_dependencies(self, dep_path):
         dependencies = []
         for line in open(dep_path).readlines():
@@ -393,6 +399,9 @@ class ARMC6(ARM_STD):
         self.ld = [join(TOOLCHAIN_PATHS["ARMC6"], "armlink")] + self.flags['ld']
         self.ar = [join(TOOLCHAIN_PATHS["ARMC6"], "armar")]
         self.elf2bin = join(TOOLCHAIN_PATHS["ARMC6"], "fromelf")
+
+    def _get_toolchain_labels(self):
+        return ["ARM", "ARM_STD", "ARMC6"]
 
     def parse_dependencies(self, dep_path):
         return mbedToolchain.parse_dependencies(self, dep_path)

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -56,6 +56,12 @@ class ARM(mbedToolchain):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
+        if getattr(target, "defalut_lib", "std") == "small":
+            if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:
+                self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")
+            if "--library_type=microlib" not in self.flags['ld']:
+                self.flags['ld'].append("--library_type=microlib")
+
         if target.core == "Cortex-M0+":
             cpu = "Cortex-M0"
         elif target.core == "Cortex-M4F":
@@ -291,8 +297,8 @@ class ARM_STD(ARM):
                  build_profile=None, build_dir=None):
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
-        if "ARM" not in target.supported_toolchains:
-            raise NotSupportedException("ARM compiler support is required for ARM build")
+        if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):
+            raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
 
 
 class ARM_MICRO(ARM):

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -56,7 +56,7 @@ class ARM(mbedToolchain):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
-        if getattr(target, "defalut_lib", "std") == "small":
+        if getattr(target, "default_lib", "std") == "small":
             if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:
                 self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")
             if "--library_type=microlib" not in self.flags['ld']:
@@ -92,7 +92,7 @@ class ARM(mbedToolchain):
         self.SHEBANG += " --cpu=%s" % cpu
 
     def _get_toolchain_labels(self):
-        if getattr(self.target, "defalut_lib", "std") == "small":
+        if getattr(self.target, "default_lib", "std") == "small":
             return ["ARM", "ARM_MICRO"]
         else:
             return ["ARM", "ARM_STD"]


### PR DESCRIPTION
### Description

Resolves #7184

This PR makes it possible to export targets that only support the
uARM toolchain through the uvision exporter. There were a few checks
that prevented this. These checks were changed. I also made the ARM
compiler heed the `target.default_lib` configuration parameter just 
like the `GCC_ARM` toolchain. You no longer need to use uARM, possibly.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change