### PR TITLE
Remove device emac check from emac greentea tests

### DIFF
--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -43,10 +43,6 @@
 #endif
 #endif
 
-#ifndef DEVICE_EMAC
-#error [NOT_SUPPORTED] Device EMAC has to be enabled for the target
-#endif
-
 #include "greentea-client/test_env.h"
 #include "unity.h"
 #include "utest.h"


### PR DESCRIPTION
### Description

DEVICE_EMAC is defined only for boards with default Ethernet emac. It is not defined for example for Realtek RTL8195AM board that does not have Ethernet. Removed the check for device emac from emac greentea tests.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

