### PR TITLE
Move BlockDevice classes inside mbed namespace

### DIFF
--- a/features/filesystem/FileSystem.h
+++ b/features/filesystem/FileSystem.h
@@ -23,7 +23,7 @@
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
 #include "platform/FileSystemLike.h"
-#include "BlockDevice.h"
+#include "bd/BlockDevice.h"
 
 namespace mbed {
 /** \addtogroup filesystem */

--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -17,8 +17,12 @@
 #ifndef MBED_BLOCK_DEVICE_H
 #define MBED_BLOCK_DEVICE_H
 
+#include "platform/platform.h"
 #include <stdint.h>
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Enum of standard error codes
  *
@@ -219,5 +223,7 @@ public:
     }
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/BufferedBlockDevice.cpp
+++ b/features/filesystem/bd/BufferedBlockDevice.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <string.h>
 
+namespace mbed {
+
 static inline uint32_t align_down(bd_size_t val, bd_size_t size)
 {
     return val / size * size;
@@ -239,3 +241,5 @@ bd_size_t BufferedBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/BufferedBlockDevice.h
+++ b/features/filesystem/bd/BufferedBlockDevice.h
@@ -24,6 +24,9 @@
 
 #include "BlockDevice.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Block device for allowing minimal read and program sizes (of 1) for the underlying BD,
  *  using a buffer on the heap.
@@ -163,5 +166,7 @@ protected:
 
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -15,8 +15,10 @@
  */
 
 #include "ChainingBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 
+namespace mbed {
 
 ChainingBlockDevice::ChainingBlockDevice(BlockDevice **bds, size_t bd_count)
     : _bds(bds), _bd_count(bd_count)
@@ -249,3 +251,5 @@ bd_size_t ChainingBlockDevice::size() const
 {
     return _size;
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -23,8 +23,10 @@
 #define MBED_CHAINING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Block device for chaining multiple block devices
  *  with the similar block sizes at sequential addresses
@@ -178,5 +180,7 @@ protected:
     uint32_t _init_ref_count;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ExhaustibleBlockDevice.cpp
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.cpp
@@ -15,9 +15,10 @@
  */
 
 #include "ExhaustibleBlockDevice.h"
-#include "mbed.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 
+namespace mbed {
 
 ExhaustibleBlockDevice::ExhaustibleBlockDevice(BlockDevice *bd, uint32_t erase_cycles)
     : _bd(bd), _erase_array(NULL), _erase_cycles(erase_cycles), _init_ref_count(0)
@@ -141,3 +142,5 @@ bd_size_t ExhaustibleBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/ExhaustibleBlockDevice.h
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.h
@@ -24,6 +24,9 @@
 
 #include "BlockDevice.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Heap backed block device which simulates failures
  *
@@ -157,5 +160,7 @@ private:
     uint32_t _init_ref_count;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/FlashSimBlockDevice.cpp
+++ b/features/filesystem/bd/FlashSimBlockDevice.cpp
@@ -15,11 +15,14 @@
  */
 
 #include "FlashSimBlockDevice.h"
-#include "mbed_assert.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
+
 #include <algorithm>
 #include <stdlib.h>
 #include <string.h>
+
+namespace mbed {
 
 static const bd_size_t min_blank_buf_size = 32;
 
@@ -160,3 +163,5 @@ int FlashSimBlockDevice::get_erase_value() const
 {
     return _erase_value;
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/FlashSimBlockDevice.h
+++ b/features/filesystem/bd/FlashSimBlockDevice.h
@@ -24,6 +24,10 @@
 
 #include "BlockDevice.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 enum {
     BD_ERROR_NOT_ERASED       = -3201,
 };
@@ -137,5 +141,8 @@ private:
     BlockDevice *_bd;
     uint32_t _init_ref_count;
 };
+
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -15,8 +15,11 @@
  */
 
 #include "HeapBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
+#include <stdlib.h>
 
+namespace mbed {
 
 HeapBlockDevice::HeapBlockDevice(bd_size_t size, bd_size_t block)
     : _read_size(block), _program_size(block), _erase_size(block)
@@ -166,3 +169,4 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
+} // namespace mbed

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -17,7 +17,9 @@
 #include "HeapBlockDevice.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_assert.h"
+
 #include <stdlib.h>
+#include <string.h>
 
 namespace mbed {
 

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -23,7 +23,11 @@
 #define MBED_MEM_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
+
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
+
 
 
 /** Lazily allocated heap-backed block device
@@ -153,5 +157,7 @@ private:
     uint32_t _init_ref_count;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -15,9 +15,11 @@
  */
 
 #include "MBRBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 #include <algorithm>
 
+namespace mbed {
 
 // On disk structures, all entries are little endian
 MBED_PACKED(struct) mbr_entry {
@@ -340,3 +342,5 @@ int MBRBlockDevice::get_partition_number() const
 {
     return _part;
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -17,7 +17,10 @@
 #include "MBRBlockDevice.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_assert.h"
+
 #include <algorithm>
+#include <stdlib.h>
+#include <string.h>
 
 namespace mbed {
 

--- a/features/filesystem/bd/MBRBlockDevice.h
+++ b/features/filesystem/bd/MBRBlockDevice.h
@@ -23,8 +23,10 @@
 #define MBED_MBR_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Additional error codes used for MBR records
  */
@@ -255,5 +257,7 @@ protected:
     uint32_t _init_ref_count;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ObservingBlockDevice.cpp
+++ b/features/filesystem/bd/ObservingBlockDevice.cpp
@@ -22,8 +22,8 @@
 
 #include "ObservingBlockDevice.h"
 #include "ReadOnlyBlockDevice.h"
-#include "mbed.h"
 
+namespace mbed {
 
 ObservingBlockDevice::ObservingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -110,3 +110,5 @@ bd_size_t ObservingBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/ObservingBlockDevice.h
+++ b/features/filesystem/bd/ObservingBlockDevice.h
@@ -26,6 +26,9 @@
 #include "PlatformMutex.h"
 #include "Callback.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 class ObservingBlockDevice : public BlockDevice
 {
@@ -141,6 +144,7 @@ private:
     mbed::Callback<void(BlockDevice *)> _change;
 };
 
-
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ProfilingBlockDevice.cpp
+++ b/features/filesystem/bd/ProfilingBlockDevice.cpp
@@ -16,6 +16,7 @@
 
 #include "ProfilingBlockDevice.h"
 
+namespace mbed {
 
 ProfilingBlockDevice::ProfilingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -118,3 +119,5 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
 {
     return _erase_count;
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/ProfilingBlockDevice.h
+++ b/features/filesystem/bd/ProfilingBlockDevice.h
@@ -23,8 +23,10 @@
 #define MBED_PROFILING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 /** Block device for measuring storage operations of another block device
  *
@@ -182,5 +184,7 @@ private:
     bd_size_t _erase_count;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -21,8 +21,9 @@
  */
 
 #include "ReadOnlyBlockDevice.h"
-#include "mbed_error.h"
+#include "platform/mbed_error.h"
 
+namespace mbed {
 
 ReadOnlyBlockDevice::ReadOnlyBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -96,3 +97,5 @@ bd_size_t ReadOnlyBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/ReadOnlyBlockDevice.h
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.h
@@ -25,6 +25,9 @@
 #include "BlockDevice.h"
 #include "PlatformMutex.h"
 
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 class ReadOnlyBlockDevice : public BlockDevice
 {
@@ -133,6 +136,7 @@ private:
     BlockDevice *_bd;
 };
 
-
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "SlicingBlockDevice.h"
+#include "platform/mbed_assert.h"
 
+namespace mbed {
 
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t stop)
     : _bd(bd)
@@ -116,3 +118,5 @@ bd_size_t SlicingBlockDevice::size() const
 {
     return _stop - _start;
 }
+
+} // namespace mbed

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -23,7 +23,10 @@
 #define MBED_SLICING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
+
+namespace mbed {
+/** \addtogroup filesystem */
+/** @{*/
 
 
 /** Block device for mapping to a slice of another block device
@@ -167,5 +170,7 @@ protected:
     bd_size_t _stop;
 };
 
+/** @}*/
+} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -27,7 +27,10 @@
 #include "FATFileSystem.h"
 
 #include <errno.h>
+#include <stdlib.h>
+
 ////// Error handling /////
+using namespace mbed;
 
 static int fat_error_remap(FRESULT res)
 {

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -29,7 +29,6 @@
 #include <stdint.h>
 #include "PlatformMutex.h"
 
-
 /**
  * FATFileSystem based on ChaN's Fat Filesystem library v0.8
  */
@@ -40,7 +39,7 @@ public:
      *  @param name     Name to add filesystem to tree as
      *  @param bd       BlockDevice to mount, may be passed instead to mount call
      */
-    FATFileSystem(const char *name = NULL, BlockDevice *bd = NULL);
+    FATFileSystem(const char *name = NULL, mbed::BlockDevice *bd = NULL);
     virtual ~FATFileSystem();
 
     /** Formats a logical drive, FDISK partitioning rule.
@@ -59,14 +58,14 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    static int format(BlockDevice *bd, bd_size_t cluster_size = 0);
+    static int format(mbed::BlockDevice *bd, mbed::bd_size_t cluster_size = 0);
 
     /** Mounts a filesystem to a block device
      *
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
      */
-    virtual int mount(BlockDevice *bd);
+    virtual int mount(mbed::BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
@@ -91,7 +90,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(BlockDevice *bd, int allocation_unit);
+    virtual int reformat(mbed::BlockDevice *bd, int allocation_unit);
 
     /** Reformats a filesystem, results in an empty and mounted filesystem
      *
@@ -101,7 +100,7 @@ public:
      *                  Default: NULL
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(BlockDevice *bd = NULL)
+    virtual int reformat(mbed::BlockDevice *bd = NULL)
     {
         // required for virtual inheritance shenanigans
         return reformat(bd, 0);
@@ -267,7 +266,7 @@ private:
 protected:
     virtual void lock();
     virtual void unlock();
-    virtual int mount(BlockDevice *bd, bool mount);
+    virtual int mount(mbed::BlockDevice *bd, bool mount);
 };
 
 #endif

--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "lfs_util.h"
 }
 
+using namespace mbed;
 
 ////// Conversion functions //////
 static int lfs_toerror(int err)

--- a/features/filesystem/littlefs/LittleFileSystem.h
+++ b/features/filesystem/littlefs/LittleFileSystem.h
@@ -51,7 +51,7 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    LittleFileSystem(const char *name=NULL, BlockDevice *bd=NULL,
+    LittleFileSystem(const char *name=NULL, mbed::BlockDevice *bd=NULL,
             lfs_size_t read_size=MBED_LFS_READ_SIZE,
             lfs_size_t prog_size=MBED_LFS_PROG_SIZE,
             lfs_size_t block_size=MBED_LFS_BLOCK_SIZE,
@@ -81,7 +81,7 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    static int format(BlockDevice *bd,
+    static int format(mbed::BlockDevice *bd,
         lfs_size_t read_size=MBED_LFS_READ_SIZE,
         lfs_size_t prog_size=MBED_LFS_PROG_SIZE,
         lfs_size_t block_size=MBED_LFS_BLOCK_SIZE,
@@ -92,7 +92,7 @@ public:
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
      */
-    virtual int mount(BlockDevice *bd);
+    virtual int mount(mbed::BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
@@ -110,7 +110,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(BlockDevice *bd);
+    virtual int reformat(mbed::BlockDevice *bd);
 
     /** Remove a file from the filesystem.
      *
@@ -267,7 +267,7 @@ protected:
 private:
     lfs_t _lfs; // _the actual filesystem
     struct lfs_config _config;
-    BlockDevice *_bd; // the block device
+    mbed::BlockDevice *_bd; // the block device
 
     // default parameters
     const lfs_size_t _read_size;

--- a/features/filesystem/mbed_filesystem.h
+++ b/features/filesystem/mbed_filesystem.h
@@ -29,7 +29,6 @@
 
 // BlockDevice classes
 #include "bd/BlockDevice.h"
-#include "bd/BlockDevice.h"
 #include "bd/ChainingBlockDevice.h"
 #include "bd/SlicingBlockDevice.h"
 #include "bd/HeapBlockDevice.h"


### PR DESCRIPTION
### Description

Move BlockDevice classes inside mbed namespace. Resolves: https://github.com/ARMmbed/mbed-os/issues/6684

Dependent on PR: #https://github.com/ARMmbed/mbed-os/pull/7660

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

