### PR TITLE
Guard testing framework with macro

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_metrics.h
@@ -4,6 +4,8 @@
 #ifndef GREENTEA_METRICS_H
 #define GREENTEA_METRICS_H
 
+#ifdef MBED_TEST
+
 /**
  *  Setup platform specific metrics
  */
@@ -14,6 +16,7 @@ void greentea_metrics_setup(void);
  */
 void greentea_metrics_report(void);
 
+#endif
 #endif
 
 /** @}*/

--- a/features/frameworks/greentea-client/greentea-client/greentea_serial.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_serial.h
@@ -4,6 +4,8 @@
 #ifndef GREENTEA_SERIAL_H
 #define GREENTEA_SERIAL_H
 
+#ifdef MBED_TEST
+
 #include "RawSerial.h"
 #include "SingletonPtr.h"
 
@@ -13,6 +15,7 @@ public:
 };
 
 extern SingletonPtr<GreenteaSerial> greentea_serial;
+#endif
 #endif
 
 /** @}*/

--- a/features/frameworks/greentea-client/greentea-client/test_env.h
+++ b/features/frameworks/greentea-client/greentea-client/test_env.h
@@ -21,6 +21,7 @@
 #ifndef GREENTEA_CLIENT_TEST_ENV_H_
 #define GREENTEA_CLIENT_TEST_ENV_H_
 
+#ifdef MBED_TEST
 #ifdef __cplusplus
 #ifdef YOTTA_GREENTEA_CLIENT_VERSION_STRING
 #define MBED_GREENTEA_CLIENT_VERSION_STRING YOTTA_GREENTEA_CLIENT_VERSION_STRING
@@ -122,6 +123,7 @@ int greentea_getc();
 }
 #endif
 
+#endif  // MBED_TEST
 #endif  // GREENTEA_CLIENT_TEST_ENV_H_
 
 /** @}*/

--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#ifdef MBED_TEST
 #include "mbed.h"
 #include "rtos.h"
 #include "mbed_stats.h"
@@ -211,4 +212,5 @@ static uint32_t print_dec(char *buf, uint32_t value)
     return pos;
 }
 
+#endif
 #endif

--- a/features/frameworks/greentea-client/source/greentea_serial.cpp
+++ b/features/frameworks/greentea-client/source/greentea_serial.cpp
@@ -1,3 +1,5 @@
+#ifdef MBED_TEST
+
 #include "greentea-client/greentea_serial.h"
 
 /**
@@ -21,3 +23,5 @@ GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATF
     set_flow_control(SerialBase::RTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
 #endif
 }
+
+#endif

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#ifdef MBED_TEST
 #include <ctype.h>
 #include <cstdio>
 #include <string.h>
@@ -779,3 +780,5 @@ static int HandleKV(char *out_key,
     getNextToken(0, 0);
     return 0;
 }
+
+#endif

--- a/features/frameworks/unity/source/unity.c
+++ b/features/frameworks/unity/source/unity.c
@@ -8,6 +8,7 @@
 #include "utest/unity_handler.h"
 #include <stddef.h>
 
+#ifdef MBED_TEST
 /* If omitted from header, declare overrideable prototypes here so they're ready for use */
 #ifdef UNITY_OMIT_OUTPUT_CHAR_HEADER_DECLARATION
 int UNITY_OUTPUT_CHAR(int);
@@ -1317,4 +1318,5 @@ int UnityEnd(void)
     return (int)(Unity.TestFailures);
 }
 
+#endif
 /*-----------------------------------------------*/

--- a/features/frameworks/unity/unity/unity.h
+++ b/features/frameworks/unity/unity/unity.h
@@ -9,6 +9,7 @@
 
 #ifndef UNITY_FRAMEWORK_H
 #define UNITY_FRAMEWORK_H
+#ifdef MBED_TEST
 #define UNITY
 
 #ifdef __cplusplus
@@ -310,5 +311,5 @@ void tearDown(void);
 }
 #endif
 #endif
-
+#endif
 /** @}*/

--- a/features/frameworks/unity/unity/unity_config.h
+++ b/features/frameworks/unity/unity/unity_config.h
@@ -22,6 +22,8 @@
 #ifndef UNITY_CONFIG_H
 #define UNITY_CONFIG_H
 
