### PR TITLE
Give an option to remove 'using namespace'

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -19,6 +19,8 @@
 
 #include <inttypes.h>
 
+using namespace mbed;
+
 /* constants */
 #define DATAFLASH_READ_SIZE        1
 #define DATAFLASH_PROG_SIZE        1

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -59,7 +59,7 @@
  *  }
  *  @endcode
  */
-class DataFlashBlockDevice : public BlockDevice {
+class DataFlashBlockDevice : public mbed::BlockDevice {
 public:
     /** Creates a DataFlashBlockDevice on a SPI bus specified by pins
      *
@@ -96,7 +96,7 @@ public:
      *  @param size     Size to read in bytes, must be a multiple of read block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -107,7 +107,7 @@ public:
      *  @param size     Size to write in bytes, must be a multiple of program block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Erase blocks on a block device
      *
@@ -117,27 +117,27 @@ public:
      *  @param size     Size to erase in bytes, must be a multiple of erase block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a programable block in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the size of a eraseable block
      *
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const;
+    virtual mbed::bd_size_t get_erase_size() const;
 
     /** Get the size of an erasable block given address
      *
@@ -145,19 +145,19 @@ public:
      *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr) const;
 
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
 private:
     // Master side hardware
-    SPI _spi;
-    DigitalOut _cs;
-    DigitalOut _nwp;
+    mbed::SPI _spi;
+    mbed::DigitalOut _cs;
+    mbed::DigitalOut _nwp;
 
     // Device configuration
     uint32_t _device_size;

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -20,7 +20,7 @@
 #include "mbed_critical.h"
 
 #include "mbed.h"
-
+using namespace mbed;
 #include <inttypes.h>
 
 #define FLASHIAP_READ_SIZE 1

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -26,7 +26,7 @@
 /** BlockDevice using the FlashIAP API
  *
  */
-class FlashIAPBlockDevice : public BlockDevice {
+class FlashIAPBlockDevice : public mbed::BlockDevice {
 public:
 
     /** Creates a FlashIAPBlockDevice
@@ -58,7 +58,7 @@ public:
      *  @param size     Size to read in bytes, must be a multiple of read block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -69,7 +69,7 @@ public:
      *  @param size     Size to write in bytes, must be a multiple of program block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Erase blocks on a block device
      *
@@ -79,27 +79,27 @@ public:
      *  @param size     Size to erase in bytes, must be a multiple of erase block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a programable block in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the size of a eraseable block
      *
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const;
+    virtual mbed::bd_size_t get_erase_size() const;
 
     /** Get the size of an erasable block given address
      *
@@ -107,7 +107,7 @@ public:
      *  @return         Size of an erasable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr) const;
 
     /** Get the value of storage when erased
      *
@@ -119,13 +119,13 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
 private:
     // Device configuration
     mbed::FlashIAP _flash;
-    bd_addr_t _base;
-    bd_size_t _size;
+    mbed::bd_addr_t _base;
+    mbed::bd_size_t _size;
     bool _is_initialized;
     uint32_t _init_ref_count;
 };

--- a/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/QSPIFBlockDevice.h
@@ -85,7 +85,7 @@ enum qspif_polarity_mode {
  *  }
  *  @endcode
  */
-class QSPIFBlockDevice : public BlockDevice {
+class QSPIFBlockDevice : public mbed::BlockDevice {
 public:
     /** Create QSPIFBlockDevice - An SFDP based Flash Block Device over QSPI bus
      *
@@ -134,7 +134,7 @@ public:
      *  @return         QSPIF_BD_ERROR_OK(0) - success
      *                  QSPIF_BD_ERROR_DEVICE_ERROR - device driver transaction failed
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -149,7 +149,7 @@ public:
      *                  QSPIF_BD_ERROR_WREN_FAILED - Write Enable failed
      *                  QSPIF_BD_ERROR_PARSING_FAILED - unexpected format or values in one of the SFDP tables
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Erase blocks on a block device
      *
@@ -164,27 +164,27 @@ public:
      *                  QSPIF_BD_ERROR_PARSING_FAILED - unexpected format or values in one of the SFDP tables
      *                  QSPIF_BD_ERROR_INVALID_ERASE_PARAMS - Trying to erase unaligned address or size
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a program block size in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the size of a eraseable block
      *
      *  @return         Size of a minimal erase block, common to all regions, in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const;
+    virtual mbed::bd_size_t get_erase_size() const;
 
     /** Get the size of minimal eraseable sector size of given address
      *
@@ -192,7 +192,7 @@ public:
      *  @return         Size of minimal erase sector size, in given address region, in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size(bd_addr_t addr);
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr);
 
     /** Get the value of storage byte after it was erased
      *
@@ -209,7 +209,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
 private:
     // Internal functions
@@ -229,17 +229,17 @@ private:
     /*   Calls to QSPI Driver APIs  */
     /********************************/
     // Send Program => Write command to Driver
-    qspi_status_t _qspi_send_program_command(unsigned int prog_instruction, const void *buffer, bd_addr_t addr,
-                                             bd_size_t *size);
+    qspi_status_t _qspi_send_program_command(unsigned int prog_instruction, const void *buffer, mbed::bd_addr_t addr,
+                                             mbed::bd_size_t *size);
 
     // Send Read command to Driver
-    qspi_status_t _qspi_send_read_command(unsigned int read_instruction, void *buffer, bd_addr_t addr, bd_size_t size);
+    qspi_status_t _qspi_send_read_command(unsigned int read_instruction, void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Erase Instruction using command_transfer command to Driver
-    qspi_status_t _qspi_send_erase_command(unsigned int erase_instruction, bd_addr_t addr, bd_size_t size);
+    qspi_status_t _qspi_send_erase_command(unsigned int erase_instruction, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Generic command_transfer command to Driver
-    qspi_status_t _qspi_send_general_command(unsigned int instruction_int, bd_addr_t addr, const char *tx_buffer,
+    qspi_status_t _qspi_send_general_command(unsigned int instruction_int, mbed::bd_addr_t addr, const char *tx_buffer,
                                              size_t tx_length, const char *rx_buffer, size_t rx_length);
 
     // Send Bus configure_format command to Driver
@@ -300,7 +300,7 @@ private:
     /* Utilities Functions */
     /***********************/
     // Find the region to which the given offset belong to
-    int _utils_find_addr_region(bd_size_t offset);
+    int _utils_find_addr_region(mbed::bd_size_t offset);
 
     // Iterate on all supported Erase Types of the Region to which the offset belong to.
     // Iterates from highest type to lowest

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.cpp
@@ -17,6 +17,8 @@
 #include "SPIFReducedBlockDevice.h"
 #include "mbed_wait_api.h"
 
+using namespace mbed;
+
 // Read/write/erase sizes
 #define SPIF_READ_SIZE  1
 #define SPIF_PROG_SIZE  1

--- a/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_RSPIF/SPIFReducedBlockDevice.h
@@ -56,7 +56,7 @@
  *  }
  *  @endcode
  */
-class SPIFReducedBlockDevice : public BlockDevice {
+class SPIFReducedBlockDevice : public mbed::BlockDevice {
 public:
     /** Creates a SPIFReducedBlockDevice on a SPI bus specified by pins
      *
@@ -87,7 +87,7 @@ public:
      *  @param size     Size to read in bytes, must be a multiple of read block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -98,7 +98,7 @@ public:
      *  @param size     Size to write in bytes, must be a multiple of program block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Erase blocks on a block device
      *
@@ -108,27 +108,27 @@ public:
      *  @param size     Size to erase in bytes, must be a multiple of erase block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a programable block in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the size of a eraseable block
      *
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const;
+    virtual mbed::bd_size_t get_erase_size() const;
 
     /** Get the size of a eraseable block
      *
@@ -136,7 +136,7 @@ public:
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr) const;
 
     /** Get the value of storage byte after it was erased
      *
@@ -153,7 +153,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
 private:
     // Master side hardware
@@ -161,7 +161,7 @@ private:
     mbed::DigitalOut _cs;
 
     // Device configuration discovered through sfdp
-    bd_size_t _size;
+    mbed::bd_size_t _size;
 
     // Internal functions
     int _wren();

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -147,6 +147,8 @@
 #include <inttypes.h>
 #include <errno.h>
 
+using namespace mbed;
+
 #ifndef MBED_CONF_SD_CMD_TIMEOUT
 #define MBED_CONF_SD_CMD_TIMEOUT                 5000   /*!< Timeout in ms for response */
 #endif

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -32,7 +32,7 @@
  *
  * Access an SD Card using SPI
  */
-class SDBlockDevice : public BlockDevice {
+class SDBlockDevice : public mbed::BlockDevice {
 public:
     /** Lifetime of an SD card
      */
@@ -58,7 +58,7 @@ public:
      *  @param size     Size to read in bytes, must be a multiple of read block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -69,7 +69,7 @@ public:
      *  @param size     Size to write in bytes, must be a multiple of program block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Mark blocks as no longer in use
      *
@@ -82,26 +82,26 @@ public:
      *  @param size     Size to mark as unused in bytes, must be a multiple of erase block size
      *  @return         0 on success, negative error code on failure
      */
-    virtual int trim(bd_addr_t addr, bd_size_t size);
+    virtual int trim(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a programable block in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
     /** Enable or disable debugging
      *
@@ -175,10 +175,10 @@ private:
     uint32_t _go_idle_state();
     int _initialise_card();
 
-    bd_size_t _sectors;
-    bd_size_t _sd_sectors();
+    mbed::bd_size_t _sectors;
+    mbed::bd_size_t _sd_sectors();
 
-    bool _is_valid_trim(bd_addr_t addr, bd_size_t size);
+    bool _is_valid_trim(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /* SPI functions */
     mbed::Timer _spi_timer;               /**< Timer Class object used for busy wait */

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -72,7 +72,7 @@ enum spif_bd_error {
  *  }
  *  @endcode
  */
-class SPIFBlockDevice : public BlockDevice {
+class SPIFBlockDevice : public mbed::BlockDevice {
 public:
     /** Creates a SPIFBlockDevice on a SPI bus specified by pins
      *
@@ -114,7 +114,7 @@ public:
      *  @return         SPIF_BD_ERROR_OK(0) - success
      *                  SPIF_BD_ERROR_DEVICE_ERROR - device driver transaction failed
      */
-    virtual int read(void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int read(void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Program blocks to a block device
      *
@@ -128,7 +128,7 @@ public:
      *                  SPIF_BD_ERROR_READY_FAILED - Waiting for Memory ready failed or timed out
      *                  SPIF_BD_ERROR_WREN_FAILED - Write Enable failed
      */
-    virtual int program(const void *buffer, bd_addr_t addr, bd_size_t size);
+    virtual int program(const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Erase blocks on a block device
      *
@@ -142,27 +142,27 @@ public:
      *                  SPIF_BD_ERROR_WREN_FAILED - Write Enable failed
      *                  SPIF_BD_ERROR_INVALID_ERASE_PARAMS - Trying to erase unaligned address or size
      */
-    virtual int erase(bd_addr_t addr, bd_size_t size);
+    virtual int erase(mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     /** Get the size of a readable block
      *
      *  @return         Size of a readable block in bytes
      */
-    virtual bd_size_t get_read_size() const;
+    virtual mbed::bd_size_t get_read_size() const;
 
     /** Get the size of a programable block
      *
      *  @return         Size of a programable block in bytes
      *  @note Must be a multiple of the read size
      */
-    virtual bd_size_t get_program_size() const;
+    virtual mbed::bd_size_t get_program_size() const;
 
     /** Get the size of a eraseable block
      *
      *  @return         Size of a eraseable block in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size() const;
+    virtual mbed::bd_size_t get_erase_size() const;
 
     /** Get the size of minimal eraseable sector size of given address
      *
@@ -170,7 +170,7 @@ public:
      *  @return         Size of minimal erase sector size, in given address region, in bytes
      *  @note Must be a multiple of the program size
      */
-    virtual bd_size_t get_erase_size(bd_addr_t addr);
+    virtual mbed::bd_size_t get_erase_size(mbed::bd_addr_t addr);
 
     /** Get the value of storage byte after it was erased
      *
@@ -187,7 +187,7 @@ public:
      *
      *  @return         Size of the underlying device in bytes
      */
-    virtual bd_size_t size() const;
+    virtual mbed::bd_size_t size() const;
 
 private:
 
@@ -231,17 +231,17 @@ private:
     /*   Calls to SPI Driver APIs   */
     /********************************/
     // Send Program => Write command to Driver
-    spif_bd_error _spi_send_program_command(int prog_inst, const void *buffer, bd_addr_t addr, bd_size_t size);
+    spif_bd_error _spi_send_program_command(int prog_inst, const void *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Read command to Driver
     //spif_bd_error _spi_send_read_command(uint8_t read_inst, void *buffer, bd_addr_t addr, bd_size_t size);
-    spif_bd_error _spi_send_read_command(int read_inst, uint8_t *buffer, bd_addr_t addr, bd_size_t size);
+    spif_bd_error _spi_send_read_command(int read_inst, uint8_t *buffer, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Erase Instruction using command_transfer command to Driver
-    spif_bd_error _spi_send_erase_command(int erase_inst, bd_addr_t addr, bd_size_t size);
+    spif_bd_error _spi_send_erase_command(int erase_inst, mbed::bd_addr_t addr, mbed::bd_size_t size);
 
     // Send Generic command_transfer command to Driver
-    spif_bd_error _spi_send_general_command(int instruction, bd_addr_t addr, char *tx_buffer,
+    spif_bd_error _spi_send_general_command(int instruction, mbed::bd_addr_t addr, char *tx_buffer,
                                             size_t tx_length, char *rx_buffer, size_t rx_length);
 
     // Send set_frequency command to Driver

--- a/events/mbed_events.h
+++ b/events/mbed_events.h
@@ -30,7 +30,9 @@
 
 #include "events/mbed_shared_queues.h"
 
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
 using namespace events;
+#endif
 
 #endif
 

--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -14,11 +14,15 @@
  * limitations under the License.
  */
 
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_BLOCK_DEVICE_H
 #define MBED_BLOCK_DEVICE_H
 
 #include <stdint.h>
 
+namespace mbed {
 
 /** Enum of standard error codes
  *
@@ -231,5 +235,17 @@ public:
     }
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::BlockDevice;
+using mbed::bd_addr_t;
+using mbed::bd_size_t;
+using mbed::BD_ERROR_OK;
+using mbed::BD_ERROR_DEVICE_ERROR;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -20,6 +20,8 @@
 #include <algorithm>
 #include <string.h>
 
+namespace mbed {
+
 static inline uint32_t align_down(bd_size_t val, bd_size_t size)
 {
     return val / size * size;
@@ -327,3 +329,5 @@ bd_size_t BufferedBlockDevice::size() const
 
     return _bd_size;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/BufferedBlockDevice.h
+++ b/features/storage/blockdevice/BufferedBlockDevice.h
@@ -19,11 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_BUFFERED_BLOCK_DEVICE_H
 #define MBED_BUFFERED_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 
+namespace mbed {
 
 /** Block device for allowing minimal read and program sizes (of 1) for the underlying BD,
  *  using a buffer on the heap.
@@ -172,6 +177,13 @@ protected:
     void invalidate_write_cache();
 
 };
+} // namespace mbed
 
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::BufferedBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -16,7 +16,9 @@
 
 #include "ChainingBlockDevice.h"
 #include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 
+namespace mbed {
 
 ChainingBlockDevice::ChainingBlockDevice(BlockDevice **bds, size_t bd_count)
     : _bds(bds), _bd_count(bd_count)
@@ -280,3 +282,5 @@ bd_size_t ChainingBlockDevice::size() const
 {
     return _size;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/ChainingBlockDevice.h
+++ b/features/storage/blockdevice/ChainingBlockDevice.h
@@ -19,12 +19,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_CHAINING_BLOCK_DEVICE_H
 #define MBED_CHAINING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 #include "platform/mbed_assert.h"
 #include <stdlib.h>
+
+namespace mbed {
 
 /** Block device for chaining multiple block devices
  *  with the similar block sizes at sequential addresses
@@ -178,4 +184,13 @@ protected:
     bool _is_initialized;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::ChainingBlockDevice;
 #endif
+
+#endif
+
+/** @}*/

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -18,6 +18,8 @@
 #include "platform/mbed_critical.h"
 #include "platform/mbed_assert.h"
 
+namespace mbed {
+
 ExhaustibleBlockDevice::ExhaustibleBlockDevice(BlockDevice *bd, uint32_t erase_cycles)
     : _bd(bd), _erase_array(NULL), _erase_cycles(erase_cycles), _init_ref_count(0), _is_initialized(false)
 {
@@ -191,3 +193,5 @@ bd_size_t ExhaustibleBlockDevice::size() const
 
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.h
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.h
@@ -19,11 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_EXHAUSTIBLE_BLOCK_DEVICE_H
 #define MBED_EXHAUSTIBLE_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 
+namespace mbed {
 
 /** Heap backed block device which simulates failures
  *
@@ -157,5 +162,13 @@ private:
     bool _is_initialized;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::ExhaustibleBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -21,6 +21,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+namespace mbed {
+
 static const bd_size_t min_blank_buf_size = 32;
 
 static inline uint32_t align_up(bd_size_t val, bd_size_t size)
@@ -209,3 +211,5 @@ int FlashSimBlockDevice::get_erase_value() const
 {
     return _erase_value;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/FlashSimBlockDevice.h
+++ b/features/storage/blockdevice/FlashSimBlockDevice.h
@@ -19,10 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_FLASH_SIM_BLOCK_DEVICE_H
 #define MBED_FLASH_SIM_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
+
+namespace mbed {
 
 enum {
     BD_ERROR_NOT_ERASED       = -3201,
@@ -139,4 +145,13 @@ private:
     bool _is_initialized;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::FlashSimBlockDevice;
 #endif
+
+#endif
+
+/** @}*/

--- a/features/storage/blockdevice/HeapBlockDevice.cpp
+++ b/features/storage/blockdevice/HeapBlockDevice.cpp
@@ -16,7 +16,10 @@
 
 #include "HeapBlockDevice.h"
 #include "platform/mbed_critical.h"
+#include <stdlib.h>
+#include <string.h>
 
+namespace mbed {
 
 HeapBlockDevice::HeapBlockDevice(bd_size_t size, bd_size_t block)
     : _read_size(block), _program_size(block), _erase_size(block)
@@ -180,3 +183,4 @@ int HeapBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     return 0;
 }
 
+} // namespace mbed

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -19,6 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_MEM_BLOCK_DEVICE_H
 #define MBED_MEM_BLOCK_DEVICE_H
 
@@ -26,6 +30,8 @@
 #include "platform/mbed_assert.h"
 #include <string.h>
 #include <stdlib.h>
+
+namespace mbed {
 
 /** Lazily allocated heap-backed block device
  *
@@ -154,5 +160,13 @@ private:
     bool _is_initialized;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::HeapBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -21,6 +21,8 @@
 #include <algorithm>
 #include <string.h>
 
+namespace mbed {
+
 // On disk structures, all entries are little endian
 MBED_PACKED(struct) mbr_entry {
     uint8_t status;
@@ -420,3 +422,5 @@ int MBRBlockDevice::get_partition_number() const
 {
     return _part;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/MBRBlockDevice.h
+++ b/features/storage/blockdevice/MBRBlockDevice.h
@@ -19,11 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_MBR_BLOCK_DEVICE_H
 #define MBED_MBR_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 
+namespace mbed {
 
 /** Additional error codes used for MBR records
  */
@@ -254,5 +259,13 @@ protected:
     bool _is_initialized;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::MBRBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/ObservingBlockDevice.cpp
+++ b/features/storage/blockdevice/ObservingBlockDevice.cpp
@@ -23,6 +23,7 @@
 #include "ObservingBlockDevice.h"
 #include "ReadOnlyBlockDevice.h"
 
+namespace mbed {
 
 ObservingBlockDevice::ObservingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -109,3 +110,5 @@ bd_size_t ObservingBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/ObservingBlockDevice.h
+++ b/features/storage/blockdevice/ObservingBlockDevice.h
@@ -19,6 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_OBSERVING_BLOCK_DEVICE_H
 #define MBED_OBSERVING_BLOCK_DEVICE_H
 
@@ -26,6 +30,7 @@
 #include "platform/PlatformMutex.h"
 #include "platform/Callback.h"
 
+namespace mbed {
 
 class ObservingBlockDevice : public BlockDevice {
 public:
@@ -140,6 +145,13 @@ private:
     mbed::Callback<void(BlockDevice *)> _change;
 };
 
+} // namespace mbed
 
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::ObservingBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/ProfilingBlockDevice.cpp
+++ b/features/storage/blockdevice/ProfilingBlockDevice.cpp
@@ -16,6 +16,7 @@
 
 #include "ProfilingBlockDevice.h"
 
+namespace mbed {
 
 ProfilingBlockDevice::ProfilingBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -118,3 +119,5 @@ bd_size_t ProfilingBlockDevice::get_erase_count() const
 {
     return _erase_count;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/ProfilingBlockDevice.h
+++ b/features/storage/blockdevice/ProfilingBlockDevice.h
@@ -19,10 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_PROFILING_BLOCK_DEVICE_H
 #define MBED_PROFILING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
+
+namespace mbed {
 
 
 /** Block device for measuring storage operations of another block device
@@ -180,5 +186,13 @@ private:
     bd_size_t _erase_count;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::ProfilingBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
@@ -20,8 +20,13 @@
  * SOFTWARE.
  */
 
+/** \addtogroup storage */
+/** @{*/
+
 #include "ReadOnlyBlockDevice.h"
-#include "mbed_error.h"
+#include "platform/mbed_error.h"
+
+namespace mbed {
 
 ReadOnlyBlockDevice::ReadOnlyBlockDevice(BlockDevice *bd)
     : _bd(bd)
@@ -95,3 +100,7 @@ bd_size_t ReadOnlyBlockDevice::size() const
 {
     return _bd->size();
 }
+
+} // namespace mbed
+
+/** @}*/

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.h
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.h
@@ -19,12 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_READ_ONLY_BLOCK_DEVICE_H
 #define MBED_READ_ONLY_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 #include "PlatformMutex.h"
 
+namespace mbed {
 
 class ReadOnlyBlockDevice : public BlockDevice {
 public:
@@ -132,6 +137,13 @@ private:
     BlockDevice *_bd;
 };
 
+} // namespace mbed
 
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::ReadOnlyBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/blockdevice/SlicingBlockDevice.cpp
+++ b/features/storage/blockdevice/SlicingBlockDevice.cpp
@@ -15,7 +15,9 @@
  */
 
 #include "SlicingBlockDevice.h"
+#include "platform/mbed_assert.h"
 
+namespace mbed {
 
 SlicingBlockDevice::SlicingBlockDevice(BlockDevice *bd, bd_addr_t start, bd_addr_t stop)
     : _bd(bd)
@@ -116,3 +118,5 @@ bd_size_t SlicingBlockDevice::size() const
 {
     return _stop - _start;
 }
+
+} // namespace mbed

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -19,11 +19,17 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_SLICING_BLOCK_DEVICE_H
 #define MBED_SLICING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
 #include "platform/mbed_assert.h"
+
+namespace mbed {
 
 /** Block device for mapping to a slice of another block device
  *
@@ -165,5 +171,13 @@ protected:
     bd_size_t _stop;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::SlicingBlockDevice;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -27,7 +27,9 @@
 #include "FATFileSystem.h"
 
 #include <errno.h>
-////// Error handling /////
+#include <stdlib.h>
+
+namespace mbed {
 
 using namespace mbed;
 
@@ -135,16 +137,14 @@ static Deferred<const char *> fat_path_prefix(int id, const char *path)
     return Deferred<const char *>(buffer, dodelete);
 }
 
-
 ////// Disk operations //////
 
 // Global access to block device from FAT driver
-static BlockDevice *_ffs[FF_VOLUMES] = {0};
+static mbed::BlockDevice *_ffs[FF_VOLUMES] = {0};
 static SingletonPtr<PlatformMutex> _ffs_mutex;
 
-
 // FAT driver functions
-DWORD get_fattime(void)
+extern "C" DWORD get_fattime(void)
 {
     time_t rawtime;
     time(&rawtime);
@@ -157,12 +157,12 @@ DWORD get_fattime(void)
            | (DWORD)(ptm->tm_sec / 2);
 }
 
-void *ff_memalloc(UINT size)
+extern "C" void *ff_memalloc(UINT size)
 {
     return malloc(size);
 }
 
-void ff_memfree(void *p)
+extern "C" void ff_memfree(void *p)
 {
     free(p);
 }
@@ -191,34 +191,35 @@ static DWORD disk_get_sector_count(BYTE pdrv)
     return scount;
 }
 
-DSTATUS disk_status(BYTE pdrv)
+extern "C" DSTATUS disk_status(BYTE pdrv)
 {
     debug_if(FFS_DBG, "disk_status on pdrv [%d]\n", pdrv);
     return RES_OK;
 }
 
-DSTATUS disk_initialize(BYTE pdrv)
+extern "C" DSTATUS disk_initialize(BYTE pdrv)
 {
     debug_if(FFS_DBG, "disk_initialize on pdrv [%d]\n", pdrv);
     return (DSTATUS)_ffs[pdrv]->init();
 }
 
-DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
+extern "C" DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 {
     debug_if(FFS_DBG, "disk_read(sector %lu, count %u) on pdrv [%d]\n", sector, count, pdrv);
     DWORD ssize = disk_get_sector_size(pdrv);
-    bd_addr_t addr = (bd_addr_t)sector * ssize;
-    bd_size_t size = (bd_size_t)count * ssize;
+    mbed::bd_addr_t addr = (mbed::bd_addr_t)sector * ssize;
+    mbed::bd_size_t size = (mbed::bd_size_t)count * ssize;
     int err = _ffs[pdrv]->read(buff, addr, size);
     return err ? RES_PARERR : RES_OK;
 }
 
-DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
+extern "C" DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 {
     debug_if(FFS_DBG, "disk_write(sector %lu, count %u) on pdrv [%d]\n", sector, count, pdrv);
     DWORD ssize = disk_get_sector_size(pdrv);
-    bd_addr_t addr = (bd_addr_t)sector * ssize;
-    bd_size_t size = (bd_size_t)count * ssize;
+    mbed::bd_addr_t addr = (mbed::bd_addr_t)sector * ssize;
+    mbed::bd_size_t size = (mbed::bd_size_t)count * ssize;
+
     int err = _ffs[pdrv]->erase(addr, size);
     if (err) {
         return RES_PARERR;
@@ -232,7 +233,7 @@ DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
     return RES_OK;
 }
 
-DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
+extern "C" DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 {
     debug_if(FFS_DBG, "disk_ioctl(%d)\n", cmd);
     switch (cmd) {
@@ -265,8 +266,8 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
             } else {
                 DWORD *sectors = (DWORD *)buff;
                 DWORD ssize = disk_get_sector_size(pdrv);
-                bd_addr_t addr = (bd_addr_t)sectors[0] * ssize;
-                bd_size_t size = (bd_size_t)(sectors[1] - sectors[0] + 1) * ssize;
+                mbed::bd_addr_t addr = (mbed::bd_addr_t)sectors[0] * ssize;
+                mbed::bd_size_t size = (mbed::bd_size_t)(sectors[1] - sectors[0] + 1) * ssize;
                 int err = _ffs[pdrv]->trim(addr, size);
                 return err ? RES_PARERR : RES_OK;
             }
@@ -274,7 +275,6 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
 
     return RES_PARERR;
 }
-
 
 ////// Generic filesystem operations //////
 
@@ -828,3 +828,4 @@ void FATFileSystem::dir_rewind(fs_dir_t dir)
     unlock();
 }
 
+} // namespace mbed

--- a/features/storage/filesystem/fat/FATFileSystem.h
+++ b/features/storage/filesystem/fat/FATFileSystem.h
@@ -19,6 +19,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_FATFILESYSTEM_H
 #define MBED_FATFILESYSTEM_H
 
@@ -29,13 +33,14 @@
 #include <stdint.h>
 #include "PlatformMutex.h"
 
+namespace mbed {
 
 /**
  * FATFileSystem based on ChaN's Fat Filesystem library v0.8
  *
  * Synchronization level: Thread safe
  */
-class FATFileSystem : public mbed::FileSystem {
+class FATFileSystem : public FileSystem {
 public:
     /** Lifetime of the FATFileSystem
      *
@@ -157,14 +162,14 @@ protected:
      *                  bitwise or'd with one of O_CREAT, O_TRUNC, O_APPEND
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_open(mbed::fs_file_t *file, const char *path, int flags);
+    virtual int file_open(fs_file_t *file, const char *path, int flags);
 
     /** Close a file
      *
      *  @param file     File handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_close(mbed::fs_file_t file);
+    virtual int file_close(fs_file_t file);
 
     /** Read the contents of a file into a buffer
      *
@@ -173,7 +178,7 @@ protected:
      *  @param len      The number of bytes to read
      *  @return         The number of bytes read, 0 at end of file, negative error on failure
      */
-    virtual ssize_t file_read(mbed::fs_file_t file, void *buffer, size_t len);
+    virtual ssize_t file_read(fs_file_t file, void *buffer, size_t len);
 
     /** Write the contents of a buffer to a file
      *
@@ -182,14 +187,14 @@ protected:
      *  @param len      The number of bytes to write
      *  @return         The number of bytes written, negative error on failure
      */
-    virtual ssize_t file_write(mbed::fs_file_t file, const void *buffer, size_t len);
+    virtual ssize_t file_write(fs_file_t file, const void *buffer, size_t len);
 
     /** Flush any buffers associated with the file
      *
      *  @param file     File handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int file_sync(mbed::fs_file_t file);
+    virtual int file_sync(fs_file_t file);
 
     /** Move the file position to a given offset from from a given location
      *
@@ -201,21 +206,21 @@ protected:
      *      SEEK_END to start from end of file
      *  @return         The new offset of the file
      */
-    virtual off_t file_seek(mbed::fs_file_t file, off_t offset, int whence);
+    virtual off_t file_seek(fs_file_t file, off_t offset, int whence);
 
     /** Get the file position of the file
      *
      *  @param file     File handle
      *  @return         The current offset in the file
      */
-    virtual off_t file_tell(mbed::fs_file_t file);
+    virtual off_t file_tell(fs_file_t file);
 
     /** Get the size of the file
      *
      *  @param file     File handle
      *  @return         Size of the file in bytes
      */
-    virtual off_t file_size(mbed::fs_file_t file);
+    virtual off_t file_size(fs_file_t file);
 
     /** Open a directory on the filesystem
      *
@@ -223,14 +228,14 @@ protected:
      *  @param path     Name of the directory to open
      *  @return         0 on success, negative error code on failure
      */
-    virtual int dir_open(mbed::fs_dir_t *dir, const char *path);
+    virtual int dir_open(fs_dir_t *dir, const char *path);
 
     /** Close a directory
      *
      *  @param dir      Dir handle
      *  @return         0 on success, negative error code on failure
      */
-    virtual int dir_close(mbed::fs_dir_t dir);
+    virtual int dir_close(fs_dir_t dir);
 
     /** Read the next directory entry
      *
@@ -238,7 +243,7 @@ protected:
      *  @param ent      The directory entry to fill out
      *  @return         1 on reading a filename, 0 at end of directory, negative error on failure
      */
-    virtual ssize_t dir_read(mbed::fs_dir_t dir, struct dirent *ent);
+    virtual ssize_t dir_read(fs_dir_t dir, struct dirent *ent);
 
     /** Set the current position of the directory
      *
@@ -246,20 +251,20 @@ protected:
      *  @param offset   Offset of the location to seek to,
      *                  must be a value returned from dir_tell
      */
-    virtual void dir_seek(mbed::fs_dir_t dir, off_t offset);
+    virtual void dir_seek(fs_dir_t dir, off_t offset);
 
     /** Get the current position of the directory
      *
      *  @param dir      Dir handle
      *  @return         Position of the directory that can be passed to dir_rewind
      */
-    virtual off_t dir_tell(mbed::fs_dir_t dir);
+    virtual off_t dir_tell(fs_dir_t dir);
 
     /** Rewind the current position to the beginning of the directory
      *
      *  @param dir      Dir handle
      */
-    virtual void dir_rewind(mbed::fs_dir_t dir);
+    virtual void dir_rewind(fs_dir_t dir);
 
 private:
     FATFS _fs; // Work area (file system object) for logical drive
@@ -272,4 +277,13 @@ protected:
     virtual int mount(BlockDevice *bd, bool mount);
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::FATFileSystem;
 #endif
+
+#endif
+
+/** @}*/

--- a/features/storage/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.cpp
@@ -20,7 +20,7 @@
 #include "lfs_util.h"
 #include "MbedCRC.h"
 
-using namespace mbed;
+namespace mbed {
 
 extern "C" void lfs_crc(uint32_t *crc, const void *buffer, size_t size)
 {
@@ -577,3 +577,4 @@ void LittleFileSystem::dir_rewind(fs_dir_t dir)
     _mutex.unlock();
 }
 
+} // namespace mbed

--- a/features/storage/filesystem/littlefs/LittleFileSystem.h
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.h
@@ -13,6 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+/** \addtogroup storage */
+/** @{*/
+
 #ifndef MBED_LFSFILESYSTEM_H
 #define MBED_LFSFILESYSTEM_H
 
@@ -21,6 +25,7 @@
 #include "PlatformMutex.h"
 #include "lfs.h"
 
+namespace mbed {
 
 /**
  * LittleFileSystem, a little filesystem
@@ -51,11 +56,13 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    LittleFileSystem(const char *name = NULL, BlockDevice *bd = NULL,
+
+    LittleFileSystem(const char *name = NULL, mbed::BlockDevice *bd = NULL,
                      lfs_size_t read_size = MBED_LFS_READ_SIZE,
                      lfs_size_t prog_size = MBED_LFS_PROG_SIZE,
                      lfs_size_t block_size = MBED_LFS_BLOCK_SIZE,
                      lfs_size_t lookahead = MBED_LFS_LOOKAHEAD);
+
     virtual ~LittleFileSystem();
 
     /** Formats a block device with the LittleFileSystem
@@ -81,7 +88,7 @@ public:
      *      The lookahead buffer requires only 1 bit per block so it can be quite
      *      large with little ram impact. Should be a multiple of 32.
      */
-    static int format(BlockDevice *bd,
+    static int format(mbed::BlockDevice *bd,
                       lfs_size_t read_size = MBED_LFS_READ_SIZE,
                       lfs_size_t prog_size = MBED_LFS_PROG_SIZE,
                       lfs_size_t block_size = MBED_LFS_BLOCK_SIZE,
@@ -92,7 +99,7 @@ public:
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
      */
-    virtual int mount(BlockDevice *bd);
+    virtual int mount(mbed::BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
@@ -110,7 +117,7 @@ public:
      *
      *  @return         0 on success, negative error code on failure
      */
-    virtual int reformat(BlockDevice *bd);
+    virtual int reformat(mbed::BlockDevice *bd);
 
     /** Remove a file from the filesystem.
      *
@@ -267,7 +274,7 @@ protected:
 private:
     lfs_t _lfs; // _the actual filesystem
     struct lfs_config _config;
-    BlockDevice *_bd; // the block device
+    mbed::BlockDevice *_bd; // the block device
 
     // default parameters
     const lfs_size_t _read_size;
@@ -279,5 +286,13 @@ private:
     PlatformMutex _mutex;
 };
 
+} // namespace mbed
+
+// Added "using" for backwards compatibility
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
+using mbed::LittleFileSystem;
+#endif
 
 #endif
+
+/** @}*/

--- a/features/storage/filesystem/mbed_filesystem.h
+++ b/features/storage/filesystem/mbed_filesystem.h
@@ -34,6 +34,5 @@
 #include "SlicingBlockDevice.h"
 #include "HeapBlockDevice.h"
 
-
 /** @}*/
 #endif

--- a/mbed.h
+++ b/mbed.h
@@ -102,7 +102,9 @@
 #include "platform/FunctionPointer.h"
 #include "platform/ScopedLock.h"
 
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
 using namespace mbed;
 using namespace std;
+#endif
 
 #endif

--- a/platform/FileSystemHandle.cpp
+++ b/platform/FileSystemHandle.cpp
@@ -18,7 +18,8 @@
 #include <errno.h>
 
 namespace mbed {
-int FileSystemHandle::open(DirHandle **dir, const char *path)
+
+int FileSystemHandle::open(mbed::DirHandle **dir, const char *path)
 {
     return -ENOSYS;
 }
@@ -47,4 +48,5 @@ int FileSystemHandle::statvfs(const char *path, struct statvfs *buf)
 {
     return -ENOSYS;
 }
-}
+
+} // namespace mbed

--- a/platform/FileSystemHandle.h
+++ b/platform/FileSystemHandle.h
@@ -110,5 +110,3 @@ public:
 } // namespace mbed
 
 #endif
-
-/** @}*/

--- a/rtos/Mail.h
+++ b/rtos/Mail.h
@@ -33,7 +33,9 @@
 
 #include "platform/NonCopyable.h"
 
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
 using namespace rtos;
+#endif
 
 namespace rtos {
 /** \addtogroup rtos */

--- a/rtos/rtos.h
+++ b/rtos/rtos.h
@@ -38,7 +38,9 @@
 #include "rtos/EventFlags.h"
 #include "rtos/ConditionVariable.h"
 
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
 using namespace rtos;
+#endif
 
 /* Get mbed lib version number, as RTOS depends on mbed lib features
    like mbed_error, Callback and others.


### PR DESCRIPTION
### Description
~~DO NOT MERGE~~

I have created this PR to get input from all teams for solution to namespace issue. 
Purpose:
1. To give an option to remove "using namespace" with `MBED_NO_NAMESPACE` macro
2. Move all classes in Mbed OS inside `mbed` namespace. Addition of existing classes inside mbed namespace breaks compatibility, hence below code should be added to maintain compatibility.

```
// Added "using" for backwards compatibility
#ifndef MBED_NO_NAMESPACE
using mbed::<Classname>;
#endif
```

List of all classes to be moved to `mbed` namespace. Feel free to add to the list or comment below if you know of any class additions.

[ ] All Block Devices
[ ] Filesystem's
 
Related: https://github.com/ARMmbed/mbed-os/issues/6684

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [X] Breaking change

CC @geky @bridadan @dlfryar @0xc0170 @pan- @kjbracey-arm 