### PR TITLE
Update mbed-coap to version 4.6.1

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v4.6.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.6.1) 
+**Closed issues:**
+-  IOTCLT-2900 - Blockwise handling leaking memory in some error cases
+
+Fix unused parameter compiler warning when blockwise is not used.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.6.0...v4.6.1)
+
 ## [v4.6.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.6.0) 
 **New feature:**
 -  Add new API which clears one item from the resend queue based on token

--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## [v4.6.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.6.0) 
+**New feature:**
+-  Add new API which clears one item from the resend queue based on token
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.5.1...v4.6.0)
+
 ## [v4.5.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.5.1) 
 **Closed issues:**
  - IOTCLT-2883 - Blockwise observations not completing

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -225,6 +225,18 @@ extern void sn_coap_protocol_remove_sent_blockwise_message(struct coap_s *handle
 extern int8_t sn_coap_protocol_delete_retransmission(struct coap_s *handle, uint16_t msg_id);
 
 /**
+ * \fn void sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle)
+ *
+ * \param *handle Pointer to CoAP library handle
+ * \token Token to be removed
+ * \token_len Length of the token
+ * \return returns 0 when success, -1 for invalid parameter, -2 if message was not found
+ *
+ * \brief If re-transmissions are enabled, this function removes message from retransmission buffer.
+ */
+extern int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, uint8_t *token, uint8_t token_len);
+
+/**
  * \fn int8_t sn_coap_convert_block_size(uint16_t block_size)
  *
  * \brief Utility function to convert block size.

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.6.0",
+  "version": "4.6.1",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.5.1",
+  "version": "4.6.0",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -120,30 +120,17 @@ int8_t sn_coap_protocol_destroy(struct coap_s *handle)
     ns_list_foreach_safe(coap_blockwise_msg_s, tmp, &handle->linked_list_blockwise_sent_msgs) {
         if (tmp->coap == handle) {
             if (tmp->coap_msg_ptr) {
-                if (tmp->coap_msg_ptr->payload_ptr) {
-                    handle->sn_coap_protocol_free(tmp->coap_msg_ptr->payload_ptr);
-                    tmp->coap_msg_ptr->payload_ptr = 0;
-                }
+                handle->sn_coap_protocol_free(tmp->coap_msg_ptr->payload_ptr);
                 sn_coap_parser_release_allocated_coap_msg_mem(tmp->coap, tmp->coap_msg_ptr);
             }
             ns_list_remove(&handle->linked_list_blockwise_sent_msgs, tmp);
             handle->sn_coap_protocol_free(tmp);
-            tmp = 0;
         }
     }
+
     ns_list_foreach_safe(coap_blockwise_payload_s, tmp, &handle->linked_list_blockwise_received_payloads) {
         if (tmp->coap == handle) {
-            if (tmp->addr_ptr) {
-                handle->sn_coap_protocol_free(tmp->addr_ptr);
-                tmp->addr_ptr = 0;
-            }
-            if (tmp->payload_ptr) {
-                handle->sn_coap_protocol_free(tmp->payload_ptr);
-                tmp->payload_ptr = 0;
-            }
-            ns_list_remove(&handle->linked_list_blockwise_received_payloads, tmp);
-            handle->sn_coap_protocol_free(tmp);
-            tmp = 0;
+            sn_coap_protocol_linked_list_blockwise_payload_remove(handle, tmp);
         }
     }
 #endif
@@ -396,6 +383,9 @@ int8_t sn_coap_protocol_delete_retransmission_by_token(struct coap_s *handle, ui
 
 int8_t prepare_blockwise_message(struct coap_s *handle, sn_coap_hdr_s *src_coap_msg_ptr)
 {
+    (void) handle;
+    (void) src_coap_msg_ptr;
+
 #if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE /* If Message blockwising is not enabled, this part of code will not be compiled */
     if ((src_coap_msg_ptr->payload_len > SN_COAP_MAX_NONBLOCKWISE_PAYLOAD_SIZE) &&
         (src_coap_msg_ptr->payload_len > handle->sn_coap_block_data_size) &&


### PR DESCRIPTION
### Description
Added new API which clears one item from the resend queue by token.

Fixes error: IOTCLT-2900 - Blockwise handling leaking memory in some error cases
* Fix memory leak when clearing blockwise payload list
* Token was not freed from the list when closing down the library

Fix unused parameter - warning when blockwise is not used

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [X] Feature
    [ ] Breaking change