+#ifdef MBED_TEST
+
 /* When using unity with the mbed RTOS printing to the serial port using the stdlib is not 
    allowed as it causes a hardfault. Unity has the following define to control how failure
    messages are written:
@@ -37,7 +39,8 @@
 #ifndef UNITY_OUTPUT_CHAR
 #define UNITY_OUTPUT_CHAR(a) utest_safe_putc(a)
 #endif //UNITY_OUTPUT_CHAR
-    
+
+#endif // MBED_TEST
 #endif // UNITY_CONFIG_H
 
 /** @}*/

--- a/features/frameworks/unity/unity/unity_internals.h
+++ b/features/frameworks/unity/unity/unity_internals.h
@@ -10,6 +10,8 @@
 #ifndef UNITY_INTERNALS_H
 #define UNITY_INTERNALS_H
 
+#ifdef MBED_TEST
+
 #ifdef UNITY_INCLUDE_CONFIG_H
 #include "unity_config.h"
 #endif
@@ -794,6 +796,7 @@ extern const char UnityStrErr64[];
 #define UNITY_TEST_SKIP(line, message)                                                           { UnitySkipPrint( (message), (UNITY_LINE_TYPE)(line)); return; }
 #define UNITY_TEST_SKIP_UNLESS(condition, line, message)                                         if (!(condition)) UNITY_TEST_SKIP((line), (message))
 
+#endif // MBED_TEST
 /* End of UNITY_INTERNALS_H */
 #endif
 

--- a/features/frameworks/utest/mbed-utest-shim.cpp
+++ b/features/frameworks/utest/mbed-utest-shim.cpp
@@ -19,6 +19,7 @@
 #include "mbed_critical.h"
 #include "utest/utest.h"
 
+#ifdef MBED_TEST
 using namespace utest::v1;
 
 void utest_v1_enter_critical_section(void)
@@ -30,3 +31,4 @@ void utest_v1_leave_critical_section(void)
 {
     core_util_critical_section_exit();
 }
+#endif

--- a/features/frameworks/utest/source/unity_handler.cpp
+++ b/features/frameworks/utest/source/unity_handler.cpp
@@ -16,6 +16,7 @@
  ****************************************************************************
  */
 
+#ifdef MBED_TEST
 #include "utest/utest_harness.h"
 #include "utest/utest_stack_trace.h"
 #include "utest/unity_handler.h"
@@ -38,4 +39,4 @@ void utest_safe_putc(int chr)
     greentea_serial->putc(chr);
 }    
 
-
+#endif

--- a/features/frameworks/utest/source/utest_case.cpp
+++ b/features/frameworks/utest/source/utest_case.cpp
@@ -16,8 +16,9 @@
  ****************************************************************************
  */
 
- #include "utest/utest_case.h"
- #include "utest/utest_serial.h"
+#ifdef MBED_TEST
+#include "utest/utest_case.h"
+#include "utest/utest_serial.h"
 
 using namespace utest::v1;
 
@@ -193,3 +194,5 @@ bool
 Case::is_empty() const {
     return !(handler || control_handler || repeat_count_handler || setup_handler || teardown_handler);
 }
+
+#endif

--- a/features/frameworks/utest/source/utest_default_handlers.cpp
+++ b/features/frameworks/utest/source/utest_default_handlers.cpp
@@ -16,6 +16,7 @@
  ****************************************************************************
  */
 
+#ifdef MBED_TEST
 #include "utest/utest_default_handlers.h"
 #include "utest/utest_case.h"
 #include "utest/utest_stack_trace.h"
