### PR TITLE
LoRaWAN: Fixing incorrect NetID causing ABP Failures

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -65,12 +65,6 @@ using namespace mbed;
  */
 #define DOWN_LINK                                   1
 
-/**
- * A mask for the network ID.
- */
-#define LORAWAN_NETWORK_ID_MASK                     ( uint32_t )0xFE000000
-
-
 LoRaMac::LoRaMac()
     : _lora_time(),
       _lora_phy(NULL),
@@ -1434,7 +1428,7 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
         const static uint8_t nwk_skey[] = MBED_CONF_LORA_NWKSKEY;
         const static uint8_t app_skey[] = MBED_CONF_LORA_APPSKEY;
 
-        _params.net_id = (MBED_CONF_LORA_DEVICE_ADDRESS & LORAWAN_NETWORK_ID_MASK);
+        _params.net_id = (MBED_CONF_LORA_DEVICE_ADDRESS & LORAWAN_NETWORK_ID_MASK) >> 25;
         _params.dev_addr = MBED_CONF_LORA_DEVICE_ADDRESS;
 
         memcpy(_params.keys.nwk_skey, nwk_skey, sizeof(_params.keys.nwk_skey));

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -35,6 +35,11 @@
 #include "platform/Callback.h"
 
 /**
+ * A mask for the network ID.
+ */
+#define LORAWAN_NETWORK_ID_MASK                     (uint32_t) 0xFE000000
+
+/**
  * Option Flags for send(), receive() APIs
  *
  * Special Notes for UPLINK:


### PR DESCRIPTION


### Description

The issue rose up when using ARMC6. A test case didn't initialize NetID
parameter for ABP while using connect(params) API. NetID is the first 7 bits
of the Device Address. It makes sense to actually remove the net-id parameter
from ABP settings as the stack can deduce it from device address. However, the ABP
structure is exposed in public APIs, so we can't really do that at the moment.
Simpler fix is to move the mask that helps us to extract first 7 bits of the device address
is exposed in lorawan_types.h and the user can use it to deduce correct net-id.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

