### PR TITLE
Fix for CM3DS GPIO api

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/gpio_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/gpio_api.c
@@ -175,7 +175,7 @@ void gpio_init(gpio_t *obj, PinName pin)
         /* MCC LEDs */
         obj->gpio_dev = NULL;
         obj->mps2_io_dev = &ARM_MPS2_IO_SCC_DEV;
-        obj->arm_mps2_io_write = NULL;
+        obj->arm_mps2_io_write = arm_mps2_io_write_leds;
         obj->pin_number = pin - LED1;
         obj->direction = PIN_OUTPUT;
         return;


### PR DESCRIPTION
### Description

This patch aims to deploy a fix for gpio_api.c, in which the led IO writing function did not get registered properly in the GPIO structure during initialization.

@ashok-rao 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

