### PR TITLE
STM32 LPTICKER : RTC wake up timer is reset before setting a new one

### DIFF
--- a/targets/TARGET_STM/lp_ticker.c
+++ b/targets/TARGET_STM/lp_ticker.c
@@ -263,6 +263,7 @@ uint32_t lp_ticker_read(void)
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    lp_ticker_disable_interrupt();
     rtc_set_wake_up_timer(timestamp);
 }
 

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -270,7 +270,7 @@ void rtc_write(time_t t)
 
 #if DEVICE_LPTICKER && !MBED_CONF_TARGET_LPTICKER_LPTIM
     /* Need to update LP_continuous_time value before new RTC time */
-    uint32_t current_lp_time = rtc_read_lp();
+    rtc_read_lp();
 
     /* LP_last_RTC_time value is updated with the new RTC time */
     LP_last_RTC_time = timeStruct.Seconds + timeStruct.Minutes * 60 + timeStruct.Hours * 60 * 60;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -724,7 +724,7 @@
         "public": false,
         "extra_labels": ["STM"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
-        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2", "LPTICKER_DELAY_TICKS=3"],
+        "macros": ["TRANSACTION_QUEUE_SIZE_SPI=2"],
         "config": {
             "lse_available": {
                 "help": "Define if a Low Speed External xtal (LSE) is available on the board (0 = No, 1 = Yes). If Yes, the LSE will be used to clock the RTC, LPUART, ... otherwise the Low Speed Internal clock (LSI) will be used",
@@ -868,6 +868,11 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_delay_ticks": {
+                "help": "For targets with low frequency system clock, set lpticker_delay_ticks value to 1",
+                "value": 1,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0755"],
@@ -886,6 +891,11 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_delay_ticks": {
+                "help": "For targets with low frequency system clock, set lpticker_delay_ticks value to 1",
+                "value": 1,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0730"],
@@ -904,6 +914,11 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_delay_ticks": {
+                "help": "For targets with low frequency system clock, set lpticker_delay_ticks value to 1",
+                "value": 1,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0750"],
@@ -1100,6 +1115,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0744"],
@@ -1224,6 +1244,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0743"],
@@ -1246,6 +1271,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0743"],
@@ -1396,12 +1426,17 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "macros_add": ["USBHOST_OTHER"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0816"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746ZG",
         "bootloader_supported": true,
@@ -1427,12 +1462,17 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "macros_add": ["TRANSACTION_QUEUE_SIZE_SPI=2", "USBHOST_OTHER", "MBEDTLS_CONFIG_HW_SUPPORT"],
         "supported_form_factors": ["ARDUINO"],
         "detect_code": ["0819"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F756ZG",
         "overrides": {
@@ -1461,12 +1501,17 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "supported_form_factors": ["ARDUINO"],
         "macros_add": ["USBHOST_OTHER"],
         "detect_code": ["0818"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "CRC", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F767ZI",
         "bootloader_supported": true,
@@ -1490,6 +1535,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0780"],
@@ -1513,6 +1563,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0790"],
@@ -1535,6 +1590,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0715"],
@@ -1557,6 +1617,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0760"],
@@ -1574,6 +1639,11 @@
                 "help": "Mask value : USE_PLL_HSE_EXTC | USE_PLL_HSE_XTAL (need HW patch) | USE_PLL_HSI",
                 "value": "USE_PLL_HSE_EXTC|USE_PLL_HSI",
                 "macro_name": "CLOCK_SOURCE"
+            },
+            "lpticker_delay_ticks": {
+                "help": "For targets with low frequency system clock, set lpticker_delay_ticks value to 1",
+                "value": 1,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0710"],
@@ -1595,6 +1665,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0770"],
@@ -1617,6 +1692,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0779"],
@@ -1660,6 +1740,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0765"],
@@ -1701,6 +1786,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0827"],
@@ -1908,6 +1998,11 @@
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
 
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "overrides": {"lse_available": 0},
@@ -1930,6 +2025,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0833"],
@@ -1965,11 +2065,16 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0815"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F746NG",
         "overrides": {
@@ -1994,11 +2099,16 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0817"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["LPTICKER", "ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
+        "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "TRNG", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F769NI",
         "overrides": {
@@ -2018,6 +2128,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "supported_form_factors": ["ARDUINO"],
@@ -2041,6 +2156,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0820"],
@@ -4100,6 +4220,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0822"],
@@ -4121,6 +4246,11 @@
             "lpticker_lptim": {
                 "help": "This target supports LPTIM. Set value 1 to use LPTIM for LPTICKER, or 0 to use RTC wakeup timer",
                 "value": 1
+            },
+            "lpticker_delay_ticks": {
+                "help": "In case of lpticker_lptim=1, set lpticker_delay_ticks=3",
+                "value": 3,
+                "macro_name": "LPTICKER_DELAY_TICKS"
             }
         },
         "detect_code": ["0823"],


### PR DESCRIPTION
### Description

Affected targets : targets supporting LPTICKER and using RTC wake up timer.

Patch:
- timer is now reset before setting a new value
- LPTICKER_DELAY_TICKS is decreased to only 1 for targets with low frequency system clock
- LPTICKER_DELAY_TICKS seems to be no more needed for targets with high frequency system clock

NB:
- LPTICKER_DELAY_TICKS is not changed for targets using LPTIM

@c1728p9 @lmestm

### Tests

Patch tested with ARM tool chain with 1 board per STM32 family

Tests with TICKLESS look OK with NUCLEO_F401RE

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change
