### PR TITLE
Fix mbed::InterruptIn.mode() in NRF5x targets

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/gpio_api.c
@@ -129,8 +129,18 @@ static void gpio_apply_config(uint8_t pin)
             cfg.hi_accuracy = false;
             cfg.is_watcher = false;
             cfg.sense = NRF_GPIOTE_POLARITY_TOGGLE;
+            switch(m_gpio_cfg[pin].pull) {
+                case PullUp:
+                    cfg.pull = NRF_GPIO_PIN_PULLUP;
+                break;
+                case PullDown:
+                    cfg.pull = NRF_GPIO_PIN_PULLDOWN;
+                break;
+                default:
+                    cfg.pull = NRF_GPIO_PIN_NOPULL;
+                break;
+            }
             if (m_gpio_cfg[pin].used_as_irq) {
-                cfg.pull = NRF_GPIO_PIN_PULLUP;
                 nrf_drv_gpiote_in_init(pin, &cfg, gpiote_irq_handler);
                 if ((m_gpio_irq_enabled & ((gpio_mask_t)1 << pin))
                     && (m_gpio_cfg[pin].irq_rise || m_gpio_cfg[pin].irq_fall))
@@ -139,17 +149,6 @@ static void gpio_apply_config(uint8_t pin)
                 }
             }
             else {
-                switch(m_gpio_cfg[pin].pull) {
-                    case PullUp:
-                        cfg.pull = NRF_GPIO_PIN_PULLUP;
-                    break;
-                    case PullDown:
-                        cfg.pull = NRF_GPIO_PIN_PULLDOWN;
-                    break;
-                    default:
-                        cfg.pull = NRF_GPIO_PIN_NOPULL;
-                    break;
-                }
                 nrf_gpio_cfg_input(pin,cfg.pull);
             }
         }

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/gpio_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/gpio_api.c
@@ -21,13 +21,13 @@
 
 
 #if defined(TARGET_MCU_NRF51822)
-    #define GPIO_PIN_COUNT 31
+#define GPIO_PIN_COUNT 31
 #elif defined(TARGET_MCU_NRF52832)
-    #define GPIO_PIN_COUNT 32
+#define GPIO_PIN_COUNT 32
 #elif defined(TARGET_MCU_NRF52840)
-    #define GPIO_PIN_COUNT 48
+#define GPIO_PIN_COUNT 48
 #else
-    #error not recognized gpio count for mcu
+#error not recognized gpio count for mcu
 #endif
 
 typedef struct {
@@ -40,9 +40,9 @@ typedef struct {
 } gpio_cfg_t;
 
 #if GPIO_PIN_COUNT > 32
-    typedef uint64_t gpio_mask_t;
+typedef uint64_t gpio_mask_t;
 #else
-    typedef uint32_t gpio_mask_t;
+typedef uint32_t gpio_mask_t;
 #endif
 
 static gpio_mask_t m_gpio_initialized;
@@ -62,12 +62,12 @@ static void gpiote_irq_handler(nrf_drv_gpiote_pin_t pin, nrf_gpiote_polarity_t a
 {
     nrf_gpio_pin_sense_t sense =  nrf_gpio_pin_sense_get(pin);
     gpio_irq_event event = (sense == NRF_GPIO_PIN_SENSE_LOW) ? IRQ_RISE : IRQ_FALL;
-    
+
     if (m_gpio_irq_enabled & ((gpio_mask_t)1 << pin)) {
         if (((event == IRQ_RISE) && m_gpio_cfg[pin].irq_rise)
-            || ((event == IRQ_FALL) && m_gpio_cfg[pin].irq_fall)) {
-                m_irq_handler(m_channel_ids[pin], event);
-            }
+                || ((event == IRQ_FALL) && m_gpio_cfg[pin].irq_fall)) {
+            m_irq_handler(m_channel_ids[pin], event);
+        }
     }
 }
 
@@ -80,9 +80,9 @@ void gpio_init(gpio_t *obj, PinName pin)
         return;
     }
     MBED_ASSERT((uint32_t)pin < GPIO_PIN_COUNT);
-    
+
     NVIC_SetVector(GPIOTE_IRQn, (uint32_t) GPIOTE_IRQHandler);
-    
+
     (void) nrf_drv_gpiote_init();
 
     m_gpio_cfg[obj->pin].used_as_gpio = true;
@@ -111,8 +111,7 @@ static void gpiote_pin_uninit(uint8_t pin)
     if (m_gpio_initialized & ((gpio_mask_t)1UL << pin)) {
         if ((m_gpio_cfg[pin].direction == PIN_OUTPUT) && (!m_gpio_cfg[pin].used_as_irq)) {
             nrf_drv_gpiote_out_uninit(pin);
-        }
-        else if (m_gpio_cfg[pin].used_as_irq) {
+        } else if (m_gpio_cfg[pin].used_as_irq) {
             nrf_drv_gpiote_in_uninit(pin);
         }
     }
