### PR TITLE
Resolve us_ticker.c api discrepancy between EV_COG_AD4050LZ and EV_COG_AD3029LZ

### DIFF
--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/api/us_ticker.c
@@ -202,12 +202,12 @@ static void event_timer()
 
         tmrConfig.nLoad        = cnt;
         tmrConfig.nAsyncLoad   = cnt;
-        adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, tmrConfig);
+        adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, &tmrConfig);
         adi_tmr_Enable(ADI_TMR_DEVICE_GP2, true);
     } else {
         tmrConfig.nLoad        = 65535u;
         tmrConfig.nAsyncLoad   = 65535u;
-        adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, tmrConfig);
+        adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, &tmrConfig);
         adi_tmr_Enable(ADI_TMR_DEVICE_GP2, true);
     }
 }
@@ -274,13 +274,13 @@ void us_ticker_init(void)
     tmrConfig.nAsyncLoad   = 0;
     tmrConfig.bReloading   = false;
     tmrConfig.bSyncBypass  = true;                    // Allow x1 prescale: requires PCLK as a clk
-    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP0, tmrConfig);
+    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP0, &tmrConfig);
 
     /* Configure GP1 to have a period 256 times longer than GP0 */
     tmrConfig.nLoad        = 0;
     tmrConfig.nAsyncLoad   = 0;
     tmrConfig.ePrescaler   = ADI_TMR_PRESCALER_256;    // TMR1 = 26MHz/256
-    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP1, tmrConfig);
+    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP1, &tmrConfig);
 
     /* Configure GP2 for doing event counts */
     tmrConfig.bCountingUp  = true;
@@ -291,7 +291,7 @@ void us_ticker_init(void)
     tmrConfig.nAsyncLoad   = 0;
     tmrConfig.bReloading   = false;
     tmrConfig.bSyncBypass  = true;                    // Allow x1 prescale
-    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, tmrConfig);
+    adi_tmr_ConfigTimer(ADI_TMR_DEVICE_GP2, &tmrConfig);
 
 
     /*------------------------- GP TIMER ENABLE ------------------------------*/

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/config/adi_tmr_config.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/config/adi_tmr_config.h
@@ -2,7 +2,7 @@
  * @file    adi_tmr_config.h
  * @brief   GP and RGB timer device driver configuration
  -----------------------------------------------------------------------------
-Copyright (c) 2016 Analog Devices, Inc.
+Copyright (c) 2016-2018 Analog Devices, Inc.
 
 All rights reserved.
 
@@ -169,7 +169,13 @@ POSSIBILITY OF SUCH DAMAGE.
     a value of 0 - 39. Please refer hardware reference manual to know
     which events can be captured by a particular GP timer.
 */
+#if defined(__ADUCM3029__)
+#define TMR0_CFG_EVENT_CAPTURE                          (9u)
+#elif defined(__ADUCM4050__)
 #define TMR0_CFG_EVENT_CAPTURE                          (27u)
+#else
+#error TMR is not ported for this processor
+#endif
 
 /*************************************************************
                         GP Timer 0 PWM0 Configuration
@@ -295,8 +301,13 @@ POSSIBILITY OF SUCH DAMAGE.
     a value of 0 - 39. Please refer hardware reference manual to know
     which events can be captured by a particular GP timer.
 */
+#if defined(__ADUCM3029__)
+#define TMR1_CFG_EVENT_CAPTURE                          (15u)
+#elif defined(__ADUCM4050__)
 #define TMR1_CFG_EVENT_CAPTURE                          (28u)
-
+#else
+#error TMR is not ported for this processor
+#endif
 /*************************************************************
                         GP Timer 1 PWM0 Configuration
  *************************************************************/
@@ -419,8 +430,13 @@ POSSIBILITY OF SUCH DAMAGE.
     a value of 0 - 39. Please refer hardware reference manual to know
     which events can be captured by a particular GP timer.
 */
+#if defined(__ADUCM3029__)
+#define TMR2_CFG_EVENT_CAPTURE                          (6u)
+#elif defined(__ADUCM4050__)
 #define TMR2_CFG_EVENT_CAPTURE                          (27u)
-
+#else
+#error TMR is not ported for this processor
+#endif
 /*************************************************************
                         GP Timer 2 PWM0 Configuration
  *************************************************************/
@@ -451,7 +467,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 /*! @} */
 
-
+#if defined(__ADUCM4050__)
 /*************************************************************
                         RGB Timer Configuration
  *************************************************************/
