### PR TITLE
QSPI HAL tests:  add DISCO_F413ZH support

### DIFF
--- a/TESTS/mbed_hal/qspi/flash_configs/MX25R6435F_config.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/MX25R6435F_config.h
@@ -108,9 +108,14 @@
 
 
 // single quad enable flag for both dual and quad mode
-#define QUAD_ENABLE_IMPLEMENTATION()                                        \
+#define QUAD_ENABLE()                                                       \
                                                                             \
     uint8_t reg_data[QSPI_STATUS_REG_SIZE];                                 \
+                                                                            \
+    if (write_enable(qspi) != QSPI_STATUS_OK) {                             \
+        return QSPI_STATUS_ERROR;                                           \
+    }                                                                       \
+    WAIT_FOR(WRSR_MAX_TIME, qspi);                                          \
                                                                             \
     reg_data[0] = STATUS_BIT_QE;                                            \
     qspi.cmd.build(QSPI_CMD_WRSR);                                          \
@@ -132,9 +137,14 @@
 
 
 
-#define QUAD_DISABLE_IMPLEMENTATION()                                       \
+#define QUAD_DISABLE()                                                      \
                                                                             \
     uint8_t reg_data[QSPI_STATUS_REG_SIZE];                                 \
+                                                                            \
+    if (write_enable(qspi) != QSPI_STATUS_OK) {                             \
+        return QSPI_STATUS_ERROR;                                           \
+    }                                                                       \
+    WAIT_FOR(WRSR_MAX_TIME, qspi);                                          \
                                                                             \
     reg_data[0] = 0;                                                        \
     qspi.cmd.build(QSPI_CMD_WRSR);                                          \
@@ -156,7 +166,7 @@
 
 
 
-#define FAST_MODE_ENABLE_IMPLEMENTATION()                                   \
+#define FAST_MODE_ENABLE()                                                  \
                                                                             \
     qspi_status_t ret;                                                      \
     const int32_t reg_size = QSPI_STATUS_REG_SIZE + QSPI_CONFIG_REG_0_SIZE; \

