### PR TITLE
When stack stats enabled, prevent exceptions if memory allocations fail

### DIFF
--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -107,7 +107,11 @@ MBED_UNUSED static void send_stack_info()
 
     // Print info for all other threads
     uint32_t thread_n = osThreadGetCount();
-    osThreadId_t *threads = new osThreadId_t[thread_n];
+    osThreadId_t *threads = new (std::nothrow) osThreadId_t[thread_n];
+    // Don't fail on lack of memory
+    if (!threads) {
+        goto end;
+    }
     thread_n = osThreadEnumerate(threads, thread_n);
 
     for(size_t i = 0; i < thread_n; i++) {
@@ -117,6 +121,7 @@ MBED_UNUSED static void send_stack_info()
 
     delete[] threads;
 
+end:
     mutex->unlock();
 }
 

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -41,7 +41,10 @@ void mbed_stats_stack_get(mbed_stats_stack_t *stats)
     osThreadId_t *threads;
 
     threads = malloc(sizeof(osThreadId_t) * thread_n);
-    MBED_ASSERT(threads != NULL);
+    // Don't fail on lack of memory
+    if (!threads) {
+        return;
+    }
 
     osKernelLock();
     thread_n = osThreadEnumerate(threads, thread_n);
@@ -69,7 +72,10 @@ size_t mbed_stats_stack_get_each(mbed_stats_stack_t *stats, size_t count)
     osThreadId_t *threads;
 
     threads = malloc(sizeof(osThreadId_t) * count);
-    MBED_ASSERT(threads != NULL);
+    // Don't fail on lack of memory
+    if (!threads) {
+        return 0;
+    }
 
     osKernelLock();
     count = osThreadEnumerate(threads, count);


### PR DESCRIPTION
### Description
Stack stats allocate memory for sending stat reports, usually based on number of threads. this may generate exceptions if not enough memory is available for this. Make sure this is handled properly.
Resolves [#7712](https://github.com/ARMmbed/mbed-os/issues/7712).

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

