### PR TITLE
Add reset internal state before call to HAL_QspiInit function

### DIFF
--- a/targets/TARGET_STM/qspi_api.c
+++ b/targets/TARGET_STM/qspi_api.c
@@ -140,6 +140,10 @@ qspi_status_t qspi_init(qspi_t *obj, PinName io0, PinName io1, PinName io2, PinN
     __HAL_RCC_QSPI_FORCE_RESET();
     __HAL_RCC_QSPI_RELEASE_RESET();
 
+    // Reset handle internal state
+    obj->handle.State = HAL_QSPI_STATE_RESET;
+    obj->handle.Lock = HAL_UNLOCKED;
+
     // Set default QSPI handle values
     obj->handle.Init.ClockPrescaler = 1;
     obj->handle.Init.FifoThreshold = 1;


### PR DESCRIPTION
### Description
This PR fixes an issue we noticed with @maciejbocianski during qspi_tests validation for ARM toolchain. (refer #7325)

2 variables in STM QSPI handle structure shall be initialized before the 1st call to HAL_QSPIInit function (at least the 1st call after the object creation)

```
hqspi->State shall be = HAL_QSPI_STATE_RESET
and hqspi->Lock shall be =HAL_UNLOCK
```
If the qspi object is created on the stack, it won't be zero-initialized and we don't know in advance the value of those 2 variables

With this PR, ARM test is passing
```
+-------------------------+---------------------+---------------------+--------+--------------------+-------------+
| target                  | platform_name       | test suite          | result | elapsed_time (sec) | copy_method |
+-------------------------+---------------------+---------------------+--------+--------------------+-------------+
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_hal-qspi | OK     | 41.5               | default     |
+-------------------------+---------------------+---------------------+--------+--------------------+-------------+
```

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

