### PR TITLE
Tools: Show Mbed-2-only targets in mbed compile -S

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -190,7 +190,8 @@ if __name__ == '__main__':
     # Only prints matrix of supported toolchains
     if options.supported_toolchains:
         if options.supported_toolchains == "matrix":
-            print(mcu_toolchain_matrix(platform_filter=options.general_filter_regex))
+            print(mcu_toolchain_matrix(platform_filter=options.general_filter_regex,
+                                       release_version=None))
         elif options.supported_toolchains == "toolchains":
             toolchain_list = mcu_toolchain_list()
             # Only print the lines that matter


### PR DESCRIPTION
### Description

The targets listed in `mbed compile -S` are currently filtered
by mbed 2 support. I have recieved many complaints that this is
unhelpful from partners, users and our CI experts offline. This
is the smallest diff I could come up with to display the info we
have.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change