### PR TITLE
STM32L4 : code cleanup in MSI SetSysClock

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/system_clock.c
@@ -309,15 +309,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -336,8 +340,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/system_clock.c
@@ -309,15 +309,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -336,8 +340,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/system_clock.c
@@ -309,15 +309,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -336,8 +340,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_SILICA_SENSOR_NODE/system_clock.c
@@ -309,15 +309,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -336,8 +340,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/system_clock.c
@@ -321,15 +321,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -348,8 +352,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_NUCLEO_L486RG/system_clock.c
@@ -309,15 +309,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -336,8 +340,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/system_clock.c
@@ -323,15 +323,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -349,8 +353,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/system_clock.c
@@ -323,15 +323,19 @@ uint8_t SetSysClock_PLL_MSI(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
 
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     // Enable LSE Oscillator to automatically calibrate the MSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // No PLL update
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
-        RCC->CR |= RCC_CR_MSIPLLEN; // Enable MSI PLL-mode
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+        return 0; // FAIL
     }
 
+    /* Enable the CSS interrupt in case LSE signal is corrupted or not present */
     HAL_RCCEx_DisableLSECSS();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Enable MSI Oscillator and activate PLL with MSI as source */
     RCC_OscInitStruct.OscillatorType      = RCC_OSCILLATORTYPE_MSI | RCC_OSCILLATORTYPE_HSI | RCC_OSCILLATORTYPE_HSE;
     RCC_OscInitStruct.MSIState             = RCC_MSI_ON;
@@ -349,8 +353,12 @@ uint8_t SetSysClock_PLL_MSI(void)
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         return 0; // FAIL
     }
+
+#if MBED_CONF_TARGET_LSE_AVAILABLE
     /* Enable MSI Auto-calibration through LSE */
     HAL_RCCEx_EnableMSIPLLMode();
+#endif /* MBED_CONF_TARGET_LSE_AVAILABLE */
+
     /* Select MSI output as USB clock source */
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_USB;
     PeriphClkInitStruct.UsbClockSelection = RCC_USBCLKSOURCE_MSI; /* 48 MHz */


### PR DESCRIPTION
### Description

This follow #7647 discussion

For STM32L4 familly, clock configuration can use MSI (multispeed internal RC oscillator clock).
When a 32.768 kHz external oscillator (LSE) is present, it is possible to configure the MSI in a PLL-mode.
When configured in PLL-mode, the MSI automatically calibrates itself thanks to the LSE.

This setting was set 2 times during MSI configuration and even if LSE is not present.

@mattbrown015 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

