### PR TITLE
Cellular: EasyCellularConnection::connect doesn't have any check that "CellularConnectionFSM" object is created or not

### DIFF
--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -156,7 +156,7 @@ nsapi_error_t EasyCellularConnection::connect(const char *sim_pin, const char *a
     }
 
     if (sim_pin) {
-        _cellularConnectionFSM->set_sim_pin(sim_pin);
+        this->set_sim_pin(sim_pin);
     }
 
     return connect();


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
EasyCellularConnection::connect doesn't have any check that "CellularConnectionFSM" object is created or not resulting into Hard Fault Handler. Instead of calling "_cellularConnectionFSM->set_sim_pin" method call "EasyCellularConnection::set_sim_pin" method. Which will create object of "CellularConnectionFSM" first, if not created already, and then set sim pin.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

