### PR TITLE
Lora: Fix cancel_sending

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -277,14 +277,16 @@ lorawan_status_t LoRaWANStack::enable_adaptive_datarate(bool adr_enabled)
 
 lorawan_status_t LoRaWANStack::stop_sending(void)
 {
+    if (_device_current_state == DEVICE_STATE_NOT_INITIALIZED) {
+        return LORAWAN_STATUS_NOT_INITIALIZED;
+    }
+
     if (_loramac.clear_tx_pipe() == LORAWAN_STATUS_OK) {
-        if (_device_current_state == DEVICE_STATE_SENDING) {
-            _ctrl_flags &= ~TX_DONE_FLAG;
-            _ctrl_flags &= ~TX_ONGOING_FLAG;
-            _loramac.set_tx_ongoing(false);
-            _device_current_state = DEVICE_STATE_IDLE;
-            return LORAWAN_STATUS_OK;
-        }
+        _ctrl_flags &= ~TX_DONE_FLAG;
+        _ctrl_flags &= ~TX_ONGOING_FLAG;
+        _loramac.set_tx_ongoing(false);
+        _device_current_state = DEVICE_STATE_IDLE;
+        return LORAWAN_STATUS_OK;
     }
 
     return LORAWAN_STATUS_BUSY;


### PR DESCRIPTION
### Description

This commit fixes some bugs from cancel_sending() method:
-  System crashed if method was called before initialization.
   Now LORAWAN_STATUS_NOT_INITIALIZED will be returned.
-  Method returned LORAWAN_STATUS_BUSY error when no send request was pending.
   LORAWAN_STATUS_OK should be returned in this case.
-  LORAWAN_STATUS_BUSY is now returned if backoff timer is just about to be
   dispatched (time_left returns 0).

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

