### PR TITLE
Cellular: Add AT+CCID and AT+CGSN

### DIFF
--- a/features/cellular/framework/API/CellularInformation.h
+++ b/features/cellular/framework/API/CellularInformation.h
@@ -70,12 +70,12 @@ public:
      *  @return         zero on success, on failure negative error code
      */
     enum SerialNumberType {
-        SN = 0,
-        IMEI = 1,
-        IMEISV = 2,
-        SVN  = 3
+        SN = 0, // Serial Number
+        IMEI = 1, // International Mobile station Equipment Identity
+        IMEISV = 2, // IMEI and Software Version number
+        SVN  = 3 // Software Version Number
     };
-    virtual nsapi_size_or_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type) = 0;
+    virtual nsapi_size_or_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type = SN) = 0;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/API/CellularInformation.h
+++ b/features/cellular/framework/API/CellularInformation.h
@@ -28,8 +28,7 @@ namespace mbed {
  *
  *  An abstract interface that provides information about cellular device.
  */
-class CellularInformation
-{
+class CellularInformation {
 protected:
     // friend of CellularDevice so that it's the only way to close/delete this class.
     friend class CellularDevice;
@@ -41,27 +40,42 @@ protected:
 public:
     /** Request manufacturer identification of cellular device
      *
-     *  @param buf      manufacturer identification
+     *  @param buf      manufacturer identification as zero terminated string
      *  @param buf_size max length of manufacturer identification is 2048 characters
-     *  @return         on success read character count, on failure negative error code
+     *  @return         zero on success, on failure negative error code
      */
-    virtual nsapi_size_or_error_t get_manufacturer(char *buf, size_t buf_size) = 0;
+    virtual nsapi_error_t get_manufacturer(char *buf, size_t buf_size) = 0;
 
     /** Request model identification of cellular device
      *
-     *  @param buf      model identification
+     *  @param buf      model identification as zero terminated string
      *  @param buf_size max length of model identification is 2048 characters
-     *  @return         on success read character count, on failure negative error code
+     *  @return         zero on success, on failure negative error code
      */
-    virtual nsapi_size_or_error_t get_model(char *buf, size_t buf_size) = 0;
+    virtual nsapi_error_t get_model(char *buf, size_t buf_size) = 0;
 
     /** Request revision identification of cellular device
      *
-     *  @param buf      revision identification
+     *  @param buf      revision identification as zero terminated string
      *  @param buf_size max length of revision identification is 2048 characters
-     *  @return         on success read character count, on failure negative error code
+     *  @return         zero on success, on failure negative error code
      */
-    virtual nsapi_size_or_error_t get_revision(char *buf, size_t buf_size) = 0;
+    virtual nsapi_error_t get_revision(char *buf, size_t buf_size) = 0;
+
+    /** Request serial number identification of cellular device
+     *
+     *  @param buf      serial number as zero terminated string
+     *  @param buf_size max length of serial number is 2048 characters
+     *  @param type     serial number type to read
+     *  @return         zero on success, on failure negative error code
+     */
+    enum SerialNumberType {
+        SN = 0,
+        IMEI = 1,
+        IMEISV = 2,
+        SVN  = 3
+    };
+    virtual nsapi_size_or_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type) = 0;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/API/CellularSIM.h
+++ b/features/cellular/framework/API/CellularSIM.h
@@ -18,19 +18,21 @@
 #ifndef CELLULAR_SIM_H_
 #define CELLULAR_SIM_H_
 
+#include <stddef.h>
+
 #include "nsapi_types.h"
 
 namespace mbed {
 
 const int MAX_SIM_READY_WAITING_TIME = 30;
 const int MAX_IMSI_LENGTH = 15;
+const int MAX_ICCID_LENGTH = 20 + 1; // +1 for zero termination
 /**
  *  Class CellularSIM
  *
  *  An abstract interface for SIM card handling.
  */
-class CellularSIM
-{
+class CellularSIM {
 protected:
     // friend of CellularDevice so that it's the only way to close/delete this class.
     friend class CellularDevice;
@@ -84,7 +86,15 @@ public:
      *  @param imsi     preallocated char* which after successful request contains imsi
      *  @return         zero on success
      */
-    virtual nsapi_error_t get_imsi(char* imsi) = 0;
+    virtual nsapi_error_t get_imsi(char *imsi) = 0;
+
+    /** Get serial number from the SIM card
+     *
+     *  @param buf      SIM ICCID as zero terminated string
+     *  @param buf_size max length of SIM ICCID is MAX_ICCID_LENGTH
+     *  @return         zero on success, on failure negative error code
+     */
+    virtual nsapi_error_t get_iccid(char *buf, size_t buf_size) = 0;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularBase.cpp
+++ b/features/cellular/framework/AT/AT_CellularBase.cpp
@@ -16,15 +16,15 @@
  */
 
 #include "AT_CellularBase.h"
+#include "CellularLog.h"
 
 using namespace mbed;
 
-AT_CellularBase::AT_CellularBase(ATHandler& at) : _at(at)
+AT_CellularBase::AT_CellularBase(ATHandler &at) : _at(at)
 {
-
 }
 
-ATHandler& AT_CellularBase::get_at_handler()
+ATHandler &AT_CellularBase::get_at_handler()
 {
     return _at;
 }
@@ -34,3 +34,25 @@ device_err_t AT_CellularBase::get_device_error() const
     return _at.get_last_device_error();
 }
 
+AT_CellularBase::SupportedFeature const *AT_CellularBase::_unsupported_features;
+
+void AT_CellularBase::set_unsupported_features(const SupportedFeature *unsupported_features)
+{
+    _unsupported_features = unsupported_features;
+}
+
+bool AT_CellularBase::is_supported(SupportedFeature feature)
+{
+    if (!_unsupported_features) {
+        return true;
+    }
+
+    for (int i = 0; _unsupported_features[i] != SUPPORTED_FEATURE_END_MARK; i++) {
+        if (_unsupported_features[i] == feature) {
+            tr_debug("Unsupported feature (%d)", (int)feature);
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -26,16 +26,15 @@ namespace mbed {
  *
  *  A base class for AT-classes.
  */
-class AT_CellularBase
-{
+class AT_CellularBase {
 public:
-    AT_CellularBase(ATHandler& at);
+    AT_CellularBase(ATHandler &at);
 
     /** Getter for at handler. Common method for all AT-classes.
      *
      *  @return reference to ATHandler
      */
-    ATHandler& get_at_handler();
+    ATHandler &get_at_handler();
 
     /** Gets the device error that happened when using AT commands/responses. This is at error
      *  returned by the device. Returned CME/CMS errors can be found from 3gpp documents 27007 and 27005.
@@ -44,8 +43,28 @@ public:
      */
     device_err_t get_device_error() const;
 
+    /** Cellular module need to define an array of unsupported features if any,
+     *  by default all features are supported.
+     *
+     *  @param features Array of type SupportedFeature with last element FEATURE_END_MARK
+     */
+    enum SupportedFeature {
+        AT_CGSN_WITH_TYPE, // AT+CGSN without type is likely always supported similar to AT+GSN
+        SUPPORTED_FEATURE_END_MARK // must be last element in the array of features
+    };
+    static void set_unsupported_features(const SupportedFeature *unsupported_features);
+
 protected:
-    ATHandler& _at;
+    ATHandler &_at;
+
+    /** Check if some functionality is supported by a cellular module. For example,
+     *  most of standard AT commands are optional and not implemented by all cellular modules.
+     *
+     *  @param feature  check for feature to support
+     *  @return         true on supported, otherwise false
+     */
+    static const SupportedFeature *_unsupported_features;
+    static bool is_supported(SupportedFeature feature);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularInformation.cpp
+++ b/features/cellular/framework/AT/AT_CellularInformation.cpp
@@ -49,6 +49,11 @@ nsapi_error_t AT_CellularInformation::get_serial_number(char *buf, size_t buf_si
     if (type == SN) {
         return get_info("AT+CGSN", buf, buf_size);
     }
+
+    if (!is_supported(AT_CGSN_WITH_TYPE)) {
+        return NSAPI_ERROR_UNSUPPORTED;
+    }
+
     _at.lock();
     _at.cmd_start("AT+CGSN=");
     _at.write_int(type);

--- a/features/cellular/framework/AT/AT_CellularInformation.cpp
+++ b/features/cellular/framework/AT/AT_CellularInformation.cpp
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include <stdio.h>
+
 #include "AT_CellularInformation.h"
 
 using namespace mbed;
@@ -42,6 +44,21 @@ nsapi_error_t AT_CellularInformation::get_revision(char *buf, size_t buf_size)
     return get_info("AT+CGMR", buf, buf_size);
 }
 
+nsapi_error_t AT_CellularInformation::get_serial_number(char *buf, size_t buf_size, SerialNumberType type)
+{
+    if (type == SN) {
+        return get_info("AT+CGSN", buf, buf_size);
+    }
+    _at.lock();
+    _at.cmd_start("AT+CGSN=");
+    _at.write_int(type);
+    _at.cmd_stop();
+    _at.resp_start("+CGSN:");
+    _at.read_string(buf, buf_size);
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}
+
 nsapi_error_t AT_CellularInformation::get_info(const char *cmd, char *buf, size_t buf_size)
 {
     _at.lock();
@@ -50,7 +67,7 @@ nsapi_error_t AT_CellularInformation::get_info(const char *cmd, char *buf, size_
     _at.cmd_stop();
     _at.set_delimiter(0);
     _at.resp_start();
-    _at.read_string(buf, buf_size-1);
+    _at.read_string(buf, buf_size - 1);
     _at.resp_stop();
     _at.set_default_delimiter();
 

--- a/features/cellular/framework/AT/AT_CellularInformation.h
+++ b/features/cellular/framework/AT/AT_CellularInformation.h
@@ -28,25 +28,26 @@ namespace mbed {
  *
  * Class that provides information about cellular device.
  */
-class AT_CellularInformation : public CellularInformation, public AT_CellularBase
-{
+class AT_CellularInformation : public CellularInformation, public AT_CellularBase {
 public:
     AT_CellularInformation(ATHandler &atHandler);
     virtual ~AT_CellularInformation();
 
 public:
-    virtual nsapi_size_or_error_t get_manufacturer(char *buf, size_t buf_size);
+    virtual nsapi_error_t get_manufacturer(char *buf, size_t buf_size);
 
-    virtual nsapi_size_or_error_t get_model(char *buf, size_t buf_size);
+    virtual nsapi_error_t get_model(char *buf, size_t buf_size);
 
-    virtual nsapi_size_or_error_t get_revision(char *buf, size_t buf_size);
+    virtual nsapi_error_t get_revision(char *buf, size_t buf_size);
+
+    virtual nsapi_error_t get_serial_number(char *buf, size_t buf_size, SerialNumberType type);
 
 protected:
     /** Request information text from cellular device
      *
      *  @param cmd      3gpp command string
-     *  @param buf      manufacturer identification
-     *  @param buf_size max length of manufacturer identification is 2048 characters
+     *  @param buf      buffer for response
+     *  @param buf_size buffer size
      *  @return         on success read character count, on failure negative error code
      */
     nsapi_error_t get_info(const char *cmd, char *buf, size_t buf_size);

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -147,3 +147,14 @@ nsapi_error_t AT_CellularSIM::get_imsi(char *imsi)
     _at.resp_stop();
     return _at.unlock_return_error();
 }
+
+nsapi_error_t AT_CellularSIM::get_iccid(char *buf, size_t buf_size)
+{
+    _at.lock();
+    _at.cmd_start("AT+CCID?");
+    _at.cmd_stop();
+    _at.resp_start("+CCID:");
+    _at.read_string(buf, buf_size);
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}

--- a/features/cellular/framework/AT/AT_CellularSIM.h
+++ b/features/cellular/framework/AT/AT_CellularSIM.h
@@ -28,8 +28,7 @@ namespace mbed {
  *
  *  Class for SIM card handling.
  */
-class AT_CellularSIM : public CellularSIM, public AT_CellularBase
-{
+class AT_CellularSIM : public CellularSIM, public AT_CellularBase {
 
 public:
     AT_CellularSIM(ATHandler &atHandler);
@@ -44,7 +43,9 @@ public:
 
     virtual nsapi_error_t get_sim_state(SimState &state);
 
-    virtual nsapi_error_t get_imsi(char* imsi);
+    virtual nsapi_error_t get_imsi(char *imsi);
+
+    virtual nsapi_error_t get_iccid(char *buf, size_t buf_size);
 };
 
 } // namespace mbed

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularSIM.cpp
@@ -47,3 +47,14 @@ nsapi_error_t QUECTEL_BC95_CellularSIM::get_sim_state(SimState &state)
     return _at.unlock_return_error();
 }
 
+// According to BC95_AT_Commands_Manual_V1.9
+nsapi_error_t QUECTEL_BC95_CellularSIM::get_iccid(char *buf, size_t buf_size)
+{
+    _at.lock();
+    _at.cmd_start("AT+NCCID?");
+    _at.cmd_stop();
+    _at.resp_start("+NCCID:");
+    _at.read_string(buf, buf_size);
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -29,8 +29,14 @@ using namespace events;
 #define MAX_STARTUP_TRIALS 5
 #define MAX_RESET_TRIALS 5
 
+static const AT_CellularBase::SupportedFeature unsupported_features[] =  {
+    AT_CellularBase::AT_CGSN_WITH_TYPE,
+    AT_CellularBase::SUPPORTED_FEATURE_END_MARK
+};
+
 QUECTEL_BG96::QUECTEL_BG96(EventQueue &queue) : AT_CellularDevice(queue)
 {
+    AT_CellularBase::set_unsupported_features(unsupported_features);
 }
 
 QUECTEL_BG96::~QUECTEL_BG96()

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularSIM.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularSIM.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "QUECTEL_BG96_CellularSIM.h"
+#include "CellularLog.h"
+
+using namespace mbed;
+
+QUECTEL_BG96_CellularSIM::QUECTEL_BG96_CellularSIM(ATHandler &atHandler) : AT_CellularSIM(atHandler)
+{
+
+}
+
+QUECTEL_BG96_CellularSIM::~QUECTEL_BG96_CellularSIM()
+{
+
+}
+
+// According to BG96_AT_Commands_Manual_V2.0
+nsapi_error_t QUECTEL_BG96_CellularSIM::get_iccid(char *buf, size_t buf_size)
+{
+    _at.lock();
+    _at.cmd_start("AT+QCCID");
+    _at.cmd_stop();
+    _at.resp_start("+QCCID:");
+    _at.read_string(buf, buf_size);
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularSIM.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularSIM.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, Arm Limited and affiliates.
+ * Copyright (c) 2018, Arm Limited and affiliates.
  * SPDX-License-Identifier: Apache-2.0
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,23 +15,22 @@
  * limitations under the License.
  */
 
-#ifndef QUECTEL_BC95_CELLULAR_SIM_H_
-#define QUECTEL_BC95_CELLULAR_SIM_H_
+#ifndef QUECTEL_BG96_CELLULAR_SIM_H_
+#define QUECTEL_BG96_CELLULAR_SIM_H_
 
 #include "AT_CellularSIM.h"
 
 namespace mbed {
 
-class QUECTEL_BC95_CellularSIM : public AT_CellularSIM {
+class QUECTEL_BG96_CellularSIM : public AT_CellularSIM {
 public:
-    QUECTEL_BC95_CellularSIM(ATHandler &atHandler);
-    virtual ~QUECTEL_BC95_CellularSIM();
+    QUECTEL_BG96_CellularSIM(ATHandler &atHandler);
+    virtual ~QUECTEL_BG96_CellularSIM();
 
 public: //from CellularSIM
-    virtual nsapi_error_t get_sim_state(SimState &state);
     virtual nsapi_error_t get_iccid(char *buf, size_t buf_size);
 };
 
 } // namespace mbed
 
-#endif // QUECTEL_BC95_CELLULAR_SIM_H_
+#endif // QUECTEL_BG96_CELLULAR_SIM_H_

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -22,9 +22,14 @@
 using namespace mbed;
 using namespace events;
 
+static const AT_CellularBase::SupportedFeature unsupported_features[] =  {
+    AT_CellularBase::AT_CGSN_WITH_TYPE, // HE910/UE910/UL865/UE866 AT Commands Reference Guide Rev. 11-2006-10-14
+    AT_CellularBase::SUPPORTED_FEATURE_END_MARK
+};
+
 TELIT_HE910::TELIT_HE910(EventQueue &queue) : AT_CellularDevice(queue)
 {
-
+    AT_CellularBase::set_unsupported_features(unsupported_features);
 }
 
 TELIT_HE910::~TELIT_HE910()


### PR DESCRIPTION
### Description

Added new methods in cellular API:
* CellularInformation::get_serial_number to read SN and IMEI of modem with AT+CGSN
* CellularSIM::get_iccid to read ICCID of SIM card with AT+CCID

Fixes Arm internal ref IOTCELL-1091.

Doxygen and return types of the CellularInformation class were fixed at the same.

Usage example:

    CellularInformation *info = _cellularDevice->open_information(_serial);
    char buf[100];
    if (info->get_serial_number(buf, sizeof(buf), CellularInformation::SN) == 0) {
        tr_info("SN: %s", buf);
    }
    _cellularDevice->close_information();

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

