### PR TITLE
CircularBuffer: volatile specifier removal

### DIFF
--- a/platform/CircularBuffer.h
+++ b/platform/CircularBuffer.h
@@ -194,9 +194,9 @@ public:
 
 private:
     T _pool[BufferSize];
-    volatile CounterType _head;
-    volatile CounterType _tail;
-    volatile bool _full;
+    CounterType _head;
+    CounterType _tail;
+    bool _full;
 };
 
 /**@}*/


### PR DESCRIPTION
Volatile specifier in this case it not required as we currently have all accesses
to the buffer protected by critical section. This shall optimize accesses in
some cases to the buffer.

Fixes #7702

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

