### PR TITLE
Add test macro MBED_TEST when building with `mbed test`

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -126,6 +126,12 @@ if __name__ == '__main__':
         all_tests = {}
         tests = {}
 
+        # Add the test macro, when compiling all test
+        if options.macros is None:
+           options.macros = ['MBED_TEST']
+        else:
+            options.macros.append('MBED_TEST')
+
         # Target
         if options.mcu is None :
             args_error(parser, "argument -m/--mcu is required")


### PR DESCRIPTION
### Description

MBED_TEST macro can be used to guard test features or to select non-test related functionality (main) when building with `mbed compile`.

Related : https://github.com/ARMmbed/mbed-os/issues/7626

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

CC @theotherjimmy  @bridadan 
