### PR TITLE
Fix us_ticker & gpio bug

### DIFF
--- a/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.c
@@ -17,9 +17,9 @@ void HAL_GPIO_DeInit(GPIO_TypeDef* GPIOx)
     GPIOx->OUTENCLR = 0xFFFF;    
     //GPIOx->INTENSET = 0x0000;    
     GPIOx->INTENCLR = 0xFFFF;    
-    //GPIOx->INTTYPESET = 0x0000;  
-    GPIOx->INTTYPECLR = 0xFFFF;  
-    //GPIOx->INTPOLSET = 0x0000;
+    GPIOx->INTTYPESET = 0x0000;  
+    //GPIOx->INTTYPECLR = 0xFFFF;  
+    //GPIOx->intpolset = 0x0000;   
     GPIOx->INTPOLCLR = 0xFFFF;   
 
 
@@ -65,10 +65,11 @@ void HAL_GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct)
 
     assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
     assert_param(IS_GPIO_PIN(GPIO_InitStruct->GPIO_Pin));
-//    assert_param(IS_GPIO_PUPD(GPIO_InitStruct->GPIO_PuPd));
+	//A170223 becky
+    assert_param(IS_GPIO_PIN(GPIO_InitStruct->GPIO_Mode));
+	////////////////////////////////////////////////////////////
+	  assert_param(IS_GPIO_PUPD(GPIO_InitStruct->GPIO_PuPd));
 
-    GPIOx->INTTYPESET = 0x00FF;  
-    
     if      (GPIOx == GPIOA)        px_pcr  = PA_PCR;
     else if (GPIOx == GPIOB)        px_pcr  = PB_PCR;
     else if (GPIOx == GPIOC)        px_pcr  = PC_PCR;
@@ -118,14 +119,14 @@ void HAL_GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct)
             }
 
             // Configure Open Drain selections bit
-            if(GPIO_InitStruct->GPIO_Pad & Px_PCR_OD)
-            {
-                px_pcr->Port[pinpos] |= Px_PCR_OD;
-            }
-           else
-            {
-                px_pcr->Port[pinpos] &= ~(Px_PCR_OD);
-            }
+            //if(GPIO_InitStruct->GPIO_Pad & Px_PCR_OD)
+            //{
+            //    px_pcr->Port[pinpos] |= Px_PCR_OD;
+            //}
+            //else
+            //{
+            //    px_pcr->Port[pinpos] &= ~(Px_PCR_OD);
+            //}
 
             // Configure Input buffer enable selection bit 
             if(GPIO_InitStruct->GPIO_Pad & Px_PCR_IE)
@@ -154,7 +155,7 @@ void HAL_GPIO_StructInit(GPIO_InitTypeDef* GPIO_InitStruct)
 {
     GPIO_InitStruct->GPIO_Pin  = GPIO_Pin_All;
     GPIO_InitStruct->GPIO_Mode = GPIO_Mode_IN;
-    GPIO_InitStruct->GPIO_Pad = (GPIOPad_TypeDef)(GPIO_PuPd_UP);
+    GPIO_InitStruct->GPIO_Pad = (GPIOPad_TypeDef)(GPIO_SUMMIT|GPIO_IE|GPIO_PuPd_UP);
 }
 
 
@@ -232,13 +233,27 @@ void HAL_GPIO_ResetBits(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin)
 
 void HAL_GPIO_WriteBit(GPIO_TypeDef* GPIOx, uint16_t GPIO_Pin, BitAction BitVal)
 {
+    uint32_t temp_gpio_lb;
+    uint32_t temp_gpio_ub;
+    
     /* Check the parameters */
     assert_param(IS_GPIO_ALL_PERIPH(GPIOx));
     assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
     assert_param(IS_GPIO_BIT_ACTION(BitVal)); 
+    
+    temp_gpio_lb = (GPIOx->LB_MASKED[(uint8_t)(GPIO_Pin)]);
+    temp_gpio_ub = (GPIOx->UB_MASKED[(uint8_t)((GPIO_Pin)>>8)]);
 
-    (GPIOx->LB_MASKED[(uint8_t)(GPIO_Pin)]) = BitVal;
-    (GPIOx->UB_MASKED[(uint8_t)((GPIO_Pin)>>8)]) = BitVal;
+    if( BitVal == Bit_SET)
+    {
+        (GPIOx->LB_MASKED[(uint8_t)(GPIO_Pin)]) = (temp_gpio_lb | GPIO_Pin);
+        (GPIOx->UB_MASKED[(uint8_t)((GPIO_Pin)>>8)]) = (temp_gpio_ub | GPIO_Pin);
+    }
+    else
+    {
+        (GPIOx->LB_MASKED[(uint8_t)(GPIO_Pin)]) = (temp_gpio_lb & ~(GPIO_Pin));
+        (GPIOx->UB_MASKED[(uint8_t)((GPIO_Pin)>>8)]) = (temp_gpio_ub & ~(GPIO_Pin));
+    }
 }
 
 void HAL_GPIO_Write(GPIO_TypeDef* GPIOx, uint16_t PortVal)
