### PR TITLE
Clear CONN_IN_PROGRESS flag after incomplete connect()

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -1080,6 +1080,7 @@ void LoRaWANStack::process_shutdown_state(lorawan_status_t &op_status)
     _device_current_state = DEVICE_STATE_SHUTDOWN;
     op_status = LORAWAN_STATUS_DEVICE_OFF;
     _ctrl_flags &= ~CONNECTED_FLAG;
+    _ctrl_flags &= ~CONN_IN_PROGRESS_FLAG;
     send_event_to_application(DISCONNECTED);
 }
 
@@ -1160,6 +1161,7 @@ void LoRaWANStack::process_joining_state(lorawan_status_t &op_status)
         bool can_continue = _loramac.continue_joining_process();
 
         if (!can_continue) {
+            _ctrl_flags &= ~CONN_IN_PROGRESS_FLAG;
             send_event_to_application(JOIN_FAILURE);
             _device_current_state = DEVICE_STATE_IDLE;
             return;


### PR DESCRIPTION
### Description

An incomplete `connect()` (either abandoned with a `disconnect()` or just failed of its own accord) would cause subsequent calls to `connect()` to fail with `LORAWAN_STATUS_BUSY` due to the `CONN_IN_PROGRESS_FLAG` remaining set in `_ctrl_flags.`

This change clears that flag in the two cases described.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

