### PR TITLE
K64f non-blocking powerup

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
@@ -485,8 +485,8 @@ bool Kinetis_EMAC::link_out(emac_mem_buf_t *buf)
         buf = copy_buf;
     }
 
-    /* Check if a descriptor is available for the transfer. */
-    if (xTXDCountSem.wait(0) == 0) {
+    /* Check if a descriptor is available for the transfer (wait 10ms before dropping the buffer) */
+    if (xTXDCountSem.wait(10) == 0) {
         memory_manager->free(buf);
         return false;
     }

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
@@ -138,6 +138,8 @@ public:
 
 private:
     bool low_level_init_successful();
+    status_t init_enet_phy(ENET_Type *base, uint32_t phyAddr, uint32_t srcClock_Hz);
+    status_t auto_negotiation(ENET_Type *base, uint32_t phyAddr);
     void rx_isr();
     void tx_isr();
     void packet_rx();

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
@@ -138,8 +138,6 @@ public:
 
 private:
     bool low_level_init_successful();
-    status_t init_enet_phy(ENET_Type *base, uint32_t phyAddr, uint32_t srcClock_Hz);
-    status_t auto_negotiation(ENET_Type *base, uint32_t phyAddr);
     void rx_isr();
     void tx_isr();
     void packet_rx();

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/fsl_phy.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/fsl_phy.h
@@ -136,9 +136,18 @@ extern "C" {
  * @param srcClock_Hz  The module clock frequency - system clock for MII management interface - SMI.
  * @retval kStatus_Success  PHY initialize success
  * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
- * @retval kStatus_PHY_AutoNegotiateFail  PHY auto negotiate fail
  */
 status_t PHY_Init(ENET_Type *base, uint32_t phyAddr, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Initiates auto negotiation.
+ *
+ * @param base       ENET peripheral base address.
+ * @param phyAddr    The PHY address.
+ * @retval kStatus_Success  PHY auto negotiation success
+ * @retval kStatus_PHY_AutoNegotiateFail  PHY auto negotiate fail
+ */
+status_t PHY_AutoNegotiation(ENET_Type *base, uint32_t phyAddr);
 
 /*!
  * @brief PHY Write function. This function write data over the SMI to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/fsl_phy.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/fsl_phy.c
@@ -1,32 +1,32 @@
 /*
-* Copyright (c) 2015, Freescale Semiconductor, Inc.
-* All rights reserved.
-*
-* Redistribution and use in source and binary forms, with or without modification,
-* are permitted provided that the following conditions are met:
-*
-* o Redistributions of source code must retain the above copyright notice, this list
-*   of conditions and the following disclaimer.
-*
-* o Redistributions in binary form must reproduce the above copyright notice, this
-*   list of conditions and the following disclaimer in the documentation and/or
-*   other materials provided with the distribution.
-*
-* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
-*   contributors may be used to endorse or promote products derived from this
-*   software without specific prior written permission.
-*
-* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
-* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
-* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+ * Copyright (c) 2015, Freescale Semiconductor, Inc.
+ * Copyright 2016-2017 NXP
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * o Redistributions of source code must retain the above copyright notice, this list
+ *   of conditions and the following disclaimer.
+ *
+ * o Redistributions in binary form must reproduce the above copyright notice, this
+ *   list of conditions and the following disclaimer in the documentation and/or
+ *   other materials provided with the distribution.
+ *
+ * o Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from this
+ *   software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
 
 #include "fsl_phy.h"
 
@@ -53,8 +53,10 @@ extern uint32_t ENET_GetInstance(ENET_Type *base);
  * Variables
  ******************************************************************************/
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
 /*! @brief Pointers to enet clocks for each instance. */
 extern clock_ip_name_t s_enetClock[FSL_FEATURE_SOC_ENET_COUNT];
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
 
 /*******************************************************************************
  * Code
@@ -62,45 +64,66 @@ extern clock_ip_name_t s_enetClock[FSL_FEATURE_SOC_ENET_COUNT];
 
 status_t PHY_Init(ENET_Type *base, uint32_t phyAddr, uint32_t srcClock_Hz)
 {
-    uint32_t bssReg;
     uint32_t counter = PHY_TIMEOUT_COUNT;
+    uint32_t idReg = 0;
     status_t result = kStatus_Success;
     uint32_t instance = ENET_GetInstance(base);
 
+#if !(defined(FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL) && FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL)
     /* Set SMI first. */
     CLOCK_EnableClock(s_enetClock[instance]);
+#endif /* FSL_SDK_DISABLE_DRIVER_CLOCK_CONTROL */
     ENET_SetSMI(base, srcClock_Hz, false);
+
+    /* Initialization after PHY stars to work. */
+    while ((idReg != PHY_CONTROL_ID1) && (counter != 0))
+    {
+        PHY_Read(base, phyAddr, PHY_ID1_REG, &idReg);
+        counter --;       
+    }
+
+    if (!counter)
+    {
+        return kStatus_Fail;
+    }
 
     /* Reset PHY. */
     result = PHY_Write(base, phyAddr, PHY_BASICCONTROL_REG, PHY_BCTL_RESET_MASK);
+
+    return result;
+}
+
+status_t PHY_AutoNegotiation(ENET_Type *base, uint32_t phyAddr)
+{
+    status_t result = kStatus_Success;
+    uint32_t bssReg;
+    uint32_t counter = PHY_TIMEOUT_COUNT;
+
+    /* Set the negotiation. */
+    result = PHY_Write(base, phyAddr, PHY_AUTONEG_ADVERTISE_REG,
+                       (PHY_100BASETX_FULLDUPLEX_MASK | PHY_100BASETX_HALFDUPLEX_MASK |
+                        PHY_10BASETX_FULLDUPLEX_MASK | PHY_10BASETX_HALFDUPLEX_MASK | 0x1U));
     if (result == kStatus_Success)
     {
-        /* Set the negotiation. */
-        result = PHY_Write(base, phyAddr, PHY_AUTONEG_ADVERTISE_REG,
-                           (PHY_100BASETX_FULLDUPLEX_MASK | PHY_100BASETX_HALFDUPLEX_MASK |
-                            PHY_10BASETX_FULLDUPLEX_MASK | PHY_10BASETX_HALFDUPLEX_MASK | 0x1U));
+        result = PHY_Write(base, phyAddr, PHY_BASICCONTROL_REG,
+                           (PHY_BCTL_AUTONEG_MASK | PHY_BCTL_RESTART_AUTONEG_MASK));
         if (result == kStatus_Success)
         {
-            result = PHY_Write(base, phyAddr, PHY_BASICCONTROL_REG,
-                               (PHY_BCTL_AUTONEG_MASK | PHY_BCTL_RESTART_AUTONEG_MASK));
-            if (result == kStatus_Success)
+            /* Check auto negotiation complete. */
+            while (counter --)
             {
-                /* Check auto negotiation complete. */
-                while (counter --)
+                result = PHY_Read(base, phyAddr, PHY_BASICSTATUS_REG, &bssReg);
+                if ( result == kStatus_Success)
                 {
-                    result = PHY_Read(base, phyAddr, PHY_BASICSTATUS_REG, &bssReg);
-                    if ( result == kStatus_Success)
+                    if ((bssReg & PHY_BSTATUS_AUTONEGCOMP_MASK) != 0)
                     {
-                        if ((bssReg & PHY_BSTATUS_AUTONEGCOMP_MASK) != 0)
-                        {
-                            break;
-                        }
+                        break;
                     }
+                }
 
-                    if (!counter)
-                    {
-                        return kStatus_PHY_AutoNegotiateFail;
-                    }
+                if (!counter)
+                {
+                    return kStatus_PHY_AutoNegotiateFail;
                 }
             }
         }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/fsl_phy.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/fsl_phy.h
@@ -136,9 +136,18 @@ extern "C" {
  * @param srcClock_Hz  The module clock frequency - system clock for MII management interface - SMI.
  * @retval kStatus_Success  PHY initialize success
  * @retval kStatus_PHY_SMIVisitTimeout  PHY SMI visit time out
- * @retval kStatus_PHY_AutoNegotiateFail  PHY auto negotiate fail
  */
 status_t PHY_Init(ENET_Type *base, uint32_t phyAddr, uint32_t srcClock_Hz);
+
+/*!
+ * @brief Initiates auto negotiation.
+ *
+ * @param base       ENET peripheral base address.
+ * @param phyAddr    The PHY address.
+ * @retval kStatus_Success  PHY auto negotiation success
+ * @retval kStatus_PHY_AutoNegotiateFail  PHY auto negotiate fail
+ */
+status_t PHY_AutoNegotiation(ENET_Type *base, uint32_t phyAddr);
 
 /*!
  * @brief PHY Write function. This function write data over the SMI to


### PR DESCRIPTION
### Description

Changed K64F/K66F power up to return without waiting for link up i.e. for the ethernet cable to be connected. This is needed for non-blocking use of driver e.g. for using the driver from event queue.

Added delay to K64F/K66F ethernet TX when all descriptors are in use. Previously, if all TX descriptors were in use and IP stack called K64F/K66F ethernet driver link out, link out dropped the packet. Added 10ms delay to link out to wait for a descriptor to become available before dropping the packet.


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

