### PR TITLE
MPS2 Re-Enablement in mbed

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M0/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M0/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -1,6 +1,6 @@
 ; MPS2 CMSIS Library
 ;
-; Copyright (c) 2006-2016 ARM Limited
+; Copyright (c) 2006-2018 ARM Limited
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -38,18 +38,6 @@
 ;-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;
 
-
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00004000
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
-__initial_sp
-
-
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
@@ -60,6 +48,17 @@ Heap_Size       EQU     0x00001000
 __heap_base
 Heap_Mem        SPACE   Heap_Size
 __heap_limit
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+
+__initial_sp    EQU     0x20400000
 
 
                 PRESERVE8

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M0P/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M0P/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -1,6 +1,6 @@
 ; MPS2 CMSIS Library
 ;
-; Copyright (c) 2006-2016 ARM Limited
+; Copyright (c) 2006-2018 ARM Limited
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -38,18 +38,6 @@
 ;-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;
 
-
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00004000
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
-__initial_sp
-
-
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
@@ -60,6 +48,17 @@ Heap_Size       EQU     0x00001000
 __heap_base
 Heap_Mem        SPACE   Heap_Size
 __heap_limit
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+
+__initial_sp    EQU     0x20400000
 
 
                 PRESERVE8

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M3/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M3/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -1,6 +1,6 @@
 ; MPS2 CMSIS Library
 ;
-; Copyright (c) 2006-2016 ARM Limited
+; Copyright (c) 2006-2018 ARM Limited
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -38,18 +38,6 @@
 ;-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;
 
-
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00004000
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
-__initial_sp
-
-
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
@@ -60,6 +48,17 @@ Heap_Size       EQU     0x00001000
 __heap_base
 Heap_Mem        SPACE   Heap_Size
 __heap_limit
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+
+__initial_sp    EQU     0x20400000
 
 
                 PRESERVE8

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M4/device/TOOLCHAIN_ARM_STD/startup_MPS2.S
@@ -1,6 +1,6 @@
 ; MPS2 CMSIS Library
 ;
-; Copyright (c) 2006-2016 ARM Limited
+; Copyright (c) 2006-2018 ARM Limited
 ; All rights reserved.
 ;
 ; Redistribution and use in source and binary forms, with or without
@@ -38,18 +38,6 @@
 ;-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;
 
-
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00004000
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
-__initial_sp
-
-
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
@@ -60,6 +48,17 @@ Heap_Size       EQU     0x00001000
 __heap_base
 Heap_Mem        SPACE   Heap_Size
 __heap_limit
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+
+__initial_sp    EQU     0x20400000
 
 
                 PRESERVE8

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M7/device/TOOLCHAIN_ARM_STD/startup_CMSDK_CM7.S
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/TARGET_MPS2_M7/device/TOOLCHAIN_ARM_STD/startup_CMSDK_CM7.S
@@ -1,33 +1,33 @@
 ; MPS2 CMSIS Library
 ;
-; Copyright (c) 2006-2016 ARM Limited
+; Copyright (c) 2006-2018 ARM Limited
 ; All rights reserved.
-; 
-; Redistribution and use in source and binary forms, with or without 
+;
+; Redistribution and use in source and binary forms, with or without
 ; modification, are permitted provided that the following conditions are met:
-; 
-; 1. Redistributions of source code must retain the above copyright notice, 
+;
+; 1. Redistributions of source code must retain the above copyright notice,
 ; this list of conditions and the following disclaimer.
-; 
-; 2. Redistributions in binary form must reproduce the above copyright notice, 
-; this list of conditions and the following disclaimer in the documentation 
+;
+; 2. Redistributions in binary form must reproduce the above copyright notice,
+; this list of conditions and the following disclaimer in the documentation
 ; and/or other materials provided with the distribution.
-; 
-; 3. Neither the name of the copyright holder nor the names of its contributors 
-; may be used to endorse or promote products derived from this software without 
+;
+; 3. Neither the name of the copyright holder nor the names of its contributors
+; may be used to endorse or promote products derived from this software without
 ; specific prior written permission.
-; 
-; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-; POSSIBILITY OF SUCH DAMAGE. 
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+; IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+; ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+; LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+; CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+; SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+; INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+; CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+; ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+; POSSIBILITY OF SUCH DAMAGE.
 ;******************************************************************************
 ; @file     startup_CMSDK_CM7.s
 ; @brief    CMSIS Core Device Startup File for
@@ -37,18 +37,6 @@
 ;
 ;-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 ;
-
-
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00004000
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
-__initial_sp
-
 
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
@@ -60,6 +48,17 @@ Heap_Size       EQU     0x00001000
 __heap_base
 Heap_Mem        SPACE   Heap_Size
 __heap_limit
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+
+__initial_sp    EQU     0x20400000
 
 
                 PRESERVE8

--- a/targets/TARGET_ARM_SSG/mbed_rtx.h
+++ b/targets/TARGET_ARM_SSG/mbed_rtx.h
@@ -23,6 +23,14 @@
 #define INITIAL_SP              (0x20020000UL)
 #endif
 
+#elif defined(TARGET_MPS2_M0) || defined(TARGET_MPS2_M0P) || \
+      defined(TARGET_MPS2_M3) || defined(TARGET_MPS2_M4) || \
+      defined(TARGET_MPS2_M7)
+
+#ifndef INITIAL_SP
+#define INITIAL_SP              (0x20400000UL)
+#endif
+
 #elif defined(TARGET_CM3DS_MPS2)
 
 #include "memory_zones.h"

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -2751,7 +2751,9 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0"],
         "macros": ["CMSDK_CM0", "CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_MPS2_M0P": {
         "inherits": ["ARM_MPS2_Target"],
@@ -2760,7 +2762,9 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0P"],
         "macros": ["CMSDK_CM0plus"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_MPS2_M3": {
         "inherits": ["ARM_MPS2_Target"],
@@ -2769,7 +2773,9 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M3"],
         "macros": ["CMSDK_CM3"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_MPS2_M4": {
         "inherits": ["ARM_MPS2_Target"],
@@ -2778,7 +2784,9 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
         "macros": ["CMSDK_CM4"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_MPS2_M7": {
         "inherits": ["ARM_MPS2_Target"],
@@ -2787,7 +2795,9 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M7"],
         "macros": ["CMSDK_CM7"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release_versions": ["2"]
+        "release_versions": ["2", "5"],
+        "copy_method": "mps2",
+        "reset_method": "reboot.txt"
     },
     "ARM_IOTSS_Target": {
         "inherits": ["Target"],


### PR DESCRIPTION
### Description

These file changes provide small fixes for various targets
on MPS2 platform in order to work properly and pass all
Greentea test cases. The __initial_sp has been explicitly set
in the targets' startup files, and also INITIAL_SP has been
given a different value. The values have been extracted from
the specific targets' Application Note documentation.
Affected targets are: ARM_MPS2_M0, ARM_MPS2_M0P, ARM_MPS2_M3,
ARM_MPS2_M4 and ARM_MPS2_M7.

@ashok-rao 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

