### PR TITLE
STM Fix support of max flash size

### DIFF
--- a/targets/TARGET_STM/qspi_api.c
+++ b/targets/TARGET_STM/qspi_api.c
@@ -35,8 +35,8 @@
 #include "PeripheralPins.h"
 
 /* Max amount of flash size is 4Gbytes */
-/* hence 2^(31+1), then FLASH_SIZE_DEFAULT = 31<<20 */
-#define QSPI_FLASH_SIZE_DEFAULT 0x1F00000
+/* hence 2^(31+1), then FLASH_SIZE_DEFAULT = 1<<31 */
+#define QSPI_FLASH_SIZE_DEFAULT 0x80000000
 
 void qspi_prepare_command(const qspi_command_t *command, QSPI_CommandTypeDef *st_command) 
 {


### PR DESCRIPTION
### Description
The current implementation does not allow a write to 0x100000 and above.

With this fix, we can.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

### How to reproduce
Change FLASH ADDRESS in TESTS/mbed_hal/qspi/main.cpp file to 0x140000 on a DISCO board that allows it (DISCO_F413ZH / DISCO_F469...) and try it.
I won't work.
With the fix it works.

cc @offirko 
