### PR TITLE
Cellular: WISE_1570's system clock back to HSE_XTAL

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1711,7 +1711,7 @@
         "config": {
             "clock_source": {
                 "help": "Mask value : USE_PLL_HSE_EXTC (need HW patch) | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI | USE_PLL_MSI",
-                "value": "USE_PLL_HSI",
+                "value": "USE_PLL_HSE_XTAL",
                 "macro_name": "CLOCK_SOURCE"
             }
         },


### PR DESCRIPTION
### Description
There was need to set LPUART clock to HSI for WISE_1570 (details in PR #7489). Initially this was not possible without setting the system clock to HSI, too. This problem has been fixed in PR: https://github.com/ARMmbed/mbed-os/pull/7498. Now wise_1570's system clock can be set back to original type: HSE_XTAL.


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

