### PR TITLE
FlashIAP & NVStore tests: Skip test if overwriting code in flash

### DIFF
--- a/features/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -66,6 +66,8 @@ static const int race_test_data_size = 128;
 static const int race_test_min_stack_size = 768;
 static const int race_test_max_stack_size = 1024;
 
+static bool nvstore_overlaps_code = false;
+
 static void gen_random(uint8_t *s, int len)
 {
     for (int i = 0; i < len; ++i) {
@@ -91,6 +93,10 @@ static void nvstore_basic_functionality_test()
         size_t area_size;
         nvstore.get_area_params(area, area_address, area_size);
         printf("Area %d: address 0x%08lx, size %d (0x%x)\n", area, area_address, area_size, area_size);
+        if (area_address < FLASHIAP_ROM_END) {
+            nvstore_overlaps_code = true;
+        }
+        TEST_SKIP_UNLESS_MESSAGE(!nvstore_overlaps_code, "Test skipped. NVStore region overlaps code.");
     }
 
     gen_random(nvstore_testing_buf_set, basic_func_max_data_size);
@@ -485,6 +491,8 @@ static void nvstore_multi_thread_test()
 
     NVStore &nvstore = NVStore::get_instance();
 
+    TEST_SKIP_UNLESS_MESSAGE(!nvstore_overlaps_code, "Test skipped. NVStore region overlaps code.");
+
     ret = nvstore.reset();
     TEST_ASSERT_EQUAL(NVSTORE_SUCCESS, ret);
 
@@ -573,6 +581,8 @@ static void nvstore_race_test()
     uint8_t *get_buff, *buffs[race_test_num_threads];
     int num_threads = race_test_num_threads;
     uint16_t actual_len_bytes;
+
+    TEST_SKIP_UNLESS_MESSAGE(!nvstore_overlaps_code, "Test skipped. NVStore region overlaps code.");
 
     NVStore &nvstore = NVStore::get_instance();
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
@@ -25,11 +25,11 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
-define block FLASH_CODE_ROM  {section FLASH_ROM_init object flash_api.o, section .text_init object tmpm46b_fc.o}; 
-define block FLASH_CODE_RAM  {section FLASH_ROM object flash_api.o, section .text object tmpm46b_fc.o};
+define block FLASH_CODE_ROM  {section FLASH_ROM_init object flash_api.o};
+define block FLASH_CODE_RAM  {section FLASH_ROM object flash_api.o};
 
 initialize by copy { readwrite };
-initialize manually { section FLASH_ROM object flash_api.o, section .text object tmpm46b_fc.o};
+initialize manually { section FLASH_ROM object flash_api.o };
 do not initialize  { section .noinit };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };


### PR DESCRIPTION
### Description

The FlashIAP test erases the last two sectors in some of its test cases. NVStore test does the same. However, with boards that have small flash components (and large last sectors), this test may overwrite the code section. This fix checks that scenario and skips the test if it is indeed the case. 
Resolves [#7149](https://github.com/ARMmbed/mbed-os/issues/7149) and [#7388](https://github.com/ARMmbed/mbed-os/issues/7388).

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

