### PR TITLE
Fix build_data functionality with python 3

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1356,4 +1356,4 @@ def merge_build_data(filename, toolchain_report, app_type):
                     if 'type' not in build[0]:
                         build[0]['type'] = app_type
                     build_data['builds'].append(build[0])
-    dump(build_data, open(filename, "wb"), indent=4, separators=(',', ': '))
+    dump(build_data, open(filename, "w"), indent=4, separators=(',', ': '))

--- a/tools/test.py
+++ b/tools/test.py
@@ -220,6 +220,9 @@ if __name__ == '__main__':
                 # NotSupportedException is handled by the build log
                 pass
             except Exception as e:
+                if options.verbose:
+                    import traceback
+                    traceback.print_exc()
                 # Some other exception occurred, print the error message
                 print(e)
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -321,7 +321,7 @@ class mbedToolchain:
         except IOError:
             old_md5 = None
         if old_md5 != new_md5:
-            with open(via_file, "w") as fd:
+            with open(via_file, "wb") as fd:
                 fd.write(to_write)
         return via_file
 


### PR DESCRIPTION
### Description

Open file in non-binary mode because "The json module always produces str objects, not bytes objects. Therefore, fp.write() must support str input." https://docs.python.org/3.6/library/json.html#basic-usage

This found originally in here: https://circleci.com/gh/ARMmbed/mbed-cli/868

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

