### PR TITLE
Tools: Add Uvision6 exporter

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -34,7 +34,8 @@ from . import (lpcxpresso, ds5_5, iar, makefile, embitz, coide, kds, simplicity,
                cdt, vscode, gnuarmeclipse, qtcreator, cmake, nb, cces, codeblocks)
 
 EXPORTERS = {
-    u'uvision5': uvision.Uvision,
+    u'uvision6': uvision.UvisionArmc6,
+    u'uvision5': uvision.UvisionArmc5,
     u'make_gcc_arm': makefile.GccArm,
     u'make_armc5': makefile.Armc5,
     u'make_armc6': makefile.Armc6,

--- a/tools/export/cmsis/__init__.py
+++ b/tools/export/cmsis/__init__.py
@@ -98,6 +98,7 @@ class DeviceCMSIS():
         cpu = cpu.replace("Cortex-","ARMC")
         cpu = cpu.replace("+","P")
         cpu = cpu.replace("F","_FP")
+        cpu = cpu.replace("-NS", "")
         return cpu
 
 

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -150,9 +150,9 @@ class Exporter(object):
         if config_header:
             def is_config_header(f):
                 return f.path == config_header
-            return filter(
+            return list(filter(
                 is_config_header, self.resources.get_file_refs(FileType.HEADER)
-            )[0]
+            ))[0]
         else:
             return None
 

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -112,10 +112,10 @@ class Exporter(object):
         flags['cxx_flags'] += c_defines
         config_header = self.config_header_ref
         if config_header:
-            flags['c_flags'] += self.toolchain.get_config_option(
+            config_option = self.toolchain.get_config_option(
                 config_header.name)
-            flags['cxx_flags'] += self.toolchain.get_config_option(
-                config_header.name)
+            flags['c_flags'] += config_option
+            flags['cxx_flags'] += config_option
         return flags
 
     @property

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -38,6 +38,7 @@ class DeviceUvision(DeviceCMSIS):
         cpu = self.core.replace("Cortex-", "C")
         cpu = cpu.replace("+", "")
         cpu = cpu.replace("F", "")
+        cpu = cpu.replace("-NS", "")
         cpu_flag = "p"+cpu
 
         # Locations found in Keil_v5/TOOLS.INI
@@ -231,15 +232,14 @@ class Uvision(Exporter):
             sct_path, dirname(sct_name))
         if ctx['linker_script'] != sct_path:
             self.generated_files.append(ctx['linker_script'])
-        core = ctx['device'].core
-        ctx['cputype'] = core.rstrip("FD")
-        if core.endswith("FD"):
+        ctx['cputype'] = ctx['device'].core.rstrip("FD").replace("-NS", "")
+        if ctx['device'].core.endswith("FD"):
             ctx['fpu_setting'] = 3
-        elif core.endswith("F"):
+        elif ctx['device'].core.endswith("F"):
             ctx['fpu_setting'] = 2
         else:
             ctx['fpu_setting'] = 1
-        ctx['fputype'] = self.format_fpu(core)
+        ctx['fputype'] = self.format_fpu(ctx['device'].core)
         ctx['armc6'] = int(self.TOOLCHAIN is 'ARMC6')
         ctx['toolchain_name'] = self.TOOLCHAIN_NAME
         ctx.update(self.format_flags())

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -175,7 +175,8 @@ class Uvision(Exporter):
         flags = copy.deepcopy(self.flags)
         asm_flag_string = (
             '--cpreproc --cpreproc_opts=-D__ASSERT_MSG,' +
-            ",".join(filter(lambda f: f.startswith("-D"), flags['asm_flags'])))
+            ",".join("-D{}".format(s) for s in
+                     self.toolchain.get_symbols(for_asm=True)))
         flags['asm_flags'] = asm_flag_string
 
         config_header = self.config_header_ref

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -164,11 +164,14 @@ class Uvision(Exporter):
             ",".join(filter(lambda f: f.startswith("-D"), flags['asm_flags'])))
         flags['asm_flags'] = asm_flag_string
 
+        config_option = self.toolchain.get_config_option(
+            self.toolchain.get_config_header())
         c_flags = set(
             flags['c_flags'] + flags['cxx_flags'] + flags['common_flags']
         )
         in_template = set(
-            ["--no_vla", "--cpp", "--c99", "-std=gnu99", "-std=g++98"]
+            ["--no_vla", "--cpp", "--c99", "-std=gnu99", "-std=g++98"] +
+            config_option 
         )
 
         def valid_flag(x):
@@ -179,6 +182,8 @@ class Uvision(Exporter):
 
         flags['c_flags'] = " ".join(f.replace('"', '\\"') for f in c_flags
                                     if (valid_flag(f) and not is_define(f)))
+        flags['c_flags'] += " "
+        flags['c_flags'] += " ".join(config_option)
         flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))
         flags['ld_flags'] = " ".join(set(flags['ld_flags']))
         return flags

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -204,7 +204,8 @@ class Uvision(Exporter):
         )
         flags['c_flags'] += " "
         flags['c_flags'] += " ".join(config_option)
