### PR TITLE
MIMXRT1050_EVK: Move clock enable after check of pin

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_api.c
@@ -33,11 +33,11 @@ void gpio_init(gpio_t *obj, PinName pin)
 {
     clock_ip_name_t gpio_clocks[] = GPIO_CLOCKS;
 
-    CLOCK_EnableClock(gpio_clocks[pin >> GPIO_PORT_SHIFT]);
-
     obj->pin = pin;
     if (pin == (PinName)NC)
         return;
+
+    CLOCK_EnableClock(gpio_clocks[pin >> GPIO_PORT_SHIFT]);
 
     pin_function(pin, GPIO_MUX_PORT);
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/gpio_irq_api.c
@@ -156,7 +156,7 @@ int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32
             break;
     }
 
-    int_index = 2 * obj->port;;
+    int_index = 2 * obj->port;
     if (obj->pin > 15) {
         int_index -= 1;
     }


### PR DESCRIPTION
### Description
MIMXRT1050_EVK: Move clock enable after check of pin. Enable clock could return an error if pin is NC

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

