### PR TITLE
hal-qspi_test: remove STM workaround

### DIFF
--- a/TESTS/mbed_hal/qspi/flash_configs/STM/DISCO_L475VG_IOT01A/flash_config.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/STM/DISCO_L475VG_IOT01A/flash_config.h
@@ -18,9 +18,5 @@
 
 #include "../../MX25R6435F_config.h"
 
-// TODO: remove when fixed
-// when perform 4IO write, when memory indicates write finish (changing WIP bit in status register)
-// but actually write is still in progress and we have to wait a bit more before reading
-#define STM_WRITE_4IO_BUG_WORKAROUND
 
 #endif // MBED_QSPI_FLASH_CONFIG_H

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -142,11 +142,6 @@ static void _qspi_write_read_test(Qspi &qspi, qspi_bus_width_t write_inst_width,
 
             timer.stop();
             write_time = timer.read_us();
-#ifdef STM_WRITE_4IO_BUG_WORKAROUND
-            if (write_cmd == QSPI_CMD_WRITE_4IO) {
-                wait_us(2000);
-            }
-#endif
         }
 
         if (read_frequency != QSPI_NONE) {


### PR DESCRIPTION
### Description

After feature-qspi branch rebase to latest master, everything works fine and workaround is not needed anymore.

@adustm can you confirm that test without workaround works fine on you side

Related PR: https://github.com/ARMmbed/mbed-os/pull/7325

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

