### PR TITLE
Tools: Persist config errors until validation occurs

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -137,27 +137,7 @@ def get_config(src_paths, target, toolchain_name, app_config=None):
                                   app_config=app_config)
 
     # Scan src_path for config files
-    resources = toolchain.scan_resources(src_paths[0])
-    for path in src_paths[1:]:
-        resources.add(toolchain.scan_resources(path))
-
-    # Update configuration files until added features creates no changes
-    prev_features = set()
-    while True:
-        # Update the configuration with any .json files found while scanning
-        toolchain.config.add_config_files(resources.json_files)
-
-        # Add features while we find new ones
-        features = set(toolchain.config.get_features())
-        if features == prev_features:
-            break
-
-        for feature in features:
-            if feature in resources.features:
-                resources += resources.features[feature]
-
-        prev_features = features
-    toolchain.config.validate_config()
+    scan_resources(src_paths, toolchain)
     if toolchain.config.has_regions:
         _ = list(toolchain.config.regions)
 

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -788,7 +788,6 @@ class Config(object):
         unit_name - the unit (library/application) that defines this parameter
         unit_kind - the kind of the unit ("library" or "application")
         """
-        self.config_errors = []
         _process_config_parameters(data.get("config", {}), params, unit_name,
                                    unit_kind)
         for label, overrides in data.get("target_overrides", {}).items():

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -430,6 +430,7 @@ class Config(object):
         search for a configuration file).
         """
         config_errors = []
+        self.config_errors = []
         self.app_config_location = app_config
         if self.app_config_location is None and top_level_dirs:
             self.app_config_location = self.find_app_config(top_level_dirs)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -68,6 +68,19 @@ class ConfigException(Exception):
     errors"""
     pass
 
+class UndefinedParameter(ConfigException):
+    def __init__(self, param, name, kind, label):
+        self.param = param
+        self.name = name
+        self.kind = kind
+        self.label = label
+
+    def __str__(self):
+        return "Attempt to override undefined parameter '{}' in '{}'".format(
+            self.param,
+            ConfigParameter.get_display_name(self.name, self.kind, self.label),
+        )
+
 class ConfigParameter(object):
     """This class keeps information about a single configuration parameter"""
 
@@ -857,13 +870,8 @@ class Config(object):
                         continue
                     else:
                         self.config_errors.append(
-                            ConfigException(
-                                "Attempt to override undefined parameter" +
-                                (" '%s' in '%s'"
-                                 % (full_name,
-                                    ConfigParameter.get_display_name(unit_name,
-                                                                     unit_kind,
-                                                                     label)))))
+                            UndefinedParameter(
+                                full_name, unit_name, unit_kind, label))
 
         for cumulatives in self.cumulative_overrides.values():
             cumulatives.update_target(self.target)
@@ -911,10 +919,7 @@ class Config(object):
                     continue
                 if (full_name not in params) or \
                    (params[full_name].defined_by[7:] not in rel_names):
-                    raise ConfigException(
-                        "Attempt to override undefined parameter '%s' in '%s'"
-                        % (name,
-                           ConfigParameter.get_display_name(tname, "target")))
+                    raise UndefinedParameter(name, tname, "target", "")
                 # Otherwise update the value of the parameter
                 params[full_name].set_value(val, tname, "target")
         return params
@@ -1050,8 +1055,13 @@ class Config(object):
 
         Arguments: None
         """
-        if self.config_errors:
-            raise self.config_errors[0]
+        params, _ = self.get_config_data()
+        for error in self.config_errors:
+            if  (isinstance(error, UndefinedParameter) and
+                 error.param in params):
+                continue
+            else:
+                raise error
         return True
 
 
@@ -1071,7 +1081,6 @@ class Config(object):
         """
         # Update configuration files until added features creates no changes
         prev_features = set()
-        self.validate_config()
         while True:
             # Add/update the configuration with any .json files found while
             # scanning

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -585,7 +585,7 @@ class Config(object):
         raise ConfigException("No sector info available")
 
     def _get_cmsis_part(self):
-        if not self.target.bootloader_supported:
+        if not getattr(self.target, "bootloader_supported", False):
             raise ConfigException("Bootloader not supported on this target.")
         if not hasattr(self.target, "device_name"):
             raise ConfigException("Bootloader not supported on this target: "


### PR DESCRIPTION
### Description


As @geky pointed out in #5416, Configuration errors in 
"not-bottom-level" library configurations, a library that's not part of 
the last feature set added, do not show errors. This was because 
processing new library configurations cleared errors. This PR removes
the clearing behavior.

Resolves #5416

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change