### PR TITLE
Remove unnecessary low power ticker rescheduling

### DIFF
--- a/hal/ticker_api.h
+++ b/hal/ticker_api.h
@@ -80,6 +80,7 @@ typedef struct {
     uint64_t tick_remainder;            /**< Ticks that have not been added to base_time */
     us_timestamp_t present_time;        /**< Store the timestamp used for present time */
     bool initialized;                   /**< Indicate if the instance is initialized */
+    bool dispatching;                   /**< The function ticker_irq_handler is dispatching */
     uint8_t frequency_shifts;           /**< If frequency is a value of 2^n, this is n, otherwise 0 */
 } ticker_event_queue_t;
 

--- a/rtos/TARGET_CORTEX/SysTimer.cpp
+++ b/rtos/TARGET_CORTEX/SysTimer.cpp
@@ -178,6 +178,7 @@ void SysTimer::handler()
     } else {
         _set_irq_pending();
         _increment_tick();
+        schedule_tick();
     }
 
     core_util_critical_section_exit();

--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -63,7 +63,7 @@ void OS_Tick_Disable (void)
 /// Acknowledge System Timer IRQ.
 void OS_Tick_AcknowledgeIRQ (void)
 {
-    os_timer->schedule_tick();
+
 }
 
 /// Get System Timer count.


### PR DESCRIPTION
### Description

This PR is an optimization to prevent the tickers, particularly the low power ticker, from being rescheduled unnecessarily.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

