### PR TITLE
Revert "Move BlockDevice classes inside mbed namespace"

### DIFF
--- a/features/filesystem/FileSystem.h
+++ b/features/filesystem/FileSystem.h
@@ -23,7 +23,7 @@
 #include "platform/FileHandle.h"
 #include "platform/DirHandle.h"
 #include "platform/FileSystemLike.h"
-#include "bd/BlockDevice.h"
+#include "BlockDevice.h"
 
 namespace mbed {
 /** \addtogroup filesystem */

--- a/features/filesystem/bd/BlockDevice.h
+++ b/features/filesystem/bd/BlockDevice.h
@@ -17,12 +17,8 @@
 #ifndef MBED_BLOCK_DEVICE_H
 #define MBED_BLOCK_DEVICE_H
 
-#include "platform/platform.h"
 #include <stdint.h>
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Enum of standard error codes
  *
@@ -223,7 +219,5 @@ public:
     }
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/BufferedBlockDevice.cpp
+++ b/features/filesystem/bd/BufferedBlockDevice.cpp
@@ -20,8 +20,6 @@
 #include <algorithm>
 #include <string.h>
 
-namespace mbed {
-
 static inline uint32_t align_down(bd_size_t val, bd_size_t size)
 {
     return val / size * size;
@@ -241,5 +239,3 @@ bd_size_t BufferedBlockDevice::size() const
 {
     return _bd->size();
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/BufferedBlockDevice.h
+++ b/features/filesystem/bd/BufferedBlockDevice.h
@@ -24,9 +24,6 @@
 
 #include "BlockDevice.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Block device for allowing minimal read and program sizes (of 1) for the underlying BD,
  *  using a buffer on the heap.
@@ -166,7 +163,5 @@ protected:
 
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ChainingBlockDevice.cpp
+++ b/features/filesystem/bd/ChainingBlockDevice.cpp
@@ -15,10 +15,8 @@
  */
 
 #include "ChainingBlockDevice.h"
-#include "platform/mbed_critical.h"
-#include "platform/mbed_assert.h"
+#include "mbed_critical.h"
 
-namespace mbed {
 
 ChainingBlockDevice::ChainingBlockDevice(BlockDevice **bds, size_t bd_count)
     : _bds(bds), _bd_count(bd_count)
@@ -251,5 +249,3 @@ bd_size_t ChainingBlockDevice::size() const
 {
     return _size;
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/ChainingBlockDevice.h
+++ b/features/filesystem/bd/ChainingBlockDevice.h
@@ -23,10 +23,8 @@
 #define MBED_CHAINING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
+#include "mbed.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Block device for chaining multiple block devices
  *  with the similar block sizes at sequential addresses
@@ -180,7 +178,5 @@ protected:
     uint32_t _init_ref_count;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ExhaustibleBlockDevice.cpp
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.cpp
@@ -15,10 +15,9 @@
  */
 
 #include "ExhaustibleBlockDevice.h"
-#include "platform/mbed_critical.h"
-#include "platform/mbed_assert.h"
+#include "mbed.h"
+#include "mbed_critical.h"
 
-namespace mbed {
 
 ExhaustibleBlockDevice::ExhaustibleBlockDevice(BlockDevice *bd, uint32_t erase_cycles)
     : _bd(bd), _erase_array(NULL), _erase_cycles(erase_cycles), _init_ref_count(0)
@@ -142,5 +141,3 @@ bd_size_t ExhaustibleBlockDevice::size() const
 {
     return _bd->size();
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/ExhaustibleBlockDevice.h
+++ b/features/filesystem/bd/ExhaustibleBlockDevice.h
@@ -24,9 +24,6 @@
 
 #include "BlockDevice.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Heap backed block device which simulates failures
  *
@@ -160,7 +157,5 @@ private:
     uint32_t _init_ref_count;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/FlashSimBlockDevice.cpp
+++ b/features/filesystem/bd/FlashSimBlockDevice.cpp
@@ -15,14 +15,11 @@
  */
 
 #include "FlashSimBlockDevice.h"
-#include "platform/mbed_critical.h"
-#include "platform/mbed_assert.h"
-
+#include "mbed_assert.h"
+#include "mbed_critical.h"
 #include <algorithm>
 #include <stdlib.h>
 #include <string.h>
-
-namespace mbed {
 
 static const bd_size_t min_blank_buf_size = 32;
 
@@ -163,5 +160,3 @@ int FlashSimBlockDevice::get_erase_value() const
 {
     return _erase_value;
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/FlashSimBlockDevice.h
+++ b/features/filesystem/bd/FlashSimBlockDevice.h
@@ -24,10 +24,6 @@
 
 #include "BlockDevice.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
-
 enum {
     BD_ERROR_NOT_ERASED       = -3201,
 };
@@ -141,8 +137,5 @@ private:
     BlockDevice *_bd;
     uint32_t _init_ref_count;
 };
-
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/HeapBlockDevice.cpp
+++ b/features/filesystem/bd/HeapBlockDevice.cpp
@@ -15,13 +15,8 @@
  */
 
 #include "HeapBlockDevice.h"
-#include "platform/mbed_critical.h"
-#include "platform/mbed_assert.h"
+#include "mbed_critical.h"
 
-#include <stdlib.h>
-#include <string.h>
-
-namespace mbed {
 
 HeapBlockDevice::HeapBlockDevice(bd_size_t size, bd_size_t block)
     : _read_size(block), _program_size(block), _erase_size(block)
@@ -171,4 +166,3 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
-} // namespace mbed

--- a/features/filesystem/bd/HeapBlockDevice.h
+++ b/features/filesystem/bd/HeapBlockDevice.h
@@ -23,11 +23,7 @@
 #define MBED_MEM_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
-
+#include "mbed.h"
 
 
 /** Lazily allocated heap-backed block device
@@ -157,7 +153,5 @@ private:
     uint32_t _init_ref_count;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/MBRBlockDevice.cpp
+++ b/features/filesystem/bd/MBRBlockDevice.cpp
@@ -15,14 +15,9 @@
  */
 
 #include "MBRBlockDevice.h"
-#include "platform/mbed_critical.h"
-#include "platform/mbed_assert.h"
-
+#include "mbed_critical.h"
 #include <algorithm>
-#include <stdlib.h>
-#include <string.h>
 
-namespace mbed {
 
 // On disk structures, all entries are little endian
 MBED_PACKED(struct) mbr_entry {
@@ -345,5 +340,3 @@ int MBRBlockDevice::get_partition_number() const
 {
     return _part;
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/MBRBlockDevice.h
+++ b/features/filesystem/bd/MBRBlockDevice.h
@@ -23,10 +23,8 @@
 #define MBED_MBR_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
+#include "mbed.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Additional error codes used for MBR records
  */
@@ -257,7 +255,5 @@ protected:
     uint32_t _init_ref_count;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ObservingBlockDevice.cpp
+++ b/features/filesystem/bd/ObservingBlockDevice.cpp
@@ -22,8 +22,8 @@
 
 #include "ObservingBlockDevice.h"
 #include "ReadOnlyBlockDevice.h"
+#include "mbed.h"
 
-namespace mbed {
 
 ObservingBlockDevice::ObservingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -110,5 +110,3 @@ bd_size_t ObservingBlockDevice::size() const
 {
     return _bd->size();
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/ObservingBlockDevice.h
+++ b/features/filesystem/bd/ObservingBlockDevice.h
@@ -26,9 +26,6 @@
 #include "PlatformMutex.h"
 #include "Callback.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 class ObservingBlockDevice : public BlockDevice
 {
@@ -144,7 +141,6 @@ private:
     mbed::Callback<void(BlockDevice *)> _change;
 };
 
-/** @}*/
-} // namespace mbed
+
 
 #endif

--- a/features/filesystem/bd/ProfilingBlockDevice.cpp
+++ b/features/filesystem/bd/ProfilingBlockDevice.cpp
@@ -16,7 +16,6 @@
 
 #include "ProfilingBlockDevice.h"
 
-namespace mbed {
 
 ProfilingBlockDevice::ProfilingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -119,5 +118,3 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
 {
     return _erase_count;
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/ProfilingBlockDevice.h
+++ b/features/filesystem/bd/ProfilingBlockDevice.h
@@ -23,10 +23,8 @@
 #define MBED_PROFILING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
+#include "mbed.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 /** Block device for measuring storage operations of another block device
  *
@@ -184,7 +182,5 @@ private:
     bd_size_t _erase_count;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/bd/ReadOnlyBlockDevice.cpp
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.cpp
@@ -21,9 +21,8 @@
  */
 
 #include "ReadOnlyBlockDevice.h"
-#include "platform/mbed_error.h"
+#include "mbed_error.h"
 
-namespace mbed {
 
 ReadOnlyBlockDevice::ReadOnlyBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -97,5 +96,3 @@ bd_size_t ReadOnlyBlockDevice::size() const
 {
     return _bd->size();
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/ReadOnlyBlockDevice.h
+++ b/features/filesystem/bd/ReadOnlyBlockDevice.h
@@ -25,9 +25,6 @@
 #include "BlockDevice.h"
 #include "PlatformMutex.h"
 
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
 
 class ReadOnlyBlockDevice : public BlockDevice
 {
@@ -136,7 +133,6 @@ private:
     BlockDevice *_bd;
 };
 
-/** @}*/
-} // namespace mbed
+
 
 #endif

--- a/features/filesystem/bd/SlicingBlockDevice.cpp
+++ b/features/filesystem/bd/SlicingBlockDevice.cpp
@@ -15,9 +15,7 @@
  */
 
 #include "SlicingBlockDevice.h"
-#include "platform/mbed_assert.h"
 
-namespace mbed {
 
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t stop)
     : _bd(bd)
@@ -118,5 +116,3 @@ bd_size_t SlicingBlockDevice::size() const
 {
     return _stop - _start;
 }
-
-} // namespace mbed

--- a/features/filesystem/bd/SlicingBlockDevice.h
+++ b/features/filesystem/bd/SlicingBlockDevice.h
@@ -23,10 +23,7 @@
 #define MBED_SLICING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-
-namespace mbed {
-/** \addtogroup filesystem */
-/** @{*/
+#include "mbed.h"
 
 
 /** Block device for mapping to a slice of another block device
@@ -170,7 +167,5 @@ protected:
     bd_size_t _stop;
 };
 
-/** @}*/
-} // namespace mbed
 
 #endif

--- a/features/filesystem/fat/FATFileSystem.cpp
+++ b/features/filesystem/fat/FATFileSystem.cpp
@@ -27,10 +27,7 @@
 #include "FATFileSystem.h"
 
 #include <errno.h>
-#include <stdlib.h>
-
 ////// Error handling /////
-using namespace mbed;
 
 static int fat_error_remap(FRESULT res)
 {

--- a/features/filesystem/fat/FATFileSystem.h
+++ b/features/filesystem/fat/FATFileSystem.h
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include "PlatformMutex.h"
 
+
 /**
  * FATFileSystem based on ChaN's Fat Filesystem library v0.8
  */
@@ -39,7 +40,7 @@ public:
      *  @param name     Name to add filesystem to tree as
      *  @param bd       BlockDevice to mount, may be passed instead to mount call
      */
-    FATFileSystem(const char *name = NULL, mbed::BlockDevice *bd = NULL);
+    FATFileSystem(const char *name = NULL, BlockDevice *bd = NULL);
     virtual ~FATFileSystem();
 
     /** Formats a logical drive, FDISK partitioning rule.
@@ -58,14 +59,14 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    static int format(mbed::BlockDevice *bd, mbed::bd_size_t cluster_size = 0);
+    static int format(BlockDevice *bd, bd_size_t cluster_size = 0);
 
     /** Mounts a filesystem to a block device
      *
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
      */
-    virtual int mount(mbed::BlockDevice *bd);
+    virtual int mount(BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
@@ -90,7 +91,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(mbed::BlockDevice *bd, int allocation_unit);
+    virtual int reformat(BlockDevice *bd, int allocation_unit);
 
     /** Reformats a filesystem, results in an empty and mounted filesystem
      *
@@ -100,7 +101,7 @@ public:
      *                  Default: NULL
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(mbed::BlockDevice *bd = NULL)
+    virtual int reformat(BlockDevice *bd = NULL)
     {
         // required for virtual inheritance shenanigans
         return reformat(bd, 0);
@@ -266,7 +267,7 @@ private:
 protected:
     virtual void lock();
     virtual void unlock();
-    virtual int mount(mbed::BlockDevice *bd, bool mount);
+    virtual int mount(BlockDevice *bd, bool mount);
 };
 
 #endif

--- a/features/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/filesystem/littlefs/LittleFileSystem.cpp
@@ -21,7 +21,6 @@ extern "C" {
 #include "lfs_util.h"
 }
 
-using namespace mbed;
 
 ////// Conversion functions //////
 static int lfs_toerror(int err)

--- a/features/filesystem/littlefs/LittleFileSystem.h
+++ b/features/filesystem/littlefs/LittleFileSystem.h
@@ -51,7 +51,7 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    LittleFileSystem(const char *name=NULL, mbed::BlockDevice *bd=NULL,
+    LittleFileSystem(const char *name=NULL, BlockDevice *bd=NULL,
             lfs_size_t read_size=MBED_LFS_READ_SIZE,
             lfs_size_t prog_size=MBED_LFS_PROG_SIZE,
             lfs_size_t block_size=MBED_LFS_BLOCK_SIZE,
@@ -81,7 +81,7 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    static int format(mbed::BlockDevice *bd,
+    static int format(BlockDevice *bd,
         lfs_size_t read_size=MBED_LFS_READ_SIZE,
         lfs_size_t prog_size=MBED_LFS_PROG_SIZE,
         lfs_size_t block_size=MBED_LFS_BLOCK_SIZE,
@@ -92,7 +92,7 @@ public:
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
      */
-    virtual int mount(mbed::BlockDevice *bd);
+    virtual int mount(BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
@@ -110,7 +110,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(mbed::BlockDevice *bd);
+    virtual int reformat(BlockDevice *bd);
 
     /** Remove a file from the filesystem.
      *
@@ -267,7 +267,7 @@ protected:
 private:
     lfs_t _lfs; // _the actual filesystem
     struct lfs_config _config;
-    mbed::BlockDevice *_bd; // the block device
+    BlockDevice *_bd; // the block device
 
     // default parameters
     const lfs_size_t _read_size;

--- a/features/filesystem/mbed_filesystem.h
+++ b/features/filesystem/mbed_filesystem.h
@@ -29,6 +29,7 @@
 
 // BlockDevice classes
 #include "bd/BlockDevice.h"
+#include "bd/BlockDevice.h"
 #include "bd/ChainingBlockDevice.h"
 #include "bd/SlicingBlockDevice.h"
 #include "bd/HeapBlockDevice.h"


### PR DESCRIPTION
Reverts ARMmbed/mbed-os#7663

don't take this as final solution to this problem. This is to trigger discussion how to and find a solution to this issue we are having now. Firstly, it looked like a small cosmetic change we could just minimize breakages... It was a good fix (yes should be in the namespace in first place).

See https://github.com/ARMmbed/mbed-cloud-client-example - this example breaks to compile with current master. There's heap.cpp (in one of its dependencies) file that includes `HeapBlockDevice` and use the object of the same name. Fails to build as there is no `HeapBlockDevice` (it is in mbed namespace now on master). We could fix it by adding namespace `mbed::HeapBlockDevice` but only for master or >= 5.10 version (5.9.x or prior would fail). See https://github.com/ARMmbed/storage-selector/pull/40 - fix for storage selector. 

I am not in favor of that migration path (if version <5.10, do not use mbed namespace, else add it). One way could be to add mbed.h include to the storage selector (just because it has using there) - there's PR 38 that is going that direction.

This should be resolved asap as our current master is breaking for some.