### PR TITLE
Ticker free() - requirements, pseudo code, tests, implementation

### DIFF
--- a/TESTS/mbed_drivers/timer/main.cpp
+++ b/TESTS/mbed_drivers/timer/main.cpp
@@ -103,6 +103,12 @@ static void stub_fire_interrupt(void)
     /* do nothing. */
 }
 
+/* User ticker interface function. */
+static void stub_free(void)
+{
+    /* do nothing. */
+}
+
 ticker_info_t info =
 { TICKER_FREQ_1MHZ, TICKER_BITS };
 
@@ -122,6 +128,7 @@ static const ticker_interface_t us_interface = {
     .clear_interrupt = stub_clear_interrupt,
     .set_interrupt = stub_set_interrupt,
     .fire_interrupt = stub_fire_interrupt,
+    .free = stub_free,
     .get_info = stub_get_info,
 };
 

--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -43,6 +43,7 @@ extern "C" {
 #define US_TICKER_OVERFLOW_DELTA2   60
 
 #define TICKER_100_TICKS 100
+#define TICKER_500_TICKS 500
 
 #define MAX_FUNC_EXEC_TIME_US 20
 #define DELTA_FUNC_EXEC_TIME_US 5
@@ -420,7 +421,18 @@ void ticker_increment_test(void)
 void ticker_speed_test(void)
 {
     Timer timer;
+#if DEVICE_LPTICKER
+    LowPowerTimer lptimer;
+#endif
     int counter = NUM_OF_CALLS;
+
+    /* Free function will disable the ticker. For time measurement
+     * we need to use other one.
+     */
+#if DEVICE_LPTICKER
+    bool us_ticker_test = (intf == get_us_ticker_data()->interface);
+    Timer * free_timer = us_ticker_test ? &lptimer : &timer;
+#endif
 
     /* ---- Test ticker_read function. ---- */
     timer.reset();
@@ -475,7 +487,69 @@ void ticker_speed_test(void)
     timer.stop();
 
     TEST_ASSERT(timer.read_us() < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
+
+    /* ---- Test free function. ---- */
+#if DEVICE_LPTICKER
+    counter = NUM_OF_CALLS;
+    free_timer->reset();
+    free_timer->start();
+    while (counter--) {
+        intf->free();
+    }
+    free_timer->stop();
+
+    TEST_ASSERT(free_timer->read_us() < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
+#endif
 }
+
+/* Test that ticker_free disables ticker interrupt. */
+void ticker_free_interrupt_test(void)
+{
+    overflow_protect();
+
+    uint32_t cycles_500_ticks = 50;
+    uint32_t reference_ticks_count = 0;
+
+    while(reference_ticks_count < TICKER_500_TICKS) {
+        cycles_500_ticks *= 2;
+        const uint32_t start = intf->read();
+        wait_cycles(cycles_500_ticks);
+        reference_ticks_count = intf->read() - start;
+    }
+
+    intFlag = 0;
+
+    intf->set_interrupt(intf->read() + (TICKER_500_TICKS / 2));
+    intf->free();
+    wait_cycles(cycles_500_ticks);
+    intf->init();
+    TEST_ASSERT_EQUAL(0, intFlag);
+}
+
+/* Test that ticker can be successfully re-initialized after free(). */
+void ticker_init_free_test(void)
+{
+    intf->free();
+    intf->init();
+
+    overflow_protect();
+
+    intFlag = 0;
+
+    const uint32_t tick_count = intf->read();
+
+    intf->set_interrupt(intf->read() + TICKER_INT_VAL);
+
+    while (intf->read() < (tick_count + TICKER_INT_VAL - TICKER_DELTA)) {
+        TEST_ASSERT_EQUAL_INT_MESSAGE(0, intFlag, "Interrupt fired too early");
+    }
+
+    while (intf->read() < (tick_count + TICKER_INT_VAL + TICKER_DELTA)) {
+    }
+
+    TEST_ASSERT_EQUAL(1, intFlag);
+}
+
 
 utest::v1::status_t us_ticker_setup(const Case *const source, const size_t index_of_case)
 {
@@ -551,6 +625,8 @@ Case cases[] = {
     Case("Microsecond ticker overflow test", us_ticker_setup, ticker_overflow_test, us_ticker_teardown),
     Case("Microsecond ticker increment test", us_ticker_setup, ticker_increment_test, us_ticker_teardown),
     Case("Microsecond ticker speed test", us_ticker_setup, ticker_speed_test, us_ticker_teardown),
+    Case("Microsecond ticker free interrupt test", us_ticker_setup, ticker_free_interrupt_test, us_ticker_teardown),
+    Case("Microsecond re-init after free test", us_ticker_setup, ticker_init_free_test, us_ticker_teardown),
 #if DEVICE_LPTICKER
     Case("lp ticker init is safe to call repeatedly", lp_ticker_setup, ticker_init_test, lp_ticker_teardown),
     Case("lp ticker info test", lp_ticker_setup, ticker_info_test, lp_ticker_teardown),
@@ -561,6 +637,8 @@ Case cases[] = {
     Case("lp ticker overflow test", lp_ticker_setup, ticker_overflow_test, lp_ticker_teardown),
     Case("lp ticker increment test", lp_ticker_setup, ticker_increment_test, lp_ticker_teardown),
     Case("lp ticker speed test", lp_ticker_setup, ticker_speed_test, lp_ticker_teardown),
+    Case("lp ticker free interrupt test", lp_ticker_setup, ticker_free_interrupt_test, lp_ticker_teardown),
+    Case("lp ticker re-init after free test", lp_ticker_setup, ticker_init_free_test, lp_ticker_teardown),
 #endif
 };
 

--- a/TESTS/mbed_hal/common_tickers/ticker_api_tests.h
+++ b/TESTS/mbed_hal/common_tickers/ticker_api_tests.h
@@ -118,6 +118,21 @@ void ticker_speed_test(void);
  */
 void ticker_overflow_test(void);
 
+/** Test ticker_free disables ticker interrupt.
+ *
+ * Given ticker is available.
+ * When ticker interrupt is set and then ticker_free is called.
+ * Then ticker interrupt is not triggered.
+ */
+void ticker_free_interrupt_test(void);
+
+/** Test that ticker can be successfully re-initialized after free().
+ *
+ * Given ticker is available.
+ * When ticker has been  re-initialized after free().
+ * Then ticker counts and generates interrupts.
+ */
+void ticker_init_free_test(void);
 /**@}*/
 
 #ifdef __cplusplus

--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -99,6 +99,10 @@ void mock_ticker_fire_interrupt()
 {
 }
 
+void mock_ticker_free()
+{
+}
+
 const ticker_info_t *mock_ticker_get_info()
 {
     static const ticker_info_t mock_ticker_info = {
@@ -115,6 +119,7 @@ ticker_interface_t mock_ticker_interface = {
     .clear_interrupt = mock_ticker_clear_interrupt,
     .set_interrupt = mock_ticker_set_interrupt,
     .fire_interrupt = mock_ticker_fire_interrupt,
+    .free = mock_ticker_free,
     .get_info = mock_ticker_get_info,
 };
 

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -35,6 +35,7 @@ static const ticker_interface_t lp_interface = {
 #endif
     .fire_interrupt = lp_ticker_fire_interrupt,
     .get_info = lp_ticker_get_info,
+    .free = lp_ticker_free,
 };
 
 static const ticker_data_t lp_data = {

--- a/hal/mbed_us_ticker_api.c
+++ b/hal/mbed_us_ticker_api.c
@@ -27,6 +27,7 @@ static const ticker_interface_t us_interface = {
     .set_interrupt = us_ticker_set_interrupt,
     .fire_interrupt = us_ticker_fire_interrupt,
     .get_info = us_ticker_get_info,
+    .free = us_ticker_free,
 };
 
 static const ticker_data_t us_data = {

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -64,6 +64,7 @@ typedef struct {
     void (*clear_interrupt)(void);                /**< Clear interrupt function */
     void (*set_interrupt)(timestamp_t timestamp); /**< Set interrupt function */
     void (*fire_interrupt)(void);                 /**< Fire interrupt right-away */
+    void (*free)(void);                           /**< Disable function */
     const ticker_info_t *(*get_info)(void);       /**< Return info about this ticker's implementation */
 } ticker_interface_t;
 

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -73,6 +73,8 @@ extern "C" {
  * Verified by ::ticker_fire_now_test
  * * The ticker operations ticker_read, ticker_clear_interrupt, ticker_set_interrupt and ticker_fire_interrupt
  * take less than 20us to complete - Verified by ::ticker_speed_test
+ * * The function ticker_free disables the ticker interrupt - ::ticker_free_interrupt_test
+ * * The function ticker_init re-initializes ticker after has been disabled by means of ticker_free - Verified by ::ticker_init_free_test
  *
  * # Undefined behavior
  * * Calling any function other than ticker_init before the initialization of the ticker
@@ -170,6 +172,25 @@ void us_ticker_init(void);
  * except us_ticker_init(), calling any function other than init is undefined.
  *
  * @note This function stops the ticker from counting.
+ *
+ * Pseudo Code:
+ * @code
+ * uint32_t us_ticker_free()
+ * {
+ *     // Disable timer
+ *     TIMER_CTRL &= ~TIMER_CTRL_ENABLE_Msk;
+ *
+ *     // Disable the compare interrupt
+ *     TIMER_CTRL &= ~TIMER_CTRL_COMPARE_ENABLE_Msk;
+ *
+ *     // Disable timer interrupt
+ *     NVIC_DisableIRQ(TIMER_IRQn);
+ *
+ *     // Disable clock gate so processor cannot read TIMER registers
+ *     POWER_CTRL &= ~POWER_CTRL_TIMER_Msk;
+ * }
+ * @endcode
+ *
  */
 void us_ticker_free(void);
 

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/lp_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/lp_ticker.c
@@ -152,4 +152,9 @@ void lp_ticker_clear_interrupt(void)
     DualTimer_ClearInterrupt(DUALTIMER0);
 }
 
+void lp_ticker_free(void)
+{
+
+}
+
 #endif

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/us_ticker.c
@@ -111,3 +111,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     Timer_ClearInterrupt(TIMER0);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/lp_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/lp_ticker.c
@@ -108,6 +108,11 @@ void lp_ticker_fire_interrupt(void)
     cmsdk_ticker_fire_interrupt(&timer_data);
 }
 
+void lp_ticker_free(void)
+{
+
+}
+
 void TIMER1_IRQHandler(void)
 {
     cmsdk_ticker_irq_handler(&timer_data);

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/us_ticker.c
@@ -112,6 +112,11 @@ void us_ticker_fire_interrupt(void)
     cmsdk_ticker_fire_interrupt(&timer_data);
 }
 
+void us_ticker_free(void)
+{
+
+}
+
 void TIMER0_IRQHandler(void)
 {
     cmsdk_ticker_irq_handler(&timer_data);

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/us_ticker.c
@@ -87,3 +87,8 @@ void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER2->TimerIntClr = 0x1;
 
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/us_ticker.c
@@ -81,3 +81,8 @@ void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER2->TimerIntClr = 0x1;
 
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/us_ticker.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/us_ticker.c
@@ -357,7 +357,7 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    adi_tmr_Enable(ADI_TMR_DEVICE_GP2, false);
 }
 
 /*

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/us_ticker.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM302X/TARGET_ADUCM3029/api/us_ticker.c
@@ -355,6 +355,10 @@ void us_ticker_fire_interrupt(void)
     event_timer();                             // enable the timer and interrupt
 }
 
+void us_ticker_free(void)
+{
+
+}
 
 /*
 ** EOF

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
@@ -353,6 +353,10 @@ void us_ticker_fire_interrupt(void)
     event_timer();                             // enable the timer and interrupt
 }
 
+void us_ticker_free(void)
+{
+
+}
 
 /*
 ** EOF

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
@@ -355,7 +355,7 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    adi_tmr_Enable(ADI_TMR_DEVICE_GP2, false);
 }
 
 /*

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/us_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/us_ticker.c
@@ -167,3 +167,8 @@ void us_ticker_clear_interrupt(void)
     tc_clear_interrupt(&us_ticker_module, TC_CALLBACK_CC_CHANNEL0);
     NVIC_ClearPendingIRQ(TICKER_COUNTER_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/lp_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/lp_ticker.c
@@ -131,3 +131,8 @@ void lp_ticker_clear_interrupt(void)
 {
     NVIC_ClearPendingIRQ(TICKER_COUNTER_IRQn2);
 }
+
+void lp_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/us_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/us_ticker.c
@@ -186,3 +186,8 @@ void us_ticker_clear_interrupt(void)
 {
     NVIC_ClearPendingIRQ(TICKER_COUNTER_IRQn1);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/us_ticker.c
@@ -158,3 +158,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT_TICKER_IRQ);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/us_ticker.c
@@ -81,3 +81,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
@@ -223,3 +223,8 @@ void us_ticker_fire_interrupt(void)
 
 #endif
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/us_ticker.c
@@ -139,5 +139,13 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
+    PIT_StopTimer(PIT, kPIT_Chnl_3);
+    PIT_StopTimer(PIT, kPIT_Chnl_2);
+    PIT_StopTimer(PIT, kPIT_Chnl_1);
+    PIT_StopTimer(PIT, kPIT_Chnl_0);
 
+    PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
+    NVIC_DisableIRQ(PIT3_IRQn);
+
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/us_ticker.c
@@ -152,3 +152,8 @@ void us_ticker_fire_interrupt(void)
 
     NVIC_SetPendingIRQ(TPM2_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/us_ticker.c
@@ -152,3 +152,8 @@ void us_ticker_fire_interrupt(void)
 
     NVIC_SetPendingIRQ(TPM2_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/us_ticker.c
@@ -137,3 +137,8 @@ void us_ticker_fire_interrupt(void)
     NVIC_SetPendingIRQ(PIT0_IRQn);
 }
 
+void us_ticker_free(void)
+{
+
+}
+

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/us_ticker.c
@@ -139,5 +139,13 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
+    PIT_StopTimer(PIT, kPIT_Chnl_3);
+    PIT_StopTimer(PIT, kPIT_Chnl_2);
+    PIT_StopTimer(PIT, kPIT_Chnl_1);
+    PIT_StopTimer(PIT, kPIT_Chnl_0);
 
+    PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
+    NVIC_DisableIRQ(PIT3_IRQn);
+
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/us_ticker.c
@@ -152,3 +152,8 @@ void us_ticker_fire_interrupt(void)
 
     NVIC_SetPendingIRQ(TPM2_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/us_ticker.c
@@ -155,5 +155,11 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
+    PIT_StopTimer(PIT, kPIT_Chnl_1);
+    PIT_StopTimer(PIT, kPIT_Chnl_0);
 
+    TPM_DisableInterrupts(TPM2, kTPM_TimeOverflowInterruptEnable);
+    NVIC_DisableIRQ(TPM2_IRQn);
+
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/us_ticker.c
@@ -139,5 +139,13 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
+    PIT_StopTimer(PIT, kPIT_Chnl_3);
+    PIT_StopTimer(PIT, kPIT_Chnl_2);
+    PIT_StopTimer(PIT, kPIT_Chnl_1);
+    PIT_StopTimer(PIT, kPIT_Chnl_0);
 
+    PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
+    NVIC_DisableIRQ(PIT3_IRQn);
+
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
@@ -70,6 +70,7 @@ void us_ticker_init(void)
     PIT_StopTimer(PIT, kPIT_Chnl_2);
     PIT_SetTimerPeriod(PIT, kPIT_Chnl_2, busClock / 1000000 - 1);
     PIT_SetTimerChainMode(PIT, kPIT_Chnl_3, true);
+    PIT_ClearStatusFlags(PIT, kPIT_Chnl_3, PIT_TFLG_TIF_MASK);
     NVIC_SetVector(PIT3_IRQn, (uint32_t) pit_isr);
     NVIC_EnableIRQ(PIT3_IRQn);
     PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
@@ -139,5 +140,13 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
+    PIT_StartTimer(PIT, kPIT_Chnl_3);
+    PIT_StartTimer(PIT, kPIT_Chnl_2);
+    PIT_StartTimer(PIT, kPIT_Chnl_1);
+    PIT_StartTimer(PIT, kPIT_Chnl_0);
 
+    PIT_DisableInterrupts(PIT, kPIT_Chnl_3, kPIT_TimerInterruptEnable);
+    NVIC_DisableIRQ(PIT3_IRQn);
+
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT3_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -117,4 +117,9 @@ void lp_ticker_clear_interrupt(void)
     LPTMR_ClearStatusFlags(LPTMR0, kLPTMR_TimerCompareFlag);
 }
 
+void lp_ticker_free(void)
+{
+
+}
+
 #endif /* DEVICE_LPTICKER */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -69,6 +69,7 @@ void lp_ticker_init(void)
         lp_ticker_inited = true;
     } else {
         LPTMR_DisableInterrupts(LPTMR0, kLPTMR_TimerInterruptEnable);
+        NVIC_EnableIRQ(LPTMR0_IRQn);
     }
 }
 
@@ -119,7 +120,8 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    LPTMR_DisableInterrupts(LPTMR0, kLPTMR_TimerInterruptEnable);
+    NVIC_DisableIRQ(LPTMR0_IRQn);
 }
 
 #endif /* DEVICE_LPTICKER */

--- a/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
@@ -255,3 +255,8 @@ uint32_t lp_ticker_read(void)
 {
     return rtc_read64();
 }
+
+void lp_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Maxim/TARGET_MAX32600/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/us_ticker.c
@@ -268,3 +268,8 @@ void us_ticker_set(timestamp_t timestamp)
         NVIC_SetPendingIRQ(US_TIMER_IRQn);
     }
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Maxim/TARGET_MAX32610/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/rtc_api.c
@@ -252,3 +252,8 @@ inline uint32_t lp_ticker_read(void)
 {
     return rtc_read64();
 }
+
+void lp_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Maxim/TARGET_MAX32610/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/us_ticker.c
@@ -268,3 +268,8 @@ void us_ticker_set(timestamp_t timestamp)
         NVIC_SetPendingIRQ(US_TIMER_IRQn);
     }
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Maxim/TARGET_MAX32620/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/rtc_api.c
@@ -306,3 +306,8 @@ inline uint32_t lp_ticker_read(void)
 {
     return rtc_read64();
 }
+
+void lp_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Maxim/TARGET_MAX32620/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/us_ticker.c
@@ -299,3 +299,8 @@ void us_ticker_set(timestamp_t timestamp)
         NVIC_SetPendingIRQ(US_TIMER_IRQn);
     }
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -318,6 +318,11 @@ void us_ticker_clear_interrupt(void)
     NRF_RTC1->EVENTS_COMPARE[0] = 0;
 }
 
+void us_ticker_free(void)
+{
+
+}
+
 
 #if defined (__CC_ARM)         /* ARMCC Compiler */
 

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/common_rtc.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/common_rtc.c
@@ -180,6 +180,15 @@ void common_rtc_init(void)
     m_common_rtc_enabled = true;
 }
 
