### PR TITLE
Include user defined static lib files in the Linker object files paths

### DIFF
--- a/tools/export/e2studio/.cproject.tmpl
+++ b/tools/export/e2studio/.cproject.tmpl
@@ -326,15 +326,18 @@
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.libs.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.libs" valueType="libs">
-									{% for lib in opts['ld']['user_libraries'] %}
+									{% for lib in opts['ld']['system_libraries'] %}
 									<listOptionValue builtIn="false" value="{{lib}}"/>
 									{% endfor %}
-									{% for lib in opts['ld']['system_libraries'] %}
+									{% for lib in opts['ld']['user_libraries'] %}
 									<listOptionValue builtIn="false" value="{{lib}}"/>
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.otherobjs.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.otherobjs" valueType="userObjs">
 									{% for path in opts['ld']['object_files'] %}
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{path}}&quot;"/>
+									{% endfor %}
+									{% for path in opts['ld']['user_library_files'] %}
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{path}}&quot;"/>
 									{% endfor %}
 								</option>

--- a/tools/export/gnuarmeclipse/.cproject.tmpl
+++ b/tools/export/gnuarmeclipse/.cproject.tmpl
@@ -326,15 +326,18 @@
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.libs.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.libs" valueType="libs">
-									{% for lib in opts['ld']['user_libraries'] %}
+									{% for lib in opts['ld']['system_libraries'] %}
 									<listOptionValue builtIn="false" value="{{lib}}"/>
 									{% endfor %}
-									{% for lib in opts['ld']['system_libraries'] %}
+									{% for lib in opts['ld']['user_libraries'] %}
 									<listOptionValue builtIn="false" value="{{lib}}"/>
 									{% endfor %}
 								</option>
 								<option id="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.otherobjs.{{u.id}}" superClass="ilg.gnuarmeclipse.managedbuild.cross.option.cpp.linker.otherobjs" valueType="userObjs">
 									{% for path in opts['ld']['object_files'] %}
+									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{path}}&quot;"/>
+									{% endfor %}
+									{% for path in opts['ld']['user_library_files'] %}
 									<listOptionValue builtIn="false" value="&quot;${ProjDirPath}/{{path}}&quot;"/>
 									{% endfor %}
 								</option>

--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -90,7 +90,9 @@ class GNUARMEclipse(Exporter):
         # TODO: use some logger to display additional info if verbose
 
         libraries = []
+        library_files = []
         for lib in self.libraries:
+            library_files.append(self.filter_dot(lib))
             l, _ = splitext(basename(lib))
             libraries.append(l[3:])
 
@@ -178,6 +180,7 @@ class GNUARMEclipse(Exporter):
 
             opts['ld']['object_files'] = objects
             opts['ld']['user_libraries'] = libraries
+            opts['ld']['user_library_files'] = library_files
             opts['ld']['system_libraries'] = self.system_libraries
             opts['ld']['script'] = join(id.capitalize(),
                                         "linker-script-%s.ld" % id)


### PR DESCRIPTION
### Description

This is to fix linker not finding symbols declared in object files inside static library files. 

For this case throwing:-

> rm-none-eabi-g++: error: unrecognized command line option '--wrap=main'; did you mean '--warn-main'?

For this case to include libmbed.a which contains

mbed_alloc_wrappers.o:
         U __real__calloc_r
         U __real__free_r
         U __real__malloc_r
         U __real__memalign_r
         U __real__realloc_r
00000000 T __wrap__calloc_r
00000000 T __wrap__free_r
00000000 T __wrap__malloc_r
00000000 T __wrap__memalign_r
00000000 T __wrap__realloc_r
00000000 T free_wrapper
00000000 T malloc_wrapper
00000000 T mbed_stats_heap_get
         U memset

This patch also changed the library order to system and then user.

-lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -lmbed

Resolves: #7155 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

