### PR TITLE
MBR: Fix issue with MBR init asserting on bad partition size

### DIFF
--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -241,7 +241,9 @@ int MBRBlockDevice::init()
     _size   = fromle32(table->entries[_part-1].lba_size)   * sector;
 
     // Check that block addresses are valid
-    MBED_ASSERT(_bd->is_valid_erase(_offset, _size));
+    if (!_bd->is_valid_erase(_offset, _size)) {
+        return BD_ERROR_INVALID_PARTITION;
+    }
 
     delete[] buffer;
     return 0;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

With the assert, applications were unable to check the corrupted MBR and correct it, so invalid data on a block device would prevent an application from recovering.

cc @marcuschangarm, @dlfryar, @ARMmbed/mbed-os-storage 


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

