### PR TITLE
Cellular: fix greentea tests C027 and BG96

### DIFF
--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -213,6 +213,7 @@ static void test_credentials()
 
 static void test_other()
 {
+    const char* devi = CELLULAR_STRINGIFY(CELLULAR_DEVICE);
     TEST_ASSERT(nw->get_3gpp_error() == 0);
 
     CellularNetwork::RateControlExceptionReports reports;
@@ -220,23 +221,24 @@ static void test_other()
     int uplinkRate;
     // can't test values as they are optional
     nsapi_error_t err = nw->get_rate_control(reports, timeUnit, uplinkRate);
-    tr_error("get_rate_control: %d", err);
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
-#if CELLULAR_DEVICE != QUECTEL_BG96 // QUECTEL_BG96 does not give any specific reason for device error
-    if (err == NSAPI_ERROR_DEVICE_ERROR) {
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+    if (strcmp(devi, "QUECTEL_BG96") != 0 && strcmp(devi, "TELIT_HE910") != 0) { // QUECTEL_BG96 does not give any specific reason for device error
+        if (err == NSAPI_ERROR_DEVICE_ERROR) {
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                    	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
     }
-#endif
 
     uplinkRate = -1;
     err = nw->get_apn_backoff_timer(uplinkRate);
-    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
+    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR || err == NSAPI_ERROR_PARAMETER);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
-#if CELLULAR_DEVICE != QUECTEL_BG96 // QUECTEL_BG96 does not give any specific reason for device error
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
-#endif
+        if (strcmp(devi, "QUECTEL_BG96") != 0 && strcmp(devi, "TELIT_HE910") != 0) { // QUECTEL_BG96 does not give any specific reason for device error
+                    TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                            	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
+    } else if (err == NSAPI_ERROR_PARAMETER) {
+        TEST_ASSERT(uplinkRate == -1);
     } else {
         TEST_ASSERT(uplinkRate >= 0);
     }
@@ -261,14 +263,13 @@ static void test_other()
 
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
-#if CELLULAR_DEVICE != TELIT_HE910 // TELIT_HE910 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
-#endif
+        if (strcmp(devi, "TELIT_HE910") != 0) { // TELIT_HE910 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                    	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
     } else {
         // should have some values, only not optional are apn and bearer id
         CellularNetwork::pdpcontext_params_t *params = params_list.get_head();
-        TEST_ASSERT(strlen(params->apn) > 0);
         TEST_ASSERT(params->bearer_id >= 0)
     }
 
@@ -276,10 +277,10 @@ static void test_other()
     err = nw->get_extended_signal_quality(rxlev, ber, rscp, ecno, rsrq, rsrp);
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
-#if CELLULAR_DEVICE != QUECTEL_BG96 // QUECTEL_BG96 does not give any specific reason for device error
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
-#endif
+        if (strcmp(devi, "QUECTEL_BG96") != 0 && strcmp(devi, "TELIT_HE910") != 0) {// QUECTEL_BG96 does not give any specific reason for device error
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
     } else {
         // we should have some values which are not optional
         TEST_ASSERT(rxlev >= 0 && ber >= 0 && rscp >= 0 && ecno >= 0 && rsrq >= 0 && rsrp >= 0);
@@ -305,53 +306,55 @@ static void test_other()
     int format = -1;
     CellularNetwork::operator_t operator_params;
     // all params are optional so can't test operator_params
-    TEST_ASSERT(nw->get_operator_params(format, operator_params) == NSAPI_ERROR_OK);
+    err = nw->get_operator_params(format, operator_params);
+    TEST_ASSERT(err == NSAPI_ERROR_OK);
 
     nsapi_connection_status_t st =  nw->get_connection_status();
     TEST_ASSERT(st == NSAPI_STATUS_DISCONNECTED);
 
     TEST_ASSERT(nw->set_blocking(true) == NSAPI_ERROR_OK);
 
-#if CELLULAR_DEVICE != QUECTEL_BG96
-    // QUECTEL_BG96 timeouts with this one, tested with 3 minute timeout
-    CellularNetwork::operator_names_list op_names;
-    err = nw->get_operator_names(op_names);
-    TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
-    if (err == NSAPI_ERROR_DEVICE_ERROR) {
-        // if device error then we must check was that really device error or that modem/network does not support the commands
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 4 // 4 == NOT SUPPORTED BY THE MODEM
-                    && ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
-    } else {
-        CellularNetwork::operator_names_t *opn = op_names.get_head();
-        TEST_ASSERT(strlen(opn->numeric) > 0);
-        TEST_ASSERT(strlen(opn->alpha > 0));
+    if (strcmp(devi, "QUECTEL_BG96") != 0) {
+        // QUECTEL_BG96 timeouts with this one, tested with 3 minute timeout
+        CellularNetwork::operator_names_list op_names;
+        err = nw->get_operator_names(op_names);
+        TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
+        if (err == NSAPI_ERROR_DEVICE_ERROR) {
+            // if device error then we must check was that really device error or that modem/network does not support the commands
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 4 // 4 == NOT SUPPORTED BY THE MODEM
+                    	&& ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        } else {
+            CellularNetwork::operator_names_t *opn = op_names.get_head();
+            TEST_ASSERT(strlen(opn->numeric) > 0);
+            TEST_ASSERT(strlen(opn->alpha) > 0);
+        }
     }
-#endif
 
-#if CELLULAR_DEVICE != TELIT_HE910
-    // TELIT_HE910 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
-    CellularNetwork::Supported_UE_Opt supported_opt = SUPPORTED_UE_OPT_MAX;
-    CellularNetwork::Preferred_UE_Opt preferred_opt = PREFERRED_UE_OPT_MAX;
+    // TELIT_HE910 and QUECTEL_BG96 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
+    CellularNetwork::Supported_UE_Opt supported_opt = CellularNetwork::SUPPORTED_UE_OPT_MAX;
+    CellularNetwork::Preferred_UE_Opt preferred_opt = CellularNetwork::PREFERRED_UE_OPT_MAX;
     err = nw->get_ciot_optimization_config(supported_opt, preferred_opt);
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
         // if device error then we must check was that really device error or that modem/network does not support the commands
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        if (!(strcmp(devi, "TELIT_HE910") == 0 || strcmp(devi, "QUECTEL_BG96") == 0)) {
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
     } else {
-        TEST_ASSERT(supported_opt != SUPPORTED_UE_OPT_MAX);
-        TEST_ASSERT(preferred_opt != PREFERRED_UE_OPT_MAX);
+        TEST_ASSERT(supported_opt != CellularNetwork::SUPPORTED_UE_OPT_MAX);
+        TEST_ASSERT(preferred_opt != CellularNetwork::PREFERRED_UE_OPT_MAX);
     }
 
     err = nw->set_ciot_optimization_config(supported_opt, preferred_opt);
     TEST_ASSERT(err == NSAPI_ERROR_OK || err == NSAPI_ERROR_DEVICE_ERROR);
     if (err == NSAPI_ERROR_DEVICE_ERROR) {
         // if device error then we must check was that really device error or that modem/network does not support the commands
-        TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
-                    ((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        if (!(strcmp(devi, "TELIT_HE910") == 0 || strcmp(devi, "QUECTEL_BG96") == 0)) {
+            TEST_ASSERT(((AT_CellularNetwork *)nw)->get_device_error().errCode == 100 && // 100 == unknown command for modem
+                	((AT_CellularNetwork *)nw)->get_device_error().errType == 3); // 3 == CME error from the modem
+        }
     }
-#endif
-
 }
 
 static void test_disconnect()

--- a/features/cellular/TESTS/api/cellular_sim/main.cpp
+++ b/features/cellular/TESTS/api/cellular_sim/main.cpp
@@ -92,6 +92,9 @@ static void test_sim_interface()
     CellularSIM *sim = cellular.get_sim();
     TEST_ASSERT(sim != NULL);
 
+    // set SIM at time out to 3000
+    cellular.get_device()->set_timeout(3000);
+    wait(4); // we need to wait for some time so that SIM interface is working in all modules.
     // 1. test set_pin
     nsapi_error_t err = sim->set_pin(MBED_CONF_APP_CELLULAR_SIM_PIN);
     MBED_ASSERT(err == NSAPI_ERROR_OK);
@@ -105,23 +108,31 @@ static void test_sim_interface()
     };
 
     // change pin and change it back
+    wait(1);
     err = sim->change_pin(MBED_CONF_APP_CELLULAR_SIM_PIN, pin);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
+
+    wait(1);
     err = sim->change_pin(pin, MBED_CONF_APP_CELLULAR_SIM_PIN);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
 
     // 3. test set_pin_query
+    wait(1);
     err = sim->set_pin_query(MBED_CONF_APP_CELLULAR_SIM_PIN, false);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
+
+    wait(1);
     err = sim->set_pin_query(MBED_CONF_APP_CELLULAR_SIM_PIN, true);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
 
+    wait(1);
     // 4. test get_sim_state
     CellularSIM::SimState state;
     err = sim->get_sim_state(state);
     TEST_ASSERT(err == NSAPI_ERROR_OK);
     TEST_ASSERT(state == CellularSIM::SimStateReady);
 
+    wait(1);
     // 5. test get_imsi
     char imsi[16] = {0};
     err = sim->get_imsi(imsi);


### PR DESCRIPTION
### Description
- Fixed greentea tests for UBLOX C027 and Quectel BG96.
- SIM test was fixed by adding additional waiting between commands or command might return sim busy
- Fixed device specific test variations in network and power tests. Fixes to both defects. Some modems don't support command and fixed to take that into account.
- Power test at timeout was increased as it might take more time than 1s.

No code changes, only test.

Internal ref to defect: IOTCELL-1139
Internal ref to defect: IOTCELL-1140

@mirelachirica please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

