### PR TITLE
STM32: Fix RTC test issue on targets using a 16-bit timer for us_ticker

### DIFF
--- a/targets/TARGET_STM/hal_tick_16b.c
+++ b/targets/TARGET_STM/hal_tick_16b.c
@@ -19,6 +19,8 @@
 #if TIM_MST_16BIT
 
 extern TIM_HandleTypeDef TimMasterHandle;
+extern uint32_t prev_time;
+extern uint32_t elapsed_time;
 
 volatile uint32_t PreviousVal = 0;
 
@@ -107,6 +109,10 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 #if !defined(NDEBUG) && defined(FREEZE_TIMER_ON_DEBUG) && defined(TIM_MST_DBGMCU_FREEZE)
     TIM_MST_DBGMCU_FREEZE;
 #endif
+
+    // Used by HAL_GetTick()
+    prev_time = 0;
+    elapsed_time = 0;
 
     return HAL_OK;
 }

--- a/targets/TARGET_STM/hal_tick_common.c
+++ b/targets/TARGET_STM/hal_tick_common.c
@@ -17,9 +17,19 @@
 
 // Overwrite default HAL functions defined as "weak"
 
+// This variable is set to 1 at the of mbed_sdk_init function.
+// The ticker_read_us function must not be called until the mbed_sdk_init is terminated.
+extern int mbed_sdk_inited;
+
 uint32_t HAL_GetTick()
 {
-    return ticker_read_us(get_us_ticker_data()) / 1000; // 1 ms tick is required for ST HAL
+    // 1 ms tick is required for ST HAL driver
+    if (mbed_sdk_inited) {
+        return (ticker_read_us(get_us_ticker_data()) / 1000);
+    }
+    else {
+        return (us_ticker_read() / 1000);
+    }
 }
 
 void HAL_SuspendTick(void)

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -27,6 +27,8 @@
  */
 #include "cmsis.h"
 
+int mbed_sdk_inited = 0;
+
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
 {
@@ -51,4 +53,6 @@ void mbed_sdk_init()
        AHB/APBx prescalers and Flash settings */
     SetSysClock();
     SystemCoreClockUpdate();
+
+    mbed_sdk_inited = 1;
 }

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -36,6 +36,8 @@
 #include "mbed_error.h"
 
 extern void rtc_synchronize(void);
+extern void save_timer_ctx(void);
+extern void restore_timer_ctx(void);
 
 /*  Wait loop - assuming tick is 1 us */
 static void wait_loop(uint32_t timeout)
@@ -161,8 +163,7 @@ void hal_deepsleep(void)
     // Disable IRQs
     core_util_critical_section_enter();
 
-    // Save the timer counter value in order to reprogram it after deepsleep
-    uint32_t EnterTimeUS = us_ticker_read();
+    save_timer_ctx();
 
     // Request to enter STOP mode with regulator in low power mode
 #if TARGET_STM32L4
@@ -187,6 +188,7 @@ void hal_deepsleep(void)
 #else /* TARGET_STM32L4 */
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 #endif /* TARGET_STM32L4 */
+
     // Verify Clock Out of Deep Sleep
     ForceClockOutofDeepSleep();
 
@@ -199,12 +201,7 @@ void hal_deepsleep(void)
      *  deep sleep */
     wait_loop(500);
 
-    // Reprogram the timer counter value saved before the deepsleep
-    TIM_HandleTypeDef TimMasterHandle;
-    TimMasterHandle.Instance = TIM_MST;
-    __HAL_TIM_SET_COUNTER(&TimMasterHandle, EnterTimeUS);
-    __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+    restore_timer_ctx();
 
 #if DEVICE_RTC
     /* Wait for RTC RSF bit synchro if RTC is configured */
@@ -216,6 +213,7 @@ void hal_deepsleep(void)
         rtc_synchronize();
     }
 #endif
+
     // Enable IRQs
     core_util_critical_section_exit();
 }

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -161,6 +161,7 @@ void hal_deepsleep(void)
     // Disable IRQs
     core_util_critical_section_enter();
 
+    // Save the timer counter value in order to reprogram it after deepsleep
     uint32_t EnterTimeUS = us_ticker_read();
 
     // Request to enter STOP mode with regulator in low power mode
@@ -198,9 +199,12 @@ void hal_deepsleep(void)
      *  deep sleep */
     wait_loop(500);
 
+    // Reprogram the timer counter value saved before the deepsleep
     TIM_HandleTypeDef TimMasterHandle;
     TimMasterHandle.Instance = TIM_MST;
     __HAL_TIM_SET_COUNTER(&TimMasterHandle, EnterTimeUS);
+    __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
+    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC1);
 
 #if DEVICE_RTC
     /* Wait for RTC RSF bit synchro if RTC is configured */

--- a/targets/TARGET_STM/us_ticker.c
+++ b/targets/TARGET_STM/us_ticker.c
@@ -78,3 +78,20 @@ void us_ticker_clear_interrupt(void)
     __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
 }
 
+uint32_t timer_cnt_reg;
+uint32_t timer_ccr1_reg;
+uint32_t timer_dier_reg;
+
+void save_timer_ctx(void)
+{
+    timer_cnt_reg = __HAL_TIM_GET_COUNTER(&TimMasterHandle);
+    timer_ccr1_reg = __HAL_TIM_GET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1);
+    timer_dier_reg = TIM_MST->DIER;
+}
+
+void restore_timer_ctx(void)
+{
+    __HAL_TIM_SET_COUNTER(&TimMasterHandle, timer_cnt_reg);
+    __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, timer_ccr1_reg);
+    TIM_MST->DIER = timer_dier_reg;
+}


### PR DESCRIPTION
### Description

This is a fix for Issue #7316 

As proposed by @c1728p9 the us_ticker_read() must be used while the SDK is not ready.

Tests:
- [X] *rtc*, *time*, *sleep* and *tick* tests OK on NUCLEO_L073RZ, NUCLEO_F070RB + ARM
- [X] HAL_Delay function tested OK inside a basic application with NUCLEO_F103RB
- [x] Run *rtc*, *time*, *sleep* and *tick* tests on all boards

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

