### PR TITLE
Cellular: fixed defect where SIM interface was closed too early

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -436,8 +436,6 @@ void CellularConnectionFSM::state_sim_pin()
             retry_state_or_fail();
             return;
         }
-        _cellularDevice->close_sim();
-        _sim = NULL;
         if (_plmn) {
             enter_to_state(STATE_MANUAL_REGISTERING_NETWORK);
         } else {
@@ -485,6 +483,8 @@ void CellularConnectionFSM::state_attaching()
 {
     _cellularDevice->set_timeout(TIMEOUT_CONNECT);
     if (_network->set_attach() == NSAPI_ERROR_OK) {
+        _cellularDevice->close_sim();
+        _sim = NULL;
         enter_to_state(STATE_ACTIVATING_PDP_CONTEXT);
     } else {
         retry_state_or_fail();

--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -117,9 +117,9 @@ public:
      */
     CellularDevice *get_device();
 
-    /** Get cellular sim interface. SIM interface is released after SIM is open and ready for use (moving from STATE_SIM_PIN to next state).
-     *  After SIM interface is closed this method will return NULL. SIM interface can be created again via CellularDevice
-     *  which you can get with the method get_device().
+    /** Get cellular sim interface. SIM interface is released when moving from STATE_ATTACHING_NETWORK to STATE_ACTIVATING_PDP_CONTEXT.
+     *  After SIM interface is closed this method will return NULL and any instances fetched via this method are invalid.
+     *  SIM interface can be created again via CellularDevice which you can get with the method get_device().
      *  @return sim interface, NULL on failure
      */
     CellularSIM *get_sim();

--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -118,8 +118,8 @@ public:
     CellularDevice *get_device();
 
     /** Get cellular sim interface. SIM interface is released when moving from STATE_ATTACHING_NETWORK to STATE_ACTIVATING_PDP_CONTEXT.
-     *  After SIM interface is closed this method will return NULL and any instances fetched via this method are invalid.
-     *  SIM interface can be created again via CellularDevice which you can get with the method get_device().
+     *  After SIM interface is closed, this method returns NULL, and any instances fetched using this method are invalid.
+     *  SIM interface can be created again using CellularDevice, which you can get with the method get_device().
      *  @return sim interface, NULL on failure
      */
     CellularSIM *get_sim();


### PR DESCRIPTION
### Description

SIM interface was closed too early in CellularConnectionFSM.cpp causing a crash if APN lookup was enabled and apn configured to '0' in application json.
Crash happened EasyCellularConnection::connect(). Moved SIM interface closing a bit later.

Internal ref to defect: IOTCELL-1122

@AriParkkila please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

