### PR TITLE
IAR: Suppress C "bypasses initialization" warning

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -53,7 +53,7 @@
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-On", "-r", "-DMBED_DEBUG",
             "-DMBED_TRAP_ERRORS_ENABLED=1", "--enable_restrict", "-D_RTE_"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -48,7 +48,7 @@
             "--no_wrap_diagnostics", "-e",
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Oh", "--enable_restrict", "-D_RTE_"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -48,7 +48,7 @@
             "--no_wrap_diagnostics", "-e",
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082", "-Ohz", "-DNDEBUG", "--enable_restrict", "-D_RTE_"],
         "asm": [],
-        "c": ["--vla"],
+        "c": ["--vla", "--diag_suppress=Pe546"],
         "cxx": ["--guard_calls", "--no_static_destruction"],
         "ld": ["--skip_dynamic_initialization", "--threaded_lib"]
     }


### PR DESCRIPTION

### Description

By default IAR generates "transfer of control bypasses initialization"
warnings for C code - it's a legal construct that frequently occurs when
doing Linux-style "goto error". Many occurrences in Nanostack.

Suppress the warning for C only, to align with GCC and ARMCC. Have to
take care not to put it in the "common" section, as this would suppress
it for C++, where it actually is illegal.

Resolves #7253 and #7254.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

