### PR TITLE
STM32: check for UART ongoing transfers before entering deepsleep

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f0xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f1xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F2/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F2/device.h
@@ -33,5 +33,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f2xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F3/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f3xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f4xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/device.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32f7xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L0/device.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32l0xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/device.h
+++ b/targets/TARGET_STM/TARGET_STM32L1/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32l1xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L4/device.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device.h
@@ -36,5 +36,7 @@
 #define DEVICE_ID_LENGTH       24
 
 #include "objects.h"
+/*  WORKAROUND waiting for mbed-os issue 4408 to be addressed */
+#include "stm32l4xx_ll_usart.h"
 
 #endif

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -690,4 +690,105 @@ int8_t get_uart_index(UARTName uart_name)
     return -1;
 }
 
+/*  Function to protect deep sleep while a seral Tx is ongoing on not complete
+ *  yet. Returns 1 if there is at least 1 serial instance with ongoing ransfer
+ *  0 otherwise.
+ */
+int serial_IsTxOngoing(void) {
+    int TxOngoing = 0;
+
+#if defined(USART1_BASE)
+    if (LL_USART_IsEnabled(USART1) && !LL_USART_IsActiveFlag_TC(USART1)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART2_BASE)
+    if (LL_USART_IsEnabled(USART2) && !LL_USART_IsActiveFlag_TC(USART2)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART3_BASE)
+    if (LL_USART_IsEnabled(USART3) && !LL_USART_IsActiveFlag_TC(USART3)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART4_BASE)
+    if (LL_USART_IsEnabled(UART4) && !LL_USART_IsActiveFlag_TC(UART4)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART4_BASE)
+    if (LL_USART_IsEnabled(USART4) && !LL_USART_IsActiveFlag_TC(USART4)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART5_BASE)
+    if (LL_USART_IsEnabled(UART5) && !LL_USART_IsActiveFlag_TC(UART5)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART5_BASE)
+    if (LL_USART_IsEnabled(USART5) && !LL_USART_IsActiveFlag_TC(USART5)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART6_BASE)
+    if (LL_USART_IsEnabled(USART6) && !LL_USART_IsActiveFlag_TC(USART6)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART7_BASE)
+    if (LL_USART_IsEnabled(UART7) && !LL_USART_IsActiveFlag_TC(UART7)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART7_BASE)
+    if (LL_USART_IsEnabled(USART7) && !LL_USART_IsActiveFlag_TC(USART7)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART8_BASE)
+    if (LL_USART_IsEnabled(UART8) && !LL_USART_IsActiveFlag_TC(UART8)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(USART8_BASE)
+    if (LL_USART_IsEnabled(USART8) && !LL_USART_IsActiveFlag_TC(USART8)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART9_BASE)
+    if (LL_USART_IsEnabled(UART9) && !LL_USART_IsActiveFlag_TC(UART9)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(UART10_BASE)
+    if (LL_USART_IsEnabled(UART10) && !LL_USART_IsActiveFlag_TC(UART10)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+#if defined(LPUART1_BASE)
+    if (LL_USART_IsEnabled(LPUART1) && !LL_USART_IsActiveFlag_TC(LPUART1)) {
+        TxOngoing |= 1;
+    }
+#endif
+
+    /*  If Tx is ongoing, then transfer is */
+    return TxOngoing;
+}
+
 #endif /* DEVICE_SERIAL */

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -694,7 +694,7 @@ int8_t get_uart_index(UARTName uart_name)
  *  yet. Returns 1 if there is at least 1 serial instance with ongoing ransfer
  *  0 otherwise.
  */
-int serial_IsTxOngoing(void) {
+int serial_is_tx_ongoing(void) {
     int TxOngoing = 0;
 
 #if defined(USART1_BASE)

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -157,8 +157,20 @@ void hal_sleep(void)
     core_util_critical_section_exit();
 }
 
+extern int serial_IsTxOngoing(void);
+
 void hal_deepsleep(void)
 {
+    /*  WORKAROUND:
+     *  MBED serial driver does not handle deepsleep lock
+     *  to prevent entering deepsleep until HW serial FIFO is empty.
+     *  This is tracked in mbed issue 4408.
+     *  For now, we're checking all Serial HW FIFO. If any transfer is ongoing
+     *  we're not entering deep sleep and returning immediately. */
+    if(serial_IsTxOngoing()) {
+        return;
+    }
+
     // Disable IRQs
     core_util_critical_section_enter();
 

--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -157,7 +157,7 @@ void hal_sleep(void)
     core_util_critical_section_exit();
 }
 
-extern int serial_IsTxOngoing(void);
+extern int serial_is_tx_ongoing(void);
 
 void hal_deepsleep(void)
 {
@@ -167,7 +167,7 @@ void hal_deepsleep(void)
      *  This is tracked in mbed issue 4408.
      *  For now, we're checking all Serial HW FIFO. If any transfer is ongoing
      *  we're not entering deep sleep and returning immediately. */
-    if(serial_IsTxOngoing()) {
+    if(serial_is_tx_ongoing()) {
         return;
     }
 


### PR DESCRIPTION
### Description

As suggested by @c1728p9 in mbed-os issue #7328, and until there is an
implementation of mbed-os issue #4408, we are implementing a workaround
at HAL level to check if there is any ongoing serial transfer (which happens
if HW FIFO is not yet empty).

In case a transfer is ongoing, we're not entering deep sleep and
return immediately.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

### Tests results

+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| target            | platform_name | test suite                                 | result | elapsed_time (sec) | copy_method |
+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_drivers-sleep_lock              | OK     | 18.45              | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-sleep                       | OK     | 19.58              | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-sleep_manager               | OK     | 17.94              | default     |
| NUCLEO_F091RC-ARM | NUCLEO_F091RC | tests-mbed_hal-sleep_manager_racecondition | OK     | 31.01              | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_drivers-sleep_lock              | OK     | 18.42              | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_hal-sleep                       | OK     | 18.28              | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_hal-sleep_manager               | OK     | 18.17              | default     |
| NUCLEO_F103RB-ARM | NUCLEO_F103RB | tests-mbed_hal-sleep_manager_racecondition | OK     | 31.32              | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_drivers-sleep_lock              | OK     | 16.96              | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_hal-sleep                       | OK     | 17.0               | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_hal-sleep_manager               | OK     | 16.69              | default     |
| NUCLEO_F207ZG-ARM | NUCLEO_F207ZG | tests-mbed_hal-sleep_manager_racecondition | OK     | 29.78              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_drivers-sleep_lock              | OK     | 18.35              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-sleep                       | OK     | 19.59              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-sleep_manager               | OK     | 17.97              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-mbed_hal-sleep_manager_racecondition | OK     | 31.0               | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_drivers-sleep_lock              | OK     | 17.47              | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-sleep                       | OK     | 18.95              | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-sleep_manager               | OK     | 17.25              | default     |
| NUCLEO_F446RE-ARM | NUCLEO_F446RE | tests-mbed_hal-sleep_manager_racecondition | OK     | 30.03              | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_drivers-sleep_lock              | OK     | 16.83              | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-sleep                       | OK     | 18.33              | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-sleep_manager               | OK     | 16.58              | default     |
| NUCLEO_F767ZI-ARM | NUCLEO_F767ZI | tests-mbed_hal-sleep_manager_racecondition | OK     | 29.73              | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_drivers-sleep_lock              | OK     | 20.06              | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-sleep                       | OK     | 21.62              | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-sleep_manager               | OK     | 19.55              | default     |
| NUCLEO_L073RZ-ARM | NUCLEO_L073RZ | tests-mbed_hal-sleep_manager_racecondition | OK     | 33.32              | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_drivers-sleep_lock              | OK     | 18.02              | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-sleep                       | OK     | 19.9               | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-sleep_manager               | OK     | 17.99              | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-mbed_hal-sleep_manager_racecondition | OK     | 30.94              | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_drivers-sleep_lock              | OK     | 17.44              | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-sleep                       | OK     | 18.92              | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-sleep_manager               | OK     | 17.67              | default     |
| NUCLEO_L476RG-ARM | NUCLEO_L476RG | tests-mbed_hal-sleep_manager_racecondition | OK     | 30.09              | default     |
+-------------------+---------------+--------------------------------------------+--------+--------------------+-------------+