### PR TITLE
Feature FAT Filesystem Configuration

### DIFF
--- a/features/filesystem/fat/ChaN/ff.h
+++ b/features/filesystem/fat/ChaN/ff.h
@@ -93,9 +93,7 @@ typedef struct {
 	WORD	id;				/* Volume mount ID */
 	WORD	n_rootdir;		/* Number of root directory entries (FAT12/16) */
 	WORD	csize;			/* Cluster size [sectors] */
-#if FF_MAX_SS != FF_MIN_SS
 	WORD	ssize;			/* Sector size (512, 1024, 2048 or 4096) */
-#endif
 #if FF_USE_LFN
 	WCHAR*	lfnbuf;			/* LFN working buffer */
 #endif

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -219,7 +219,7 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		1
+#define FF_FS_TINY		MBED_FAT_FS_TINY
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
@@ -232,7 +232,7 @@
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
 
-#define FF_FS_HEAPBUF   1
+#define FF_FS_HEAPBUF   MBED_FAT_FS_HEAPBUF
 /* This option enables the use of the heap for allocating buffers. Otherwise
 /  _MAX_SS sized buffers are allocated statically in relevant structures (in
 /  FATFS if _FS_TINY, otherwise in FATFS and FIL)
@@ -265,8 +265,7 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-
-#define FF_FS_REENTRANT	0
+#define FF_FS_REENTRANT	MBED_FAT_FS_REENTRANT
 #define FF_FS_TIMEOUT	1000
 #define FF_SYNC_t		HANDLE
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -99,7 +99,7 @@
 */
 
 
-#define FF_USE_LFN		3
+#define FF_USE_LFN		MBED_FAT_FS_LFN_HANDLING
 #define FF_MAX_LFN		255
 /* The FF_USE_LFN switches the support for LFN (long file name).
 /

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -186,8 +186,8 @@
 /  funciton will be available. */
 
 
-#define FF_MIN_SS		512
-#define FF_MAX_SS		4096
+#define FF_MIN_SS		MBED_FAT_FS_MIN_SS
+#define FF_MAX_SS		MBED_FAT_FS_MAX_SS
 /* This set of options configures the range of sector size to be supported. (512,
 /  1024, 2048 or 4096) Always set both 512 for most systems, generic memory card and
 /  harddisk. But a larger value may be required for on-board flash memory and some

--- a/features/filesystem/fat/ChaN/ffconf.h
+++ b/features/filesystem/fat/ChaN/ffconf.h
@@ -265,7 +265,7 @@
 /      can be opened simultaneously under file lock control. Note that the file
 /      lock control is independent of re-entrancy. */
 
-#define FF_FS_REENTRANT	MBED_FAT_FS_REENTRANT
+#define FF_FS_REENTRANT	0
 #define FF_FS_TIMEOUT	1000
 #define FF_SYNC_t		HANDLE
 /* The option FF_FS_REENTRANT switches the re-entrancy (thread safe) of the FatFs

--- a/features/filesystem/fat/mbed_lib.json
+++ b/features/filesystem/fat/mbed_lib.json
@@ -15,6 +15,17 @@
         "macro_name": "MBED_FAT_FS_LFN_HANDLING",
         "value": 3,
         "help": "Set how the FAT Filesystem manages memory used for handling long file names.\n0: No long file name support\n1:BSS allocated long file name buffer memory (not thread safe)\n2:Stack based long file name memory buffer\n3:Heap based long file name buffer"
+    },
+    "minimum_sector_size": {
+        "macro_name": "MBED_FAT_FS_MIN_SS",
+        "value": 512,
+        "help": "Set the minimum sector size to be supported by the FAT filesystem. This has an effect on the memory footprint of an allocated file handle if TINY_FS is set to false."
+    },
+    "maximum_sector_size": {
+        "macro_name": "MBED_FAT_FS_MAX_SS",
+        "value": 4096,
+        "help": "Set the maximum sector size to be supported by the FAT filesystem. This has an effect on the memory footprint of an allocated file handle if TINY_FS is set to false."
     }
+
   }
 }

--- a/features/filesystem/fat/mbed_lib.json
+++ b/features/filesystem/fat/mbed_lib.json
@@ -1,11 +1,6 @@
 {
   "name": "fat",
   "config": {
-    "reentrant": {
-        "macro_name": "MBED_FAT_FS_REENTRANT",
-        "value": 0,
-        "help": "Turn on the reentrancy feature of the FAT Filesystem. This allows concurrent writes to the SD card in threaded applications"
-    },
     "tiny": {
         "macro_name": "MBED_FAT_FS_TINY",
         "value": 1,

--- a/features/filesystem/fat/mbed_lib.json
+++ b/features/filesystem/fat/mbed_lib.json
@@ -15,6 +15,11 @@
         "macro_name": "MBED_FAT_FS_HEAPBUF",
         "value": 1,
         "help": "Allow the FAT Filesystem to use the heap for allocating buffers. Turn this off and define your own memory to prevent any dynamic memory allocation by the library"
+    },
+    "long_file_name_handling": {
+        "macro_name": "MBED_FAT_FS_LFN_HANDLING",
+        "value": 3,
+        "help": "Set how the FAT Filesystem manages memory used for handling long file names.\n0: No long file name support\n1:BSS allocated long file name buffer memory (not thread safe)\n2:Stack based long file name memory buffer\n3:Heap based long file name buffer"
     }
   }
 }

--- a/features/filesystem/fat/mbed_lib.json
+++ b/features/filesystem/fat/mbed_lib.json
@@ -1,0 +1,20 @@
+{
+  "name": "fat",
+  "config": {
+    "reentrant": {
+        "macro_name": "MBED_FAT_FS_REENTRANT",
+        "value": 0,
+        "help": "Turn on the reentrancy feature of the FAT Filesystem. This allows concurrent writes to the SD card in threaded applications"
+    },
+    "tiny": {
+        "macro_name": "MBED_FAT_FS_TINY",
+        "value": 1,
+        "help": "Set the _FS_TINY option of the FAT Filesystem. If this is true, the size of the FIL objects used by FFChan will be reduced"
+    },
+    "use_heap_buffers": {
+        "macro_name": "MBED_FAT_FS_HEAPBUF",
+        "value": 1,
+        "help": "Allow the FAT Filesystem to use the heap for allocating buffers. Turn this off and define your own memory to prevent any dynamic memory allocation by the library"
+    }
+  }
+}


### PR DESCRIPTION
### Description
It would be useful to be able to set some configuration options for the FATFilesystem library using an mbed library config file. I have added such a configuration file with hooks for setting the macros:

- FF_USE_LFN
  - Some projects may not want to use dynamic memory for this. You can now set the library config to not use dynamic memory by setting it to appropriate values
- FF_FS_TINY
  - Some projects may want to cache writes for longer
- FF_FS_HEAPBUF
  - This is another dynamic memory concern

I believe I have set the defaults of these values correctly so they shouldn't change any existing behaviour for any of the targets.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change

