### PR TITLE
USBMSD fixes

### DIFF
--- a/usb/device/USBMSD/USBMSD.h
+++ b/usb/device/USBMSD/USBMSD.h
@@ -189,6 +189,9 @@ private:
         uint8_t  Status;
     } CSW;
 
+    // If this class has been initialized
+    bool _init;
+
     //state of the bulk-only state machine
     Stage _stage;
 
@@ -232,6 +235,7 @@ private:
     Task<void()> _configure_task;
 
     BlockDevice *_bd;
+    rtos::Mutex _mutex_init;
     rtos::Mutex _mutex;
 
     // space for config descriptor


### PR DESCRIPTION
### Description

Make the following fixes:
- deinit in destructor to prevent race conditions
- cancel the reset task before calling it since it may be in progress
- wait for tasks to complete without mutex held
- prevent double connect with _init flag


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

