### PR TITLE
Replace macro to functions in SHA256/512

### DIFF
--- a/features/mbedtls/src/sha256.c
+++ b/features/mbedtls/src/sha256.c
@@ -65,13 +65,13 @@ do {                                                    \
 #endif
 
 #ifndef PUT_UINT32_BE
-#define PUT_UINT32_BE(n,b,i)                            \
-do {                                                    \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n)       );       \
-} while( 0 )
+void PUT_UINT32_BE(uint32_t n, unsigned char* b, uint32_t i)                            
+{                                                    
+    b[(i)    ] = (unsigned char) ( (n) >> 24 );       
+    b[(i) + 1] = (unsigned char) ( (n) >> 16 );       
+    b[(i) + 2] = (unsigned char) ( (n) >>  8 );       
+    b[(i) + 3] = (unsigned char) ( (n)       );       
+}
 #endif
 
 void mbedtls_sha256_init( mbedtls_sha256_context *ctx )
@@ -178,17 +178,19 @@ static const uint32_t K[] =
            S0(W[t - 15]) + W[t - 16]            \
 )
 
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
+static void sha256_P_process(uint32_t a,uint32_t b, uint32_t c, uint32_t *d, uint32_t e, uint32_t f, uint32_t g, uint32_t *h, uint32_t x, uint32_t K)
+{
+	uint32_t temp1, temp2;
+	temp1 = *h + S3(e) + F1(e,f,g) + K + x;
+	temp2 = S2(a) + F0(a,b,c);
+	*d += temp1;
+	*h = temp1 + temp2;
 }
 
 int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
                                 const unsigned char data[64] )
 {
-    uint32_t temp1, temp2, W[64];
+    uint32_t W[64];
     uint32_t A[8];
     unsigned int i;
 
@@ -214,26 +216,26 @@ int mbedtls_internal_sha256_process( mbedtls_sha256_context *ctx,
 
     for( i = 0; i < 16; i += 8 )
     {
-        P( A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], W[i+0], K[i+0] );
-        P( A[7], A[0], A[1], A[2], A[3], A[4], A[5], A[6], W[i+1], K[i+1] );
-        P( A[6], A[7], A[0], A[1], A[2], A[3], A[4], A[5], W[i+2], K[i+2] );
-        P( A[5], A[6], A[7], A[0], A[1], A[2], A[3], A[4], W[i+3], K[i+3] );
-        P( A[4], A[5], A[6], A[7], A[0], A[1], A[2], A[3], W[i+4], K[i+4] );
-        P( A[3], A[4], A[5], A[6], A[7], A[0], A[1], A[2], W[i+5], K[i+5] );
-        P( A[2], A[3], A[4], A[5], A[6], A[7], A[0], A[1], W[i+6], K[i+6] );
-        P( A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[0], W[i+7], K[i+7] );
+        sha256_P_process( A[0], A[1], A[2], &A[3], A[4], A[5], A[6], &A[7], W[i+0], K[i+0] );
+        sha256_P_process( A[7], A[0], A[1], &A[2], A[3], A[4], A[5], &A[6], W[i+1], K[i+1] );
+        sha256_P_process( A[6], A[7], A[0], &A[1], A[2], A[3], A[4], &A[5], W[i+2], K[i+2] );
+        sha256_P_process( A[5], A[6], A[7], &A[0], A[1], A[2], A[3], &A[4], W[i+3], K[i+3] );
+        sha256_P_process( A[4], A[5], A[6], &A[7], A[0], A[1], A[2], &A[3], W[i+4], K[i+4] );
+        sha256_P_process( A[3], A[4], A[5], &A[6], A[7], A[0], A[1], &A[2], W[i+5], K[i+5] );
+        sha256_P_process( A[2], A[3], A[4], &A[5], A[6], A[7], A[0], &A[1], W[i+6], K[i+6] );
+        sha256_P_process( A[1], A[2], A[3], &A[4], A[5], A[6], A[7], &A[0], W[i+7], K[i+7] );
     }
 
     for( i = 16; i < 64; i += 8 )
     {
-        P( A[0], A[1], A[2], A[3], A[4], A[5], A[6], A[7], R(i+0), K[i+0] );
-        P( A[7], A[0], A[1], A[2], A[3], A[4], A[5], A[6], R(i+1), K[i+1] );
-        P( A[6], A[7], A[0], A[1], A[2], A[3], A[4], A[5], R(i+2), K[i+2] );
-        P( A[5], A[6], A[7], A[0], A[1], A[2], A[3], A[4], R(i+3), K[i+3] );
-        P( A[4], A[5], A[6], A[7], A[0], A[1], A[2], A[3], R(i+4), K[i+4] );
-        P( A[3], A[4], A[5], A[6], A[7], A[0], A[1], A[2], R(i+5), K[i+5] );
-        P( A[2], A[3], A[4], A[5], A[6], A[7], A[0], A[1], R(i+6), K[i+6] );
-        P( A[1], A[2], A[3], A[4], A[5], A[6], A[7], A[0], R(i+7), K[i+7] );
+        sha256_P_process( A[0], A[1], A[2], &A[3], A[4], A[5], A[6], &A[7], R(i+0), K[i+0] );
+        sha256_P_process( A[7], A[0], A[1], &A[2], A[3], A[4], A[5], &A[6], R(i+1), K[i+1] );
+        sha256_P_process( A[6], A[7], A[0], &A[1], A[2], A[3], A[4], &A[5], R(i+2), K[i+2] );
+        sha256_P_process( A[5], A[6], A[7], &A[0], A[1], A[2], A[3], &A[4], R(i+3), K[i+3] );
+        sha256_P_process( A[4], A[5], A[6], &A[7], A[0], A[1], A[2], &A[3], R(i+4), K[i+4] );
+        sha256_P_process( A[3], A[4], A[5], &A[6], A[7], A[0], A[1], &A[2], R(i+5), K[i+5] );
+        sha256_P_process( A[2], A[3], A[4], &A[5], A[6], A[7], A[0], &A[1], R(i+6), K[i+6] );
+        sha256_P_process( A[1], A[2], A[3], &A[4], A[5], A[6], A[7], &A[0], R(i+7), K[i+7] );
     }
 #endif /* MBEDTLS_SHA256_SMALLER */
 

--- a/features/mbedtls/src/sha512.c
+++ b/features/mbedtls/src/sha512.c
@@ -57,6 +57,27 @@
 
 #if !defined(MBEDTLS_SHA512_ALT)
 
+#define SHR(x,n) (x >> n)
+#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
+
+#define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
+#define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
+
+#define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
+#define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
+
+#define F0(x,y,z) ((x & y) | (z & (x | y)))
+#define F1(x,y,z) (z ^ (x & (y ^ z)))
+
+static void sha512_process(uint64_t a,uint64_t b, uint64_t c, uint64_t *d, uint64_t e, uint64_t f, uint64_t g, uint64_t *h, uint64_t x, uint64_t K)
+{
+	uint64_t temp1, temp2;
+	temp1 = *h + S3(e) + F1(e,f,g) + K + x;
+	temp2 = S2(a) + F0(a,b,c);
+	*d += temp1;
+	*h = temp1 + temp2;
+}
+
 /*
  * 64-bit integer manipulation macros (big endian)
  */
@@ -75,16 +96,16 @@
 #endif /* GET_UINT64_BE */
 
 #ifndef PUT_UINT64_BE
-#define PUT_UINT64_BE(n,b,i)                            \
-{                                                       \
-    (b)[(i)    ] = (unsigned char) ( (n) >> 56 );       \
-    (b)[(i) + 1] = (unsigned char) ( (n) >> 48 );       \
-    (b)[(i) + 2] = (unsigned char) ( (n) >> 40 );       \
-    (b)[(i) + 3] = (unsigned char) ( (n) >> 32 );       \
-    (b)[(i) + 4] = (unsigned char) ( (n) >> 24 );       \
-    (b)[(i) + 5] = (unsigned char) ( (n) >> 16 );       \
-    (b)[(i) + 6] = (unsigned char) ( (n) >>  8 );       \
-    (b)[(i) + 7] = (unsigned char) ( (n)       );       \
+static void PUT_UINT64_BE(uint64_t n, unsigned char * b, uint8_t i )
+{
+	(b)[(i)    ] = (unsigned char) ( (n) >> 56 );
+	(b)[(i) + 1] = (unsigned char) ( (n) >> 48 );
+	(b)[(i) + 2] = (unsigned char) ( (n) >> 40 );
+	(b)[(i) + 3] = (unsigned char) ( (n) >> 32 );
+	(b)[(i) + 4] = (unsigned char) ( (n) >> 24 );
+	(b)[(i) + 5] = (unsigned char) ( (n) >> 16 );
+	(b)[(i) + 6] = (unsigned char) ( (n) >>  8 );
+	(b)[(i) + 7] = (unsigned char) ( (n)       );
 }
 #endif /* PUT_UINT64_BE */
 
@@ -209,25 +230,6 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
     uint64_t temp1, temp2, W[80];
     uint64_t A, B, C, D, E, F, G, H;
 
-#define  SHR(x,n) (x >> n)
-#define ROTR(x,n) (SHR(x,n) | (x << (64 - n)))
-
-#define S0(x) (ROTR(x, 1) ^ ROTR(x, 8) ^  SHR(x, 7))
-#define S1(x) (ROTR(x,19) ^ ROTR(x,61) ^  SHR(x, 6))
-
-#define S2(x) (ROTR(x,28) ^ ROTR(x,34) ^ ROTR(x,39))
-#define S3(x) (ROTR(x,14) ^ ROTR(x,18) ^ ROTR(x,41))
-
-#define F0(x,y,z) ((x & y) | (z & (x | y)))
-#define F1(x,y,z) (z ^ (x & (y ^ z)))
-
-#define P(a,b,c,d,e,f,g,h,x,K)                  \
-{                                               \
-    temp1 = h + S3(e) + F1(e,f,g) + K + x;      \
-    temp2 = S2(a) + F0(a,b,c);                  \
-    d += temp1; h = temp1 + temp2;              \
-}
-
     for( i = 0; i < 16; i++ )
     {
         GET_UINT64_BE( W[i], data, i << 3 );
@@ -251,14 +253,14 @@ int mbedtls_internal_sha512_process( mbedtls_sha512_context *ctx,
 
     do
     {
-        P( A, B, C, D, E, F, G, H, W[i], K[i] ); i++;
-        P( H, A, B, C, D, E, F, G, W[i], K[i] ); i++;
-        P( G, H, A, B, C, D, E, F, W[i], K[i] ); i++;
-        P( F, G, H, A, B, C, D, E, W[i], K[i] ); i++;
-        P( E, F, G, H, A, B, C, D, W[i], K[i] ); i++;
-        P( D, E, F, G, H, A, B, C, W[i], K[i] ); i++;
-        P( C, D, E, F, G, H, A, B, W[i], K[i] ); i++;
-        P( B, C, D, E, F, G, H, A, W[i], K[i] ); i++;
+		 sha512_process( A, B, C, &D, E, F, G, &H, W[i], K[i] ); i++;
+		 sha512_process( H, A, B, &C, D, E, F, &G, W[i], K[i] ); i++;
+		 sha512_process( G, H, A, &B, C, D, E, &F, W[i], K[i] ); i++;
+		 sha512_process( F, G, H, &A, B, C, D, &E, W[i], K[i] ); i++;
+		 sha512_process( E, F, G, &H, A, B, C, &D, W[i], K[i] ); i++;
+		 sha512_process( D, E, F, &G, H, A, B, &C, W[i], K[i] ); i++;
+		 sha512_process( C, D, E, &F, G, H, A, &B, W[i], K[i] ); i++;
+		 sha512_process( B, C, D, &E, F, G, H, &A, W[i], K[i] ); i++;
     }
     while( i < 80 );
 


### PR DESCRIPTION
### Description
Replace macros in mbedtls SHA256 & SHA512 to function ro reduce code size
the tradeoff in replacing the macro is size over speed benchmark testing show the following results:
```
Macro
SHA-256  515 Kb/s
SHA-512  338 Kb/s

Functions
SHA-256  456 Kb/s
SHA-512  309 Kb/s
```
SHA256 drops by 12%  and SHA512 drops by 9%
### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

