### PR TITLE
Fix storage rtos types - remove including internal header file

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -21,7 +21,13 @@
 #include "hal/us_ticker_api.h"
 #include "hal/lp_ticker_api.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "os_tick.h"
+#ifdef __cplusplus
+}
+#endif // __cplusplus
 
 #if !DEVICE_USTICKER
 #error [NOT_SUPPORTED] test not supported

--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -21,6 +21,8 @@
 #include "hal/us_ticker_api.h"
 #include "hal/lp_ticker_api.h"
 
+#include "os_tick.h"
+
 #if !DEVICE_USTICKER
 #error [NOT_SUPPORTED] test not supported
 #endif
@@ -117,7 +119,7 @@ void ticker_event_handler_stub(const ticker_data_t * const ticker)
     }
 
     /* Indicate that ISR has been executed in interrupt context. */
-    if (IsIrqMode()) {
+    if (core_util_is_isr_active()) {
         intFlag++;
     }
 }

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -63,7 +63,7 @@ void overflow_protect()
 void ticker_event_handler_stub(const ticker_data_t * const ticker)
 {
     /* Indicate that ISR has been executed in interrupt context. */
-    if (IsIrqMode()) {
+    if (core_util_is_isr_active()) {
         intFlag++;
     }
 

--- a/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
@@ -182,7 +182,7 @@ void test_heap_in_range(void)
  */
 void test_main_stack_in_range(void)
 {
-    os_thread_t *thread = (os_thread_t*) osThreadGetId();
+    mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *) osThreadGetId();
 
     uint32_t psp = __get_PSP();
     uint8_t *stack_mem = (uint8_t*) thread->stack_mem;

--- a/features/device_key/source/DeviceKey.cpp
+++ b/features/device_key/source/DeviceKey.cpp
@@ -22,6 +22,8 @@
 #include "mbed_wait_api.h"
 #include "stdlib.h"
 
+#include <string.h>
+
 #if !defined(MBEDTLS_CMAC_C)
 #error [NOT_SUPPORTED] MBEDTLS_CMAC_C needs to be enabled for this driver
 #else

--- a/features/lwipstack/LWIPStack.h
+++ b/features/lwipstack/LWIPStack.h
@@ -141,20 +141,20 @@ public:
             void *hw; /**< alternative implementation pointer - used for PPP */
         };
 
-        os_semaphore_t linked_sem;
+        mbed_rtos_storage_semaphore_t linked_sem;
         osSemaphoreId_t linked;
-        os_semaphore_t unlinked_sem;
+        mbed_rtos_storage_semaphore_t unlinked_sem;
         osSemaphoreId_t unlinked;
-        os_semaphore_t has_any_addr_sem;
+        mbed_rtos_storage_semaphore_t has_any_addr_sem;
         osSemaphoreId_t has_any_addr;
     #define HAS_ANY_ADDR 1
     #if PREF_ADDR_TIMEOUT
-        os_semaphore_t has_pref_addr_sem;
+        mbed_rtos_storage_semaphore_t has_pref_addr_sem;
         osSemaphoreId_t has_pref_addr;
     #define HAS_PREF_ADDR 2
     #endif
     #if BOTH_ADDR_TIMEOUT
-        os_semaphore_t has_both_addr_sem;
+        mbed_rtos_storage_semaphore_t has_both_addr_sem;
         osSemaphoreId_t has_both_addr;
     #define HAS_BOTH_ADDR 4
     #endif

--- a/features/lwipstack/lwip-sys/arch/sys_arch.h
+++ b/features/lwipstack/lwip-sys/arch/sys_arch.h
@@ -21,6 +21,8 @@
 #include "lwip/opt.h"
 #include "mbed_rtos_storage.h"
 
+#include <stdbool.h>
+
 extern u8_t lwip_ram_heap[];
 
 #if NO_SYS == 0

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.cpp
@@ -80,14 +80,14 @@ Kinetis_EMAC::Kinetis_EMAC() : xTXDCountSem(ENET_TX_RING_LEN, ENET_TX_RING_LEN),
 {
 }
 
-static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, os_thread_t *thread_cb)
+static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, mbed_rtos_storage_thread_t *thread_cb)
 {
     osThreadAttr_t attr = {0};
     attr.name = threadName;
     attr.stack_mem  = malloc(stacksize);
     attr.cb_mem  = thread_cb;
     attr.stack_size = stacksize;
-    attr.cb_size = sizeof(os_thread_t);
+    attr.cb_size = sizeof(mbed_rtos_storage_thread_t);
     attr.priority = priority;
     return osThreadNew(thread, arg, &attr);
 }

--- a/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_Freescale_EMAC/kinetis_emac.h
@@ -149,7 +149,7 @@ private:
     void phy_task();
     static void ethernet_callback(ENET_Type *base, enet_handle_t *handle, enet_event_t event, void *param);
 
