### PR TITLE
Fix for issue #7724 - stub of Ticker free function needs to be fixed

### DIFF
--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/lp_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/lp_ticker.c
@@ -154,7 +154,7 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }
 
 #endif

--- a/targets/TARGET_ARM_SSG/TARGET_BEETLE/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_BEETLE/us_ticker.c
@@ -114,5 +114,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/lp_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/lp_ticker.c
@@ -110,7 +110,7 @@ void lp_ticker_fire_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }
 
 void TIMER1_IRQHandler(void)

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/us_ticker.c
@@ -114,7 +114,7 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }
 
 void TIMER0_IRQHandler(void)

--- a/targets/TARGET_ARM_SSG/TARGET_IOTSS/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_IOTSS/us_ticker.c
@@ -90,5 +90,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_ARM_SSG/TARGET_MPS2/us_ticker.c
+++ b/targets/TARGET_ARM_SSG/TARGET_MPS2/us_ticker.c
@@ -84,5 +84,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/us_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM0P/us_ticker.c
@@ -170,5 +170,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/lp_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/lp_ticker.c
@@ -134,5 +134,5 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Atmel/TARGET_SAM_CortexM4/us_ticker.c
+++ b/targets/TARGET_Atmel/TARGET_SAM_CortexM4/us_ticker.c
@@ -189,5 +189,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/us_ticker.c
@@ -161,5 +161,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/us_ticker.c
@@ -84,5 +84,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_KLXX/us_ticker.c
@@ -226,5 +226,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/us_ticker.c
@@ -139,5 +139,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/us_ticker.c
@@ -155,5 +155,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/us_ticker.c
@@ -155,5 +155,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/us_ticker.c
@@ -139,6 +139,6 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/us_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/us_ticker.c
@@ -139,5 +139,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/rtc_api.c
@@ -258,5 +258,5 @@ uint32_t lp_ticker_read(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32600/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32600/us_ticker.c
@@ -271,5 +271,5 @@ void us_ticker_set(timestamp_t timestamp)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32610/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/rtc_api.c
@@ -255,5 +255,5 @@ inline uint32_t lp_ticker_read(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32610/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32610/us_ticker.c
@@ -271,5 +271,5 @@ void us_ticker_set(timestamp_t timestamp)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32620/rtc_api.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/rtc_api.c
@@ -309,5 +309,5 @@ inline uint32_t lp_ticker_read(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }

--- a/targets/TARGET_Maxim/TARGET_MAX32620/us_ticker.c
+++ b/targets/TARGET_Maxim/TARGET_MAX32620/us_ticker.c
@@ -302,5 +302,5 @@ void us_ticker_set(timestamp_t timestamp)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/targets/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -320,7 +320,7 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }
 
 

--- a/targets/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/us_ticker.c
@@ -68,5 +68,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/us_ticker.c
@@ -68,5 +68,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/us_ticker.c
@@ -68,5 +68,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC13XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/us_ticker.c
@@ -68,5 +68,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
@@ -89,5 +89,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC408X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/us_ticker.c
@@ -70,5 +70,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/us_ticker.c
@@ -70,5 +70,5 @@ void us_ticker_clear_interrupt(void) {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC81X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/us_ticker.c
@@ -139,5 +139,5 @@ void us_ticker_clear_interrupt() {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_LPC82X/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_LPC82X/us_ticker.c
@@ -112,5 +112,5 @@ void us_ticker_clear_interrupt() {
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/lp_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/lp_ticker.c
@@ -114,7 +114,7 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }
 
 #endif /* DEVICE_LPTICKER */

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/us_ticker.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/us_ticker.c
@@ -143,5 +143,5 @@ void us_ticker_fire_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
+++ b/targets/TARGET_ONSEMI/TARGET_NCS36510/ncs36510_us_ticker_api.c
@@ -206,5 +206,5 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM066/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM066/us_ticker.c
@@ -110,5 +110,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM3H6/us_ticker.c
@@ -86,5 +86,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/us_ticker.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/us_ticker.c
@@ -134,5 +134,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
+++ b/targets/TARGET_WIZNET/TARGET_W7500x/us_ticker.c
@@ -133,5 +133,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }

--- a/targets/TARGET_ublox/TARGET_HI2110/lp_ticker.c
+++ b/targets/TARGET_ublox/TARGET_HI2110/lp_ticker.c
@@ -349,5 +349,5 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
-
+    lp_ticker_disable_interrupt();
 }

--- a/targets/TARGET_ublox/TARGET_HI2110/us_ticker.c
+++ b/targets/TARGET_ublox/TARGET_HI2110/us_ticker.c
@@ -254,5 +254,5 @@ void us_ticker_clear_interrupt(void)
 
 void us_ticker_free(void)
 {
-
+    us_ticker_disable_interrupt();
 }


### PR DESCRIPTION
### Description

Implementation of Ticker free function has been added only for CI boards. This caused that `TESTS-MBED_HAL-COMMON_TICKERS` test is now failing for non CI boards (test cases which verifies behaviour of ticker free function fails).
To solve this problem we can change empty stubs of ticker free function, used for non CI boards, to disable ticker interrupt only. This should be good enough to make the test pass and consistent with the requirements. In the next step implementation should be improved. Free function should also disable the counter if it is possible.

For details please see issue: https://github.com/ARMmbed/mbed-os/issues/7724

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

