### PR TITLE
EFM32: fix weak PeripheralPins configuration

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -41,7 +41,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap MBED_WEAK PinMap_DAC[] = {
+MBED_WEAK const PinMap PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -50,7 +50,7 @@ const PinMap MBED_WEAK PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -72,7 +72,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -94,7 +94,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -117,7 +117,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -139,7 +139,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -161,7 +161,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -183,7 +183,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -206,7 +206,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -254,7 +254,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap PinMap_DAC[] = {
+const PinMap __attribute__((weak)) PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap __attribute__((weak)) PinMap_DAC[] = {
+const PinMap MBED_WEAK PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap __attribute__((weak)) PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
@@ -26,7 +26,7 @@
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
 #if DEVICE_ANALOGIN
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #if ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -70,7 +70,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 
 /************I2C SCL***********/
 #if DEVICE_I2C
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA1,  I2C_0, 0},
@@ -106,7 +106,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA0,  I2C_0, 0},
@@ -146,7 +146,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 
 /************PWM***************/
 #if DEVICE_PWMOUT
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
     {PC13, PWM_CH0, 0},
     {PE10, PWM_CH0, 1},
     {PB0,  PWM_CH0, 2},
@@ -189,7 +189,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 
 /*************SPI**************/
 #if DEVICE_SPI
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     {PE10, SPI_0, 0},
     {PE7,  SPI_0, 1},
@@ -245,7 +245,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     {PE11, SPI_0,  0},
     {PE6,  SPI_0,  1},
@@ -301,7 +301,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0,  0},
@@ -358,7 +358,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0,  0},
@@ -416,7 +416,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     {PE10, USART_0, 0},
     {PE7,  USART_0, 1},
@@ -474,7 +474,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #endif
 
 #if DEVICE_SERIAL
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     {PE11, USART_0,  0},
     {PE6,  USART_0,  1},
@@ -532,7 +532,7 @@ const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #endif
 
 #if DEVICE_CAN
