### PR TITLE
Fixes for tickless and LPTICKER_DELAY_TICKS

### DIFF
--- a/TESTS/mbed_drivers/sleep_lock/main.cpp
+++ b/TESTS/mbed_drivers/sleep_lock/main.cpp
@@ -29,90 +29,90 @@ using namespace utest::v1;
 
 void deep_sleep_lock_lock_test()
 {
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Check basic usage works
         DeepSleepLock lock;
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Check that unlock and lock change can deep sleep as expected
         DeepSleepLock lock;
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
         lock.unlock();
-        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
         lock.lock();
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Check that unlock releases sleep based on count
         DeepSleepLock lock;
         lock.lock();
         lock.lock();
         lock.unlock();
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Check that unbalanced locks do not leave deep sleep locked
         DeepSleepLock lock;
         lock.lock();
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
     }
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
 
 }
 
 void timer_lock_test()
 {
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Just creating a timer object does not lock sleep
         Timer timer;
-        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Starting a timer does lock sleep
         Timer timer;
         timer.start();
-        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(false, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Stopping a timer after starting it allows sleep
         Timer timer;
         timer.start();
         timer.stop();
-        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     }
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Starting a timer multiple times still lets you sleep
         Timer timer;
         timer.start();
         timer.start();
     }
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
 
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     {
         // Stopping a timer multiple times still lets you sleep
         Timer timer;
         timer.start();
         timer.stop();
         timer.stop();
-        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+        TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
     }
