### PR TITLE
Update mesh_system_heap_error_handler to use new error handler

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/mesh_system.c
+++ b/features/nanostack/mbed-mesh-api/source/mesh_system.c
@@ -24,6 +24,7 @@
 #include "ns_hal_init.h"
 #include "include/mesh_system.h"
 #include "mbed_assert.h"
+#include "mbed_error.h"
 // For tracing we need to define flag, have include and define group
 #define HAVE_DEBUG 1
 #include "ns_trace.h"
@@ -46,19 +47,7 @@ MBED_CONF_MBED_MESH_API_HEAP_STAT_INFO_DEFINITION;
  */
 static void mesh_system_heap_error_handler(heap_fail_t event)
 {
-    tr_error("Heap error, mesh_system_heap_error_handler() %d", event);
-    switch (event) {
-        case NS_DYN_MEM_NULL_FREE:
-        case NS_DYN_MEM_DOUBLE_FREE:
-        case NS_DYN_MEM_ALLOCATE_SIZE_NOT_VALID:
-        case NS_DYN_MEM_POINTER_NOT_VALID:
-        case NS_DYN_MEM_HEAP_SECTOR_CORRUPTED:
-        case NS_DYN_MEM_HEAP_SECTOR_UNITIALIZED:
-            break;
-        default:
-            break;
-    }
-    while (1);
+    MBED_ERROR1(MBED_MAKE_ERROR(MBED_MODULE_NETWORK_STACK, MBED_ERROR_CODE_OUT_OF_MEMORY), "Heap error, mesh_system_heap_error_handler()", event);
 }
 
 void mesh_system_init(void)


### PR DESCRIPTION
Update mesh_system_heap_error_handler to use new error codes and mbed

### Description

Tested with K64F with EPS8266

Fixes: https://github.com/ARMmbed/mbed-os/issues/6853

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

