### PR TITLE
STM32F7: remove HAL_InitTick() declaration in us_ticker_data.h files

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/us_ticker_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/us_ticker_data.h
@@ -36,9 +36,6 @@
 
 #define TIM_MST_PCLK  1 // Select the peripheral clock number (1 or 2)
 
-
-HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority);
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/us_ticker_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/us_ticker_data.h
@@ -36,9 +36,6 @@
 
 #define TIM_MST_PCLK  1 // Select the peripheral clock number (1 or 2)
 
-
-HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority);
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/us_ticker_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/us_ticker_data.h
@@ -36,9 +36,6 @@
 
 #define TIM_MST_PCLK  1 // Select the peripheral clock number (1 or 2)
 
-
-HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority);
-
 #ifdef __cplusplus
 }
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/us_ticker_data.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/us_ticker_data.h
@@ -36,9 +36,6 @@
 
 #define TIM_MST_PCLK  1 // Select the peripheral clock number (1 or 2)
 
-
-HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description

Clean-up. These useless declarations were left in these STM32F7 files.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

