### PR TITLE
Rename text region in ARM linker file for Renesas & Realtek boards

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/MBRZA1LU.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/MBRZA1LU.sct
@@ -23,7 +23,7 @@ LOAD_TTB    __TTB_BASE __TTB_SIZE ; Page 0 of On-Chip Data Retention RAM
     { }                           ; Level-1 Translation Table for MMU
 }
 
-SFLASH MBED_APP_START MBED_APP_SIZE       ; load region size_region
+LR_IROM1 MBED_APP_START MBED_APP_SIZE       ; load region size_region
 {
 #if (MBED_APP_START == 0x18000000)
   BOOT_LOADER_BEGIN MBED_APP_START FIXED

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/TOOLCHAIN_ARM_STD/MBRZA1H.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/TOOLCHAIN_ARM_STD/MBRZA1H.sct
@@ -23,7 +23,7 @@ LOAD_TTB    __TTB_BASE __TTB_SIZE ; Page 0 of On-Chip Data Retention RAM
     { }                           ; Level-1 Translation Table for MMU
 }
 
-SFLASH MBED_APP_START MBED_APP_SIZE       ; load region size_region
+LR_IROM1 MBED_APP_START MBED_APP_SIZE       ; load region size_region
 {
 #if (MBED_APP_START == 0x18000000)
   BOOT_LOADER_BEGIN MBED_APP_START FIXED

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/TOOLCHAIN_ARM_STD/VKRZA1H.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/TOOLCHAIN_ARM_STD/VKRZA1H.sct
@@ -16,7 +16,7 @@ LOAD_TTB    __TTB_BASE __TTB_SIZE ; Page 0 of On-Chip Data Retention RAM
     { }                           ; Level-1 Translation Table for MMU
 }
 
-SFLASH __ROM_BASE __ROM_SIZE       ; load region size_region
+LR_IROM1 __ROM_BASE __ROM_SIZE       ; load region size_region
 {
   VECTORS __VECTOR_BASE FIXED
   {

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/device/TOOLCHAIN_ARM_STD/rtl8195a.sct
@@ -17,7 +17,7 @@ LR_IRAM 0x10007000 (0x70000 - 0x7000) {
     *rtl8195a_init*.o(.image2.validate.rodata*)
   }
 
-  ER_IRAM +0 FIXED {
+  LR_IROM1 +0 FIXED {
     *(.ARM.exidx)
     *(.init_array)
     *rtl8195a_crypto*.o (+RO)
@@ -55,7 +55,7 @@ LR_TCM 0x1FFF0000 0x10000 {
     }
 }
 
-LR_DRAM 0x30000000 0x200000 {
+LR_IROM1 0x30000000 0x200000 {
 
   ER_DRAM +0 FIXED {
     .ANY (+RO)


### PR DESCRIPTION
### Description
Continuing the work from [#7242](https://github.com/ARMmbed/mbed-os/pull/7242), to name the text load region LR_IROM1. This is required for uniformity sake, claiming that this should be the region name for all boards (also mentioned in Handbook). Work is done here on few Renesas and Realtek boards.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

