### PR TITLE
NANO130: Change PLL clock source to HIRC instead of HXT

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3953,6 +3953,11 @@
             "gpio-irq-debounce-sample-rate": {
                 "help": "Select GPIO IRQ debounce sample rate: GPIO_DBCLKSEL_1, GPIO_DBCLKSEL_2, GPIO_DBCLKSEL_4, ..., or GPIO_DBCLKSEL_32768",
                 "value": "GPIO_DBCLKSEL_16"
+            },
+            "clock-pll": {
+                "help": "Choose clock source to clock PLL: NU_HXT_PLL or NU_HIRC_PLL",
+                "macro_name": "NU_CLOCK_PLL",
+                "value": "NU_HIRC_PLL"
             }
         },
         "inherits": ["Target"],


### PR DESCRIPTION
### Description

This PR is to reduce delay of wake-up from power-down to pass Greentea test (require 10ms) by changing PLL clock source to HIRC from HXT. Because HIRC's accuracy is worse than HXT's, we must switch back to HXT for e.g. USBD application. This can be done through setting NU_CLOCK_PLL to NU_HXT_PLL.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

