### PR TITLE
Tools: Secure Partition merging

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NUMAKER_PFM_M2351/TARGET_M23_NS/mbed_lib.json
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NUMAKER_PFM_M2351/TARGET_M23_NS/mbed_lib.json
@@ -1,0 +1,9 @@
+{
+    "name": "secure partition",
+    "target_overrides": {
+        "NUMAKER_PFM_M2351": {
+            "target.secure_partition": "NuMaker-mbed-TZ-secure-example.hex",
+            "target.app_offset": "0x40000"
+        }
+    }
+}

--- a/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NUMAKER_PFM_M2351/TARGET_M23_NS/mbed_lib.json
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/TARGET_NUMAKER_PFM_M2351/TARGET_M23_NS/mbed_lib.json
@@ -3,6 +3,7 @@
     "target_overrides": {
         "NUMAKER_PFM_M2351": {
             "target.secure_partition": "NuMaker-mbed-TZ-secure-example.hex",
+            "target.reserve_ram": "0x8000",
             "target.app_offset": "0x40000"
         }
     }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4293,10 +4293,7 @@
                 "value": "GPIO_DBCTL_DBCLKSEL_16"
             }
         },
-        "mbed_rom_start":   "0x10040000",
-        "mbed_rom_size":    "0x40000",
-        "mbed_ram_start":   "0x30008000",
-        "mbed_ram_size":    "0x10000", 
+        "non_secure_mask": "0x10000000",
         "inherits": ["Target"],
         "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG", "FLASH"],
         "detect_code": ["1305"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -399,7 +399,13 @@ def _fill_header(region_list, current_region):
         start += Config.header_member_size(member)
     return header
 
-def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
+def merge_region_list(
+        region_list,
+        destination,
+        notify,
+        padding=b'\xFF',
+        non_secure_mask=0
+):
     """Merge the region_list into a single image
 
     Positional Arguments:
@@ -538,7 +544,16 @@ def build_project(src_paths, build_path, target, toolchain_name,
                            for r in region_list]
             res = "%s.%s" % (join(build_path, name),
                              getattr(toolchain.target, "OUTPUT_EXT", "bin"))
-            merge_region_list(region_list, res, notify)
+            merge_region_list(
+                region_list,
+                res,
+                notify,
+                non_secure_mask=int(getattr(
+                    toolchain.target,
+                    "non_secure_mask",
+                    "0"
+                ), 0)
+            )
         else:
             res, _ = toolchain.link_program(resources, build_path, name)
 


### PR DESCRIPTION
### Description

This is a quality of life improvement for v8m targets: it allows
a porter to specify the target attribute `non_secure_mask`, and a user
to specify the target attribute `secure_partition` and `reserve_ram`. 

They mean:
 * `target.non_secure_mask` allows the build system's baked in managed merge 
 mode to understand your targets memory layout and merge a secure partition
 and non-secure partition into the correct locations in ROM.
 * `target.secure_partition` specifies the secure partition to use.
 * `target.reserve_ram` is an amount of RAM to be reserved for a boot loader,
 secure partition, soft device or similarly functioning piece of code.
 
Further, this PR includes an update to the `NUMAKE_PFM_M2351` target to use
these new configuration options.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change