### PR TITLE
Fix lpc43xx serial pin map compiling error

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -89,7 +89,7 @@ static const PinMap PinMap_UART_RTS[] = {
 
 static const PinMap PinMap_UART_CTS[] = {
     {P1_11, UART_1, (SCU_PINIO_FAST | 1)},
-    {P5_4,  UART_1, (SCU_PINIO_FAST | 4),
+    {P5_4,  UART_1, (SCU_PINIO_FAST | 4)},
     {PC_2,  UART_1, (SCU_PINIO_FAST | 2)},
     {PE_7,  UART_1, (SCU_PINIO_FAST | 2)},
     {NC,    NC,     0}


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Fix lpc43xx compiling error on serial pin map

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

