### PR TITLE
BLE: store secure connections ltk in both local and peer entry

### DIFF
--- a/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
+++ b/features/FEATURE_BLE/source/generic/GenericSecurityManager.cpp
@@ -1464,6 +1464,7 @@ void GenericSecurityManager::on_secure_connections_ltk_generated(
     flags->secure_connections_paired = true;
 
     _db->set_entry_peer_ltk(cb->db_entry, ltk);
+    _db->set_entry_local_ltk(cb->db_entry, ltk);
 }
 
 void GenericSecurityManager::on_keys_distributed_ltk(


### PR DESCRIPTION
### Description

Secure connections LTK was being stored only in the peer entry which meant the remote encryption request wouldn't find the correct key. This fix stores the key in both entries.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

