### PR TITLE
Remove inclusion of mbed.h and mbed namespace from filesystem code

### DIFF
--- a/features/filesystem/Dir.cpp
+++ b/features/filesystem/Dir.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "Dir.h"
-#include "mbed.h"
 #include <errno.h>
 
+namespace mbed {
 
 Dir::Dir()
     : _fs(0), _dir(0)
@@ -92,3 +92,5 @@ size_t Dir::size()
     MBED_ASSERT(_fs);
     return _fs->dir_size(_dir);
 }
+
+} // namespace mbed

--- a/features/filesystem/File.cpp
+++ b/features/filesystem/File.cpp
@@ -15,9 +15,9 @@
  */
 
 #include "File.h"
-#include "mbed.h"
 #include <errno.h>
 
+namespace mbed {
 
 File::File()
     : _fs(0), _file(0)
@@ -110,3 +110,4 @@ off_t File::size()
     return _fs->file_size(_file);
 }
 
+} // namespace mbed

--- a/features/filesystem/FileSystem.cpp
+++ b/features/filesystem/FileSystem.cpp
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
 #include "filesystem/Dir.h"
 #include "filesystem/File.h"
 #include "filesystem/FileSystem.h"
 #include <errno.h>
 
+namespace mbed {
 
 FileSystem::FileSystem(const char *name)
     : FileSystemLike(name)
@@ -170,3 +170,5 @@ int FileSystem::open(DirHandle **dir, const char *path) {
     *dir = d;
     return 0;
 }
+
+} // namespace mbed

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -19,17 +19,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-#include "mbed.h"
-
 #include "diskio.h"
 #include "ffconf.h"
-#include "mbed_debug.h"
-#include "mbed_critical.h"
-#include <errno.h>
-
+#include "platform/mbed_debug.h"
+#include "platform/mbed_critical.h"
+#include "filesystem/mbed_filesystem.h"
 #include "FATFileSystem.h"
 
-
+#include <errno.h>
 ////// Error handling /////
 
 static int fat_error_remap(FRESULT res)

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -29,12 +29,11 @@
 #include <stdint.h>
 #include "PlatformMutex.h"
 
-using namespace mbed;
 
 /**
  * FATFileSystem based on ChaN's Fat Filesystem library v0.8
  */
-class FATFileSystem : public FileSystem {
+class FATFileSystem : public mbed::FileSystem {
 public:
     /** Lifetime of the FATFileSystem
      *
@@ -156,14 +155,14 @@ protected:
      *                  bitwise or'd with one of O_CREAT, O_TRUNC, O_APPEND
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_open(fs_file_t *file, const char *path, int flags);
+    virtual int file_open(mbed::fs_file_t *file, const char *path, int flags);
 
     /** Close a file
      *
      *  @param file     File handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_close(fs_file_t file);
+    virtual int file_close(mbed::fs_file_t file);
 
     /** Read the contents of a file into a buffer
      *
@@ -172,7 +171,7 @@ protected:
      *  @param len      The number of bytes to read
      *  @return         The number of bytes read, 0 at end of file, negative error on failure
      */
-    virtual ssize_t file_read(fs_file_t file, void *buffer, size_t len);
+    virtual ssize_t file_read(mbed::fs_file_t file, void *buffer, size_t len);
 
     /** Write the contents of a buffer to a file
      *
@@ -181,14 +180,14 @@ protected:
      *  @param len      The number of bytes to write
      *  @return         The number of bytes written, negative error on failure
      */
-    virtual ssize_t file_write(fs_file_t file, const void *buffer, size_t len);
+    virtual ssize_t file_write(mbed::fs_file_t file, const void *buffer, size_t len);
 
     /** Flush any buffers associated with the file
      *
      *  @param file     File handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_sync(fs_file_t file);
+    virtual int file_sync(mbed::fs_file_t file);
 
     /** Move the file position to a given offset from from a given location
      *
@@ -200,21 +199,21 @@ protected:
      *      SEEK_END to start from end of file
      *  @return         The new offset of the file
      */
-    virtual off_t file_seek(fs_file_t file, off_t offset, int whence);
+    virtual off_t file_seek(mbed::fs_file_t file, off_t offset, int whence);
 
     /** Get the file position of the file
      *
      *  @param file     File handle
      *  @return         The current offset in the file
      */
-    virtual off_t file_tell(fs_file_t file);
+    virtual off_t file_tell(mbed::fs_file_t file);
 
     /** Get the size of the file
      *
      *  @param file     File handle
      *  @return         Size of the file in bytes
      */
-    virtual off_t file_size(fs_file_t file);
+    virtual off_t file_size(mbed::fs_file_t file);
 
     /** Open a directory on the filesystem
      *
@@ -222,14 +221,14 @@ protected:
      *  @param path     Name of the directory to open
      *  @return         0 on success, negative error code on failure
      */
-    virtual int dir_open(fs_dir_t *dir, const char *path);
+    virtual int dir_open(mbed::fs_dir_t *dir, const char *path);
 
     /** Close a directory
      *
      *  @param dir      Dir handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int dir_close(fs_dir_t dir);
+    virtual int dir_close(mbed::fs_dir_t dir);
 
     /** Read the next directory entry
      *
@@ -237,7 +236,7 @@ protected:
      *  @param ent      The directory entry to fill out
      *  @return         1 on reading a filename, 0 at end of directory, negative error on failure
      */
-    virtual ssize_t dir_read(fs_dir_t dir, struct dirent *ent);
+    virtual ssize_t dir_read(mbed::fs_dir_t dir, struct dirent *ent);
 
     /** Set the current position of the directory
      *
@@ -245,20 +244,20 @@ protected:
      *  @param offset   Offset of the location to seek to,
      *                  must be a value returned from dir_tell
      */
-    virtual void dir_seek(fs_dir_t dir, off_t offset);
+    virtual void dir_seek(mbed::fs_dir_t dir, off_t offset);
 
     /** Get the current position of the directory
      *
      *  @param dir      Dir handle
      *  @return         Position of the directory that can be passed to dir_rewind
      */
-    virtual off_t dir_tell(fs_dir_t dir);
+    virtual off_t dir_tell(mbed::fs_dir_t dir);
 
     /** Rewind the current position to the beginning of the directory
      *
      *  @param dir      Dir handle
      */
-    virtual void dir_rewind(fs_dir_t dir);
+    virtual void dir_rewind(mbed::fs_dir_t dir);
 
 private:
     FATFS _fs; // Work area (file system object) for logical drive

--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "mbed.h"
+#include "filesystem/mbed_filesystem.h"
 #include "LittleFileSystem.h"
 #include "errno.h"
 extern "C" {


### PR DESCRIPTION
### Description

Remove inclusion of mbed.h and mbed namespace from filesystem code.

Resolves https://github.com/ARMmbed/mbed-os/issues/5679

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

