### PR TITLE
Unity: Fix behavior of Unity's TEST_IGNORE macro

### DIFF
--- a/features/frameworks/unity/unity/unity.h
+++ b/features/frameworks/unity/unity/unity.h
@@ -294,6 +294,13 @@ void tearDown(void);
 #define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, (message))
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
 
+/*-------------------------------------------------------
+ * Test Ignore conditions
+ *-------------------------------------------------------*/
+
+#define TEST_IGNORE_UNLESS(condition)                                                              UNITY_TEST_IGNORE_UNLESS(       (condition), __LINE__, "Test ignored")
+#define TEST_IGNORE_UNLESS_MESSAGE(condition, message)                                             UNITY_TEST_IGNORE_UNLESS(       (condition), __LINE__, message)
+
 /* end of UNITY_FRAMEWORK_H */
 #ifdef __cplusplus
 }

--- a/features/frameworks/unity/unity/unity_internals.h
+++ b/features/frameworks/unity/unity/unity_internals.h
@@ -785,6 +785,12 @@ extern const char UnityStrErr64[];
 #define UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE(actual, line, message)                       UnityAssertDoubleSpecial((_UD)(actual), (message), (UNITY_LINE_TYPE)(line), UNITY_FLOAT_IS_NOT_DET)
 #endif
 
+/*-------------------------------------------------------
+ * Test Ignore conditions
+ *-------------------------------------------------------*/
+
+#define UNITY_TEST_IGNORE_UNLESS(condition, line, message)                                       if (condition) {} else {UNITY_TEST_IGNORE((UNITY_LINE_TYPE)(line), (message));}
+
 /* End of UNITY_INTERNALS_H */
 #endif
 

--- a/features/frameworks/utest/source/unity_handler.cpp
+++ b/features/frameworks/utest/source/unity_handler.cpp
@@ -30,7 +30,7 @@ void utest_unity_assert_failure(void)
 void utest_unity_ignore_failure(void)
 {
     UTEST_LOG_FUNCTION();
-    utest::v1::Harness::raise_failure(utest::v1::failure_reason_t(utest::v1::REASON_ASSERTION | utest::v1::REASON_IGNORE));
+    utest::v1::Harness::raise_failure(utest::v1::REASON_IGNORE);
 }
 
 void utest_safe_putc(int chr)

--- a/features/frameworks/utest/source/utest_harness.cpp
+++ b/features/frameworks/utest/source/utest_harness.cpp
@@ -172,6 +172,7 @@ void Harness::raise_failure(const failure_reason_t reason)
     utest::v1::status_t fail_status = STATUS_ABORT;
     if (handlers->test_failure) handlers->test_failure(failure_t(reason, location));
     if (handlers->case_failure) fail_status = handlers->case_failure(case_current, failure_t(reason, location));
+    if (reason == REASON_IGNORE) fail_status = STATUS_IGNORE;
 
     {
         UTEST_ENTER_CRITICAL_SECTION;


### PR DESCRIPTION
### Description
Right now, Unity's `TEST_IGNORE` macro has a bug - it fails the test the same way `TEST_ASSERT` does, while the intention would have been to ignore the error and skip the test. This commit fixes the situation. This macro is hardly used in our code, but we plan to use in the future, in order to skip tests if the hardware doesn't support them (for instance boards with insufficient memory for the test).
In addition, added the `TEST_IGNORE_UNLESS` macro - a helper macro to call `TEST_IGNORE` based on a condition.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

