### PR TITLE
Fix race condition in serial_api.c for NRF52 series

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/README.md
@@ -108,15 +108,15 @@ All buffers can be resized to fit the application:
 ```
     "name": "nordic",
     "config": {
-        "uart-dma-size": {
+        "uart_dma_size": {
             "help": "UART DMA buffer. 2 buffers per instance. DMA buffer is filled by UARTE",
             "value": 8
         },
-        "uart-0-fifo-size": {
+        "uart_0_fifo_size": {
             "help": "UART0 FIFO buffer. FIFO buffer is filled from DMA buffer.",
             "value": 32
         },
-        "uart-1-fifo-size": {
+        "uart_1_fifo_size": {
             "help": "UART1 FIFO buffer. FIFO buffer is filled from DMA buffer.",
             "value": 32
         }


### PR DESCRIPTION
### Description

* Elevate RTC2 interrupt priority to same level as UARTE to prevent race condition on shared variables.
* Remove unused TXDRDY event code.
* Fix typo in macro.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

