### PR TITLE
Remove extra ARMc6 instance in unique mapping

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -885,7 +885,7 @@ SEPARATE_NAMES = [
     'mbed_main.o',
     'mbed_sdk_boot.o',
 ]
- 
+
 
 def build_mbed_libs(target, toolchain_name, clean=False, macros=None,
                     notify=None, jobs=1, report=None, properties=None,
@@ -1067,9 +1067,6 @@ def get_unique_supported_toolchains(release_targets=None):
             for toolchain in target[1]:
                 if toolchain not in unique_supported_toolchains:
                     unique_supported_toolchains.append(toolchain)
-
-    if "ARM" in unique_supported_toolchains:
-        unique_supported_toolchains.append("ARMC6")
 
     return unique_supported_toolchains
 


### PR DESCRIPTION
### Description

This recent commit (https://github.com/ARMmbed/mbed-os/pull/7302/files#diff-8ae3dde46b55f3a922724cd3585922b2) added ARMc6 which ends up multiplicly defining ARMc6 in what is suppose to be a set with unique entries.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

