### PR TITLE
Provide default WiFi interfaces for Ublox and Realtek

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/default_wifi_interface.cpp
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/default_wifi_interface.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "RTWInterface.h"
+
+WiFiInterface *WiFiInterface::get_target_default_instance()
+{
+    static RTWInterface wifi;
+    return &wifi;
+}

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/default_wifi_interface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/default_wifi_interface.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "OdinWiFiInterface.h"
+
+WiFiInterface *WiFiInterface::get_target_default_instance()
+{
+    static OdinWiFiInterface wifi;
+    return &wifi;
+}

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4006,7 +4006,7 @@
         },
         "release_versions": ["5"],
         "overrides": {
-            "network-default-interface-type": "ETHERNET"
+            "network-default-interface-type": "WIFI"
         }
     },
     "VBLUNO51_LEGACY": {


### PR DESCRIPTION
### Description

To allow application to choose default WiFi interface by calling `WiFiInterface::get_default_instance()` provide its implementation on these two targets.

Partially fixes:
#7257 
#7246

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

