### PR TITLE
Tools: Differential Memap

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -5,9 +5,9 @@ from __future__ import print_function, division, absolute_import
 
 from abc import abstractmethod, ABCMeta
 from sys import stdout, exit, argv
-from os import sep, rename
+from os import sep, rename, remove
 from os.path import (basename, dirname, join, relpath, abspath, commonprefix,
-                     splitext)
+                     splitext, exists)
 import re
 import csv
 import json
@@ -824,7 +824,10 @@ class MemapParser(object):
             except IOError:
                 self.old_modules = None
             if not COMPARE_FIXED:
-                rename(mapfile, "%s.old" % mapfile)
+                old_mapfile = "%s.old" % mapfile
+                if exists(old_mapfile):
+                    remove(old_mapfile)
+                rename(mapfile, old_mapfile)
             return True
 
         except IOError as error:

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -514,17 +514,16 @@ class MemapParser(object):
                 self.short_modules.setdefault(new_name, defaultdict(int))
                 for section_idx, value in v.items():
                     self.short_modules[new_name][section_idx] += self.modules[module_name][section_idx]
-                    try:
-                        new_size = self.modules[module_name][section_idx]
-                        try:
-                            old_size = self.old_modules[module_name][section_idx]
-                        except KeyError:
-                            old_size = 0
-                        self.short_modules[new_name][section_idx + '-delta'] += (
-                            new_size - old_size
-                        )
-                    except TypeError:
-                        self.short_modules[new_name][section_idx + '-delta'] += 0
+                    self.short_modules[new_name][section_idx + '-delta'] += self.modules[module_name][section_idx]
+            if self.old_modules:
+                for module_name, v in self.old_modules.items():
+                    split_name = module_name.split(sep)
+                    if split_name[0] == '':
+                        split_name = split_name[1:]
+                    new_name = join(*split_name[:depth])
+                    self.short_modules.setdefault(new_name, defaultdict(int))
+                    for section_idx, value in v.items():
+                        self.short_modules[new_name][section_idx + '-delta'] -= self.old_modules[module_name][section_idx]
 
     export_formats = ["json", "csv-ci", "html", "table"]
 

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -610,32 +610,33 @@ class MemapParser(object):
                 cur_text = self._move_up_tree(cur_text, next_module)
                 cur_data = self._move_up_tree(cur_data, next_module)
                 cur_bss = self._move_up_tree(cur_bss, next_module)