@@ -629,7 +645,7 @@ POSSIBILITY OF SUCH DAMAGE.
     the PWM output remains idle. It can be any value from 0 to 65535.
 */
 #define TMR3_CFG_PWM2_MATCH_VALUE                       (0u)
-
+#endif
 /*! @} */
 
 /*************************************************************
@@ -676,8 +692,16 @@ POSSIBILITY OF SUCH DAMAGE.
 #error "Invalid configuration"
 #endif
 
+#if defined(__ADUCM3029__)
+#if TMR0_CFG_EVENT_CAPTURE > 15u
+#error "Invalid configuration"
+#endif
+#elif defined(__ADUCM4050__)
 #if TMR0_CFG_EVENT_CAPTURE > 39u
 #error "Invalid configuration"
+#endif
+#else
+#error TMR is not ported for this processor
 #endif
 
 #if TMR0_CFG_ENABLE_PWM0_MATCH_MODE > 1u
@@ -736,8 +760,16 @@ POSSIBILITY OF SUCH DAMAGE.
 #error "Invalid configuration"
 #endif
 
+#if defined(__ADUCM3029__)
+#if TMR1_CFG_EVENT_CAPTURE > 15u
+#error "Invalid configuration"
+#endif
+#elif defined(__ADUCM4050__)
 #if TMR1_CFG_EVENT_CAPTURE > 39u
 #error "Invalid configuration"
+#endif
+#else
+#error TMR is not ported for this processor
 #endif
 
 #if TMR1_CFG_ENABLE_PWM0_MATCH_MODE > 1u
@@ -796,8 +828,16 @@ POSSIBILITY OF SUCH DAMAGE.
 #error "Invalid configuration"
 #endif
 
+#if defined(__ADUCM3029__)
+#if TMR2_CFG_EVENT_CAPTURE > 15u
+#error "Invalid configuration"
+#endif
+#elif defined(__ADUCM4050__)
 #if TMR2_CFG_EVENT_CAPTURE > 39u
 #error "Invalid configuration"
+#endif
+#else
+#error TMR is not ported for this processor
 #endif
 
 #if TMR2_CFG_ENABLE_PWM0_MATCH_MODE > 1u
@@ -812,6 +852,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #error "Invalid configuration"
 #endif 
 
+#if defined(__ADUCM4050__)
 /*************************************************************
                         RGB Timer Macro Validation
 **************************************************************/
@@ -896,6 +937,7 @@ POSSIBILITY OF SUCH DAMAGE.
 #error "Invalid configuration"
 #endif 
 
+#endif
 /*! @} */
 
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/drivers/tmr/adi_tmr.h
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/drivers/tmr/adi_tmr.h
@@ -2,7 +2,7 @@
  * @file    adi_tmr.h
  * @brief   GP and RGB timer device driver public header file
  -----------------------------------------------------------------------------
-Copyright (c) 2016 Analog Devices, Inc.
+Copyright (c) 2016-2018 Analog Devices, Inc.
 
 All rights reserved.
 
