### PR TITLE
fix comment copy/paste error

### DIFF
--- a/rtos/Queue.h
+++ b/rtos/Queue.h
@@ -35,7 +35,7 @@ namespace rtos {
 /** \addtogroup rtos */
 /** @{*/
 /**
- * \defgroup rtos_EventFlags EventFlags class
+ * \defgroup rtos_Queue Queue class
  * @{
  */
  


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
All other header files under `rtos/` have `@defgroup` as the class name. I assume this one should, too.

EDIT: Feel free to squash.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

