### PR TITLE
NRF51 Post-build: Allow Hex BL, SD, APP

### DIFF
--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -513,11 +513,13 @@ class MCU_NRF51Code(object):
             t_self.notify.debug("Merge SoftDevice file %s"
                                 % softdevice_and_offset_entry['name'])
             sdh = IntelHex(sdf)
+            sdh.start_addr = None
             binh.merge(sdh)
 
         if t_self.target.MERGE_BOOTLOADER is True and blf is not None:
             t_self.notify.debug("Merge BootLoader file %s" % blf)
             blh = IntelHex(blf)
+            blh.start_addr = None
             binh.merge(blh)
 
         with open(binf.replace(".bin", ".hex"), "w") as fileout:


### PR DESCRIPTION
### Description

See ARMmbed/mbed-cli#589 for full details.

This PR fixes an issue with the NRF51 post-build script that would fail
when an application was compiled into an Intex Hex format. This prevents
"Address overlap" errors (which are really initial program counter conflicts)
from breaking the build.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change