### PR TITLE
Add init reference count to all block devices

### DIFF
--- a/features/TESTS/filesystem/util_block_device/main.cpp
+++ b/features/TESTS/filesystem/util_block_device/main.cpp
@@ -80,10 +80,6 @@ void test_slicing() {
         TEST_ASSERT_EQUAL(0xff & rand(), read_block[i]);
     }
 
-    err = slice1.deinit();
-    TEST_ASSERT_EQUAL(0, err);
-
-
     // Test with second slice of block device
     SlicingBlockDevice slice2(&bd, -(BLOCK_COUNT/2)*BLOCK_SIZE);
 
@@ -98,6 +94,10 @@ void test_slicing() {
     for (int i = 0; i < BLOCK_SIZE; i++) {
         write_block[i] = 0xff & rand();
     }
+
+    // Deinitialize slice1 here, to check whether init reference count works
+    err = slice1.deinit();
+    TEST_ASSERT_EQUAL(0, err);
 
     // Write, sync, and read the block
     err = slice2.program(write_block, 0, BLOCK_SIZE);

--- a/features/filesystem/bd/BufferedBlockDevice.h
+++ b/features/filesystem/bd/BufferedBlockDevice.h
@@ -153,6 +153,7 @@ protected:
     bd_size_t _curr_aligned_addr;
     bool _flushed;
     uint8_t *_cache;
+    uint32_t _init_ref_count;
 
     /** Flush data in cache
      *

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -64,7 +64,7 @@ public:
     template <size_t Size>
     ChainingBlockDevice(BlockDevice *(&bds)[Size])
         : _bds(bds), _bd_count(sizeof(bds) / sizeof(bds[0]))
-        , _read_size(0), _program_size(0), _erase_size(0), _size(0)
+        , _read_size(0), _program_size(0), _erase_size(0), _size(0),  _init_ref_count(0)
     {
     }
 
@@ -175,6 +175,7 @@ protected:
     bd_size_t _erase_size;
     bd_size_t _size;
     int _erase_value;
+    uint32_t _init_ref_count;
 };
 
 

--- a/features/filesystem/bd/ExhaustibleBlockDevice.h
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.h
@@ -154,6 +154,7 @@ private:
     BlockDevice *_bd;
     uint32_t *_erase_array;
     uint32_t _erase_cycles;
+    uint32_t _init_ref_count;
 };
 
 

--- a/features/filesystem/bd/FlashSimBlockDevice.h
+++ b/features/filesystem/bd/FlashSimBlockDevice.h
@@ -135,6 +135,7 @@ private:
     bd_size_t _blank_buf_size;
     uint8_t *_blank_buf;
     BlockDevice *_bd;
+    uint32_t _init_ref_count;
 };
 
 #endif

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -150,6 +150,7 @@ private:
     bd_size_t _erase_size;
     bd_size_t _count;
     uint8_t **_blocks;
+    uint32_t _init_ref_count;
 };
 
 

--- a/features/filesystem/bd/MBRBlockDevice.h
+++ b/features/filesystem/bd/MBRBlockDevice.h
@@ -252,6 +252,7 @@ protected:
     bd_size_t _size;
     uint8_t _type;
     uint8_t _part;
+    uint32_t _init_ref_count;
 };
 
 


### PR DESCRIPTION
### Description
This PR fixes the problem of multiple calls to BD init/deinit APIs, by simply adding an init ref count. This is required due to the fact that utility block devices, which include underlying block devices, call the underlying init/deinit APIs automatically.
This PR partially resolves [#7455](https://github.com/ARMmbed/mbed-os/issues/7455) (for all BDs included in mbed-os). External BDs should be handled in a different PR.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

