### PR TITLE
Fix TMPM64B IAR linker file

### DIFF
--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/device/TOOLCHAIN_IAR/tmpm46bf10fg.icf
@@ -25,11 +25,11 @@ define region RAM_region   = mem:[from __ICFEDIT_region_RAM_start__   to __ICFED
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
-define block FLASH_CODE_ROM  {section FLASH_ROM_init object flash_api.o, section .text_init object tmpm46b_fc.o}; 
-define block FLASH_CODE_RAM  {section FLASH_ROM object flash_api.o, section .text object tmpm46b_fc.o};
+define block FLASH_CODE_ROM  {section FLASH_ROM_init object flash_api.o};
+define block FLASH_CODE_RAM  {section FLASH_ROM object flash_api.o};
 
 initialize by copy { readwrite };
-initialize manually { section FLASH_ROM object flash_api.o, section .text object tmpm46b_fc.o};
+initialize manually { section FLASH_ROM object flash_api.o };
 do not initialize  { section .noinit };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };


### PR DESCRIPTION

### Description
Remove unnecessary manual inclusion of tmpm64b_fc object file in linker script
This manual inclusion is unnecessary and causes linker issues when trying to add changes (as in [#7212](https://github.com/ARMmbed/mbed-os/pull/7212)).

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

