### PR TITLE
makes wait_us to use 64bit counter space

### DIFF
--- a/platform/mbed_wait_api_no_rtos.c
+++ b/platform/mbed_wait_api_no_rtos.c
@@ -31,8 +31,8 @@ void wait_ms(int ms) {
 
 void wait_us(int us) {
     const ticker_data_t *const ticker = get_us_ticker_data();
-    uint32_t start = ticker_read(ticker);
-    while ((ticker_read(ticker) - start) < (uint32_t)us);
+    us_timestamp_t start = ticker_read_us(ticker);
+    while ((ticker_read_us(ticker) - start) < (us_timestamp_t)us);
 }
 
 #endif // #ifndef MBED_CONF_RTOS_PRESENT

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -35,7 +35,7 @@ void wait_ms(int ms) {
 void wait_us(int us) {
     const ticker_data_t *const ticker = get_us_ticker_data();
 
-    uint32_t start = ticker_read(ticker);
+    us_timestamp_t start = ticker_read_us(ticker);
     // Use the RTOS to wait for millisecond delays if possible
     int ms = us / 1000;
     if ((ms > 0) && core_util_are_interrupts_enabled()) {
@@ -45,7 +45,7 @@ void wait_us(int us) {
     }
     // Use busy waiting for sub-millisecond delays, or for the whole
     // interval if interrupts are not enabled
-    while ((ticker_read(ticker) - start) < (uint32_t)us);
+    while ((ticker_read_us(ticker) - start) < (us_timestamp_t)us);
 }
 
 #endif // #if MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION


### Description

Change `wait_us` implementation to use 64bit counter space.

Using 32bit counter space can cause that every 71 minutes (when 32bit value overflows) we can get wrong wait time

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

