### PR TITLE
skip the flashsim test if not enough memory cannot be allocated for it.

### DIFF
--- a/features/storage/TESTS/blockdevice/flashsim_block_device/main.cpp
+++ b/features/storage/TESTS/blockdevice/flashsim_block_device/main.cpp
@@ -34,6 +34,11 @@ static const uint8_t   blank = 0xFF;
 // Simple test for all APIs
 void functionality_test()
 {
+
+    uint8_t *dummy = new (std::nothrow) uint8_t[num_blocks * erase_size];
+    TEST_SKIP_UNLESS_MESSAGE(dummy, "Not enough memory for test");
+    delete[] dummy;
+    
     HeapBlockDevice heap_bd(num_blocks * erase_size, read_size, prog_size, erase_size);
     FlashSimBlockDevice bd(&heap_bd, blank);
 


### PR DESCRIPTION
Along the lines of, https://github.com/ARMmbed/mbed-os/pull/7465, we need to skip flashsim test if we cannot allocate enough memory for it. We have seen the test failing on wizwiki_7500 for IAR toolchain, http://mbed-ci-master-2.austin.arm.com:8081/job/text_matrix_raas_staging/91/target=WIZWIKI_W7500,toolchain=IAR/consoleFull.

Failure log snippet:

> 00:08:17.484 [1533313625.50][CONN][INF] found KV pair in stream: {{__testcase_name;FlashSimBlockDevice functionality test}}, queued...
00:08:17.587 [1533313625.60][CONN][RXD] >>> Running case #1: 'FlashSimBlockDevice functionality test'...
00:08:17.587 [1533313625.61][CONN][INF] found KV pair in stream: {{__testcase_start;FlashSimBlockDevice functionality test}}, queued...
00:08:17.685 mbedgt: :61::FAIL: Expected 0 Was -4001
00:08:17.685 [1533313625.70][CONN][RXD] :61::FAIL: Expected 0 Was -4001
00:08:17.686 [1533313625.70][CONN][INF] found KV pair in stream: {{__testcase_finish;FlashSimBlockDevice functionality test;0;1}}, queued...
00:08:17.785 [1533313625.80][CONN][RXD] >>> 'FlashSimBlockDevice functionality test': 0 passed, 1 failed with reason 'Assertion Failed'
00:08:17.785 [1533313625.80][CONN][RXD]
00:08:17.885 [1533313625.90][CONN][RXD] >>> Test cases: 0 passed, 1 failed with reason 'Assertion Failed'
00:08:17.885 [1533313625.90][CONN][RXD] >>> TESTS FAILED!
00:08:17.985 [1533313626.00][CONN][INF] found KV pair in stream: {{__testcase_summary;0;1}}, queued...
00:08:17.985 [1533313626.00][CONN][INF] found KV pair in stream: {{max_heap_usage;560}}, queued...
00:08:17.985 [1533313626.00][CONN][INF] found KV pair in stream: {{reserved_heap;1024}}, queued...
00:08:17.985 [1533313626.00][HTST][ERR] orphan event in main phase: {{max_heap_usage;560}}, timestamp=1533313626.002998
00:08:17.986 [1533313626.00][HTST][ERR] orphan event in main phase: {{reserved_heap;1024}}, timestamp=1533313626.003002
00:08:18.085 [1533313626.10][CONN][INF] found KV pair in stream: {{__thread_info;"0x020000c74",912,4096}}, queued...
00:08:18.085 [1533313626.10][HTST][ERR] orphan event in main phase: {{__thread_info;"0x020000c74",912,4096}}, timestamp=1533313626.102826
00:08:18.085 [1533313626.10][CONN][INF] found KV pair in stream: {{__thread_info;"0x020002b04",64,512}}, queued...
00:08:18.085 [1533313626.10][HTST][ERR] orphan event in main phase: {{__thread_info;"0x020002b04",64,512}}, timestamp=1533313626.102833
00:08:18.085 [1533313626.10][CONN][INF] found KV pair in stream: {{__thread_info;"0x020002b4c",112,768}}, queued...
00:08:18.085 [1533313626.10][HTST][ERR] orphan event in main phase: {{__thread_info;"0x020002b4c",112,768}}, timestamp=1533313626.102837
00:08:18.188 [1533313626.21][CONN][RXD] {{__cpu_info        up time;0}}
00:08:18.189 [1533313626.21][CONN][RXD] {{__cpu_info     sleep time;0}}
00:08:18.189 [1533313626.21][CONN][RXD] {{__cpu_info deepsleep time;0}}
00:08:18.287 [1533313626.30][CONN][RXD] {{__cpu_info  %  sleep/deep;0;0}}
00:08:18.287 [1533313626.31][CONN][INF] found KV pair in stream: {{end;failure}}, queued...
00:08:18.287 [1533313626.31][CONN][INF] found KV pair in stream: {{__exit;0}}, queued...
00:08:18.297 [1533313626.31][HTST][INF] __exit(0)
00:08:18.297 [1533313626.32][HTST][INF] __notify_complete(False)
00:08:18.297 [1533313626.32][HTST][INF] __exit_event_queue received
00:08:18.297 [1533313626.32][HTST][INF] test suite run finished after 0.90 sec...
00:08:18.297 [1533313626.32][CONN][INF] received special event '__host_test_finished' value='True', finishing
00:08:18.298 [1533313626.32][urllib3.connectionpool]Starting new HTTP connection (1): goku.austin.arm.com:8000
00:08:18.403 [1533313626.42][urllib3.connectionpool]http://goku.austin.arm.com:8000 "PUT /resource/2201000003b9f89e00000000000000000000000097969902/disconnect HTTP/1.1" 200 2
00:08:18.405 [1533313626.42][urllib3.connectionpool]Starting new HTTP connection (1): goku.austin.arm.com:8000
00:08:21.565 [1533313629.58][urllib3.connectionpool]http://goku.austin.arm.com:8000 "PUT /resource/2201000003b9f89e00000000000000000000000097969902/release HTTP/1.1" 200 66
00:08:21.568 [1533313629.59][HTST][INF] CONN exited with code: 0
00:08:21.569 [1533313629.59][HTST][INF] Some events in queue
00:08:21.569 [1533313629.59][HTST][INF] stopped consuming events
00:08:21.569 [1533313629.59][HTST][INF] host test result() call skipped, received: False
00:08:21.569 [1533313629.59][HTST][INF] calling blocking teardown()
00:08:21.569 [1533313629.59][HTST][INF] teardown() finished
00:08:21.569 [1533313629.59][HTST][INF] {{result;failure}}
00:08:21.598 mbedgt: retry mbedhtrun 3/3
00:08:21.598 mbedgt: ['mbedhtrun', '-m', 'WIZWIKI_W7500', '-p', 'DUMMY:9600', '-f', u'"BUILD/tests/WIZWIKI_W7500/IAR/features/TESTS/filesystem/flashsim_block_device/flashsim_block_device.bin"', '--grm', 'raas_client:goku.austin.arm.com:8000', '-C', '4', '--sync', '10', '-P', '60'] failed after 3 count
00:08:21.598 mbedgt: checking for GCOV data...
00:08:21.598 mbedgt: mbed-host-test-runner: stopped and returned 'FAIL'
00:08:21.598 mbedgt: test on hardware with target id: DUMMY
00:08:21.598 mbedgt: test suite 'features-tests-filesystem-flashsim_block_device' ................................. FAIL in 21.75 sec
00:08:21.598 	test case: 'FlashSimBlockDevice functionality test' .......................................... FAIL in 0.09 sec


    [x ] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change