@@ -254,38 +269,37 @@ void HAL_PAD_AFConfig(PAD_Type Px, uint16_t GPIO_Pin, PAD_AF_TypeDef P_AF)
     int i;
     uint16_t idx =0x1;
     assert_param(IS_PAD_Type(Px));
-
+	//A170223 becky 
+		assert_param(IS_GET_GPIO_PIN(GPIO_Pin));
+	
+	
     for(i=0;i<16;i++)
     {
         if(GPIO_Pin & (idx<<i))
         {
             if(Px == PAD_PA)
             {
-                assert_param(IS_PA_NUM(i));
-                //PA_AFSR->Port[i] &= ~(0x03ul);
-                //PA_AFSR->Port[i] |= P_AF;
-                PA_AFSR->Port[i] = P_AF;
+                assert_param(IS_PA_NUM(i)); 
+                PA_AFSR->Port[i] &= ~(0x03ul);
+                PA_AFSR->Port[i] |= P_AF;
             }
             else if(Px == PAD_PB)
             {
                 assert_param(IS_PB_NUM(i));
-                //PB_AFSR->Port[i] &= ~(0x03ul);
-                //PB_AFSR->Port[i] |= P_AF;
-                PB_AFSR->Port[i] = P_AF;
+                PB_AFSR->Port[i] &= ~(0x03ul);
+                PB_AFSR->Port[i] |= P_AF;
             }
             else if(Px == PAD_PC)
             {
                 assert_param(IS_PC_NUM(i));
-                //PC_AFSR->Port[i] &= ~(0x03ul);
-                //PC_AFSR->Port[i] |= P_AF;
-                PC_AFSR->Port[i] = P_AF;
+                PC_AFSR->Port[i] &= ~(0x03ul);
+                PC_AFSR->Port[i] |= P_AF;
             }
             else
             {
                 assert_param(IS_PD_NUM(i));
-                //PD_AFSR->Port[i] &= ~(0x03ul);
-                //PD_AFSR->Port[i] |= P_AF;
-                PD_AFSR->Port[i] = P_AF;
+                PD_AFSR->Port[i] &= ~(0x03ul);
+                PD_AFSR->Port[i] |= P_AF;
             }				
         }
     }

--- a/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.c
@@ -12,14 +12,10 @@ void HAL_GPIO_DeInit(GPIO_TypeDef* GPIOx)
 
     /* DeInit GPIOx Registers */
     GPIOx->DATA = 0x0000;        
-    GPIOx->DATAOUT = 0x0000;     
-    //GPIOx->OUTENSET = 0x0000;    
-    GPIOx->OUTENCLR = 0xFFFF;    
-    //GPIOx->INTENSET = 0x0000;    
+    GPIOx->DATAOUT = 0x0000;       
+    GPIOx->OUTENCLR = 0xFFFF;      
     GPIOx->INTENCLR = 0xFFFF;    
-    GPIOx->INTTYPESET = 0x0000;  
-    //GPIOx->INTTYPECLR = 0xFFFF;  
-    //GPIOx->intpolset = 0x0000;   
+    GPIOx->INTTYPESET = 0x0000;    
     GPIOx->INTPOLCLR = 0xFFFF;   
 
 
