### PR TITLE
STM32L496: fix RAM size in ARM scatter file

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_MICRO/stm32l496xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_MICRO/stm32l496xx.sct
@@ -1,6 +1,6 @@
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Copyright (c) 2015, STMicroelectronics
+; Copyright (c) 2018, STMicroelectronics
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 1MB FLASH (0x100000) + 320KB SRAM (0xxxxx)
+; 1MB FLASH (0x100000) + 320KB SRAM (0x50000)
 LR_IROM1 0x08000000 0x100000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
@@ -37,7 +37,7 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x00500000-0x1AC)  { ; RW data 320k L4-SRAM1
+  RW_IRAM1 (0x20000000+0x1AC) (0x50000-0x1AC)  { ; RW data 320k L4-SRAM1
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_STD/stm32l496xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_STD/stm32l496xx.sct
@@ -1,6 +1,6 @@
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Copyright (c) 2015, STMicroelectronics
+; Copyright (c) 2018, STMicroelectronics
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -27,7 +27,7 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; 1MB FLASH (0x100000) + 320KB SRAM (0xxxxx)
+; 1MB FLASH (0x100000) + 320KB SRAM (0x50000)
 LR_IROM1 0x08000000 0x100000  {    ; load region size_region
 
   ER_IROM1 0x08000000 0x100000  {  ; load address = execution address
@@ -37,7 +37,7 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x00500000-0x1AC)  { ; RW data 320k L4-SRAM1
+  RW_IRAM1 (0x20000000+0x1AC) (0x50000-0x1AC)  { ; RW data 320k L4-SRAM1
    .ANY (+RW +ZI)
   }
 }


### PR DESCRIPTION
### Description

The RAM size was defined as 10 times the correct size...

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

