### PR TITLE
Makes Greentea TCP test cases to timeout less in connection errors

### DIFF
--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -21,11 +21,17 @@
 NetworkInterface* get_interface();
 void drop_bad_packets(TCPSocket& sock, int orig_timeout);
 void fill_tx_buffer_ascii(char *buff, size_t len);
-void tcpsocket_connect_to_echo_srv(TCPSocket& sock);
-void tcpsocket_connect_to_discard_srv(TCPSocket& sock);
+nsapi_error_t tcpsocket_connect_to_echo_srv(TCPSocket& sock);
+nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket& sock);
+
+/**
+ * Single testcase might take only half of the remaining execution time
+ */
+int split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global
 {
+static const int TESTS_TIMEOUT = 480;
 static const int TCP_OS_STACK_SIZE = 1024;
 
 static const int RX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/tcp/tcpsocket_send_repeat.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_repeat.cpp
@@ -30,12 +30,15 @@ void TCPSOCKET_SEND_REPEAT()
     TCPSocket sock;
     tcpsocket_connect_to_discard_srv(sock);
 
-    int err;
+    int snd;
     Timer timer;
     static const char tx_buffer[] = {'h','e','l','l','o'};
     for (int i = 0; i < 1000; i++) {
-        err = sock.send(tx_buffer, sizeof(tx_buffer));
-        TEST_ASSERT_EQUAL(sizeof(tx_buffer), err);
+        snd = sock.send(tx_buffer, sizeof(tx_buffer));
+        if (snd != sizeof(tx_buffer)) {
+            TEST_FAIL();
+            break;
+        }
     }
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());

--- a/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_send_timeout.cpp
@@ -28,7 +28,10 @@ using namespace utest::v1;
 void TCPSOCKET_SEND_TIMEOUT()
 {
     TCPSocket sock;
-    tcpsocket_connect_to_discard_srv(sock);
+    if (tcpsocket_connect_to_discard_srv(sock) != NSAPI_ERROR_OK) {
+        TEST_FAIL();
+        return;
+    }
 
     int err;
     Timer timer;
@@ -38,8 +41,12 @@ void TCPSOCKET_SEND_TIMEOUT()
         timer.start();
         err = sock.send(tx_buffer, sizeof(tx_buffer));
         timer.stop();
-        TEST_ASSERT_EQUAL(sizeof(tx_buffer), err);
-        TEST_ASSERT(timer.read_ms() <= 800);
+        if ((err == sizeof(tx_buffer)) &&
+            (timer.read_ms() <= 800)) {
+            continue;
+        }
+        TEST_FAIL();
+        break;
     }
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -65,11 +65,13 @@ static void check_const_len_rand_sequence()
             if (sent == NSAPI_ERROR_WOULD_BLOCK) {
                 if(osSignalWait(SIGNAL_SIGIO1, SIGIO_TIMEOUT).status == osEventTimeout) {
                     TEST_FAIL();
+                    goto END;
                 }
                 continue;
             } else if (sent < 0) {
                 printf("network error %d\n", sent);
                 TEST_FAIL();
+                goto END;
             }
             bytes2process -= sent;
         }
@@ -82,6 +84,7 @@ static void check_const_len_rand_sequence()
             } else if (recvd < 0) {
                 printf("network error %d\n", recvd);
                 TEST_FAIL();
+                goto END;
             }
             bytes2process -= recvd;
         }
@@ -89,9 +92,11 @@ static void check_const_len_rand_sequence()
         if (bytes2process != 0) {
             drop_bad_packets(sock, 0);
             TEST_FAIL();
+            goto END;
         }
         TEST_ASSERT_EQUAL(0, memcmp(tx_buff, rx_buff, BUFF_SIZE));
     }
+END:
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
 
@@ -117,11 +122,13 @@ static void check_var_len_rand_sequence()
             if (sent == NSAPI_ERROR_WOULD_BLOCK) {
                 if(osSignalWait(SIGNAL_SIGIO2, SIGIO_TIMEOUT).status == osEventTimeout) {
                     TEST_FAIL();
+                    goto END;
                 }
                 continue;
             } else if (sent < 0) {
                 printf("[%02d] network error %d\n", i, sent);
                 TEST_FAIL();
+                goto END;
             }
            bytes2process -= sent;
         }
@@ -134,6 +141,7 @@ static void check_var_len_rand_sequence()
             } else if (recvd < 0) {
                 printf("[%02d] network error %d\n", i, recvd);
                 TEST_FAIL();
+                goto END;
             }
             bytes2process -= recvd;
         }
@@ -141,10 +149,11 @@ static void check_var_len_rand_sequence()
         if (bytes2process != 0) {
             drop_bad_packets(sock, 0);
             TEST_FAIL();
+            goto END;
         }
         TEST_ASSERT_EQUAL(0, memcmp(tx_buff, rx_buff, i));
     }
-
+END:
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());
 }
 


### PR DESCRIPTION
### Description

Makes Greentea TCP test cases to timeout less in connection errors

Made to prevent timeout if a single test case fails. The goal is that
each test case might wait only half of the remaining time reserved for
running TCP test cases.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

