### PR TITLE
Tools: Detect Arm Compiler version using Component

### DIFF
--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -31,6 +31,13 @@ def test_arm_version_check(_run_cmd):
     toolchain.version_check()
     assert notifier.messages == []
     _run_cmd.return_value = ("""
+    Product: MDK Professional 5.22
+    Component: ARM Compiler 5.06 update 5 (build 528)
+    Tool: armcc [4d3621]
+    """, "", 0)
+    toolchain.version_check()
+    assert notifier.messages == []
+    _run_cmd.return_value = ("""
     Product: ARM Compiler
     Component: ARM Compiler
     Tool: armcc [4d3621]

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -41,7 +41,7 @@ class ARM(mbedToolchain):
     SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
                        "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD", "Cortex-A9"]
     ARMCC_RANGE = (LooseVersion("5.06"), LooseVersion("5.07"))
-    ARMCC_VERSION_RE = re.compile("Product: ARM Compiler (\d+\.\d+)")
+    ARMCC_VERSION_RE = re.compile("Component: ARM Compiler (\d+\.\d+)")
 
     @staticmethod
     def check_executable():


### PR DESCRIPTION
### Description

In an offline discussion, I found that the arm compiler may spit out:
```
Product: MDK Professional 5.22
Component: ARM Compiler 5.06 update 6 (build 750)
```

instead of what I was expecting.

This PR fixes detection logic to use the component field instead of 
the product field like I was using before.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change