### PR TITLE
Modify RAM size definition of ARMCC for GR-LYCHEE

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/mem_RZ_A1LU.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/mem_RZ_A1LU.h
@@ -46,7 +46,7 @@
 /*--------------------- RAM Configuration -----------------------------------
  *----------------------------------------------------------------------------*/
 #define __RAM_BASE       0x20000000
-#define __RAM_SIZE       0x00200000
+#define __RAM_SIZE       0x00300000
 #define __NC_RAM_SIZE    0x00100000
 #define __NM_RAM_SIZE    (__RAM_SIZE - __NC_RAM_SIZE)
 #define __DATA_NC_BASE   (__RAM_BASE + __NM_RAM_SIZE + 0x40000000)


### PR DESCRIPTION
### Description

I modified RAM size of ARMCC compiler for GR-LYCHEE.
In case of GR-LYCHEE, RAM size is 3M Byte(including Non-Cache area), but there was a typo at MACRO definition.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

