### PR TITLE
On STM32F439xI IAR linker file decreased stack size and increased heap

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_IAR/stm32f439xx_flash.icf
@@ -15,9 +15,9 @@ define symbol __ICFEDIT_region_RAM_end__      = 0x2002FFFF;
 define symbol __ICFEDIT_region_CCMRAM_start__ = 0x10000000;
 define symbol __ICFEDIT_region_CCMRAM_end__   = 0x1000FFFF;
 /*-Sizes-*/
-/*Heap 64kB and stack 24kB */
-define symbol __ICFEDIT_size_cstack__ = 0x6000;
-define symbol __ICFEDIT_size_heap__   = 0x10000;
+/*Heap 89kB and stack 1kB */
+define symbol __ICFEDIT_size_cstack__ = 0x400;
+define symbol __ICFEDIT_size_heap__   = 0x15C00;
 /**** End of ICF editor section. ###ICF###*/
 
 


### PR DESCRIPTION
### Description

On STM32F439xI IAR linker file decreased stack size from 24kbytes to 1kbytes (stack is used on boot-up/interrupt handler). Increased heap size from 65kbytes to 89kbytes.

Change is related to issue https://github.com/ARMmbed/mbed-os/issues/7137 where UBLOX_EVK_ODIN_W2 runs out of heap on WLAN.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