-const PinMap __attribute__((weak)) PinMap_CAN_TX[] = {
+const PinMap MBED_WEAK PinMap_CAN_TX[] = {
 #ifdef CAN0_BASE
     {PC1,  CAN_0, 0},
     {PF2,  CAN_0, 1},
@@ -555,7 +555,7 @@ const PinMap __attribute__((weak)) PinMap_CAN_TX[] = {
 #endif
 };
 
-const PinMap __attribute__((weak)) PinMap_CAN_RX[] = {
+const PinMap MBED_WEAK PinMap_CAN_RX[] = {
 #ifdef CAN0_BASE
     {PC0,  CAN_0, 0},
     {PF0,  CAN_0, 1},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
@@ -26,7 +26,7 @@
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
 #if DEVICE_ANALOGIN
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #if ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -70,7 +70,7 @@ const PinMap PinMap_ADC[] = {
 
 /************I2C SCL***********/
 #if DEVICE_I2C
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA1,  I2C_0, 0},
@@ -106,7 +106,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA0,  I2C_0, 0},
@@ -146,7 +146,7 @@ const PinMap PinMap_I2C_SDA[] = {
 
 /************PWM***************/
 #if DEVICE_PWMOUT
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
     {PC13, PWM_CH0, 0},
     {PE10, PWM_CH0, 1},
     {PB0,  PWM_CH0, 2},
@@ -189,7 +189,7 @@ const PinMap PinMap_PWM[] = {
 
 /*************SPI**************/
 #if DEVICE_SPI
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     {PE10, SPI_0, 0},
     {PE7,  SPI_0, 1},
@@ -245,7 +245,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     {PE11, SPI_0,  0},
     {PE6,  SPI_0,  1},
@@ -301,7 +301,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0,  0},
@@ -358,7 +358,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0,  0},
@@ -416,7 +416,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     {PE10, USART_0, 0},
     {PE7,  USART_0, 1},
@@ -474,7 +474,7 @@ const PinMap PinMap_UART_TX[] = {
 #endif
 
 #if DEVICE_SERIAL
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     {PE11, USART_0,  0},
     {PE6,  USART_0,  1},
@@ -532,7 +532,7 @@ const PinMap PinMap_UART_RX[] = {
 #endif
 
 #if DEVICE_CAN
-const PinMap PinMap_CAN_TX[] = {
+const PinMap __attribute__((weak)) PinMap_CAN_TX[] = {
 #ifdef CAN0_BASE
     {PC1,  CAN_0, 0},
     {PF2,  CAN_0, 1},
@@ -555,7 +555,7 @@ const PinMap PinMap_CAN_TX[] = {
 #endif
 };
 
-const PinMap PinMap_CAN_RX[] = {
+const PinMap __attribute__((weak)) PinMap_CAN_RX[] = {
 #ifdef CAN0_BASE
     {PC0,  CAN_0, 0},
     {PF0,  CAN_0, 1},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG11/PeripheralPins.c
@@ -27,7 +27,7 @@
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
 #if DEVICE_ANALOGIN
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #if ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -71,7 +71,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 
 /************I2C SCL***********/
 #if DEVICE_I2C
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA1,  I2C_0, 0},
@@ -107,7 +107,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
     /* I2C0 */
 #ifdef I2C0_BASE
     {PA0,  I2C_0, 0},
@@ -147,7 +147,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 
 /************PWM***************/
 #if DEVICE_PWMOUT
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
     {PC13, PWM_CH0, 0},
     {PE10, PWM_CH0, 1},
     {PB0,  PWM_CH0, 2},
@@ -190,7 +190,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 
 /*************SPI**************/
 #if DEVICE_SPI
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     {PE10, SPI_0, 0},
     {PE7,  SPI_0, 1},
@@ -246,7 +246,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     {PE11, SPI_0,  0},
     {PE6,  SPI_0,  1},
@@ -302,7 +302,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0,  0},
@@ -359,7 +359,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0,  0},
@@ -417,7 +417,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     {PE10, USART_0, 0},
     {PE7,  USART_0, 1},
@@ -475,7 +475,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #endif
 
 #if DEVICE_SERIAL
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     {PE11, USART_0,  0},
     {PE6,  USART_0,  1},
@@ -533,7 +533,7 @@ const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #endif
 
 #if DEVICE_CAN
-const PinMap MBED_WEAK PinMap_CAN_TX[] = {
+MBED_WEAK const PinMap PinMap_CAN_TX[] = {
 #ifdef CAN0_BASE
     {PC1,  CAN_0, 0},
     {PF2,  CAN_0, 1},
@@ -556,7 +556,7 @@ const PinMap MBED_WEAK PinMap_CAN_TX[] = {
 #endif
 };
 
-const PinMap MBED_WEAK PinMap_CAN_RX[] = {
+MBED_WEAK const PinMap PinMap_CAN_RX[] = {
 #ifdef CAN0_BASE
     {PC0,  CAN_0, 0},
     {PF0,  CAN_0, 1},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
@@ -24,7 +24,7 @@
 #include "PeripheralPins.h"
 
 /************ADC***************/
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -35,7 +35,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -49,7 +49,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -62,7 +62,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -82,7 +82,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -100,7 +100,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -118,7 +118,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -136,7 +136,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -154,7 +154,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, USART_0, 0},
@@ -179,7 +179,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, USART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
@@ -24,7 +24,7 @@
 #include "PeripheralPins.h"
 
 /************ADC***************/
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -35,7 +35,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -49,7 +49,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -62,7 +62,7 @@ const PinMap PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -82,7 +82,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -100,7 +100,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -118,7 +118,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -136,7 +136,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -154,7 +154,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, USART_0, 0},
@@ -179,7 +179,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, USART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
@@ -25,7 +25,7 @@
 #include "mbed_toolchain.h"
 
 /************ADC***************/
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -36,7 +36,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -50,7 +50,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -63,7 +63,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -83,7 +83,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -101,7 +101,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -119,7 +119,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -137,7 +137,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -155,7 +155,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, USART_0, 0},
@@ -180,7 +180,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, USART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 const PinMap MBED_WEAK PinMap_ADC[] = {

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -41,7 +41,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap MBED_WEAK PinMap_DAC[] = {
+MBED_WEAK const PinMap PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -50,7 +50,7 @@ const PinMap MBED_WEAK PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -72,7 +72,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -94,7 +94,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -117,7 +117,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -139,7 +139,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -161,7 +161,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -183,7 +183,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -206,7 +206,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -254,7 +254,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap PinMap_DAC[] = {
+const PinMap __attribute__((weak)) PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap __attribute__((weak)) PinMap_DAC[] = {
+const PinMap MBED_WEAK PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap __attribute__((weak)) PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -107,7 +107,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -148,7 +148,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -197,7 +197,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -239,7 +239,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -282,7 +282,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -326,7 +326,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -369,7 +369,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -414,7 +414,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -68,7 +68,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -108,7 +108,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -149,7 +149,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -198,7 +198,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -240,7 +240,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -283,7 +283,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -327,7 +327,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -370,7 +370,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -415,7 +415,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -107,7 +107,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -148,7 +148,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -197,7 +197,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -239,7 +239,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -282,7 +282,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -326,7 +326,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -369,7 +369,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -414,7 +414,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -139,7 +139,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -212,7 +212,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -261,7 +261,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -341,7 +341,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -422,7 +422,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -504,7 +504,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -585,7 +585,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -668,7 +668,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -139,7 +139,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -212,7 +212,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -261,7 +261,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -341,7 +341,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -422,7 +422,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -504,7 +504,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -585,7 +585,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -668,7 +668,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32PG12/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -68,7 +68,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -140,7 +140,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -213,7 +213,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -262,7 +262,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -342,7 +342,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -423,7 +423,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -505,7 +505,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -586,7 +586,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -669,7 +669,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -41,7 +41,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap MBED_WEAK PinMap_DAC[] = {
+MBED_WEAK const PinMap PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -50,7 +50,7 @@ const PinMap MBED_WEAK PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -72,7 +72,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -94,7 +94,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -117,7 +117,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -139,7 +139,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -161,7 +161,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -183,7 +183,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -206,7 +206,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -254,7 +254,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap PinMap_DAC[] = {
+const PinMap __attribute__((weak)) PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD0, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH0},
     {PD1, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH1},
@@ -40,7 +40,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************DAC***************/
-const PinMap __attribute__((weak)) PinMap_DAC[] = {
+const PinMap MBED_WEAK PinMap_DAC[] = {
 #ifdef DAC0_BASE
     {PB11, DAC_0, 0},
     {PB12, DAC_0, 1},
@@ -49,7 +49,7 @@ const PinMap __attribute__((weak)) PinMap_DAC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -71,7 +71,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -93,7 +93,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA8,  PWM_CH0, 0},
@@ -116,7 +116,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE10, SPI_0, 0},
@@ -138,7 +138,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE11, SPI_0, 0},
@@ -160,7 +160,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE12, SPI_0, 0},
@@ -182,7 +182,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PE13, SPI_0, 0},
@@ -205,7 +205,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF6, UART_0, 0},
@@ -253,7 +253,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef UART0_BASE
     /* UART0 */
     {PF7, UART_0, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
@@ -24,7 +24,7 @@
 #include "PeripheralPins.h"
 
 /************ADC***************/
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -35,7 +35,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -49,7 +49,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -62,7 +62,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -79,7 +79,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, SPI_1, 0},
@@ -89,7 +89,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, SPI_1, 0},
@@ -99,7 +99,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB7, SPI_1, 0},
@@ -109,7 +109,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB8, SPI_1, 0},
@@ -120,7 +120,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, USART_1, 0},
@@ -137,7 +137,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, USART_1, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
@@ -24,7 +24,7 @@
 #include "PeripheralPins.h"
 
 /************ADC***************/
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -35,7 +35,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -49,7 +49,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -62,7 +62,7 @@ const PinMap PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -79,7 +79,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, SPI_1, 0},
@@ -89,7 +89,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, SPI_1, 0},
@@ -99,7 +99,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB7, SPI_1, 0},
@@ -109,7 +109,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB8, SPI_1, 0},
@@ -120,7 +120,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, USART_1, 0},
@@ -137,7 +137,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, USART_1, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
@@ -25,7 +25,7 @@
 #include "mbed_toolchain.h"
 
 /************ADC***************/
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PD4, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH4},
     {PD5, ADC_0, ADC_SINGLECTRL_INPUTSEL_CH5},