+void common_rtc_free()
+{
+    nrf_rtc_task_trigger(COMMON_RTC_INSTANCE, NRF_RTC_TASK_STOP);
+    nrf_rtc_int_disable(COMMON_RTC_INSTANCE, LP_TICKER_INT_MASK);
+    NVIC_DisableIRQ(nrf_drv_get_IRQn(COMMON_RTC_INSTANCE));
+
+    m_common_rtc_enabled = false;
+}
+
 void common_rtc_set_interrupt(uint32_t ticks_count, uint32_t cc_channel,
                               uint32_t int_mask)
 {

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/lp_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/lp_ticker.c
@@ -36,8 +36,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    // A common counter is used for RTC, lp_ticker and us_ticker, so it can't be
-    // disabled here, but this does not cause any extra cost.
+    common_rtc_free();
 }
 
 uint32_t lp_ticker_read()

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/us_ticker.c
@@ -140,8 +140,7 @@ void us_ticker_clear_interrupt(void)
 void us_ticker_free(void)
 {
     nrf_timer_task_trigger(NRF_TIMER1, NRF_TIMER_TASK_STOP);
-
     nrf_timer_int_disable(NRF_TIMER1, nrf_timer_compare_int_get(NRF_TIMER_CC_CHANNEL0));
-
+    NVIC_DisableIRQ(TIMER1_IRQn);
     us_ticker_initialized = false;
 }

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
@@ -65,3 +65,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
@@ -65,3 +65,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/us_ticker.c
@@ -65,3 +65,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC13XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/us_ticker.c
@@ -65,3 +65,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
@@ -86,3 +86,8 @@ void us_ticker_clear_interrupt(void) {
     // Clear SCT3 event 0 interrupt flag
     LPC_SCT3->EVFLAG = (1 << 0);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
@@ -77,3 +77,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/us_ticker.c
@@ -80,5 +80,8 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
+    US_TICKER_TIMER->TCR = 0;
 
+    US_TICKER_TIMER->MCR &= ~1;
+    NVIC_DisableIRQ(US_TICKER_TIMER_IRQn);
 }

