### PR TITLE
Fix tool crashing when lines end with cr(not crlf)

### DIFF
--- a/tools/debug_tools/crash_log_parser/crash_log_parser.py
+++ b/tools/debug_tools/crash_log_parser/crash_log_parser.py
@@ -115,7 +115,7 @@ def parse_line_for_register(line):
 def main(crash_log, elfhelper):
     mmfar_val = 0
     bfar_val = 0
-    lines = iter(crash_log.readlines())
+    lines = iter(crash_log.read().splitlines())
     
     for eachline in lines:
         if "++ MbedOS Fault Handler ++" in eachline:


### PR DESCRIPTION
### Description
Fix tool crashing when lines end with just cr (not crlf)

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

