### PR TITLE
NRF52: rename the STRINGIFY macro to avoid compiler warnings

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/balloc/nrf_balloc.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/balloc/nrf_balloc.h
@@ -157,7 +157,7 @@ typedef struct
 #endif // NRF_BALLOC_CONFIG_DEBUG_ENABLED
 
 #if NRF_BALLOC_CONFIG_DEBUG_ENABLED
-#define __NRF_BALLOC_ASSIGN_POOL_NAME(_name)            .p_name = STRINGIFY(_name),
+#define __NRF_BALLOC_ASSIGN_POOL_NAME(_name)            .p_name = NRF_STRINGIFY(_name),
 #define __NRF_BALLOC_ASSIGN_DEBUG_FLAGS(_debug_flags)   .debug_flags = (_debug_flags),
 #else
 #define __NRF_BALLOC_ASSIGN_DEBUG_FLAGS(_debug_flags)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_log/nrf_log.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_log/nrf_log.h
@@ -214,7 +214,7 @@ uint32_t nrf_log_push(char * const p_str);
 #define NRF_LOG_MODULE_REGISTER()                                                             \
     NRF_SECTION_ITEM_REGISTER(NRF_LOG_CONST_SECTION_NAME(NRF_LOG_MODULE_NAME),                \
                             _CONST nrf_log_module_const_data_t NRF_LOG_MODULE_DATA_CONST) = { \
-            .p_module_name = STRINGIFY(NRF_LOG_MODULE_NAME),                                  \
+            .p_module_name = NRF_STRINGIFY(NRF_LOG_MODULE_NAME),                              \
             .info_color_id = NRF_LOG_INFO_COLOR,                                              \
             .debug_color_id = NRF_LOG_DEBUG_COLOR,                                            \
             .compiled_lvl   = COMPILED_LOG_LEVEL,                                             \

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/experimental_section_vars/nrf_section.h
@@ -73,7 +73,7 @@ extern "C" {
 #define NRF_SECTION_START_ADDR(section_name)       &CONCAT_2(__start_, section_name)
 
 #elif defined(__ICCARM__)
-#define NRF_SECTION_START_ADDR(section_name)       __section_begin(STRINGIFY(section_name))
+#define NRF_SECTION_START_ADDR(section_name)       __section_begin(NRF_STRINGIFY(section_name))
 #endif
 
 
@@ -89,7 +89,7 @@ extern "C" {
 #define NRF_SECTION_END_ADDR(section_name)         &CONCAT_2(__stop_, section_name)
 
 #elif defined(__ICCARM__)
-#define NRF_SECTION_END_ADDR(section_name)         __section_end(STRINGIFY(section_name))
+#define NRF_SECTION_END_ADDR(section_name)         __section_end(NRF_STRINGIFY(section_name))
 #endif
 
 
@@ -123,7 +123,7 @@ extern "C" {
 
 #elif defined(__ICCARM__)
 #define NRF_SECTION_DEF(section_name, data_type)                \
-    _Pragma(STRINGIFY(section = STRINGIFY(section_name)));
+    _Pragma(NRF_STRINGIFY(section = NRF_STRINGIFY(section_name)));
 
 #endif
 
@@ -142,15 +142,15 @@ extern "C" {
  */
 #if defined(__CC_ARM)
 #define NRF_SECTION_ITEM_REGISTER(section_name, section_var) \
-    section_var __attribute__ ((section(STRINGIFY(section_name)))) __attribute__((used))
+    section_var __attribute__ ((section(NRF_STRINGIFY(section_name)))) __attribute__((used))
 
 #elif defined(__GNUC__)
 #define NRF_SECTION_ITEM_REGISTER(section_name, section_var) \
-    section_var __attribute__ ((section("." STRINGIFY(section_name)))) __attribute__((used))
+    section_var __attribute__ ((section("." NRF_STRINGIFY(section_name)))) __attribute__((used))
 
 #elif defined(__ICCARM__)
 #define NRF_SECTION_ITEM_REGISTER(section_name, section_var) \
-    __root section_var @ STRINGIFY(section_name)
+    __root section_var @ NRF_STRINGIFY(section_name)
 #endif
 
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/util/nordic_common.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/libraries/util/nordic_common.h
@@ -132,10 +132,10 @@ extern "C" {
 /** Auxiliary macro used by @ref CONCAT_3 */
 #define CONCAT_3_(p1, p2, p3) p1##p2##p3
 
-#define STRINGIFY_(val) #val
+#define NRF_STRINGIFY_(val) #val
 /** Converts a macro argument into a character constant.
  */
-#define STRINGIFY(val)  STRINGIFY_(val)
+#define NRF_STRINGIFY(val)  NRF_STRINGIFY_(val)
 
 /** Counts number of elements inside the array
  */


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
The macro `STRINGIFY` in `nordic_common.h` conflicts with the macro `STRINGIFY` in `rtx_core_cm.h`, which causes the compiler to prompt a large number of warnings when using the IAR to compile the NRF52 platform. 

This PR avoids these warnings by renaming it to NRF_STRINGIFY.

In addition, it is recommended that it should check if there are too many warnings when main repository merge code. Our current main repository code compiles with a lot of warnings


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

