### PR TITLE
Make clock source changeable over mbed_app.json for EFM32-Targets

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/common/mbed_overrides.c
@@ -29,6 +29,7 @@
 #include "device.h"
 #include "em_usart.h"
 #include "gpio_api.h"
+#include "clocking.h"
 
 gpio_t bc_enable;
 


### PR DESCRIPTION
By adding the missing include the clock source for EFM32-Targets is changeable over mbed_app.json.

### Description
Referencing issue #7346. Because nothing happens by silicon-labs regarding this issue I created this PR.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

