### PR TITLE
Disable LSE for MTB_USI_WM_BN_BM_22

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1193,6 +1193,9 @@
         }
     },
     "MTB_USI_WM_BN_BM_22": {
+        "overrides": {
+            "lse_available": 0
+        },
         "inherits": ["USI_WM_BN_BM_22"]
     },
     "MTB_ADV_WISE_1530": {


### PR DESCRIPTION
### Description

Current MTB_USI_WM_BN_BM_22 modules do not have OSC32_IN connected, so
external xtal is not in use.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

