### PR TITLE
Bug fix for receive windows

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -868,12 +868,8 @@ void LoRaMac::open_rx1_window(void)
 
     _mcps_indication.rx_datarate = _params.rx_window1_config.datarate;
 
-    if (_lora_phy.rx_config(&_params.rx_window1_config)) {
-        _lora_phy.handle_receive();
-    } else {
-        tr_error("Receive failed. Radio is not IDLE");
-        return;
-    }
+    _lora_phy.rx_config(&_params.rx_window1_config);
+    _lora_phy.handle_receive();
 
     tr_debug("Opening RX1 Window");
 }
@@ -888,8 +884,6 @@ void LoRaMac::open_rx2_window()
     _params.rx_window2_config.frequency = _params.sys_params.rx2_channel.frequency;
     _params.rx_window2_config.dl_dwell_time = _params.sys_params.downlink_dwell_time;
     _params.rx_window2_config.is_repeater_supported = _params.is_repeater_supported;
-    _params.rx_window2_config.rx_slot = _params.rx_window2_config.is_rx_continuous ?
-                                        RX_SLOT_WIN_CLASS_C : RX_SLOT_WIN_2;
 
     if (get_device_class() == CLASS_C) {
         _params.rx_window2_config.is_rx_continuous = true;
@@ -897,15 +891,14 @@ void LoRaMac::open_rx2_window()
         _params.rx_window2_config.is_rx_continuous = false;
     }
 
+    _params.rx_window2_config.rx_slot = _params.rx_window2_config.is_rx_continuous ?
+                                        RX_SLOT_WIN_CLASS_C : RX_SLOT_WIN_2;
+
     _mcps_indication.rx_datarate = _params.rx_window2_config.datarate;
 
-    if (_lora_phy.rx_config(&_params.rx_window2_config)) {
-        _lora_phy.handle_receive();
-        _params.rx_slot = _params.rx_window2_config.rx_slot;
-    } else {
-        tr_error("Receive failed. Radio is not IDLE");
-        return;
-    }
+    _lora_phy.rx_config(&_params.rx_window2_config);
+    _lora_phy.handle_receive();
+    _params.rx_slot = _params.rx_window2_config.rx_slot;
 
     tr_debug("Opening RX2 Window, Frequency = %lu", _params.rx_window2_config.frequency);
 }

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -813,15 +813,6 @@ bool LoRaPHY::rx_config(rx_config_params_t *rx_conf)
     uint8_t phy_dr = 0;
     uint32_t frequency = rx_conf->frequency;
 
-    _radio->lock();
-
-    if (_radio->get_status() != RF_IDLE) {
-        _radio->unlock();
-        return false;
-    }
-
-    _radio->unlock();
-
     if (rx_conf->rx_slot == RX_SLOT_WIN_1) {
         // Apply window 1 frequency
         frequency = phy_params.channels.channel_list[rx_conf->channel].frequency;


### PR DESCRIPTION


### Description

In rx_config(params) API we shouldn't check for radio state as radio may never get
idle for a class C device. That check made sense only for class A. As the PHY layer
have no conecpt of receive windows which is a MAC layer construct, we should remove the
state check.
The API will be changed later to void rx_config(params).

In addition to that another bug is fixed in the open_rx2_windows() API. We should set the rx slot
first before instantiating a test based on its value.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

