### PR TITLE
Raytac: target removal

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3617,13 +3617,6 @@
         "macros_add": ["TARGET_MCU_NORDIC_16K", "TARGET_MCU_NRF51_16K_S130", "TARGET_MCU_NRF51_16K"],
         "public": false
     },
-    "Raytac_MDBT40": {
-        "inherits": ["MCU_NRF51_16K_UNIFIED_S130"],
-        "macros_add": ["TARGET_NRF_LFCLK_RC"],
-        "release_versions": ["2"],
-        "device_has": ["ANALOGIN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
-        "device_name": "nRF51822_xxAA"
-    },
     "MCU_NRF51_32K_UNIFIED": {
         "inherits": ["MCU_NRF51_UNIFIED"],
         "extra_labels_add": ["MCU_NORDIC_32K", "MCU_NRF51_32K"],


### PR DESCRIPTION
No files to build - should not be in targets
Reverts part of the https://github.com/ARMmbed/mbed-os/pull/6178

This target should not be defined in targets (no files related in the codebase).

@andrewleech 

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

