### PR TITLE
Tools: Move exporter alias handling to CLI

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -34,8 +34,6 @@ from . import (lpcxpresso, ds5_5, iar, makefile, embitz, coide, kds, simplicity,
 
 EXPORTERS = {
     u'uvision5': uvision.Uvision,
-    u'uvision': uvision.Uvision,
-    u'gcc_arm': makefile.GccArm,
     u'make_gcc_arm': makefile.GccArm,
     u'make_armc5': makefile.Armc5,
     u'make_armc6': makefile.Armc6,

--- a/tools/project.py
+++ b/tools/project.py
@@ -304,7 +304,7 @@ def get_args(argv):
 def main():
     """Entry point"""
     # Parse Options
-    options, parser = get_args(sys.argv)
+    options, parser = get_args(sys.argv[1:])
 
     # Print available tests in order and exit
     if options.list_tests:

--- a/tools/project.py
+++ b/tools/project.py
@@ -245,7 +245,7 @@ def get_args(argv):
         action="store_true",
         dest="supported_ides_html",
         default=False,
-        help="writes tools/export/README.md"
+        help="Generate a markdown version of the results of -S in README.md"
     )
 
     parser.add_argument(
@@ -316,7 +316,7 @@ def main():
             print(mcu_ide_list())
     elif options.supported_ides_html:
         html = mcu_ide_matrix(verbose_html=True)
-        with open("./export/README.md", "w") as readme:
+        with open("README.md", "w") as readme:
             readme.write("Exporter IDE/Platform Support\n")
             readme.write("-----------------------------------\n")
             readme.write("\n")

--- a/tools/project.py
+++ b/tools/project.py
@@ -16,11 +16,22 @@ from argparse import ArgumentParser
 
 from tools.paths import EXPORT_DIR, MBED_HAL, MBED_LIBRARIES, MBED_TARGETS_PATH
 from tools.settings import BUILD_DIR
-from tools.export import EXPORTERS, mcu_ide_matrix, mcu_ide_list, export_project, get_exporter_toolchain
+from tools.export import (
+    EXPORTERS,
+    mcu_ide_matrix,
+    mcu_ide_list,
+    export_project,
+    get_exporter_toolchain,
+)
 from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known, Test
 from tools.targets import TARGET_NAMES
-from tools.utils import argparse_filestring_type, argparse_profile_filestring_type, argparse_many, args_error
+from tools.utils import (
+    argparse_filestring_type,
+    argparse_profile_filestring_type,
+    argparse_many,
+    args_error,
+)
 from tools.utils import argparse_force_lowercase_type
 from tools.utils import argparse_force_uppercase_type
 from tools.utils import print_large_string
@@ -41,7 +52,14 @@ def resolve_exporter_alias(ide):
         return ide
 
 
-def setup_project(ide, target, program=None, source_dir=None, build=None, export_path=None):
+def setup_project(
+        ide,
+        target,
+        program=None,
+        source_dir=None,
+        build=None,
+        export_path=None
+):
     """Generate a name, if not provided, and find dependencies
 
     Positional arguments:
@@ -75,7 +93,6 @@ def setup_project(ide, target, program=None, source_dir=None, build=None, export
                 test.dependencies.append(MBED_HAL)
                 test.dependencies.append(MBED_TARGETS_PATH)
 
-
         src_paths = [test.source_dir]
         lib_paths = test.dependencies
         project_name = "_".join([test.id, ide, target])
@@ -104,15 +121,31 @@ def export(target, ide, build=None, src=None, macros=None, project_id=None,
 
     Returns an object of type Exporter (tools/exports/exporters.py)
     """
-    project_dir, name, src, lib = setup_project(ide, target, program=project_id,
-                                                source_dir=src, build=build, export_path=export_path)
+    project_dir, name, src, lib = setup_project(
+        ide,
+        target,
+        program=project_id,
+        source_dir=src,
+        build=build,
+        export_path=export_path,
+    )
 
     zip_name = name+".zip" if zip_proj else None
 
-    return export_project(src, project_dir, target, ide, name=name,
-                          macros=macros, libraries_paths=lib, zip_proj=zip_name,
-                          build_profile=build_profile, notify=notify,
-                          app_config=app_config, ignore=ignore)
+    return export_project(
+        src,
+        project_dir,
+        target,
+        ide,
+        name=name,
+        macros=macros,
+        libraries_paths=lib,
+        zip_proj=zip_name,
+        build_profile=build_profile,
+        notify=notify,
+        app_config=app_config,
+        ignore=ignore
+    )
 
 
 def main():
@@ -125,100 +158,139 @@ def main():
     toolchainlist = list(EXPORTERS.keys() + EXPORTER_ALIASES.keys())
     toolchainlist.sort()
 
-    parser.add_argument("-m", "--mcu",
-                        metavar="MCU",
-                        help="generate project for the given MCU ({})".format(
-                            ', '.join(targetnames)))
+    parser.add_argument(
+        "-m", "--mcu",
+        metavar="MCU",
+        help="generate project for the given MCU ({})".format(
+            ', '.join(targetnames))
+    )
 
-    parser.add_argument("-i",
-                        dest="ide",
-                        type=argparse_force_lowercase_type(
-                            toolchainlist, "toolchain"),
-                        help="The target IDE: %s"% str(toolchainlist))
+    parser.add_argument(
+        "-i",
+        dest="ide",
+        type=argparse_force_lowercase_type(
+            toolchainlist, "toolchain"),
+        help="The target IDE: %s" % str(toolchainlist)
+    )
 
-    parser.add_argument("-c", "--clean",
-                        action="store_true",
-                        default=False,
-                        help="clean the export directory")
+    parser.add_argument(
+        "-c", "--clean",
+        action="store_true",
+        default=False,
+        help="clean the export directory"
+    )
 
     group = parser.add_mutually_exclusive_group(required=False)
     group.add_argument(
         "-p",
         type=test_known,
         dest="program",
-        help="The index of the desired test program: [0-%s]"% (len(TESTS)-1))
+        help="The index of the desired test program: [0-%s]" % (len(TESTS) - 1)
+    )
 
-    group.add_argument("-n",
-                       type=test_name_known,
-                       dest="program",
-                       help="The name of the desired test program")
+    group.add_argument(
+        "-n",
+        type=test_name_known,
+        dest="program",
+        help="The name of the desired test program"
+    )
 
-    parser.add_argument("-b",
-                      dest="build",
-                      default=False,
-                      action="store_true",
-                      help="use the mbed library build, instead of the sources")
+    parser.add_argument(
+        "-b",
+        dest="build",
+        default=False,
+        action="store_true",
+        help="use the mbed library build, instead of the sources"
+    )
 
-    group.add_argument("-L", "--list-tests",
-                       action="store_true",
-                       dest="list_tests",
-                       default=False,
-                       help="list available programs in order and exit")
+    group.add_argument(
+        "-L", "--list-tests",
+        action="store_true",
+        dest="list_tests",
+        default=False,
+        help="list available programs in order and exit"
+    )
 
-    group.add_argument("-S", "--list-matrix",
-                       dest="supported_ides",
-                       default=False,
-                       const="matrix",
-                       choices=["matrix", "ides"],
-                       nargs="?",
-                       help="displays supported matrix of MCUs and IDEs")
+    group.add_argument(
+        "-S", "--list-matrix",
+        dest="supported_ides",
+        default=False,
+        const="matrix",
+        choices=["matrix", "ides"],
+        nargs="?",
+        help="displays supported matrix of MCUs and IDEs"
+    )
 
-    parser.add_argument("-E",
-                        action="store_true",
-                        dest="supported_ides_html",
-                        default=False,
-                        help="writes tools/export/README.md")
+    parser.add_argument(
+        "-E",
+        action="store_true",
+        dest="supported_ides_html",
+        default=False,
+        help="writes tools/export/README.md"
+    )
 
-    parser.add_argument("--build",
-                        type=argparse_filestring_type,
-                        dest="build_dir",
-                        default=None,
-                        help="Directory for the exported project files")
+    parser.add_argument(
+        "--build",
+        type=argparse_filestring_type,
+        dest="build_dir",
+        default=None,
+        help="Directory for the exported project files"
+    )
 
-    parser.add_argument("--source",
-                        action="append",
-                        type=argparse_filestring_type,
-                        dest="source_dir",
-                        default=[],
-                        help="The source (input) directory")
+    parser.add_argument(
+        "--source",
+        action="append",
+        type=argparse_filestring_type,
+        dest="source_dir",
+        default=[],
+        help="The source (input) directory"
+    )
 
-    parser.add_argument("-D",
-                        action="append",
-                        dest="macros",
-                        help="Add a macro definition")
+    parser.add_argument(
+        "-D",
+        action="append",
+        dest="macros",
+        help="Add a macro definition"
+    )
 
-    parser.add_argument("--profile", dest="profile", action="append",
-                        type=argparse_profile_filestring_type,
-                        help="Build profile to use. Can be either path to json" \
-                        "file or one of the default one ({})".format(", ".join(list_profiles())),
-                        default=[])
+    parser.add_argument(
+        "--profile",
+        dest="profile",
+        action="append",
+        type=argparse_profile_filestring_type,
+        help=("Build profile to use. Can be either path to json"
+              "file or one of the default one ({})".format(
+                  ", ".join(list_profiles()))),
+        default=[]
+    )
 
-    parser.add_argument("--update-packs",
-                        dest="update_packs",
-                        action="store_true",
-                        default=False)
-    parser.add_argument("--app-config",
-                        dest="app_config",
-                        default=None)
+    parser.add_argument(
+        "--update-packs",
+        dest="update_packs",
+        action="store_true",
+        default=False
+    )
 
-    parser.add_argument("--ignore", dest="ignore", type=argparse_many(str),
-                        default=None, help="Comma separated list of patterns to add to mbedignore (eg. ./main.cpp)")
+    parser.add_argument(
+        "--app-config",
+        dest="app_config",
+        default=None
+    )
+
+    parser.add_argument(
+        "--ignore",
+        dest="ignore",
+        type=argparse_many(str),
+        default=None,
+        help=("Comma separated list of patterns to add to mbedignore "
+              "(eg. ./main.cpp)")
+    )
 
     options = parser.parse_args()
 
     # Print available tests in order and exit
     if options.list_tests is True:
-        print('\n'.join([str(test) for test in  sorted(TEST_MAP.values())]))
+        print('\n'.join(str(test) for test in sorted(TEST_MAP.values())))
         sys.exit()
 
     # Only prints matrix of supported IDEs
@@ -232,17 +304,11 @@ def main():
     # Only prints matrix of supported IDEs
     if options.supported_ides_html:
         html = mcu_ide_matrix(verbose_html=True)
-        try:
-            with open("./export/README.md", "w") as readme:
-                readme.write("Exporter IDE/Platform Support\n")
-                readme.write("-----------------------------------\n")
-                readme.write("\n")
-                readme.write(html)
-        except IOError as exc:
-            print("I/O error({0}): {1}".format(exc.errno, exc.strerror))
-        except:
-            print("Unexpected error:", sys.exc_info()[0])
-            raise
+        with open("./export/README.md", "w") as readme:
+            readme.write("Exporter IDE/Platform Support\n")
+            readme.write("-----------------------------------\n")
+            readme.write("\n")
+            readme.write(html)
         exit(0)
 
     if options.update_packs:
@@ -267,14 +333,17 @@ def main():
 
     notify = TerminalNotifier()
 
-    if (options.program is None) and (not options.source_dir):
-        args_error(parser, "one of -p, -n, or --source is required")
     ide = resolve_exporter_alias(options.ide)
     exporter, toolchain_name = get_exporter_toolchain(ide)
+    profile = extract_profile(parser, options, toolchain_name, fallback="debug")
     mcu = extract_mcus(parser, options)[0]
+
     if not exporter.is_target_supported(mcu):
         args_error(parser, "%s not supported by %s" % (mcu, ide))
-    profile = extract_profile(parser, options, toolchain_name, fallback="debug")
+
+    if (options.program is None) and (not options.source_dir):
+        args_error(parser, "one of -p, -n, or --source is required")
+
     if options.clean:
         for cls in EXPORTERS.values():
             try:
@@ -287,14 +356,22 @@ def main():
             except (IOError, OSError):
                 pass
     try:
-        export(mcu, ide, build=options.build,
-               src=options.source_dir, macros=options.macros,
-               project_id=options.program, zip_proj=zip_proj,
-               build_profile=profile, app_config=options.app_config,
-               export_path=options.build_dir, notify=notify,
-               ignore=options.ignore)
+        export(
+            mcu,
+            ide,
+            build=options.build,
+            src=options.source_dir,
+            macros=options.macros,
+            project_id=options.program,
+            zip_proj=zip_proj,
+            build_profile=profile,
+            app_config=options.app_config,
+            export_path=options.build_dir,
+            notify=notify,
+            ignore=options.ignore
+        )
     except NotSupportedException as exc:
-        print("[ERROR] %s" % str(exc))
+        print("[Not Supported] %s" % str(exc))
 
 if __name__ == "__main__":
     main()

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -17,10 +17,12 @@ sys.path.insert(0, ROOT)
 from tools.build_api import get_mbed_official_release
 from tools.targets import TARGET_MAP
 from tools.export import EXPORTERS
+from tools.project import EXPORTER_ALIASES
 from tools.toolchains import TOOLCHAINS
 
 SUPPORTED_TOOLCHAINS = list(TOOLCHAINS - set(u'uARM'))
-SUPPORTED_IDES = [exp for exp in EXPORTERS.keys() if exp != "cmsis" and exp != "zip"]
+SUPPORTED_IDES = [exp for exp in EXPORTERS.keys() + EXPORTER_ALIASES.keys()
+                  if exp != "cmsis" and exp != "zip"]
 
 
 def print_list(lst):


### PR DESCRIPTION
### Description

Both the online compiler and the offline tools use the same code for 
exporting and compilation. This is great, as it significantly reduces
code duplication and maintenance efforts. A knock-on effect of this
is that the exporters available on the command line are all available
online. Including the aliases.

This PR removes the aliases from the online compiler.

@thegecko as promised.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change