### PR TITLE
Fix issue #5119, changed pwmout_api.

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/pwmout_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/pwmout_api.c
@@ -127,18 +127,18 @@ void pwmout_period_us(pwmout_t* obj, int us)
     uint32_t pwm_base_clock;
     uint32_t clkdiv = 0;
     pwm_base_clock = CLOCK_GetFreq(kCLOCK_BusClk);
-    pwm_clock_mhz = (float)pwm_base_clock / 1000000.0f;
-    uint32_t mod = (pwm_clock_mhz*(float)us) - 1;
-    while(mod > 0xFFFF){
-    	++clkdiv;
-    	pwm_clock_mhz /= 2.0f;
-    	mod = (pwm_clock_mhz*(float)us) - 1;
-    	if(clkdiv==7){
-    		break;
-    	}
+    pwm_clock_mhz = (float) pwm_base_clock / 1000000.0f;
+    uint32_t mod = (pwm_clock_mhz * (float) us) - 1;
+    while (mod > 0xFFFF) {
+        ++clkdiv;
+        pwm_clock_mhz /= 2.0f;
+        mod = (pwm_clock_mhz * (float) us) - 1;
+        if (clkdiv == 7) {
+            break;
+        }
     }
     uint32_t SC = base->SC & ~FTM_SC_PS_MASK;
-    SC |= FTM_SC_PS((ftm_clock_prescale_t)clkdiv);
+    SC |= FTM_SC_PS((ftm_clock_prescale_t) clkdiv);
     base->SC = SC;
 
     //Stop FTM clock to ensure instant update of MOD register

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/pwmout_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/pwmout_api.c
@@ -124,8 +124,25 @@ void pwmout_period_us(pwmout_t* obj, int us)
     FTM_Type *base = ftm_addrs[obj->pwm_name >> TPM_SHIFT];
     float dc = pwmout_read(obj);
 
-    // Stop FTM clock to ensure instant update of MOD register
-    base->MOD = FTM_MOD_MOD((pwm_clock_mhz * (float)us) - 1);
+    uint32_t pwm_base_clock;
+    uint32_t clkdiv = 0;
+    pwm_base_clock = CLOCK_GetFreq(kCLOCK_BusClk);
+    pwm_clock_mhz = (float)pwm_base_clock / 1000000.0f;
+    uint32_t mod = (pwm_clock_mhz*(float)us) - 1;
+    while(mod > 0xFFFF){
+    	++clkdiv;
+    	pwm_clock_mhz /= 2.0f;
+    	mod = (pwm_clock_mhz*(float)us) - 1;
+    	if(clkdiv==7){
+    		break;
+    	}
+    }
+    uint32_t SC = base->SC & ~FTM_SC_PS_MASK;
+    SC |= FTM_SC_PS((ftm_clock_prescale_t)clkdiv);
+    base->SC = SC;
+
+    //Stop FTM clock to ensure instant update of MOD register
+    base->MOD = FTM_MOD_MOD(mod);
     pwmout_write(obj, dc);
 }
 


### PR DESCRIPTION
### Description

K64F was not able to generate pwm with 100 ms long period. This PR fix the problem, by computing and setting the optimal prescaler value while setting the pwm period. This way we also don't lose accuracy for short periods, but it is even enhanced a little. 
### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

