### PR TITLE
Cellular: Add CellularDevice::init_module API to be called at startup

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -37,13 +37,12 @@
 
 #define RETRY_COUNT_DEFAULT 3
 
-namespace mbed
-{
+namespace mbed {
 
 CellularConnectionFSM::CellularConnectionFSM() :
-        _serial(0), _state(STATE_INIT), _next_state(_state), _status_callback(0), _event_status_cb(0), _network(0), _power(0), _sim(0),
-        _queue(8 * EVENTS_EVENT_SIZE), _queue_thread(0), _cellularDevice(0), _retry_count(0), _event_timeout(-1),
-        _at_queue(8 * EVENTS_EVENT_SIZE), _event_id(0), _plmn(0), _command_success(false), _plmn_network_found(false)
+    _serial(0), _state(STATE_INIT), _next_state(_state), _status_callback(0), _event_status_cb(0), _network(0), _power(0), _sim(0),
+    _queue(8 * EVENTS_EVENT_SIZE), _queue_thread(0), _cellularDevice(0), _retry_count(0), _event_timeout(-1),
+    _at_queue(8 * EVENTS_EVENT_SIZE), _event_id(0), _plmn(0), _command_success(false), _plmn_network_found(false)
 {
     memset(_sim_pin, 0, sizeof(_sim_pin));
 #if MBED_CONF_CELLULAR_RANDOM_MAX_START_DELAY == 0
@@ -147,7 +146,7 @@ bool CellularConnectionFSM::power_on()
 void CellularConnectionFSM::set_sim_pin(const char *sim_pin)
 {
     strncpy(_sim_pin, sim_pin, sizeof(_sim_pin));
-    _sim_pin[sizeof(_sim_pin)-1] = '\0';
+    _sim_pin[sizeof(_sim_pin) - 1] = '\0';
 }
 
 void CellularConnectionFSM::set_plmn(const char *plmn)
@@ -202,7 +201,7 @@ bool CellularConnectionFSM::is_registered()
 }
 
 bool CellularConnectionFSM::get_network_registration(CellularNetwork::RegistrationType type,
-        CellularNetwork::RegistrationStatus &status, bool &is_registered)
+                                                     CellularNetwork::RegistrationStatus &status, bool &is_registered)
 {
     is_registered = false;
     bool is_roaming = false;
@@ -581,7 +580,7 @@ void CellularConnectionFSM::event()
         if (_event_timeout == -1) {
             _event_timeout = 0;
         }
-        _event_id = _queue.call_in(_event_timeout*1000, callback(this, &CellularConnectionFSM::event));
+        _event_id = _queue.call_in(_event_timeout * 1000, callback(this, &CellularConnectionFSM::event));
         if (!_event_id) {
             report_failure("Cellular event failure!");
             return;

--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -161,7 +161,7 @@ private:
     bool open_sim();
     bool get_network_registration(CellularNetwork::RegistrationType type, CellularNetwork::RegistrationStatus &status, bool &is_registered);
     bool is_registered();
-    void device_ready();
+    bool device_ready();
 
     // state functions to keep state machine simple
     void state_init();

--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -43,8 +43,7 @@ const int MAX_RETRY_ARRAY_SIZE = 10;
  *
  *  Finite State Machine for connecting to cellular network
  */
-class CellularConnectionFSM
-{
+class CellularConnectionFSM {
 public:
     CellularConnectionFSM();
     virtual ~CellularConnectionFSM();
@@ -148,7 +147,7 @@ public:
      *
      *  @param plmn operator in numeric format. See more from 3GPP TS 27.007 chapter 7.3.
      */
-    void set_plmn(const char* plmn);
+    void set_plmn(const char *plmn);
 
     /** returns readable format of the given state. Used for printing states while debugging.
      *
@@ -186,7 +185,7 @@ private:
     NetworkStack *get_stack();
 
 private:
-    void report_failure(const char* msg);
+    void report_failure(const char *msg);
     void event();
     void ready_urc_cb();
 
@@ -203,7 +202,7 @@ private:
     events::EventQueue _queue;
     rtos::Thread *_queue_thread;
     CellularDevice *_cellularDevice;
-    char _sim_pin[PIN_SIZE+1];
+    char _sim_pin[PIN_SIZE + 1];
     int _retry_count;
     int _start_time;
     int _event_timeout;

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -114,6 +114,16 @@ public:
      *  @return network stack
      */
     virtual NetworkStack *get_stack() = 0;
+
+    /** Initialize cellular module must be called right after module is ready.
+     *  For example, when multiple modules are supported in a single AT driver this function detects
+     *  and adapts to an actual module at runtime.
+     *
+     *  @param fh    file handle used in communication to modem.
+     *
+     *  @return 0 on success
+     */
+    virtual nsapi_error_t init_module(FileHandle *fh) = 0;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -27,8 +27,7 @@
 #include "CellularInformation.h"
 #include "NetworkStack.h"
 
-namespace mbed
-{
+namespace mbed {
 
 /**
  *  Class CellularDevice
@@ -36,8 +35,7 @@ namespace mbed
  *  An abstract interface that defines opening and closing of cellular interfaces.
  *  Deleting/Closing of opened interfaces can be done only via this class.
  */
-class CellularDevice
-{
+class CellularDevice {
 public:
     /** virtual Destructor
      */

--- a/features/cellular/framework/AT/AT_CellularDevice.cpp
+++ b/features/cellular/framework/AT/AT_CellularDevice.cpp
@@ -246,3 +246,8 @@ NetworkStack *AT_CellularDevice::get_stack()
     }
     return _network->get_stack();
 }
+
+nsapi_error_t AT_CellularDevice::init_module(FileHandle *fh)
+{
+    return NSAPI_ERROR_OK;
+}

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -81,6 +81,8 @@ public: // CellularDevice
 
     virtual NetworkStack *get_stack();
 
+    virtual nsapi_error_t init_module(FileHandle *fh);
+
 protected:
     AT_CellularNetwork *_network;
     AT_CellularSMS *_sms;

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -28,8 +28,7 @@
 
 #include "ATHandler.h"
 
-namespace mbed
-{
+namespace mbed {
 
 /**
  *  Class AT_CellularDevice
@@ -37,8 +36,7 @@ namespace mbed
  *  A class defines opening and closing of cellular interfaces.
  *  Deleting/Closing of opened interfaces can be done only through this class.
  */
-class AT_CellularDevice : public CellularDevice
-{
+class AT_CellularDevice : public CellularDevice {
 public:
     AT_CellularDevice(events::EventQueue &queue);
     virtual ~AT_CellularDevice();
@@ -52,7 +50,7 @@ protected:
      *
      *  @param at_handler
      */
-    void release_at_handler(ATHandler* at_handler);
+    void release_at_handler(ATHandler *at_handler);
 
 public: // CellularDevice
     virtual CellularNetwork *open_network(FileHandle *fh);
@@ -87,8 +85,8 @@ protected:
     AT_CellularNetwork *_network;
     AT_CellularSMS *_sms;
     AT_CellularSIM *_sim;
-    AT_CellularPower* _power;
-    AT_CellularInformation* _information;
+    AT_CellularPower *_power;
+    AT_CellularInformation *_information;
 
 protected:
     events::EventQueue &_queue;


### PR DESCRIPTION
### Description

Added a new API CellularDevice::init_module to initialize cellular module. This function need to be called right after cellular module is ready to make any module specific initialization.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

