### PR TITLE
Nuvoton: Replace __wrap__sbrk with overriding _sbrk

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1196,12 +1196,10 @@ extern "C" uint32_t  __HeapLimit;
 extern "C" int errno;
 
 // Dynamic memory allocation related syscall.
-#if (defined(TARGET_NUVOTON) || defined(TWO_RAM_REGIONS))
+#if defined(TWO_RAM_REGIONS)
 
 // Overwrite _sbrk() to support two region model (heap and stack are two distinct regions).
 // __wrap__sbrk() is implemented in:
-// TARGET_NUMAKER_PFM_NUC472    targets/TARGET_NUVOTON/TARGET_NUC472/TARGET_NUMAKER_PFM_NUC472/TOOLCHAIN_GCC_ARM/nuc472_retarget.c
-// TARGET_NUMAKER_PFM_M453      targets/TARGET_NUVOTON/TARGET_M451/TARGET_NUMAKER_PFM_M453/TOOLCHAIN_GCC_ARM/m451_retarget.c
 // TARGET_STM32L4               targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4/l4_retarget.c
 extern "C" void *__wrap__sbrk(int incr);
 extern "C" caddr_t _sbrk(int incr)

--- a/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/m2351_retarget.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/device/TOOLCHAIN_GCC_ARM/m2351_retarget.c
@@ -18,18 +18,20 @@ extern uint32_t __mbed_krbs_start;
 
 #define NU_HEAP_ALIGN       4
 
-/**
- * The default implementation of _sbrk() (in common/retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
- * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk() to
- * override the default _sbrk(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+/* Support heap with two-region model
+ *
+ * The default implementation of _sbrk() (in mbed_retarget.cpp) for GCC_ARM requires one-region
+ * model (heap and stack share one region), which doesn't fit two-region model (heap and stack
+ * are two distinct regions), e.g., stack in internal SRAM/heap in external SRAM on NUMAKER_PFM_NUC472.
+ * Hence, override _sbrk() here to support heap with two-region model.
  */
-void *__wrap__sbrk(int incr)
+void *_sbrk(int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
     uint32_t heap_ind_old = NU_ALIGN_UP(heap_ind, NU_HEAP_ALIGN);
     uint32_t heap_ind_new = NU_ALIGN_UP(heap_ind_old + incr, NU_HEAP_ALIGN);
     
-    if (heap_ind_new > &__mbed_krbs_start) {
+    if (heap_ind_new > (uint32_t) &__mbed_krbs_start) {
         errno = ENOMEM;
         return (void *) -1;
     } 

--- a/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/m480_retarget.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/device/TOOLCHAIN_GCC_ARM/m480_retarget.c
@@ -18,12 +18,14 @@ extern uint32_t __mbed_krbs_start;
 
 #define NU_HEAP_ALIGN       32
 
-/**
- * The default implementation of _sbrk() (in common/retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
- * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk() to
- * override the default _sbrk(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+/* Support heap with two-region model
+ *
+ * The default implementation of _sbrk() (in mbed_retarget.cpp) for GCC_ARM requires one-region
+ * model (heap and stack share one region), which doesn't fit two-region model (heap and stack
+ * are two distinct regions), e.g., stack in internal SRAM/heap in external SRAM on NUMAKER_PFM_NUC472.
+ * Hence, override _sbrk() here to support heap with two-region model.
  */
-void *__wrap__sbrk(int incr)
+void *_sbrk(int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
     uint32_t heap_ind_old = NU_ALIGN_UP(heap_ind, NU_HEAP_ALIGN);

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/nano100_retarget.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/device/TOOLCHAIN_GCC_ARM/nano100_retarget.c
@@ -18,18 +18,20 @@ extern uint32_t __mbed_krbs_start;
 
 #define NU_HEAP_ALIGN       4
 
-/**
- * The default implementation of _sbrk() (in common/retarget.cpp) for GCC_ARM requires one-region model (heap and stack share one region), which doesn't
- * fit two-region model (heap and stack are two distinct regions), for example, NUMAKER-PFM-NUC472 locates heap on external SRAM. Define __wrap__sbrk() to
- * override the default _sbrk(). It is expected to get called through gcc hooking mechanism ('-Wl,--wrap,_sbrk') or in _sbrk().
+/* Support heap with two-region model
+ *
+ * The default implementation of _sbrk() (in mbed_retarget.cpp) for GCC_ARM requires one-region
+ * model (heap and stack share one region), which doesn't fit two-region model (heap and stack
+ * are two distinct regions), e.g., stack in internal SRAM/heap in external SRAM on NUMAKER_PFM_NUC472.
+ * Hence, override _sbrk() here to support heap with two-region model.
  */
-void *__wrap__sbrk(int incr)
+void *_sbrk(int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
     uint32_t heap_ind_old = NU_ALIGN_UP(heap_ind, NU_HEAP_ALIGN);
     uint32_t heap_ind_new = NU_ALIGN_UP(heap_ind_old + incr, NU_HEAP_ALIGN);
     
-    if (heap_ind_new > &__mbed_krbs_start) {
+    if (heap_ind_new > (uint32_t) &__mbed_krbs_start) {
         errno = ENOMEM;
         return (void *) -1;
     } 

--- a/targets/TARGET_NUVOTON/mbed_rtx.h
+++ b/targets/TARGET_NUVOTON/mbed_rtx.h
@@ -31,14 +31,14 @@
     #define ISR_STACK_START       ((unsigned char*)Image$$ARM_LIB_STACK$$ZI$$Base)
     #define ISR_STACK_SIZE        ((uint32_t)Image$$ARM_LIB_STACK$$ZI$$Length)
 #elif defined(__GNUC__)
-    extern uint32_t               __StackTop[];
-    extern uint32_t               __StackLimit[];
-    extern uint32_t               __end__[];
-    extern uint32_t               __HeapLimit[];
-    #define HEAP_START            ((unsigned char*)__end__)
-    #define HEAP_SIZE             ((uint32_t)((uint32_t)__HeapLimit - (uint32_t)HEAP_START))
-    #define ISR_STACK_START       ((unsigned char*)__StackLimit)
-    #define ISR_STACK_SIZE        ((uint32_t)((uint32_t)__StackTop - (uint32_t)__StackLimit))
+    extern uint32_t               __StackTop;
+    extern uint32_t               __StackLimit;
+    extern uint32_t               __end__;
+    extern uint32_t               __HeapLimit;
+    #define HEAP_START            ((unsigned char*) &__end__)
+    #define HEAP_SIZE             ((uint32_t) ((uint32_t) &__HeapLimit - (uint32_t) HEAP_START))
+    #define ISR_STACK_START       ((unsigned char*) &__StackLimit)
+    #define ISR_STACK_SIZE        ((uint32_t)((uint32_t) &__StackTop - (uint32_t) &__StackLimit))
 #elif defined(__ICCARM__)
     /* No region declarations needed */
 #else


### PR DESCRIPTION
### Description

With `_sbrk` being weak (#5994), this PR replaces `__wrap__sbrk` with overriding `_sbrk` to support heap with two-region model on Nuvoton targets.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
