### PR TITLE
Cellular: Fixed AT+COPN

### DIFF
--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -1265,7 +1265,7 @@ nsapi_error_t AT_CellularNetwork::get_operator_names(operator_names_list &op_nam
 {
     _at.lock();
 
-    _at.cmd_start("AT+COPN?");
+    _at.cmd_start("AT+COPN");
     _at.cmd_stop();
 
     _at.resp_start("+COPN:");


### PR DESCRIPTION
### Description

Fixed `AT+COPS` command as per 3GPP TS 27.007 V15.1.0.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