@@ -102,3 +103,5 @@ utest::v1::status_t utest::v1::verbose_case_failure_handler(const Case *const /*
     if (failure.reason & REASON_IGNORE) return STATUS_IGNORE;
     return STATUS_CONTINUE;
 }
+
+#endif

--- a/features/frameworks/utest/source/utest_greentea_handlers.cpp
+++ b/features/frameworks/utest/source/utest_greentea_handlers.cpp
@@ -16,6 +16,7 @@
  ****************************************************************************
  */
 
+#ifdef MBED_TEST
 #include "utest/utest_default_handlers.h"
 #include "utest/utest_case.h"
 #include "greentea-client/test_env.h"
@@ -145,3 +146,4 @@ utest::v1::status_t utest::v1::greentea_case_failure_continue_handler(const Case
     UTEST_LOG_FUNCTION();
     return verbose_case_failure_handler(source, failure);
 }
+#endif

--- a/features/frameworks/utest/source/utest_harness.cpp
+++ b/features/frameworks/utest/source/utest_harness.cpp
@@ -16,6 +16,7 @@
  ****************************************************************************
  */
 
+#ifdef MBED_TEST
 #include "utest/utest_harness.h"
 #include "utest/utest_stack_trace.h"
 #include "utest/utest_serial.h"
@@ -373,3 +374,5 @@ void Harness::run_next_case()
         exit(test_failed);
     }
 }
+
+#endif

--- a/features/frameworks/utest/source/utest_shim.cpp
+++ b/features/frameworks/utest/source/utest_shim.cpp
@@ -16,6 +16,7 @@
  ****************************************************************************
  */
 
+#ifdef MBED_TEST
 #include "utest/utest_shim.h"
 #include "utest/utest_stack_trace.h"
 
@@ -146,4 +147,6 @@ utest_v1_scheduler_t utest_v1_get_scheduler()
 // their functionality is implemented using the CriticalSectionLock class
 void utest_v1_enter_critical_section(void) {}
 void utest_v1_leave_critical_section(void) {}
+#endif
+
 #endif

--- a/features/frameworks/utest/source/utest_stack_trace.cpp
+++ b/features/frameworks/utest/source/utest_stack_trace.cpp
@@ -14,6 +14,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#ifdef MBED_TEST
 #ifdef UTEST_STACK_TRACE
  
 #include "greentea-client/test_env.h"
@@ -61,4 +63,5 @@ void utest_dump_trace()
     utest_printf("==================================================================\n");
 }
 
+#endif
 #endif

--- a/features/frameworks/utest/source/utest_types.cpp
+++ b/features/frameworks/utest/source/utest_types.cpp
@@ -16,7 +16,8 @@
  ****************************************************************************
  */
 
- #include "utest/utest_types.h"
+#ifdef MBED_TEST
+#include "utest/utest_types.h"
 
 const char* utest::v1::stringify(utest::v1::failure_reason_t reason)
 {
@@ -133,3 +134,5 @@ const utest::v1::base_control_t utest::v1::CaseRepeat = { REPEAT_ALL, TIMEOUT_UN
 
 // equal to CaseRepeatHandler
 const utest::v1::base_control_t utest::v1::CaseRepeatHandlerOnly = { REPEAT_HANDLER, TIMEOUT_UNDECLR };
+
+#endif

--- a/features/frameworks/utest/utest/unity_handler.h
+++ b/features/frameworks/utest/utest/unity_handler.h
@@ -22,6 +22,8 @@
 #ifndef UTEST_UNITY_ASSERT_FAILURE_H
 #define UTEST_UNITY_ASSERT_FAILURE_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -40,6 +42,7 @@ void utest_safe_putc(int chr);
 }
 #endif
 
+#endif // MBED_TEST
 #endif // UTEST_UNITY_ASSERT_FAILURE_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_case.h
+++ b/features/frameworks/utest/utest/utest_case.h
@@ -19,6 +19,8 @@
 #ifndef UTEST_CASES_H
 #define UTEST_CASES_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -175,6 +177,7 @@ namespace v1 {
 }   // namespace v1
 }   // namespace utest
 
- #endif // UTEST_CASES_H
+#endif // MBED_TEST
+#endif // UTEST_CASES_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_default_handlers.h
+++ b/features/frameworks/utest/utest/utest_default_handlers.h
@@ -19,6 +19,8 @@
 #ifndef UTEST_DEFAULT_HANDLER_H
 #define UTEST_DEFAULT_HANDLER_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -200,6 +202,7 @@ namespace v1 {
 }   // namespace v1
 }   // namespace utest
 
+#endif // MBED_TEST
 #endif // UTEST_DEFAULT_HANDLER_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_harness.h