-    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep());
+    TEST_ASSERT_EQUAL(true, sleep_manager_can_deep_sleep_test_check());
 }
 
 Case cases[] = {

--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -263,7 +263,7 @@ void test_sleep(void)
     timer.start();
     timeout.attach_callback(mbed::callback(sem_callback, &sem), delay_us);
 
-    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_FALSE_MESSAGE(deep_sleep_allowed, "Deep sleep should be disallowed");
     while (sem.wait(0) != 1) {
         sleep();
@@ -322,7 +322,7 @@ void test_deepsleep(void)
     timer.start();
     timeout.attach_callback(mbed::callback(sem_callback, &sem), delay_us);
 
-    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
     while (sem.wait(0) != 1) {
         sleep();

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -130,7 +130,7 @@ void lp_ticker_deepsleep_test()
      * tick_count + TICKER_INT_VAL. */
     lp_ticker_set_interrupt(tick_count + TICKER_INT_VAL);
 
-    TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep());
+    TEST_ASSERT_TRUE(sleep_manager_can_deep_sleep_test_check());
 
     while (!intFlag) {
         sleep();

--- a/TESTS/mbed_hal/lp_ticker/main.cpp
+++ b/TESTS/mbed_hal/lp_ticker/main.cpp
@@ -20,6 +20,7 @@
 #include "rtos.h"
 #include "lp_ticker_api_tests.h"
 #include "hal/lp_ticker_api.h"
+#include "hal/mbed_lp_ticker_wrapper.h"
 
 #if !DEVICE_LPTICKER
 #error [NOT_SUPPORTED] Low power timer not supported for this target
@@ -28,6 +29,8 @@
 using namespace utest::v1;
 
 volatile int intFlag = 0;
+
+ticker_irq_handler_type prev_handler;
 
 #define US_PER_MS 1000
 
@@ -113,8 +116,6 @@ void lp_ticker_deepsleep_test()
 {
     intFlag = 0;
 
-    set_lp_ticker_irq_handler(ticker_event_handler_stub);
-
     lp_ticker_init();
 
     /* Give some time Green Tea to finish UART transmission before entering
@@ -157,6 +158,32 @@ void lp_ticker_glitch_test()
     }
 }
 
+#if DEVICE_LPTICKER
+utest::v1::status_t lp_ticker_deepsleep_test_setup_handler(const Case *const source, const size_t index_of_case)
+{
+    /* disable everything using the lp ticker for this test */
+    osKernelSuspend();
+    ticker_suspend(get_lp_ticker_data());
+#if DEVICE_LPTICKER && (LPTICKER_DELAY_TICKS > 0)
+    lp_ticker_wrapper_suspend();
+#endif
+    prev_handler = set_lp_ticker_irq_handler(ticker_event_handler_stub);
+    return greentea_case_setup_handler(source, index_of_case);
+}
+
+utest::v1::status_t lp_ticker_deepsleep_test_teardown_handler(const Case *const source, const size_t passed, const size_t failed,
+                                                              const failure_t reason)
+{
+    set_lp_ticker_irq_handler(prev_handler);
+#if DEVICE_LPTICKER && (LPTICKER_DELAY_TICKS > 0)
+    lp_ticker_wrapper_resume();
+#endif
+    ticker_resume(get_lp_ticker_data());
+    osKernelResume(0);
+    return greentea_case_teardown_handler(source, passed, failed, reason);
+}
+#endif
+
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
     GREENTEA_SETUP(20, "default_auto");
@@ -166,7 +193,7 @@ utest::v1::status_t test_setup(const size_t number_of_cases)
 Case cases[] = {
     Case("lp ticker info test", lp_ticker_info_test),
 #if DEVICE_SLEEP
-    Case("lp ticker sleep test", lp_ticker_deepsleep_test),
+    Case("lp ticker sleep test", lp_ticker_deepsleep_test_setup_handler, lp_ticker_deepsleep_test, lp_ticker_deepsleep_test_teardown_handler),
 #endif
     Case("lp ticker glitch test", lp_ticker_glitch_test)
 };

--- a/TESTS/mbed_hal/rtc/main.cpp
+++ b/TESTS/mbed_hal/rtc/main.cpp
@@ -74,7 +74,7 @@ void rtc_sleep_test_support(bool deepsleep_mode)
 
     timeout.attach(callback, DELAY_4S);
 
-    TEST_ASSERT(sleep_manager_can_deep_sleep() == deepsleep_mode);
+    TEST_ASSERT(sleep_manager_can_deep_sleep_test_check() == deepsleep_mode);
 
     while (!expired) {
         sleep();

--- a/TESTS/mbed_hal/sleep_manager/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager/main.cpp
@@ -25,15 +25,15 @@ using namespace utest::v1;
 
 void sleep_manager_deepsleep_counter_test()
 {
-    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE(deep_sleep_allowed);
 
     sleep_manager_lock_deep_sleep();
-    deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_FALSE(deep_sleep_allowed);
 
     sleep_manager_unlock_deep_sleep();
-    deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE(deep_sleep_allowed);
 }
 

--- a/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -55,7 +55,7 @@ void sleep_manager_multithread_test()
         t2.join();
     }
 
-    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
 }
 
@@ -83,7 +83,7 @@ void sleep_manager_irq_test()
         timer.stop();
     }
 
-    bool deep_sleep_allowed = sleep_manager_can_deep_sleep();
+    bool deep_sleep_allowed = sleep_manager_can_deep_sleep_test_check();
     TEST_ASSERT_TRUE_MESSAGE(deep_sleep_allowed, "Deep sleep should be allowed");
 }
 

--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -313,7 +313,7 @@ void test_deepsleep(void)
 
     lptimer.start();
     st.schedule_tick(TEST_TICKS);
-    TEST_ASSERT_TRUE_MESSAGE(sleep_manager_can_deep_sleep(), "Deep sleep should be allowed");
+    TEST_ASSERT_TRUE_MESSAGE(sleep_manager_can_deep_sleep_test_check(), "Deep sleep should be allowed");
     while (st.sem_wait(0) != 1) {
         sleep();
     }

