### PR TITLE
LoRaWAN: Reduced priority for automatic uplinks & higher data rate usage for connection establishment

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -805,8 +805,12 @@ void LoRaWANStack::send_event_to_application(const lorawan_event_t event) const
 
 void LoRaWANStack::send_automatic_uplink_message(const uint8_t port)
 {
+    // we will silently ignore the automatic uplink event if the user is already
+    // sending something
     const int16_t ret = handle_tx(port, NULL, 0, MSG_CONFIRMED_FLAG, true, true);
-    if (ret < 0) {
+    if (ret == LORAWAN_STATUS_WOULD_BLOCK) {
+        _automatic_uplink_ongoing = false;
+    } else if (ret < 0) {
         tr_debug("Failed to generate AUTOMATIC UPLINK, error code = %d", ret);
         send_event_to_application(AUTOMATIC_UPLINK_ERROR);
     }

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -170,6 +170,8 @@ void LoRaMac::post_process_mcps_req()
             if (_params.is_ul_frame_counter_fixed == false) {
                 _params.ul_frame_counter++;
             }
+        } else {
+            _mcps_confirmation.status = LORAMAC_EVENT_INFO_STATUS_ERROR;
         }
     } else {
         //UNCONFIRMED or PROPRIETARY

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -673,7 +673,7 @@ void LoRaMac::on_radio_rx_done(const uint8_t *const payload, uint16_t size,
 {
     if (_device_class == CLASS_C && !_continuous_rx2_window_open) {
         open_rx2_window();
-    } else {
+    } else if (_device_class != CLASS_C){
         _lora_time.stop(_params.timers.rx_window1_timer);
         _lora_phy->put_radio_to_sleep();
     }

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1080,13 +1080,13 @@ lorawan_status_t LoRaMac::schedule_tx()
     uint8_t dr_offset = _lora_phy->apply_DR_offset(_params.sys_params.channel_data_rate,
                                                   _params.sys_params.rx1_dr_offset);
 
-    _lora_phy->compute_rx_win_params(dr_offset, _params.sys_params.min_rx_symb,
-                                    _params.sys_params.max_sys_rx_error,
+    _lora_phy->compute_rx_win_params(dr_offset, MBED_CONF_LORA_DOWNLINK_PREAMBLE_LENGTH,
+                                    MBED_CONF_LORA_MAX_SYS_RX_ERROR,
                                     &_params.rx_window1_config);
 
     _lora_phy->compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
-                                    _params.sys_params.min_rx_symb,
-                                    _params.sys_params.max_sys_rx_error,
+                                    MBED_CONF_LORA_DOWNLINK_PREAMBLE_LENGTH,
+                                    MBED_CONF_LORA_MAX_SYS_RX_ERROR,
                                     &_params.rx_window2_config);
 
     if (!_is_nwk_joined) {
@@ -1355,8 +1355,8 @@ void LoRaMac::set_device_class(const device_class_t &device_class,
         _params.is_node_ack_requested = false;
         _lora_phy->put_radio_to_sleep();
         _lora_phy->compute_rx_win_params(_params.sys_params.rx2_channel.datarate,
-                                        _params.sys_params.min_rx_symb,
-                                        _params.sys_params.max_sys_rx_error,
+                                        MBED_CONF_LORA_DOWNLINK_PREAMBLE_LENGTH,
+                                        MBED_CONF_LORA_MAX_SYS_RX_ERROR,
                                         &_params.rx_window2_config);
     }
 
@@ -1732,9 +1732,6 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue)
     _params.timers.aggregated_timeoff = 0;
 
     _lora_phy->reset_to_default_values(&_params, true);
-
-    _params.sys_params.max_sys_rx_error = 10;
-    _params.sys_params.min_rx_symb = 6;
     _params.sys_params.retry_num = 1;
 
     reset_mac_parameters();

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1755,9 +1755,7 @@ lorawan_status_t LoRaMac::initialize(EventQueue *queue)
     _params.timers.mac_init_time = _lora_time.get_current_time();
 
     _params.sys_params.adr_on = MBED_CONF_LORA_ADR_ON;
-
-    _params.is_nwk_public = MBED_CONF_LORA_PUBLIC_NETWORK;
-    _lora_phy->setup_public_network_mode(MBED_CONF_LORA_PUBLIC_NETWORK);
+    _params.sys_params.channel_data_rate = _lora_phy->get_default_max_tx_datarate();
 
     return LORAWAN_STATUS_OK;
 }

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -853,7 +853,8 @@ bool LoRaPHY::rx_config(rx_config_params_t *rx_conf)
                               false, rx_conf->is_rx_continuous);
     } else {
         modem = MODEM_LORA;
-        _radio->set_rx_config(modem, rx_conf->bandwidth, phy_dr, 1, 0, 8,
+        _radio->set_rx_config(modem, rx_conf->bandwidth, phy_dr, 1, 0,
+                              MBED_CONF_LORA_DOWNLINK_PREAMBLE_LENGTH,
                               rx_conf->window_timeout, false, 0, false, 0, 0,
                               true, rx_conf->is_rx_continuous);
     }
@@ -903,7 +904,8 @@ bool LoRaPHY::tx_config(tx_config_params_t *tx_conf, int8_t *tx_power,
                               3000);
     } else {
         modem = MODEM_LORA;
-        _radio->set_tx_config(modem, phy_tx_power, 0, bandwidth, phy_dr, 1, 8,
+        _radio->set_tx_config(modem, phy_tx_power, 0, bandwidth, phy_dr, 1,
+                              MBED_CONF_LORA_UPLINK_PREAMBLE_LENGTH,
                               false, true, 0, 0, false, 3000);
     }
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -514,13 +514,16 @@ void LoRaPHY::reset_to_default_values(loramac_protocol_params *params, bool init
 
     params->sys_params.channel_tx_power = get_default_tx_power();
 
-    params->sys_params.channel_data_rate = get_default_tx_datarate();
+    // We shall always start with highest achievable data rate.
+    // Subsequent decrease in data rate will mean increase in range henceforth.
+    params->sys_params.channel_data_rate = get_default_max_tx_datarate();
 
     params->sys_params.rx1_dr_offset = phy_params.default_rx1_dr_offset;
 
     params->sys_params.rx2_channel.frequency = get_default_rx2_frequency();
 
-    params->sys_params.rx2_channel.datarate = get_default_rx2_datarate();
+    // RX2 data rate should also start from the maximum
+    params->sys_params.rx2_channel.datarate = get_default_max_tx_datarate();
 
     params->sys_params.uplink_dwell_time = phy_params.ul_dwell_time_setting;
 
@@ -558,6 +561,11 @@ uint8_t LoRaPHY::get_minimum_tx_datarate()
 uint8_t LoRaPHY::get_default_tx_datarate()
 {
     return phy_params.default_datarate;
+}
+
+uint8_t  LoRaPHY::get_default_max_tx_datarate()
+{
+    return phy_params.default_max_datarate;
 }
 
 uint8_t LoRaPHY::get_default_tx_power()

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -424,6 +424,14 @@ public:
     uint8_t get_default_tx_datarate();
 
     /**
+     * @brief get_default_max_tx_datarate Gets the maximum achievable data rate for
+     *        LoRa modulation. This will always be the highest data rate achievable with
+     *        LoRa as defined in the regional specifications.
+     * @return Maximum achievable data rate with LoRa modulation.
+     */
+    uint8_t get_default_max_tx_datarate();
+
+    /**
      * @brief get_default_tx_power Gets the default TX power
      * @return Default TX power
      */

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -67,7 +67,7 @@
  */
 #define AS923_DEFAULT_DATARATE                      DR_2
 
-#define AS923_DEFAULT_MAX_DATARATE                  DR_7
+#define AS923_DEFAULT_MAX_DATARATE                  DR_5
 
 /*!
  * The minimum datarate which is used when the

--- a/features/lorawan/mbed_lib.json
+++ b/features/lorawan/mbed_lib.json
@@ -64,6 +64,18 @@
         "automatic-uplink-message": {
             "help": "Stack will automatically send an uplink message when lora server requires immediate response",
             "value": true
+        },
+        "max-sys-rx-error": {
+        	"help": "Maximum timing error of the receiver in ms. The receiver will turn on in [-RxError : + RxError]",
+        	"value": 10
+        },
+        "downlink-preamble-length": {
+        	"help": "Number of preamble symbols need to be captured (out of 8) for successful demodulation",
+        	"value": 5
+        },
+        "uplink-preamble-length": {
+        	"help": "Number of preamble symbols to transmit. Must be <= 8",
+        	"value": 8
         }
     }
 }

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -167,17 +167,6 @@ typedef struct {
      */
     int8_t channel_data_rate;
     /*!
-     * The system overall timing error in milliseconds.
-     * [-SystemMaxRxError : +SystemMaxRxError]
-     * Default: +/-10 ms
-     */
-    uint32_t max_sys_rx_error;
-    /*!
-     * The minimum number of symbols required to detect an RX frame.
-     * Default: 6 symbols
-     */
-    uint8_t min_rx_symb;
-    /*!
      * LoRaMac maximum time a reception window stays open.
      */
     uint32_t max_rx_win_time;


### PR DESCRIPTION
### Description

This PR handles two issues:

i) User transmissions should have priority over automatic uplinks. 
   The stack schedules an event for the automatic uplink when needed and the control goes back to 
   application, if the user stays silent and there is nothing else to do, the automatic uplink goes out as 
   planned, otherwise user transmission gets priority and automatic uplink gets cancelled.

ii) We should use higher data rates to begin with as they result in smaller transmission times which 
    doesn't block the channel too long. Plus it also helps getting in synch with the network server faster 
    which is crucial to set network delays in order to open receive windows.  

In addition to that a bug is fixed in post processing of CONFIRMED messages.
As receive timing error and preamle lengths are constants but could be configurable, we have made them configurable and loaded most optimal values as defaults.

Changes in the API and usage is internal to the stack.
 
### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

