### PR TITLE
Correct MTB_ADV_WISE_1530 led configuration

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
@@ -201,6 +201,7 @@ typedef enum {
     // Generic signals namings
     LED1        = PB_2,
     LED2        = PB_10,
+    LED3        = NC,
     LED_RED     = LED1,
     LED_BLUE    = LED2,
     USER_BUTTON = PC_13,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PinNames.h
@@ -241,12 +241,24 @@ typedef enum {
 
 
     // Generic signals namings
+#ifdef MBED_CONF_TARGET_LED1
+    LED1        = MBED_CONF_TARGET_LED1,
+#else
     LED1        = PA_7,
+#endif
+#ifdef MBED_CONF_TARGET_LED2
+    LED2        = MBED_CONF_TARGET_LED2,
+#else
     LED2        = PC_4,
+#endif
+#ifdef MBED_CONF_TARGET_LED3
+    LED3        = MBED_CONF_TARGET_LED3,
+#else
     LED3        = PC_11,
+#endif
     LED_RED     = LED1,
     LED_BLUE    = LED2,
-    LED_GREEN    = LED3,
+    LED_GREEN   = LED3,
     USER_BUTTON = PB_14,
 
     // Standardized button names

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1200,6 +1200,11 @@
     },
     "MTB_ADV_WISE_1530": {
         "inherits": ["USI_WM_BN_BM_22"],
+        "config": {
+            "led1": "PA_4",
+            "led2": "PC_12",
+            "led3": "NC"
+            },
         "overrides": {
             "stdio_uart_tx": "PB_10",
             "stdio_uart_rx": "PC_11"


### PR DESCRIPTION
mbed-os-example_blinky didn't work with MTB_ADV_WISE_1530, so led configuration have been updated. Also minor update to MTB_MXCHIP_EMW3166 led configuration, led3 is now
defined but not connected.

### Description
mbed-os-example-blinky have been tested and verified with these 3 boards:
 MTB_ADV_WISE_1530
MTB_USI_WM_BN_BM_22
MTB_MXCHIP_EMW

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

