### PR TITLE
Fix MeshInterface::get_default_instance()

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -165,8 +165,8 @@ bool LoWPANNDInterface::getRouterIpAddress(char *address, int8_t len)
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == LOWPAN && DEVICE_802_15_4_PHY
 MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
 {
-    static LoWPANNDInterface lowpan(NanostackRfPhy::get_default_instance());
+    static LoWPANNDInterface lowpan(&NanostackRfPhy::get_default_instance());
 
-    return lowpan;
+    return &lowpan;
 }
 #endif

--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -163,7 +163,7 @@ bool LoWPANNDInterface::getRouterIpAddress(char *address, int8_t len)
 
 #define LOWPAN 0x2345
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == LOWPAN && DEVICE_802_15_4_PHY
-MBED_WEAK MeshInterface *MeshInterface::get_default_instance()
+MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
 {
     static LoWPANNDInterface lowpan(&NanostackRfPhy::get_default_instance());
 

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -255,8 +255,8 @@ mesh_error_t Nanostack::ThreadInterface::device_pskd_set(const char *pskd)
 #if MBED_CONF_NSAPI_DEFAULT_MESH_TYPE == THREAD && DEVICE_802_15_4_PHY
 MBED_WEAK MeshInterface *MeshInterface::get_target_default_instance()
 {
-    static ThreadInterface thread(NanostackRfPhy::get_default_instance());
+    static ThreadInterface thread(&NanostackRfPhy::get_default_instance());
 
-    return thread;
+    return &thread;
 }
 #endif

--- a/features/nanostack/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
+++ b/features/nanostack/targets/TARGET_NCS36510/NanostackRfPhyNcs36510.cpp
@@ -902,3 +902,8 @@ void NanostackRfPhyNcs36510::set_mac_address(uint8_t *mac)
     platform_exit_critical();
 }
 
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+    static NanostackRfPhyNcs36510 rf_phy;
+    return rf_phy;
+}

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -9,7 +9,10 @@
         "default-cellular-apn": null,
         "default-cellular-username": null,
         "default-cellular-password": null,
-        "default-mesh-type": "THREAD",
+        "default-mesh-type": {
+            "help": "Configuration type for MeshInterface::get_default_instance(). [LOWPAN/THREAD]",
+            "value": "THREAD"
+        },
         "dns-response-wait-time": {
             "help": "How long the DNS translator waits for a reply from a server in milliseconds",
             "value": 5000

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4100,8 +4100,11 @@
         "post_binary_hook": {"function": "NCS36510TargetCode.ncs36510_addfib"},
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
-        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "TRNG", "SPISLAVE"],
-        "release_versions": ["2", "5"]
+        "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "TRNG", "SPISLAVE", "802_15_4_PHY"],
+        "release_versions": ["2", "5"],
+        "overrides": {
+            "network-default-interface-type": "MESH"
+        }
     },
     "NUMAKER_PFM_M453": {
         "core": "Cortex-M4F",

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4101,10 +4101,7 @@
         "macros": ["CM3", "CPU_NCS36510", "TARGET_NCS36510", "LOAD_ADDRESS=0x3000"],
         "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
         "device_has": ["ANALOGIN", "SERIAL", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "TRNG", "SPISLAVE", "802_15_4_PHY"],
-        "release_versions": ["2", "5"],
-        "overrides": {
-            "network-default-interface-type": "MESH"
-        }
+        "release_versions": ["2", "5"]
     },
     "NUMAKER_PFM_M453": {
         "core": "Cortex-M4F",

--- a/tools/test_configs/6lowpanInterface_host.json
+++ b/tools/test_configs/6lowpanInterface_host.json
@@ -1,0 +1,27 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "MESH",
+            "nsapi.default-stack": "NANOSTACK",
+            "nsapi.default-mesh-type": "LOWPAN",
+            "nanostack.configuration": "lowpan_host",
+            "mbed-mesh-api.heap-size": 14000,
+            "mbed-mesh-api.6lowpan-nd-device-type": "NET_6LOWPAN_HOST",
+            "mbed-mesh-api.6lowpan-nd-panid-filter": "0xffff",
+            "mbed-mesh-api.6lowpan-nd-channel-page": 0,
+            "mbed-mesh-api.6lowpan-nd-channel": 12,
+            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<12)",
+            "mbed-trace.enable": false
+        }
+    }
+}

