### PR TITLE
STM32: Add comments for HAL_InitTick function

### DIFF
--- a/targets/TARGET_STM/hal_tick_16b.c
+++ b/targets/TARGET_STM/hal_tick_16b.c
@@ -34,7 +34,8 @@ void timer_irq_handler(void)
 
 #if defined(TARGET_STM32F0)
 } // end timer_update_irq_handler function
-// Used for mbed timeout (channel 1) and HAL tick (channel 2)
+
+// Channel 1 used for mbed timeout
 void timer_oc_irq_handler(void)
 {
     TimMasterHandle.Instance = TIM_MST;

--- a/targets/TARGET_STM/hal_tick_16b.c
+++ b/targets/TARGET_STM/hal_tick_16b.c
@@ -49,7 +49,12 @@ void timer_oc_irq_handler(void)
     }
 }
 
-// Reconfigure the HAL tick using a standard timer instead of systick.
+// Overwrite the default ST HAL function (defined as "weak") in order to configure an HW timer
+// used for mbed timeouts only (not used for the Systick configuration).
+// Additional notes:
+// - The default ST HAL_InitTick function initializes the Systick to 1 ms and this is not correct for mbed
+//   as the mbed Systick as to be configured to 1 us instead.
+// - Furthermore the Systick is configured by mbed RTOS directly.
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
     // Enable timer clock

--- a/targets/TARGET_STM/hal_tick_32b.c
+++ b/targets/TARGET_STM/hal_tick_32b.c
@@ -35,7 +35,12 @@ void timer_irq_handler(void)
     }
 }
 
-// Reconfigure the HAL tick using a standard timer instead of systick.
+// Overwrite the default ST HAL function (defined as "weak") in order to configure an HW timer
+// used for mbed timeouts only (not used for the Systick configuration).
+// Additional notes:
+// - The default ST HAL_InitTick function initializes the Systick to 1 ms and this is not correct for mbed
+//   as the mbed Systick as to be configured to 1 us instead.
+// - Furthermore the Systick is configured by mbed RTOS directly.
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
     RCC_ClkInitTypeDef RCC_ClkInitStruct;


### PR DESCRIPTION
### Description

Add more comments for the HAL_InitTick function to explain this function is not intended to configure the SysTick but rather a HW timer used for timeouts only. I hope it is clearer, otherwise tell me...

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

