### PR TITLE
Renesas : Improve LWIP speed

### DIFF
--- a/features/lwipstack/lwipopts.h
+++ b/features/lwipstack/lwipopts.h
@@ -139,6 +139,26 @@
 
 #define LWIP_RAM_HEAP_POINTER       lwip_ram_heap
 
+// Number of simultaneously queued TCP segments.
+#ifdef MBED_CONF_LWIP_MEMP_NUM_TCP_SEG
+#define MEMP_NUM_TCP_SEG            MBED_CONF_LWIP_MEMP_NUM_TCP_SEG
+#endif
+
+// TCP Maximum segment size.
+#ifdef MBED_CONF_LWIP_TCP_MSS
+#define TCP_MSS                     MBED_CONF_LWIP_TCP_MSS
+#endif
+
+// TCP sender buffer space (bytes).
+#ifdef MBED_CONF_LWIP_TCP_SND_BUF
+#define TCP_SND_BUF                 MBED_CONF_LWIP_TCP_SND_BUF
+#endif
+
+// TCP sender buffer space (bytes).
+#ifdef MBED_CONF_LWIP_TCP_WND
+#define TCP_WND                     MBED_CONF_LWIP_TCP_WND
+#endif
+
 // Number of pool pbufs.
 // Each requires 684 bytes of RAM (if MSS=536 and PBUF_POOL_BUFSIZE defaulting to be based on MSS)
 #ifdef MBED_CONF_LWIP_PBUF_POOL_SIZE

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -72,6 +72,22 @@
             "help": "Maximum number of open UDPSocket instances allowed, including one used internally for DNS.  Each requires 84 bytes of pre-allocated RAM",
             "value": 4
         },
+        "memp-num-tcp-seg": {
+            "help": "Number of simultaneously queued TCP segments. Current default (used if null here) is set to 16 in opt.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
+        "tcp-mss": {
+            "help": "TCP Maximum segment size. Current default (used if null here) is set to 536 in opt.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
+        "tcp-snd-buf": {
+            "help": "TCP sender buffer space (bytes). Current default (used if null here) is set to (2 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
+        "tcp-wnd": {
+            "help": "TCP sender buffer space (bytes). Current default (used if null here) is set to (4 * TCP_MSS) in opt.h, unless overridden by target Ethernet drivers.",
+            "value": null
+        },
         "pbuf-pool-size": {
             "help": "Number of pbufs in pool - usually used for received packets, so this determines how much data can be buffered between reception and the application reading. If a driver uses PBUF_RAM for reception, less pool may be needed. Current default (used if null here) is set to 5 in lwipopts.h, unless overridden by target Ethernet drivers.",
             "value": null
@@ -132,6 +148,11 @@
             "tcpip-thread-stacksize": 1328,
             "default-thread-stacksize": 640,
             "ppp-thread-stacksize": 896,
+            "memp-num-tcp-seg": 32,
+            "tcp-mss": 1460,
+            "tcp-snd-buf": "(8 * TCP_MSS)",
+            "tcp-wnd": "(TCP_MSS * 8)",
+            "pbuf-pool-size": 16,
             "mem-size": 51200
         }
     }

--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -149,7 +149,7 @@
             "default-thread-stacksize": 640,
             "ppp-thread-stacksize": 896,
             "memp-num-tcp-seg": 32,
-            "tcp-mss": 1460,
+            "tcp-mss": 1440,
             "tcp-snd-buf": "(8 * TCP_MSS)",
             "tcp-wnd": "(TCP_MSS * 8)",
             "pbuf-pool-size": 16,


### PR DESCRIPTION
### Description
For speeding up of LWIP on RZ/A1, I added four new config processes in `mbed_lib.json` and `lwipopts.h`, overriden the values.
Since RZ/A1 incorporates a large-capacity memory, can actualize speeding up by running with the overriden value.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change
