### PR TITLE
enable MOTE_L152 for OS5

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -48,7 +48,7 @@ extern "C" {
 #define TICKER_100_TICKS 100
 #define TICKER_500_TICKS 500
 
-#define MAX_FUNC_EXEC_TIME_US 20
+#define MAX_FUNC_EXEC_TIME_US 30
 #define DELTA_FUNC_EXEC_TIME_US 5
 #define NUM_OF_CALLS 100
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2310,14 +2310,14 @@
     },
     "MOTE_L152RC": {
         "inherits": ["FAMILY_STM32"],
+        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M3",
-        "default_toolchain": "uARM",
+        "default_toolchain": "ARM",
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels_add": ["STM32L1", "STM32L152RC"],
-        "overrides": {"lse_available": 0},
         "detect_code": ["4100"],
-        "device_has_add": ["ANALOGOUT"],
-        "default_lib": "small",
-        "release_versions": ["2"],
+        "device_has_add": ["ANALOGOUT", "SERIAL_ASYNCH", "FLASH"],
+        "release_versions": ["2", "5"],
         "device_name": "STM32L152RC"
     },
     "DISCO_F401VC": {


### PR DESCRIPTION
### Description
Enabling OS5 support for the MOTE_L152RC target.  This supersedes the now closed #6250.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [x] New target
    [ ] Feature
    [ ] Breaking change

Test logs from mbed-os v5.9.2:
[MOTE_L152RC_GCC_20180716-163839.log](https://github.com/ARMmbed/mbed-os/files/2203161/MOTE_L152RC_GCC_20180716-163839.log)
[MOTE_L152RC_IAR_20180717-111451.log](https://github.com/ARMmbed/mbed-os/files/2203162/MOTE_L152RC_IAR_20180717-111451.log)
[MOTE_L152RC_ARM_20180717-111451.log](https://github.com/ARMmbed/mbed-os/files/2203163/MOTE_L152RC_ARM_20180717-111451.log)

NVStore ~~test failures appear to be heap related (32K RAM) and similar to comments on #7127.  Needs further investigation.~~ fixed!  Depends on #7746 
IAR Filesystem ~~test failures are also likely due to lack of heap and this target should have these tests disabled.  Issue  #6008.~~  fixed with rebase.
lpticker test ~~failures being reported in separate issue.~~ fixed with commit "Increase max func exec time to allow slower sys clock" in this PR 

@dudmuck 

Updated logs showing all previously failing tests now passing:
[MOTE_L152RC_ARM_20180822-111451.log](https://github.com/ARMmbed/mbed-os/files/2311789/MOTE_L152RC_ARM_20180822-111451.log)
[MOTE_L152RC_GCC_20180822-163839.log](https://github.com/ARMmbed/mbed-os/files/2311790/MOTE_L152RC_GCC_20180822-163839.log)
[MOTE_L152RC_IAR_20180822-111451.log](https://github.com/ARMmbed/mbed-os/files/2311791/MOTE_L152RC_IAR_20180822-111451.log)

Dependent PR: #7746 
