### PR TITLE
Download astyle from AWS instead of SourceForge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,8 +109,8 @@ matrix:
     - env:
         - NAME=astyle
       install:
-      - wget https://downloads.sourceforge.net/project/astyle/astyle/astyle%203.1/astyle_3.1_linux.tar.gz;
-        mkdir -p BUILD && tar xf astyle_3.1_linux.tar.gz -C BUILD;
+      - curl -L0 http://mbed-os.s3-eu-west-1.amazonaws.com/builds/deps/astyle_3.1_linux.tar.gz --output astyle.tar.gz;
+        mkdir -p BUILD && tar xf astyle.tar.gz -C BUILD;
         pushd BUILD/astyle/build/gcc;
         make;
         export PATH=$PWD/bin:$PATH;


### PR DESCRIPTION
SF has been failing intermitantly, and appears to not explicitly allow the automatic downloading of archives.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Example of the success: https://travis-ci.org/cmonr/mbed-os/jobs/396958157

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

