### PR TITLE
Update BLE error calls to use new error codes and mbed_error

### DIFF
--- a/features/FEATURE_BLE/ble/services/EddystoneService.h
+++ b/features/FEATURE_BLE/ble/services/EddystoneService.h
@@ -529,7 +529,7 @@ public:
             DBG("attached tlmCallback every %d seconds", TlmAdvPeriod);
         }
         if (NONE == frameIndex) {
-            error("No Frames were Initialized! Please initialize a frame before starting an eddystone beacon.");
+            MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_NO_FRAME_INITIALIZED), "No Frames were Initialized! Please initialize a frame before starting an eddystone beacon.");
         }
         //uidRFU = 0;
 

--- a/features/FEATURE_BLE/source/BLE.cpp
+++ b/features/FEATURE_BLE/source/BLE.cpp
@@ -141,7 +141,7 @@ BLE::initImplementation(FunctionPointerWithContext<InitializationCompleteCallbac
 
 // this stub is required by ARMCC otherwise link will systematically fail
 MBED_WEAK BLEInstanceBase* createBLEInstance() {
-    error("Please provide an implementation for mbed BLE");
+    MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_NOT_IMPLEMENTED), "Please provide an implementation for mbed BLE");
     return NULL;
 }
 
@@ -191,7 +191,7 @@ void defaultSchedulingCallback(BLE::OnEventsToProcessCallbackContext* params) {
 bool BLE::hasInitialized(void) const
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->hasInitialized();
@@ -200,7 +200,7 @@ bool BLE::hasInitialized(void) const
 ble_error_t BLE::shutdown(void)
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     event_signaled = false;
@@ -210,7 +210,7 @@ ble_error_t BLE::shutdown(void)
 const char *BLE::getVersion(void)
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getVersion();
@@ -219,7 +219,7 @@ const char *BLE::getVersion(void)
 const Gap &BLE::gap() const
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGap();
@@ -228,7 +228,7 @@ const Gap &BLE::gap() const
 Gap &BLE::gap()
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGap();
@@ -237,7 +237,7 @@ Gap &BLE::gap()
 const GattServer& BLE::gattServer() const
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGattServer();
@@ -246,7 +246,7 @@ const GattServer& BLE::gattServer() const
 GattServer& BLE::gattServer()
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGattServer();
@@ -255,7 +255,7 @@ GattServer& BLE::gattServer()
 const GattClient& BLE::gattClient() const
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGattClient();
@@ -264,7 +264,7 @@ const GattClient& BLE::gattClient() const
 GattClient& BLE::gattClient()
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getGattClient();
@@ -273,7 +273,7 @@ GattClient& BLE::gattClient()
 const SecurityManager& BLE::securityManager() const
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getSecurityManager();
@@ -282,7 +282,7 @@ const SecurityManager& BLE::securityManager() const
 SecurityManager& BLE::securityManager()
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     return transport->getSecurityManager();
@@ -291,7 +291,7 @@ SecurityManager& BLE::securityManager()
 void BLE::waitForEvent(void)
 {
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     transport->waitForEvent();
@@ -304,7 +304,7 @@ void BLE::processEvents()
     }
 
     if (!transport) {
-        error("bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
     }
 
     event_signaled = false;

--- a/features/FEATURE_BLE/source/BLE.cpp
+++ b/features/FEATURE_BLE/source/BLE.cpp
@@ -141,7 +141,7 @@ BLE::initImplementation(FunctionPointerWithContext<InitializationCompleteCallbac
 
 // this stub is required by ARMCC otherwise link will systematically fail
 MBED_WEAK BLEInstanceBase* createBLEInstance() {
-    MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_NOT_IMPLEMENTED), "Please provide an implementation for mbed BLE");
+    MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_CREATION_FAILED), "Please provide an implementation for mbed BLE");
     return NULL;
 }
 
