### PR TITLE
Remove template walls

### DIFF
--- a/events/Event.h
+++ b/events/Event.h
@@ -22,7 +22,7 @@
 namespace events {
 /** \addtogroup events */
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -30,7 +30,7 @@ namespace events {
 template <typename F>
 class Event;
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -444,7 +444,7 @@ public:
     }
 };
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -862,7 +862,7 @@ public:
     }
 };
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -1280,7 +1280,7 @@ public:
     }
 };
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -1698,7 +1698,7 @@ public:
     }
 };
 
-/** Event
+/*  Event
  *
  *  Representation of an event for fine-grain dispatch control
  * @ingroup events
@@ -2308,7 +2308,7 @@ private:
     }
 
 public:
-    /** Create an event
+    /*  Create an event
      *  @param q                Event queue to dispatch on
      *  @param f                Function to execute when the event is dispatched
      *  @param c0               Argument to bind to the callback, these arguments are
@@ -2321,7 +2321,7 @@ public:
         new (this) Event(q, EventQueue::context15<F, C0, A0, A1, A2, A3, A4>(f, c0));
     }
 
-    /** Create an event
+    /*  Create an event
      *  @param q                Event queue to dispatch on
      *  @param f                Function to execute when the event is dispatched
      *  @param c0,c1            Arguments to bind to the callback, these arguments are
@@ -2334,7 +2334,7 @@ public:
         new (this) Event(q, EventQueue::context25<F, C0, C1, A0, A1, A2, A3, A4>(f, c0, c1));
     }
 
-    /** Create an event
+    /*  Create an event
      *  @param q                Event queue to dispatch on
      *  @param f                Function to execute when the event is dispatched
      *  @param c0,c1,c2         Arguments to bind to the callback, these arguments are
@@ -2347,7 +2347,7 @@ public:
         new (this) Event(q, EventQueue::context35<F, C0, C1, C2, A0, A1, A2, A3, A4>(f, c0, c1, c2));
     }
 
-    /** Create an event
+    /*  Create an event
      *  @param q                Event queue to dispatch on
      *  @param f                Function to execute when the event is dispatched
      *  @param c0,c1,c2,c3      Arguments to bind to the callback, these arguments are
@@ -2373,7 +2373,7 @@ public:
         new (this) Event(q, EventQueue::context55<F, C0, C1, C2, C3, C4, A0, A1, A2, A3, A4>(f, c0, c1, c2, c3, c4));
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0>
@@ -2381,7 +2381,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0>
@@ -2389,7 +2389,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0>
@@ -2397,7 +2397,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0>
@@ -2405,7 +2405,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1>
@@ -2413,7 +2413,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1>
@@ -2421,7 +2421,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1>
@@ -2429,7 +2429,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1>
@@ -2437,7 +2437,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2>
@@ -2445,7 +2445,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2>
@@ -2453,7 +2453,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2>
@@ -2461,7 +2461,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2>
@@ -2469,7 +2469,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3>
@@ -2477,7 +2477,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3>
@@ -2485,7 +2485,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3>
@@ -2493,7 +2493,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3>
@@ -2502,14 +2502,20 @@ public:
     }
 
     /** Create an event
-     *  @see Event::Event
+     *  @param q                Event queue to dispatch on
+     *  @param obj              Object to execute the member function on
+     *  @param method           Member function to execute when the event is dispatched
+     *  @param b0,b1,b2,b3,b4   Arguments to bind to the callback, these arguments are
+     *                          allocated on an irq-safe allocator from the event queue's
+     *                          memory pool. Must be type-compatible with b0..b4, the
+     *                          arguments to the underlying callback.
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4>
     Event(EventQueue *q, T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), B0 b0, B1 b1, B2 b2, B3 b3, B4 b4) {
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3, b4);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4>
@@ -2517,7 +2523,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3, b4);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4>
@@ -2525,7 +2531,7 @@ public:
         new (this) Event(q, mbed::callback(obj, method), b0, b1, b2, b3, b4);
     }
 
-    /** Create an event
+    /*  Create an event
      *  @see Event::Event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4>

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -180,7 +180,7 @@ public:
      */
     void chain(EventQueue *target);
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *
      *  The specified callback will be executed in the context of the event
      *  queue's dispatch loop.
