### PR TITLE
Corrected casting issue with an assert within the error_handling test

### DIFF
--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -124,7 +124,7 @@ void test_error_context_capture()
     mbed_error_status_t status = mbed_get_last_error_info( &error_ctx );
     TEST_ASSERT(status == MBED_SUCCESS);
     TEST_ASSERT_EQUAL_UINT(error_value, error_ctx.error_value);
-    TEST_ASSERT_EQUAL_UINT(osThreadGetId(), error_ctx.thread_id);
+    TEST_ASSERT_EQUAL_UINT((uint32_t)osThreadGetId(), error_ctx.thread_id);
     
     //Capture thread info and compare
     osRtxThread_t *current_thread = osRtxInfo.thread.run.curr;

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if MBED_CONF_RTOS_PRESENT
+
 #include "greentea-client/test_env.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
@@ -363,3 +366,5 @@ int main()
 {
     return !utest::v1::Harness::run(specification);
 }
+
+#endif //MBED_CONF_RTOS_PRESENT

--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#if MBED_CONF_RTOS_PRESENT
-
 #include "greentea-client/test_env.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
@@ -349,15 +347,19 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 Case cases[] = {
     Case("Test error counting and reset", test_error_count_and_reset),
     Case("Test error encoding, value capture, first and last errors", test_error_capturing),
+#if MBED_CONF_RTOS_PRESENT
     Case("Test error context capture", test_error_context_capture),
+#endif //MBED_CONF_RTOS_PRESENT
     Case("Test error hook", test_error_hook),
 #ifndef MBED_CONF_ERROR_HIST_DISABLED    
     Case("Test error logging", test_error_logging),
+#if MBED_CONF_RTOS_PRESENT
     Case("Test error handling multi-threaded", test_error_logging_multithread),
+#endif //MBED_CONF_RTOS_PRESENT
 #ifdef MBED_TEST_SIM_BLOCKDEVICE    
     Case("Test error save log", test_save_error_log),
-#endif    
-#endif    
+#endif //MBED_TEST_SIM_BLOCKDEVICE
+#endif //MBED_CONF_ERROR_HIST_DISABLED
 };
 
 utest::v1::Specification specification(test_setup, cases);
@@ -366,5 +368,3 @@ int main()
 {
     return !utest::v1::Harness::run(specification);
 }
-
-#endif //MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Discovered via https://github.com/ARMmbed/mbed-os/pull/7105.
If both values are negative values, they are casted in such a way that -1 != -1. This small commit fixes that.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

