### PR TITLE
Revise heap and stack size for Ethernet of GR-PEACH

### DIFF
--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -127,6 +127,12 @@
         },
         "EFM32GG11-STK3701": {
             "mem-size": 36560
+        },
+        "RZ_A1_EMAC": {
+            "tcpip-thread-stacksize": 1328,
+            "default-thread-stacksize": 640,
+            "ppp-thread-stacksize": 896,
+            "mem-size": 51200
         }
     }
 }


### PR DESCRIPTION
### Description
I changed stack size because the deafult stack size may not be enough for Ethernet of GR-PEACH(Cortex-A).
Stack size is default size + 128 byte.

In order to maximize the performance of Ethernet, I changed heap size to below.
Heap size is default size * 32 byte(send descriptor num is 16 and recv descriptoer num is 16).

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

