### PR TITLE
build_api script : separate PeripheralPins.o

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1075,7 +1075,7 @@ def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
         #   - mbed_overrides.o: this contains platform overrides of various
         #                       weak SDK functions
         #   - mbed_main.o: this contains main redirection
-        separate_names, separate_objects = ['mbed_retarget.o', 'mbed_board.o',
+        separate_names, separate_objects = ['PeripheralPins.o', 'mbed_retarget.o', 'mbed_board.o',
                                             'mbed_overrides.o', 'mbed_main.o', 'mbed_sdk_boot.o'], []
 
         for obj in objects:


### PR DESCRIPTION
### Description

This is done with @0xc0170 advice... 
https://github.com/ARMmbed/mbed-os/issues/7193#issuecomment-396886090

Goal is to compile peripheral pins as separate object files in OS2

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

