### PR TITLE
Update Greentea netsocket and wifi tests

### DIFF
--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -96,7 +96,7 @@ void fill_tx_buffer_ascii(char *buff, size_t len)
 // Test setup
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(240, "default_auto");
+    GREENTEA_SETUP(480, "default_auto");
     _ifup();
     return greentea_test_setup_handler(number_of_cases);
 }

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -73,7 +73,7 @@ void fill_tx_buffer_ascii(char *buff, size_t len)
 // Test setup
 utest::v1::status_t greentea_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(240, "default_auto");
+    GREENTEA_SETUP(480, "default_auto");
     _ifup();
     return greentea_test_setup_handler(number_of_cases);
 }

--- a/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -30,8 +30,11 @@ void wifi_connect_secure_fail(void)
     WiFiInterface *wifi = get_interface();
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, "aaaaaaaa", get_security()));
-
-    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_AUTH_FAILURE, wifi->connect());
+    nsapi_error_t error;
+    error = wifi->connect();
+    TEST_ASSERT(error == NSAPI_ERROR_AUTH_FAILURE ||
+                error == NSAPI_ERROR_CONNECTION_TIMEOUT ||
+                error == NSAPI_ERROR_NO_CONNECTION);
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID)


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Increase timeout for netsocket TCP and UDP tests. Old timeout
(240 seconds) was not enough for slower devices to complete the
tests.
Accept error codes NSAPI_ERROR_CONNECTION_TIMEOUT and
NSAPI_ERROR_NO_CONNECTION when running test wifi_connect_secure_fail

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

