### PR TITLE
Add combined hex target to CMake

### DIFF
--- a/tools/export/cmake/CMakeLists.txt.tmpl
+++ b/tools/export/cmake/CMakeLists.txt.tmpl
@@ -71,6 +71,16 @@ add_custom_command(TARGET {{name}} POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E echo "-- built: $<TARGET_FILE:{{name}}>.hex"
                   )
 
+{% if hex_files %}
+add_custom_command(TARGET {{name}} POST_BUILD
+                   COMMAND ${SREC_CAT}
+                        {% for f in hex_files %}${CMAKE_CURRENT_SOURCE_DIR}/{{f}} {% endfor %}
+                        -intel $<TARGET_FILE:{{name}}>.hex
+                        -intel -o $<TARGET_FILE:{{name}}>-combined.hex -intel --line-length=44
+                   COMMAND ${CMAKE_COMMAND} -E echo "-- built: $<TARGET_FILE:{{name}}>-combined.hex"
+                   )
+{% endif %}
+
 
 ##########################################################################
 # mbed-cli specific targets


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Adding a combined-hex build target to CMake exporter, copied from Make exporter. Makes working with Nordic softdevices easier

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Feature
    [ ] Breaking change