+++ b/features/frameworks/utest/utest/utest_harness.h
@@ -19,6 +19,8 @@
 #ifndef UTEST_HARNESS_H
 #define UTEST_HARNESS_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -100,6 +102,7 @@ namespace v1 {
 }   // namespace v1
 }   // namespace utest
 
+#endif // MBED_TEST
 #endif // UTEST_HARNESS_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_scheduler.h
+++ b/features/frameworks/utest/utest/utest_scheduler.h
@@ -22,6 +22,8 @@
 #ifndef UTEST_SCHEDULER_H
 #define UTEST_SCHEDULER_H
 
+#ifdef MBED_TEST
+
 #include "mbed.h"
 #include <stdint.h>
 #include <stdbool.h>
@@ -104,6 +106,7 @@ typedef struct {
 }
 #endif
 
+#endif // MBED_TEST
 #endif // UTEST_SCHEDULER_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_serial.h
+++ b/features/frameworks/utest/utest/utest_serial.h
@@ -22,10 +22,12 @@
 #ifndef UTEST_SERIAL_H
 #define UTEST_SERIAL_H
 
+#ifdef MBED_TEST
 #include "greentea-client/greentea_serial.h"
 
 #define utest_printf(...) greentea_serial->printf(__VA_ARGS__)
 
+#endif // MBED_TEST
 #endif // UTEST_SERIAL_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_shim.h
+++ b/features/frameworks/utest/utest/utest_shim.h
@@ -22,6 +22,8 @@
 #ifndef UTEST_SHIM_H
 #define UTEST_SHIM_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -87,6 +89,7 @@ utest_v1_scheduler_t utest_v1_get_scheduler(void);
 }
 #endif
 
+#endif // MBED_TEST
 #endif // UTEST_SHIM_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_specification.h
+++ b/features/frameworks/utest/utest/utest_specification.h
@@ -19,6 +19,8 @@
 #ifndef UTEST_SPECIFICATION_H
 #define UTEST_SPECIFICATION_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -185,6 +187,7 @@ namespace v1 {
 }   // namespace v1
 }   // namespace utest
 
+#endif // MBED_TEST
  #endif // UTEST_SPECIFICATION_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_stack_trace.h
+++ b/features/frameworks/utest/utest/utest_stack_trace.h
@@ -22,6 +22,8 @@
 #ifndef UTEST_STACK_TRACE_H
 #define UTEST_STACK_TRACE_H
 
+#ifdef MBED_TEST
+
 #ifdef UTEST_STACK_TRACE
 #include <string>
 
@@ -43,7 +45,7 @@ extern void utest_dump_trace();
 #define UTEST_DUMP_TRACE
 
 #endif // UTEST_STACK_TRACE
-
+#endif // MBED_TEST
 #endif // UTEST_STACK_TRACE_H
 
 /** @}*/

--- a/features/frameworks/utest/utest/utest_types.h
+++ b/features/frameworks/utest/utest/utest_types.h
@@ -19,6 +19,8 @@
 #ifndef UTEST_TYPES_H
 #define UTEST_TYPES_H
 
+#ifdef MBED_TEST
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -407,6 +409,7 @@ namespace v1 {
 }   // namespace v1
 }   // namespace utest
 
+#endif // MBED_TEST
 #endif // UTEST_TYPES_H
 
 /** @}*/

--- a/tools/test.py
+++ b/tools/test.py
@@ -126,6 +126,12 @@ if __name__ == '__main__':
         all_tests = {}
         tests = {}
 
+        # Add the test macro, when compiling all test
+        if options.macros is None:
+           options.macros = ['MBED_TEST']
+        else:
+            options.macros.append(['MBED_TEST'])
+
         # Target
         if options.mcu is None :
             args_error(parser, "argument -m/--mcu is required")


### PR DESCRIPTION
### Description

Current build scans and builds all files. Test related infrastructure is technically required only for building test and not application. Hence adding a macro guard to skip them from `mbed compile` by default.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

Related : https://github.com/ARMmbed/mbed-os/issues/7626

Dependent on https://github.com/ARMmbed/mbed-os/pull/7627