### PR TITLE
MPS2 platform: Enable interrupt on rx for UART

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/serial_api.c
@@ -326,6 +326,9 @@ static void serial_irq_set_internal(serial_t *obj, SerialIrq irq, uint32_t enabl
 }
 
 void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) {
+    if (RxIrq == irq) {
+        uart_data[obj->index].rx_irq_set_api = enable;
+    }
     serial_irq_set_internal(obj, irq, enable);
 }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Rx interrupt flag enabled, (in the same way as it is done in serial_api.c for TARGET_ARM_SSG/TARGET_IOTSS, TARGET_ARM_SSG/TARGET_BEETLE and other targets).
Tested with RawSerial class, which would not have any attached rx interrupt handler called without this fix.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

