### PR TITLE
Tools: Generate update images with managed bl mode

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -587,8 +587,8 @@ def build_project(src_paths, build_path, target, toolchain_name,
             cur_result["result"] = "OK"
             cur_result["memory_usage"] = (memap_instance.mem_report
                                           if memap_instance is not None else None)
-            cur_result["bin"] = res
-            cur_result["elf"] = splitext(res)[0] + ".elf"
+            cur_result["bin"] = res[0]
+            cur_result["elf"] = splitext(res[0])[0] + ".elf"
             cur_result.update(toolchain.report)
 
             add_result_to_report(report, cur_result)

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -446,6 +446,12 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
     merged.tofile(destination, format=format.strip("."))
 
 
+UPDATE_WHITELIST = (
+    "application",
+    "header",
+)
+
+
 def build_project(src_paths, build_path, target, toolchain_name,
                   libraries_paths=None, linker_script=None, clean=False,
                   notify=None, name=None, macros=None, inc_dirs=None, jobs=1,
@@ -532,15 +538,28 @@ def build_project(src_paths, build_path, target, toolchain_name,
 
         # Link Program
         if toolchain.config.has_regions:
-            res, _ = toolchain.link_program(resources, build_path, name + "_application")
+            binary, _ = toolchain.link_program(resources, build_path, name + "_application")
             region_list = list(toolchain.config.regions)
-            region_list = [r._replace(filename=res) if r.active else r
+            region_list = [r._replace(filename=binary) if r.active else r
                            for r in region_list]
             res = "%s.%s" % (join(build_path, name),
                              getattr(toolchain.target, "OUTPUT_EXT", "bin"))
             merge_region_list(region_list, res, notify)
+            update_regions = [
+                r for r in region_list if r.name in UPDATE_WHITELIST
+            ]
+            if update_regions:
+                update_res = "%s_update.%s" % (
+                    join(build_path, name),
+                    getattr(toolchain.target, "OUTPUT_EXT", "bin")
+                )
+                merge_region_list(update_regions, update_res, notify)
+                res = (res, update_res)
+            else:
+                res = (res, None)
         else:
             res, _ = toolchain.link_program(resources, build_path, name)
+            res = (res, None)
 
         memap_instance = getattr(toolchain, 'memap_instance', None)
         memap_table = ''

--- a/tools/make.py
+++ b/tools/make.py
@@ -273,23 +273,28 @@ if __name__ == '__main__':
             build_dir = options.build_dir
 
         try:
-            bin_file = build_project(test.source_dir, build_dir, mcu, toolchain,
-                                     set(test.dependencies),
-                                     linker_script=options.linker_script,
-                                     clean=options.clean,
-                                     notify=notify,
-                                     report=build_data_blob,
-                                     macros=options.macros,
-                                     jobs=options.jobs,
-                                     name=options.artifact_name,
-                                     app_config=options.app_config,
-                                     inc_dirs=[dirname(MBED_LIBRARIES)],
-                                     build_profile=extract_profile(parser,
-                                                                   options,
-                                                                   toolchain),
-                                     stats_depth=options.stats_depth,
-                                     ignore=options.ignore)
-            print('Image: %s'% bin_file)
+            bin_file, update_file = build_project(
+                test.source_dir,
+                build_dir,
+                mcu,
+                toolchain,
+                set(test.dependencies),
+                linker_script=options.linker_script,
+                clean=options.clean,
+                notify=notify,
+                report=build_data_blob,
+                macros=options.macros,
+                jobs=options.jobs,
+                name=options.artifact_name,
+                app_config=options.app_config,
+                inc_dirs=[dirname(MBED_LIBRARIES)],
+                build_profile=extract_profile(parser, options, toolchain),
+                stats_depth=options.stats_depth,
+                ignore=options.ignore
+            )
+            if update_file:
+                print('Update Image: %s' % update_file)
+            print('Image: %s' % bin_file)
 
             if options.disk:
                 # Simple copy to the mbed disk

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2174,7 +2174,7 @@ def build_test_worker(*args, **kwargs):
     del kwargs['toolchain_paths']
 
     try:
-        bin_file = build_project(*args, **kwargs)
+        bin_file, _ = build_project(*args, **kwargs)
         ret['result'] = True
         ret['bin_file'] = bin_file
         ret['kwargs'] = kwargs


### PR DESCRIPTION
### Description

This PR add generation of update images, which do not include the 
bootloader, to managed bootloader mode builds. The output will include
`Update Image: <image_name>` to tell you where the update image is 
located.

Resolves #7394 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change