### PR TITLE
Enable Link time optimization for ARMC6

### DIFF
--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -19,11 +19,11 @@
                    "-Wno-armcc-pragma-push-pop", "-Wno-armcc-pragma-anon-unions",
                    "-DMULADDC_CANNOT_USE_R7", "-fdata-sections",
                    "-fno-exceptions", "-MMD", "-D_LIBCPP_EXTERN_TEMPLATE(...)=",
-                   "-fshort-enums", "-fshort-wchar"],
+                   "-fshort-enums", "-fshort-wchar", "-flto"],
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--show_full_path", "--legacyalign"]
+        "ld": ["--show_full_path", "--legacyalign", "--lto"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
## Description

As part of the Mbed hackaton effort to reduce code size of mbed-os & mbed-cloud-client link-time optimization can help.

GCC: `-flto` flag was added to the compiler and to the linker.
ARMC6: `-flto` flag was added to the compiler and `--lto` to the linker.

It was tested with [simple-mbed-cloud-client](https://github.com/ARMmbed/simple-mbed-cloud-client-template-restricted), did not checked mbed-os tests yet.

* It was tested with ARM_GCC compiler version 7.3.1 and ARM compiler version 6.9.
* ARM_GCC compiler version 6.x.x doesn't work, see [https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86490](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86490).
* Minus side is that the memory statistics no longer works so you can't see the each module memory usage anymore.
* IAR is still in the todo-list.. (use --mfc there)

### ARM_GCC

#### Without Link-Time optimization

```bash
+-------------------------------------------------------+------------+----------+-----------+
| Module                                                |      .text |    .data |      .bss |
+-------------------------------------------------------+------------+----------+-----------+
| [fill]                                                |    750(+0) |   14(+0) |  2208(+0) |
| [lib]/c.a                                             |  56355(+0) | 2572(+0) |   127(+0) |
| [lib]/gcc.a                                           |   7420(+0) |    0(+0) |     0(+0) |
| [lib]/misc                                            |    204(+0) |    4(+0) |    28(+0) |
| [lib]/nosys.a                                         |     32(+0) |    0(+0) |     0(+0) |
| [lib]/stdc++.a                                        |   6920(+0) |    8(+0) |    44(+0) |
| main.o                                                |   3716(+0) |    0(+0) |   712(+0) |
| mbed-os/drivers                                       |   2188(+0) |    0(+0) |    84(+0) |
| mbed-os/events                                        |   1768(+0) |    0(+0) |  3152(+0) |
| mbed-os/features                                      | 153032(+0) |  198(+0) | 52842(+0) |
| mbed-os/hal                                           |   1600(+0) |    4(+0) |    68(+0) |
| mbed-os/platform                                      |   3565(+0) |  276(+0) |   642(+0) |
| mbed-os/rtos                                          |  14896(+0) |  168(+0) |  6593(+0) |
| mbed-os/targets                                       |  12279(+0) |   12(+0) |   533(+0) |
| mbed_cloud_dev_credentials.o                          |   1541(+0) |    0(+0) |     0(+0) |
| sd-driver/SDBlockDevice.o                             |   3102(+0) |    0(+0) |     0(+0) |
| simple-mbed-cloud-client/mbed-cloud-client            | 116185(+0) |  412(+0) |  6993(+0) |
| simple-mbed-cloud-client/mbed_cloud_client_resource.o |   1207(+0) |    0(+0) |     0(+0) |
| simple-mbed-cloud-client/resource.o                   |    558(+0) |    0(+0) |     0(+0) |
| simple-mbed-cloud-client/simple-mbed-cloud-client.o   |   3509(+0) |    0(+0) |     8(+0) |
| simple-mbed-cloud-client/update_ui_example.o          |    444(+0) |    0(+0) |     6(+0) |
| update_default_resources.o                            |     73(+0) |    0(+0) |     0(+0) |
| Subtotals                                             | 391344(+0) | 3668(+0) | 74040(+0) |
+-------------------------------------------------------+------------+----------+-----------+
Total Static RAM memory (data + bss): 77708(+0) bytes
Total Flash memory (text + data): 395012(+0) bytes
```

#### With Link-Time optimization (diff is from not-optimized image)

```bash
+-------------------------------------------------------+-----------------+------------+---------------+
| Module                                                |           .text |      .data |          .bss |
+-------------------------------------------------------+-----------------+------------+---------------+
| ../..                                                 | 285178(+285178) |  939(+939) | 71540(+71540) |
| BUILD/K64F                                            |       904(+904) |      0(+0) |         0(+0) |
| [fill]                                                |       131(-619) |     13(-1) |     2145(-63) |
| [lib]/c.a                                             |       56355(+0) |   2572(+0) |       127(+0) |
| [lib]/gcc.a                                           |        7420(+0) |      0(+0) |         0(+0) |
| [lib]/misc                                            |         204(+0) |      0(-4) |        28(+0) |
| [lib]/nosys.a                                         |          32(+0) |      0(+0) |         0(+0) |
| [lib]/stdc++.a                                        |        6919(-1) |      8(+0) |        44(+0) |
| main.o                                                |        0(-3716) |      0(+0) |       0(-712) |
| mbed-os/drivers                                       |        0(-2188) |      0(+0) |        0(-84) |
| mbed-os/events                                        |        0(-1768) |      0(+0) |      0(-3152) |
| mbed-os/features                                      |      0(-153032) |    0(-198) |     0(-52842) |
| mbed-os/hal                                           |        0(-1600) |      0(-4) |        0(-68) |
| mbed-os/platform                                      |        0(-3565) |    0(-276) |       0(-642) |
| mbed-os/rtos                                          |       0(-14896) |    0(-168) |      0(-6593) |
| mbed-os/targets                                       |       0(-12279) |     0(-12) |       0(-533) |
| mbed_cloud_dev_credentials.o                          |        0(-1541) |      0(+0) |         0(+0) |
| sd-driver/SDBlockDevice.o                             |        0(-3102) |      0(+0) |         0(+0) |
| simple-mbed-cloud-client/mbed-cloud-client            |      0(-116185) |    0(-412) |      0(-6993) |
| simple-mbed-cloud-client/mbed_cloud_client_resource.o |        0(-1207) |      0(+0) |         0(+0) |
| simple-mbed-cloud-client/resource.o                   |         0(-558) |      0(+0) |         0(+0) |
| simple-mbed-cloud-client/simple-mbed-cloud-client.o   |        0(-3509) |      0(+0) |         0(-8) |
| simple-mbed-cloud-client/update_ui_example.o          |         0(-444) |      0(+0) |         0(-6) |
| update_default_resources.o                            |          0(-73) |      0(+0) |         0(+0) |
| Subtotals                                             |  357143(-34201) | 3532(-136) |   73884(-156) |
+-------------------------------------------------------+-----------------+------------+---------------+
Total Static RAM memory (data + bss): 77416(-292) bytes
Total Flash memory (text + data): 360675(-34337) bytes
```

### ARMC6

#### Without Link-Time optimization

```bash
+-------------------------------------------------------+------------+---------+-----------+
| Module                                                |      .text |   .data |      .bss |
+-------------------------------------------------------+------------+---------+-----------+
| [lib]/c_wu.l                                          |  19347(+0) |  20(+0) |   392(+0) |
| [lib]/fz_wm.l                                         |   1838(+0) |   0(+0) |     0(+0) |
| [lib]/libcpp_wnu.l                                    |      1(+0) |   0(+0) |     0(+0) |
| [lib]/libcppabi_wnu.l                                 |     44(+0) |   0(+0) |     0(+0) |
| [lib]/m_wm.l                                          |    802(+0) |   0(+0) |     0(+0) |
| anon$$obj.o                                           |     32(+0) |   0(+0) |  1024(+0) |
| main.o                                                |   3783(+0) |   0(+0) |   720(+0) |
| mbed-os/drivers                                       |   2041(+0) |   0(+0) |    84(+0) |
| mbed-os/events                                        |   1905(+0) |   0(+0) |  3152(+0) |
| mbed-os/features                                      | 158079(+0) | 240(+0) | 52966(+0) |
| mbed-os/hal                                           |   1814(+0) |   4(+0) |    68(+0) |
| mbed-os/platform                                      |   4636(+0) |  80(+0) |   549(+0) |
| mbed-os/rtos                                          |  15787(+0) | 168(+0) |  7246(+0) |
| mbed-os/targets                                       |  21943(+0) |  20(+0) |   477(+0) |
| mbed_cloud_dev_credentials.o                          |   1541(+0) |   0(+0) |     0(+0) |
| sd-driver/SDBlockDevice.o                             |   4443(+0) |   0(+0) |     0(+0) |
| simple-mbed-cloud-client/mbed-cloud-client            | 118794(+0) | 377(+0) |  7042(+0) |
| simple-mbed-cloud-client/mbed_cloud_client_resource.o |   1256(+0) |   0(+0) |     0(+0) |
| simple-mbed-cloud-client/resource.o                   |    586(+0) |   0(+0) |     0(+0) |
| simple-mbed-cloud-client/simple-mbed-cloud-client.o   |   3574(+0) |   0(+0) |     8(+0) |
| simple-mbed-cloud-client/update_ui_example.o          |    395(+0) |   0(+0) |     6(+0) |
| update_default_resources.o                            |     73(+0) |   0(+0) |     0(+0) |
| Subtotals                                             | 362714(+0) | 909(+0) | 73734(+0) |
+-------------------------------------------------------+------------+---------+-----------+
Total Static RAM memory (data + bss): 74643(+0) bytes
Total Flash memory (text + data): 363623(+0) bytes
```

#### With Link-Time optimization (diff is from not-optimized image)

```bash
+-------------------------------------------------------+-----------------+-----------+---------------+
| Module                                                |           .text |     .data |          .bss |
+-------------------------------------------------------+-----------------+-----------+---------------+
| ../..                                                 | 306677(+306677) | 716(+716) | 72240(+72240) |
| BUILD/K64F                                            |     1888(+1888) |     0(+0) |         0(+0) |
| [lib]/c_wu.l                                          |     19965(+618) |    20(+0) |       392(+0) |
| [lib]/fz_wm.l                                         |        1838(+0) |     0(+0) |         0(+0) |
| [lib]/libcpp_wnu.l                                    |           0(-1) |     0(+0) |         0(+0) |
| [lib]/libcppabi_wnu.l                                 |          44(+0) |     0(+0) |         0(+0) |
| [lib]/m_wm.l                                          |         802(+0) |     0(+0) |         0(+0) |
| anon$$obj.o                                           |          32(+0) |     0(+0) |      1024(+0) |
| main.o                                                |        0(-3783) |     0(+0) |       0(-720) |
| mbed-os/drivers                                       |        0(-2041) |     0(+0) |        0(-84) |
| mbed-os/events                                        |        0(-1905) |     0(+0) |      0(-3152) |
| mbed-os/features                                      |      0(-158079) |   0(-240) |     0(-52966) |
| mbed-os/hal                                           |        0(-1814) |     0(-4) |        0(-68) |
| mbed-os/platform                                      |        0(-4636) |    0(-80) |       0(-549) |
| mbed-os/rtos                                          |       0(-15787) |   0(-168) |      0(-7246) |
| mbed-os/targets                                       |       0(-21943) |    0(-20) |       0(-477) |
| mbed_cloud_dev_credentials.o                          |        0(-1541) |     0(+0) |         0(+0) |
| sd-driver/SDBlockDevice.o                             |        0(-4443) |     0(+0) |         0(+0) |
| simple-mbed-cloud-client/mbed-cloud-client            |      0(-118794) |   0(-377) |      0(-7042) |
| simple-mbed-cloud-client/mbed_cloud_client_resource.o |        0(-1256) |     0(+0) |         0(+0) |
| simple-mbed-cloud-client/resource.o                   |         0(-586) |     0(+0) |         0(+0) |
| simple-mbed-cloud-client/simple-mbed-cloud-client.o   |        0(-3574) |     0(+0) |         0(-8) |
| simple-mbed-cloud-client/update_ui_example.o          |         0(-395) |     0(+0) |         0(-6) |
| update_default_resources.o                            |          0(-73) |     0(+0) |         0(+0) |
| Subtotals                                             |  331246(-31468) | 736(-173) |    73656(-78) |
+-------------------------------------------------------+-----------------+-----------+---------------+
Total Static RAM memory (data + bss): 74392(-251) bytes
Total Flash memory (text + data): 331982(-31641) bytes
```

## Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

