### PR TITLE
MXRT1050: Ensure the pins are in input mode for analogin

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/analogin_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/analogin_api.c
@@ -20,6 +20,7 @@
 
 #include "cmsis.h"
 #include "pinmap.h"
+#include "gpio_api.h"
 #include "PeripheralNames.h"
 #include "fsl_adc.h"
 #include "PeripheralPins.h"
@@ -34,6 +35,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 
     uint32_t instance = obj->adc >> ADC_INSTANCE_SHIFT;
     adc_config_t adc_config;
+    gpio_t gpio;
 
     ADC_GetDefaultConfig(&adc_config);
     ADC_Init(adc_addrs[instance], &adc_config);
@@ -41,6 +43,10 @@ void analogin_init(analogin_t *obj, PinName pin)
     ADC_EnableHardwareTrigger(adc_addrs[instance], false);
 #endif
     ADC_DoAutoCalibration(adc_addrs[instance]);
+
+    /* Need to ensure the pin is in input mode */
+    gpio_init(&gpio, pin);
+    gpio_dir(&gpio, PIN_INPUT);
 }
 
 uint16_t analogin_read_u16(analogin_t *obj)

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralPins.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralPins.c
@@ -23,8 +23,12 @@ const PinMap PinMap_RTC[] = {
 
 /************ADC***************/
 const PinMap PinMap_ADC[] = {
-    {GPIO_AD_B1_11, ADC1_0, 0},
-    {GPIO_AD_B1_04, ADC1_9, 0},
+    {GPIO_AD_B1_10, ADC1_15, 5},
+    {GPIO_AD_B1_11, ADC2_0,  5},
+    {GPIO_AD_B1_04, ADC1_9,  5},
+    {GPIO_AD_B1_05, ADC1_10, 5},
+    {GPIO_AD_B1_01, ADC1_6,  5},
+    {GPIO_AD_B1_00, ADC1_5,  5},
     {NC   , NC       , 0}
 };
 


### PR DESCRIPTION
### Description
MXRT1050: Ensure the pins are in input mode for analogin.  This issue was uncovered when running the ci-test shield tests. Test shield AnalogIn tests pass after this fix.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