@@ -56,12 +56,16 @@ POSSIBILITY OF SUCH DAMAGE.
  *  @{
  */
 
+/* C++ linkage */
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
 
 /*!
  *****************************************************************************
  *  \enum ADI_TMR_RESULT
  *   Enumeration for result code returned from the timer device driver functions.
- *   The return value of all timer APIs returning #ADI_TMR_RESULT should always 
+ *   The return value of all timer APIs returning #ADI_TMR_RESULT should always
  *   be tested at the application level for success or failure.
  *****************************************************************************/
 typedef enum {
@@ -97,10 +101,17 @@ typedef enum {
     ADI_TMR_DEVICE_GP1 = 1u,
     /*! General purpose timer 2 */
     ADI_TMR_DEVICE_GP2 = 2u,
+#if defined(__ADUCM3029__)
+    /*! Total number of devices (private) */
+    ADI_TMR_DEVICE_NUM = 3u,
+#elif defined(__ADUCM4050__)
     /*! RGB timer */
     ADI_TMR_DEVICE_RGB = 3u,
     /*! Total number of devices (private) */
     ADI_TMR_DEVICE_NUM = 4u,
+#else
+#error TMR is not ported for this processor
+#endif
 } ADI_TMR_DEVICE;
 
 /*!
@@ -110,7 +121,7 @@ typedef enum {
  *****************************************************************************/
 typedef enum {
   /*! Timeout event occurred */
-  ADI_TMR_EVENT_TIMEOUT = 0x01,  
+  ADI_TMR_EVENT_TIMEOUT = 0x01,
   /*! Event capture event occurred */
   ADI_TMR_EVENT_CAPTURE = 0x02,
 } ADI_TMR_EVENT;
@@ -124,7 +135,7 @@ typedef enum {
     /*! Count every 1 source clock periods */
     ADI_TMR_PRESCALER_1   = 0u,
     /*! Count every 16 source clock periods */
-    ADI_TMR_PRESCALER_16  = 1u, 
+    ADI_TMR_PRESCALER_16  = 1u,
     /*! Count every 64 source clock periods */
     ADI_TMR_PRESCALER_64  = 2u,
     /*! Count every 256 source clock periods */
@@ -138,11 +149,11 @@ typedef enum {
  *****************************************************************************/
 typedef enum {
     /*! Use periphreal clock (PCLK) */
-    ADI_TMR_CLOCK_PCLK  = 0u, 
+    ADI_TMR_CLOCK_PCLK  = 0u,
     /*! Use internal high frequency clock (HFOSC) */
-    ADI_TMR_CLOCK_HFOSC = 1u, 
+    ADI_TMR_CLOCK_HFOSC = 1u,
     /*! Use internal low frequency clock (LFOSC) */
-    ADI_TMR_CLOCK_LFOSC = 2u, 
+    ADI_TMR_CLOCK_LFOSC = 2u,
     /*! Use external low frequency clock (LFXTAL) */
     ADI_TMR_CLOCK_LFXTAL = 3u,
 } ADI_TMR_CLOCK_SOURCE;
@@ -151,7 +162,7 @@ typedef enum {
  *****************************************************************************
  *  \enum ADI_TMR_PWM_OUTPUT
  *   RGB PWM outputs, used to specify which PWM output to configure. For the GP
- *   timers only #ADI_TMR_PWM_OUTPUT_0 is allowed. The RGB timer has all three 
+ *   timers only #ADI_TMR_PWM_OUTPUT_0 is allowed. The RGB timer has all three
  *   outputs.
  *****************************************************************************/
 typedef enum {
@@ -168,7 +179,7 @@ typedef enum {
 /*!
  *****************************************************************************
  *  \struct ADI_TMR_CONFIG
- *   Configuration structure to fill and pass to #adi_tmr_ConfigTimer when  
+ *   Configuration structure to fill and pass to #adi_tmr_ConfigTimer when
  *   configuring the GP or RGB timer
  *****************************************************************************/
 typedef struct {
@@ -180,7 +191,7 @@ typedef struct {
     ADI_TMR_PRESCALER    ePrescaler;
     /*! Clock source */
     ADI_TMR_CLOCK_SOURCE eClockSource;
-    /*! Load value (only relent in periodic mode) */
+    /*! Load value (only relevant in periodic mode) */
     uint16_t             nLoad;
     /*! Asynchronous load value (only relevant in periodic mode, and when PCLK is used) */
     uint16_t             nAsyncLoad;
@@ -193,7 +204,7 @@ typedef struct {
 /*!
  *****************************************************************************
  *  \struct ADI_TMR_EVENT_CONFIG
- *   Configuration structure to fill and pass to #adi_tmr_ConfigEvent when  
+ *   Configuration structure to fill and pass to #adi_tmr_ConfigEvent when
  *   configuring event capture
  *****************************************************************************/
 typedef struct {
@@ -208,7 +219,7 @@ typedef struct {
 /*!
  *****************************************************************************
  *  \struct ADI_TMR_PWM_CONFIG
- *   Configuration structure to fill and pass to #adi_tmr_ConfigPwm when  
+ *   Configuration structure to fill and pass to #adi_tmr_ConfigPwm when
  *   configuring pulse width modulation output
  *****************************************************************************/
 typedef struct {
@@ -232,9 +243,9 @@ typedef struct {
 ADI_TMR_RESULT adi_tmr_Init            (ADI_TMR_DEVICE const eDevice, ADI_CALLBACK const pfCallback, void * const pCBParam, bool bEnableInt);
 
 /* Configuration interface functions */
-ADI_TMR_RESULT adi_tmr_ConfigTimer     (ADI_TMR_DEVICE const eDevice, ADI_TMR_CONFIG       timerConfig);
-ADI_TMR_RESULT adi_tmr_ConfigEvent     (ADI_TMR_DEVICE const eDevice, ADI_TMR_EVENT_CONFIG eventConfig);
-ADI_TMR_RESULT adi_tmr_ConfigPwm       (ADI_TMR_DEVICE const eDevice, ADI_TMR_PWM_CONFIG   pwmConfig  );
+ADI_TMR_RESULT adi_tmr_ConfigTimer     (ADI_TMR_DEVICE const eDevice, ADI_TMR_CONFIG*       timerConfig);
+ADI_TMR_RESULT adi_tmr_ConfigEvent     (ADI_TMR_DEVICE const eDevice, ADI_TMR_EVENT_CONFIG* eventConfig);
+ADI_TMR_RESULT adi_tmr_ConfigPwm       (ADI_TMR_DEVICE const eDevice, ADI_TMR_PWM_CONFIG*   pwmConfig  );
 
 /* Timer start and stop */
 ADI_TMR_RESULT adi_tmr_Enable          (ADI_TMR_DEVICE const eDevice, bool bEnable);
@@ -246,7 +257,9 @@ ADI_TMR_RESULT adi_tmr_GetCaptureCount (ADI_TMR_DEVICE const eDevice, uint16_t *
 /* Reload function */
 ADI_TMR_RESULT adi_tmr_Reload          (ADI_TMR_DEVICE const eDevice);
 
-
+#ifdef __cplusplus
+}
+#endif
 /*! @} */
 
 

--- a/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/tmr/adi_tmr_data.c
+++ b/targets/TARGET_Analog_Devices/TARGET_ADUCM4X50/TARGET_ADUCM4050/bsp/tmr/adi_tmr_data.c
@@ -51,6 +51,34 @@ POSSIBILITY OF SUCH DAMAGE.
 #include <adi_tmr_config.h>
 #include <drivers/tmr/adi_tmr.h>
 
+/* Macro mapping from ADuCM4050 to ADuCM3029 */
+#if defined(__ADUCM3029__)
+#define BITM_TMR_RGB_CTL_EN             BITM_TMR_CTL_EN
+#define PWM0CTL                         PWMCTL
+#define PWM0MATCH                       PWMMATCH
+#define BITM_TMR_RGB_STAT_BUSY          BITM_TMR_STAT_BUSY  
+#define BITM_TMR_RGB_CTL_EVTEN          BITM_TMR_CTL_EVTEN
+#define BITM_TMR_RGB_CTL_RSTEN          BITM_TMR_CTL_RSTEN
+#define BITP_TMR_RGB_CTL_RSTEN          BITP_TMR_CTL_RSTEN
+#define BITP_TMR_RGB_CTL_EVTEN          BITP_TMR_CTL_EVTEN
+#define BITP_TMR_RGB_CTL_PRE            BITP_TMR_CTL_PRE
+#define BITP_TMR_RGB_CTL_CLK            BITP_TMR_CTL_CLK
+#define BITP_TMR_RGB_CTL_MODE           BITP_TMR_CTL_MODE
+#define BITP_TMR_RGB_CTL_UP             BITP_TMR_CTL_UP
+#define BITP_TMR_RGB_CTL_RLD            BITP_TMR_CTL_RLD
+#define BITP_TMR_RGB_CTL_SYNCBYP        BITP_TMR_CTL_SYNCBYP
+#define BITP_TMR_RGB_PWM0CTL_IDLESTATE  BITP_TMR_PWMCTL_IDLESTATE
+#define BITP_TMR_RGB_PWM0CTL_MATCH      BITP_TMR_PWMCTL_MATCH
+#define BITM_TMR_RGB_CLRINT_TIMEOUT     BITM_TMR_CLRINT_TIMEOUT
+#define BITM_TMR_RGB_STAT_PDOK          BITM_TMR_STAT_PDOK
+#define BITM_TMR_RGB_STAT_TIMEOUT       BITM_TMR_STAT_TIMEOUT
+#define BITM_TMR_RGB_STAT_CAPTURE       BITM_TMR_STAT_CAPTURE
+#define BITM_TMR_RGB_CLRINT_EVTCAPT     BITM_TMR_CLRINT_EVTCAPT
+#define BITM_TMR_RGB_CLRINT_TIMEOUT     BITM_TMR_CLRINT_TIMEOUT
+#define BITM_TMR_RGB_CTL_RLD            BITM_TMR_CTL_RLD
+#endif /*__ADUCM3029__*/
+
+#ifndef TARGET_Analog_Devices
 /* CTL register static configuration */
 static uint16_t aTimerCtlConfig[] =
 {
@@ -80,7 +108,7 @@ static uint16_t aTimerCtlConfig[] =
     (TMR2_CFG_ENABLE_SYNC_BYPASS    << BITP_TMR_RGB_CTL_SYNCBYP) |
     (TMR2_CFG_ENABLE_PRESCALE_RESET << BITP_TMR_RGB_CTL_RSTEN)   |
     (TMR2_CFG_ENABLE_EVENT_CAPTURE  << BITP_TMR_RGB_CTL_EVTEN),
-
+#if defined(__ADUCM4050__)
     (TMR3_CFG_COUNT_UP              << BITP_TMR_RGB_CTL_UP)      |
     (TMR3_CFG_MODE                  << BITP_TMR_RGB_CTL_MODE)    |
     (TMR3_CFG_PRESCALE_FACTOR       << BITP_TMR_RGB_CTL_PRE)     |
@@ -89,6 +117,7 @@ static uint16_t aTimerCtlConfig[] =
     (TMR3_CFG_ENABLE_SYNC_BYPASS    << BITP_TMR_RGB_CTL_SYNCBYP) |
     (TMR3_CFG_ENABLE_PRESCALE_RESET << BITP_TMR_RGB_CTL_RSTEN)   |
     (TMR3_CFG_ENABLE_EVENT_CAPTURE  << BITP_TMR_RGB_CTL_EVTEN),
+#endif
 };
 
 /* LOAD register static configuration */
@@ -97,7 +126,9 @@ static uint16_t aTimerLoadConfig[] =
     TMR0_CFG_LOAD_VALUE,
     TMR1_CFG_LOAD_VALUE,
     TMR2_CFG_LOAD_VALUE,
+#if defined(__ADUCM4050__)
     TMR3_CFG_LOAD_VALUE,
+#endif
 };
 
 /* Asynchronous LOAD static configuraton */
@@ -106,10 +137,13 @@ static uint16_t aTimerALoadConfig[] =
     TMR0_CFG_ASYNC_LOAD_VALUE,
     TMR1_CFG_ASYNC_LOAD_VALUE,
     TMR2_CFG_ASYNC_LOAD_VALUE,
+#if defined(__ADUCM4050__)
     TMR3_CFG_ASYNC_LOAD_VALUE,
+#endif
 };
 
 /* EVENTSELECT static configuration */
+#if defined(__ADUCM4050__)
 static uint16_t aTimerEventConfig[] =
 {
     TMR0_CFG_EVENT_CAPTURE,
@@ -117,6 +151,7 @@ static uint16_t aTimerEventConfig[] =
     TMR2_CFG_EVENT_CAPTURE,
     TMR3_CFG_EVENT_CAPTURE,
 };
+#endif
 
 /* PWM CTL static configuration */
 static uint16_t aTimerPwmCtlConfig[] =
@@ -129,7 +164,7 @@ static uint16_t aTimerPwmCtlConfig[] =
 
   (TMR2_CFG_PWM0_IDLE_STATE  << BITP_TMR_RGB_PWM0CTL_IDLESTATE) |
   (TMR2_CFG_PWM0_MATCH_VALUE << BITP_TMR_RGB_PWM0CTL_MATCH),
-
+#if defined(__ADUCM4050__)
   (TMR3_CFG_PWM0_IDLE_STATE  << BITP_TMR_RGB_PWM0CTL_IDLESTATE) |
   (TMR3_CFG_PWM0_MATCH_VALUE << BITP_TMR_RGB_PWM0CTL_MATCH),
 
@@ -138,6 +173,7 @@ static uint16_t aTimerPwmCtlConfig[] =
 
   (TMR3_CFG_PWM2_IDLE_STATE  << BITP_TMR_RGB_PWM2CTL_IDLESTATE) |
   (TMR3_CFG_PWM2_MATCH_VALUE << BITP_TMR_RGB_PWM2CTL_MATCH),
+#endif
 };
 
 /* PWM MATCH static configuration */
@@ -145,10 +181,12 @@ static uint16_t aTimerPwmMatchConfig[] = {
   TMR0_CFG_PWM0_MATCH_VALUE,
   TMR1_CFG_PWM0_MATCH_VALUE,
   TMR2_CFG_PWM0_MATCH_VALUE,
+#if defined(__ADUCM4050__)
   TMR3_CFG_PWM0_MATCH_VALUE,
   TMR3_CFG_PWM1_MATCH_VALUE,
   TMR3_CFG_PWM2_MATCH_VALUE
+#endif
 };
-
+#endif
 
 #endif /* ADI_TMR_DATA */


### PR DESCRIPTION
### Description

- Revise adi_tmr related files to support consistent BSP api between EV_COG_AD4050LZ and EV_COG_AD3029LZ.
- Add MCU specific configurations
- Fix compiler warnings due to unused data.
- Make easier application porting between ADuCM4050 and ADuCM3029
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
- [ ] Fix
- [x] Refactor
- [ ] New target
- [ ] Feature
- [ ] Breaking change

