### PR TITLE
Export: Impl Makefile-based response/command files

### DIFF
--- a/tools/export/makefile/Makefile.tmpl
+++ b/tools/export/makefile/Makefile.tmpl
@@ -135,8 +135,9 @@ $(PROJECT).link_script{{link_script_ext}}: $(LINKER_SCRIPT)
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS) {% if pp_cmd -%} $(PROJECT).link_script{{link_script_ext}} {% else%} $(LINKER_SCRIPT) {% endif %}
+	$(file > $@.in, $(filter %.o, $^))
 	+@echo "link: $(notdir $@)"
-	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ $(filter %.o, $^) $(LIBRARIES) $(LD_SYS_LIBS)
+	@$(LD) $(LD_FLAGS) {{link_script_option}} $(filter-out %.o, $^) $(LIBRARY_PATHS) --output $@ {{response_option}}$@.in $(LIBRARIES) $(LD_SYS_LIBS)
 {% endblock %}
 
 $(PROJECT).bin: $(PROJECT).elf

--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -100,6 +100,7 @@ class Makefile(Exporter):
             'link_script_option': self.LINK_SCRIPT_OPTION,
             'user_library_flag': self.USER_LIBRARY_FLAG,
             'needs_asm_preproc': self.PREPROCESS_ASM,
+            'response_option': self.RESPONSE_OPTION,
         }
 
         if hasattr(self.toolchain, "preproc"):
@@ -217,6 +218,7 @@ class GccArm(Makefile):
     TOOLCHAIN = "GCC_ARM"
     LINK_SCRIPT_OPTION = "-T"
     USER_LIBRARY_FLAG = "-L"
+    RESPONSE_OPTION = "@"
 
     @staticmethod
     def prepare_lib(libname):
@@ -234,6 +236,7 @@ class Arm(Makefile):
     LINK_SCRIPT_OPTION = "--scatter"
     USER_LIBRARY_FLAG = "--userlibpath "
     TEMPLATE = 'make-arm'
+    RESPONSE_OPTION = "--via "
 
     @staticmethod
     def prepare_lib(libname):
@@ -284,6 +287,7 @@ class IAR(Makefile):
     TOOLCHAIN = "IAR"
     LINK_SCRIPT_OPTION = "--config"
     USER_LIBRARY_FLAG = "-L"
+    RESPONSE_OPTION = "-f "
 
     @staticmethod
     def prepare_lib(libname):

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -137,8 +137,8 @@ class Resources(object):
         self._label_paths = []
         self._labels = {"TARGET": [], "TOOLCHAIN": [], "FEATURE": []}
 
-        # Should we convert all paths to unix-style?
-        self._win_to_unix = False
+        # Path seperator style (defaults to OS-specific seperator)
+        self._sep = sep
 
         # Ignore patterns from .mbedignore files and add_ignore_patters
         self._ignore_patterns = []
@@ -181,11 +181,12 @@ class Resources(object):
         return count
 
     def win_to_unix(self):
-        self._win_to_unix = True
-        for file_type in self.ALL_FILE_TYPES:
-            v = [f._replace(name=f.name.replace('\\', '/')) for
-                 f in self.get_file_refs(file_type)]
-            self._file_refs[file_type] = v
+        self._sep = "/"
+        if self._sep != sep:
+            for file_type in self.ALL_FILE_TYPES:
+                v = [f._replace(name=f.name.replace(sep, self._sep)) for
+                     f in self.get_file_refs(file_type)]
+                self._file_refs[file_type] = v
 
     def __str__(self):
         s = []
@@ -262,8 +263,8 @@ class Resources(object):
                 dirname[len(label_type) + 1:] not in self._labels[label_type])
 
     def add_file_ref(self, file_type, file_name, file_path):
-        if self._win_to_unix:
-            ref = FileRef(file_name.replace("\\", "/"), file_path)
+        if sep != self._sep:
+            ref = FileRef(file_name.replace(sep, self._sep), file_path)
         else:
             ref = FileRef(file_name, file_path)
         self._file_refs[file_type].add(ref)
@@ -272,12 +273,11 @@ class Resources(object):
         """Return a list of FileRef for every file of the given type"""
         return list(self._file_refs[file_type])
 
-    @staticmethod
-    def _all_parents(files):
+    def _all_parents(self, files):
         for name in files:
-            components = name.split(sep)
+            components = name.split(self._sep)
             for n in range(1, len(components)):
-                parent = join(*components[:n])
+                parent = self._sep.join(components[:n])
                 yield parent
 
     def _get_from_refs(self, file_type, key):

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -276,7 +276,8 @@ class Resources(object):
     def _all_parents(self, files):
         for name in files:
             components = name.split(self._sep)
-            for n in range(1, len(components)):
+            start_at = 2 if components[0] == '' else 1
+            for n in range(2, len(components)):
                 parent = self._sep.join(components[:n])
                 yield parent
 


### PR DESCRIPTION
### Description

This PR updates all of the Makefile-based exporers to inculde a
response file for the link step. This should circumvent some windows
path length related issues.

Fix affects the following exporters:
 * `make_gcc_arm`
 * `make_armc5`
 * `make_armc6`
 * `make_iar`
 * `eclipse_gcc_arm`
 * `eclipse_armc5`
 * `eclipse_iar`

Fixes #6335 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change