### PR TITLE
Tools: Force small lib when compiling with uARM

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -312,6 +312,7 @@ class ARM_MICRO(ARM):
     def __init__(self, target, notify=None, macros=None,
                  silent=False, extra_verbose=False, build_profile=None,
                  build_dir=None):
+        target.default_lib = "small"
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
         if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):


### PR DESCRIPTION
### Description

PR #7197 blurred the lines between the ARM and uARM compilers. When making 
those changes, I forgot to force -t uARM to compile with microlib. This PR
corrects the bad behavior that I introduced then


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change