### PR TITLE
Suppress shift warning for IAR compiler as well

### DIFF
--- a/drivers/MbedCRC.h
+++ b/drivers/MbedCRC.h
@@ -32,6 +32,8 @@ but we check for ( width < 8) before performing shift, so it should not be an is
 #elif defined ( __GNUC__ )
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wshift-count-negative"
+#elif defined (__ICCARM__)
+#pragma diag_suppress=Pe062  // Shift count is negative
 #endif
 
 namespace mbed {
@@ -457,6 +459,7 @@ private:
 #if   defined ( __CC_ARM )
 #elif defined ( __GNUC__ )
 #pragma GCC diagnostic pop
+#elif defined (__ICCARM__)
 #endif
 
 /** @}*/


### PR DESCRIPTION
### Description
Compiler gives invalid warning for shift operation, more details at https://github.com/ARMmbed/mbed-os/blob/master/drivers/MbedCRC.h#L23

Suppressing the warning for IAR compiler as well.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

Issue: https://github.com/ARMmbed/mbed-os/issues/7251
