### PR TITLE
STM32 wrong MBED_ASSERT use

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO - not connected by default)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO - not connected by default)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32f0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
 #define USE_PLL_HSE_XTAL     0x4  // Use external xtal (X3 on board - not provided by default)
@@ -138,8 +138,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/system_clock.c
@@ -35,7 +35,7 @@
   */
 
 #include "stm32f1xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -145,8 +145,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f2xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -120,8 +120,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/TARGET_NUCLEO_F302R8/system_clock.c
@@ -36,7 +36,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -130,8 +130,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/TARGET_NUCLEO_F303K8/system_clock.c
@@ -36,7 +36,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -130,8 +130,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TARGET_DISCO_F303VC/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/TARGET_DISCO_F303VC/system_clock.c
@@ -35,7 +35,7 @@
 **/
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -129,8 +129,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303RE/system_clock.c
@@ -31,7 +31,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/TARGET_NUCLEO_F303ZE/system_clock.c
@@ -31,7 +31,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_DISCO_F334C8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_DISCO_F334C8/system_clock.c
@@ -36,7 +36,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -130,8 +130,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_NUCLEO_F334R8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/TARGET_NUCLEO_F334R8/system_clock.c
@@ -36,7 +36,7 @@
 
 
 #include "stm32f3xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -130,8 +130,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_NUCLEO_F401RE/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_STEVAL_3DP001V1/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/TARGET_STEVAL_3DP001V1/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/TARGET_DISCO_F407VG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/TARGET_DISCO_F407VG/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -124,8 +124,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/TARGET_NUCLEO_F410RB/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/TARGET_NUCLEO_F410RB/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_NUCLEO_F411RE/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
@@ -110,8 +110,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_SAKURAIO_EVB_01/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/TARGET_SAKURAIO_EVB_01/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -126,8 +126,8 @@ void SetSysClock(void)
             if (ret_HSIclk_status == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -125,8 +125,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -126,8 +126,8 @@ void SetSysClock(void)
             if (ret_HSIclk_status == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -126,8 +126,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -126,8 +126,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_DISCO_F429ZI/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
@@ -107,8 +107,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/TARGET_NUCLEO_F429ZI/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
@@ -107,8 +107,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_NUCLEO_F439ZI/system_clock.c
@@ -36,7 +36,7 @@
 
 #include "stm32f4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
@@ -122,8 +122,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/system_clock.c
@@ -36,7 +36,7 @@
 
 #include "stm32f4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC     0x8  // Use external clock (ST Link MCO)
@@ -122,8 +122,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446RE/system_clock.c
@@ -35,7 +35,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 // clock source is selected with CLOCK_SOURCE in json config
 #define USE_PLL_HSE_EXTC 0x8 // Use external clock (ST Link MCO)
@@ -119,8 +119,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -129,8 +129,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f4xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -129,8 +129,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f7xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -123,8 +123,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f7xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -124,8 +124,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f7xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -123,8 +123,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f7xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -124,8 +124,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/system_clock.c
@@ -30,7 +30,7 @@
 **/
 
 #include "stm32f7xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -123,8 +123,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -112,8 +112,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -112,8 +112,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -112,8 +112,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_DISCO_L053C8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_DISCO_L053C8/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -112,8 +112,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_NUCLEO_L053R8/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/TARGET_NUCLEO_L053R8/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -112,8 +112,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/TARGET_DISCO_L072CZ_LRWAN1/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -115,8 +115,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while (1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/TARGET_MTB_MURATA_ABZ/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/TARGET_MTB_MURATA_ABZ/system_clock.c
@@ -27,7 +27,7 @@
   */
 
 #include "stm32l0xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -85,8 +85,8 @@ void SystemInit(void)
 void SetSysClock(void)
 {
     if (SetSysClock_PLL_HSI() == 0) {
-        while (1) {
-            MBED_ASSERT(1);
+        {
+            error("SetSysClock failed\n");
         }
     }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/system_clock.c
@@ -29,7 +29,7 @@
   */
 
 #include "stm32l1xx.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -114,8 +114,8 @@ void SetSysClock(void)
             if (SetSysClock_PLL_HSI() == 0)
 #endif
             {
-                while(1) {
-                    MBED_ASSERT(1);
+                {
+                    error("SetSysClock failed\n");
                 }
             }
         }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/system_clock.c
@@ -45,7 +45,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -147,8 +147,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/system_clock.c
@@ -45,7 +45,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -147,8 +147,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_MTB_ADV_WISE_1510/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/TARGET_MTB_ADV_WISE_1510/system_clock.c
@@ -45,7 +45,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -147,8 +147,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/system_clock.c
@@ -32,7 +32,7 @@
 
 #include "stm32l4xx.h"
 #include "nvic_addr.h"
-#include "mbed_assert.h"
+#include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -134,8 +134,8 @@ void SetSysClock(void)
                 if (SetSysClock_PLL_MSI() == 0)
 #endif
                 {
-                    while (1) {
-                        MBED_ASSERT(1);
+                    {
+                        error("SetSysClock failed\n");
                     }
                 }
             }


### PR DESCRIPTION
### Description

In all SetSysClock functions, when system clock configuration is failing, we go into :
MBED_ASSERT(1)
which will actually never assert...

Code is then replaced by the error macro

Thx @mattbrown015 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

