### PR TITLE
Allow legacy TCPServer::accept() to override inherited Socket::accept()

### DIFF
--- a/features/netsocket/TCPServer.h
+++ b/features/netsocket/TCPServer.h
@@ -59,6 +59,9 @@ public:
      */
     virtual ~TCPServer();
 
+    // Allow legacy TCPServer::accept() to override inherited Socket::accept()
+    using TCPSocket::accept;
+
     /** Accepts a connection on a TCP socket
      *
      *  The server socket must be bound and set to listen for connections.


### PR DESCRIPTION
### Description
Allow legacy `TCPServer::accept()` to override inherited `Socket::accept()`

Fixes #7435


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

