### PR TITLE
Added json options for nanostack heap statictics

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -9,6 +9,14 @@
             "help": "Use `malloc()` for reserving the Nanostack's internal heap.",
             "value": false
         },
+        "heap-stat-info": {
+            "help": "Pointer to heap statistics `mem_stat_t` storage.",
+            "value": "NULL"
+        },
+        "heap-stat-info-definition": {
+            "help": "Definition of heap statistics `mem_stat_t` storage.",
+            "value": null
+        },
         "6lowpan-nd-channel-mask": {
             "help": "Channel mask, bit-mask of channels to use. [0-0x07fff800]",
             "value": "0x7fff800"

--- a/features/nanostack/mbed-mesh-api/source/mesh_system.c
+++ b/features/nanostack/mbed-mesh-api/source/mesh_system.c
@@ -36,6 +36,9 @@ static uint8_t app_stack_heap[MBED_CONF_MBED_MESH_API_HEAP_SIZE + 1];
 static uint8_t *app_stack_heap;
 #endif
 static bool mesh_initialized = false;
+#ifdef MBED_CONF_MBED_MESH_API_HEAP_STAT_INFO_DEFINITION
+MBED_CONF_MBED_MESH_API_HEAP_STAT_INFO_DEFINITION;
+#endif
 
 /*
  * Heap error handler, called when heap problem is detected.
@@ -66,7 +69,7 @@ void mesh_system_init(void)
         MBED_ASSERT(app_stack_heap);
 #endif
         ns_hal_init(app_stack_heap, MBED_CONF_MBED_MESH_API_HEAP_SIZE,
-                    mesh_system_heap_error_handler, NULL);
+                    mesh_system_heap_error_handler, MBED_CONF_MBED_MESH_API_HEAP_STAT_INFO);
         eventOS_scheduler_mutex_wait();
         net_init_core();
         eventOS_scheduler_mutex_release();


### PR DESCRIPTION
### Description

Added configuration options to mbed-mesh-api mbed_lib.json to enable nanostack nsdynmemLIB heap statistics.

This can be used on application to get memory statistics from nanostack heap.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