-        flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))
+        flags['c_defines'] = " ".join(f[2:].replace('"', '\\"')
+                                      for f in c_flags if is_define(f))
         flags['ld_flags'] = " ".join(set(flags['ld_flags']))
         return flags
 

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -170,7 +170,7 @@ class Uvision(Exporter):
             flags['c_flags'] + flags['cxx_flags'] + flags['common_flags']
         )
         in_template = set(
-            ["--no_vla", "--cpp", "--c99"] + config_option
+            ["--no_vla", "--cpp", "--c99", "-MMD"] + config_option
         )
 
         def valid_flag(x):

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -170,12 +170,15 @@ class Uvision(Exporter):
             flags['c_flags'] + flags['cxx_flags'] + flags['common_flags']
         )
         in_template = set(
-            ["--no_vla", "--cpp", "--c99", "-std=gnu99", "-std=g++98"] +
-            config_option 
+            ["--no_vla", "--cpp", "--c99"] + config_option
         )
 
         def valid_flag(x):
-            return x not in in_template or not x.startswith("-O")
+            return (
+                x not in in_template or
+                not x.startswith("-O") or
+                not x.startswith("-std")
+            )
 
         def is_define(s):
             return s.startswith("-D")

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -191,11 +191,12 @@ class Uvision(Exporter):
             return (
                 x not in in_template or
                 not x.startswith("-O") or
-                not x.startswith("-std")
+                not x.startswith("-std") or
+                not x.startswith("-D")
             )
 
         def is_define(s):
-            return s.startswith("-D")
+            return s.startswith("-D") and "(" not in s
 
         flags['c_flags'] = " ".join(f.replace('"', '\\"') for f in c_flags
                                     if (valid_flag(f) and not is_define(f)))

--- a/tools/export/uvision/__init__.py
+++ b/tools/export/uvision/__init__.py
@@ -178,8 +178,8 @@ class Uvision(Exporter):
             ",".join(filter(lambda f: f.startswith("-D"), flags['asm_flags'])))
         flags['asm_flags'] = asm_flag_string
 
-        config_option = self.toolchain.get_config_option(
-            self.toolchain.get_config_header())
+        config_header = self.config_header_ref
+        config_option = self.toolchain.get_config_option(config_header.name)
         c_flags = set(
             flags['c_flags'] + flags['cxx_flags'] + flags['common_flags']
         )
@@ -189,17 +189,18 @@ class Uvision(Exporter):
 
         def valid_flag(x):
             return (
-                x not in in_template or
-                not x.startswith("-O") or
-                not x.startswith("-std") or
+                x not in in_template and
+                not x.startswith("-O") and
+                not x.startswith("-std") and
                 not x.startswith("-D")
             )
 
         def is_define(s):
             return s.startswith("-D") and "(" not in s
 
-        flags['c_flags'] = " ".join(f.replace('"', '\\"') for f in c_flags
-                                    if (valid_flag(f) and not is_define(f)))
+        flags['c_flags'] = " ".join(
+            f.replace('"', '\\"') for f in c_flags if valid_flag(f)
+        )
         flags['c_flags'] += " "
         flags['c_flags'] += " ".join(config_option)
         flags['c_defines'] = " ".join(f[2:] for f in c_flags if is_define(f))

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -10,6 +10,10 @@
       <TargetName>{{name}}</TargetName>
       <ToolsetNumber>0x4</ToolsetNumber>
       <ToolsetName>ARM-ADS</ToolsetName>
+      {% if toolchain_name %}
+      <pCCUsed>{{toolchain_name}}</pCCUsed>
+      {% endif %}
+      <uAC6>{{armc6}}</uAC6>
       <TargetOption>
         <TargetCommonOption>
           <Device>{{device.dname}}</Device>
@@ -354,7 +358,7 @@
             <Optim>1</Optim>
             <oTime>0</oTime>
             <SplitLS>0</SplitLS>
-            <OneElfS>0</OneElfS>
+            <OneElfS>1</OneElfS>
             <Strict>0</Strict>
             <EnumInt>0</EnumInt>
             <PlainCh>0</PlainCh>
@@ -365,8 +369,8 @@
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <useXO>0</useXO>
-            <v6Lang>1</v6Lang>
-            <v6LangP>1</v6LangP>
+            <v6Lang>4</v6Lang>
+            <v6LangP>2</v6LangP>
             <vShortEn>1</vShortEn>
             <vShortWch>1</vShortWch>
             <v6Lto>0</v6Lto>
@@ -374,7 +378,7 @@
             <v6Rtti>0</v6Rtti>
             <VariousControls>
               <MiscControls>{{c_flags}}</MiscControls>
-              <Define></Define>
+              <Define>{{c_defines}}</Define>
               <Undefine></Undefine>
               <IncludePath>{{include_paths}}</IncludePath>
             </VariousControls>
@@ -434,5 +438,4 @@
       </Groups>
     </Target>
   </Targets>
-
 </Project>

--- a/tools/export/uvision/uvision.tmpl
+++ b/tools/export/uvision/uvision.tmpl
@@ -217,7 +217,7 @@
             <AdsLsxf>1</AdsLsxf>
             <RvctClst>0</RvctClst>
             <GenPPlst>0</GenPPlst>
-            <AdsCpuType>"{{device.core.replace("D","").replace("F","")}}"</AdsCpuType>
+            <AdsCpuType>"{{cputype}}"</AdsCpuType>
             <RvctDeviceName></RvctDeviceName>
             <mOS>0</mOS>
             <uocRom>0</uocRom>


### PR DESCRIPTION
### Description

This PR adds a new exporter: `uvision6`. This new exporter shares an 
IDE and template with the `uvision5` exporter, changing the compiler
used by the exported project from Arm compiler 5 to Arm compiler 6.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change