--- a/TESTS/mbed_hal/qspi/flash_configs/N25Q128A_config.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/N25Q128A_config.h
@@ -1,0 +1,182 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_QSPI_FLASH_N25Q128A_H
+#define MBED_QSPI_FLASH_N25Q128A_H
+
+
+#define QSPI_FLASH_CHIP_STRING "Micron N25Q128A"
+
+// Command for reading status register
+#define QSPI_CMD_RDSR                           0x05
+// Command for reading configuration register 0 (NONVOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_RDCR0                          0xB5
+// Command for reading configuration register 1 (VOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_RDCR1                          0x85
+// Command for reading configuration register 2 (ENHANCED VOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_RDCR2                          0x65
+// Command for writing status
+#define QSPI_CMD_WRSR                           0x01
+// Command for writing configuration register 0 (NONVOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_WRCR0                          0xB1
+// Command for writing configuration register 1 (VOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_WRCR1                          0x81
+// Command for writing configuration register 2 (ENHANCED VOLATILE CONFIGURATION REGISTER)
+#define QSPI_CMD_WRCR2                          0x61
+// Command for reading security register
+#define QSPI_CMD_RDSCUR                         0x2B
+
+// Command for setting Reset Enable
+#define QSPI_CMD_RSTEN                          0x66
+// Command for setting Reset
+#define QSPI_CMD_RST                            0x99
+
+// Command for setting write enable
+#define QSPI_CMD_WREN                           0x06
+// Command for setting write disable
+#define QSPI_CMD_WRDI                           0x04
+
+// WRSR operations max time [us] (datasheet max time + 15%)
+#define QSPI_WRSR_MAX_TIME                      9200   // 8ms
+// general wait max time [us]
+#define QSPI_WAIT_MAX_TIME                      100000   // 100ms
+
+
+// Commands for writing (page programming)
+#define QSPI_CMD_WRITE_1IO                      0x02    // 1-1-1 mode
+#define QSPI_CMD_WRITE_2IO                      0xD2    // 1-2-2 mode
+#define QSPI_CMD_WRITE_4IO                      0x12    // 1-4-4 mode
+
+// write operations max time [us] (datasheet max time + 15%)
+#define QSPI_PAGE_PROG_MAX_TIME                 5750   // 5ms
+
+#define QSPI_PAGE_SIZE                          256    // 256B
+
+// Commands for reading
+#define QSPI_CMD_READ_1IO_FAST                  0x0B   // 1-1-1 mode
+#define QSPI_CMD_READ_1IO                       0x03   // 1-1-1 mode
+#define QSPI_CMD_READ_2IO                       0xBB   // 1-2-2 mode
+#define QSPI_CMD_READ_1I2O                      0x3B   // 1-1-2 mode
+#define QSPI_CMD_READ_4IO                       0xEB   // 1-4-4 mode
+#define QSPI_CMD_READ_1I4O                      0x6B   // 1-1-4 mode
+
+
+#define QSPI_READ_1IO_DUMMY_CYCLE               0
+#define QSPI_READ_FAST_DUMMY_CYCLE              8
+// 8 dummy (10 dummy when quad SPI protocol is enabled)
+#define QSPI_READ_2IO_DUMMY_CYCLE               8
+#define QSPI_READ_1I2O_DUMMY_CYCLE              8
+#define QSPI_READ_4IO_DUMMY_CYCLE               10
+#define QSPI_READ_1I4O_DUMMY_CYCLE              8
+
+// Commands for erasing
+#define QSPI_CMD_ERASE_SECTOR                   0x20    // 4kB
+#define QSPI_CMD_ERASE_BLOCK_32                 0x52    // 32kB
+#define QSPI_CMD_ERASE_BLOCK_64                 0xD8    // 64kB
+#define QSPI_CMD_ERASE_CHIP                     0x60    // or 0xC7
+
+// erase operations max time [us] (datasheet max time + 15%)
+#define QSPI_ERASE_SECTOR_MAX_TIME              276000      // 240 ms
+#define QSPI_ERASE_BLOCK_32_MAX_TIME            3000000     // 3s
+#define QSPI_ERASE_BLOCK_64_MAX_TIME            3500000     // 3.5s
+
+// max frequency for basic rw operation
+#define QSPI_COMMON_MAX_FREQUENCY               50000000
+
+#define QSPI_STATUS_REG_SIZE                    1
+#define QSPI_CONFIG_REG_0_SIZE                  2
+#define QSPI_CONFIG_REG_1_SIZE                  1
+#define QSPI_CONFIG_REG_2_SIZE                  1
+#define QSPI_MAX_REG_SIZE                       2
+
+// status register
+#define STATUS_BIT_WIP   (1 << 0)   // write in progress bit
+#define STATUS_BIT_WEL   (1 << 1)   // write enable latch
+#define STATUS_BIT_BP0   (1 << 2)   // block
+#define STATUS_BIT_BP1   (1 << 3)   //
+#define STATUS_BIT_BP2   (1 << 4)   //
+#define STATUS_BIT_BP_TB (1 << 5)   // Block protect top/bottom
+#define STATUS_BIT_BP3   (1 << 6)   //
+#define STATUS_BIT_SRWD  (1 << 7)   // status register write protect
+
+// configuration register 0 (Nonvolatile Configuration Register)
+// bit 1, 5, reserved
+#define CONFIG0_BIT_LOCK        (1 << 0)   // Lock nonvolatile configuration register
+#define CONFIG0_BIT_DE          (1 << 2)   // Dual Enable   0 = Enabled / 1 = Disabled
+#define CONFIG0_BIT_QE          (1 << 3)   // Quad Enable   0 = Enabled / 1 = Disabled
+#define CONFIG0_BIT_RH          (1 << 4)   // Reset/hold
+#define CONFIG0_BIT_ODS0        (1 << 6)   // Output driver strength
+#define CONFIG0_BIT_ODS1        (1 << 7)   // Output driver strength
+#define CONFIG0_BIT_ODS2        (1 << 8)   // Output driver strength
+#define CONFIG0_BIT_XIP_MODE0   (1 << 9)   // XIP mode at power-on reset
+#define CONFIG0_BIT_XIP_MODE1   (1 << 10)  // XIP mode at power-on reset
+#define CONFIG0_BIT_XIP_MODE2   (1 << 11)  // XIP mode at power-on reset
+#define CONFIG0_BIT_DCYCLE0     (1 << 12)  // Dummy Cycle
+#define CONFIG0_BIT_DCYCLE1     (1 << 13)  // Dummy Cycle
+#define CONFIG0_BIT_DCYCLE2     (1 << 14)  // Dummy Cycle
+#define CONFIG0_BIT_DCYCLE3     (1 << 15)  // Dummy Cycle
+#define CONFIG0_BITS_DEFAULT    0xFFFF  // reg default state
+
+
+// configuration register 1 (Volatile Configuration Register)
+// bit 2, reserved
+#define CONFIG1_BIT_WRAP0   (1 << 0)   // Output data wrap
+#define CONFIG1_BIT_WRAP1   (1 << 1)   // Output data wrap
+#define CONFIG1_BIT_XIP     (1 << 3)   // 0 = Enable / 1 = Disable (default)
+#define CONFIG1_BIT_DCYCLE0 (1 << 4)   // Number of dummy clock cycles
+#define CONFIG1_BIT_DCYCLE1 (1 << 5)   // Number of dummy clock cycles
+#define CONFIG1_BIT_DCYCLE2 (1 << 6)   // Number of dummy clock cycles
+#define CONFIG1_BIT_DCYCLE3 (1 << 7)   // Number of dummy clock cycles
+#define CONFIG1_BITS_DEFAULT    0xB  // reg default state
+
+
+// configuration register 2 (Enhanced Volatile Configuration Register)
+// bit 5, reserved
+#define CONFIG2_BIT_ODS0   (1 << 0)   // Output driver strength     111 = 30 Ohms (Default)
+#define CONFIG2_BIT_ODS1   (1 << 1)   // Output driver strength
+#define CONFIG2_BIT_ODS2   (1 << 2)   // Output driver strength
+#define CONFIG2_BIT_VPP    (1 << 3)   // VPP accelerator            1 = Disabled (Default)
+#define CONFIG2_BIT_RH     (1 << 4)   // Reset/hold
+#define CONFIG2_BIT_DE     (1 << 6)   // Dual I/O protocol          0 = Enabled / 1 = Disabled (Default, extended SPI protocol)
+#define CONFIG2_BIT_QE     (1 << 7)   // Quad I/O protocol          0 = Enabled / 1 = Disabled (Default, extended SPI protocol)
+#define CONFIG2_BITS_DEFAULT    0xDF  // reg default state
+
+
+#define DUAL_ENABLE()                                                           \
+    /* TODO: add implementation */                                              \
+    return QSPI_STATUS_OK
+
+
+#define DUAL_DISABLE()                                                          \
+    /* TODO: add implementation */                                              \
+    return QSPI_STATUS_OK
+
+
+#define QUAD_ENABLE()                                                           \
+    /* TODO: add implementation */                                              \
+    return QSPI_STATUS_OK
+
+
+#define QUAD_DISABLE()                                                          \
+    /* TODO: add implementation */                                              \
+    return QSPI_STATUS_OK
+
+
+#define FAST_MODE_ENABLE()                                                      \
+    /* TODO: add implementation */                                              \
+    return QSPI_STATUS_OK
+
+
+#endif // MBED_QSPI_FLASH_N25Q128A_H

