### PR TITLE
python scripts : table print with github policy

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1162,7 +1162,7 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
     release_version - get the matrix for this major version number
     """
     # Only use it in this function so building works without extra modules
-    from prettytable import PrettyTable
+    from prettytable import PrettyTable, HEADER
     release_version = _lowercase_release_version(release_version)
     version_release_targets = {}
     version_release_target_names = {}
@@ -1184,7 +1184,7 @@ def mcu_toolchain_matrix(verbose_html=False, platform_filter=None,
 
     # All tests status table print
     columns = prepend_columns + unique_supported_toolchains
-    table_printer = PrettyTable(columns)
+    table_printer = PrettyTable(columns, junction_char="|", hrules=HEADER)
     # Align table
     for col in columns:
         table_printer.align[col] = "c"
@@ -1272,10 +1272,10 @@ def print_build_memory_usage(report):
     Positional arguments:
     report - Report generated during build procedure.
     """
-    from prettytable import PrettyTable
+    from prettytable import PrettyTable, HEADER
     columns_text = ['name', 'target', 'toolchain']
     columns_int = ['static_ram', 'total_flash']
-    table = PrettyTable(columns_text + columns_int)
+    table = PrettyTable(columns_text + columns_int, junction_char="|", hrules=HEADER)
 
     for col in columns_text:
         table.align[col] = 'l'

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -14,7 +14,7 @@ import json
 from argparse import ArgumentParser
 from copy import deepcopy
 from collections import defaultdict
-from prettytable import PrettyTable
+from prettytable import PrettyTable, HEADER
 from jinja2 import FileSystemLoader, StrictUndefined
 from jinja2.environment import Environment
 
@@ -669,7 +669,7 @@ class MemapParser(object):
         columns = ['Module']
         columns.extend(self.print_sections)
 
-        table = PrettyTable(columns)
+        table = PrettyTable(columns, junction_char="|", hrules=HEADER)
         table.align["Module"] = "l"
         for col in self.print_sections:
             table.align[col] = 'r'

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -32,7 +32,7 @@ import threading
 import ctypes
 import functools
 from colorama import Fore, Back, Style
-from prettytable import PrettyTable
+from prettytable import PrettyTable, HEADER
 from copy import copy, deepcopy
 
 from time import sleep, time
@@ -765,7 +765,7 @@ class SingleTestRunner(object):
                     result_dict[test[TEST_INDEX]][test[TOOLCHAIN_INDEX]] = test[RESULT_INDEX]
 
             pt_cols = ["Target", "Test ID", "Test Description"] + unique_target_toolchains
-            pt = PrettyTable(pt_cols)
+            pt = PrettyTable(pt_cols, junction_char="|", hrules=HEADER)
             for col in pt_cols:
                 pt.align[col] = "l"
             pt.padding_width = 1 # One space between column edges and contents (default)
@@ -793,7 +793,7 @@ class SingleTestRunner(object):
         result = "Test summary:\n"
         # Pretty table package is used to print results
         pt = PrettyTable(["Result", "Target", "Toolchain", "Test ID", "Test Description",
-                          "Elapsed Time (sec)", "Timeout (sec)", "Loops"])
+                          "Elapsed Time (sec)", "Timeout (sec)", "Loops"], junction_char="|", hrules=HEADER)
         pt.align["Result"] = "l" # Left align
         pt.align["Target"] = "l" # Left align
         pt.align["Toolchain"] = "l" # Left align
@@ -1327,7 +1327,7 @@ def print_muts_configuration_from_json(json_data, join_delim=", ", platform_filt
 
     # Prepare pretty table object to display all MUTs
     pt_cols = ["index"] + muts_info_cols
-    pt = PrettyTable(pt_cols)
+    pt = PrettyTable(pt_cols, junction_char="|", hrules=HEADER)
     for col in pt_cols:
         pt.align[col] = "l"
 
@@ -1365,7 +1365,7 @@ def print_test_configuration_from_json(json_data, join_delim=", "):
 
     # Prepare pretty table object to display test specification
     pt_cols = ["mcu"] + sorted(toolchains_info_cols)
-    pt = PrettyTable(pt_cols)
+    pt = PrettyTable(pt_cols, junction_char="|", hrules=HEADER)
     for col in pt_cols:
         pt.align[col] = "l"
 
@@ -1454,7 +1454,7 @@ def get_avail_tests_summary_table(cols=None, result_summary=True, join_delim=','
                        'duration'] if cols is None else cols
 
     # All tests status table print
-    pt = PrettyTable(test_properties)
+    pt = PrettyTable(test_properties, junction_char="|", hrules=HEADER)
     for col in test_properties:
         pt.align[col] = "l"
     pt.align['duration'] = "r"
@@ -1494,7 +1494,7 @@ def get_avail_tests_summary_table(cols=None, result_summary=True, join_delim=','
     if result_summary and not platform_filter:
         # Automation result summary
         test_id_cols = ['automated', 'all', 'percent [%]', 'progress']
-        pt = PrettyTable(test_id_cols)
+        pt = PrettyTable(test_id_cols, junction_char="|", hrules=HEADER)
         pt.align['automated'] = "r"
         pt.align['all'] = "r"
         pt.align['percent [%]'] = "r"
@@ -1508,7 +1508,7 @@ def get_avail_tests_summary_table(cols=None, result_summary=True, join_delim=','
 
         # Test automation coverage table print
         test_id_cols = ['id', 'automated', 'all', 'percent [%]', 'progress']
-        pt = PrettyTable(test_id_cols)
+        pt = PrettyTable(test_id_cols, junction_char="|", hrules=HEADER)
         pt.align['id'] = "l"
         pt.align['automated'] = "r"
         pt.align['all'] = "r"


### PR DESCRIPTION
### Description

This is following ARMmbed/greentea#277 discussion

Goal is to get test console print compatible with github like :

| target                  | platform_name       | test suite                                  | result | elapsed_time (sec) | copy_method |
|-------------------------|---------------------|---------------------------------------------|--------|--------------------|-------------|
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-lp_ticker                | OK     | 21.31              | default     |
| DISCO_L475VG_IOT01A-ARM | DISCO_L475VG_IOT01A | tests-mbed_drivers-lp_timeout               | OK     | 59.35              | default     |


### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

