### PR TITLE
STM32F1 RTC : wrong Sunday value

### DIFF
--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -250,8 +250,8 @@ void rtc_write(time_t t)
     }
 
     // Fill RTC structures
-    if (timeinfo.tm_wday == 0) {
-        dateStruct.WeekDay    = 7;
+    if (timeinfo.tm_wday == 0) { /* Sunday specific case */
+        dateStruct.WeekDay    = RTC_WEEKDAY_SUNDAY;
     } else {
         dateStruct.WeekDay    = timeinfo.tm_wday;
     }


### PR DESCRIPTION
### Description

In struc tm, tm_wday is the day since Sunday with value from 0 to 6

In ST RTC driver, Sunday is coded as 7 for all STM32 family,
except for STM32F1, where value is 0


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

