### PR TITLE
Fix memory leakage with MBR on exiting error path

### DIFF
--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -242,6 +242,7 @@ int MBRBlockDevice::init()
 
     // Check that block addresses are valid
     if (!_bd->is_valid_erase(_offset, _size)) {
+        delete[] buffer;
         return BD_ERROR_INVALID_PARTITION;
     }
 


### PR DESCRIPTION
### Description

This PR fixes memory leakage on exiting error path in `MBRBlockDevice::init`.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