--- a/targets/TARGET_NXP/TARGET_LPC408X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/us_ticker.c
@@ -67,3 +67,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
@@ -67,3 +67,8 @@ void us_ticker_disable_interrupt(void) {
 void us_ticker_clear_interrupt(void) {
     US_TICKER_TIMER->IR = 1;
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC81X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/us_ticker.c
@@ -136,3 +136,8 @@ void us_ticker_clear_interrupt() {
         ticker_expired_count_us += ticker_fullcount_us;
     }
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_LPC82X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/us_ticker.c
@@ -109,3 +109,8 @@ void us_ticker_clear_interrupt() {
           ticker_expired_count_us += ticker_fullcount_us;
     }
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/lp_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/lp_ticker.c
@@ -112,4 +112,9 @@ void lp_ticker_clear_interrupt(void)
     GPT_ClearStatusFlags(GPT2, kGPT_OutputCompare1Flag);
 }
 
+void lp_ticker_free(void)
+{
+
+}
+
 #endif /* DEVICE_LPTICKER */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/us_ticker.c
@@ -140,3 +140,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(PIT_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
@@ -97,3 +97,8 @@ void us_ticker_fire_interrupt(void)
 {
     NVIC_SetPendingIRQ(CTIMER1_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/us_ticker.c
@@ -100,5 +100,8 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    CTIMER_StopTimer(CTIMER1);
+    CTIMER1->MCR &= ~1;
+    NVIC_DisableIRQ(CTIMER1_IRQn);
+    us_ticker_inited = false;
 }

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
@@ -203,3 +203,8 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
     // we set the full reminder of 16 bit, the next ISR will do the upper part
     ticker_set(delta & 0xFFFF);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/us_ticker.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/us_ticker.c
@@ -122,5 +122,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    HalTimerOp.HalTimerDis((u32)TimerAdapter.TimerId);
 }

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/us_ticker.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/us_ticker.c
@@ -119,3 +119,8 @@ void us_ticker_disable_interrupt(void)
 void us_ticker_clear_interrupt(void)
 {
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -231,7 +231,7 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }
 
 /*****************************************************************/
@@ -278,12 +278,12 @@ void lp_ticker_disable_interrupt(void)
 
 void lp_ticker_clear_interrupt(void)
 {
-    NVIC_DisableIRQ(RTC_WKUP_IRQn);
+    lp_ticker_disable_interrupt();
 }
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }
 
 #endif /* MBED_CONF_TARGET_LPTICKER_LPTIM */

--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -229,7 +229,10 @@ void lp_ticker_clear_interrupt(void)
     NVIC_ClearPendingIRQ(LPTIM1_IRQn);
 }
 
