### PR TITLE
LoRaWAN: Refactoring LoRaRadio::receive(uint32_t) API

### DIFF
--- a/features/lorawan/LoRaRadio.h
+++ b/features/lorawan/LoRaRadio.h
@@ -300,16 +300,11 @@ public:
     virtual void send(uint8_t *buffer, uint8_t size) = 0;
 
     /**
-     *  Sets the radio in reception mode for a given time.
+     *  Sets the radio in reception mode.
      *
-     *  If the timeout is set to 0, it essentially puts the receiver in continuous mode and it should
-     *  be treated as if in continuous mode. However, an appropriate way to set the receiver in continuous mode is
-     *  to use the `set_rx_config()` API.
-     *
-     *  @param timeout       Reception timeout [ms].
-     *
+     *  For configuration of the receiver use the `set_rx_config()` API.
      */
-    virtual void receive(uint32_t timeout) = 0;
+    virtual void receive(void) = 0;
 
     /**
      *  Sets the carrier frequency

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -869,10 +869,13 @@ void LoRaMac::open_rx1_window(void)
     }
 
     _mcps_indication.rx_datarate = _params.rx_window1_config.datarate;
-    _lora_phy.rx_config(&_params.rx_window1_config);
 
-    _lora_phy.setup_rx_window(_params.rx_window1_config.is_rx_continuous,
-                              _params.sys_params.max_rx_win_time);
+    if (_lora_phy.rx_config(&_params.rx_window1_config)) {
+        _lora_phy.handle_receive();
+    } else {
+        tr_error("Receive failed. Radio is not IDLE");
+        return;
+    }
 
     tr_debug("Opening RX1 Window");
 }
@@ -899,14 +902,14 @@ void LoRaMac::open_rx2_window()
     _mcps_indication.rx_datarate = _params.rx_window2_config.datarate;
 
     if (_lora_phy.rx_config(&_params.rx_window2_config)) {
-
-        _lora_phy.setup_rx_window(_params.rx_window2_config.is_rx_continuous,
-                                  _params.sys_params.max_rx_win_time);
-
+        _lora_phy.handle_receive();
         _params.rx_slot = _params.rx_window2_config.rx_slot;
+    } else {
+        tr_error("Receive failed. Radio is not IDLE");
+        return;
     }
 
-    tr_debug("Opening RX2 Window, Frequency = %u", _params.rx_window2_config.frequency);
+    tr_debug("Opening RX2 Window, Frequency = %lu", _params.rx_window2_config.frequency);
 }
 
 void LoRaMac::on_ack_timeout_timer_event(void)

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -88,14 +88,10 @@ void LoRaPHY::setup_public_network_mode(bool set)
     _radio->unlock();
 }
 
-void LoRaPHY::setup_rx_window(bool rx_continuous, uint32_t max_rx_window)
+void LoRaPHY::handle_receive(void)
 {
     _radio->lock();
-    if (!rx_continuous) {
-        _radio->receive(max_rx_window);
-    } else {
-        _radio->receive(0); // Continuous mode
-    }
+    _radio->receive();
     _radio->unlock();
 }
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -68,15 +68,9 @@ public:
 
     /** Puts radio in receive mode.
      *
-     * Requests the radio driver to enter receive mode for a given time or to
-     * enter continuous reception mode.
-     *
-     * @param is_rx_continuous    if true, sets the radio to enter continuous
-     *                            reception mode.
-     *
-     * @param max_rx_window       duration of receive window
+     * Requests the radio driver to enter receive mode.
      */
-    void setup_rx_window(bool is_rx_continuous, uint32_t max_rx_window);
+    void handle_receive(void);
 
     /** Delegates MAC layer request to transmit packet.
      *


### PR DESCRIPTION


### Description

receive(uint32_t) API in the LoRaRadio class (base class for the radio drivers) should
not take any argument as we decided to take hardware timers for RX timeout interrupts
instead of software timers. It is being refactored to receive(void).
This is an API change, but as it is not an application interface, we will not put a
deprecation notice. Only user of this API is our stack (LoRaPHY layer) which has been updated
accordingly.
Actual driver comes out of the tree and a PR is open there to update the drivers:
https://github.com/ARMmbed/mbed-semtech-lora-rf-drivers/pull/22

In addition to this an internal API belonging to LoRaPHY class is refactored.
set_rx_window(parameters) is refactored to handle_receive(void) which is more consistent with
handle_send().


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

### Target
Mbed OS 5.10