### PR TITLE
Nordic BLE: Accept connection parameter update

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF51/source/btle/btle.cpp
@@ -215,6 +215,15 @@ void btle_handler(ble_evt_t *p_ble_evt)
             break;
         }
 
+        case BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST: {
+            Gap::Handle_t connection = p_ble_evt->evt.gap_evt.conn_handle;
+            const ble_gap_evt_conn_param_update_request_t *update_request =
+                &p_ble_evt->evt.gap_evt.params.conn_param_update_request;
+
+            sd_ble_gap_conn_param_update(connection, &update_request->conn_params);
+            break;
+        }
+
         case BLE_GAP_EVT_TIMEOUT:
             gap.processTimeoutEvent(static_cast<Gap::TimeoutSource_t>(p_ble_evt->evt.gap_evt.params.timeout.src));
             break;

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.cpp
@@ -376,6 +376,14 @@ void btle_handler(const ble_evt_t *p_ble_evt)
         		break;
         }
 #endif
+        case BLE_GAP_EVT_CONN_PARAM_UPDATE_REQUEST: {
+            Gap::Handle_t connection = p_ble_evt->evt.gap_evt.conn_handle;
+            const ble_gap_evt_conn_param_update_request_t *update_request =
+                &p_ble_evt->evt.gap_evt.params.conn_param_update_request;
+
+            sd_ble_gap_conn_param_update(connection, &update_request->conn_params);
+            break;
+        }
 
         case BLE_GAP_EVT_TIMEOUT:
             gap.processTimeoutEvent(static_cast<Gap::TimeoutSource_t>(p_ble_evt->evt.gap_evt.params.timeout.src));


### PR DESCRIPTION
### Description

A peer device that sends a connection parameter update may get block if it doesn't receive a response.

This patch accept the peer request unconditionnally. At some point this event will be manageable by the application.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