--- a/hal/LowPowerTickerWrapper.cpp
+++ b/hal/LowPowerTickerWrapper.cpp
@@ -1,0 +1,290 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "hal/LowPowerTickerWrapper.h"
+#include "platform/Callback.h"
+
+LowPowerTickerWrapper::LowPowerTickerWrapper(const ticker_data_t *data, const ticker_interface_t *interface, uint32_t min_cycles_between_writes, uint32_t min_cycles_until_match)
+    : _intf(data->interface), _min_count_between_writes(min_cycles_between_writes + 1), _min_count_until_match(min_cycles_until_match + 1), _suspended(false)
+{
+    core_util_critical_section_enter();
+
+    this->data.interface = interface;
+    this->data.queue = data->queue;
+    _reset();
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::irq_handler(ticker_irq_handler_type handler)
+{
+    core_util_critical_section_enter();
+
+    if (_suspended) {
+        if (handler) {
+            handler(&data);
+        }
+        core_util_critical_section_exit();
+        return;
+    }
+
+    if (_pending_fire_now || _match_check(_intf->read())) {
+        _timeout.detach();
+        _pending_timeout = false;
+        _pending_match = false;
+        _pending_fire_now = false;
+        if (handler) {
+            handler(&data);
+        }
+    } else {
+        // Spurious interrupt
+        _intf->clear_interrupt();
+    }
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::suspend()
+{
+    core_util_critical_section_enter();
+
+    // Wait until rescheduling is allowed
+    while (!_set_interrupt_allowed) {
+        timestamp_t current = _intf->read();
+        if (((current - _last_actual_set_interrupt) & _mask) >= _min_count_between_writes) {
+            _set_interrupt_allowed  = true;
+        }
+    }
+
+    _reset();
+    _suspended = true;
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::resume()
+{
+    core_util_critical_section_enter();
+
+    _suspended = false;
+
+    core_util_critical_section_exit();
+}
+
+bool LowPowerTickerWrapper::timeout_pending()
+{
+    core_util_critical_section_enter();
+
+    bool pending = _pending_timeout;
+
+    core_util_critical_section_exit();
+    return pending;
+}
+
+void LowPowerTickerWrapper::init()
+{
+    core_util_critical_section_enter();
+
+    _reset();
+    _intf->init();
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::free()
+{
+    core_util_critical_section_enter();
+
+    _reset();
+    _intf->free();
+
+    core_util_critical_section_exit();
+}
+
+uint32_t LowPowerTickerWrapper::read()
+{
+    core_util_critical_section_enter();
+
+    timestamp_t current = _intf->read();
+    if (_match_check(current)) {
+        _intf->fire_interrupt();
+    }
+
+    core_util_critical_section_exit();
+    return current;
+}
+
+void LowPowerTickerWrapper::set_interrupt(timestamp_t timestamp)
+{
+    core_util_critical_section_enter();
+
+    _last_set_interrupt = _intf->read();
+    _cur_match_time = timestamp;
+    _pending_match = true;
+    _schedule_match(_last_set_interrupt);
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::disable_interrupt()
+{
+    core_util_critical_section_enter();
+
+    _intf->disable_interrupt();
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::clear_interrupt()
+{
+    core_util_critical_section_enter();
+
+    _intf->clear_interrupt();
+
+    core_util_critical_section_exit();
+}
+
+void LowPowerTickerWrapper::fire_interrupt()
+{
+    core_util_critical_section_enter();
+
+    _pending_fire_now = 1;
+    _intf->fire_interrupt();
+
+    core_util_critical_section_exit();
+}
+
+const ticker_info_t *LowPowerTickerWrapper::get_info()
+{
+
+    core_util_critical_section_enter();
+
+    const ticker_info_t *info = _intf->get_info();
+
+    core_util_critical_section_exit();
+    return info;
+}
+
+void LowPowerTickerWrapper::_reset()
+{
+    MBED_ASSERT(core_util_in_critical_section());
+
+    _timeout.detach();
+    _pending_timeout = false;
+    _pending_match = false;
+    _pending_fire_now = false;
+    _set_interrupt_allowed = true;
+    _cur_match_time = 0;
+    _last_set_interrupt = 0;
+    _last_actual_set_interrupt = 0;
+
+    const ticker_info_t *info = _intf->get_info();
+    if (info->bits >= 32) {
+        _mask = 0xffffffff;
+    } else {
+        _mask = ((uint64_t)1 << info->bits) - 1;
+    }
+
+    // Round us_per_tick up
+    _us_per_tick = (1000000 + info->frequency - 1) / info->frequency;
+}
+
+void LowPowerTickerWrapper::_timeout_handler()
+{
+    core_util_critical_section_enter();
+    _pending_timeout = false;
+
+    timestamp_t current = _intf->read();
+    if (_ticker_match_interval_passed(_last_set_interrupt, current, _cur_match_time)) {
+        _intf->fire_interrupt();
+    } else {
+        _schedule_match(current);
+    }
+
+    core_util_critical_section_exit();
+}
+
+bool LowPowerTickerWrapper::_match_check(timestamp_t current)
+{
+    MBED_ASSERT(core_util_in_critical_section());
+
+    if (!_pending_match) {
+        return false;
+    }
+    return _ticker_match_interval_passed(_last_set_interrupt, current, _cur_match_time);
+}
+
+uint32_t LowPowerTickerWrapper::_lp_ticks_to_us(uint32_t ticks)
+{
+    MBED_ASSERT(core_util_in_critical_section());
+
+    // Add 4 microseconds to round up the micro second ticker time (which has a frequency of at least 250KHz - 4us period)
+    return _us_per_tick * ticks + 4;
+}
+
+void LowPowerTickerWrapper::_schedule_match(timestamp_t current)
+{
+    MBED_ASSERT(core_util_in_critical_section());
+
+    // Check if _intf->set_interrupt is allowed
+    if (!_set_interrupt_allowed) {
+        if (((current - _last_actual_set_interrupt) & _mask) >= _min_count_between_writes) {
+            _set_interrupt_allowed  = true;
+        }
+    }
+
+    uint32_t cycles_until_match = (_cur_match_time - _last_set_interrupt) & _mask;
+    bool too_close = cycles_until_match < _min_count_until_match;
+
+    if (!_set_interrupt_allowed) {
+
+        // Can't use _intf->set_interrupt so use microsecond Timeout instead
+        uint32_t ticks = cycles_until_match < _min_count_until_match ? cycles_until_match : _min_count_until_match;
+        _timeout.attach_us(mbed::callback(this, &LowPowerTickerWrapper::_timeout_handler), _lp_ticks_to_us(ticks));
+        _pending_timeout = true;
+        return;
+    }
+
+    if (!too_close) {
+
+        // Schedule LP ticker
+        _intf->set_interrupt(_cur_match_time);
+        current = _intf->read();
+        _last_actual_set_interrupt = current;
+        _set_interrupt_allowed  = false;
+
+        // Check for overflow
+        uint32_t new_cycles_until_match = (_cur_match_time - current) & _mask;
+        if (new_cycles_until_match > cycles_until_match) {
+            // Overflow so fire now
+            _intf->fire_interrupt();
+            return;
+        }
+
+        // Update variables with new time
+        cycles_until_match = new_cycles_until_match;
+        too_close = cycles_until_match < _min_count_until_match;
+    }
+
+    if (too_close) {
+
+        // Low power ticker incremented to less than _min_count_until_match
+        // so low power ticker may not fire. Use Timeout to ensure it does fire.
+        uint32_t ticks = cycles_until_match < _min_count_until_match ? cycles_until_match : _min_count_until_match;
+        _timeout.attach_us(mbed::callback(this, &LowPowerTickerWrapper::_timeout_handler), _lp_ticks_to_us(ticks));
+        _pending_timeout = true;
+        return;
+    }
+}

--- a/hal/LowPowerTickerWrapper.cpp
+++ b/hal/LowPowerTickerWrapper.cpp
@@ -251,9 +251,14 @@ void LowPowerTickerWrapper::_schedule_match(timestamp_t current)
     if (!_set_interrupt_allowed) {
 
         // Can't use _intf->set_interrupt so use microsecond Timeout instead
-        uint32_t ticks = cycles_until_match < _min_count_until_match ? cycles_until_match : _min_count_until_match;
-        _timeout.attach_us(mbed::callback(this, &LowPowerTickerWrapper::_timeout_handler), _lp_ticks_to_us(ticks));
-        _pending_timeout = true;
+
+        // Speed optimization - if a timer has already been scheduled
+        // then don't schedule it again.
+        if (!_pending_timeout) {
+            uint32_t ticks = cycles_until_match < _min_count_until_match ? cycles_until_match : _min_count_until_match;
+            _timeout.attach_us(mbed::callback(this, &LowPowerTickerWrapper::_timeout_handler), _lp_ticks_to_us(ticks));
+            _pending_timeout = true;
+        }
         return;
     }
 

--- a/hal/LowPowerTickerWrapper.h
+++ b/hal/LowPowerTickerWrapper.h
@@ -1,0 +1,239 @@
+
+/** \addtogroup hal */
+/** @{*/
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_LOW_POWER_TICKER_WRAPPER_H
+#define MBED_LOW_POWER_TICKER_WRAPPER_H
+
+#include "device.h"
+
+#include "hal/ticker_api.h"
+#include "hal/us_ticker_api.h"
+#include "drivers/Timeout.h"
+
+
+class LowPowerTickerWrapper {
+public:
+
+
+    /**
+     * Create a new wrapped low power ticker object
+     *
+     * @param data Low power ticker data to wrap
+     * @param interface new ticker interface functions
+     * @param min_cycles_between_writes The number of whole low power clock periods
+     * which must complete before subsequent calls to set_interrupt
+     * @param min_cycles_until_match The minimum number of whole low power clock periods
+     * from the current time for which the match timestamp passed to set_interrupt is
+     * guaranteed to fire.
+     *
+     *  N = min_cycles_between_writes
+     *
+     *       0       1             N - 1     N     N + 1   N + 2   N + 3
+     *       |-------|------...------|-------|-------|-------|-------|
+     *           ^                                    ^
+     *           |                                    |
+     *       set_interrupt                   Next set_interrupt allowed
+     *
+     * N = min_cycles_until_match
+     *
+     *      0       1             N - 1     N     N + 1   N + 2   N + 3
+     *      |-------|------...------|-------|-------|-------|-------|
+     *          ^                                   ^
+     *          |                                   |
+     *      set_interrupt              Earliest match timestamp allowed
+     *
+     *
+     */
+
+    LowPowerTickerWrapper(const ticker_data_t *data, const ticker_interface_t *interface, uint32_t min_cycles_between_writes, uint32_t min_cycles_until_match);
+
+    /**
+     * Interrupt handler called by the underlying driver/hardware
+     *
+     * @param handler The callback which would normally be called by the underlying driver/hardware
+     */
+    void irq_handler(ticker_irq_handler_type handler);
+
+    /**
+     * Suspend wrapper operation and pass through interrupts.
+     *
+     * This stops to wrapper layer from using the microsecond ticker.
+     * This should be called before using the low power ticker APIs directly.
+     */
+    void suspend();
+
+    /**
+     * Resume wrapper operation and filter interrupts normally
+     */
+    void resume();
+
+    /**
+     * Check if a Timeout object is being used
+     *
+     * @return true if Timeout is used for scheduling false otherwise
+     */
+    bool timeout_pending();
+
+    /*
+     * Implementation of ticker_init
+     */
+    void init();
+
+    /*
+     * Implementation of free
+     */
+    void free();
+
+    /*
+     * Implementation of read
+     */
+    uint32_t read();
+
+    /*
+     * Implementation of set_interrupt
+     */
+    void set_interrupt(timestamp_t timestamp);
+
+    /*
+     * Implementation of disable_interrupt
+     */
+    void disable_interrupt();
+
+    /*
+     * Implementation of clear_interrupt
+     */
+    void clear_interrupt();
+
+    /*
+     * Implementation of fire_interrupt
+     */
+    void fire_interrupt();
+
+    /*
+     * Implementation of get_info
+     */
+    const ticker_info_t *get_info();
+
+    ticker_data_t data;
+
+private:
+    mbed::Timeout _timeout;
+    const ticker_interface_t *const _intf;
+
+    /*
+     * The number of low power clock cycles which must pass between subsequent
+     * calls to intf->set_interrupt
+     */
+    const uint32_t _min_count_between_writes;
+
+    /*
+     * The minimum number of low power clock cycles in the future that
+     * a match value can be set to and still fire
+     */
+    const uint32_t _min_count_until_match;
+
+    /*
+     * Flag to indicate if the timer is suspended
+     */
+    bool _suspended;
+
+    /*
+     * _cur_match_time is valid and Timeout is scheduled to fire
+     */
+    bool _pending_timeout;
+
+    /*
+     * set_interrupt has been called and _cur_match_time is valid
+     */
+    bool _pending_match;
+
+    /*
+     * The function LowPowerTickerWrapper::fire_interrupt has been called
+     * and an interrupt is expected.
+     */
+    bool _pending_fire_now;
+
+    /*
+     * It is safe to call intf->set_interrupt
+     */
+    bool _set_interrupt_allowed;
+
+    /*
+     * Last value written by LowPowerTickerWrapper::set_interrupt
+     */
+    timestamp_t _cur_match_time;
+
+    /*
+     * Time of last call to LowPowerTickerWrapper::set_interrupt
+     */
+    uint32_t _last_set_interrupt;
+
+    /*
+     * Time of last call to intf->set_interrupt
+     */
+    uint32_t _last_actual_set_interrupt;
+
+    /*
+     * Mask of valid bits from intf->read()
+     */
+    uint32_t _mask;
+
+    /*
+     * Microsecond per low power tick (rounded up)
+     */
+    uint32_t _us_per_tick;
+
+
+    void _reset();
+
+    /**
+     * Set the low power ticker match time when hardware is ready
+     *
+     * This event is scheduled to set the lp timer after the previous write
+     * has taken effect and it is safe to write a new value without blocking.
+     * If the time has already passed then this function fires and interrupt
+     * immediately.
+     */
+    void _timeout_handler();
+
+    /*
+     * Check match time has passed
+     */
+    bool _match_check(timestamp_t current);
+
+    /*
+     * Convert low power ticks to approximate microseconds
+     *
+     * This value is always larger or equal to exact value.
+     */
+    uint32_t _lp_ticks_to_us(uint32_t);
+
+    /*
+     * Schedule a match interrupt to fire at the correct time
+     *
+     * @param current The current low power ticker time
+     */
+    void _schedule_match(timestamp_t current);
+
+};
+
+#endif
+
+/** @}*/
+
+

--- a/hal/mbed_lp_ticker_api.c
+++ b/hal/mbed_lp_ticker_api.c
@@ -14,10 +14,9 @@
  * limitations under the License.
  */
 #include "hal/lp_ticker_api.h"
+#include "hal/mbed_lp_ticker_wrapper.h"
 
 #if DEVICE_LPTICKER
-
-void lp_ticker_set_interrupt_wrapper(timestamp_t timestamp);
 
 static ticker_event_queue_t events = { 0 };
 
@@ -28,11 +27,7 @@ static const ticker_interface_t lp_interface = {
     .read = lp_ticker_read,
     .disable_interrupt = lp_ticker_disable_interrupt,
     .clear_interrupt = lp_ticker_clear_interrupt,
-#if LPTICKER_DELAY_TICKS > 0
-    .set_interrupt = lp_ticker_set_interrupt_wrapper,
-#else
     .set_interrupt = lp_ticker_set_interrupt,
-#endif
     .fire_interrupt = lp_ticker_fire_interrupt,
     .get_info = lp_ticker_get_info,
     .free = lp_ticker_free,
@@ -45,7 +40,11 @@ static const ticker_data_t lp_data = {
 
 const ticker_data_t *get_lp_ticker_data(void)
 {
+#if LPTICKER_DELAY_TICKS > 0
+    return get_lp_ticker_wrapper_data(&lp_data);
+#else
     return &lp_data;
+#endif
 }
 
 ticker_irq_handler_type set_lp_ticker_irq_handler(ticker_irq_handler_type ticker_irq_handler)
@@ -59,9 +58,13 @@ ticker_irq_handler_type set_lp_ticker_irq_handler(ticker_irq_handler_type ticker
 
 void lp_ticker_irq_handler(void)
 {
+#if LPTICKER_DELAY_TICKS > 0
+    lp_ticker_wrapper_irq_handler(irq_handler);
+#else
     if (irq_handler) {
         irq_handler(&lp_data);
     }
+#endif
 }
 
 #endif

--- a/hal/mbed_lp_ticker_wrapper.h
+++ b/hal/mbed_lp_ticker_wrapper.h
@@ -1,0 +1,78 @@
+
+/** \addtogroup hal */
+/** @{*/
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_LP_TICKER_WRAPPER_H
+#define MBED_LP_TICKER_WRAPPER_H
+
+#include "device.h"
+
+#if DEVICE_LPTICKER
+
+#include "hal/ticker_api.h"
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*ticker_irq_handler_type)(const ticker_data_t *const);
+
+/**
+ * Interrupt handler for the wrapped lp ticker
+ *
+ * @param handler the function which would normally be called by the
+ *      lp ticker handler when it is not wrapped
+ */
+void lp_ticker_wrapper_irq_handler(ticker_irq_handler_type handler);
+
+/**
+ * Get wrapped lp ticker data
+ *
+ * @param data hardware low power ticker object
+ * @return wrapped low power ticker object
+ */
+const ticker_data_t *get_lp_ticker_wrapper_data(const ticker_data_t *data);
+
+/**
+ * Suspend the wrapper layer code
+ *
+ * Pass through all interrupts to the low power ticker and stop using
+ * the microsecond ticker.
+ */
+void lp_ticker_wrapper_suspend(void);
+
+/**
+ * Resume the wrapper layer code
+ *
+ * Resume operation of the wrapper layer. Interrupts will be filtered
+ * as normal and the microsecond timer will be used for interrupts scheduled
+ * too quickly back-to-back.
+ */
+void lp_ticker_wrapper_resume(void);
+
+/**@}*/
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+
+#endif
+
+/** @}*/

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -21,6 +21,7 @@
 #include "mbed_error.h"
 #include "mbed_debug.h"
 #include "mbed_stats.h"
+#include "us_ticker_api.h"
 #include "lp_ticker_api.h"
 #include <limits.h>
 #include <stdio.h>
@@ -181,6 +182,19 @@ void sleep_manager_unlock_deep_sleep_internal(void)
 bool sleep_manager_can_deep_sleep(void)
 {
     return deep_sleep_lock == 0 ? true : false;
+}
+
+bool sleep_manager_can_deep_sleep_test_check()
+{
+    const uint32_t check_time_us = 2000;
+    const ticker_data_t *const ticker = get_us_ticker_data();
+    uint32_t start = ticker_read(ticker);
+    while ((ticker_read(ticker) - start) < check_time_us) {
+        if (sleep_manager_can_deep_sleep()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void sleep_manager_sleep_auto(void)

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -32,6 +32,9 @@ static void initialize(const ticker_data_t *ticker)
     if (ticker->queue->initialized) {
         return;
     }
+    if (ticker->queue->suspended) {
+        return;
+    }
 
     ticker->interface->init();
 
@@ -70,6 +73,7 @@ static void initialize(const ticker_data_t *ticker)
     ticker->queue->max_delta_us = max_delta_us;
     ticker->queue->present_time = 0;
     ticker->queue->dispatching = false;
+    ticker->queue->suspended = false;
     ticker->queue->initialized = true;
 
     update_present_time(ticker);
@@ -121,6 +125,9 @@ static us_timestamp_t convert_timestamp(us_timestamp_t ref, timestamp_t timestam
 static void update_present_time(const ticker_data_t *const ticker)
 {
     ticker_event_queue_t *queue = ticker->queue;
+    if (queue->suspended) {
+        return;
+    }
     uint32_t ticker_time = ticker->interface->read();
     if (ticker_time == ticker->queue->tick_last_read) {
         // No work to do
@@ -230,7 +237,7 @@ int _ticker_match_interval_passed(timestamp_t prev_tick, timestamp_t cur_tick, t
 static void schedule_interrupt(const ticker_data_t *const ticker)
 {
     ticker_event_queue_t *queue = ticker->queue;
-    if (ticker->queue->dispatching) {
+    if (queue->suspended || ticker->queue->dispatching) {
         // Don't schedule the next interrupt until dispatching is
         // finished. This prevents repeated calls to interface->set_interrupt
         return;
@@ -285,6 +292,10 @@ void ticker_irq_handler(const ticker_data_t *const ticker)
     core_util_critical_section_enter();
 
     ticker->interface->clear_interrupt();
+    if (ticker->queue->suspended) {
+        core_util_critical_section_exit();
+        return;
+    }
 
     /* Go through all the pending TimerEvents */
     ticker->queue->dispatching = true;
@@ -429,4 +440,30 @@ int ticker_get_next_timestamp(const ticker_data_t *const data, timestamp_t *time
     core_util_critical_section_exit();
 
     return ret;
+}
+
+void ticker_suspend(const ticker_data_t *const ticker)
+{
+    core_util_critical_section_enter();
+
+    ticker->queue->suspended = true;
+
+    core_util_critical_section_exit();
+}
+
+void ticker_resume(const ticker_data_t *const ticker)
+{
+    core_util_critical_section_enter();
+
+    ticker->queue->suspended = false;
+    if (ticker->queue->initialized) {
+        ticker->queue->tick_last_read = ticker->interface->read();
+
+        update_present_time(ticker);
+        schedule_interrupt(ticker);
+    } else {
+        initialize(ticker);
+    }
+
+    core_util_critical_section_exit();
 }

--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -82,6 +82,7 @@ typedef struct {
     us_timestamp_t present_time;        /**< Store the timestamp used for present time */
     bool initialized;                   /**< Indicate if the instance is initialized */
     bool dispatching;                   /**< The function ticker_irq_handler is dispatching */
+    bool suspended;                     /**< Indicate if the instance is suspended */
     uint8_t frequency_shifts;           /**< If frequency is a value of 2^n, this is n, otherwise 0 */
 } ticker_event_queue_t;
 
@@ -183,6 +184,27 @@ us_timestamp_t ticker_read_us(const ticker_data_t *const ticker);
  * @return 1 if timestamp is pending event, 0 if there's no event pending
  */
 int ticker_get_next_timestamp(const ticker_data_t *const ticker, timestamp_t *timestamp);
+
+/** Suspend this ticker
+ *
+ * When suspended reads will always return the same time and no
+ * events will be dispatched. When suspended the common layer
+ * will only ever call the interface function clear_interrupt()
+ * and that is only if ticker_irq_handler is called.
+ *
+ *
+ * @param ticker        The ticker object.
+ */
+void ticker_suspend(const ticker_data_t *const ticker);
+
+/** Resume this ticker
+ *
+ * When resumed the ticker will ignore any time that has passed
+ * and continue counting up where it left off.
+ *
+ * @param ticker        The ticker object.
+ */
+void ticker_resume(const ticker_data_t *const ticker);
 
 /* Private functions
  *

--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -122,6 +122,17 @@ void sleep_manager_unlock_deep_sleep_internal(void);
  */
 bool sleep_manager_can_deep_sleep(void);
 
+/** Check if the target can deep sleep within a period of time
+ *
+ * This function in intended for use in testing. The amount
+ * of time this functions waits for deeps sleep to be available
+ * is currently 2ms. This may change in the future depending
+ * on testing requirements.
+ *
+ * @return true if a target can go to deepsleep, false otherwise
+ */
+bool sleep_manager_can_deep_sleep_test_check(void);
+
 /** Enter auto selected sleep mode. It chooses the sleep or deeepsleep modes based
  *  on the deepsleep locking counter
  *


### PR DESCRIPTION
### Description

This PR fixes problems that occur when both tickless and LPTICKER_DELAY_TICKS are turned on. The two primary problems are:
1. Tests which use the microsecond ticker directly interfere with the lp ticker wrapper
2. The Timeout object used by the lp ticker wrapper locks deep sleep at various times causing tests which assert that deep sleep is allowed to fail

The tests susceptible to problem 1 are:
- mbed_hal/common_tickers
- mbed_hal/sleep

The tests susceptible to problem 2 are:
- mbed_drivers/sleep_lock
- mbed_drivers/timeout
- mbed_hal/lp_ticker
- mbed_hal/rtc
- mbed_hal/sleep
- mbed_hal/sleep_manager
- mbed_hal/sleep_manager_racecondition

This PR fixes the problems mentioned above. Unfortunately, there are still additional problems which need to be addressed. Further fixes require:
- Common ticker handling should be suspended before calling us/lp ticker directly. This is important for the below test, but is not currently causing failures.
  - mbed_hal/common_tickers
  - mbed_hal/common_tickers_freq
  - mbed_hal/lp_ticker
  - mbed_hal/sleep
- The Serial driver must unlock deep sleep only after all bytes have been sent to prevent bytes from being dropped by entering deep sleep. This requires a HAL extension. I am seeing test failures due to this on the NUCLEO_F401RE when tickless is enabled.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

