### PR TITLE
RTOS SYSTIMER test error in TICKLESS mode

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/systimer/main.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#if !MBED_TICKLESS
+#ifndef MBED_TICKLESS
 #error [NOT_SUPPORTED] Tickless mode not supported for this target.
 #endif
 


### PR DESCRIPTION
### Description

If we enable MBED_TICKLESS, we got a compilation error:

        [DEBUG] Output: ".\TESTS\mbedmicro-rtos-mbed\systimer\main.cpp", line 16: Error:  #29: expected an expression

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

