### PR TITLE
LPC546XX: Fix UART mux setting in the LPCXpresso board

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/PeripheralPins.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/PeripheralPins.c
@@ -65,13 +65,13 @@ const PinMap PinMap_I2C_SCL[] = {
 /************UART***************/
 const PinMap PinMap_UART_TX[] = {
     {P0_30, UART_0, 1},
-    {P3_27, UART_1, 1},
+    {P3_27, UART_1, 3},
     {NC   ,  NC   , 0}
 };
 
 const PinMap PinMap_UART_RX[] = {
     {P0_29, UART_0, 1},
-    {P3_26, UART_1, 1},
+    {P3_26, UART_1, 3},
     {NC   ,  NC   , 0}
 };
 


### PR DESCRIPTION
Signed-off-by: Mahesh Mahadevan <mahesh.mahadevan@nxp.com>

### Description
This patch fixes the MUX setting for UART pin connected to D0 and D1 

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

