### PR TITLE
Cellular: Handle AT response stop in case IP address is missing from …

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -61,6 +61,7 @@ const char *AT_CellularStack::get_ip_address()
         int len = _at.read_string(_ip, NSAPI_IPv4_SIZE - 1);
         if (len == -1) {
             _ip[0] = '\0';
+            _at.resp_stop();
             _at.unlock();
             // no IPV4 address, return
             return NULL;


### PR DESCRIPTION
…CGPADDR response

### Description
Failing to handle the AT+CGPADDR response to the end, in case IP address, which is an optional parameter, is missing. This is causing issues for AT commands coming after(noticed with socket creation AT+NSOCR for wise_1570). 


### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

