### PR TITLE
DISCO STM32L4 : Add TWO_RAM_REGIONS macro

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2013,7 +2013,7 @@
         },
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0764"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L475VG",
@@ -2035,7 +2035,7 @@
             }
         },
         "detect_code": ["0820"],
-        "macros_add": ["USBHOST_OTHER"],
+        "macros_add": ["USBHOST_OTHER", "TWO_RAM_REGIONS"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32L476VG",


### PR DESCRIPTION
### Description

Hi

TWO_RAM_REGIONS macro has been removed accidentally in https://github.com/ARMmbed/mbed-os/pull/7009/commits/d429458ac718cea0c8d48c8de3f7c903411d15bc

It should solve #7379 


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

