### PR TITLE
Clean-up targets.json

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1151,8 +1151,8 @@
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32F4", "STM32F412xG", "STM32F412ZG", "WICED", "CYW43362"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "EMAC"],
-        "release_versions": ["2", "5"],
+        "device_has_add": ["CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "release_versions": ["5"],
         "device_name": "STM32F412ZG",
         "bootloader_supported": true,
         "config": {
@@ -1161,16 +1161,19 @@
                 "value": "USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             }
+        },
+        "overrides": {
+            "network-default-interface-type": "WIFI"
         }
     },
     "USI_WM_BN_BM_22": {
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32F4", "STM32F412xG", "STM32F412ZG", "WICED", "CYW4343X", "CORDIO"],
-        "features": ["LWIP", "BLE"],
+        "features": ["BLE"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "EMAC"],
-        "release_versions": ["2", "5"],
+        "device_has_add": ["SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "release_versions": ["5"],
         "device_name": "STM32F412ZG",
         "bootloader_supported": true,
         "public": false,
@@ -1180,6 +1183,9 @@
                 "value": "USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
             }
+        },
+        "overrides": {
+            "network-default-interface-type": "WIFI"
         }
     },
     "MTB_USI_WM_BN_BM_22": {


### PR DESCRIPTION
Cleaning MTB_USI_WM_BN_BM_22, MTB_ADV_WISE_1530 and MTB_MXCHIP_EMW3166 targets.
These wiced targets are not supported at mbed-os 2 release, so removing
"2" from release_versions.
LWIP feature flag removed, since it isn't needed anymore.
EMAC removed from device_has_add, since it isn't needed with these targets.