### PR TITLE
Lora: Add support for runtime PHY selection

### DIFF
--- a/features/lorawan/LoRaWANInterface.cpp
+++ b/features/lorawan/LoRaWANInterface.cpp
@@ -20,16 +20,28 @@
  */
 
 #include "LoRaWANInterface.h"
+#include "lorastack/phy/loraphy_target.h"
 
 using namespace events;
 
 LoRaWANInterface::LoRaWANInterface(LoRaRadio &radio)
+    : _default_phy(NULL)
 {
-    _lw_stack.bind_radio_driver(radio);
+    _default_phy = new LoRaPHY_region;
+    MBED_ASSERT(_default_phy);
+    _lw_stack.bind_phy_and_radio_driver(radio, *_default_phy);
+}
+
+LoRaWANInterface::LoRaWANInterface(LoRaRadio &radio, LoRaPHY &phy)
+    : _default_phy(NULL)
+{
+    _lw_stack.bind_phy_and_radio_driver(radio, phy);
 }
 
 LoRaWANInterface::~LoRaWANInterface()
 {
+    delete _default_phy;
+    _default_phy = NULL;
 }
 
 lorawan_status_t LoRaWANInterface::initialize(EventQueue *queue)

--- a/features/lorawan/LoRaWANInterface.h
+++ b/features/lorawan/LoRaWANInterface.h
@@ -24,6 +24,8 @@
 #include "LoRaRadio.h"
 #include "LoRaWANBase.h"
 
+class LoRaPHY;
+
 class LoRaWANInterface: public LoRaWANBase {
 
 public:
@@ -33,8 +35,18 @@ public:
      * Currently, LoRaWANStack is a singleton and you should only
      * construct a single instance of LoRaWANInterface.
      *
+     * LoRaWANInterface will construct PHY based on "lora.phy" setting in mbed_app.json.
+     *
+     * @param radio A reference to radio object
      */
     LoRaWANInterface(LoRaRadio &radio);
+
+    /** Constructs a LoRaWANInterface using the user provided PHY object.
+
+     * @param radio A reference to radio object
+     * @param phy   A reference to PHY object
+     */
+    LoRaWANInterface(LoRaRadio &radio, LoRaPHY &phy);
 
     virtual ~LoRaWANInterface();
 
@@ -508,6 +520,13 @@ private:
     typedef mbed::ScopedLock<LoRaWANInterface> Lock;
 
     LoRaWANStack _lw_stack;
+
+    /** PHY object if created by LoRaWANInterface
+     *
+     * PHY object if LoRaWANInterface has created it.
+     * If PHY object is provided by the application, this pointer is NULL.
+     */
+    LoRaPHY *_default_phy;
 };
 
 #endif /* LORAWANINTERFACE_H_ */

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -98,7 +98,7 @@ LoRaWANStack::LoRaWANStack()
 /*****************************************************************************
  * Public Methods                                                            *
  ****************************************************************************/
