### PR TITLE
BLE: call secure connections versions of ltk functions

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
@@ -762,7 +762,7 @@ nRF5xSecurityManager& nRF5xSecurityManager::get_security_manager()
 
 bool is_rand_invalid(const uint8_t* rand)
 {
-    for (int i = 0; i < 8; ++i) {
+    for (int i = 0; i < BLE_GAP_SEC_RAND_LEN; ++i) {
         if (rand[i]) {
             return false;
         }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
@@ -956,7 +956,10 @@ bool nRF5xSecurityManager::sm_handler(const ble_evt_t *evt)
                         peer_dist = pairing_cb->initiator_dist;
                     }
 
-                    if (status.lesc) {
+                    uint8_t invalid_rand[BLE_GAP_SEC_RAND_LEN] = { 0 };
+                    if (pairing_cb->own_enc_key.master_id.ediv == 0 &&
+                        memcmp(pairing_cb->own_enc_key.master_id.rand, invalid_rand, sizeof(invalid_rand) == 0)
+                    ) {
                         handler->on_secure_connections_ltk_generated(
                             connection,
                             ltk_t(pairing_cb->own_enc_key.enc_info.ltk)

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xPalSecurityManager.cpp
@@ -760,6 +760,16 @@ nRF5xSecurityManager& nRF5xSecurityManager::get_security_manager()
     return _security_manager;
 }
 
+bool is_rand_invalid(const uint8_t* rand)
+{
+    for (int i = 0; i < 8; ++i) {
+        if (rand[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
 bool nRF5xSecurityManager::sm_handler(const ble_evt_t *evt)
 {
     nRF5xSecurityManager& self = nRF5xSecurityManager::get_security_manager();
@@ -846,9 +856,8 @@ bool nRF5xSecurityManager::sm_handler(const ble_evt_t *evt)
             const ble_gap_evt_sec_info_request_t& req =
                 gap_evt.params.sec_info_request;
 
-            uint8_t invalid_rand[BLE_GAP_SEC_RAND_LEN] = { 0 };
             if (req.master_id.ediv == 0 &&
-                memcmp(req.master_id.rand, invalid_rand, sizeof(invalid_rand) == 0)
+                is_rand_invalid(req.master_id.rand)
             ) {
                 // request ltk generated with secure connection
                 handler->on_ltk_request(connection);
@@ -956,9 +965,8 @@ bool nRF5xSecurityManager::sm_handler(const ble_evt_t *evt)
                         peer_dist = pairing_cb->initiator_dist;
                     }
 
-                    uint8_t invalid_rand[BLE_GAP_SEC_RAND_LEN] = { 0 };
                     if (pairing_cb->own_enc_key.master_id.ediv == 0 &&
-                        memcmp(pairing_cb->own_enc_key.master_id.rand, invalid_rand, sizeof(invalid_rand) == 0)
+                        is_rand_invalid(pairing_cb->own_enc_key.master_id.rand)
                     ) {
                         handler->on_secure_connections_ltk_generated(
                             connection,


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

NRF implementation of the security manager called legacy pairing functions for storing the ltk instead of the secure connections versions which need to be called for correct flags to be set.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

