### PR TITLE
Lora: Fix TX_ERROR event if corrupted msg is received for CONFIRMED request

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -668,7 +668,8 @@ void LoRaWANStack::process_reception(const uint8_t *const payload, uint16_t size
             _ctrl_flags &= ~TX_ONGOING_FLAG;
             state_controller(DEVICE_STATE_STATUS_CHECK);
         } else {
-            if (!_loramac.continue_sending_process()) {
+            if (!_loramac.continue_sending_process() &&
+                _loramac.get_current_slot() != RX_SLOT_WIN_1) {
                 tr_error("Retries exhausted for Class A device");
                 _ctrl_flags &= ~TX_DONE_FLAG;
                 _ctrl_flags |= TX_ONGOING_FLAG;

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -780,6 +780,7 @@ bool LoRaMac::continue_sending_process()
     if (_params.ack_timeout_retry_counter > _params.max_ack_timeout_retries) {
         _mac_commands.clear_command_buffer();
         _params.adr_ack_counter++;
+        _lora_time.stop(_params.timers.ack_timeout_timer);
         return false;
     }
 


### PR DESCRIPTION
### Description

When node sends a CONFIRMED message and gateway sends ACK in RX1 window but the
message gets corrupted during the transmission (e.g. MIC fails), currently
our stack already checks for retransmission after RX1 and if retries attemps are
exhausted, TX_ERROR event is sent to application. This is wrong as MAC layer
will still attempt reception in RX2 window.

This commit fixes the behaviour so that TX_ERROR is not sent until RX2 window
has been closed.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

