### PR TITLE
LoRa: Fix MAC initialization for connection with parameters

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1419,6 +1419,11 @@ lorawan_status_t LoRaMac::prepare_join(const lorawan_connect_t *params, bool is_
             }
             // Reset variable JoinRequestTrials
             _params.join_request_trial_counter = 0;
+
+            reset_mac_parameters();
+
+            _params.sys_params.channel_data_rate =
+                _lora_phy->get_alternate_DR(_params.join_request_trial_counter + 1);
         } else {
             if ((params->connection_u.abp.dev_addr == 0)
                     || (params->connection_u.abp.nwk_id == 0)


### PR DESCRIPTION
### Description

LoRaMAC was not initialized properly if application called
connect(const lorawan_connect_t &connect);

This causes problems for example in case where application
first disconnects and then reconnects as counter values are not
initialized.

This fixes https://github.com/ARMmbed/mbed-os/issues/7759.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

