### PR TITLE
Rename text region in ARM linker file for a few NXP CPUs

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/device/TOOLCHAIN_ARM_STD/MK66FN2M0xxx18.sct
@@ -91,14 +91,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_ARM_STD/MK82FN256xxx15.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/device/TOOLCHAIN_ARM_STD/MK82FN256xxx15.sct
@@ -90,7 +90,7 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
@@ -100,7 +100,7 @@ LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; loa
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/device/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
@@ -84,14 +84,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/device/TOOLCHAIN_ARM_STD/MKL43Z256xxx4.sct
@@ -81,14 +81,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_ARM_STD/MKL82Z128xxx7.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/device/TOOLCHAIN_ARM_STD/MKL82Z128xxx7.sct
@@ -94,7 +94,7 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
@@ -104,7 +104,7 @@ LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; loa
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/device/TOOLCHAIN_ARM_STD/MKW24D512xxx5.sct
@@ -90,14 +90,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_ARM_STD/MKW41Z512xxx4.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/device/TOOLCHAIN_ARM_STD/MKW41Z512xxx4.sct
@@ -79,14 +79,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/device/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
@@ -88,14 +88,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_ARM_STD/MK24FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/device/TOOLCHAIN_ARM_STD/MK24FN1M0xxx12.sct
@@ -82,14 +82,14 @@
 #define m_data_2_size                  0x00030000
 
 
-LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -95,14 +95,14 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
   ER_m_flash_config m_flash_config_start FIXED m_flash_config_size { ; load address = execution address
     * (FlashConfig)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/TOOLCHAIN_ARM_STD/LPC54114J256_cm4.sct
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/device/TARGET_LPC54114_M4/TOOLCHAIN_ARM_STD/LPC54114J256_cm4.sct
@@ -88,11 +88,11 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_text m_text_start m_text_size  {  ; load address = execution address
+  ER_IROM1 m_text_start m_text_size  {  ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/device/TOOLCHAIN_ARM_STD/LPC54628J512.sct
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/device/TOOLCHAIN_ARM_STD/LPC54628J512.sct
@@ -80,11 +80,11 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start { ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_text m_text_start FIXED m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start FIXED m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/TOOLCHAIN_ARM_STD/MIMXRT1052xxxxx.sct
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/TOOLCHAIN_ARM_STD/MIMXRT1052xxxxx.sct
@@ -80,11 +80,11 @@
   #define Heap_Size                    0x0400
 #endif
 
-LR_m_text m_interrupts_start m_text_start+m_text_size-m_interrupts_size {   ; load region size_region
+LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_size {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
     * (RESET,+FIRST)
   }
-  ER_m_text m_text_start m_text_size { ; load address = execution address
+  ER_IROM1 m_text_start m_text_size { ; load address = execution address
     * (InRoot$$Sections)
     .ANY (+RO)
   }


### PR DESCRIPTION
### Description
In most of the linker files for the ARM toolchain, the text region has a uniform name `LR_IROM1`. However, a few Freescale/NXP boards had the `LR_m_text` name instead. Beside this being not uniform, it doesn't allow us to determine the text region size at run time (which is required in a few future tests). In addition, the `LR_IROM1` name is referred to in a few Handbook documents (like [Bootstrap](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/reference/contributing/target/bootstrap.md) or [Flash](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/reference/contributing/target/flash.md)) and the `LR_m_text` name deviates from this documentation. 
This change currently has no effect on anything other than the linker files themselves (These names aren't mentioned in the code).

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