+void lp_ticker_free(void)
+{
 
+}
 
 /*****************************************************************/
 /* lpticker_lptim config is 0 or not defined in json config file */
@@ -276,6 +279,11 @@ void lp_ticker_disable_interrupt(void)
 void lp_ticker_clear_interrupt(void)
 {
     NVIC_DisableIRQ(RTC_WKUP_IRQn);
+}
+
+void lp_ticker_free(void)
+{
+
 }
 
 #endif /* MBED_CONF_TARGET_LPTICKER_LPTIM */

--- a/targets/TARGET_STM/us_ticker.c
+++ b/targets/TARGET_STM/us_ticker.c
@@ -256,3 +256,9 @@ void restore_timer_ctx(void)
     __HAL_TIM_SET_COMPARE(&TimMasterHandle, TIM_CHANNEL_1, timer_ccr1_reg);
     TIM_MST->DIER = timer_dier_reg;
 }
+
+void us_ticker_free(void)
+{
+
+}
+

--- a/targets/TARGET_STM/us_ticker.c
+++ b/targets/TARGET_STM/us_ticker.c
@@ -206,6 +206,7 @@ void us_ticker_init(void)
 {
     // Timer is already initialized in HAL_InitTick()
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC1);
+    HAL_TIM_OC_Start(&TimMasterHandle, TIM_CHANNEL_1);
 }
 
 uint32_t us_ticker_read()