--- a/tools/test_configs/6lowpanInterface_router.json
+++ b/tools/test_configs/6lowpanInterface_router.json
@@ -1,0 +1,27 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "MESH",
+            "nsapi.default-stack": "NANOSTACK",
+            "nsapi.default-mesh-type": "LOWPAN",
+            "nanostack.configuration": "lowpan_router",
+            "mbed-mesh-api.heap-size": 14000,
+            "mbed-mesh-api.6lowpan-nd-device-type": "NET_6LOWPAN_ROUTER",
+            "mbed-mesh-api.6lowpan-nd-panid-filter": "0xffff",
+            "mbed-mesh-api.6lowpan-nd-channel-page": 0,
+            "mbed-mesh-api.6lowpan-nd-channel": 12,
+            "mbed-mesh-api.6lowpan-nd-channel-mask": "(1<<12)",
+            "mbed-trace.enable": false
+        }
+    }
+}

--- a/tools/test_configs/ThreadInterface_end_device.json
+++ b/tools/test_configs/ThreadInterface_end_device.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "MESH",
+            "nsapi.default-stack": "NANOSTACK",
+            "nsapi.default-mesh-type": "THREAD",
+            "nanostack.configuration": "thread_end_device",
+            "mbed-mesh-api.thread-device-type": "MESH_DEVICE_TYPE_THREAD_MINIMAL_END_DEVICE",
+            "mbed-mesh-api.thread-config-panid": "0x0700",
+            "mbed-mesh-api.thread-master-key": "{0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}",
+            "mbed-mesh-api.thread-config-channel": 22,
+            "mbed-trace.enable": false
+        }
+    }
+}

--- a/tools/test_configs/ThreadInterface_router.json
+++ b/tools/test_configs/ThreadInterface_router.json
@@ -1,0 +1,25 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "MESH",
+            "nsapi.default-stack": "NANOSTACK",
+            "nsapi.default-mesh-type": "THREAD",
+            "nanostack.configuration": "thread_router",
+            "mbed-mesh-api.thread-device-type": "MESH_DEVICE_TYPE_THREAD_ROUTER",
+            "mbed-mesh-api.thread-config-panid": "0x0700",
+            "mbed-mesh-api.thread-master-key": "{0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff}",
+            "mbed-mesh-api.thread-config-channel": 22,
+            "mbed-trace.enable": false
+        }
+    }
+}

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -5,5 +5,9 @@
     "HEAPBLOCKDEVICE_AND_WIFI": "HeapBlockDeviceAndWifiInterface.json",
     "ESP8266_WIFI" : "ESP8266Interface.json",
     "ISM43362_WIFI" : "ISM43362Interface.json",
-    "IDW0XX1_WIFI" : "SpwfSAInterface.json"
+    "IDW0XX1_WIFI" : "SpwfSAInterface.json",
+    "6LOWPAN_HOST" : "6lowpanInterface_host.json",
+    "6LOWPAN_ROUTER" : "6lowpanInterface_router.json",
+    "THREAD_END_DEVICE" : "ThreadInterface_end_device.json",
+    "THREAD_ROUTER" : "ThreadInterface_router.json"
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -42,9 +42,5 @@
     "NUCLEO_F401RE": {
         "default_test_configuration": "NONE",
         "test_configurations": ["IDW0XX1_WIFI"]
-    },
-    "NCS36510": {
-        "default_test_configuration": "6LOWPAN_HOST",
-        "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_ROUTER", "THREAD_END_DEVICE"]
     }
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -42,5 +42,9 @@
     "NUCLEO_F401RE": {
         "default_test_configuration": "NONE",
         "test_configurations": ["IDW0XX1_WIFI"]
+    },
+    "NCS36510": {
+        "default_test_configuration": "6LOWPAN_HOST",
+        "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_ROUTER", "THREAD_END_DEVICE"]
     }
 }


### PR DESCRIPTION
### Description

Fix `MeshInterface::get_default_instance()`
Both 6LoWPAN and Thread interfaces were returning and referencing wrong types. Pointers instead of reference, and objects where pointer should have been.

Also enable targets like MCR20A and NCS36510 to provide the default Nanostack RF driver.

Tested quickly on K64F+Atmel shield, K64F+MCR20 shield, MCR20A.

*Requires following PRs to be usable:*
* https://github.com/ARMmbed/atmel-rf-driver/pull/65
* https://github.com/ARMmbed/mcr20a-rf-driver/pull/18

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

