### PR TITLE
Add names to Idle/timer thread

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -70,8 +70,12 @@
 #define OS_IDLE_THREAD_TZ_MOD_ID     1
 #define OS_TIMER_THREAD_TZ_MOD_ID    1
 
+
 // Don't adopt default multi-thread support for ARM/ARMC6 toolchains from RTX code base.
 // Provide Mbed-specific instead.
 #define RTX_NO_MULTITHREAD_CLIB
+
+#define OS_IDLE_THREAD_NAME         "idle_thread"
+#define OS_TIMER_THREAD_NAME        "timer_thread"
 
 #endif /* MBED_RTX_CONF_H */


### PR DESCRIPTION
### Description

User configurable option was added to CMSIS for Idle/timer thread names.  https://github.com/ARM-software/CMSIS_5/commit/aa7a332938feb50f2e9d3d998c8ced442445ffd2

With recent CMSIS upgrade in Mbed OS, we can have config name option as well.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

