### PR TITLE
Remove endpoint parameter from USB callbacks

### DIFF
--- a/TESTS/usb_device/basic/USBTester.cpp
+++ b/TESTS/usb_device/basic/USBTester.cpp
@@ -221,7 +221,7 @@ void USBTester::callback_set_configuration(uint8_t configuration)
 }
 
 bool USBTester::setup_iterface(uint8_t ep_in, uint8_t ep_out, uint32_t ep_size, usb_ep_type_t ep_type,
-                               uint8_t *buf, uint32_t buf_size, void (USBTester::*callback)(usb_ep_t endpoint))
+                               uint8_t *buf, uint32_t buf_size, void (USBTester::*callback)())
 {
     bool success = false;
 
@@ -690,13 +690,13 @@ const uint8_t *USBTester::configuration_desc(uint8_t index)
     }
 }
 
-void USBTester::epint_out_callback(usb_ep_t endpoint)
+void USBTester::epint_out_callback()
 {
-    read_finish(endpoint);
-    read_start(endpoint, int_buf, sizeof(int_buf));
+    read_finish(int_out);
+    read_start(int_out, int_buf, sizeof(int_buf));
 }
-void USBTester::epbulk_out_callback(usb_ep_t endpoint)
+void USBTester::epbulk_out_callback()
 {
-    read_finish(endpoint);
-    read_start(endpoint, bulk_buf, sizeof(bulk_buf));
+    read_finish(bulk_out);
+    read_start(bulk_out, bulk_buf, sizeof(bulk_buf));
 }

--- a/TESTS/usb_device/basic/USBTester.h
+++ b/TESTS/usb_device/basic/USBTester.h
@@ -62,7 +62,7 @@ private:
     bool set_configuration(uint16_t configuration);
     bool set_interface(uint16_t interface, uint16_t alternate);
     bool setup_iterface(uint8_t ep_in, uint8_t ep_out, uint32_t ep_size, usb_ep_type_t ep_type,
-                        uint8_t *buf, uint32_t buf_size, void (USBTester::*callback)(usb_ep_t endpoint));
+                        uint8_t *buf, uint32_t buf_size, void (USBTester::*callback)());
     void remove_iterface(uint16_t interface);
     int16_t interface_0_alt_set;
     int16_t interface_1_alt_set;
@@ -117,8 +117,8 @@ protected:
     virtual void callback_request_xfer_done(const setup_packet_t *setup, bool aborted);
     virtual void callback_set_configuration(uint8_t configuration);
     virtual void callback_set_interface(uint16_t interface, uint8_t alternate);
-    virtual void epbulk_out_callback(usb_ep_t endpoint);
-    virtual void epint_out_callback(usb_ep_t endpoint);
+    virtual void epbulk_out_callback();
+    virtual void epint_out_callback();
     virtual void callback_reset();
     uint8_t ctrl_buf[2048];
 

--- a/usb/device/USBAudio/USBAudio.cpp
+++ b/usb/device/USBAudio/USBAudio.cpp
@@ -883,10 +883,9 @@ void USBAudio::_receive_change(ChannelState new_state)
     }
 }
 
-void USBAudio::_receive_isr(usb_ep_t ep)
+void USBAudio::_receive_isr()
 {
     assert_locked();
-    MBED_ASSERT(ep == _episo_out);
 
     uint32_t size = read_finish(_episo_out);
 
@@ -984,10 +983,9 @@ void USBAudio::_send_isr_next_sync()
     _tx_frame_fract += _tx_fract_frames_per_xfer;
 }
 
-void USBAudio::_send_isr(usb_ep_t ep)
+void USBAudio::_send_isr()
 {
     assert_locked();
-    MBED_ASSERT(ep == _episo_in);
 
     write_finish(_episo_in);
 

--- a/usb/device/USBAudio/USBAudio.h
+++ b/usb/device/USBAudio/USBAudio.h
@@ -275,11 +275,11 @@ private:
     void _build_configuration_desc();
 
     void _receive_change(ChannelState new_state);
-    void _receive_isr(usb_ep_t ep);
+    void _receive_isr();
     void _send_change(ChannelState new_state);
     void _send_isr_start();
     void _send_isr_next_sync();
-    void _send_isr(usb_ep_t ep);
+    void _send_isr();
 
     // has connect been called
     bool _connected;

--- a/usb/device/USBDevice/USBDevice.cpp
+++ b/usb/device/USBDevice/USBDevice.cpp
@@ -939,7 +939,7 @@ void USBDevice::out(usb_ep_t endpoint)
     MBED_ASSERT(info->pending >= 1);
     info->pending -= 1;
     if (info->callback) {
-        (this->*(info->callback))(endpoint);
+        (this->*(info->callback))();
     }
 }
 
@@ -957,7 +957,7 @@ void USBDevice::in(usb_ep_t endpoint)
     MBED_ASSERT(info->pending >= 1);
     info->pending -= 1;
     if (info->callback) {
-        (this->*(info->callback))(endpoint);
+        (this->*(info->callback))();
     }
 }
 

