### PR TITLE
Export: Support Make + ArmC6 + v8m

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -75,11 +75,11 @@ SREC_CAT = srec_cat
 {%- endif %}
 {%- block additional_executables -%}{%- endblock %}
 
-{% for flag in c_flags %}C_FLAGS += "{{flag}}"
+{% for flag in c_flags %}C_FLAGS += {{shell_escape(flag)}}
 {% endfor %}
-{% for flag in cxx_flags %}CXX_FLAGS += "{{flag}}"
+{% for flag in cxx_flags %}CXX_FLAGS += {{shell_escape(flag)}}
 {% endfor %}
-{% for flag in asm_flags %}ASM_FLAGS += "{{flag}}"
+{% for flag in asm_flags %}ASM_FLAGS += {{shell_escape(flag)}}
 {% endfor %}
 
 LD_FLAGS :={%- block ld_flags -%} {{ld_flags|join(" ")}} {% endblock %}

--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -75,11 +75,11 @@ SREC_CAT = srec_cat
 {%- endif %}
 {%- block additional_executables -%}{%- endblock %}
 
-{% for flag in c_flags %}C_FLAGS += {{flag}}
+{% for flag in c_flags %}C_FLAGS += "{{flag}}"
 {% endfor %}
-{% for flag in cxx_flags %}CXX_FLAGS += {{flag}}
+{% for flag in cxx_flags %}CXX_FLAGS += "{{flag}}"
 {% endfor %}
-{% for flag in asm_flags %}ASM_FLAGS += {{flag}}
+{% for flag in asm_flags %}ASM_FLAGS += "{{flag}}"
 {% endfor %}
 
 LD_FLAGS :={%- block ld_flags -%} {{ld_flags|join(" ")}} {% endblock %}

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -88,12 +88,9 @@ class Makefile(Exporter):
                       if (basename(dirname(dirname(self.export_dir)))
                           == "projectfiles")
                       else [".."]),
-            'cc_cmd': " ".join([basename(self.toolchain.cc[0])] +
-                               self.toolchain.cc[1:]),
-            'cppc_cmd': " ".join([basename(self.toolchain.cppc[0])] +
-                                 self.toolchain.cppc[1:]),
-            'asm_cmd': " ".join([basename(self.toolchain.asm[0])] +
-                                self.toolchain.asm[1:]),
+            'cc_cmd': basename(self.toolchain.cc[0]),
+            'cppc_cmd': basename(self.toolchain.cppc[0]),
+            'asm_cmd': basename(self.toolchain.asm[0]),
             'ld_cmd': basename(self.toolchain.ld[0]),
             'elf2bin_cmd': basename(self.toolchain.elf2bin),
             'link_script_ext': self.toolchain.LINKER_EXT,
@@ -123,6 +120,9 @@ class Makefile(Exporter):
                     'to_be_compiled']:
             ctx[key] = sorted(ctx[key])
         ctx.update(self.format_flags())
+        ctx['asm_flags'].extend(self.toolchain.asm[1:])
+        ctx['c_flags'].extend(self.toolchain.cc[1:])
+        ctx['cxx_flags'].extend(self.toolchain.cppc[1:])
 
         # Add the virtual path the the include option in the ASM flags
         new_asm_flags = []

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -265,17 +265,6 @@ class Armc6(Arm):
     NAME = 'Make-ARMc6'
     TOOLCHAIN = "ARMC6"
 
-    @classmethod
-    def is_target_supported(cls, target_name):
-        target = TARGET_MAP[target_name]
-        if target.core in (
-                "Cortex-M23", "Cortex-M23-NS",
-                "Cortex-M33", "Cortex-M33-NS"
-        ):
-            return False
-        return apply_supported_whitelist(
-            cls.TOOLCHAIN, cls.POST_BINARY_WHITELIST, target)
-
 
 class IAR(Makefile):
     """IAR specific makefile target"""

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -29,6 +29,15 @@ from tools.export.exporters import Exporter, apply_supported_whitelist
 from tools.utils import NotSupportedException
 from tools.targets import TARGET_MAP
 
+SHELL_ESCAPE_TABLE = {
+    "(": "\(",
+    ")": "\)",
+}
+
+
+def shell_escape(string):
+    return "".join(SHELL_ESCAPE_TABLE.get(char, char) for char in string)
+
 
 class Makefile(Exporter):
     """Generic Makefile template that mimics the behavior of the python build
@@ -97,6 +106,7 @@ class Makefile(Exporter):
             'link_script_option': self.LINK_SCRIPT_OPTION,
             'user_library_flag': self.USER_LIBRARY_FLAG,
             'needs_asm_preproc': self.PREPROCESS_ASM,
+            'shell_escape': shell_escape,
         }
 
         if hasattr(self.toolchain, "preproc"):

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -347,7 +347,7 @@ class Resources(object):
     def linker_script(self):
         options = self.get_file_names(FileType.LD_SCRIPT)
         if options:
-            return options[-1]
+            return options[0]
         else:
             return None
 


### PR DESCRIPTION
### Description

There were a few issues preventing v8m support for `make_armc6`:
    * a -D flag with `(...)` in it
    * the wrong scatterfile was used, making use of `armcc` in 
      the preprocessing step

This PR fixes both of these issues.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change