### PR TITLE
Fix target definition for NRF52 series

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3675,12 +3675,12 @@
             "SERIAL",
             "SERIAL_ASYNCH",
             "SERIAL_FC",
+            "SLEEP",
             "SPI",
             "SPI_ASYNCH",
             "STCLK_OFF_DURING_SLEEP",
             "TRNG",
-            "USTICKER",
-            "SLEEP"
+            "USTICKER"
         ],
         "extra_labels": [
             "NORDIC",
@@ -3771,7 +3771,6 @@
             "PORTINOUT",
             "PORTOUT",
             "PWMOUT",
-            "RTC",
             "SERIAL",
             "SERIAL_ASYNCH",
             "SERIAL_FC",


### PR DESCRIPTION

### Description
 * Removed RTC, NRF52840 doesn't support RTC API.
 * Reorganized DEVICE_HAS order for NRF52832.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

