### PR TITLE
BLE: Add setScanParams overload to the Gap API

### DIFF
--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2113,15 +2113,12 @@ public:
      * @note All restrictions from setScanParams(uint16_t, uint16_t, uint16_t, bool) apply.
      */
     ble_error_t setScanParams(const GapScanningParams& scanningParams) {
-        ble_error_t rc;
-        if (((rc = _scanningParams.setInterval(scanningParams.getInterval())) == BLE_ERROR_NONE) &&
-            ((rc = _scanningParams.setWindow(scanningParams.getWindow()))     == BLE_ERROR_NONE) &&
-            ((rc = _scanningParams.setTimeout(scanningParams.getTimeout()))   == BLE_ERROR_NONE)) {
-            _scanningParams.setActiveScanning(scanningParams.getActiveScanning());
-            return BLE_ERROR_NONE;
-        }
-
-        return rc;
+        return setScanParams(
+            scanningParams.getInterval(),
+            scanningParams.getWindow(),
+            scanningParams.getTimeout(),
+            scanningParams.getActiveScanning()
+        );
     }
 
     /**

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2112,9 +2112,16 @@ public:
      *
      * @note All restrictions from setScanParams(uint16_t, uint16_t, uint16_t, bool) apply.
      */
-    ble_error_t setScanParams(GapScanningParams scanningParams) {
-        _scanningParams = scanningParams;
-        return BLE_ERROR_NONE;
+    ble_error_t setScanParams(const GapScanningParams& scanningParams) {
+        ble_error_t rc;
+        if (((rc = _scanningParams.setInterval(scanningParams.getInterval())) == BLE_ERROR_NONE) &&
+            ((rc = _scanningParams.setWindow(scanningParams.getWindow()))     == BLE_ERROR_NONE) &&
+            ((rc = _scanningParams.setTimeout(scanningParams.getTimeout()))   == BLE_ERROR_NONE)) {
+            _scanningParams.setActiveScanning(scanningParams.getActiveScanning());
+            return BLE_ERROR_NONE;
+        }
+
+        return rc;
     }
 
     /**

--- a/features/FEATURE_BLE/ble/Gap.h
+++ b/features/FEATURE_BLE/ble/Gap.h
@@ -2103,6 +2103,21 @@ public:
     }
 
     /**
+     * Set the parameters used during a scan procedure.
+     *
+     * @param[in] scanningParams Parameter struct containing the interval, period,
+     * timeout and active scanning toggle.
+     *
+     * @return BLE_ERROR_NONE if the scan parameters were correctly set.
+     *
+     * @note All restrictions from setScanParams(uint16_t, uint16_t, uint16_t, bool) apply.
+     */
+    ble_error_t setScanParams(GapScanningParams scanningParams) {
+        _scanningParams = scanningParams;
+        return BLE_ERROR_NONE;
+    }
+
+    /**
      * Set the interval parameter used during scanning procedures.
      *
      * @param[in] interval Interval in ms between the start of two consecutive


### PR DESCRIPTION
### Description

Adding a missing overload for setScanParams so that it matches the advertising API calls.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

