### PR TITLE
Compiling Cortex-A cores in uVision is not supported.

### DIFF
--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -137,6 +137,8 @@ class Uvision(Exporter):
             return False
         if not DeviceCMSIS.check_supported(target_name):
             return False
+        if "Cortex-A" in target.core:
+            return False
         if not hasattr(target, "post_binary_hook"):
             return True
         if target.post_binary_hook['function'] in cls.POST_BINARY_WHITELIST:


### PR DESCRIPTION
### Description

Fix to allow https://github.com/ARMmbed/mbed-os/pull/6925 to progress. Uvision cannot build Cortex-A cores.

Reference: http://www2.keil.com/mdk5/selector

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

