### PR TITLE
Updating the test to handle Greentea exception

### DIFF
--- a/TESTS/mbedmicro-mbed/call_before_main/main.cpp
+++ b/TESTS/mbedmicro-mbed/call_before_main/main.cpp
@@ -20,7 +20,7 @@ namespace {
 }
 
 extern "C" void mbed_main() {
-    printf("MBED: mbed_main() call before main()\r\n");
+    printf("MBED: mbed_main() call before main()");
     mbed_main_called = true;
 }
 


### PR DESCRIPTION
We are failing this test for certain targets because uart after re-initialization behaves weirdly (see https://github.com/ARMmbed/mbed-os/issues/7511 for further details). Thus, removing newline in the test to avoid re-initialization. This doesnt change the functionality of the test in any way, and we are tracking the issue, so we will revert this change once the issue is fixed.

    [x ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