--- a/TESTS/mbed_hal/qspi/flash_configs/STM/DISCO_F413ZH/flash_config.h
+++ b/TESTS/mbed_hal/qspi/flash_configs/STM/DISCO_F413ZH/flash_config.h
@@ -13,16 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#ifndef MBED_QSPI_FLASH_CONFIG_H
+#define MBED_QSPI_FLASH_CONFIG_H
 
-#ifndef MBED_FLASH_CONFIGS_H
-#define MBED_FLASH_CONFIGS_H
+#include "../../N25Q128A_config.h"
 
-#if defined(TARGET_DISCO_L475VG_IOT01A)
-#include "STM/DISCO_L475VG_IOT01A/flash_config.h"
-#elif defined(TARGET_NRF52840)
-#include "NORDIC/NRF52840_DK/flash_config.h"
-#elif defined(TARGET_DISCO_F413ZH)
-#include "STM/DISCO_F413ZH/flash_config.h"
-#endif
 
-#endif // MBED_FLASH_CONFIGS_H
+#endif // MBED_QSPI_FLASH_CONFIG_H

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -71,11 +71,11 @@ uint8_t rx_buf[DATA_SIZE_1024];
 
 static void log_data(const char *str, uint8_t *data, uint32_t size)
 {
-    printf("%s: ", str);
+    utest_printf("%s: ", str);
     for (uint32_t j = 0; j < size; j++) {
-            printf("%02X ", data[j]);
+        utest_printf("%02X ", data[j]);
     }
-    printf("\r\n");
+    utest_printf("\r\n");
 }
 
 
