### PR TITLE
Skip a few tests if not enough memory can be allocated for them

### DIFF
--- a/TESTS/mbed_platform/error_handling/main.cpp
+++ b/TESTS/mbed_platform/error_handling/main.cpp
@@ -199,6 +199,7 @@ void test_error_logging()
 }
 
 #define NUM_TEST_THREADS 5
+#define THREAD_STACK_SIZE 512
 
 //Error logger threads
 void err_thread_func(mbed_error_status_t *error_status)
@@ -211,16 +212,20 @@ void err_thread_func(mbed_error_status_t *error_status)
  */
 void test_error_logging_multithread()
 {
+    uint8_t *dummy = new (std::nothrow) uint8_t[NUM_TEST_THREADS * THREAD_STACK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
     mbed_error_ctx error_ctx = {0};
-    int i=0;
+    int i;
     Thread *errThread[NUM_TEST_THREADS];
     mbed_error_status_t error_status[NUM_TEST_THREADS] = { 
                                         MBED_ERROR_INVALID_ARGUMENT, MBED_ERROR_INVALID_DATA_DETECTED, MBED_ERROR_INVALID_FORMAT, MBED_ERROR_INVALID_SIZE, MBED_ERROR_INVALID_OPERATION
     };
     
         
-    for(; i<NUM_TEST_THREADS; i++) {
-        errThread[i] = new Thread(osPriorityNormal1, 512, NULL, NULL);
+    for(i=0; i<NUM_TEST_THREADS; i++) {
+        errThread[i] = new Thread(osPriorityNormal1, THREAD_STACK_SIZE, NULL, NULL);
         errThread[i]->start(callback(err_thread_func, &error_status[i]));
     }
     wait(2.0);

--- a/features/TESTS/filesystem/buffered_block_device/main.cpp
+++ b/features/TESTS/filesystem/buffered_block_device/main.cpp
@@ -30,6 +30,10 @@ static const bd_size_t num_blocks = 4;
 
 void functionality_test()
 {
+    uint8_t *dummy = new (std::nothrow) uint8_t[num_blocks * heap_erase_size + heap_prog_size];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
     HeapBlockDevice heap_bd(num_blocks * heap_erase_size, heap_read_size, heap_prog_size, heap_erase_size);
     BufferedBlockDevice bd(&heap_bd);
 
@@ -37,8 +41,10 @@ void functionality_test()
     TEST_ASSERT_EQUAL(0, err);
 
     uint8_t *read_buf, *write_buf;
-    read_buf = new uint8_t[heap_prog_size];
-    write_buf = new uint8_t[heap_prog_size];
+    read_buf = new (std::nothrow) uint8_t[heap_prog_size];
+    TEST_SKIP_UNLESS_MESSAGE(read_buf, "Not enough memory for test");
+    write_buf = new (std::nothrow) uint8_t[heap_prog_size];
+    TEST_SKIP_UNLESS_MESSAGE(write_buf, "Not enough memory for test");
 
     TEST_ASSERT_EQUAL(1, bd.get_read_size());
     TEST_ASSERT_EQUAL(1, bd.get_program_size());

--- a/features/TESTS/filesystem/mbr_block_device/main.cpp
+++ b/features/TESTS/filesystem/mbr_block_device/main.cpp
@@ -37,6 +37,10 @@ HeapBlockDevice bd(BLOCK_COUNT*BLOCK_SIZE, BLOCK_SIZE);
 // Testing formatting of master boot record
 void test_mbr_format()
 {
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
     // Create two partitions splitting device in ~half
     int err = MBRBlockDevice::partition(&bd, 1, 0x83, 0, (BLOCK_COUNT/2)*BLOCK_SIZE);
     TEST_ASSERT_EQUAL(0, err);
@@ -68,6 +72,10 @@ void test_mbr_format()
 // Testing mbr attributes
 void test_mbr_attr()
 {
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
     // Load partitions
     MBRBlockDevice part1(&bd, 1);
     int err = part1.init();
@@ -123,9 +131,15 @@ void test_mbr_attr()
 // Testing mbr read write
 void test_mbr_read_write()
 {
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
+    int err;
+
     // Load partitions
     MBRBlockDevice part1(&bd, 1);
-    int err = part1.init();
+    err = part1.init();
     TEST_ASSERT_EQUAL(0, err);
 
     MBRBlockDevice part2(&bd, 2);
@@ -133,8 +147,12 @@ void test_mbr_read_write()
     TEST_ASSERT_EQUAL(0, err);
 
     // Test reading/writing the partitions
-    uint8_t *write_block = new uint8_t[BLOCK_SIZE];
-    uint8_t *read_block = new uint8_t[BLOCK_SIZE];
+    uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    if (!write_block || !read_block) {
+        printf("Not enough memory for test");
+        goto end;
+    }
 
     // Fill with random sequence
     srand(1);
@@ -200,15 +218,16 @@ void test_mbr_read_write()
         TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
     }
 
-    // Clean up
-    delete[] write_block;
-    delete[] read_block;
-
     err = part1.deinit();
     TEST_ASSERT_EQUAL(0, err);
 
     err = part2.deinit();
     TEST_ASSERT_EQUAL(0, err);
+
+end:
+    // Clean up
+    delete[] write_block;
+    delete[] read_block;
 }
 
 

--- a/features/TESTS/filesystem/util_block_device/main.cpp
+++ b/features/TESTS/filesystem/util_block_device/main.cpp
@@ -37,19 +37,31 @@ using namespace utest::v1;
 
 // Simple test which read/writes blocks on a sliced block device
 void test_slicing() {
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
+    int err;
+
     HeapBlockDevice bd(BLOCK_COUNT*BLOCK_SIZE, BLOCK_SIZE);
-    uint8_t *write_block = new uint8_t[BLOCK_SIZE];
-    uint8_t *read_block = new uint8_t[BLOCK_SIZE];
+
+    SlicingBlockDevice slice1(&bd, 0, (BLOCK_COUNT/2)*BLOCK_SIZE);
+    SlicingBlockDevice slice2(&bd, -(BLOCK_COUNT/2)*BLOCK_SIZE);
 
     // Test with first slice of block device
-    SlicingBlockDevice slice1(&bd, 0, (BLOCK_COUNT/2)*BLOCK_SIZE);
-
-    int err = slice1.init();
+    err = slice1.init();
     TEST_ASSERT_EQUAL(0, err);
 
     TEST_ASSERT_EQUAL(BLOCK_SIZE, slice1.get_program_size());
     TEST_ASSERT_EQUAL(BLOCK_SIZE, slice1.get_erase_size(BLOCK_SIZE));
     TEST_ASSERT_EQUAL((BLOCK_COUNT/2)*BLOCK_SIZE, slice1.size());
+
+    uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    if (!write_block || !read_block) {
+        printf("Not enough memory for test");
+        goto end;
+    }
 
     // Fill with random sequence
     srand(1);
@@ -85,8 +97,6 @@ void test_slicing() {
 
 
     // Test with second slice of block device
-    SlicingBlockDevice slice2(&bd, -(BLOCK_COUNT/2)*BLOCK_SIZE);
-
     err = slice2.init();
     TEST_ASSERT_EQUAL(0, err);
 
@@ -122,24 +132,38 @@ void test_slicing() {
         TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
     }
 
-    delete[] write_block;
-    delete[] read_block;
     err = slice2.deinit();
     TEST_ASSERT_EQUAL(0, err);
+
+end:
+    delete[] write_block;
+    delete[] read_block;
 }
 
 // Simple test which read/writes blocks on a chain of block devices
 void test_chaining() {
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+
+    int err;
+
     HeapBlockDevice bd1((BLOCK_COUNT/2)*BLOCK_SIZE, BLOCK_SIZE);
     HeapBlockDevice bd2((BLOCK_COUNT/2)*BLOCK_SIZE, BLOCK_SIZE);
-    uint8_t *write_block = new uint8_t[BLOCK_SIZE];
-    uint8_t *read_block = new uint8_t[BLOCK_SIZE];
 
     // Test with chain of block device
     BlockDevice *bds[] = {&bd1, &bd2};
     ChainingBlockDevice chain(bds);
 
-    int err = chain.init();
+    uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+
+    if (!write_block || !read_block) {
+        printf("Not enough memory for test");
+        goto end;
+    }
+
+    err = chain.init();
     TEST_ASSERT_EQUAL(0, err);
 
     TEST_ASSERT_EQUAL(BLOCK_SIZE, chain.get_program_size());
@@ -178,26 +202,40 @@ void test_chaining() {
         TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
     }
 
-    delete[] write_block;
-    delete[] read_block;
     err = chain.deinit();
     TEST_ASSERT_EQUAL(0, err);
+
+end:
+    delete[] write_block;
+    delete[] read_block;
 }
 
 // Simple test which read/writes blocks on a chain of block devices
 void test_profiling() {
-    HeapBlockDevice bd(BLOCK_COUNT*BLOCK_SIZE, BLOCK_SIZE);
-    uint8_t *write_block = new uint8_t[BLOCK_SIZE];
-    uint8_t *read_block = new uint8_t[BLOCK_SIZE];
+    uint8_t *dummy = new (std::nothrow) uint8_t[BLOCK_COUNT * BLOCK_SIZE];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
 
+    int err;
+    bd_size_t read_count, program_count, erase_count;
+
+    HeapBlockDevice bd(BLOCK_COUNT*BLOCK_SIZE, BLOCK_SIZE);
     // Test under profiling
     ProfilingBlockDevice profiler(&bd);
 
-    int err = profiler.init();
+    err = profiler.init();
     TEST_ASSERT_EQUAL(0, err);
 
     TEST_ASSERT_EQUAL(BLOCK_SIZE, profiler.get_erase_size());
     TEST_ASSERT_EQUAL(BLOCK_COUNT*BLOCK_SIZE, profiler.size());
+
+    uint8_t *write_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+    uint8_t *read_block = new (std::nothrow) uint8_t[BLOCK_SIZE];
+
+    if (!write_block || !read_block) {
+        printf("Not enough memory for test");
+        goto end;
+    }
 
     // Fill with random sequence
     srand(1);
@@ -231,18 +269,20 @@ void test_profiling() {
         TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
     }
 
-    delete[] write_block;
-    delete[] read_block;
     err = profiler.deinit();
     TEST_ASSERT_EQUAL(0, err);
 
     // Check that profiled operations match expectations
-    bd_size_t read_count = profiler.get_read_count();
+    read_count = profiler.get_read_count();
     TEST_ASSERT_EQUAL(BLOCK_SIZE, read_count);
-    bd_size_t program_count = profiler.get_program_count();
+    program_count = profiler.get_program_count();
     TEST_ASSERT_EQUAL(BLOCK_SIZE, program_count);
-    bd_size_t erase_count = profiler.get_erase_count();
+    erase_count = profiler.get_erase_count();
     TEST_ASSERT_EQUAL(BLOCK_SIZE, erase_count);
+
+end:
+    delete[] write_block;
+    delete[] read_block;
 }
 
 


### PR DESCRIPTION
### Description
Some tests need large amounts of memory in order to work. These tests will fail on low end boards, having low memory. This is also shown in [issue #7115](https://github.com/ARMmbed/mbed-os/issues/7115) where these tests fail on the TMPM066 board. This PR fixes the problem by simply skipping the test if there's not enough memory. All allocations use the std::nothrow directive.
~~PR depends on [#7448](https://github.com/ARMmbed/mbed-os/pull/7448).~~

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

