### PR TITLE
Tools: Check compiler version

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -552,6 +552,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         src_paths, build_path, target, toolchain_name, macros=macros,
         clean=clean, jobs=jobs, notify=notify, config=config,
         app_config=app_config, build_profile=build_profile, ignore=ignore)
+    toolchain.version_check()
 
     # The first path will give the name to the library
     name = (name or toolchain.config.name or

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -18,6 +18,7 @@ from tools.notifier.mock import MockNotifier
 
 ALPHABET = [char for char in printable if char not in [u'.', u'/', u'\\']]
 
+
 @patch('tools.toolchains.arm.run_cmd')
 def test_arm_version_check(_run_cmd):
     _run_cmd.return_value = ("""
@@ -36,6 +37,28 @@ def test_arm_version_check(_run_cmd):
     """, "", 0)
     toolchain.version_check()
     assert len(notifier.messages) == 1
+
+
+@patch('tools.toolchains.iar.run_cmd')
+def test_iar_version_check(_run_cmd):
+    _run_cmd.return_value = ("""
+    IAR ANSI C/C++ Compiler V7.80.1.28/LNX for ARM
+    """, "", 0)
+    notifier = MockNotifier()
+    toolchain = TOOLCHAIN_CLASSES["IAR"](TARGET_MAP["K64F"], notify=notifier)
+    toolchain.version_check()
+    assert notifier.messages == []
+    _run_cmd.return_value = ("""
+    IAR ANSI C/C++ Compiler V/LNX for ARM
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 1
+    _run_cmd.return_value = ("""
+    IAR ANSI C/C++ Compiler V/8.80LNX for ARM
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 2
+
 
 @given(fixed_dictionaries({
     'common': lists(text()),

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -18,6 +18,25 @@ from tools.notifier.mock import MockNotifier
 
 ALPHABET = [char for char in printable if char not in [u'.', u'/', u'\\']]
 
+@patch('tools.toolchains.arm.run_cmd')
+def test_arm_version_check(_run_cmd):
+    _run_cmd.return_value = ("""
+    Product: ARM Compiler 5.06
+    Component: ARM Compiler 5.06 update 5 (build 528)
+    Tool: armcc [4d3621]
+    """, "", 0)
+    notifier = MockNotifier()
+    toolchain = TOOLCHAIN_CLASSES["ARM"](TARGET_MAP["K64F"], notify=notifier)
+    toolchain.version_check()
+    assert notifier.messages == []
+    _run_cmd.return_value = ("""
+    Product: ARM Compiler
+    Component: ARM Compiler
+    Tool: armcc [4d3621]
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 1
+
 @given(fixed_dictionaries({
     'common': lists(text()),
     'c': lists(text()),

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -60,6 +60,37 @@ def test_iar_version_check(_run_cmd):
     assert len(notifier.messages) == 2
 
 
+@patch('tools.toolchains.gcc.run_cmd')
+def test_gcc_version_check(_run_cmd):
+    _run_cmd.return_value = ("""
+    arm-none-eabi-gcc (Arch Repository) 6.4.4
+    Copyright (C) 2018 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    """, "", 0)
+    notifier = MockNotifier()
+    toolchain = TOOLCHAIN_CLASSES["GCC_ARM"](
+        TARGET_MAP["K64F"], notify=notifier)
+    toolchain.version_check()
+    assert notifier.messages == []
+    _run_cmd.return_value = ("""
+    arm-none-eabi-gcc (Arch Repository) 8.1.0
+    Copyright (C) 2018 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 1
+    _run_cmd.return_value = ("""
+    arm-none-eabi-gcc (Arch Repository)
+    Copyright (C) 2018 Free Software Foundation, Inc.
+    This is free software; see the source for copying conditions.  There is NO
+    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    """, "", 0)
+    toolchain.version_check()
+    assert len(notifier.messages) == 2
+
+
 @given(fixed_dictionaries({
     'common': lists(text()),
     'c': lists(text()),

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1539,6 +1539,13 @@ class mbedToolchain:
     def get_config_macros(self):
         return self.config.config_to_macros(self.config_data) if self.config_data else []
 
+    @abstractmethod
+    def version_check(self):
+        """Check the version of a compiler being used and raise a
+        NotSupportedException when it's incorrect.
+        """
+        raise NotImplemented
+
     @property
     def report(self):
         to_ret = {}

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -99,8 +99,8 @@ class ARM(mbedToolchain):
         msg = None
         min_ver, max_ver = self.ARMCC_RANGE
         match = self.ARMCC_VERSION_RE.search(stdout)
-        found_version = LooseVersion(match.group(0)) if match else None
-        min_ver, max_ver = self.ARM_RANGE
+        found_version = LooseVersion(match.group(1)) if match else None
+        min_ver, max_ver = self.ARMCC_RANGE
         if found_version and (found_version < min_ver or found_version >= max_ver):
             msg = ("Compiler version mismatch: Have {}; "
                    "expected version >= {} and < {}"

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -105,7 +105,7 @@ class ARM(mbedToolchain):
             msg = ("Compiler version mismatch: Have {}; "
                    "expected version >= {} and < {}"
                    .format(found_version, min_ver, max_ver))
-        elif len(match.groups()) != 1:
+        elif not match or len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could not detect version; "
                    "expected version >= {} and < {}"
                    .format(min_ver, max_ver))

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -41,7 +41,7 @@ class ARM(mbedToolchain):
     SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
                        "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD", "Cortex-A9"]
     ARMCC_RANGE = (LooseVersion("5.06"), LooseVersion("5.07"))
-    ARMCC_VERSION_RE = re.compile("Product: ARM Compiler (\d+.\d+)")
+    ARMCC_VERSION_RE = re.compile("Product: ARM Compiler (\d+\.\d+)")
 
     @staticmethod
     def check_executable():

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -41,7 +41,7 @@ class ARM(mbedToolchain):
     SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
                        "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD", "Cortex-A9"]
     ARMCC_RANGE = (LooseVersion("5.06"), LooseVersion("5.07"))
-    ARMCC_VERSION_RE = re.compile("^Product: ARM Compiler ([.0-9]*)")
+    ARMCC_VERSION_RE = re.compile("^Product: ARM Compiler (\d+.\d+)")
 
     @staticmethod
     def check_executable():

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -41,7 +41,7 @@ class ARM(mbedToolchain):
     SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
                        "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD", "Cortex-A9"]
     ARMCC_RANGE = (LooseVersion("5.06"), LooseVersion("5.07"))
-    ARMCC_VERSION_RE = re.compile("^Product: ARM Compiler (\d+.\d+)")
+    ARMCC_VERSION_RE = re.compile("Product: ARM Compiler (\d+.\d+)")
 
     @staticmethod
     def check_executable():
@@ -98,17 +98,16 @@ class ARM(mbedToolchain):
         stdout, _, retcode = run_cmd([self.cc[0], "--vsn"], redirect=True)
         msg = None
         min_ver, max_ver = self.ARMCC_RANGE
-        first_line = stdout.splitlines()[0]
-        match = self.ARMCC_VERSION_RE.match(first_line)
-        if match:
-            found_version = LooseVersion(match.group(1))
-            if found_version < min_ver or found_version > max_ver:
-                msg = ("Compiler version mismatch: Have {}; "
-                       "expected >= {} < {}"
-                       .format(found_version, min_ver, max_ver))
-        else:
+        match = self.ARMCC_VERSION_RE.search(stdout)
+        found_version = LooseVersion(match.group(0)) if match else None
+        min_ver, max_ver = self.ARM_RANGE
+        if found_version and (found_version < min_ver or found_version >= max_ver):
+            msg = ("Compiler version mismatch: Have {}; "
+                   "expected version >= {} and < {}"
+                   .format(found_version, min_ver, max_ver))
+        elif len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could not detect version; "
-                   "expected >= {} < {}"
+                   "expected version >= {} and < {}"
                    .format(min_ver, max_ver))
 
         if msg:

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -17,6 +17,7 @@ limitations under the License.
 import re
 from os.path import join, basename, splitext, dirname, exists
 from distutils.spawn import find_executable
+from distutils.version import LooseVersion
 
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
@@ -29,7 +30,7 @@ class GCC(mbedToolchain):
     STD_LIB_NAME = "lib%s.a"
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(?P<col>\d+):? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
 
-    GCC_MAJOR = "6"
+    GCC_RANGE = (LooseVersion("6.0.0"), LooseVersion("7.0.0"))
     GCC_VERSION_RE = re.compile("[0-9]*\.[0-9]*\.[0-9]*")
 
     def __init__(self, target,  notify=None, macros=None, build_profile=None,
@@ -118,15 +119,24 @@ class GCC(mbedToolchain):
             for word in line.split():
                 match = self.GCC_VERSION_RE.match(word)
                 if match:
-                    found_version = match.group(0)
-        if found_version and not found_version.startswith(self.GCC_MAJOR + "."):
-            raise NotSupportedException(
-                "GCC_ARM compiler version mismatch: Have {}; expected major version {}"
-                .format(found_version, self.GCC_MAJOR))
+                    found_version = LooseVersion(match.group(0))
+        min_ver, max_ver = self.GCC_RANGE
+        if found_version and (found_version < min_ver or found_version >= max_ver):
+            msg = ("Compiler version mismatch: Have {}; "
+                   "expected version >= {} and < {}"
+                   .format(found_version, min_ver, max_ver))
         elif not found_version:
-            raise NotSupportedException(
-                "GCC_ARM compiler version mismatch: Could Not detect compiler "
-                "version; expected {}".format(self.GCC_MAJOR))
+            msg = ("Compiler version mismatch: Could not detect version; "
+                   "expected version >= {} and < {}"
+                   .format(min_ver, max_ver))
+        if msg:
+            self.notify.cc_info({
+                "message": msg,
+                "file": "",
+                "line": "",
+                "col": "",
+                "severity": "ERROR",
+            })
 
     def is_not_supported_error(self, output):
         return "error: #error [NOT_SUPPORTED]" in output

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -122,7 +122,7 @@ class GCC(mbedToolchain):
             msg = ("Compiler version mismatch: Have {}; "
                    "expected version >= {} and < {}"
                    .format(found_version, min_ver, max_ver))
-        elif len(match.groups()) != 1:
+        elif not match or len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could not detect version; "
                    "expected version >= {} and < {}"
                    .format(min_ver, max_ver))

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -31,7 +31,7 @@ class GCC(mbedToolchain):
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(?P<col>\d+):? (?P<severity>warning|[eE]rror|fatal error): (?P<message>.+)')
 
     GCC_RANGE = (LooseVersion("6.0.0"), LooseVersion("7.0.0"))
-    GCC_VERSION_RE = re.compile("[0-9]*\.[0-9]*\.[0-9]*")
+    GCC_VERSION_RE = re.compile("\d+\.\d+\.\d+")
 
     def __init__(self, target,  notify=None, macros=None, build_profile=None,
                  build_dir=None):
@@ -122,7 +122,7 @@ class GCC(mbedToolchain):
             msg = ("Compiler version mismatch: Have {}; "
                    "expected version >= {} and < {}"
                    .format(found_version, min_ver, max_ver))
-        elif not match or len(match.groups()) != 1:
+        elif not match:
             msg = ("Compiler version mismatch: Could not detect version; "
                    "expected version >= {} and < {}"
                    .format(min_ver, max_ver))

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -114,18 +114,15 @@ class GCC(mbedToolchain):
 
     def version_check(self):
         stdout, _, retcode = run_cmd([self.cc[0], "--version"], redirect=True)
-        found_version = None
-        for line in stdout.splitlines():
-            for word in line.split():
-                match = self.GCC_VERSION_RE.match(word)
-                if match:
-                    found_version = LooseVersion(match.group(0))
+        msg = None
+        match = self.GCC_VERSION_RE.search(stdout)
+        found_version = LooseVersion(match.group(0)) if match else None
         min_ver, max_ver = self.GCC_RANGE
         if found_version and (found_version < min_ver or found_version >= max_ver):
             msg = ("Compiler version mismatch: Have {}; "
                    "expected version >= {} and < {}"
                    .format(found_version, min_ver, max_ver))
-        elif not found_version:
+        elif len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could not detect version; "
                    "expected version >= {} and < {}"
                    .format(min_ver, max_ver))

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -97,16 +97,13 @@ class IAR(mbedToolchain):
 
     def version_check(self):
         stdout, _, retcode = run_cmd([self.cc[0], "--version"], redirect=True)
-        found_version = None
-        for line in stdout.splitlines():
-            match = self.IAR_VERSION_RE.match(line)
-            if match:
-                found_version = match.group(1)
         msg = None
+        match = self.IAR_VERSION_RE.search(stdout)
+        found_version = match.group(1) if match else None
         if found_version and LooseVersion(found_version) != self.IAR_VERSION:
             msg = "Compiler version mismatch: Have {}; expected {}".format(
                 found_version, self.IAR_VERSION)
-        elif not found_version:
+        elif len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could Not detect compiler "
                    "version; expected {}".format(self.IAR_VERSION))
         if msg:

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -30,7 +30,7 @@ class IAR(mbedToolchain):
 
     DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error|Fatal error)(?P<message>.+)')
     INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
-    IAR_VERSION_RE = re.compile("IAR ANSI C/C\+\+ Compiler V([0-9]+.[0-9]+)")
+    IAR_VERSION_RE = re.compile("IAR ANSI C/C\+\+ Compiler V(\d+\.\d+)")
     IAR_VERSION = LooseVersion("7.80")
 
     @staticmethod

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -103,7 +103,7 @@ class IAR(mbedToolchain):
         if found_version and LooseVersion(found_version) != self.IAR_VERSION:
             msg = "Compiler version mismatch: Have {}; expected {}".format(
                 found_version, self.IAR_VERSION)
-        elif len(match.groups()) != 1:
+        elif not match or len(match.groups()) != 1:
             msg = ("Compiler version mismatch: Could Not detect compiler "
                    "version; expected {}".format(self.IAR_VERSION))
         if msg:


### PR DESCRIPTION
### Description

In the past, we allowed any version of any toolchain. That will be a 
problem if/when we upgrade to ARM Compiler 5.10 or IAR 8. This PR
has the tools enforce the version of the compiler on `mbed compile`,
preventing any issues with compiler version

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change