-    os_thread_t thread_cb;
+    mbed_rtos_storage_thread_t thread_cb;
     osThreadId_t thread; /**< Processing thread */
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */
     rtos::Semaphore xTXDCountSem; /**< TX free buffer counting semaphore */

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
@@ -58,14 +58,14 @@ NUMAKER_EMAC::NUMAKER_EMAC() : thread(0), hwaddr()
 {
 }
 
-static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, os_thread_t *thread_cb)
+static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, mbed_rtos_storage_thread_t *thread_cb)
 {
     osThreadAttr_t attr = {0};
     attr.name = threadName;
     attr.stack_mem  = malloc(stacksize);
     attr.cb_mem  = thread_cb;
     attr.stack_size = stacksize;
-    attr.cb_size = sizeof(os_thread_t);
+    attr.cb_size = sizeof(mbed_rtos_storage_thread_t);
     attr.priority = priority;
     return osThreadNew(thread, arg, &attr);
 }

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.h
@@ -146,7 +146,7 @@ private:
     void phy_task();
     static void ethernet_callback(char event, void *param);
 
-    os_thread_t thread_cb;
+    mbed_rtos_storage_thread_t thread_cb;
     osThreadId_t thread; /**< Processing thread */
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */
     rtos::Semaphore xTXDCountSem; /**< TX free buffer counting semaphore */

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPC546XX/lpc546xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPC546XX/lpc546xx_emac.cpp
@@ -60,14 +60,14 @@ LPC546XX_EMAC::LPC546XX_EMAC() : xTXDCountSem(ENET_TX_RING_LEN, ENET_TX_RING_LEN
 {
 }
 
-static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, os_thread_t *thread_cb)
+static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, mbed_rtos_storage_thread_t *thread_cb)
 {
     osThreadAttr_t attr = {0};
     attr.name = threadName;
     attr.stack_mem  = malloc(stacksize);
     attr.cb_mem  = thread_cb;
     attr.stack_size = stacksize;
-    attr.cb_size = sizeof(os_thread_t);
+    attr.cb_size = sizeof(mbed_rtos_storage_thread_t);
     attr.priority = priority;
     return osThreadNew(thread, arg, &attr);
 }

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPC546XX/lpc546xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPC546XX/lpc546xx_emac.h
@@ -149,7 +149,7 @@ private:
     void phy_task();
     static void ethernet_callback(ENET_Type *base, enet_handle_t *handle, enet_event_t event, uint8_t channel, void *param);
 
-    os_thread_t thread_cb;
+    mbed_rtos_storage_thread_t thread_cb;
     osThreadId_t thread; /**< Processing thread */
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */
     rtos::Semaphore xTXDCountSem; /**< TX free buffer counting semaphore */

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.cpp
@@ -169,14 +169,14 @@ ETHMEM_SECTION uint8_t tx_clean_thread_stack[DEFAULT_THREAD_STACKSIZE];
 #endif
 ETHMEM_SECTION uint8_t phy_thread_stack[DEFAULT_THREAD_STACKSIZE];
 
-static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, void *stack_ptr, int stacksize, osPriority_t priority, os_thread_t *thread_cb)
+static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, void *stack_ptr, int stacksize, osPriority_t priority, mbed_rtos_storage_thread_t *thread_cb)
 {
     osThreadAttr_t attr = {0};
     attr.name = threadName;
     attr.stack_mem  = stack_ptr;
     attr.cb_mem  = thread_cb;
     attr.stack_size = stacksize;
-    attr.cb_size = sizeof(os_thread_t);
+    attr.cb_size = sizeof(mbed_rtos_storage_thread_t);
     attr.priority = priority;
     return osThreadNew(thread, arg, &attr);
 }

--- a/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_NXP_EMAC/TARGET_LPCTarget/lpc17_emac.h
@@ -151,7 +151,7 @@ public:
     void update_link_status(bool up);
 
     osThreadId_t RxThread;
-    os_thread_t RxThread_cb;
+    mbed_rtos_storage_thread_t RxThread_cb;
     rtos::Semaphore TxCleanSem;
 
 private:
@@ -176,9 +176,9 @@ private:
     uint8_t hwaddr[6];
 
     osThreadId_t TxCleanThread;
-    os_thread_t TxCleanThread_cb;
+    mbed_rtos_storage_thread_t TxCleanThread_cb;
     osThreadId_t PhyThread;
-    os_thread_t PhyThread_cb;
+    mbed_rtos_storage_thread_t PhyThread_cb;
     rtos::Mutex TXLockMutex;
     rtos::Semaphore xTXDCountSem;
 

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.cpp
@@ -89,14 +89,14 @@ STM32_EMAC::STM32_EMAC()
 {
 }
 
