### PR TITLE
Allow STDIO pins to be NC in NRF52 series

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
@@ -789,9 +789,16 @@ static void nordic_nrf5_uart_configure_object(serial_t *obj)
 #endif
 
     /* Configure Tx and Rx pins. */
-    nrf_gpio_pin_set(uart_object->tx);
-    nrf_gpio_cfg_output(uart_object->tx);
-    nrf_gpio_cfg_input(uart_object->rx, NRF_GPIO_PIN_NOPULL);
+    if (uart_object->tx != NRF_UART_PSEL_DISCONNECTED) {
+
+        nrf_gpio_pin_set(uart_object->tx);
+        nrf_gpio_cfg_output(uart_object->tx);
+    }
+
+    if (uart_object->rx != NRF_UART_PSEL_DISCONNECTED) {
+
+        nrf_gpio_cfg_input(uart_object->rx, NRF_GPIO_PIN_NOPULL);
+    }
 
     nrf_uarte_txrx_pins_set(nordic_nrf5_uart_register[uart_object->instance],
                             uart_object->tx,


### PR DESCRIPTION
### Description
Prevent ASSERT from triggering when one of the STDIO pins is not connected.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

