### PR TITLE
Tools: Select compiler based on arch version

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -44,7 +44,7 @@ from .paths import (MBED_CMSIS_PATH, MBED_TARGETS_PATH, MBED_LIBRARIES,
                     BUILD_DIR)
 from .resources import Resources, FileType, FileRef
 from .notifier.mock import MockNotifier
-from .targets import TARGET_NAMES, TARGET_MAP
+from .targets import TARGET_NAMES, TARGET_MAP, CORE_ARCH
 from .libraries import Library
 from .toolchains import TOOLCHAIN_CLASSES
 from .config import Config
@@ -316,9 +316,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
         raise NotSupportedException(
             "Target {} is not supported by toolchain {}".format(
                 target.name, toolchain_name))
-    if (toolchain_name == "ARM" and
-        target.core in ("Cortex-M23", "Cortex-M23-NS",
-                        "Cortex-M33", "Cortex-M33-NS")):
+    if (toolchain_name == "ARM" and CORE_ARCH[target.core] == 8):
         toolchain_name = "ARMC6"
 
     try:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1198,9 +1198,13 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
             row.append(text)
 
         for unique_toolchain in unique_supported_toolchains:
-            if (unique_toolchain in TARGET_MAP[target].supported_toolchains or
+            tgt_obj = TARGET_MAP[target]
+            if (unique_toolchain in tgt_obj.supported_toolchains or
                 (unique_toolchain == "ARMC6" and
-                 "ARM" in TARGET_MAP[target].supported_toolchains)):
+                 "ARM" in tgt_obj.supported_toolchains) or
+                (unique_toolchain == "ARM" and
+                 "ARMC6" in tgt_obj.supported_toolchains and
+                 CORE_ARCH[tgt_obj.core] == 8)):
                 text = "Supported"
                 perm_counter += 1
             else:

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -316,6 +316,10 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
         raise NotSupportedException(
             "Target {} is not supported by toolchain {}".format(
                 target.name, toolchain_name))
+    if (toolchain_name == "ARM" and
+        target.core in ("Cortex-M23", "Cortex-M23-NS",
+                        "Cortex-M33", "Cortex-M33-NS")):
+        toolchain_name = "ARMC6"
 
     try:
         cur_tc = TOOLCHAIN_CLASSES[toolchain_name]

--- a/tools/targets/__init__.py
+++ b/tools/targets/__init__.py
@@ -30,7 +30,7 @@ from tools.paths import TOOLS_BOOTLOADERS
 from tools.utils import json_file_to_dict
 
 __all__ = ["target", "TARGETS", "TARGET_MAP", "TARGET_NAMES", "CORE_LABELS",
-           "HookError", "generate_py_target", "Target",
+           "CORE_ARCH", "HookError", "generate_py_target", "Target",
            "CUMULATIVE_ATTRIBUTES", "get_resolution_order"]
 
 CORE_LABELS = {
@@ -48,6 +48,23 @@ CORE_LABELS = {
     "Cortex-M23-NS": ["M23", "M23_NS", "CORTEX_M", "LIKE_CORTEX_M23", "CORTEX"],
     "Cortex-M33": ["M33", "CORTEX_M", "LIKE_CORTEX_M33", "CORTEX"],
     "Cortex-M33-NS": ["M33", "M33_NS", "CORTEX_M", "LIKE_CORTEX_M33", "CORTEX"]
+}
+
+CORE_ARCH = {
+    "Cortex-M0": 6,
+    "Cortex-M0+": 6,
+    "Cortex-M1": 6,
+    "Cortex-M3": 7,
+    "Cortex-M4": 7,
+    "Cortex-M4F": 7,
+    "Cortex-M7": 7,
+    "Cortex-M7F": 7,
+    "Cortex-M7FD": 7,
+    "Cortex-A9": 7,
+    "Cortex-M23": 8,
+    "Cortex-M23-NS": 8,
+    "Cortex-M33": 8,
+    "Cortex-M33-NS": 8,
 }
 
 ################################################################################

--- a/tools/test/toolchains/api_test.py
+++ b/tools/test/toolchains/api_test.py
@@ -184,7 +184,7 @@ def test_toolchain_profile_asm(profile, source_file):
     with patch('os.mkdir') as _mkdir:
         for _, tc_class in TOOLCHAIN_CLASSES.items():
             toolchain = tc_class(TARGET_MAP["K64F"], build_profile=profile,
-                                 notify=MockNotifier)
+                                 notify=MockNotifier())
             toolchain.inc_md5 = ""
             toolchain.build_dir = ""
             for parameter in profile['asm']:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -25,6 +25,7 @@ from tempfile import mkstemp
 from shutil import rmtree
 from distutils.version import LooseVersion
 
+from tools.targets import CORE_ARCH
 from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 from tools.utils import mkdir, NotSupportedException, run_cmd
@@ -368,6 +369,14 @@ class ARMC6(ARM_STD):
         if target.core not in self.SUPPORTED_CORES:
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
+        if CORE_ARCH[target.core] < 8:
+            self.notify.cc_info({
+                'severity': "Error", 'file': "", 'line': "", 'col': "",
+                'message': "ARMC6 does not support ARM architecture v{}"
+                " targets".format(CORE_ARCH[target.core]),
+                'text': '', 'target_name': self.target.name,
+                'toolchain_name': self.name
+            })
 
         if not set(("ARM", "ARMC6")).intersection(set(target.supported_toolchains)):
             raise NotSupportedException("ARM/ARMC6 compiler support is required for ARMC6 build")


### PR DESCRIPTION
### Description

This allows users to use the approprate arm compiler with the `-t ARM`
switch. It picks Arm Compiler 5 for v6m and v7m and picks Arm Compiler 6
for v8m.

This also emits an error (but still builds) with `-t ARMC6` and v6m and 
v7m.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change