### PR TITLE
Renesas : Improve Flash iap

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
@@ -40,6 +40,7 @@
 #define FLASH_BASE                 (0x18000000UL) /**< Flash Base Address */
 #define FLASH_SIZE                 (0x00800000UL) /**< Available Flash Memory */
 #define FLASH_PAGE_SIZE            256            /**< Flash Memory page size (interleaving off) */
+                                                  /**< Maximum size per one writing is 256 byte and minimum size per one writing is 1 byte */
 #define FLASH_SECTOR_SIZE          4096           /**< Flash Memory sector size (interleaving off) */
 
 #endif

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/mbed_drv_cfg.h
@@ -40,6 +40,7 @@
 #define FLASH_BASE                 (0x18000000UL) /**< Flash Base Address */
 #define FLASH_SIZE                 (0x00800000UL) /**< Available Flash Memory */
 #define FLASH_PAGE_SIZE            256            /**< Flash Memory page size (interleaving off) */
+                                                  /**< Maximum size per one writing is 256 byte and minimum size per one writing is 1 byte */
 #define FLASH_SECTOR_SIZE          4096           /**< Flash Memory sector size (interleaving off) */
 
 #endif


### PR DESCRIPTION
### Description
I revised flash_iap.c file of Renesas.

I modified the `_page_program()` because when request size is over the maximum size(256 byte) per one writing, it was not able to loop the writing every 256 byte.
Also I modified the return value of `flash_get_page_size()` because the minimum size per one writing was 1 byte by Flash spec.
`FLASH_PAGE_SIZE` macro is remain 256, it doesn't be used at `flash_get_page_size()`, used at `_page_program()` as the maximum page size.


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Relation Issue
https://github.com/ARMmbed/mbed-os/issues/7649#issuecomment-409437568

### Test result
NVStore and Flash iAP was passed.

[Test_PEACH_GCC_NVStore_Flash.txt](https://github.com/ARMmbed/mbed-os/files/2252188/Test_PEACH_GCC_NVStore_Flash.txt)
[Test_LYCHEE_GCC_NVStore_Flash.txt](https://github.com/ARMmbed/mbed-os/files/2252189/Test_LYCHEE_GCC_NVStore_Flash.txt)



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