@@ -259,6 +260,7 @@ void restore_timer_ctx(void)
 
 void us_ticker_free(void)
 {
-
+    HAL_TIM_OC_Stop(&TimMasterHandle, TIM_CHANNEL_1);
+    us_ticker_disable_interrupt();
 }
 

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/us_ticker.c
@@ -107,3 +107,8 @@ void us_ticker_clear_interrupt(void)
 {
     //no flags to clear
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/us_ticker.c
@@ -83,3 +83,8 @@ void us_ticker_clear_interrupt(void)
     TSB_T32A0->STC = T32A_INT_MASK;
     NVIC_ClearPendingIRQ(INTT32A00C_IRQn);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/us_ticker.c
@@ -131,3 +131,8 @@ void us_ticker_clear_interrupt(void)
 {
     // No flag to clear
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
@@ -130,3 +130,8 @@ void us_ticker_clear_interrupt(void)
 {
     DUALTIMER_IntClear(TIMER_0);
 }
+
+void us_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_ublox/TARGET_HI2110/lp_ticker.c
+++ b/targets/TARGET_ublox/TARGET_HI2110/lp_ticker.c
@@ -346,3 +346,8 @@ void lp_ticker_clear_interrupt(void)
     g_user_interrupt_pending = false;
     g_user_interrupt_set = false;
 }
+
+void lp_ticker_free(void)
+{
+
+}

--- a/targets/TARGET_ublox/TARGET_HI2110/us_ticker.c
+++ b/targets/TARGET_ublox/TARGET_HI2110/us_ticker.c
@@ -251,3 +251,8 @@ void us_ticker_clear_interrupt(void)
     g_timer_extra_loops_required = 0;
     g_us_overflow_increment = 0;
 }
+
+void us_ticker_free(void)
+{
+
+}


### PR DESCRIPTION
### Description

This patch fixes ticker `ticker_free()` issue. 

> The ticker HAL API has been well defined (defined/undefined behaviour, potential bugs) in the ticker header files the tests which verifies each requirement have been also created. We had all done.
> But meanwhile lp/us_ticker_free() functions have been added: https://github.com/ARMmbed/mbed-os/pull/5856
> 
> This PR added lp/us_ticker_free() functions to the ticker HAL header files and implementation for only some targets, but did not specify the requirements for these functions (defined/undefined behaviour, potential bugs) as this has been done for other functions.
> As a result we have now ready requirements/tests and function in HAL API which is not verified.


@c1728p9 Can you please take a look at the requirements, tests and example implementation?

### TODO

- [x] Add requirements and pseudo code for HAL ticker_free() function.
- [X] Add ticker_free() function to the ticker interface.
- [X] Add ticker_free() functional tests.
- [X] Add example implementation of `ticker_free()` for one target for verification (`NRF5x` family boards).
- [X] Add/update `ticker_free()` implementation for the remaining boards.

### Pull request type

    [] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

