### PR TITLE
Changing default SPI CS pin to SD card on MTB

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
@@ -217,7 +217,7 @@ typedef enum {
     SPI_MOSI    = P_4,
     SPI_MISO    = P_7,
     SPI_SCK     = P_6,
-    SPI_CS      = P_16,
+    SPI_CS      = P_5,
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX


### PR DESCRIPTION
### Description

Changing default SPI CS pin on MXCHIP MTB to SD card adapter on the target. This is required for Simple Mbed Cloud Client example when using SD card as default storage.

@0xc0170 / @cmonr  what tests would be required for this? Can you please let me know so I can provide relevant logs as required? Thanks.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

