### PR TITLE
MIMXRT1050_EVK: Fix the GPIO IRQ number assignements

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
@@ -38,7 +38,7 @@ static gpio_irq_handler irq_handler;
 static GPIO_Type * const gpio_addrs[] = GPIO_BASE_PTRS;
 
 /* Array of PORT IRQ number. */
-static const IRQn_Type gpio_irqs[] = GPIO_IRQS;
+static const IRQn_Type gpio_irqs[] = GPIO_COMBINED_IRQS;
 
 static void handle_interrupt_in(PortName port, int ch_base)
 {
@@ -117,6 +117,8 @@ void gpio5_irq(void)
 
 int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id)
 {
+    uint32_t int_index;
+
     if (pin == NC) {
         return -1;
     }
@@ -153,8 +155,14 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
             error("gpio_irq only supported on port A-E.");
             break;
     }
-    NVIC_SetVector(gpio_irqs[obj->port], vector);
-    NVIC_EnableIRQ(gpio_irqs[obj->port]);
+
+    int_index = 2 * obj->port;;
+    if (obj->pin > 15) {
+        int_index -= 1;
+    }
+
+    NVIC_SetVector(gpio_irqs[int_index], vector);
+    NVIC_EnableIRQ(gpio_irqs[int_index]);
 
     obj->ch = ch_base + obj->pin;
     channel_ids[obj->ch] = id;

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/MIMXRT1052.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/device/MIMXRT1052.h
@@ -12095,7 +12095,7 @@ typedef struct {
 #define GPIO_BASE_PTRS                           { (GPIO_Type *)0u, GPIO1, GPIO2, GPIO3, GPIO4, GPIO5 }
 /** Interrupt vectors for the GPIO peripheral type */
 #define GPIO_IRQS                                { NotAvail_IRQn, GPIO1_INT0_IRQn, GPIO1_INT1_IRQn, GPIO1_INT2_IRQn, GPIO1_INT3_IRQn, GPIO1_INT4_IRQn, GPIO1_INT5_IRQn, GPIO1_INT6_IRQn, GPIO1_INT7_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn, NotAvail_IRQn }
-#define GPIO_COMBINED_IRQS                       { NotAvail_IRQn, GPIO1_Combined_16_31_IRQn, GPIO2_Combined_16_31_IRQn, GPIO2_Combined_0_15_IRQn, GPIO3_Combined_16_31_IRQn, GPIO3_Combined_0_15_IRQn, GPIO4_Combined_16_31_IRQn, GPIO4_Combined_0_15_IRQn, GPIO5_Combined_16_31_IRQn, GPIO5_Combined_0_15_IRQn }
+#define GPIO_COMBINED_IRQS                       { NotAvail_IRQn, GPIO1_Combined_16_31_IRQn, GPIO1_Combined_0_15_IRQn, GPIO2_Combined_16_31_IRQn, GPIO2_Combined_0_15_IRQn, GPIO3_Combined_16_31_IRQn, GPIO3_Combined_0_15_IRQn, GPIO4_Combined_16_31_IRQn, GPIO4_Combined_0_15_IRQn, GPIO5_Combined_16_31_IRQn, GPIO5_Combined_0_15_IRQn }
 
 /*!
  * @}


### PR DESCRIPTION
### Description
MIMXRT1050_EVK: Fix the GPIO IRQ number assignements. Use the GPIO_Combined IRQ array. 
This issue was uncovered when running ci-test shield tests. With this fix the GPIO Interrrupt tests passes.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

