### PR TITLE
Tools: Fix incrimental compile dep tracking

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -1124,10 +1124,14 @@ class Config(object):
         Config._check_required_parameters(params)
         params_with_values = [p for p in params.values() if p.value is not None]
         ctx = {
-            "cfg_params" : [(p.macro_name, str(p.value), p.set_by)
-                            for p in params_with_values],
-            "macros": [(m.macro_name, str(m.macro_value or ""), m.defined_by)
-                       for m in macros.values()],
+            "cfg_params": sorted([
+                (p.macro_name, str(p.value), p.set_by)
+                for p in params_with_values
+            ]),
+            "macros": sorted([
+                (m.macro_name, str(m.macro_value or ""), m.defined_by)
+                for m in macros.values()
+            ]),
             "name_len":  max([len(m.macro_name) for m in macros.values()] +
                              [len(m.macro_name) for m in params_with_values]
                              + [0]),

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -312,12 +312,17 @@ class mbedToolchain:
         """ Generate a via file for a pile of defines
         ARM, GCC, IAR cross compatible
         """
-        option_md5 = md5(' '.join(options).encode('utf-8')).hexdigest()
-        via_file = join(self.build_dir, naming.format(option_md5))
-        if not exists(via_file):
+        to_write = " ".join(options).encode('utf-8')
+        new_md5 = md5(to_write).hexdigest()
+        via_file = join(self.build_dir, naming.format(new_md5))
+        try:
+            with open(via_file, "r") as fd:
+                old_md5 = md5(fd.read().encode('utf-8')).hexdigest()
+        except IOError:
+            old_md5 = None
+        if old_md5 != new_md5:
             with open(via_file, "w") as fd:
-                string = " ".join(options)
-                fd.write(string)
+                fd.write(to_write)
         return via_file
 
     def get_inc_file(self, includes):


### PR DESCRIPTION
### Description

I recently introduced a general purpose function for creating command files.
This function used the hash in naming the file, but not in checking for 
updates. This PR corrects the incrimental compile behavior of links.

In the process, I noticed that `mbed_config.h` changes every compile under
python 3. ~I'll be correcting that shortly.~ That should be resolved now


#### TODO
- [x] Fix incrimental flags for linker
- [x] Fix Python 3 `mbed_config.h` orering

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change