@@ -191,7 +191,7 @@ void defaultSchedulingCallback(BLE::OnEventsToProcessCallbackContext* params) {
 bool BLE::hasInitialized(void) const
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->hasInitialized();
@@ -200,7 +200,7 @@ bool BLE::hasInitialized(void) const
 ble_error_t BLE::shutdown(void)
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     event_signaled = false;
@@ -210,7 +210,7 @@ ble_error_t BLE::shutdown(void)
 const char *BLE::getVersion(void)
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getVersion();
@@ -219,7 +219,7 @@ const char *BLE::getVersion(void)
 const Gap &BLE::gap() const
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGap();
@@ -228,7 +228,7 @@ const Gap &BLE::gap() const
 Gap &BLE::gap()
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGap();
@@ -237,7 +237,7 @@ Gap &BLE::gap()
 const GattServer& BLE::gattServer() const
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGattServer();
@@ -246,7 +246,7 @@ const GattServer& BLE::gattServer() const
 GattServer& BLE::gattServer()
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGattServer();
@@ -255,7 +255,7 @@ GattServer& BLE::gattServer()
 const GattClient& BLE::gattClient() const
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGattClient();
@@ -264,7 +264,7 @@ const GattClient& BLE::gattClient() const
 GattClient& BLE::gattClient()
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getGattClient();
@@ -273,7 +273,7 @@ GattClient& BLE::gattClient()
 const SecurityManager& BLE::securityManager() const
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getSecurityManager();
@@ -282,7 +282,7 @@ const SecurityManager& BLE::securityManager() const
 SecurityManager& BLE::securityManager()
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     return transport->getSecurityManager();
@@ -291,7 +291,7 @@ SecurityManager& BLE::securityManager()
 void BLE::waitForEvent(void)
 {
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     transport->waitForEvent();
@@ -304,7 +304,7 @@ void BLE::processEvents()
     }
 
     if (!transport) {
-        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BAD_TRANSPORT_HANDLE), "bad handle to underlying transport");
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_BLE, MBED_ERROR_CODE_BLE_BACKEND_NOT_INITIALIZED), "bad handle to underlying transport");
     }
 
     event_signaled = false;

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -283,6 +283,7 @@ typedef enum _mbed_module_type {
     MBED_MODULE_DRIVER_QSPI,
     MBED_MODULE_DRIVER_USB,
     MBED_MODULE_TARGET_SDK,
+    MBED_MODULE_BLE,
     /* Add More entities here as required */
 
     MBED_MODULE_UNKNOWN = 255,
@@ -776,6 +777,9 @@ typedef enum _mbed_error_code {
     MBED_DEFINE_SYSTEM_ERROR(MEMMANAGE_EXCEPTION, 62),                  /* 318      MemManage exception */
     MBED_DEFINE_SYSTEM_ERROR(BUSFAULT_EXCEPTION, 63),                   /* 319      BusFault exception */
     MBED_DEFINE_SYSTEM_ERROR(USAGEFAULT_EXCEPTION, 64),                 /* 320      UsageFault exception*/
+    MBED_DEFINE_SYSTEM_ERROR(BLE_NO_FRAME_INITIALIZED, 65),             /* 321      BLE No frame initialized */
+    MBED_DEFINE_SYSTEM_ERROR(BLE_NOT_IMPLEMENTED, 66),                  /* 322      BLE Not implemented */
+    MBED_DEFINE_SYSTEM_ERROR(BLE_BAD_TRANSPORT_HANDLE, 67),             /* 323      BLE Bad transport handle */
 
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -778,8 +778,8 @@ typedef enum _mbed_error_code {
     MBED_DEFINE_SYSTEM_ERROR(BUSFAULT_EXCEPTION, 63),                   /* 319      BusFault exception */
     MBED_DEFINE_SYSTEM_ERROR(USAGEFAULT_EXCEPTION, 64),                 /* 320      UsageFault exception*/
     MBED_DEFINE_SYSTEM_ERROR(BLE_NO_FRAME_INITIALIZED, 65),             /* 321      BLE No frame initialized */
-    MBED_DEFINE_SYSTEM_ERROR(BLE_NOT_IMPLEMENTED, 66),                  /* 322      BLE Not implemented */
-    MBED_DEFINE_SYSTEM_ERROR(BLE_BAD_TRANSPORT_HANDLE, 67),             /* 323      BLE Bad transport handle */
+    MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_CREATION_FAILED, 66),          /* 322      BLE Backend creation failed */
+    MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_NOT_INITIALIZED, 67),          /* 323      BLE Backend not initialized */
 
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on


### PR DESCRIPTION
### Description
This is to update BLE error() calls to use the new error handler methods, this enables use of error codes, produces more informative error report and also enables use of error decoding tools like Mbed-Error microsite - https://armmbed.github.io/mbedos-error/

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

