### PR TITLE
Nuvoton: Fix NUC472 SD-Host HW IP reset definition

### DIFF
--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
@@ -222,7 +222,7 @@ bool NUMAKER_EMAC::link_out(emac_mem_buf_t *buf)
 {
     bool result;
     emac_mem_buf_t *q;
-    uint8_t *buffer = numaker_eth_get_tx_buf();
+    uint8_t *buffer = NULL;
     uint32_t framelength = 0;
     uint32_t bufferoffset = 0;
     uint32_t byteslefttocopy = 0;
@@ -230,7 +230,9 @@ bool NUMAKER_EMAC::link_out(emac_mem_buf_t *buf)
 
     /* Get exclusive access */
     TXLockMutex.lock();
+    buffer = numaker_eth_get_tx_buf();
     NU_DEBUGF(("%s ... buffer=0x%x\r\n",__FUNCTION__, buffer));
+    if( buffer == NULL ) goto error;
     /* copy frame from buf to driver buffers */
     for (q = buf; q != NULL; q = memory_manager->get_next(q)) {
 

--- a/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_NUVOTON_EMAC/numaker_emac.cpp
@@ -220,7 +220,7 @@ void NUMAKER_EMAC::packet_rx()
  */
 bool NUMAKER_EMAC::link_out(emac_mem_buf_t *buf)
 {
-    bool result;
+    bool result = false;
     emac_mem_buf_t *q;
     uint8_t *buffer = NULL;
     uint32_t framelength = 0;

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/device/NUC472_442.h
@@ -24427,8 +24427,11 @@ typedef struct {
 #define SYS_IPRST0_USBHRST_Pos           (4)                                               /*!< SYS IPRST0: USBHRST Position           */
 #define SYS_IPRST0_USBHRST_Msk           (0x1ul << SYS_IPRST0_USBHRST_Pos)                 /*!< SYS IPRST0: USBHRST Mask               */
 
-#define SYS_IPRST0_SDHRST_Pos            (5)                                               /*!< SYS IPRST0: SDHRST Position            */
-#define SYS_IPRST0_SDHRST_Msk            (0x1ul << SYS_IPRST0_SDHRST_Pos)                  /*!< SYS IPRST0: SDHRST Mask                */
+#define SYS_IPRST0_EMACRST_Pos           (5)                                               /*!< SYS_T::IPRST0: EMACRST Position            */
+#define SYS_IPRST0_EMACRST_Msk           (0x1ul << SYS_IPRST0_EMACRST_Pos)                 /*!< SYS_T::IPRST0: EMACRST Mask                */
+
+#define SYS_IPRST0_SDHRST_Pos            (6)                                               /*!< SYS_T::IPRST0: SDHRST Position        */
+#define SYS_IPRST0_SDHRST_Msk            (0x1ul << SYS_IPRST0_SDHRST_Pos)                  /*!< SYS_T::IPRST0: SDHRST Mask            */
 
 #define SYS_IPRST0_SDHOST_RST_Pos        (6)                                               /*!< SYS IPRST0: SDHOST_RST Position        */
 #define SYS_IPRST0_SDHOST_RST_Msk        (0x1ul << SYS_IPRST0_SDHOST_RST_Pos)              /*!< SYS IPRST0: SDHOST_RST Mask            */


### PR DESCRIPTION
### Description
This PR could fix the wrong definition of NUC472 SD-Host HW IP reset. The wrong definition will encounter EMAC reset as while call `SD_Init()`. 

### Pull request type

    [V] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

### Test

Verified OK by cloud client v1.3.3 
