### PR TITLE
Update mbed-coap version to 4.5.1

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.5.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.5.1) 
+**Closed issues:**
+ - IOTCLT-2883 - Blockwise observations not completing
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.5.0...v4.5.1)
+
 ## [v4.5.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.5.0) 
 **Closed issues:**
  - IIOTCLT-2769 - mbed-coap: extra response received after registration

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -1723,7 +1723,7 @@ static coap_blockwise_msg_s *sn_coap_stored_blockwise_msg_get(struct coap_s *han
         }
     }
 
-    return NULL;
+    return ns_list_get_first(&handle->linked_list_blockwise_sent_msgs);
 }
 
 /**************************************************************************//**


### PR DESCRIPTION
### Description

Fixes error: IOTCLT-2883 - Blockwise observations not completing

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

