### PR TITLE
nrf_drv_twi: remove redundant nrf_drv_disable call in nrf_drv_twi_uninit

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/twi_master/nrf_drv_twi.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/twi_master/nrf_drv_twi.c
@@ -345,7 +345,6 @@ void nrf_drv_twi_uninit(nrf_drv_twi_t const * p_instance)
             nrf_drv_common_irq_disable(nrf_drv_get_IRQn((void *)p_instance->reg.p_twi));
         )
     }
-    nrf_drv_twi_disable(p_instance);
 
 #if NRF_MODULE_ENABLED(PERIPHERAL_RESOURCE_SHARING)
     nrf_drv_common_per_res_release(p_instance->reg.p_regs);


### PR DESCRIPTION
I2C API implementation for NRF5x does a disable() followed by uninit().
The uninit() implementation in NRF drivers layer makes another call to
disable(). This throws off the state of the I2C instance leading to an
assert. Since the disable is only invoked from the I2C API layer for
Nordic, remove this redundant call.

Signed-off-by: Naveen Kaje <Naveen.Kaje@arm.com>

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
