### PR TITLE
tests-mbed_hal-common_tickers: disable ticker free test cases.

### DIFF
--- a/TESTS/mbed_hal/common_tickers/ticker_api_tests.h
+++ b/TESTS/mbed_hal/common_tickers/ticker_api_tests.h
@@ -118,21 +118,6 @@ void ticker_speed_test(void);
  */
 void ticker_overflow_test(void);
 
-/** Test ticker_free disables ticker interrupt.
- *
- * Given ticker is available.
- * When ticker interrupt is set and then ticker_free is called.
- * Then ticker interrupt is not triggered.
- */
-void ticker_free_interrupt_test(void);
-
-/** Test that ticker can be successfully re-initialized after free().
- *
- * Given ticker is available.
- * When ticker has been  re-initialized after free().
- * Then ticker counts and generates interrupts.
- */
-void ticker_init_free_test(void);
 /**@}*/
 
 #ifdef __cplusplus

--- a/hal/us_ticker_api.h
+++ b/hal/us_ticker_api.h
@@ -73,8 +73,6 @@ extern "C" {
  * Verified by ::ticker_fire_now_test
  * * The ticker operations ticker_read, ticker_clear_interrupt, ticker_set_interrupt and ticker_fire_interrupt
  * take less than 20us to complete - Verified by ::ticker_speed_test
- * * The function ticker_free disables the ticker interrupt - ::ticker_free_interrupt_test
- * * The function ticker_init re-initializes ticker after has been disabled by means of ticker_free - Verified by ::ticker_init_free_test
  *
  * # Undefined behavior
  * * Calling any function other than ticker_init before the initialization of the ticker


### PR DESCRIPTION
### Description

Resolves #7724.

Ticker free tests have been disabled since ticker free function has been implemented only for CI boards.
Implementation for the remaining platforms will be done on feature branch `feature-hal-ticker-free`.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