@@ -207,7 +207,7 @@ public:
         return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see                    EventQueue::call
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0               Argument to pass to the callback
@@ -217,7 +217,7 @@ public:
         return call(context10<F, A0>(f, a0));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see                    EventQueue::call
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1            Arguments to pass to the callback
@@ -227,7 +227,7 @@ public:
         return call(context20<F, A0, A1>(f, a0, a1));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see                    EventQueue::call
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2         Arguments to pass to the callback
@@ -237,7 +237,7 @@ public:
         return call(context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see                     EventQueue::call
      *  @param f                 Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2,a3       Arguments to pass to the callback
@@ -248,16 +248,27 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see                    EventQueue::call
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2,a3,a4   Arguments to pass to the callback
+     *  @return                 A unique id that represents the posted event and can
+     *                          be passed to cancel, or an id of 0 if there is not
+     *                          enough memory to allocate the event.
+     *                          Returned id will remain valid until event has finished
+     *                          executing.
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call(F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call(context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R>
@@ -265,7 +276,7 @@ public:
         return call(mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R>
@@ -273,7 +284,7 @@ public:
         return call(mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R>
@@ -281,7 +292,7 @@ public:
         return call(mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R>
@@ -289,7 +300,7 @@ public:
         return call(mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0>
@@ -297,7 +308,7 @@ public:
         return call(mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0>
@@ -305,7 +316,7 @@ public:
         return call(mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0>
@@ -313,7 +324,7 @@ public:
         return call(mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0>
@@ -321,7 +332,7 @@ public:
         return call(mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -329,7 +340,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -337,7 +348,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -345,7 +356,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -353,7 +364,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -361,7 +372,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -369,7 +380,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -377,7 +388,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -385,7 +396,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -393,7 +404,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -401,7 +412,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -409,7 +420,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -418,14 +429,28 @@ public:
     }
 
     /** Calls an event on the queue
-     *  @see EventQueue::call
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param obj              Object to call with the member function
+     *  @param method           Member function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4   Arguments to pass to the callback
+     *  @return                 A unique id that represents the posted event and can
+     *                          be passed to cancel, or an id of 0 if there is not
+     *                          enough memory to allocate the event.
+     *                          Returned id will remain valid until event has finished
+     *                          executing.
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call(T *obj, R (T::*method)(A0, A1, A2, A3, A4), A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call(mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -433,7 +458,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -441,7 +466,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue
+    /*  Calls an event on the queue
      *  @see EventQueue::call
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -449,7 +474,7 @@ public:
         return call(mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *
      *  The specified callback will be executed in the context of the event
      *  queue's dispatch loop.
@@ -457,8 +482,8 @@ public:
      *  The call_in function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param f        Function to execute in the context of the dispatch loop
      *  @param ms       Time to delay in milliseconds
+     *  @param f        Function to execute in the context of the dispatch loop
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
@@ -476,7 +501,7 @@ public:
         return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see                        EventQueue::call_in
      *  @param ms                   Time to delay in milliseconds
      *  @param f                    Function to execute in the context of the dispatch loop
@@ -487,7 +512,7 @@ public:
         return call_in(ms, context10<F, A0>(f, a0));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see                        EventQueue::call_in
      *  @param ms                   Time to delay in milliseconds
      *  @param f                    Function to execute in the context of the dispatch loop
@@ -498,7 +523,7 @@ public:
         return call_in(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see                        EventQueue::call_in
      *  @param ms                   Time to delay in milliseconds
      *  @param f                    Function to execute in the context of the dispatch loop
@@ -509,7 +534,7 @@ public:
         return call_in(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see                        EventQueue::call_in
      *  @param ms                   Time to delay in milliseconds
      *  @param f                    Function to execute in the context of the dispatch loop
@@ -521,17 +546,26 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see                        EventQueue::call_in
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_in function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
      *  @param ms                   Time to delay in milliseconds
      *  @param f                    Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2,a3,a4       Arguments to pass to the callback
+     *  @return                     A unique id that represents the posted event and can
+     *                              be passed to cancel, or an id of 0 if there is not
+     *                              enough memory to allocate the event.
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_in(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call_in(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R>
@@ -539,7 +573,7 @@ public:
         return call_in(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R>
@@ -547,7 +581,7 @@ public:
         return call_in(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R>
@@ -555,7 +589,7 @@ public:
         return call_in(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R>
@@ -563,7 +597,7 @@ public:
         return call_in(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0>
@@ -571,7 +605,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0>
@@ -579,7 +613,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0>
@@ -587,7 +621,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0>
@@ -595,7 +629,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -603,7 +637,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -611,7 +645,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -619,7 +653,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -627,7 +661,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -635,7 +669,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -643,7 +677,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -651,7 +685,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -659,7 +693,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -667,7 +701,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -675,7 +709,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -683,7 +717,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -692,14 +726,27 @@ public:
     }
 
     /** Calls an event on the queue after a specified delay
-     *  @see EventQueue::call_in
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_in function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param ms                   Time to delay in milliseconds
+     *  @param obj                  Object to call with the member function
+     *  @param method               Member function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4       Arguments to pass to the callback
+     *  @return                     A unique id that represents the posted event and can
+     *                              be passed to cancel, or an id of 0 if there is not
+     *                              enough memory to allocate the event.
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_in(int ms, T *obj, R (T::*method)(A0, A1, A2, A3, A4), A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -707,7 +754,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -715,7 +762,7 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue after a specified delay
+    /*  Calls an event on the queue after a specified delay
      *  @see EventQueue::call_in
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -723,22 +770,19 @@ public:
         return call_in(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue periodically
-     *
-     *  @note The first call_every event occurs after the specified delay.
-     *  To create a periodic event that fires immediately, @see Event.
+    /*  Calls an event on the queue periodically
      *
      *  The specified callback will be executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call_every function is irq safe and can act as a mechanism for
-     *  moving events out of irq contexts.
+     *  The call_every function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
      *
-     *  @param f        Function to execute in the context of the dispatch loop
-     *  @param ms       Period of the event in milliseconds
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to cancel, or an id of 0 if there is not
-     *                  enough memory to allocate the event.
+     *  @param ms                   Period of the event in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @return                     A unique id that represents the posted event and can
+     *                              be passed to cancel, or an id of 0 if there is not
+     *                              enough memory to allocate the event.
      */
     template <typename F>
     int call_every(int ms, F f) {
@@ -754,7 +798,7 @@ public:
         return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see                    EventQueue::call_every
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0               Argument to pass to the callback
@@ -765,7 +809,7 @@ public:
         return call_every(ms, context10<F, A0>(f, a0));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see                    EventQueue::call_every
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1            Arguments to pass to the callback
@@ -776,7 +820,7 @@ public:
         return call_every(ms, context20<F, A0, A1>(f, a0, a1));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see                    EventQueue::call_every
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2         Arguments to pass to the callback
@@ -787,7 +831,7 @@ public:
         return call_every(ms, context30<F, A0, A1, A2>(f, a0, a1, a2));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see                    EventQueue::call_every
      *  @param f                Function to execute in the context of the dispatch loop
      *  @param a0,a1,a2,a3      Arguments to pass to the callback
@@ -799,17 +843,26 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see                    EventQueue::call_every
-     *  @param f                Function to execute in the context of the dispatch loop
-     *  @param a0,a1,a2,a3,a4   Arguments to pass to the callback
-     *  @param ms               Period of the event in milliseconds
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_every function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param ms                   Period of the event in milliseconds
+     *  @param f                    Function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4       Arguments to pass to the callback
+     *  @return                     A unique id that represents the posted event and can
+     *                              be passed to cancel, or an id of 0 if there is not
+     *                              enough memory to allocate the event.
      */
     template <typename F, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_every(int ms, F f, A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call_every(ms, context50<F, A0, A1, A2, A3, A4>(f, a0, a1, a2, a3, a4));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R>
@@ -817,7 +870,7 @@ public:
         return call_every(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R>
@@ -825,7 +878,7 @@ public:
         return call_every(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R>
@@ -833,7 +886,7 @@ public:
         return call_every(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R>
@@ -841,7 +894,7 @@ public:
         return call_every(ms, mbed::callback(obj, method));
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0>
@@ -849,7 +902,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0>
@@ -857,7 +910,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0>
@@ -865,7 +918,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0>
@@ -873,7 +926,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -881,7 +934,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -889,7 +942,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -897,7 +950,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1>
@@ -905,7 +958,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -913,7 +966,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -921,7 +974,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -929,7 +982,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
@@ -937,7 +990,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -945,7 +998,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -953,7 +1006,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -961,7 +1014,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
@@ -970,14 +1023,27 @@ public:
     }
 
     /** Calls an event on the queue periodically
-     *  @see EventQueue::call_every
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_every function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param ms                   Period of the event in milliseconds
+     *  @param obj                  Object to call with the member function
+     *  @param method               Member function to execute in the context of the dispatch loop
+     *  @param a0,a1,a2,a3,a4       Arguments to pass to the callback
+     *  @return                     A unique id that represents the posted event and can
+     *                              be passed to cancel, or an id of 0 if there is not
+     *                              enough memory to allocate the event.
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     int call_every(int ms, T *obj, R (T::*method)(A0, A1, A2, A3, A4), A0 a0, A1 a1, A2 a2, A3 a3, A4 a4) {
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -985,7 +1051,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -993,7 +1059,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Calls an event on the queue periodically
+    /*  Calls an event on the queue periodically
      *  @see EventQueue::call_every
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
@@ -1001,7 +1067,7 @@ public:
         return call_every(ms, mbed::callback(obj, method), a0, a1, a2, a3, a4);
     }
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *
      *  Constructs an event bound to the specified event queue. The specified
      *  callback acts as the target for the event and is executed in the
@@ -1013,1291 +1079,1306 @@ public:
     template <typename R>
     Event<void()> event(R (*func)());
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R>
     Event<void()> event(T *obj, R (T::*method)());
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R>
     Event<void()> event(const T *obj, R (T::*method)() const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R>
     Event<void()> event(volatile T *obj, R (T::*method)() volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R>
     Event<void()> event(const volatile T *obj, R (T::*method)() const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R>
     Event<void()> event(mbed::Callback<R()> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0>
     Event<void()> event(R (*func)(B0), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0>
     Event<void()> event(T *obj, R (T::*method)(B0), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0>
     Event<void()> event(const T *obj, R (T::*method)(B0) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0>
     Event<void()> event(volatile T *obj, R (T::*method)(B0) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0>
     Event<void()> event(mbed::Callback<R(B0)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(R (*func)(B0, B1), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(T *obj, R (T::*method)(B0, B1), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(const T *obj, R (T::*method)(B0, B1) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(volatile T *obj, R (T::*method)(B0, B1) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1>
     Event<void()> event(mbed::Callback<R(B0, B1)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(R (*func)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(T *obj, R (T::*method)(B0, B1, B2), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2>
     Event<void()> event(mbed::Callback<R(B0, B1, B2)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(R (*func)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(T *obj, R (T::*method)(B0, B1, B2, B3), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2, B3) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3>
     Event<void()> event(mbed::Callback<R(B0, B1, B2, B3)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(R (*func)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4>
     Event<void()> event(mbed::Callback<R(B0, B1, B2, B3, B4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0>
     Event<void(A0)> event(R (*func)(A0));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(A0));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(A0) const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(A0) volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(A0) const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0>
     Event<void(A0)> event(mbed::Callback<R(A0)> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(R (*func)(B0, A0), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, A0), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(B0, A0) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, A0) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, A0) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0>
     Event<void(A0)> event(mbed::Callback<R(B0, A0)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, A0), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, A0), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, A0) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, A0) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, A0) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0>
     Event<void(A0)> event(mbed::Callback<R(B0, B1, A0)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, A0), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, A0) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0>
     Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, A0)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0>
     Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, B3, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(R (*func)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0>
     Event<void(A0)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(A0, A1));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(A0, A1));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(A0, A1) const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(A0, A1) volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(A0, A1) const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(A0, A1)> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, A0, A1), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, A0, A1), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, A0, A1) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, A0, A1) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, A0, A1) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(B0, A0, A1)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, A0, A1), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, A0, A1), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, A0, A1) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, A0, A1)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, A0, A1)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1>
     Event<void(A0, A1)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(A0, A1, A2));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(A0, A1, A2));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(A0, A1, A2) const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(A0, A1, A2) volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(A0, A1, A2) const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(A0, A1, A2)> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, A0, A1, A2), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, A0, A1, A2), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, A0, A1, A2) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, A0, A1, A2)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, A0, A1, A2), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, A0, A1, A2)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2>
     Event<void(A0, A1, A2)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(A0, A1, A2, A3));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(A0, A1, A2, A3));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(A0, A1, A2, A3) const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3) volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3) const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(A0, A1, A2, A3)> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, A0, A1, A2, A3), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, A0, A1, A2, A3), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, A0, A1, A2, A3)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, A0, A1, A2, A3)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3>
     Event<void(A0, A1, A2, A3)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(A0, A1, A2, A3, A4));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(A0, A1, A2, A3, A4));
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(A0, A1, A2, A3, A4) const);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(A0, A1, A2, A3, A4) const volatile);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(A0, A1, A2, A3, A4)> cb);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, A0, A1, A2, A3, A4), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4), C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, A0, A1, A2, A3, A4) const volatile, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename C0, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, A0, A1, A2, A3, A4)> cb, C0 c0);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4), C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename C0, typename C1, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename C0, typename C1, typename C2, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename C0, typename C1, typename C2, typename C3, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, B3, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3);
 
     /** Creates an event bound to the event queue
-     *  @see EventQueue::event
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param func             Function to execute when the event is dispatched
+     *  @param c0,c1,c2,c3,c4   Arguments bound to the callback when creating the event object
+     *  @return                 Event that will dispatch on the specific queue
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(R (*func)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
     /** Creates an event bound to the event queue
-     *  @see EventQueue::event
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @param obj              Object to call with the member function
+     *  @param method           Member function to execute in the context of the dispatch loop
+     *  @param c0,c1,c2,c3,c4   Arguments bound to the callback when creating the event object
+     *  @return                 Event that will dispatch on the specific queue
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4), C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename T, typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(const volatile T *obj, R (T::*method)(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4) const volatile, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
 
-    /** Creates an event bound to the event queue
+    /*  Creates an event bound to the event queue
      *  @see EventQueue::event
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>

--- a/platform/Callback.h
+++ b/platform/Callback.h
@@ -30,7 +30,7 @@ namespace mbed {
  * @{
  */
 
-/** Callback class based on template specialization
+/*  Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -67,7 +67,7 @@ namespace detail {
             sizeof(F) <= sizeof(uintptr_t)                                  \
         >::type = detail::nil()
 
-/** Callback class based on template specialization
+/* Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -641,7 +641,7 @@ private:
     };
 };
 
-/** Callback class based on template specialization
+/* Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -1216,7 +1216,7 @@ private:
     };
 };
 
-/** Callback class based on template specialization
+/* Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -1792,7 +1792,7 @@ private:
     };
 };
 
-/** Callback class based on template specialization
+/* Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -2369,7 +2369,7 @@ private:
     };
 };
 
-/** Callback class based on template specialization
+/* Callback class based on template specialization
  *
  * @note Synchronization level: Not protected
  */
@@ -2984,7 +2984,7 @@ public:
         generate(method_context<T, R (T::*)(A0, A1, A2, A3, A4)>(obj, method));
     }
 
-    /** Create a Callback with a member function
+    /*  Create a Callback with a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
@@ -2993,7 +2993,7 @@ public:
         generate(method_context<const T, R (T::*)(A0, A1, A2, A3, A4) const>(obj, method));
     }
 
-    /** Create a Callback with a member function
+    /*  Create a Callback with a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
@@ -3002,7 +3002,7 @@ public:
         generate(method_context<volatile T, R (T::*)(A0, A1, A2, A3, A4) volatile>(obj, method));
     }
 
-    /** Create a Callback with a member function
+    /*  Create a Callback with a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      */
@@ -3020,7 +3020,7 @@ public:
         generate(function_context<R (*)(T*, A0, A1, A2, A3, A4), T>(func, arg));
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
@@ -3029,7 +3029,7 @@ public:
         generate(function_context<R (*)(const T*, A0, A1, A2, A3, A4), const T>(func, arg));
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
@@ -3038,7 +3038,7 @@ public:
         generate(function_context<R (*)(volatile T*, A0, A1, A2, A3, A4), volatile T>(func, arg));
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function 
      */
@@ -3056,7 +3056,7 @@ public:
         generate(f);
     }
 
-    /** Create a Callback with a function object
+    /*  Create a Callback with a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
@@ -3065,7 +3065,7 @@ public:
         generate(f);
     }
 
-    /** Create a Callback with a function object
+    /*  Create a Callback with a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
@@ -3074,7 +3074,7 @@ public:
         generate(f);
     }
 
-    /** Create a Callback with a function object
+    /*  Create a Callback with a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      */
@@ -3083,7 +3083,7 @@ public:
         generate(f);
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3096,7 +3096,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3109,7 +3109,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3122,7 +3122,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Create a Callback with a static function and bound pointer
+    /*  Create a Callback with a static function and bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3143,7 +3143,7 @@ public:
         }
     }
 
-    /** Attach a static function
+    /*  Attach a static function
      *  @param func     Static function to attach
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3155,7 +3155,7 @@ public:
         new (this) Callback(func);
     }
 
-    /** Attach a Callback
+    /*  Attach a Callback
      *  @param func     The Callback to attach
      *  @deprecated
      *      Replaced by simple assignment 'Callback cb = func'
@@ -3167,7 +3167,7 @@ public:
         new (this) Callback(func);
     }
 
-    /** Attach a member function
+    /*  Attach a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      *  @deprecated
@@ -3181,7 +3181,7 @@ public:
         new (this) Callback(obj, method);
     }
 
-    /** Attach a member function
+    /*  Attach a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      *  @deprecated
@@ -3195,7 +3195,7 @@ public:
         new (this) Callback(obj, method);
     }
 
-    /** Attach a member function
+    /*  Attach a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      *  @deprecated
@@ -3209,7 +3209,7 @@ public:
         new (this) Callback(obj, method);
     }
 
-    /** Attach a member function
+    /*  Attach a member function
      *  @param obj      Pointer to object to invoke member function on
      *  @param method   Member function to attach
      *  @deprecated
@@ -3223,7 +3223,7 @@ public:
         new (this) Callback(obj, method);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      *  @deprecated
@@ -3237,7 +3237,7 @@ public:
         new (this) Callback(func, arg);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      *  @deprecated
@@ -3251,7 +3251,7 @@ public:
         new (this) Callback(func, arg);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      *  @deprecated
@@ -3265,7 +3265,7 @@ public:
         new (this) Callback(func, arg);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param func     Static function to attach
      *  @param arg      Pointer argument to function
      *  @deprecated
@@ -3279,7 +3279,7 @@ public:
         new (this) Callback(func, arg);
     }
 
-    /** Attach a function object
+    /*  Attach a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
@@ -3293,7 +3293,7 @@ public:
         new (this) Callback(f);
     }
 
-    /** Attach a function object
+    /*  Attach a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
@@ -3307,7 +3307,7 @@ public:
         new (this) Callback(f);
     }
 
-    /** Attach a function object
+    /*  Attach a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
@@ -3321,7 +3321,7 @@ public:
         new (this) Callback(f);
     }
 
-    /** Attach a function object
+    /*  Attach a function object
      *  @param f Function object to attach
      *  @note The function object is limited to a single word of storage
      *  @deprecated
@@ -3335,7 +3335,7 @@ public:
         new (this) Callback(f);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3349,7 +3349,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3363,7 +3363,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3377,7 +3377,7 @@ public:
         new (this) Callback(func, obj);
     }
 
-    /** Attach a static function with a bound pointer
+    /*  Attach a static function with a bound pointer
      *  @param obj  Pointer to object to bind to function
      *  @param func Static function to attach
      *  @deprecated
@@ -3530,7 +3530,7 @@ private:
 typedef Callback<void(int)> event_callback_t;
 
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3540,7 +3540,7 @@ Callback<R()> callback(R (*func)() = 0) {
     return Callback<R()>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3550,7 +3550,7 @@ Callback<R()> callback(const Callback<R()> &func) {
     return Callback<R()>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3561,7 +3561,7 @@ Callback<R()> callback(U *obj, R (T::*method)()) {
     return Callback<R()>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3572,7 +3572,7 @@ Callback<R()> callback(const U *obj, R (T::*method)() const) {
     return Callback<R()>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3583,7 +3583,7 @@ Callback<R()> callback(volatile U *obj, R (T::*method)() volatile) {
     return Callback<R()>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3594,7 +3594,7 @@ Callback<R()> callback(const volatile U *obj, R (T::*method)() const volatile) {
     return Callback<R()>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3605,7 +3605,7 @@ Callback<R()> callback(R (*func)(T*), U *arg) {
     return Callback<R()>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3616,7 +3616,7 @@ Callback<R()> callback(R (*func)(const T*), const U *arg) {
     return Callback<R()>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3627,7 +3627,7 @@ Callback<R()> callback(R (*func)(volatile T*), volatile U *arg) {
     return Callback<R()>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3638,7 +3638,7 @@ Callback<R()> callback(R (*func)(const volatile T*), const volatile U *arg) {
     return Callback<R()>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3653,7 +3653,7 @@ Callback<R()> callback(U *obj, R (*func)(T*)) {
     return Callback<R()>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3668,7 +3668,7 @@ Callback<R()> callback(const U *obj, R (*func)(const T*)) {
     return Callback<R()>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3683,7 +3683,7 @@ Callback<R()> callback(volatile U *obj, R (*func)(volatile T*)) {
     return Callback<R()>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3699,7 +3699,7 @@ Callback<R()> callback(const volatile U *obj, R (*func)(const volatile T*)) {
 }
 
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3709,7 +3709,7 @@ Callback<R(A0)> callback(R (*func)(A0) = 0) {
     return Callback<R(A0)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3719,7 +3719,7 @@ Callback<R(A0)> callback(const Callback<R(A0)> &func) {
     return Callback<R(A0)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3730,7 +3730,7 @@ Callback<R(A0)> callback(U *obj, R (T::*method)(A0)) {
     return Callback<R(A0)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3741,7 +3741,7 @@ Callback<R(A0)> callback(const U *obj, R (T::*method)(A0) const) {
     return Callback<R(A0)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3752,7 +3752,7 @@ Callback<R(A0)> callback(volatile U *obj, R (T::*method)(A0) volatile) {
     return Callback<R(A0)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3763,7 +3763,7 @@ Callback<R(A0)> callback(const volatile U *obj, R (T::*method)(A0) const volatil
     return Callback<R(A0)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3774,7 +3774,7 @@ Callback<R(A0)> callback(R (*func)(T*, A0), U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3785,7 +3785,7 @@ Callback<R(A0)> callback(R (*func)(const T*, A0), const U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3796,7 +3796,7 @@ Callback<R(A0)> callback(R (*func)(volatile T*, A0), volatile U *arg) {
     return Callback<R(A0)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3807,7 +3807,7 @@ Callback<R(A0)> callback(R (*func)(const volatile T*, A0), const volatile U *arg
     return Callback<R(A0)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3822,7 +3822,7 @@ Callback<R(A0)> callback(U *obj, R (*func)(T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3837,7 +3837,7 @@ Callback<R(A0)> callback(const U *obj, R (*func)(const T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3852,7 +3852,7 @@ Callback<R(A0)> callback(volatile U *obj, R (*func)(volatile T*, A0)) {
     return Callback<R(A0)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3868,7 +3868,7 @@ Callback<R(A0)> callback(const volatile U *obj, R (*func)(const volatile T*, A0)
 }
 
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3878,7 +3878,7 @@ Callback<R(A0, A1)> callback(R (*func)(A0, A1) = 0) {
     return Callback<R(A0, A1)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -3888,7 +3888,7 @@ Callback<R(A0, A1)> callback(const Callback<R(A0, A1)> &func) {
     return Callback<R(A0, A1)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3899,7 +3899,7 @@ Callback<R(A0, A1)> callback(U *obj, R (T::*method)(A0, A1)) {
     return Callback<R(A0, A1)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3910,7 +3910,7 @@ Callback<R(A0, A1)> callback(const U *obj, R (T::*method)(A0, A1) const) {
     return Callback<R(A0, A1)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3921,7 +3921,7 @@ Callback<R(A0, A1)> callback(volatile U *obj, R (T::*method)(A0, A1) volatile) {
     return Callback<R(A0, A1)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -3932,7 +3932,7 @@ Callback<R(A0, A1)> callback(const volatile U *obj, R (T::*method)(A0, A1) const
     return Callback<R(A0, A1)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3943,7 +3943,7 @@ Callback<R(A0, A1)> callback(R (*func)(T*, A0, A1), U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3954,7 +3954,7 @@ Callback<R(A0, A1)> callback(R (*func)(const T*, A0, A1), const U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3965,7 +3965,7 @@ Callback<R(A0, A1)> callback(R (*func)(volatile T*, A0, A1), volatile U *arg) {
     return Callback<R(A0, A1)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -3976,7 +3976,7 @@ Callback<R(A0, A1)> callback(R (*func)(const volatile T*, A0, A1), const volatil
     return Callback<R(A0, A1)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -3991,7 +3991,7 @@ Callback<R(A0, A1)> callback(U *obj, R (*func)(T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4006,7 +4006,7 @@ Callback<R(A0, A1)> callback(const U *obj, R (*func)(const T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4021,7 +4021,7 @@ Callback<R(A0, A1)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1)) {
     return Callback<R(A0, A1)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4037,7 +4037,7 @@ Callback<R(A0, A1)> callback(const volatile U *obj, R (*func)(const volatile T*,
 }
 
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -4047,7 +4047,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(A0, A1, A2) = 0) {
     return Callback<R(A0, A1, A2)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -4057,7 +4057,7 @@ Callback<R(A0, A1, A2)> callback(const Callback<R(A0, A1, A2)> &func) {
     return Callback<R(A0, A1, A2)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4068,7 +4068,7 @@ Callback<R(A0, A1, A2)> callback(U *obj, R (T::*method)(A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4079,7 +4079,7 @@ Callback<R(A0, A1, A2)> callback(const U *obj, R (T::*method)(A0, A1, A2) const)
     return Callback<R(A0, A1, A2)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4090,7 +4090,7 @@ Callback<R(A0, A1, A2)> callback(volatile U *obj, R (T::*method)(A0, A1, A2) vol
     return Callback<R(A0, A1, A2)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4101,7 +4101,7 @@ Callback<R(A0, A1, A2)> callback(const volatile U *obj, R (T::*method)(A0, A1, A
     return Callback<R(A0, A1, A2)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4112,7 +4112,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(T*, A0, A1, A2), U *arg) {
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4123,7 +4123,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(const T*, A0, A1, A2), const U *arg) 
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4134,7 +4134,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(volatile T*, A0, A1, A2), volatile U 
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4145,7 +4145,7 @@ Callback<R(A0, A1, A2)> callback(R (*func)(const volatile T*, A0, A1, A2), const
     return Callback<R(A0, A1, A2)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4160,7 +4160,7 @@ Callback<R(A0, A1, A2)> callback(U *obj, R (*func)(T*, A0, A1, A2)) {
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4175,7 +4175,7 @@ Callback<R(A0, A1, A2)> callback(const U *obj, R (*func)(const T*, A0, A1, A2)) 
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4190,7 +4190,7 @@ Callback<R(A0, A1, A2)> callback(volatile U *obj, R (*func)(volatile T*, A0, A1,
     return Callback<R(A0, A1, A2)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4206,7 +4206,7 @@ Callback<R(A0, A1, A2)> callback(const volatile U *obj, R (*func)(const volatile
 }
 
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -4216,7 +4216,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(A0, A1, A2, A3) = 0) {
     return Callback<R(A0, A1, A2, A3)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @return         Callback with infered type
@@ -4226,7 +4226,7 @@ Callback<R(A0, A1, A2, A3)> callback(const Callback<R(A0, A1, A2, A3)> &func) {
     return Callback<R(A0, A1, A2, A3)>(func);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4237,7 +4237,7 @@ Callback<R(A0, A1, A2, A3)> callback(U *obj, R (T::*method)(A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4248,7 +4248,7 @@ Callback<R(A0, A1, A2, A3)> callback(const U *obj, R (T::*method)(A0, A1, A2, A3
     return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4259,7 +4259,7 @@ Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R (T::*method)(A0, A1, A2,
     return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4270,7 +4270,7 @@ Callback<R(A0, A1, A2, A3)> callback(const volatile U *obj, R (T::*method)(A0, A
     return Callback<R(A0, A1, A2, A3)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4281,7 +4281,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(T*, A0, A1, A2, A3), U *arg) {
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4292,7 +4292,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(const T*, A0, A1, A2, A3), const 
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4303,7 +4303,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(volatile T*, A0, A1, A2, A3), vol
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4314,7 +4314,7 @@ Callback<R(A0, A1, A2, A3)> callback(R (*func)(const volatile T*, A0, A1, A2, A3
     return Callback<R(A0, A1, A2, A3)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4329,7 +4329,7 @@ Callback<R(A0, A1, A2, A3)> callback(U *obj, R (*func)(T*, A0, A1, A2, A3)) {
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4344,7 +4344,7 @@ Callback<R(A0, A1, A2, A3)> callback(const U *obj, R (*func)(const T*, A0, A1, A
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4359,7 +4359,7 @@ Callback<R(A0, A1, A2, A3)> callback(volatile U *obj, R (*func)(volatile T*, A0,
     return Callback<R(A0, A1, A2, A3)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4406,7 +4406,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R (T::*method)(A0, A1, A2, A3, 
     return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4417,7 +4417,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R (T::*method)(A0, A1, A2
     return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4428,7 +4428,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R (T::*method)(A0, A1,
     return Callback<R(A0, A1, A2, A3, A4)>(obj, method);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj      Optional pointer to object to bind to function
  *  @param method   Member function to attach
@@ -4450,7 +4450,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(T*, A0, A1, A2, A3, A4), U *a
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4461,7 +4461,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const T*, A0, A1, A2, A3, A4)
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4472,7 +4472,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(volatile T*, A0, A1, A2, A3, 
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param func     Static function to attach
  *  @param arg      Pointer argument to function
@@ -4483,7 +4483,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(R (*func)(const volatile T*, A0, A1, A2
     return Callback<R(A0, A1, A2, A3, A4)>(func, arg);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4498,7 +4498,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(U *obj, R (*func)(T*, A0, A1, A2, A3, A
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4513,7 +4513,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(const U *obj, R (*func)(const T*, A0, A
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach
@@ -4528,7 +4528,7 @@ Callback<R(A0, A1, A2, A3, A4)> callback(volatile U *obj, R (*func)(volatile T*,
     return Callback<R(A0, A1, A2, A3, A4)>(func, obj);
 }
 
-/** Create a callback class with type infered from the arguments
+/*  Create a callback class with type infered from the arguments
  *
  *  @param obj  Optional pointer to object to bind to function
  *  @param func Static function to attach


### PR DESCRIPTION
### Description

By selectively removing doxygen comments, we can present only the useful function documentation to users. Note that in C++11 these would just be vararg functions.

Still included are a single overload for functions + args, member function + args, and function + state + args.

In:
- EventQueue.h
  - call
  - call_in
  - call_every
  - event
- Event
  - constructor
- Callback
  - constructor
  - attach
  - callback


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

cc @AnotherButler, @pan-, @kegilbert 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

