### PR TITLE
apply FatFs 0.13b hotfix - fix readdir() never terminates when dir is full

### DIFF
--- a/features/filesystem/fat/ChaN/ff.cpp
+++ b/features/filesystem/fat/ChaN/ff.cpp
@@ -1740,7 +1740,8 @@ FRESULT dir_next (	/* FR_OK(0):succeeded, FR_NO_FILE:End of table, FR_DENIED:Cou
 
 
 	ofs = dp->dptr + SZDIRE;	/* Next entry */
-	if (dp->sect == 0 || ofs >= (DWORD)((FF_FS_EXFAT && fs->fs_type == FS_EXFAT) ? MAX_DIR_EX : MAX_DIR)) return FR_NO_FILE;	/* Report EOT when offset has reached max value */
+	if (ofs >= (DWORD)((FF_FS_EXFAT && fs->fs_type == FS_EXFAT) ? MAX_DIR_EX : MAX_DIR)) dp->sect = 0;	/* Disable it if the offset reached the max value */
+	if (dp->sect == 0) return FR_NO_FILE;	/* Report EOT if it has been disabled */
 
 	if (ofs % SS(fs) == 0) {	/* Sector changed? */
 		dp->sect++;				/* Next sector */


### PR DESCRIPTION
### Description

Apply this patch...
http://elm-chan.org/fsw/ff/patches.html
http://elm-chan.org/fsw/ff/ff13b_p1.diff

...to resolve the final issue remaining [1] on https://github.com/ARMmbed/mbed-os/issues/5780.

The issue is that when a FAT FS directory is full, `readdir()` would never return `NULL` to terminate the listing.

Cherry-picked onto `mbed-os-5.9.2` for testing. Tested with LPC4088.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