@@ -122,44 +121,40 @@ static void gpio_apply_config(uint8_t pin)
 {
     if (m_gpio_cfg[pin].used_as_gpio || m_gpio_cfg[pin].used_as_irq) {
         if ((m_gpio_cfg[pin].direction == PIN_INPUT)
-            || (m_gpio_cfg[pin].used_as_irq)) {
+                || (m_gpio_cfg[pin].used_as_irq)) {
             //Configure as input.
             nrf_drv_gpiote_in_config_t cfg;
 
             cfg.hi_accuracy = false;
             cfg.is_watcher = false;
             cfg.sense = NRF_GPIOTE_POLARITY_TOGGLE;
-            switch(m_gpio_cfg[pin].pull) {
+            switch (m_gpio_cfg[pin].pull) {
                 case PullUp:
                     cfg.pull = NRF_GPIO_PIN_PULLUP;
-                break;
+                    break;
                 case PullDown:
                     cfg.pull = NRF_GPIO_PIN_PULLDOWN;
-                break;
+                    break;
                 default:
                     cfg.pull = NRF_GPIO_PIN_NOPULL;
-                break;
+                    break;
             }
             if (m_gpio_cfg[pin].used_as_irq) {
                 nrf_drv_gpiote_in_init(pin, &cfg, gpiote_irq_handler);
                 if ((m_gpio_irq_enabled & ((gpio_mask_t)1 << pin))
-                    && (m_gpio_cfg[pin].irq_rise || m_gpio_cfg[pin].irq_fall))
-                {
+                        && (m_gpio_cfg[pin].irq_rise || m_gpio_cfg[pin].irq_fall)) {
                     nrf_drv_gpiote_in_event_enable(pin, true);
                 }
+            } else {
+                nrf_gpio_cfg_input(pin, cfg.pull);
             }
-            else {
-                nrf_gpio_cfg_input(pin,cfg.pull);
-            }
-        }
-        else {
+        } else {
             // Configure as output.
             nrf_drv_gpiote_out_config_t cfg = GPIOTE_CONFIG_OUT_SIMPLE(nrf_gpio_pin_out_read(pin));
             nrf_drv_gpiote_out_init(pin, &cfg);
         }
         m_gpio_initialized |= ((gpio_mask_t)1UL << pin);
-    }
-    else {
+    } else {
         m_gpio_initialized &= ~((gpio_mask_t)1UL << pin);
     }
 }
@@ -168,9 +163,9 @@ static void gpio_apply_config(uint8_t pin)
 void gpio_mode(gpio_t *obj, PinMode mode)
 {
     MBED_ASSERT(obj->pin != (PinName)NC);
-    
+
     gpiote_pin_uninit(obj->pin); // try to uninitialize gpio before a change.
-    
+
     m_gpio_cfg[obj->pin].pull = mode;
     gpio_apply_config(obj->pin);
 }
@@ -179,9 +174,9 @@ void gpio_mode(gpio_t *obj, PinMode mode)
 void gpio_dir(gpio_t *obj, PinDirection direction)
 {
     MBED_ASSERT(obj->pin != (PinName)NC);
-    
+
     gpiote_pin_uninit(obj->pin); // try to uninitialize gpio before a change.
-    
+
     m_gpio_cfg[obj->pin].direction = direction;
     gpio_apply_config(obj->pin);
 }
@@ -200,8 +195,9 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
     (void) nrf_drv_gpiote_init();
 
     gpiote_pin_uninit(pin); // try to uninitialize gpio before a change.
-    
+
     m_gpio_cfg[pin].used_as_irq = true;
+    m_gpio_cfg[pin].pull = PullNone;
     m_channel_ids[pin] = id;
     obj->ch            = pin;
     m_irq_handler      = handler;
@@ -224,15 +220,14 @@ void gpio_irq_free(gpio_irq_t *obj)
 
 void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable)
 {
-    gpio_cfg_t* cfg = &m_gpio_cfg[obj->ch];
+    gpio_cfg_t *cfg = &m_gpio_cfg[obj->ch];
     bool irq_enabled_before =
         (m_gpio_irq_enabled & ((gpio_mask_t)1 << obj->ch)) &&
         (cfg->irq_rise || cfg->irq_fall);
 
     if (event == IRQ_RISE) {
         cfg->irq_rise = enable ? true : false;
-    }
-    else if (event == IRQ_FALL) {
+    } else if (event == IRQ_FALL) {
         cfg->irq_fall = enable ? true : false;
     }
 


### PR DESCRIPTION
Fix mbed::InterruptIn.mode() for NRF5x targets

# Description

The interruptIn mode() didn't do anything in nrf5x targets, it always remained with a pullup resistor enabled.
We're migrating from MBed OS 3 to MBed OS 5 and found this problematic issue. The pullup or pulldown resistor should be configurable in the InterruptIn class. Currently this is for a unknown reason fixed to pullup resistor always enabled.

Tested locally on the nrf51422_xxac with GCC_ARM toolchain. 

# Pull request type

[x] Fix
[ ] Refactor
[ ] New Target
[ ] Feature