### PR TITLE
NRF_52840: Fix us ticker counter size

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/us_ticker.c
@@ -77,7 +77,7 @@ void us_ticker_init(void)
 
     nrf_timer_frequency_set(NRF_TIMER1, NRF_TIMER_FREQ_1MHz);
 
-#ifdef NRF52
+#ifdef TARGET_NRF52
     nrf_timer_bit_width_set(NRF_TIMER1, NRF_TIMER_BIT_WIDTH_32);
 #else
     nrf_timer_bit_width_set(NRF_TIMER1, NRF_TIMER_BIT_WIDTH_16);


### PR DESCRIPTION
### Description

It has been noticed that there is a problem with us ticker on NRF_52840 board after 32 bit counter has been used for us ticker on NRF52 family boards.

Currently `NRF52` symbol is defined only for MCU_NRF52832 (not for MCU_NRF52840) and based on this symbol 16 or 32 bit counter is selected (16 bit for NRF51 family and 32 for NRF52 family).
Since MCU_NRF52840 defines `NRF52840_XXAA` and provides 32 bit counters, 32 bit counter should be selected also when `NRF52840_XXAA` symbol is defined.

@marcuschangarm Can you review this PR?

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

