### PR TITLE
Fix LED_RED mapping on NUCLEO_F429ZI

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/PinNames.h
@@ -259,7 +259,7 @@ typedef enum {
     LED2        = PB_7,  // Blue
     LED3        = PB_14, // Red
     LED4        = PB_0,
-    LED_RED     = LED2,
+    LED_RED     = LED3,
     USER_BUTTON = PC_13,
     // Standardized button names
     BUTTON1 = USER_BUTTON,


### PR DESCRIPTION
### Description

the LED_RED was mapped to blue color led by mistake.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

