### PR TITLE
Feature addition to GreenTea client to take care of bogus sync packets

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/test_env.h
+++ b/features/frameworks/greentea-client/greentea-client/test_env.h
@@ -55,6 +55,7 @@
 extern const char* GREENTEA_TEST_ENV_END;
 extern const char* GREENTEA_TEST_ENV_EXIT;
 extern const char* GREENTEA_TEST_ENV_SYNC;
+extern const char* GREENTEA_TEST_HOST_ACK;
 extern const char* GREENTEA_TEST_ENV_TIMEOUT;
 extern const char* GREENTEA_TEST_ENV_HOST_TEST_NAME;
 extern const char* GREENTEA_TEST_ENV_HOST_TEST_VERSION;

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -30,7 +30,7 @@
 const char* GREENTEA_TEST_ENV_END = "end";
 const char* GREENTEA_TEST_ENV_EXIT = "__exit";
 const char* GREENTEA_TEST_ENV_SYNC = "__sync";
-const char* GREENTEA_TEST_HOST_ACK = "__hstAk";
+const char* GREENTEA_TEST_HOST_ACK = "__host_ack";
 const char* GREENTEA_TEST_ENV_TIMEOUT = "__timeout";
 const char* GREENTEA_TEST_ENV_HOST_TEST_NAME = "__host_test_name";
 const char* GREENTEA_TEST_ENV_HOST_TEST_VERSION = "__version";
@@ -72,7 +72,7 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
     // Sync preamble: "{{__sync;0dad4a9d-59a3-4aec-810d-d5fb09d852c1}}"
     // Example value of sync_uuid == "0dad4a9d-59a3-4aec-810d-d5fb09d852c1"
 
-    char _key[8] = {0};
+    char _key[11] = {0};
     bool runTests = false;
 
     while (!runTests) {

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -30,7 +30,7 @@
 const char* GREENTEA_TEST_ENV_END = "end";
 const char* GREENTEA_TEST_ENV_EXIT = "__exit";
 const char* GREENTEA_TEST_ENV_SYNC = "__sync";
-const char* GREENTEA_TEST_HOST_ACK = "hostAck";
+const char* GREENTEA_TEST_HOST_ACK = "__hstAk";
 const char* GREENTEA_TEST_ENV_TIMEOUT = "__timeout";
 const char* GREENTEA_TEST_ENV_HOST_TEST_NAME = "__host_test_name";
 const char* GREENTEA_TEST_ENV_HOST_TEST_VERSION = "__version";
@@ -89,6 +89,7 @@ void _GREENTEA_SETUP_COMMON(const int timeout, const char *host_test_name, char 
           *  is to take care of issues when we encounter old keys in buffer and assume them to be right ones.
           */
         if (strcmp(_key, GREENTEA_TEST_HOST_ACK) == 0) {
+            greentea_send_kv(_key, buffer);
             runTests = true;
         }
     }


### PR DESCRIPTION
 
Often we are faced with a problem where the serial port has some old sync packets from a previous run, and the next test sends in new sync packets but DUT echoes back to the host with the old ones, and that leaves the host state machine in a weird state resulting in a timeout because of sync failure. After that the DUT is locked and is essentially doing nothing. 
Here is a failure log:
https://github.com/ARMmbed/htrun/issues/193

The solution to the problem is that when DUT echoes back with the sync key, it waits for an ack from host which confirms that the key it received from the device is correct. If no ack was received, the device will keep waiting for another sync packet, and if host receives wrong sync message from device, it will resend the sync packet.

I was able to reproduce the problem by sending faulty sync packets from host and then device would read them and echo them back, and host would complain about faulty sync and the test eventually times out because the sync could not be established. To solve the problem, I have added a new event flag (__hstAk) which host sends after it has received a sync reply from device and it has the correct value. Once the device receives the ack, only then it proceeds to run its tests, until then it keeps waiting for another  sync packet. Now i intentionally send faulty sync values, and the host complains about fault sync and then resends the right sync and device responds right away and sync is established and life goes on.

Please NOTE: If we merge in this change, it would need an updated version of htrun with follwing fix merged
https://github.com/ARMmbed/htrun/pull/195
Without this change on htrun, this standalone change will not be able to establish communication with host and timeout eventually.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

