### PR TITLE
Make common tickers test more strict

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -206,17 +206,17 @@ void ticker_interrupt_test(void)
          * tick_count + ticker_timeout[i]. */
         intf->set_interrupt(tick_count + ticker_timeout[i]);
 
-        /* Wait until ticker count reach value: tick_count + ticker_timeout[i] - TICKER_DELTA.
+        /* Wait until ticker count reach value: tick_count + ticker_timeout[i].
          * Interrupt should not be fired. */
-        while (intf->read() < (tick_count + ticker_timeout[i] - TICKER_DELTA)) {
-            /* Indicate failure if interrupt has fired earlier. */
-            TEST_ASSERT_EQUAL_INT_MESSAGE(0, intFlag, "Interrupt fired too early");
-        }
+        uint32_t last_flag = intFlag;
+        uint32_t last_read = intf->read();
+        while (last_read < (tick_count + ticker_timeout[i])) {
 
-        /* Wait until ticker count reach value: tick_count + ticker_timeout[i] + TICKER_DELTA.
-         * Interrupt should be fired after this time. */
-        while (intf->read() < (tick_count + ticker_timeout[i] + TICKER_DELTA)) {
-            /* Just wait. */
+            /* Indicate failure if interrupt has fired earlier. */
+            TEST_ASSERT_EQUAL_INT_MESSAGE(0, last_flag, "Interrupt fired too early");
+
+            last_flag = intFlag;
+            last_read = intf->read();
         }
 
         TEST_ASSERT_EQUAL(1, intFlag);
@@ -342,7 +342,7 @@ void ticker_overflow_test(void)
     intf->set_interrupt(tick_count + TICKER_INT_VAL);
 
     /* Wait for the interrupt. */
-    while (intf->read() < (tick_count + TICKER_INT_VAL + TICKER_DELTA)) {
+    while (intf->read() < (tick_count + TICKER_INT_VAL)) {
         /* Just wait. */
     }
 


### PR DESCRIPTION
### Description

The ticker specification requires that the ticker interrupt fires only
when the ticker times increments to or past the value set by
ticker_set_interrupt. The test for this, ticker_interrupt_test,
only asserted that the interrupt to fired within +-TICKER_DELTA of the
match value.

This patch removes TICKER_DELTA tolerance so the test will fail if the
interrupt does not fire at the exact time specified.
### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

