### PR TITLE
Improve efficiency and formatting of ITM output

### DIFF
--- a/drivers/SerialWireOutput.h
+++ b/drivers/SerialWireOutput.h
@@ -33,12 +33,8 @@ public:
 
     virtual ssize_t write(const void *buffer, size_t size)
     {
-        const unsigned char *buf = static_cast<const unsigned char *>(buffer);
+        mbed_itm_send_block(ITM_PORT_SWO, buffer, size);
 
-        /* Send buffer one character at a time over the ITM SWO port */
-        for (size_t i = 0; i < size; i++) {
-            mbed_itm_send(ITM_PORT_SWO, buf[i]);
-        }
         return size;
     }
 

--- a/hal/itm_api.h
+++ b/hal/itm_api.h
@@ -22,6 +22,7 @@
 #if defined(DEVICE_ITM)
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,11 +69,25 @@ void mbed_itm_init(void);
  * @brief      Send data over ITM stimulus port.
  *
  * @param[in]  port  The stimulus port to send data over.
- * @param[in]  data  The data to send.
+ * @param[in]  data  The 32-bit data to send.
+ *
+ * The data is written as a single 32-bit write to the port.
  *
  * @return     value of data sent.
  */
 uint32_t mbed_itm_send(uint32_t port, uint32_t data);
+
+/**
+ * @brief      Send a block of data over ITM stimulus port.
+ *
+ * @param[in]  port  The stimulus port to send data over.
+ * @param[in]  data  The block of data to send.
+ * @param[in]  len   The number of bytes of data to send.
+ *
+ * The data is written using multiple appropriately-sized port accesses for
+ * efficient transfer.
+ */
+void mbed_itm_send_block(uint32_t port, const void *data, size_t len);
 
 /**@}*/
 


### PR DESCRIPTION
### Description

SerialWireOutput was outputting 1 character per 32-bit write to the ITM stimulus port. This is inefficient, and causes processing problems with some viewers due to them receiving 3 NUL bytes between each desired character.

Rework to allow us to be more efficient, and eliminate those NUL bytes:

* Retain existing mbed_itm_send() and clarify it's a single 32-bit write.
* Add new mbed_itm_send_block() that is appropriate for sending character data, and modify SerialWireOutput to use it.
* Move "wait for FIFO ready" check to before the write, rather than after.

One minor correction - FIFOREADY is a single bit of the register read. Don't interpret reserved bits.

Fixes #7373 

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

