### PR TITLE
replace all c & c++ standard to nano

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -110,7 +110,7 @@ class GCC(mbedToolchain):
 
         self.flags['ld'] += self.cpu
         self.ld = [join(tool_path, "arm-none-eabi-gcc")] + self.flags['ld']
-        self.sys_libs = ["stdc++", "supc++", "m", "c", "gcc", "nosys"]
+        self.sys_libs = ["stdc++_nano", "supc++_nano", "m", "c_nano", "gcc", "nosys"]
         self.preproc = [join(tool_path, "arm-none-eabi-cpp"), "-E", "-P"]
 
         self.ar = join(tool_path, "arm-none-eabi-ar")


### PR DESCRIPTION
### Description
replace standart c & c++ libraries to the nano impelantation.

currently only for arm gcc

the reduction is

original libc
-----------
Total Static RAM memory (data + bss): 78204 bytes
Total Flash memory (text + data): 386128 bytes

with libc_nano
--------------

Total Static RAM memory (data + bss): 76124 bytes
Total Flash memory (text + data): 354492 bytes


with nano c and nano cpp
--------------------------
Total Static RAM memory (data + bss): 76140 bytes
Total Flash memory (text + data): 341828 bytes


total: 386128  - 341828  = 44300 bytes saved
### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

