### PR TITLE
Lora: Fix join-response failure handling

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -651,6 +651,7 @@ void LoRaWANStack::process_reception(const uint8_t *const payload, uint16_t size
     }
 
     if (!_loramac.nwk_joined()) {
+        _ready_for_rx = true;
         return;
     }
 
@@ -1172,7 +1173,8 @@ void LoRaWANStack::process_joining_state(lorawan_status_t &op_status)
         return;
     }
 
-    if (_device_current_state == DEVICE_STATE_AWAITING_JOIN_ACCEPT) {
+    if (_device_current_state == DEVICE_STATE_AWAITING_JOIN_ACCEPT &&
+        _loramac.get_current_slot() != RX_SLOT_WIN_1) {
         _device_current_state = DEVICE_STATE_JOINING;
         // retry join
         bool can_continue = _loramac.continue_joining_process();


### PR DESCRIPTION

### Description

Thix commit fixes a bug where stack was resending join-accept already
after RX1 if received join-response was invalid.

Stack should wait for RX2 before resending the join-accept.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