-        for name, dct in self.old_modules.items():
-            cur_text = tree_text
-            cur_bss = tree_bss
-            cur_data = tree_data
-            modules = name.split(sep)
-            while True:
-                try:
-                    cur_text["delta"] -= dct['.text']
-                except KeyError:
-                    pass
-                try:
-                    cur_bss["delta"] -= dct['.bss']
-                except KeyError:
-                    pass
-                try:
-                    cur_data["delta"] -= dct['.data']
-                except KeyError:
-                    pass
-                if not modules:
-                    break
-                next_module = modules.pop(0)
-                if not any(cld['name'] == next_module for cld in cur_text['children']):
-                    break
-                cur_text = self._move_up_tree(cur_text, next_module)
-                cur_data = self._move_up_tree(cur_data, next_module)
-                cur_bss = self._move_up_tree(cur_bss, next_module)
+        if self.old_modules:
+            for name, dct in self.old_modules.items():
+                cur_text = tree_text
+                cur_bss = tree_bss
+                cur_data = tree_data
+                modules = name.split(sep)
+                while True:
+                    try:
+                        cur_text["delta"] -= dct['.text']
+                    except KeyError:
+                        pass
+                    try:
+                        cur_bss["delta"] -= dct['.bss']
+                    except KeyError:
+                        pass
+                    try:
+                        cur_data["delta"] -= dct['.data']
+                    except KeyError:
+                        pass
+                    if not modules:
+                        break
+                    next_module = modules.pop(0)
+                    if not any(cld['name'] == next_module for cld in cur_text['children']):
+                        break
+                    cur_text = self._move_up_tree(cur_text, next_module)
+                    cur_data = self._move_up_tree(cur_data, next_module)
+                    cur_bss = self._move_up_tree(cur_bss, next_module)
 
         tree_rom = {
             "name": "ROM",

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -5,7 +5,7 @@ from __future__ import print_function, division, absolute_import
 
 from abc import abstractmethod, ABCMeta
 from sys import stdout, exit, argv
-from os import sep
+from os import sep, rename
 from os.path import (basename, dirname, join, relpath, abspath, commonprefix,
                      splitext)
 import re
@@ -20,6 +20,7 @@ from jinja2.environment import Environment
 
 from .utils import (argparse_filestring_type, argparse_lowercase_hyphen_type,
                     argparse_uppercase_type)
+from .settings import COMPARE_FIXED
 
 
 class _Parser(object):
@@ -801,6 +802,8 @@ class MemapParser(object):
                     self.old_modules = parser().parse_mapfile(old_input)
             except IOError:
                 self.old_modules = None
+            if not COMPARE_FIXED:
+                rename(mapfile, "%s.old" % mapfile)
             return True
 
         except IOError as error:

--- a/tools/memap_flamegraph.html
+++ b/tools/memap_flamegraph.html
@@ -80,16 +80,35 @@
       .direction("s")
       .offset([8, 0])
       .attr('class', 'd3-flame-graph-tip')
-      .html(function(d) { return "module: " + d.data.name + ", bytes: " + d.data.value; });
+      .html(function(d) { return "module: " + d.data.name + ", bytes: " + d.data.value + ", delta: " + d.data.delta; });
+    var colorizer = function (d) {
+        if (d.data.delta > 0) {
+            ratio = (d.data.value - d.data.delta) / d.data.value;
+            green = ("0" + (Number(ratio * 0xFF | 0).toString(16))).slice(-2).toUpperCase();
+            blue = ("0" + (Number(ratio * 0xEE | 0).toString(16))).slice(-2).toUpperCase();
+            console.log(d.data.name, green, blue);
+            return "#EE" + green + blue
+        } else if (d.data.delta < 0) {
+            ratio = (d.data.value + d.data.delta) / d.data.value;
+            green = ("0" + (Number(ratio * 0xFF | 0).toString(16))).slice(-2).toUpperCase();
+            red = ("0" + (Number(ratio * 0xFF | 0).toString(16))).slice(-2).toUpperCase();
+            console.log(d.data.name, red, green);
+            return "#" + red + green + "EE";
+        } else {
+            return "#FFFFEE";
+        }
+    }
     var flameGraph_rom = d3.flameGraph()
       .transitionDuration(250)
       .transitionEase(d3.easeCubic)
       .sort(true)
+      .color(colorizer)
       .tooltip(tip);
     var flameGraph_ram = d3.flameGraph()
       .transitionDuration(250)
       .transitionEase(d3.easeCubic)
       .sort(true)
+      .color(colorizer)
       .tooltip(tip);
     var rom_elem = d3.select("#chart-rom");
     flameGraph_rom.width(rom_elem.node().getBoundingClientRect().width);

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -58,6 +58,9 @@ MBED_ORG_USER = ""
 # Print compiler warnings and errors as link format
 PRINT_COMPILER_OUTPUT_AS_LINK = False
 
+# Compare against a fixed build of the project for space consumption
+COMPARE_FIXED = False
+
 # Print warnings/errors in color
 COLOR = False
 
@@ -91,7 +94,7 @@ for _n in _ENV_PATHS:
             print("WARNING: MBED_%s set as environment variable but doesn't"
                   " exist" % _n)
 
-_ENV_VARS = ['PRINT_COMPILER_OUTPUT_AS_LINK', 'COLOR']
+_ENV_VARS = ['PRINT_COMPILER_OUTPUT_AS_LINK', 'COLOR', 'COMPARE_FIXED']
 for _n in _ENV_VARS:
     value = getenv('MBED_%s' % _n)
     if value:


### PR DESCRIPTION
### Description

This PR adds a new feature to our memory analysis package: Differental
Analysis. With this new feature, every build of an Mbed OS project will
print out a comparison between the previous build, or a fixed build, and
the current build. Use the environment vairable `MBED_COMPARE_FIXED` 
to use the prior build as the fixed comparison point.

#### Example

In this example, I added a printf to blinky as follows:
```diff
diff --git a/main.cpp b/main.cpp
index 2df9a05..e292ab4 100644
--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@ DigitalOut led1(LED1);
 // main() runs in its own thread in the OS
 int main() {
     while (true) {
+        printf("foo");
         led1 = !led1;
         wait(0.5);
     }
```

Which results in the following table (stats depth at the defualt of 2):
```
Building project blinky (K64F, GCC_ARM)
Scan: blinky
Scan: env
Compile [100.0%]: main.cpp
Link: blinky
Elf2Bin: blinky
+------------------+--------------+----------+----------+
| Module           |        .text |    .data |     .bss |
+------------------+--------------+----------+----------+
| [fill]           |      103(-8) |    4(+0) | 2464(+0) |
| [lib]/c.a        | 31623(+7074) | 2472(+0) |   89(+0) |
| [lib]/gcc.a      |     3112(+0) |    0(+0) |    0(+0) |
| [lib]/misc       |      204(+0) |    4(+0) |   28(+0) |
| [lib]/nosys.a    |       32(+0) |    0(+0) |    0(+0) |
| main.o           |      72(+16) |    0(+0) |    4(+0) |
| mbed-os/drivers  |       56(+0) |    0(+0) |    0(+0) |
| mbed-os/features |       42(+0) |    0(+0) |  184(+0) |
| mbed-os/hal      |     1725(+0) |    4(+0) |   68(+0) |
| mbed-os/platform |     2673(+0) |  260(+0) |  133(+0) |
| mbed-os/rtos     |     9290(+0) |  168(+0) | 6073(+0) |
| mbed-os/targets  |     8479(+0) |   12(+0) |  381(+0) |
| Subtotals        | 57411(+7082) | 2924(+0) | 9424(+0) |
+------------------+--------------+----------+----------+
Total Static RAM memory (data + bss): 12348(+0) bytes
Total Flash memory (text + data): 60335(+7082) bytes

```

Printf costs an extra 7074 bytes! and the call costs 16 bytes.

The following is a link to the flame graph generated by the same build 
and colorized based on the delta:
http://mbed-os.s3-eu-west-1.amazonaws.com/builds/diff-memap-demo.html

The colorization scheme is:
 * light yellow: No change
 * Dark red: +100% of the current code size
 * Vibrant blue: -99.99% of the current code size (-100% would not show 
        up, as we don't show modules with size 0)


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [x] Feature
    [ ] Breaking change