### PR TITLE
Make mbed_getc and gets compatible with POSIX ( and also IAR 8.x )

### DIFF
--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1347,34 +1347,16 @@ void mbed_set_unbuffered_stream(std::FILE *_file)
 
 int mbed_getc(std::FILE *_file)
 {
-#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
-    /*This is only valid for unbuffered streams*/
     int res = std::fgetc(_file);
-    if (res >= 0) {
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }
+    std::fseek( _file, 0, SEEK_CUR );
     return res;
-#else
-    return std::fgetc(_file);
-#endif
 }
 
 char *mbed_gets(char *s, int size, std::FILE *_file)
 {
-#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
-    /*This is only valid for unbuffered streams*/
-    char *str = fgets(s, size, _file);
-    if (str != NULL) {
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }
-    return str;
-#else
-    return std::fgets(s, size, _file);
-#endif
+    int res = std::fgets(s, size, _file);
+    std::fseek( _file, 0, SEEK_CUR );
+    return res;
 }
 
 } // namespace mbed


### PR DESCRIPTION
### Description

I came across this while trying to get the Stream object to work in IAR 8.x.  As you can see, there was already a kludge fix for IAR 7.x that touched the _FILE descriptor.  This fix won't compile in 8.x so it is simply disabled.  This causes streams to fail in IAR 8.x ( specifically, putc stops working after you call getc )

I tracked this down to the root cause.  Basically, you are allowed in POSIX / ANSI C to read and write on the same stream, BUT, you have to do an fseek in between.  From the Linux man pages ( https://www.systutorials.com/docs/linux/man/3-fdopen/ ):

"Reads and writes may be intermixed on read/write streams in any order. Note that ANSI C requires that a file positioning function intervene between output and input, unless an input operation encounters end-of-file. (If this condition is not met, then a read is allowed to return the result of writes other than the most recent.) Therefore it is good practice (and indeed sometimes necessary under Linux) to put an fseek(3) or fgetpos(3) operation between write and read operations on such a stream. This operation may be an apparent no-op (as in fseek(..., 0L, SEEK_CUR) called for its synchronizing side effect."

I did the prescribed "no op" and now it works in IAR 8.x.  I would think this should also work for IAR 7.x as well ( but I don't have 7.x installed to test with)  And also...whatever future POSIX platforms mbed ends up on.  :-)

    [ X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

