### PR TITLE
IAR Exporter does not correctly use the "device_name" key

### DIFF
--- a/tools/export/iar/__init__.py
+++ b/tools/export/iar/__init__.py
@@ -20,7 +20,7 @@ from multiprocessing import cpu_count
 def _supported(mcu, iar_targets):
     if "IAR" not in mcu.supported_toolchains:
         return False
-    if hasattr(mcu, 'device_name') and mcu.device_name in iar_targets:
+    if hasattr(mcu, 'device_name') and mcu.device_name[0] in iar_targets:
         return True
     if mcu.name in iar_targets:
         return True
@@ -70,7 +70,7 @@ class IAR(Exporter):
     def iar_device(self):
         """Retrieve info from iar_definitions.json"""
         tgt = TARGET_MAP[self.target]
-        device_name = (tgt.device_name if hasattr(tgt, "device_name") else
+        device_name = (tgt.device_name[0] if hasattr(tgt, "device_name") else
                        tgt.name)
         device_info = _GUI_OPTIONS[device_name]
         iar_defaults ={


### PR DESCRIPTION
### Description

The IAR exporter code as written will never correctly use the "device_name" key.  When it tries to use it, it needs to access the json bundle like a list ( list happens to only have one entry ).  I think right now the export works simply b/c the name in targets.json always matches the "device_name" key, and the iar exporter falls back to the target name if it can't use the device_name.  I discovered this b/c I'm trying to add a custom target and I want to use the functionality of having several targets use the same export profile.  This snippet from my debugger shows the root of the error:

```
>>> mcu.device_name in iar_targets # This is the wrong result.
False
>>> mcu.device_name  # This will show up as a list!!
[u'MK22FX512Axxx12']
>>> 'MK22FX512Axxx12' in iar_targets
True
>>> mcu.device_name[0] in iar_targets  # Index into the list to fix
True
```




### Pull request type

    [ X ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