--- a/usb/device/USBDevice/USBDevice.h
+++ b/usb/device/USBDevice/USBDevice.h
@@ -42,7 +42,7 @@
  */
 class USBDevice: public  USBPhyEvents {
 public:
-    typedef void (USBDevice::*ep_cb_t)(usb_ep_t endpoint);
+    typedef void (USBDevice::*ep_cb_t)();
 
     enum RequestResult {
         Receive = 0,
@@ -157,7 +157,7 @@ public:
     * @returns true if successful, false otherwise
     */
     template<typename T>
-    bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type, void (T::*callback)(usb_ep_t endpoint))
+    bool endpoint_add(usb_ep_t endpoint, uint32_t max_packet, usb_ep_type_t type, void (T::*callback)())
     {
         return endpoint_add(endpoint, max_packet, type, static_cast<ep_cb_t>(callback));
     }
@@ -539,7 +539,7 @@ private:
     void _complete_set_interface();
 
     struct endpoint_info_t {
-        void (USBDevice::*callback)(usb_ep_t endpoint);
+        ep_cb_t callback;
         uint16_t max_packet_size;
         uint16_t transfer_size;
         uint8_t flags;

--- a/usb/device/USBHID/USBHID.cpp
+++ b/usb/device/USBHID/USBHID.cpp
@@ -233,7 +233,7 @@ bool USBHID::read_nb(HID_REPORT *report)
     return success;
 }
 
-void USBHID::_send_isr(usb_ep_t endpoint)
+void USBHID::_send_isr()
 {
     assert_locked();
 
@@ -247,7 +247,7 @@ void USBHID::_send_isr(usb_ep_t endpoint)
 
 }
 
-void USBHID::_read_isr(usb_ep_t endpoint)
+void USBHID::_read_isr()
 {
     assert_locked();
 

--- a/usb/device/USBHID/USBHID.h
+++ b/usb/device/USBHID/USBHID.h
@@ -245,8 +245,8 @@ protected:
 
 private:
     void _init(uint8_t output_report_length, uint8_t input_report_length);
-    void _send_isr(usb_ep_t endpoint);
-    void _read_isr(usb_ep_t endpoint);
+    void _send_isr();
+    void _read_isr();
 
     class AsyncSend;
     class AsyncRead;

--- a/usb/device/USBMIDI/USBMIDI.cpp
+++ b/usb/device/USBMIDI/USBMIDI.cpp
@@ -311,14 +311,14 @@ const uint8_t *USBMIDI::configuration_desc(uint8_t index)
     return _config_descriptor;
 }
 
-void USBMIDI::_in_callback(usb_ep_t ep)
+void USBMIDI::_in_callback()
 {
     assert_locked();
 
     _flags.set(FLAG_WRITE_DONE);
 }
 
-void USBMIDI::_out_callback(usb_ep_t ep)
+void USBMIDI::_out_callback()
 {
     assert_locked();
 

--- a/usb/device/USBMIDI/USBMIDI.h
+++ b/usb/device/USBMIDI/USBMIDI.h
@@ -176,8 +176,8 @@ private:
     Callback<void()> _callback;
 
     void _init();
-    void _in_callback(usb_ep_t);
-    void _out_callback(usb_ep_t);
+    void _in_callback();
+    void _out_callback();
     bool _next_message();
 };
 

--- a/usb/device/USBMSD/USBMSD.cpp
+++ b/usb/device/USBMSD/USBMSD.cpp
@@ -216,12 +216,12 @@ int USBMSD::disk_status()
     return 0;
 }
 
-void USBMSD::_isr_out(usb_ep_t endpoint)
+void USBMSD::_isr_out()
 {
     _out_task.call();
 }
 
-void USBMSD::_isr_in(usb_ep_t endpoint)
+void USBMSD::_isr_in()
 {
     _in_task.call();
 }

--- a/usb/device/USBMSD/USBMSD.h
+++ b/usb/device/USBMSD/USBMSD.h
@@ -246,8 +246,8 @@ private:
     virtual void callback_request(const setup_packet_t *setup);
     virtual void callback_request_xfer_done(const setup_packet_t *setup, bool aborted);
 
-    void _isr_out(usb_ep_t endpoint);
-    void _isr_in(usb_ep_t endpoint);
+    void _isr_out();
+    void _isr_in();
 
     void _out();
     void _in();

--- a/usb/device/USBSerial/USBCDC.cpp
+++ b/usb/device/USBSerial/USBCDC.cpp
@@ -410,11 +410,11 @@ void USBCDC::_send_isr_start()
 * Called by when CDC data is sent
 * Warning: Called in ISR
 */
-void USBCDC::_send_isr(usb_ep_t endpoint)
+void USBCDC::_send_isr()
 {
     assert_locked();
 
-    write_finish(endpoint);
+    write_finish(_bulk_in);
     _tx_buf = _tx_buffer;
     _tx_size = 0;
     _tx_in_progress = false;
@@ -472,7 +472,7 @@ void USBCDC::_receive_isr_start()
 * Called by when CDC data is received
 * Warning: Called in ISR
 */
-void USBCDC::_receive_isr(usb_ep_t endpoint)
+void USBCDC::_receive_isr()
 {
     assert_locked();
 

--- a/usb/device/USBSerial/USBCDC.h
+++ b/usb/device/USBSerial/USBCDC.h
@@ -194,10 +194,10 @@ protected:
     void _change_terminal_connected(bool connected);
 
     void _send_isr_start();
-    void _send_isr(usb_ep_t endpoint);
+    void _send_isr();
 
     void _receive_isr_start();
-    void _receive_isr(usb_ep_t endpoint);
+    void _receive_isr();
 
     usb_ep_t _bulk_in;
     usb_ep_t _bulk_out;


### PR DESCRIPTION


### Description
Remove the endpoint parameter from endpoint callbacks. This
information is redundant because endpoints are known at construction time because they must be in the configuration descriptor.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [x] Breaking change

