### PR TITLE
Enable HAL Flash API on Fast Models MPS2 targets

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017-2018 ARM Limited
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "device.h"
+#include "flash_api.h"
+#include "memory_zones.h"
+
+/* Fast Model FVP MPS2 is modeling after V2M-MPS2 platform with a FPGA (AN385).
+ * The implementation emulates flash over SRAM.
+ */
+
+#define FLASH_PAGE_SIZE   256
+#define FLASH_OFS_START   FLASH_START
+#define FLASH_SECTOR_SIZE 0x1000
+#define FLASH_OFS_END     (FLASH_OFS_START + FLASH_SIZE)
+
+int32_t flash_init(flash_t *obj)
+{
+    (void)obj;
+
+    return 0;
+}
+
+int32_t flash_free(flash_t *obj)
+{
+    (void)obj;
+
+    return 0;
+}
+
+int32_t flash_erase_sector(flash_t *obj, uint32_t address)
+{
+    (void)obj;
+
+    memset((void *)address, 0xff, FLASH_SECTOR_SIZE);
+
+    return 0;
+}
+
+int32_t flash_read(flash_t *obj, uint32_t address,
+                   uint8_t *data, uint32_t size)
+{
+    (void)obj;
+
+    memcpy(data, (void *)address, size);
+
+    return 0;
+}
+
+int32_t flash_program_page(flash_t *obj, uint32_t address,
+                           const uint8_t *data, uint32_t size)
+{
+    (void)obj;
+
+    memcpy((void *)address, data, size);
+
+    return 0;
+}
+
+uint32_t flash_get_sector_size(const flash_t *obj, uint32_t address)
+{
+    (void)obj;
+
+    if (address < FLASH_OFS_START || address >= FLASH_OFS_END) {
+        return MBED_FLASH_INVALID_SIZE;
+    }
+
+    return FLASH_SECTOR_SIZE;
+}
+
+uint32_t flash_get_page_size(const flash_t *obj)
+{
+    (void)obj;
+
+    return FLASH_PAGE_SIZE;
+}
+
+uint32_t flash_get_start_address(const flash_t *obj)
+{
+    (void)obj;
+
+    return FLASH_OFS_START;
+}
+
+uint32_t flash_get_size(const flash_t *obj)
+{
+    (void)obj;
+
+    return FLASH_SIZE;
+}

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/memory_zones.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/memory_zones.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2017-2018 ARM Limited
+ *
+ * Licensed under the Apache License Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * This file contains the information of memory zones for code and data on
+ * ARM Versatile Express Cortex-M Prototyping Systems (V2M-MPS2) TRM.
+ * It is used in startup code and linker scripts of supported compilers (ARM and
+ * GCC_ARM).
+ *
+ * WARNING: IAR does not include this file and re-define these values in
+ * MPS2.icf file. Please make sure that the two files share the same values.
+ *
+ * These memory zones are defined in section 4.2 of ARM V2M-MPS2 RTL and
+ * Fast Model Reference Guide.
+ */
+
+#ifndef MEMORY_ZONES_H
+#define MEMORY_ZONES_H
+
+/*
+ * Code memory zones
+ * Please note that MPS2 on Fast Models do not simulate persistent flash memory.
+ * The FLASH memory zone is a 256 KiB SRAM block and named FLASH
+ * only to keep the same name than in the CMSDK RTL and Fast Models Reference
+ * Guide.
+ */
+#define FLASH_START      0x00000000
+#define FLASH_SIZE       0x00040000 /* 256 KiB */
+#define ZBT_SRAM1_START  0x00400000
+#define ZBT_SRAM1_SIZE   0x00400000 /* 4 MiB */
+
+/* Data memory zones */
+#define ZBT_SRAM2_START  0x20000000
+#define ZBT_SRAM2_SIZE   0x00800000 /* 8 MiB */
+
+#endif /* MEMORY_ZONES_H */
+

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/objects.h
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/objects.h
@@ -73,6 +73,11 @@ struct analogin_s {
     __IO uint32_t address;
 };
 
+/* This structure is not used by the HAL implementation. */
+struct flash_s {
+    uint8_t not_used;
+};
+
 #include "gpio_object.h"
 
 #ifdef __cplusplus

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4239,7 +4239,7 @@
         "public": false,
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "OUTPUT_EXT": "elf",
-        "device_has": ["AACI", "ANALOGIN", "CLCD", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC", "USTICKER"],
+        "device_has": ["AACI", "ANALOGIN", "CLCD", "FLASH", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC", "USTICKER"],
         "release_versions": ["5"]
     },
     "FVP_MPS2_M0": {


### PR DESCRIPTION
### Enable HAL Flash API on Fast Models MPS2 targets

This pull request enable the HAL Flash API on all Fast Models MPS2 targets.
And this enabled the Fast Models MPS2 target to run all flash tests and other flash realted functions, IAP etc.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change
