### PR TITLE
BLE: set correct default privacy configuration for centrals

### DIFF
--- a/features/FEATURE_BLE/source/Gap.cpp
+++ b/features/FEATURE_BLE/source/Gap.cpp
@@ -79,7 +79,7 @@ const Gap::PeripheralPrivacyConfiguration_t Gap::default_peripheral_privacy_conf
 
 const Gap::CentralPrivacyConfiguration_t Gap::default_central_privacy_configuration = {
     /* use_non_resolvable_random_address */ false,
-    /* resolution_strategy */ CentralPrivacyConfiguration_t::DO_NOT_RESOLVE
+    /* resolution_strategy */ CentralPrivacyConfiguration_t::RESOLVE_AND_FORWARD
 };
 
 void Gap::processConnectionEvent(


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Advertisements were not being resolved by default, which is contratry to the intention and documentation in the API.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