-void LoRaWANStack::bind_radio_driver(LoRaRadio &radio)
+void LoRaWANStack::bind_phy_and_radio_driver(LoRaRadio &radio, LoRaPHY &phy)
 {
     radio_events.tx_done = mbed::callback(this, &LoRaWANStack::tx_interrupt_handler);
     radio_events.rx_done = mbed::callback(this, &LoRaWANStack::rx_interrupt_handler);
@@ -106,7 +106,8 @@ void LoRaWANStack::bind_radio_driver(LoRaRadio &radio)
     radio_events.tx_timeout = mbed::callback(this, &LoRaWANStack::tx_timeout_interrupt_handler);
     radio_events.rx_timeout = mbed::callback(this, &LoRaWANStack::rx_timeout_interrupt_handler);
 
-    _loramac.bind_radio_driver(radio);
+    phy.set_radio_instance(radio);
+    _loramac.bind_phy(phy);
 
     radio.lock();
     radio.init_radio(&radio_events);

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -51,23 +51,27 @@
 #include "system/lorawan_data_structures.h"
 #include "LoRaRadio.h"
 
+class LoRaPHY;
+
 class LoRaWANStack: private mbed::NonCopyable<LoRaWANStack> {
 
 public:
     LoRaWANStack();
 
-    /** Binds radio driver to PHY layer.
+    /** Binds PHY layer and radio driver to stack.
      *
      * MAC layer is totally detached from the PHY layer so the stack layer
-     * needs to play the role of an arbitrator. This API gets a radio driver
-     * object from the application (via LoRaWANInterface), binds it to the PHY
-     * layer and initialises radio callback handles which the radio driver will
+     * needs to play the role of an arbitrator.
+     * This API sets the PHY layer object to stack and bind the radio driver
+     * object from the application to the PHY layer.
+     * Also initialises radio callback handles which the radio driver will
      * use in order to report events.
      *
      * @param radio            LoRaRadio object, i.e., the radio driver
+     * @param phy              LoRaPHY object.
      *
      */
-    void bind_radio_driver(LoRaRadio &radio);
+    void bind_phy_and_radio_driver(LoRaRadio &radio, LoRaPHY &phy);
 
     /** End device initialization.
      * @param queue            A pointer to an EventQueue passed from the application.

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -73,7 +73,7 @@ using namespace mbed;
 
 LoRaMac::LoRaMac()
     : _lora_time(),
-      _lora_phy(_lora_time),
+      _lora_phy(),
       _mac_commands(),
       _channel_plan(),
       _lora_crypto(),
@@ -1687,6 +1687,7 @@ void LoRaMac::set_tx_continuous_wave(uint8_t channel, int8_t datarate, int8_t tx
 lorawan_status_t LoRaMac::initialize(EventQueue *queue)
 {
     _lora_time.activate_timer_subsystem(queue);
+    _lora_phy.initialize(&_lora_time);
 
     _ev_queue = queue;
 

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -73,7 +73,7 @@ using namespace mbed;
 
 LoRaMac::LoRaMac()
     : _lora_time(),
-      _lora_phy(),
+      _lora_phy(NULL),
       _mac_commands(),
       _channel_plan(),
       _lora_crypto(),
@@ -266,7 +266,7 @@ void LoRaMac::handle_join_accept_frame(const uint8_t *payload, uint16_t size)
         _params.sys_params.recv_delay2 = _params.sys_params.recv_delay1 + 1000;
 
         // Size of the regular payload is 12. Plus 1 byte MHDR and 4 bytes MIC
-        _lora_phy.apply_cf_list(&_params.rx_buffer[13], size - 17);
+        _lora_phy->apply_cf_list(&_params.rx_buffer[13], size - 17);
 
         _mlme_confirmation.status = LORAMAC_EVENT_INFO_STATUS_OK;
         _is_nwk_joined = true;
@@ -281,7 +281,7 @@ void LoRaMac::handle_join_accept_frame(const uint8_t *payload, uint16_t size)
 
 void LoRaMac::check_frame_size(uint16_t size)
 {
-    uint8_t value = _lora_phy.get_max_payload(_mcps_indication.rx_datarate,
+    uint8_t value = _lora_phy->get_max_payload(_mcps_indication.rx_datarate,
                                               _params.is_repeater_supported);
 
     if (MAX(0, (int16_t)((int16_t)size - (int16_t)LORA_MAC_FRMPAYLOAD_OVERHEAD))
@@ -330,7 +330,7 @@ bool LoRaMac::message_integrity_check(const uint8_t *const payload,
         return false;
     }
 
-    if (sequence_counter_diff >= _lora_phy.get_maximum_frame_counter_gap()) {
+    if (sequence_counter_diff >= _lora_phy->get_maximum_frame_counter_gap()) {
         _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_DOWNLINK_TOO_MANY_FRAMES_LOST;
         _mcps_indication.dl_frame_counter = *downlink_counter;
         return false;
@@ -373,7 +373,7 @@ void LoRaMac::extract_data_and_mac_commands(const uint8_t *payload,
 
             if (_mac_commands.process_mac_commands(_params.rx_buffer, 0, frame_len,
                                                    snr, _mlme_confirmation,
-                                                   _params.sys_params, _lora_phy)
+                                                   _params.sys_params, *_lora_phy)
                     != LORAWAN_STATUS_OK) {
                 _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
                 return;
@@ -402,7 +402,7 @@ void LoRaMac::extract_data_and_mac_commands(const uint8_t *payload,
                                                snr,
                                                _mlme_confirmation,
                                                _params.sys_params,
-                                               _lora_phy) != LORAWAN_STATUS_OK) {
+                                               *_lora_phy) != LORAWAN_STATUS_OK) {
             _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
             return;
         }
@@ -438,7 +438,7 @@ void LoRaMac::extract_mac_commands_only(const uint8_t *payload,
     if (fopts_len > 0) {
         if (_mac_commands.process_mac_commands(payload, 8, payload_start_index,
                                                snr, _mlme_confirmation,
-                                               _params.sys_params, _lora_phy)
+                                               _params.sys_params, *_lora_phy)
                 != LORAWAN_STATUS_OK) {
             _mcps_indication.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
             return;
@@ -635,7 +635,7 @@ void LoRaMac::on_radio_tx_done(lorawan_time_t timestamp)
         // this will open a continuous RX2 window until time==RECV_DELAY1
         open_rx2_window();
     } else {
-        _lora_phy.put_radio_to_sleep();
+        _lora_phy->put_radio_to_sleep();
     }
 
     if (_params.is_rx_window_enabled == true) {
@@ -652,7 +652,7 @@ void LoRaMac::on_radio_tx_done(lorawan_time_t timestamp)
         if (_params.is_node_ack_requested) {
             _lora_time.start(_params.timers.ack_timeout_timer,
                              (_params.rx_window2_delay - time_diff) +
-                             _lora_phy.get_ack_timeout());
+                             _lora_phy->get_ack_timeout());
         }
     } else {
         _mcps_confirmation.status = LORAMAC_EVENT_INFO_STATUS_OK;
@@ -661,7 +661,7 @@ void LoRaMac::on_radio_tx_done(lorawan_time_t timestamp)
 
     _params.last_channel_idx = _params.channel;
 
-    _lora_phy.set_last_tx_done(_params.channel, _is_nwk_joined, timestamp);
+    _lora_phy->set_last_tx_done(_params.channel, _is_nwk_joined, timestamp);
 
     _params.timers.aggregated_last_tx_time = timestamp;
 }
@@ -673,7 +673,7 @@ void LoRaMac::on_radio_rx_done(const uint8_t *const payload, uint16_t size,
         open_rx2_window();
     } else {
         _lora_time.stop(_params.timers.rx_window1_timer);
-        _lora_phy.put_radio_to_sleep();
+        _lora_phy->put_radio_to_sleep();
     }
 
     loramac_mhdr_t mac_hdr;
@@ -716,7 +716,7 @@ void LoRaMac::on_radio_tx_timeout(void)
     if (_device_class == CLASS_C) {
         open_rx2_window();
     } else {
-        _lora_phy.put_radio_to_sleep();
+        _lora_phy->put_radio_to_sleep();
     }
 
     _mcps_confirmation.status = LORAMAC_EVENT_INFO_STATUS_TX_TIMEOUT;
@@ -734,7 +734,7 @@ void LoRaMac::on_radio_rx_timeout(bool is_timeout)
     if (_device_class == CLASS_C && !_continuous_rx2_window_open) {
         open_rx2_window();
     } else {
-        _lora_phy.put_radio_to_sleep();
+        _lora_phy->put_radio_to_sleep();
     }
 
     if (_params.rx_slot == RX_SLOT_WIN_1) {
@@ -799,7 +799,7 @@ lorawan_status_t LoRaMac::send_join_request()
     loramac_frame_ctrl_t fctrl;
 
     _params.sys_params.channel_data_rate =
-        _lora_phy.get_alternate_DR(_params.join_request_trial_counter + 1);
+        _lora_phy->get_alternate_DR(_params.join_request_trial_counter + 1);
 
     mac_hdr.value = 0;
     mac_hdr.bits.mtype = FRAME_TYPE_JOIN_REQ;
@@ -863,13 +863,13 @@ void LoRaMac::open_rx1_window(void)
     _params.rx_window1_config.rx_slot = _params.rx_slot;
 
     if (_device_class == CLASS_C) {
-        _lora_phy.put_radio_to_standby();
+        _lora_phy->put_radio_to_standby();
     }
 
     _mcps_indication.rx_datarate = _params.rx_window1_config.datarate;
 
-    _lora_phy.rx_config(&_params.rx_window1_config);
-    _lora_phy.handle_receive();
+    _lora_phy->rx_config(&_params.rx_window1_config);
+    _lora_phy->handle_receive();
 
     tr_debug("Opening RX1 Window");
 }
@@ -896,8 +896,8 @@ void LoRaMac::open_rx2_window()
 
     _mcps_indication.rx_datarate = _params.rx_window2_config.datarate;
 
-    _lora_phy.rx_config(&_params.rx_window2_config);
-    _lora_phy.handle_receive();
+    _lora_phy->rx_config(&_params.rx_window2_config);
+    _lora_phy->handle_receive();
     _params.rx_slot = _params.rx_window2_config.rx_slot;
 
     tr_debug("Opening RX2 Window, Frequency = %lu", _params.rx_window2_config.frequency);
@@ -925,7 +925,7 @@ void LoRaMac::on_ack_timeout_timer_event(void)
     if ((_params.ack_timeout_retry_counter % 2)
             && (_params.sys_params.adr_on)) {
         tr_debug("Trading datarate for range");
-        _params.sys_params.channel_data_rate = _lora_phy.get_next_lower_tx_datarate(_params.sys_params.channel_data_rate);
+        _params.sys_params.channel_data_rate = _lora_phy->get_next_lower_tx_datarate(_params.sys_params.channel_data_rate);
     }
 
     _mcps_confirmation.nb_retries = _params.ack_timeout_retry_counter;
@@ -958,7 +958,7 @@ bool LoRaMac::validate_payload_length(uint16_t length,
     uint16_t max_value = 0;
     uint16_t payloadSize = 0;
 
-    max_value = _lora_phy.get_max_payload(datarate, _params.is_repeater_supported);
+    max_value = _lora_phy->get_max_payload(datarate, _params.is_repeater_supported);
 
     // Calculate the resulting payload size
     payloadSize = (length + fopts_len);
@@ -1051,7 +1051,7 @@ lorawan_status_t LoRaMac::schedule_tx()
     next_channel.joined = _is_nwk_joined;
     next_channel.last_aggregate_tx_time = _params.timers.aggregated_last_tx_time;
 
-    lorawan_status_t status = _lora_phy.set_next_channel(&next_channel,
+    lorawan_status_t status = _lora_phy->set_next_channel(&next_channel,
                                                          &_params.channel,
                                                          &backoff_time,
                                                          &_params.timers.aggregated_timeoff);
@@ -1072,14 +1072,14 @@ lorawan_status_t LoRaMac::schedule_tx()
 
     tr_debug("TX: Channel=%d, DR=%d", _params.channel, next_channel.current_datarate);
 
-    uint8_t dr_offset = _lora_phy.apply_DR_offset(_params.sys_params.channel_data_rate,
+    uint8_t dr_offset = _lora_phy->apply_DR_offset(_params.sys_params.channel_data_rate,
                                                   _params.sys_params.rx1_dr_offset);
 
-    _lora_phy.compute_rx_win_params(dr_offset, _params.sys_params.min_rx_symb,
+    _lora_phy->compute_rx_win_params(dr_offset, _params.sys_params.min_rx_symb,
                                     _params.sys_params.max_sys_rx_error,
                                     &_params.rx_window1_config);
 
-    _lora_phy.compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
+    _lora_phy->compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
                                     _params.sys_params.min_rx_symb,
                                     _params.sys_params.max_sys_rx_error,
                                     &_params.rx_window2_config);
@@ -1116,7 +1116,7 @@ void LoRaMac::calculate_backOff(uint8_t channel)
 
     _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
 
-    _lora_phy.calculate_backoff(_is_nwk_joined, _params.is_last_tx_join_request, _params.is_dutycycle_on,
+    _lora_phy->calculate_backoff(_is_nwk_joined, _params.is_last_tx_join_request, _params.is_dutycycle_on,
                                 channel, elapsed_time, _params.timers.tx_toa);
 
     // Update aggregated time-off. This must be an assignment and no incremental
@@ -1148,7 +1148,7 @@ void LoRaMac::reset_mac_parameters(void)
 
     _params.is_rx_window_enabled = true;
 
-    _lora_phy.reset_to_default_values(&_params, false);
+    _lora_phy->reset_to_default_values(&_params, false);
 
     _params.is_node_ack_requested = false;
     _params.is_srv_ack_requested = false;
@@ -1164,7 +1164,7 @@ void LoRaMac::reset_mac_parameters(void)
 
 uint8_t LoRaMac::get_default_tx_datarate()
 {
-    return _lora_phy.get_default_tx_datarate();
+    return _lora_phy->get_default_tx_datarate();
 }
 
 void LoRaMac::enable_adaptive_datarate(bool adr_enabled)
@@ -1179,7 +1179,7 @@ lorawan_status_t LoRaMac::set_channel_data_rate(uint8_t data_rate)
         return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    if (_lora_phy.verify_tx_datarate(data_rate, false) == true) {
+    if (_lora_phy->verify_tx_datarate(data_rate, false) == true) {
         _params.sys_params.channel_data_rate = data_rate;
     } else {
         return LORAWAN_STATUS_PARAMETER_INVALID;
@@ -1272,7 +1272,7 @@ lorawan_status_t LoRaMac::send_ongoing_tx()
     int8_t datarate = _params.sys_params.channel_data_rate;
 
     // This prohibits the data rate going below the minimum value.
-    datarate = MAX(datarate, (int8_t)_lora_phy.get_minimum_tx_datarate());
+    datarate = MAX(datarate, (int8_t)_lora_phy->get_minimum_tx_datarate());
 
     loramac_mhdr_t machdr;
     machdr.value = 0;
@@ -1294,7 +1294,7 @@ lorawan_status_t LoRaMac::send_ongoing_tx()
     }
 
     if (_params.sys_params.adr_on == false) {
-        if (_lora_phy.verify_tx_datarate(datarate, false) == true) {
+        if (_lora_phy->verify_tx_datarate(datarate, false) == true) {
             _params.sys_params.channel_data_rate = datarate;
         } else {
             return LORAWAN_STATUS_PARAMETER_INVALID;
@@ -1323,11 +1323,11 @@ void LoRaMac::set_device_class(const device_class_t &device_class,
 
     if (CLASS_A == _device_class) {
         tr_debug("Changing device class to -> CLASS_A");
-        _lora_phy.put_radio_to_sleep();
+        _lora_phy->put_radio_to_sleep();
     } else if (CLASS_C == _device_class) {
         _params.is_node_ack_requested = false;
-        _lora_phy.put_radio_to_sleep();
-        _lora_phy.compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
+        _lora_phy->put_radio_to_sleep();
+        _lora_phy->compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
                                         _params.sys_params.min_rx_symb,
                                         _params.sys_params.max_sys_rx_error,
                                         &_params.rx_window2_config);
@@ -1363,7 +1363,7 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
             _params.keys.app_key = params->connection_u.otaa.app_key;
             _params.max_join_request_trials = params->connection_u.otaa.nb_trials;
 
-            if (!_lora_phy.verify_nb_join_trials(params->connection_u.otaa.nb_trials)) {
+            if (!_lora_phy->verify_nb_join_trials(params->connection_u.otaa.nb_trials)) {
                 // Value not supported, get default
                 _params.max_join_request_trials = MBED_CONF_LORA_NB_TRIALS;
             }
@@ -1403,7 +1403,7 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
         reset_mac_parameters();
 
         _params.sys_params.channel_data_rate =
-            _lora_phy.get_alternate_DR(_params.join_request_trial_counter + 1);
+            _lora_phy->get_alternate_DR(_params.join_request_trial_counter + 1);
 
 #else
         const static uint8_t nwk_skey[] = MBED_CONF_LORA_NWKSKEY;
@@ -1481,7 +1481,7 @@ lorawan_status_t LoRaMac::prepare_frame(loramac_mhdr_t *machdr,
                                      _params.keys.dev_eui, 8);
             _params.tx_buffer_len += 8;
 
-            _params.dev_nonce = _lora_phy.get_radio_rng();
+            _params.dev_nonce = _lora_phy->get_radio_rng();
 
             _params.tx_buffer[_params.tx_buffer_len++] = _params.dev_nonce & 0xFF;
             _params.tx_buffer[_params.tx_buffer_len++] = (_params.dev_nonce >> 8) & 0xFF;
@@ -1509,7 +1509,7 @@ lorawan_status_t LoRaMac::prepare_frame(loramac_mhdr_t *machdr,
             }
 
             if (_params.sys_params.adr_on) {
-                if (_lora_phy.get_next_ADR(true,
+                if (_lora_phy->get_next_ADR(true,
                                            _params.sys_params.channel_data_rate,
                                            _params.sys_params.channel_tx_power,
                                            _params.adr_ack_counter)) {
@@ -1630,7 +1630,7 @@ lorawan_status_t LoRaMac::send_frame_on_channel(uint8_t channel)
     tx_config.antenna_gain = _params.sys_params.antenna_gain;
     tx_config.pkt_len = _params.tx_buffer_len;
 
-    _lora_phy.tx_config(&tx_config, &tx_power, &_params.timers.tx_toa);
+    _lora_phy->tx_config(&tx_config, &tx_power, &_params.timers.tx_toa);
 
     _mlme_confirmation.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
 
@@ -1646,7 +1646,7 @@ lorawan_status_t LoRaMac::send_frame_on_channel(uint8_t channel)
         _params.join_request_trial_counter++;
     }
 
-    _lora_phy.handle_send(_params.tx_buffer, _params.tx_buffer_len);
+    _lora_phy->handle_send(_params.tx_buffer, _params.tx_buffer_len);
 
     return LORAWAN_STATUS_OK;
 }
@@ -1681,17 +1681,17 @@ void LoRaMac::set_tx_continuous_wave(uint8_t channel, int8_t datarate, int8_t tx
     continuous_wave.antenna_gain = antenna_gain;
     continuous_wave.timeout = timeout;
 
-    _lora_phy.set_tx_cont_mode(&continuous_wave);
+    _lora_phy->set_tx_cont_mode(&continuous_wave);
 }
 
 lorawan_status_t LoRaMac::initialize(EventQueue *queue)
 {
     _lora_time.activate_timer_subsystem(queue);
-    _lora_phy.initialize(&_lora_time);
+    _lora_phy->initialize(&_lora_time);
 
     _ev_queue = queue;
 
-    _channel_plan.activate_channelplan_subsystem(&_lora_phy);
+    _channel_plan.activate_channelplan_subsystem(_lora_phy);
 
     _device_class = CLASS_A;
 
@@ -1702,7 +1702,7 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue)
     _params.timers.aggregated_last_tx_time = 0;
     _params.timers.aggregated_timeoff = 0;
 
-    _lora_phy.reset_to_default_values(&_params, true);
+    _lora_phy->reset_to_default_values(&_params, true);
 
     _params.sys_params.max_sys_rx_error = 10;
     _params.sys_params.min_rx_symb = 6;
@@ -1710,11 +1710,11 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue)
 
     reset_mac_parameters();
 
-    srand(_lora_phy.get_radio_rng());
+    srand(_lora_phy->get_radio_rng());
 
     _params.is_nwk_public = MBED_CONF_LORA_PUBLIC_NETWORK;
-    _lora_phy.setup_public_network_mode(_params.is_nwk_public);
-    _lora_phy.put_radio_to_sleep();
+    _lora_phy->setup_public_network_mode(_params.is_nwk_public);
+    _lora_phy->put_radio_to_sleep();
 
     _lora_time.init(_params.timers.backoff_timer,
                     mbed::callback(this, &LoRaMac::on_backoff_timer_expiry));
@@ -1730,7 +1730,7 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue)
     _params.sys_params.adr_on = MBED_CONF_LORA_ADR_ON;
 
     _params.is_nwk_public = MBED_CONF_LORA_PUBLIC_NETWORK;
-    _lora_phy.setup_public_network_mode(MBED_CONF_LORA_PUBLIC_NETWORK);
+    _lora_phy->setup_public_network_mode(MBED_CONF_LORA_PUBLIC_NETWORK);
 
     return LORAWAN_STATUS_OK;
 }
@@ -1742,7 +1742,7 @@ void LoRaMac::disconnect()
     _lora_time.stop(_params.timers.rx_window2_timer);
     _lora_time.stop(_params.timers.ack_timeout_timer);
 
-    _lora_phy.put_radio_to_sleep();
+    _lora_phy->put_radio_to_sleep();
 
     _is_nwk_joined = false;
     _params.is_ack_retry_timeout_expired = false;
@@ -1767,12 +1767,12 @@ uint8_t LoRaMac::get_max_possible_tx_size(uint8_t size)
                        + _mac_commands.get_repeat_commands_length();
 
     if (_params.sys_params.adr_on) {
-        _lora_phy.get_next_ADR(false, _params.sys_params.channel_data_rate,
+        _lora_phy->get_next_ADR(false, _params.sys_params.channel_data_rate,
                                _params.sys_params.channel_tx_power,
                                _params.adr_ack_counter);
     }
 
-    current_payload_size = _lora_phy.get_max_payload(_params.sys_params.channel_data_rate, _params.is_repeater_supported);
+    current_payload_size = _lora_phy->get_max_payload(_params.sys_params.channel_data_rate, _params.is_repeater_supported);
 
     if (current_payload_size >= fopt_len) {
         max_possible_payload_size = current_payload_size - fopt_len;
@@ -1820,7 +1820,7 @@ lorawan_status_t LoRaMac::remove_channel_plan()
 
 lorawan_status_t LoRaMac::get_channel_plan(lorawan_channelplan_t &plan)
 {
-    return _channel_plan.get_plan(plan, _lora_phy.get_phy_channels());
+    return _channel_plan.get_plan(plan, _lora_phy->get_phy_channels());
 }
 
 lorawan_status_t LoRaMac::remove_single_channel(uint8_t id)
@@ -1886,9 +1886,9 @@ lorawan_status_t LoRaMac::multicast_channel_unlink(multicast_params_t *channel_p
     return LORAWAN_STATUS_OK;
 }
 
-void LoRaMac::bind_radio_driver(LoRaRadio &radio)
+void LoRaMac::bind_phy(LoRaPHY &phy)
 {
-    _lora_phy.set_radio_instance(radio);
+    _lora_phy = &phy;
 }
 
 #if defined(LORAWAN_COMPLIANCE_TEST)
@@ -1946,7 +1946,7 @@ lorawan_status_t LoRaMac::test_request(loramac_compliance_test_req_t *mcpsReques
     // TODO: The comment is different than the code???
     // Apply the minimum possible datarate.
     // Some regions have limitations for the minimum datarate.
-    datarate = MAX(datarate, (int8_t)_lora_phy.get_minimum_tx_datarate());
+    datarate = MAX(datarate, (int8_t)_lora_phy->get_minimum_tx_datarate());
 
     machdr.value = 0;
 
@@ -1980,7 +1980,7 @@ lorawan_status_t LoRaMac::test_request(loramac_compliance_test_req_t *mcpsReques
 //    }
 
     if (_params.sys_params.adr_on == false) {
-        if (_lora_phy.verify_tx_datarate(datarate, false) == true) {
+        if (_lora_phy->verify_tx_datarate(datarate, false) == true) {
             _params.sys_params.channel_data_rate = datarate;
         } else {
             return LORAWAN_STATUS_PARAMETER_INVALID;
@@ -2024,7 +2024,7 @@ void LoRaMac::LoRaMacTestSetMic(uint16_t txPacketCounter)
 
 void LoRaMac::LoRaMacTestSetDutyCycleOn(bool enable)
 {
-    if (_lora_phy.verify_duty_cycle(enable) == true) {
+    if (_lora_phy->verify_duty_cycle(enable) == true) {
         _params.is_dutycycle_on = enable;
     }
 }

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -42,7 +42,6 @@
 
 #include "events/EventQueue.h"
 
-#include "lorastack/phy/loraphy_target.h"
 #include "lorastack/phy/LoRaPHY.h"
 
 #include "system/LoRaWANTimer.h"
@@ -210,18 +209,11 @@ public:
      */
     lorawan_status_t multicast_channel_unlink(multicast_params_t *channel_param);
 
-    /** Binds radio driver to PHY layer.
+    /** Binds phy layer to MAC.
      *
-     * MAC layer is totally detached from the PHY layer so the stack layer
-     * needs to play the role of an arbitrator. This API gets a radio driver
-     * object from the application (via LoRaWANInterface), binds it to the PHY
-     * layer and initialises radio callback handles which the radio driver will
-     * use in order to report events.
-     *
-     * @param radio            LoRaRadio object, i.e., the radio driver
-     *
+     * @param phy   LoRaPHY object
      */
-    void bind_radio_driver(LoRaRadio &radio);
+    void bind_phy(LoRaPHY &phy);
 
     /**
      * @brief Configures the events to trigger an MLME-Indication with
@@ -635,7 +627,7 @@ private:
     /**
      * LoRa PHY layer object storage
      */
-    LoRaPHY_region _lora_phy;
+    LoRaPHY *_lora_phy;
 
     /**
      * MAC command handle

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -35,9 +35,8 @@ SPDX-License-Identifier: BSD-3-Clause
 
 #define CHANNELS_IN_MASK  16
 
-LoRaPHY::LoRaPHY(LoRaWANTimeHandler &lora_time)
-    : _radio(NULL),
-      _lora_time(lora_time)
+LoRaPHY::LoRaPHY()
+    : _radio(NULL)
 {
     memset(&phy_params, 0, sizeof(phy_params));
 }
@@ -45,6 +44,11 @@ LoRaPHY::LoRaPHY(LoRaWANTimeHandler &lora_time)
 LoRaPHY::~LoRaPHY()
 {
     _radio = NULL;
+}
+
+void LoRaPHY::initialize(LoRaWANTimeHandler *lora_time)
+{
+    _lora_time = lora_time;
 }
 
 bool LoRaPHY::mask_bit_test(const uint16_t *mask, unsigned bit)
@@ -268,9 +272,9 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
     for (uint8_t i = 0; i < nb_bands; i++) {
 
         if (joined == false) {
-            uint32_t txDoneTime =  MAX(_lora_time.get_elapsed_time(bands[i].last_join_tx_time),
+            uint32_t txDoneTime =  MAX(_lora_time->get_elapsed_time(bands[i].last_join_tx_time),
                                        (duty_cycle == true) ?
-                                       _lora_time.get_elapsed_time(bands[i].last_tx_time) : 0);
+                                       _lora_time->get_elapsed_time(bands[i].last_tx_time) : 0);
 
             if (bands[i].off_time <= txDoneTime) {
                 bands[i].off_time = 0;
@@ -284,12 +288,12 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
             // if network has been joined
             if (duty_cycle == true) {
 
-                if (bands[i].off_time <= _lora_time.get_elapsed_time(bands[i].last_tx_time)) {
+                if (bands[i].off_time <= _lora_time->get_elapsed_time(bands[i].last_tx_time)) {
                     bands[i].off_time = 0;
                 }
 
                 if (bands[i].off_time != 0) {
-                    next_tx_delay = MIN(bands[i].off_time - _lora_time.get_elapsed_time(bands[i].last_tx_time),
+                    next_tx_delay = MIN(bands[i].off_time - _lora_time->get_elapsed_time(bands[i].last_tx_time),
                                         next_tx_delay);
                 }
             } else {
@@ -1222,7 +1226,7 @@ lorawan_status_t LoRaPHY::set_next_channel(channel_selection_params_t *params,
     }
 
     if (params->aggregate_timeoff
-            <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
+            <= _lora_time->get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -1238,7 +1242,7 @@ lorawan_status_t LoRaPHY::set_next_channel(channel_selection_params_t *params,
     } else {
         delay_tx++;
         next_tx_delay = params->aggregate_timeoff -
-                        _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
+                        _lora_time->get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (channel_count > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -45,6 +45,14 @@ class LoRaPHY : private mbed::NonCopyable<LoRaPHY> {
 public:
     virtual ~LoRaPHY();
 
+    /** Initialize LoRaPHY
+     *
+     *  LoRaMac calls this to initialize LoRaPHY.
+     *
+     * @param lora_time a pointer to LoRaWANTimeHandler object
+     */
+    void initialize(LoRaWANTimeHandler *lora_time);
+
     /** Stores a reference to Radio object.
      *
      * Application is responsible for constructing a 'LoRaRadio' object
@@ -517,7 +525,7 @@ public: //Verifiers
     bool verify_nb_join_trials(uint8_t nb_join_trials);
 
 protected:
-    LoRaPHY(LoRaWANTimeHandler &lora_time);
+    LoRaPHY();
 
     /**
      * Looks up corresponding band for a frequency. Returns -1 if not in any band.
@@ -624,7 +632,7 @@ protected:
 
 protected:
     LoRaRadio *_radio;
-    LoRaWANTimeHandler &_lora_time;
+    LoRaWANTimeHandler *_lora_time;
     loraphy_params_t phy_params;
 };
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -60,7 +60,7 @@ public:
      *
      * @param radio    a reference to radio driver object
      */
-    void set_radio_instance(LoRaRadio& radio);
+    void set_radio_instance(LoRaRadio &radio);
 
     /** Puts radio in sleep mode.
      *

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -241,8 +241,7 @@ static const uint32_t bandwidths_AS923[] = {125000, 125000, 125000, 125000, 1250
  */
 static const int8_t rx1_dr_offset_AS923[] = {0, 1, 2, 3, 4, 5, -1, -2};
 
-LoRaPHYAS923::LoRaPHYAS923(LoRaWANTimeHandler &lora_time)
-    : LoRaPHY(lora_time)
+LoRaPHYAS923::LoRaPHYAS923()
 {
     bands[0] = AS923_BAND0;
 
@@ -352,7 +351,7 @@ lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t* next
         channel_mask[0] |= LC(1) + LC(2);
     }
 
-    if (next_channel_prams->aggregate_timeoff <= _lora_time.get_elapsed_time(next_channel_prams->last_aggregate_tx_time)) {
+    if (next_channel_prams->aggregate_timeoff <= _lora_time->get_elapsed_time(next_channel_prams->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -368,7 +367,7 @@ lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t* next
                                                     enabled_channels, &delay_tx);
     }  else {
         delay_tx++;
-        next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time.get_elapsed_time(next_channel_prams->last_aggregate_tx_time);
+        next_tx_delay = next_channel_prams->aggregate_timeoff - _lora_time->get_elapsed_time(next_channel_prams->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.h
@@ -50,7 +50,7 @@
 class LoRaPHYAS923 : public LoRaPHY {
 
 public:
-    LoRaPHYAS923(LoRaWANTimeHandler &lora_time);
+    LoRaPHYAS923();
     virtual ~LoRaPHYAS923();
 
     virtual int8_t get_alternate_DR(uint8_t nb_trials);

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -221,8 +221,7 @@ static const uint8_t max_payload_with_repeater_AU915[] = { 51, 51, 51, 115,
     222, 222, 222, 0, 33, 109, 222, 222, 222, 222, 0, 0 };
 
 
-LoRaPHYAU915::LoRaPHYAU915(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYAU915::LoRaPHYAU915()
 {
     bands[0] = AU915_BAND0;
 
@@ -584,7 +583,7 @@ lorawan_status_t LoRaPHYAU915::set_next_channel(channel_selection_params_t* next
         }
     }
 
-    if (next_chan_params->aggregate_timeoff <= _lora_time.get_elapsed_time(next_chan_params->last_aggregate_tx_time)) {
+    if (next_chan_params->aggregate_timeoff <= _lora_time->get_elapsed_time(next_chan_params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregated_timeOff = 0;
 
@@ -600,7 +599,7 @@ lorawan_status_t LoRaPHYAU915::set_next_channel(channel_selection_params_t* next
                                                      enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = next_chan_params->aggregate_timeoff - _lora_time.get_elapsed_time(next_chan_params->last_aggregate_tx_time);
+        next_tx_delay = next_chan_params->aggregate_timeoff - _lora_time->get_elapsed_time(next_chan_params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.h
@@ -53,7 +53,7 @@ class LoRaPHYAU915 : public LoRaPHY{
 
 public:
 
-    LoRaPHYAU915(LoRaWANTimeHandler &lora_time);
+    LoRaPHYAU915();
     virtual ~LoRaPHYAU915();
 
     virtual bool rx_config(rx_config_params_t* config);

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -204,8 +204,7 @@ static const uint8_t max_payloads_CN470[] = {51, 51, 51, 115, 222, 222};
 static const uint8_t max_payloads_with_repeater_CN470[] = {51, 51, 51, 115, 222, 222};
 
 
-LoRaPHYCN470::LoRaPHYCN470(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYCN470::LoRaPHYCN470()
 {
     bands[0] = CN470_BAND0;
 

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.h
@@ -53,7 +53,7 @@ class LoRaPHYCN470 : public LoRaPHY {
 
 public:
 
-    LoRaPHYCN470(LoRaWANTimeHandler &lora_time);
+    LoRaPHYCN470();
     virtual ~LoRaPHYCN470();
 
     virtual bool rx_config(rx_config_params_t* config);

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.cpp
@@ -230,8 +230,7 @@ static const uint8_t max_payloads_CN779[] = {51, 51, 51, 115, 242, 242, 242, 242
 static const uint8_t max_payloads_with_repeater_CN779[] = {51, 51, 51, 115, 222, 222, 222, 222};
 
 
-LoRaPHYCN779::LoRaPHYCN779(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYCN779::LoRaPHYCN779()
 {
     bands[0] = CN779_BAND0;
 

--- a/features/lorawan/lorastack/phy/LoRaPHYCN779.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN779.h
@@ -45,7 +45,7 @@ class LoRaPHYCN779 : public LoRaPHY {
 
 public:
 
-    LoRaPHYCN779(LoRaWANTimeHandler &lora_time);
+    LoRaPHYCN779();
     virtual ~LoRaPHYCN779();
 
 private:

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.cpp
@@ -231,8 +231,7 @@ static const uint8_t max_payloads_EU433[] = {51, 51, 51, 115, 242, 242, 242, 242
 static const uint8_t max_payloads_with_repeater_EU433[] = {51, 51, 51, 115, 222, 222, 222, 222};
 
 
-LoRaPHYEU433::LoRaPHYEU433(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYEU433::LoRaPHYEU433()
 {
     bands[0] = EU433_BAND0;
 

--- a/features/lorawan/lorastack/phy/LoRaPHYEU433.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU433.h
@@ -51,7 +51,7 @@ class LoRaPHYEU433 : public LoRaPHY {
 
 public:
 
-    LoRaPHYEU433(LoRaWANTimeHandler &lora_time);
+    LoRaPHYEU433();
     virtual ~LoRaPHYEU433();
 
 private:

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.cpp
@@ -256,8 +256,7 @@ static const uint8_t max_payloads_EU868[] = {51, 51, 51, 115, 242, 242, 242, 242
  */
 static const uint8_t max_payloads_repeater_EU868[] = {51, 51, 51, 115, 222, 222, 222, 222};
 
-LoRaPHYEU868::LoRaPHYEU868(LoRaWANTimeHandler &lora_time)
-    : LoRaPHY(lora_time)
+LoRaPHYEU868::LoRaPHYEU868()
 {
     bands[0] = EU868_BAND0;
     bands[1] = EU868_BAND1;

--- a/features/lorawan/lorastack/phy/LoRaPHYEU868.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYEU868.h
@@ -54,7 +54,7 @@
 class LoRaPHYEU868 : public LoRaPHY {
 
 public:
-    LoRaPHYEU868(LoRaWANTimeHandler &lora_time);
+    LoRaPHYEU868();
     virtual ~LoRaPHYEU868();
 
 private:

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.cpp
@@ -232,8 +232,7 @@ static const uint8_t max_payloads_with_repeater[] = { 51, 51, 51, 115, 222, 222,
  */
 static const int8_t rx1_dr_offset_IN865[] = { 0, 1, 2, 3, 4, 5, -1, -2 };
 
-LoRaPHYIN865::LoRaPHYIN865(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYIN865::LoRaPHYIN865()
 {
     bands[0] = IN865_BAND0;
 

--- a/features/lorawan/lorastack/phy/LoRaPHYIN865.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYIN865.h
@@ -52,7 +52,7 @@ class LoRaPHYIN865 : public LoRaPHY {
 
 public:
 
-    LoRaPHYIN865(LoRaWANTimeHandler &lora_time);
+    LoRaPHYIN865();
     virtual ~LoRaPHYIN865();
 
     virtual uint8_t apply_DR_offset(int8_t dr, int8_t dr_offset );

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -241,8 +241,7 @@ static const uint8_t max_payloads_KR920[] = { 51, 51, 51, 115, 242, 242 };
  */
 static const uint8_t max_payloads_with_repeater_KR920[] = { 51, 51, 51, 115, 222, 222 };
 
-LoRaPHYKR920::LoRaPHYKR920(LoRaWANTimeHandler &lora_time)
-    : LoRaPHY(lora_time)
+LoRaPHYKR920::LoRaPHYKR920()
 {
     bands[0] = KR920_BAND0;
 
@@ -422,7 +421,7 @@ lorawan_status_t LoRaPHYKR920::set_next_channel(channel_selection_params_t* para
         channel_mask[0] |= LC(1) + LC(2) + LC(3);
     }
 
-    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time->get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeoff = 0;
 
@@ -436,7 +435,7 @@ lorawan_status_t LoRaPHYKR920::set_next_channel(channel_selection_params_t* para
                                                      enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        nextTxDelay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
+        nextTxDelay = params->aggregate_timeoff - _lora_time->get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.h
@@ -51,7 +51,7 @@ class LoRaPHYKR920 : public LoRaPHY {
 
 public:
 
-    LoRaPHYKR920(LoRaWANTimeHandler &lora_time);
+    LoRaPHYKR920();
     virtual ~LoRaPHYKR920();
 
     virtual bool verify_frequency_for_band(uint32_t freq, uint8_t band) const;

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -211,8 +211,7 @@ static const uint8_t max_payloads_US915[] = { 11, 53, 125, 242, 242, 0, 0, 0, 53
  */
 static const uint8_t max_payloads_with_repeater_US915[] = {11, 53, 125, 242, 242, 0, 0, 0, 33, 109, 222, 222, 222, 222, 0, 0};
 
-LoRaPHYUS915::LoRaPHYUS915(LoRaWANTimeHandler &lora_time)
-        : LoRaPHY(lora_time)
+LoRaPHYUS915::LoRaPHYUS915()
 {
     bands[0] = US915_BAND0;
 
@@ -624,7 +623,7 @@ lorawan_status_t LoRaPHYUS915::set_next_channel(channel_selection_params_t* para
         }
     }
 
-    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time(params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time->get_elapsed_time(params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeOff = 0;
 
@@ -638,7 +637,7 @@ lorawan_status_t LoRaPHYUS915::set_next_channel(channel_selection_params_t* para
                                                     enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
+        next_tx_delay = params->aggregate_timeoff - _lora_time->get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.h
@@ -51,7 +51,7 @@ class LoRaPHYUS915 : public LoRaPHY {
 
 public:
 
-    LoRaPHYUS915(LoRaWANTimeHandler &lora_time);
+    LoRaPHYUS915();
     virtual ~LoRaPHYUS915();
 
     virtual void restore_default_channels();

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -210,8 +210,7 @@ static const uint8_t max_payloads_US915_HYBRID[] = { 11, 53, 125, 242, 242, 0, 0
  */
 static const uint8_t max_payloads_with_repeater_US915_HYBRID[] = { 11, 53, 125, 242, 242, 0, 0, 0, 33, 109, 222, 222, 222, 222, 0, 0 };
 
-LoRaPHYUS915Hybrid::LoRaPHYUS915Hybrid(LoRaWANTimeHandler &lora_time)
-    : LoRaPHY(lora_time)
+LoRaPHYUS915Hybrid::LoRaPHYUS915Hybrid()
 {
     bands[0] = US915_HYBRID_BAND0;
 
@@ -622,7 +621,7 @@ lorawan_status_t LoRaPHYUS915Hybrid::set_next_channel(channel_selection_params_t
         }
     }
 
-    if (params->aggregate_timeoff <= _lora_time.get_elapsed_time( params->last_aggregate_tx_time)) {
+    if (params->aggregate_timeoff <= _lora_time->get_elapsed_time( params->last_aggregate_tx_time)) {
         // Reset Aggregated time off
         *aggregate_timeOff = 0;
 
@@ -638,7 +637,7 @@ lorawan_status_t LoRaPHYUS915Hybrid::set_next_channel(channel_selection_params_t
                                                     enabled_channels, &delay_tx);
     } else {
         delay_tx++;
-        next_tx_delay = params->aggregate_timeoff - _lora_time.get_elapsed_time(params->last_aggregate_tx_time);
+        next_tx_delay = params->aggregate_timeoff - _lora_time->get_elapsed_time(params->last_aggregate_tx_time);
     }
 
     if (nb_enabled_channels > 0) {

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.h
@@ -51,7 +51,7 @@ class LoRaPHYUS915Hybrid : public LoRaPHY {
 
 public:
 
-    LoRaPHYUS915Hybrid(LoRaWANTimeHandler &lora_time);
+    LoRaPHYUS915Hybrid();
     virtual ~LoRaPHYUS915Hybrid();
 
     virtual void restore_default_channels();


### PR DESCRIPTION
### Description

Add support to set up lora stack using user given PHY object. This will enable PHY selection at run time (usefull for example to roaming devices).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change