@@ -36,7 +36,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0, 0},
@@ -50,7 +50,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0, 0},
@@ -63,7 +63,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
     {NC  , NC   , NC}
 };
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0, PWM_CH0, 0},
@@ -80,7 +80,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, SPI_1, 0},
@@ -90,7 +90,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, SPI_1, 0},
@@ -100,7 +100,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB7, SPI_1, 0},
@@ -110,7 +110,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PB8, SPI_1, 0},
@@ -121,7 +121,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC0, USART_1, 0},
@@ -138,7 +138,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART1_BASE
     /* USART1 */
     {PC1, USART_1, 0},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 const PinMap MBED_WEAK PinMap_ADC[] = {

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -107,7 +107,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -148,7 +148,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -197,7 +197,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -239,7 +239,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -282,7 +282,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -326,7 +326,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -369,7 +369,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -414,7 +414,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -68,7 +68,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -108,7 +108,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -149,7 +149,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -198,7 +198,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -240,7 +240,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -283,7 +283,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -327,7 +327,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -370,7 +370,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -415,7 +415,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG1/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -107,7 +107,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -148,7 +148,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -197,7 +197,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -239,7 +239,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -282,7 +282,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -326,7 +326,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -369,7 +369,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -414,7 +414,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap PinMap_ADC[] = {
+const PinMap __attribute__((weak)) PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap PinMap_I2C_SCL[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -140,7 +140,7 @@ const PinMap PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap PinMap_I2C_SDA[] = {
+const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -215,7 +215,7 @@ const PinMap PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap PinMap_PWM[] = {
+const PinMap __attribute__((weak)) PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -264,7 +264,7 @@ const PinMap PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap PinMap_SPI_MOSI[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -344,7 +344,7 @@ const PinMap PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_MISO[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -425,7 +425,7 @@ const PinMap PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CLK[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -507,7 +507,7 @@ const PinMap PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_SPI_CS[] = {
+const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -588,7 +588,7 @@ const PinMap PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap PinMap_UART_TX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -671,7 +671,7 @@ const PinMap PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap PinMap_UART_RX[] = {
+const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
@@ -25,7 +25,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap __attribute__((weak)) PinMap_ADC[] = {
+const PinMap MBED_WEAK PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -67,7 +67,7 @@ const PinMap __attribute__((weak)) PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
+const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -140,7 +140,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
+const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -215,7 +215,7 @@ const PinMap __attribute__((weak)) PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap __attribute__((weak)) PinMap_PWM[] = {
+const PinMap MBED_WEAK PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -264,7 +264,7 @@ const PinMap __attribute__((weak)) PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
+const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -344,7 +344,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
+const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -425,7 +425,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
+const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -507,7 +507,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
+const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -588,7 +588,7 @@ const PinMap __attribute__((weak)) PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
+const PinMap MBED_WEAK PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -671,7 +671,7 @@ const PinMap __attribute__((weak)) PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap __attribute__((weak)) PinMap_UART_RX[] = {
+const PinMap MBED_WEAK PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include "PeripheralPins.h"
+#include "mbed_toolchain.h"
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/PeripheralPins.c
@@ -26,7 +26,7 @@
 
 /************ADC***************/
 /* The third "function" value is used to select the correct ADC channel */
-const PinMap MBED_WEAK PinMap_ADC[] = {
+MBED_WEAK const PinMap PinMap_ADC[] = {
 #ifdef ADC0_BASE
     {PA0,  ADC_0, adcPosSelAPORT3XCH8},
     {PA1,  ADC_0, adcPosSelAPORT4XCH9},
@@ -68,7 +68,7 @@ const PinMap MBED_WEAK PinMap_ADC[] = {
 };
 
 /************I2C SCL***********/
-const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
+MBED_WEAK const PinMap PinMap_I2C_SCL[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA1,  I2C_0,  0},
@@ -141,7 +141,7 @@ const PinMap MBED_WEAK PinMap_I2C_SCL[] = {
 };
 
 /************I2C SDA***********/
-const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
+MBED_WEAK const PinMap PinMap_I2C_SDA[] = {
 #ifdef I2C0_BASE
     /* I2C0 */
     {PA0,  I2C_0,  0},
@@ -216,7 +216,7 @@ const PinMap MBED_WEAK PinMap_I2C_SDA[] = {
 };
 
 /************PWM***************/
-const PinMap MBED_WEAK PinMap_PWM[] = {
+MBED_WEAK const PinMap PinMap_PWM[] = {
 #if defined(TIMER_ROUTE_CC0PEN) || defined(TIMER_ROUTEPEN_CC0PEN)
     /* PWM0 */
     {PA0,  PWM_CH0,  0},
@@ -265,7 +265,7 @@ const PinMap MBED_WEAK PinMap_PWM[] = {
 };
 
 /*************SPI**************/
-const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
+MBED_WEAK const PinMap PinMap_SPI_MOSI[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  0},
@@ -345,7 +345,7 @@ const PinMap MBED_WEAK PinMap_SPI_MOSI[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
+MBED_WEAK const PinMap PinMap_SPI_MISO[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 31},
@@ -426,7 +426,7 @@ const PinMap MBED_WEAK PinMap_SPI_MISO[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
+MBED_WEAK const PinMap PinMap_SPI_CLK[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0, 30},
@@ -508,7 +508,7 @@ const PinMap MBED_WEAK PinMap_SPI_CLK[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_SPI_CS[] = {
+MBED_WEAK const PinMap PinMap_SPI_CS[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  SPI_0,  29},
@@ -589,7 +589,7 @@ const PinMap MBED_WEAK PinMap_SPI_CS[] = {
 };
 
 /************UART**************/
-const PinMap MBED_WEAK PinMap_UART_TX[] = {
+MBED_WEAK const PinMap PinMap_UART_TX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0,  0},
@@ -672,7 +672,7 @@ const PinMap MBED_WEAK PinMap_UART_TX[] = {
     {NC  , NC   , NC}
 };
 
-const PinMap MBED_WEAK PinMap_UART_RX[] = {
+MBED_WEAK const PinMap PinMap_UART_RX[] = {
 #ifdef USART0_BASE
     /* USART0 */
     {PA0,  USART_0, 31},


### PR DESCRIPTION
### Description
PR for Issue #7424 .
Making the configuration tables weakly defined to be overridable. 
This would be needed for i.e. custom targets which uses different Pin-Profiles as default defined.

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

