### PR TITLE
Atecc608a ecdsa verify fix

### DIFF
--- a/features/atcryptoauth/ATCADevice.cpp
+++ b/features/atcryptoauth/ATCADevice.cpp
@@ -355,7 +355,7 @@ int ATCADevice::Verify(uint8_t * pk, size_t pk_len, const uint8_t * sig,
     memcpy(cmd + 4 + 64, pk, 64);
 
     err = RunCommand(&cmd_info);
-    if (err != ATCA_SUCCESS)
+    if (err == ATCA_SUCCESS)
     {
         err = (ATCAError)cmd_info.resp()[0];
     }

--- a/features/atcryptoauth/ATCAKey.cpp
+++ b/features/atcryptoauth/ATCAKey.cpp
@@ -32,8 +32,8 @@ ATCAError ATCAKey::Verify( const unsigned char *hash, size_t hash_len,
                            const unsigned char *sig,
                            size_t sig_len )
 {
-    return (ATCAError)device.Verify(pk, ATCA_ECC_ECC_PK_LEN, hash, hash_len, sig,
-                         sig_len);
+    return (ATCAError)device.Verify(pk, ATCA_ECC_ECC_PK_LEN, sig, sig_len, hash,
+                         hash_len);
 }
 
 uint8_t * ATCAKey::GetPubKey()

--- a/features/atcryptoauth/mbedtls_atca_engine.cpp
+++ b/features/atcryptoauth/mbedtls_atca_engine.cpp
@@ -197,7 +197,7 @@ static int atca_verify_func( void *ctx, mbedtls_md_type_t md_alg,
         return ret;
     }
     /* Verify the signature */
-    ATCAError err = key->Verify( rs, sizeof(rs), hash, hash_len);
+    ATCAError err = key->Verify( hash, hash_len, rs, sizeof(rs) );
     if (err == ATCA_ERR_CHECK_MAC_OR_VERIFY_FAIL)
     {
         return MBEDTLS_ERR_PK_INVALID_SIGNATURE;


### PR DESCRIPTION
### Description
Fixes for atecc608a verify functionality.
This PR contains 2 fixes:
1. Reading the device response on successful command execution in `ATCADevice::Verify`
2. Sending parameters in the expected order

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