@@ -68,7 +64,7 @@ void HAL_GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct)
 	//A170223 becky
     assert_param(IS_GPIO_PIN(GPIO_InitStruct->GPIO_Mode));
 	////////////////////////////////////////////////////////////
-	  assert_param(IS_GPIO_PUPD(GPIO_InitStruct->GPIO_PuPd));
+    assert_param(IS_GPIO_PUPD(GPIO_InitStruct->GPIO_PuPd));
 
     if      (GPIOx == GPIOA)        px_pcr  = PA_PCR;
     else if (GPIOx == GPIOB)        px_pcr  = PB_PCR;
@@ -117,16 +113,6 @@ void HAL_GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct)
             {
                 px_pcr->Port[pinpos] &= ~(Px_PCR_DS_HIGH);
             }
-
-            // Configure Open Drain selections bit
-            //if(GPIO_InitStruct->GPIO_Pad & Px_PCR_OD)
-            //{
-            //    px_pcr->Port[pinpos] |= Px_PCR_OD;
-            //}
-            //else
-            //{
-            //    px_pcr->Port[pinpos] &= ~(Px_PCR_OD);
-            //}
 
             // Configure Input buffer enable selection bit 
             if(GPIO_InitStruct->GPIO_Pad & Px_PCR_IE)

--- a/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.h
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/W7500x_Peripheral_Library/W7500x_gpio.h
@@ -64,11 +64,15 @@ typedef enum
 
 typedef enum
 {
-    GPIO_NO_PUPD = 0x0ul,
     GPIO_PuPd_UP = Px_PCR_PUPD_UP,
     GPIO_PuPd_DOWN = Px_PCR_PUPD_DOWN,
-    GPIO_PuPd_Default = 0x0ul,
+	GPIO_DS = Px_PCR_DS_HIGH,
+	GPIO_IE = Px_PCR_IE,
+    GPIO_SUMMIT = Px_PCR_CS_SUMMIT
 }GPIOPad_TypeDef;
+
+
+#define IS_GPIO_PUPU(PUPD)  (((PUPD) == GPIO_PuPd_UP) || ((PUPD) == GPIO_PuPd_DOWN))
 
 typedef struct
 {
@@ -79,12 +83,24 @@ typedef struct
 
 typedef enum
 {
+    Falling = 0,
+    Rising = 1
+}GPIOPol_TypeDef;
+
+typedef enum
+{
+    Reset = 0,
+    Set = 1
+}GPIOSet_TypeDef;
+
+typedef enum
+{
     Bit_RESET = 0,
     Bit_SET
 }BitAction;
 
 
-#define IS_PAD_TYPE(Px)  (((Px) == PAD_PA) || ((Px) == PAD_PB) \
+#define IS_PAD_TYPE(Px)  (((Px) == PAD_PA) || ((Px) == PAD_PB) || \
                           ((Px) == PAD_PC) || ((Px) == PAD_PD))
 
 #define IS_PA_NUM(NUM) (((NUM)>=0) && ((NUM)<16))

--- a/targets/TARGET_WIZNET/TARGET_W7500x/mbed_overrides.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/mbed_overrides.c
@@ -35,4 +35,5 @@ void mbed_sdk_init()
 {
     // Update the SystemCoreClock variable.
     SystemInit();
+    SysTick_Config((GetSystemClock()/1000));
 }

--- a/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
@@ -51,11 +51,8 @@ extern "C"{
 
 void DUALTIMER0_Handler(void)
 {
-   if(DUALTIMER_GetIntStatus(DUALTIMER0_0))
-    {
-        DUALTIMER_IntClear(DUALTIMER0_0);
-        us_ticker_irq_handler();
-    }
+    DUALTIMER_IntClear(DUALTIMER0_0);
+    us_ticker_irq_handler();}
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
for greenteatest
dualtime : modified about Interrupt callback function check error

for winetinterface
gpio : modified initialize function

### Description

Fix problems that could critical section along with adding tests to verify this behavior is fixed.

Tested locally with two targets and all toolchains.

You can see test results [link](http://mail.naver.com/file/download/each/?attachType=normal&mailSN=43321&attachIndex=2&virus=1&domain=mail.naver.com&u=khj098765)
### Pull request type

    [*] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

