### PR TITLE
Fix issue #6872 - Mutex lock has possibility to fail at runtime (returning status flag)

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -48,9 +48,9 @@ volatile bool mutex_defect = false;
 bool manipulate_protected_zone(const int thread_delay)
 {
     bool result = true;
+    osStatus stat;
 
-    osStatus stat = stdio_mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    stdio_mutex.lock();
 
     core_util_critical_section_enter();
     if (changing_counter == true) {
@@ -118,8 +118,8 @@ void test_multiple_threads(void)
 
 void test_dual_thread_nolock_lock_thread(Mutex *mutex)
 {
-    osStatus stat = mutex->lock(osWaitForever);
-    TEST_ASSERT_EQUAL(osOK, stat);
+    osStatus stat;
+    mutex->lock();
 
     stat = mutex->unlock();
     TEST_ASSERT_EQUAL(osOK, stat);
@@ -161,8 +161,7 @@ void test_dual_thread_nolock(void)
 
 void test_dual_thread_lock_unlock_thread(Mutex *mutex)
 {
-    osStatus stat = mutex->lock(osWaitForever);
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex->lock();
 }
 
 /** Test dual thread lock unlock
@@ -180,8 +179,7 @@ void test_dual_thread_lock_unlock(void)
     osStatus stat;
     Thread thread(osPriorityNormal, TEST_STACK_SIZE);
 
-    stat = mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.lock();
 
     thread.start(callback(test_dual_thread_lock_unlock_thread, &mutex));
 
@@ -202,9 +200,9 @@ void test_dual_thread_lock_lock_thread(Mutex *mutex)
     Timer timer;
     timer.start();
 
-    osStatus stat = mutex->lock(TEST_DELAY);
-    TEST_ASSERT_EQUAL(osErrorTimeout, stat);
-    TEST_ASSERT_UINT32_WITHIN(5000, TEST_DELAY * 1000, timer.read_us());
+    bool stat = mutex->trylock_for(TEST_DELAY);
+    TEST_ASSERT_EQUAL(false, stat);
+    TEST_ASSERT_UINT32_WITHIN(5000, TEST_DELAY*1000, timer.read_us());
 }
 
 /** Test dual thread lock
@@ -228,8 +226,7 @@ void test_dual_thread_lock(void)
     osStatus stat;
     Thread thread(osPriorityNormal, TEST_STACK_SIZE);
 
-    stat = mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.lock();
 
     thread.start(callback(F, &mutex));
 
@@ -250,11 +247,9 @@ void test_single_thread_lock_recursive(void)
     Mutex mutex;
     osStatus stat;
 
-    stat = mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.lock();
 
-    stat = mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.lock();
 
     stat = mutex.unlock();
     TEST_ASSERT_EQUAL(osOK, stat);
@@ -291,8 +286,7 @@ void test_single_thread_lock(void)
     Mutex mutex;
     osStatus stat;
 
-    stat = mutex.lock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.lock();
 
     stat = mutex.unlock();
     TEST_ASSERT_EQUAL(osOK, stat);

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -68,8 +68,8 @@ bool manipulate_protected_zone(const int thread_delay)
     changing_counter = false;
     core_util_critical_section_exit();
 
-    stat = stdio_mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    stdio_mutex.unlock();
+
     return result;
 }
 
@@ -121,8 +121,7 @@ void test_dual_thread_nolock_lock_thread(Mutex *mutex)
     osStatus stat;
     mutex->lock();
 
-    stat = mutex->unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex->unlock();
 }
 
 void test_dual_thread_nolock_trylock_thread(Mutex *mutex)
@@ -130,8 +129,7 @@ void test_dual_thread_nolock_trylock_thread(Mutex *mutex)
     bool stat_b = mutex->trylock();
     TEST_ASSERT_EQUAL(true, stat_b);
 
-    osStatus stat = mutex->unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex->unlock();
 }
 
 /** Test dual thread no-lock
@@ -140,13 +138,13 @@ void test_dual_thread_nolock_trylock_thread(Mutex *mutex)
     Given two threads A & B and a mutex
     When thread A creates a mutex and starts thread B
         and thread B calls @a lock and @a unlock
-    Then returned statuses are osOK
+    Then @a lock and @a unlock operations are successfully performed.
 
     Test dual thread second thread trylock
     Given two threads A & B and a mutex
     When thread A creates a mutex and starts thread B
         and thread B calls @a trylock and @a unlock
-    Then returned statuses are true and osOK
+    Then @a trylock and @a unlock operations are successfully performed.
 */
 template <void (*F)(Mutex *)>
 void test_dual_thread_nolock(void)
@@ -183,8 +181,7 @@ void test_dual_thread_lock_unlock(void)
 
     thread.start(callback(test_dual_thread_lock_unlock_thread, &mutex));
 
-    stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 
     wait_ms(TEST_DELAY);
 }
@@ -232,15 +229,14 @@ void test_dual_thread_lock(void)
 
     wait_ms(TEST_LONG_DELAY);
 
-    stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 }
 
 /** Test single thread lock recursive
 
     Given a mutex and a single running thread
     When thread calls @a lock twice and @a unlock twice on the mutex
-    Then the returned statuses are osOK
+    Then @a lock and @a unlock operations are successfully performed.
 */
 void test_single_thread_lock_recursive(void)
 {
@@ -251,18 +247,16 @@ void test_single_thread_lock_recursive(void)
 
     mutex.lock();
 
-    stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 
-    stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 }
 
 /** Test single thread trylock
 
     Given a mutex and a single running thread
     When thread calls @a trylock and @a unlock on the mutex
-    Then the returned statuses are osOK
+    Then @a trylock and @a unlock operations are successfully performed.
 */
 void test_single_thread_trylock(void)
 {
@@ -271,15 +265,14 @@ void test_single_thread_trylock(void)
     bool stat_b = mutex.trylock();
     TEST_ASSERT_EQUAL(true, stat_b);
 
-    osStatus stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 }
 
 /** Test single thread lock
 
     Given a mutex and a single running thread
     When thread calls @a lock and @a unlock on the mutex
-    Then the returned statuses are osOK
+    Then @a lock and @a unlock operations are successfully performed.
 */
 void test_single_thread_lock(void)
 {
@@ -288,8 +281,7 @@ void test_single_thread_lock(void)
 
     mutex.lock();
 
-    stat = mutex.unlock();
-    TEST_ASSERT_EQUAL(osOK, stat);
+    mutex.unlock();
 }
 
 utest::v1::status_t test_setup(const size_t number_of_cases)

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -415,9 +415,7 @@ public:
     }
     void unlock(void)
     {
-        osStatus status = _mutex.unlock();
-        MBED_ASSERT(status == osOK);
-        (void) status;
+        _mutex.unlock();
     }
 #else
     void lock(void) { }

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -411,9 +411,7 @@ public:
 #if MBED_CONF_RTOS_PRESENT
     void lock(void)
     {
-        osStatus status = _mutex.lock();
-        MBED_ASSERT(status == osOK);
-        (void) status;
+        _mutex.lock();
     }
     void unlock(void)
     {

--- a/rtos/Mutex.cpp
+++ b/rtos/Mutex.cpp
@@ -41,7 +41,8 @@ Mutex::Mutex(const char *name)
 void Mutex::constructor(const char *name)
 {
     memset(&_obj_mem, 0, sizeof(_obj_mem));
-    osMutexAttr_t attr = { 0 };
+    osMutexAttr_t attr =
+    { 0 };
     attr.name = name ? name : "aplication_unnamed_mutex";
     attr.cb_mem = &_obj_mem;
     attr.cb_size = sizeof(_obj_mem);
@@ -50,7 +51,8 @@ void Mutex::constructor(const char *name)
     MBED_ASSERT(_id);
 }
 
-void Mutex::lock(void) {
+void Mutex::lock(void)
+{
     osStatus status = osMutexAcquire(_id, osWaitForever);
     if (osOK == status) {
         _count++;
@@ -59,7 +61,8 @@ void Mutex::lock(void) {
     MBED_ASSERT(status == osOK);
 }
 
-osStatus Mutex::lock(uint32_t millisec) {
+osStatus Mutex::lock(uint32_t millisec)
+{
     osStatus status = osMutexAcquire(_id, millisec);
     if (osOK == status) {
         _count++;
@@ -72,11 +75,13 @@ osStatus Mutex::lock(uint32_t millisec) {
     return status;
 }
 
-bool Mutex::trylock() {
+bool Mutex::trylock()
+{
     return trylock_for(0);
 }
 
-bool Mutex::trylock_for(uint32_t millisec) {
+bool Mutex::trylock_for(uint32_t millisec)
+{
     osStatus status = osMutexAcquire(_id, millisec);
     if (status == osOK) {
         return true;
@@ -89,7 +94,8 @@ bool Mutex::trylock_for(uint32_t millisec) {
     return false;
 }
 
-bool Mutex::trylock_until(uint64_t millisec) {
+bool Mutex::trylock_until(uint64_t millisec)
+{
     uint64_t now = Kernel::get_ms_count();
 
     if (now >= millisec) {
@@ -102,16 +108,19 @@ bool Mutex::trylock_until(uint64_t millisec) {
     }
 }
 
-osStatus Mutex::unlock() {
+osStatus Mutex::unlock()
+{
     _count--;
     return osMutexRelease(_id);
 }
 
-osThreadId Mutex::get_owner() {
+osThreadId Mutex::get_owner()
+{
     return osMutexGetOwner(_id);
 }
 
-Mutex::~Mutex() {
+Mutex::~Mutex()
+{
     osMutexDelete(_id);
 }
 

--- a/rtos/Mutex.cpp
+++ b/rtos/Mutex.cpp
@@ -108,10 +108,13 @@ bool Mutex::trylock_until(uint64_t millisec)
     }
 }
 
-osStatus Mutex::unlock()
+void Mutex::unlock()
 {
     _count--;
-    return osMutexRelease(_id);
+
+    osStatus status = osMutexRelease(_id);
+
+    MBED_ASSERT(status == osOK);
 }
 
 osThreadId Mutex::get_owner()

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -74,7 +74,6 @@ public:
     /** Create and Initialize a Mutex object
 
      @param name name to be used for this mutex. It has to stay allocated for the lifetime of the thread.
-
      @note You cannot call this function from ISR context.
     */
     Mutex(const char *name);
@@ -82,26 +81,31 @@ public:
     /**
       Wait until a Mutex becomes available.
 
+      @return  status code that indicates the execution status of the function:
+               @a osOK the mutex has been obtained.
+
       @note You cannot call this function from ISR context.
+      @note This function treats RTOS errors as fatal system errors, so can only return osOK.
+            Use of the return value is deprecated, as the return is expected to become void in the future.
      */
-    void lock(void);
+    osStatus lock(void);
 
     /**
       For backwards compatibility.
-      @deprecated Do not use this function. This function has been replaced with trylock_for and lock(void) functions.
+      @deprecated Do not use this function. This function has been replaced with lock(), trylock() and trylock_for() functions.
 
       Wait until a Mutex becomes available.
       @param   millisec  timeout value or 0 in case of no time-out.
       @return  status code that indicates the execution status of the function:
                @a osOK the mutex has been obtained.
                @a osErrorTimeout the mutex could not be obtained in the given time.
-               @a osErrorParameter internal error.
                @a osErrorResource the mutex could not be obtained when no timeout was specified.
-               @a osErrorISR this function cannot be called from the interrupt service routine.
 
       @note You cannot call this function from ISR context.
+      @note This function treats RTOS errors as fatal system errors, so can only return osOK or
+            osErrorResource in case when millisec is 0 or osErrorTimeout if millisec is not osWaitForever.
      */
-    MBED_DEPRECATED_SINCE("mbed-os-5.10.0", "Replaced with trylock_for and lock(void) functions")
+    MBED_DEPRECATED_SINCE("mbed-os-5.10.0", "Replaced with lock(), trylock() and trylock_for() functions")
     osStatus lock(uint32_t millisec);
 
     /** Try to lock the mutex, and return immediately
@@ -139,9 +143,14 @@ public:
     /**
       Unlock the mutex that has previously been locked by the same thread
 
+      @return status code that indicates the execution status of the function:
+              @a osOK the mutex has been released.
+
       @note You cannot call this function from ISR context.
+      @note This function treats RTOS errors as fatal system errors, so can only return osOK.
+            Use of the return value is deprecated, as the return is expected to become void in the future.
      */
-    void unlock();
+    osStatus unlock();
 
     /** Get the owner the this mutex
       @return  the current owner of this mutex.

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -90,7 +90,7 @@ public:
       @deprecated Do not use this function. This function has been replaced with trylock_for and lock(void) functions.
 
       Wait until a Mutex becomes available.
-      @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever)
+      @param   millisec  timeout value or 0 in case of no time-out.
       @return  status code that indicates the execution status of the function:
                @a osOK the mutex has been obtained.
                @a osErrorTimeout the mutex could not be obtained in the given time.
@@ -101,7 +101,7 @@ public:
       @note You cannot call this function from ISR context.
      */
     MBED_DEPRECATED_SINCE("mbed-os-5.10.0", "Replaced with trylock_for and lock(void) functions")
-    osStatus lock(uint32_t millisec=osWaitForever);
+    osStatus lock(uint32_t millisec);
 
     /** Try to lock the mutex, and return immediately
       @return true if the mutex was acquired, false otherwise.

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -135,16 +135,12 @@ public:
      */
     bool trylock_until(uint64_t millisec);
 
-    /** Unlock the mutex that has previously been locked by the same thread
-      @return status code that indicates the execution status of the function:
-              @a osOK the mutex has been released.
-              @a osErrorParameter internal error.
-              @a osErrorResource the mutex was not locked or the current thread wasn't the owner.
-              @a osErrorISR this function cannot be called from the interrupt service routine.
+    /**
+      Unlock the mutex that has previously been locked by the same thread
 
       @note You cannot call this function from ISR context.
      */
-    osStatus unlock();
+    void unlock();
 
     /** Get the owner the this mutex
       @return  the current owner of this mutex.

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -78,7 +78,18 @@ public:
     */
     Mutex(const char *name);
 
-    /** Wait until a Mutex becomes available.
+    /**
+      Wait until a Mutex becomes available.
+
+      @note You cannot call this function from ISR context.
+     */
+    void lock(void);
+
+    /**
+      For backwards compatibility.
+      @deprecated Do not use this function. This function has been replaced with trylock_for and lock(void) functions.
+
+      Wait until a Mutex becomes available.
       @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever)
       @return  status code that indicates the execution status of the function:
                @a osOK the mutex has been obtained.
@@ -89,6 +100,7 @@ public:
 
       @note You cannot call this function from ISR context.
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.10.0", "Replaced with trylock_for and lock(void) functions")
     osStatus lock(uint32_t millisec=osWaitForever);
 
     /** Try to lock the mutex, and return immediately

--- a/rtos/Mutex.h
+++ b/rtos/Mutex.h
@@ -29,6 +29,7 @@
 
 #include "platform/NonCopyable.h"
 #include "platform/ScopedLock.h"
+#include "platform/mbed_toolchain.h"
 
 namespace rtos {
 /** \addtogroup rtos */


### PR DESCRIPTION
### Description

This patch is a partial fix for issue https://github.com/ARMmbed/mbed-os/issues/6872.

This is the first step which adds an assertion, so we get the indication in develop builds, not just debug.
Potentially in the next step we could perform total elimination of the error return in the non-time-limited Mutex claim.

More information can be found here:
https://jira.arm.com/browse/IOTMORF-2350


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [X] Breaking change

