### PR TITLE
Replace mbed_mem_tracing_enabled macro with config option

### DIFF
--- a/TESTS/mbed_drivers/mem_trace/main.cpp
+++ b/TESTS/mbed_drivers/mem_trace/main.cpp
@@ -24,8 +24,8 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#ifndef MBED_MEM_TRACING_ENABLED
-#error [NOT_SUPPORTED] test not supported
+#if !MBED_MEM_TRACING_ENABLED
+  #error [NOT_SUPPORTED] test not supported
 #endif
 
 using utest::v1::Case;

--- a/platform/mbed_alloc_wrappers.cpp
+++ b/platform/mbed_alloc_wrappers.cpp
@@ -30,7 +30,7 @@
   activated by defining the MBED_HEAP_STATS_ENABLED macro.
 - the second can be used to trace each memory call by automatically invoking
   a callback on each memory operation (see hal/api/mbed_mem_trace.h). It is
-  activated by defining the MBED_MEM_TRACING_ENABLED macro.
+  activated by setting the configuration option MBED_MEM_TRACING_ENABLED to true.
 
 Both tracers can be activated and deactivated in any combination. If both tracers
 are active, the second one (MBED_MEM_TRACING_ENABLED) will trace the first one's
@@ -96,7 +96,7 @@ extern "C" void *__wrap__malloc_r(struct _reent *r, size_t size)
 extern "C" void *malloc_wrapper(struct _reent *r, size_t size, void *caller)
 {
     void *ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -118,17 +118,17 @@ extern "C" void *malloc_wrapper(struct _reent *r, size_t size, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = __real__malloc_r(r, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_malloc(ptr, size, caller);
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
 extern "C" void *__wrap__realloc_r(struct _reent *r, void *ptr, size_t size)
 {
     void *new_ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -161,10 +161,10 @@ extern "C" void *__wrap__realloc_r(struct _reent *r, void *ptr, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     new_ptr = __real__realloc_r(r, ptr, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_realloc(new_ptr, ptr, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return new_ptr;
 }
 
@@ -175,7 +175,7 @@ extern "C" void __wrap__free_r(struct _reent *r, void *ptr)
 
 extern "C" void free_wrapper(struct _reent *r, void *ptr, void *caller)
 {
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -191,16 +191,16 @@ extern "C" void free_wrapper(struct _reent *r, void *ptr, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     __real__free_r(r, ptr);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_free(ptr, caller);
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
 }
 
 extern "C" void *__wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
     void *ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -213,10 +213,10 @@ extern "C" void *__wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = __real__calloc_r(r, nmemb, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_calloc(ptr, nmemb, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -275,7 +275,7 @@ extern "C" void *SUB_MALLOC(size_t size)
 extern "C" void *malloc_wrapper(size_t size, void *caller)
 {
     void *ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -297,10 +297,10 @@ extern "C" void *malloc_wrapper(size_t size, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = SUPER_MALLOC(size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_malloc(ptr, size, caller);
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -308,7 +308,7 @@ extern "C" void *malloc_wrapper(size_t size, void *caller)
 extern "C" void *SUB_REALLOC(void *ptr, size_t size)
 {
     void *new_ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -336,17 +336,17 @@ extern "C" void *SUB_REALLOC(void *ptr, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     new_ptr = SUPER_REALLOC(ptr, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_realloc(new_ptr, ptr, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return new_ptr;
 }
 
 extern "C" void *SUB_CALLOC(size_t nmemb, size_t size)
 {
     void *ptr = NULL;
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -358,10 +358,10 @@ extern "C" void *SUB_CALLOC(size_t nmemb, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = SUPER_CALLOC(nmemb, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_calloc(ptr, nmemb, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -372,7 +372,7 @@ extern "C" void SUB_FREE(void *ptr)
 
 extern "C" void free_wrapper(void *ptr, void *caller)
 {
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -388,10 +388,10 @@ extern "C" void free_wrapper(void *ptr, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     SUPER_FREE(ptr);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_free(ptr, caller);
     mbed_mem_trace_unlock();
-#endif // #ifdef MBED_MEM_TRACING_ENABLED
+#endif // #if MBED_MEM_TRACING_ENABLED
 }
 
 #endif // #if defined(MBED_MEM_TRACING_ENABLED) || defined(MBED_HEAP_STATS_ENABLED)
@@ -402,7 +402,7 @@ extern "C" void free_wrapper(void *ptr, void *caller)
 
 #else
 
-#ifdef MBED_MEM_TRACING_ENABLED
+#if MBED_MEM_TRACING_ENABLED
 #error Memory tracing is not supported with the current toolchain.
 #endif
 

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -64,6 +64,11 @@
         "max-error-filename-len": {
             "help": "Sets the maximum length of buffer used for capturing the filename in error context. This needs error-filename-capture-enabled feature.",
             "value": 16
+        },
+        "memory-tracing-enabled": {
+            "macro_name": "MBED_MEM_TRACING_ENABLED",
+            "help": "Enable tracing of each memory call by invoking a callback on each memory operation. See mbed_mem_trace.h in the HAL API for more information",
+            "value": false
         }
     },
     "target_overrides": {

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1469,7 +1469,7 @@ extern "C" void __cxa_guard_abort(int *guard_object_p)
 
 #endif
 
-#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
+#if MBED_MEM_TRACING_ENABLED && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
 
 // If the memory tracing is enabled, the wrappers in mbed_alloc_wrappers.cpp
 // provide the implementation for these. Note: this needs to use the wrappers
@@ -1515,7 +1515,7 @@ void operator delete[](void *ptr)
     free_wrapper(ptr, MBED_CALLER_ADDR());
 }
 
-#elif defined(MBED_MEM_TRACING_ENABLED) && defined(__GNUC__)
+#elif MBED_MEM_TRACING_ENABLED && defined(__GNUC__)
 
 #include <reent.h>
 


### PR DESCRIPTION
### Description

Move the memory tracing enabled macro to a config option - https://github.com/ARMmbed/mbed-os/issues/5225

There are a few macros that'd benefit from this (heap/stack/etc reporting for one). This does however break existing mbed_app.json files that relied on just defining the macro (you should get compile time warnings about redefinitions if you are defining the macro separately):

```
[Warning] mbed_config.h@147,0: "MBED_MEM_TRACING_ENABLED" redefined  
```
Is this a reasonable path forward? How should we handle transitioning to the config option definition rather than if the macro exists style?

**NOTE** Need to update the docs to match this as well. See - https://github.com/ARMmbed/mbed-os-5-docs/issues/275
### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [X] Breaking change