-static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, os_thread_t *thread_cb)
+static osThreadId_t create_new_thread(const char *threadName, void (*thread)(void *arg), void *arg, int stacksize, osPriority_t priority, mbed_rtos_storage_thread_t *thread_cb)
 {
     osThreadAttr_t attr = {0};
     attr.name = threadName;
     attr.stack_mem  = malloc(stacksize);
     attr.cb_mem  = thread_cb;
     attr.stack_size = stacksize;
-    attr.cb_size = sizeof(os_thread_t);
+    attr.cb_size = sizeof(mbed_rtos_storage_thread_t);
     attr.priority = priority;
     return osThreadNew(thread, arg, &attr);
 }

--- a/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
+++ b/features/netsocket/emac-drivers/TARGET_STM_EMAC/stm32xx_emac.h
@@ -161,10 +161,10 @@ private:
     void enable_interrupts();
     void disable_interrupts();
 
-    os_thread_t thread_cb;
+    mbed_rtos_storage_thread_t thread_cb;
 #if defined (STM32F767xx) || defined (STM32F769xx) || defined (STM32F777xx)\
     || defined (STM32F779xx)
-    os_thread_t rmii_watchdog_thread_cb;
+    mbed_rtos_storage_thread_t rmii_watchdog_thread_cb;
     osThreadId_t rmii_watchdog_thread; /**< Watchdog processing thread */
 #endif
     rtos::Mutex TXLockMutex;/**< TX critical section mutex */

--- a/rtos/TARGET_CORTEX/mbed_rtos_storage.h
+++ b/rtos/TARGET_CORTEX/mbed_rtos_storage.h
@@ -40,17 +40,17 @@ extern "C" {
  implementation specific, header file, therefore limiting scope of possible changes.
  */
 
-#include "rtx_lib.h"
+#include "rtx_os.h"
 #include "mbed_rtx_conf.h"
 
-typedef os_mutex_t mbed_rtos_storage_mutex_t;
-typedef os_semaphore_t mbed_rtos_storage_semaphore_t;
-typedef os_thread_t mbed_rtos_storage_thread_t;
-typedef os_memory_pool_t mbed_rtos_storage_mem_pool_t;
-typedef os_message_queue_t mbed_rtos_storage_msg_queue_t;
-typedef os_event_flags_t mbed_rtos_storage_event_flags_t;
-typedef os_message_t mbed_rtos_storage_message_t;
-typedef os_timer_t mbed_rtos_storage_timer_t;
+typedef osRtxMutex_t mbed_rtos_storage_mutex_t;
+typedef osRtxSemaphore_t mbed_rtos_storage_semaphore_t;
+typedef osRtxThread_t mbed_rtos_storage_thread_t;
+typedef osRtxMemoryPool_t mbed_rtos_storage_mem_pool_t;
+typedef osRtxMessageQueue_t mbed_rtos_storage_msg_queue_t;
+typedef osRtxEventFlags_t mbed_rtos_storage_event_flags_t;
+typedef osRtxMessage_t mbed_rtos_storage_message_t;
+typedef osRtxTimer_t mbed_rtos_storage_timer_t;
 
 #ifdef __cplusplus
 }

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -74,6 +74,8 @@
 // Don't adopt default multi-thread support for ARM/ARMC6 toolchains from RTX code base.
 // Provide Mbed-specific instead.
 #define RTX_NO_MULTITHREAD_CLIB
+// LIBSPACE default value set for ARMCC
+#define OS_THREAD_LIBSPACE_NUM      4
 
 #define OS_IDLE_THREAD_NAME         "idle_thread"
 #define OS_TIMER_THREAD_NAME        "timer_thread"

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -274,7 +274,7 @@ uint32_t Thread::free_stack() {
 
 #if defined(MBED_OS_BACKEND_RTX5)
     if (_tid != NULL) {
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         size = (uint32_t)thread->sp - (uint32_t)thread->stack_mem;
     }
 #endif
@@ -289,7 +289,7 @@ uint32_t Thread::used_stack() {
 
 #if defined(MBED_OS_BACKEND_RTX5)
     if (_tid != NULL) {
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         size = ((uint32_t)thread->stack_mem + thread->stack_size) - thread->sp;
     }
 #endif
@@ -304,7 +304,7 @@ uint32_t Thread::max_stack() {
 
     if (_tid != NULL) {
 #if defined(MBED_OS_BACKEND_RTX5)
-        os_thread_t *thread = (os_thread_t *)_tid;
+        mbed_rtos_storage_thread_t *thread = (mbed_rtos_storage_thread_t *)_tid;
         uint32_t high_mark = 0;
         while (((uint32_t *)(thread->stack_mem))[high_mark] == 0xE25A2EA5)
             high_mark++;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Remove internal types from our storage rtos header file. And do some refactor (some files still use internal types). Plus some other fixes as I removed one internal rtx from our include, I discovered 2 files not including needed header files!

As result, this also fix some warnings about redefinition STRINGIFY for some platforms (nordic at least).

@JonatanAntoni who I discussed the issue with

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

