### PR TITLE
Cellular: Remove max_packet_size

### DIFF
--- a/features/cellular/UNITTESTS/at/at_cellularstack/test_at_cellularstack.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularstack/test_at_cellularstack.cpp
@@ -34,7 +34,6 @@ public:
     bool bool_value;
     bool max_sock_value;
     nsapi_error_t create_error;
-    int max_packet_size;
     CellularSocket socket;
 
     MyStack(ATHandler &atr, int cid, nsapi_ip_stack_t typ) : AT_CellularStack(atr, cid, typ)
@@ -42,12 +41,9 @@ public:
         bool_value = false;
         max_sock_value = 0;
         create_error = NSAPI_ERROR_OK;
-        max_packet_size = 0;
     }
 
     virtual int get_max_socket_count(){return max_sock_value;}
-
-    virtual int get_max_packet_size(){return max_packet_size;}
 
     virtual bool is_protocol_supported(nsapi_protocol_t protocol){return bool_value;}
 
@@ -266,7 +262,6 @@ void Test_AT_CellularStack::test_AT_CellularStack_socket_sendto()
     CHECK(NSAPI_ERROR_CONNECTION_LOST == st.socket_sendto(sock, addr, "addr", 4));
 
     st.create_error = NSAPI_ERROR_OK;
-    st.max_packet_size = 6;
     CHECK(NSAPI_ERROR_OK == st.socket_sendto(sock, addr, "addr", 4));
 }
 
@@ -301,7 +296,6 @@ void Test_AT_CellularStack::test_AT_CellularStack_socket_recvfrom()
     CHECK(NSAPI_ERROR_CONNECTION_LOST == st.socket_recvfrom(sock, &addr, table, 4));
 
     st.create_error = NSAPI_ERROR_OK;
-    st.max_packet_size = 6;
     CHECK(NSAPI_ERROR_OK == st.socket_recvfrom(sock, &addr, table, 4));
 }
 

--- a/features/cellular/UNITTESTS/at/at_cellularstack/test_at_cellularstack.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularstack/test_at_cellularstack.cpp
@@ -239,7 +239,7 @@ void Test_AT_CellularStack::test_AT_CellularStack_socket_send()
     nsapi_socket_t sock = &st.socket;
     st.socket_open(&sock, NSAPI_TCP);
     st.socket_connect(sock, addr);
-    CHECK(NSAPI_ERROR_DEVICE_ERROR == st.socket_send(sock, "addr", 4));
+    CHECK(NSAPI_ERROR_OK == st.socket_send(sock, "addr", 4));
 }
 
 void Test_AT_CellularStack::test_AT_CellularStack_socket_sendto()

--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -257,11 +257,8 @@ nsapi_size_or_error_t AT_CellularStack::socket_sendto(nsapi_socket_t handle, con
         }
     }
 
-    unsigned max_packet_size = get_max_packet_size();
-
     /* Check parameters */
-    if (addr.get_ip_version() == NSAPI_UNSPEC ||
-            size > max_packet_size) {
+    if (addr.get_ip_version() == NSAPI_UNSPEC) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -106,11 +106,6 @@ protected:
     virtual int get_max_socket_count() = 0;
 
     /**
-    * Gets maximum packet size
-    */
-    virtual int get_max_packet_size() = 0;
-
-    /**
     * Checks if modem supports the given protocol
     *
     * @param protocol   Protocol type

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -61,11 +61,6 @@ int QUECTEL_BC95_CellularStack::get_max_socket_count()
     return BC95_SOCKET_MAX;
 }
 
-int QUECTEL_BC95_CellularStack::get_max_packet_size()
-{
-    return BC95_MAX_PACKET_SIZE;
-}
-
 bool QUECTEL_BC95_CellularStack::is_protocol_supported(nsapi_protocol_t protocol)
 {
     return (protocol == NSAPI_UDP);
@@ -146,7 +141,7 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
 {
     int sent_len = 0;
 
-    char *hexstr = new char[BC95_MAX_PACKET_SIZE*2+1];
+    char *hexstr = new char[size*2+1];
     int hexlen = char_str_to_hex_str((const char*)data, size, hexstr);
     // NULL terminated for write_string
     hexstr[hexlen] = 0;
@@ -154,7 +149,7 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_sendto_impl(CellularSoc
     _at.write_int(socket->id);
     _at.write_string(address.get_ip_address(), false);
     _at.write_int(address.get_port());
-    _at.write_int(size <= BC95_MAX_PACKET_SIZE ? size : BC95_MAX_PACKET_SIZE);
+    _at.write_int(size);
     _at.write_string(hexstr, false);
     _at.cmd_stop();
     _at.resp_start();
@@ -181,7 +176,7 @@ nsapi_size_or_error_t QUECTEL_BC95_CellularStack::socket_recvfrom_impl(CellularS
 
     _at.cmd_start("AT+NSORF=");
     _at.write_int(socket->id);
-    _at.write_int(size <= BC95_MAX_PACKET_SIZE ? size : BC95_MAX_PACKET_SIZE);
+    _at.write_int(size);
     _at.cmd_stop();
     _at.resp_start();
     // receiving socket id

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.h
@@ -21,7 +21,6 @@
 #include "AT_CellularStack.h"
 
 #define BC95_SOCKET_MAX 7
-#define BC95_MAX_PACKET_SIZE 1358
 
 namespace mbed {
 
@@ -41,8 +40,6 @@ protected: // NetworkStack
 protected: // AT_CellularStack
 
     virtual int get_max_socket_count();
-
-    virtual int get_max_packet_size();
 
     virtual bool is_protocol_supported(nsapi_protocol_t protocol);
 

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -64,11 +64,6 @@ int QUECTEL_BG96_CellularStack::get_max_socket_count()
     return BG96_SOCKET_MAX;
 }
 
-int QUECTEL_BG96_CellularStack::get_max_packet_size()
-{
-    return BG96_MAX_PACKET_SIZE;
-}
-
 bool QUECTEL_BG96_CellularStack::is_protocol_supported(nsapi_protocol_t protocol)
 {
     return (protocol == NSAPI_UDP);

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.h
@@ -23,7 +23,6 @@
 namespace mbed {
 
 #define BG96_SOCKET_MAX 12
-#define BG96_MAX_PACKET_SIZE 1460
 #define BG96_CREATE_SOCKET_TIMEOUT 150000 //150 seconds
 
 class QUECTEL_BG96_CellularStack : public AT_CellularStack
@@ -42,8 +41,6 @@ protected: // NetworkStack
 protected: // AT_CellularStack
 
     virtual int get_max_socket_count();
-
-    virtual int get_max_packet_size();
 
     virtual bool is_protocol_supported(nsapi_protocol_t protocol);
 


### PR DESCRIPTION
### Description

Removed `get_max_packet_size()` from the cellular AT stack. Now the implementation always tries to write a packet to modem without checking its size. If the size was bigger than protocol MTU or that modem can handle, then modem will return an error.

There is no change in API (except a slight delay due to extra AT command/response), because `sendto()` API request still returns the same error code as before.

Fixes PR #7181 and Arm internal ref IOTCELL-1089.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