@@ -171,19 +171,19 @@ static void _qspi_write_read_test(Qspi &qspi, qspi_bus_width_t write_inst_width,
             if (tx_buf[i] != rx_buf[i]) {
                 log_data("tx data", tx_buf, data_size);
                 log_data("rx data", rx_buf, data_size);
-                printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
+                utest_printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
                 TEST_ASSERT_EQUAL(tx_buf[i], rx_buf[i]);
             }
         }
 
 #ifdef QSPI_TEST_LOG_FLASH_TIME
-        printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
+        utest_printf("erase/write/read time: %d/%d/%d [us]\r\n", erase_time, write_time, read_time);
 #endif
 
 #ifdef QSPI_TEST_LOG_DATA
         log_data("tx data", tx_buf, data_size);
         log_data("rx data", rx_buf, data_size);
-        printf("rx/tx data match\r\n");
+        utest_printf("rx/tx data match\r\n");
 #endif
     }
 }
@@ -222,9 +222,6 @@ void qspi_write_read_test(void)
 
     if (is_dual_cmd(write_inst_width, write_addr_width, write_data_width) ||
         is_dual_cmd(read_inst_width, read_addr_width, read_data_width)) {
-        ret = write_enable(qspi);
-        TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
-        WAIT_FOR(WRSR_MAX_TIME, qspi);
         ret = dual_enable(qspi);
         TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
         WAIT_FOR(WRSR_MAX_TIME, qspi);
@@ -232,9 +229,6 @@ void qspi_write_read_test(void)
 
     if (is_quad_cmd(write_inst_width, write_addr_width, write_data_width) ||
         is_quad_cmd(read_inst_width, read_addr_width, read_data_width)) {
-        ret = write_enable(qspi);
-        TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
-        WAIT_FOR(WRSR_MAX_TIME, qspi);
         ret = quad_enable(qspi);
         TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
         WAIT_FOR(WRSR_MAX_TIME, qspi);
@@ -248,10 +242,13 @@ void qspi_write_read_test(void)
     WAIT_FOR(WRSR_MAX_TIME, qspi);
 
 #ifdef QSPI_TEST_LOG_FLASH_STATUS
-    printf("Status ");   log_register(STATUS_REG, QSPI_STATUS_REG_SIZE, qspi);
-    printf("Config 0 "); log_register(CONFIG_REG0, QSPI_CONFIG_REG_0_SIZE, qspi);
+    utest_printf("Status\r\n");   log_register(STATUS_REG, QSPI_STATUS_REG_SIZE, qspi);
+    utest_printf("Config 0\r\n"); log_register(CONFIG_REG0, QSPI_CONFIG_REG_0_SIZE, qspi);
 #ifdef CONFIG_REG1
-    printf("Config 1 "); log_register(CONFIG_REG1, QSPI_CONFIG_REG_1_SIZE, qspi);
+    utest_printf("Config 1\r\n"); log_register(CONFIG_REG1, QSPI_CONFIG_REG_1_SIZE, qspi);
+#endif
+#ifdef CONFIG_REG2
+    utest_printf("Config 2\r\n"); log_register(CONFIG_REG2, QSPI_CONFIG_REG_2_SIZE, qspi);
 #endif
 #endif
 
@@ -265,9 +262,6 @@ void qspi_write_read_test(void)
 
     if (is_dual_cmd(write_inst_width, write_addr_width, write_data_width) ||
         is_dual_cmd(read_inst_width, read_addr_width, read_data_width)) {
-        ret = write_enable(qspi);
-        TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
-        WAIT_FOR(WRSR_MAX_TIME, qspi);
         ret = dual_disable(qspi);
         TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
         WAIT_FOR(WRSR_MAX_TIME, qspi);
@@ -275,9 +269,6 @@ void qspi_write_read_test(void)
 
     if (is_quad_cmd(write_inst_width, write_addr_width, write_data_width) ||
         is_quad_cmd(read_inst_width, read_addr_width, read_data_width)) {
-        ret = write_enable(qspi);
-        TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
-        WAIT_FOR(WRSR_MAX_TIME, qspi);
         ret = quad_disable(qspi);
         TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
         WAIT_FOR(WRSR_MAX_TIME, qspi);
@@ -321,10 +312,13 @@ void qspi_init_free_test(void)
     flash_init(qspi);
 
 #ifdef QSPI_TEST_LOG_FLASH_STATUS
-    printf("Status ");   log_register(STATUS_REG, QSPI_STATUS_REG_SIZE, qspi);
-    printf("Config 0 "); log_register(CONFIG_REG0, QSPI_CONFIG_REG_0_SIZE, qspi);
+    utest_printf("Status\r\n");   log_register(STATUS_REG, QSPI_STATUS_REG_SIZE, qspi);
+    utest_printf("Config 0\r\n"); log_register(CONFIG_REG0, QSPI_CONFIG_REG_0_SIZE, qspi);
 #ifdef CONFIG_REG1
-    printf("Config 1 "); log_register(CONFIG_REG1, QSPI_CONFIG_REG_1_SIZE, qspi);
+    utest_printf("Config 1\r\n"); log_register(CONFIG_REG1, QSPI_CONFIG_REG_1_SIZE, qspi);
+#endif
+#ifdef CONFIG_REG2
+    utest_printf("Config 2\r\n"); log_register(CONFIG_REG2, QSPI_CONFIG_REG_2_SIZE, qspi);
 #endif
 #endif
 
@@ -375,7 +369,7 @@ void qspi_frequency_test(void)
 
 void qspi_memory_id_test()
 {
-    printf("*** %s memory config loaded ***\r\n", QSPI_FLASH_CHIP_STRING);
+    utest_printf("*** %s memory config loaded ***\r\n", QSPI_FLASH_CHIP_STRING);
 }
 
 

--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -13,6 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if !DEVICE_QSPI
+#error [NOT_SUPPORTED] QSPI not supported for this target
+#endif
+
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "greentea-client/test_env.h"
@@ -23,8 +28,8 @@
 #include "qspi_api.h"
 
 
-#if !DEVICE_QSPI || !defined(QSPI_FLASH_CHIP_STRING)
-#error [NOT_SUPPORTED] QSPI not supported for this target
+#if !defined(QSPI_FLASH_CHIP_STRING)
+#error [NOT_SUPPORTED] QSPI test not supported for this target
 #endif
 
 using namespace utest::v1;
@@ -276,9 +281,6 @@ void qspi_write_read_test(void)
 
     qspi_free(&qspi.handle);
 }
-
-
-
 
 
 void qspi_init_free_test(void)

--- a/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
+++ b/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
@@ -74,6 +74,12 @@ qspi_status_t read_register(uint32_t cmd, uint8_t *buf, uint32_t size, Qspi &q)
     return qspi_command_transfer(&q.handle, q.cmd.get(), NULL, 0, buf, size);
 }
 
+qspi_status_t write_register(uint32_t cmd, uint8_t *buf, uint32_t size, Qspi &q)
+{
+    q.cmd.build(cmd);
+    return qspi_command_transfer(&q.handle, q.cmd.get(), buf, size, NULL, 0);
+}
+
 
 QspiStatus flash_wait_for(uint32_t time_us, Qspi &qspi)
 {

--- a/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
+++ b/TESTS/mbed_hal/qspi/qspi_test_utils.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "utest/utest.h"
 
 #include "hal/qspi_api.h"
 #include "qspi_test_utils.h"
@@ -166,12 +167,12 @@ void log_register(uint32_t cmd, uint32_t reg_size, Qspi &qspi)
     ret = read_register(cmd, reg, reg_size, qspi);
     TEST_ASSERT_EQUAL(QSPI_STATUS_OK, ret);
 
-    for (int j = 0; j < reg_size; j++) {
-        printf("register byte %d data: ", j);
+    for (uint32_t j = 0; j < reg_size; j++) {
+        utest_printf("register byte %u data: ", j);
         for(int i = 0; i < 8; i++) {
-            printf("%s ", ((reg[j] & (1 << i)) & 0xFF) == 0 ? "0" : "1");
+            utest_printf("%s ", ((reg[j] & (1 << i)) & 0xFF) == 0 ? "0" : "1");
         }
-        printf("\r\n");
+        utest_printf("\r\n");
     }
 }
 
@@ -183,36 +184,36 @@ qspi_status_t erase(uint32_t erase_cmd, uint32_t flash_addr, Qspi &qspi)
 
 qspi_status_t dual_enable(Qspi &qspi)
 {
-#ifdef DUAL_ENABLE_IMPLEMENTATION
-    DUAL_ENABLE_IMPLEMENTATION();
+#ifdef DUAL_ENABLE
+    DUAL_ENABLE();
 #else
-    QUAD_ENABLE_IMPLEMENTATION();
+    QUAD_ENABLE();
 #endif
 }
 
 qspi_status_t dual_disable(Qspi &qspi)
 {
-#ifdef DUAL_DISABLE_IMPLEMENTATION
-    DUAL_DISABLE_IMPLEMENTATION();
+#ifdef DUAL_DISABLE
+    DUAL_DISABLE();
 #else
-    QUAD_DISABLE_IMPLEMENTATION();
+    QUAD_DISABLE();
 #endif
 
 }
 
 qspi_status_t quad_enable(Qspi &qspi)
 {
-    QUAD_ENABLE_IMPLEMENTATION();
+    QUAD_ENABLE();
 }
 
 qspi_status_t quad_disable(Qspi &qspi)
 {
-    QUAD_DISABLE_IMPLEMENTATION();
+    QUAD_DISABLE();
 }
 
 qspi_status_t fast_mode_enable(Qspi &qspi)
 {
-    FAST_MODE_ENABLE_IMPLEMENTATION();
+    FAST_MODE_ENABLE();
 }
 
 bool is_dual_cmd(qspi_bus_width_t inst_width, qspi_bus_width_t addr_width, qspi_bus_width_t data_width)

--- a/TESTS/mbed_hal/qspi/qspi_test_utils.h
+++ b/TESTS/mbed_hal/qspi/qspi_test_utils.h
@@ -84,10 +84,17 @@ struct Qspi {
 #ifdef QSPI_CMD_RDCR1
 #define CONFIG_REG1      QSPI_CMD_RDCR1
 #endif
+#ifdef QSPI_CMD_RDCR2
+#define CONFIG_REG2      QSPI_CMD_RDCR2
+#endif
 #define SECURITY_REG    QSPI_CMD_RDSCUR
 
 #ifndef QSPI_CONFIG_REG_1_SIZE
 #define QSPI_CONFIG_REG_1_SIZE 0
+#endif
+
+#ifndef QSPI_CONFIG_REG_2_SIZE
+#define QSPI_CONFIG_REG_2_SIZE 0
 #endif
 
 
@@ -105,6 +112,7 @@ struct Qspi {
 
 
 qspi_status_t read_register(uint32_t cmd, uint8_t *buf, uint32_t size, Qspi &q);
+qspi_status_t write_register(uint32_t cmd, uint8_t *buf, uint32_t size, Qspi &q);
 
 QspiStatus flash_wait_for(uint32_t time_us, Qspi &qspi);
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
@@ -303,6 +303,14 @@ typedef enum {
     SYS_WKUP2 = PC_0,
     SYS_WKUP3 = PC_1,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_PIN_IO0 = PF_8,
+    QSPI_PIN_IO1 = PF_9,
+    QSPI_PIN_IO2 = PE_2,
+    QSPI_PIN_IO3 = PD_13,
+    QSPI_PIN_SCK = PB_2,
+    QSPI_PIN_CSN = PG_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
### Description

This PR adds (to qspi_hal test):
- new qspi flash chip Micron N25Q128A config
- support for DISCO_F413ZH

TODO:
- implement enable dual/quad mode

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] New target
    [X] Feature
    [ ] Breaking change

