### PR TITLE
Fetch the RAM start/size from CMSIS pack as defaults

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -631,7 +631,7 @@ class Config(object):
         """Generate a list of ram regions from the config"""
         cmsis_part = self._get_cmsis_part()
         ram_start, ram_size = self._get_mem_specs(
-            ["IRAM1", "SRAM0"],
+            ["IRAM1", "SRAM", "SRAM_LOWER", "SRAM_ITC"],
             cmsis_part,
             "Not enough information in CMSIS packs to build a ram sharing project"
         )
@@ -640,9 +640,9 @@ class Config(object):
         # This is usually done for a target which:
         # 1. Doesn't support CMSIS pack, or
         # 2. Supports TrustZone and user needs to change its flash partition
-        ram_start = getattr(self.target, "mbed_ram_start", False) or ram_start
-        ram_size = getattr(self.target, "mbed_ram_size", False) or ram_size
-        return [RamRegion("application_ram", int(ram_start, 0), int(ram_size, 0), True)]
+        ram_start = int(getattr(self.target, "mbed_ram_start", False) or ram_start, 0)
+        ram_size = int(getattr(self.target, "mbed_ram_size", False) or ram_size, 0)
+        return (ram_start, ram_size)
 
     @property
     def regions(self):

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -1242,6 +1242,15 @@ class mbedToolchain:
             )
         except ConfigException:
             pass
+        try:
+            ram_start, ram_size = self.config.ram_regions
+            Region = namedtuple("RamRegion", "name start size")
+            self._add_defines_from_region(
+                Region("MBED_RAM", ram_start, ram_size),
+                suffixes=["_START", "_SIZE"]
+            )
+        except ConfigException:
+            pass
 
     # Set the configuration data
     def set_config_data(self, config_data):


### PR DESCRIPTION
### Description

Fixes: 
1. Names used for RAM memory in "https://raw.githubusercontent.com/ARMmbed/mbed-os/master/tools/arm_pack_manager/index.json" are SRAM / IRAM1(2) / SRAM_UPPER(LOWER) and SRAM_ITC(DTC)

2. Fetching of default RAM values in toolchain init script was missing

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @theotherjimmy 
