### PR TITLE
Cellular: Add getters for device and serial to EasyCellularConnection

### DIFF
--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -336,6 +336,16 @@ NetworkStack *EasyCellularConnection::get_stack()
     }
 }
 
+CellularDevice *EasyCellularConnection::get_device()
+{
+    return _cellularConnectionFSM->get_device();
+}
+
+UARTSerial *EasyCellularConnection::get_serial()
+{
+    return &_cellularSerial;
+}
+
 } // namespace
 
 #endif // CELLULAR_DEVICE

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -135,6 +135,19 @@ public:
      *  @param plmn operator in numeric format. See more from 3GPP TS 27.007 chapter 7.3.
      */
     void set_plmn(const char *plmn);
+
+    /** Get the cellular device from the cellular state machine
+     *
+     * @return cellular device
+     */
+    CellularDevice *get_device();
+
+    /** Get the UART serial file handle used by cellular subsystem
+     *
+     * @return address of cellular UART serial
+     */
+    UARTSerial *get_serial();
+
 protected:
 
     /** Provide access to the NetworkStack object


### PR DESCRIPTION
### Description
Addresses need to have direct access from application to power interface:
https://github.com/ARMmbed/mbed-os/issues/7470#issuecomment-412504814

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x ] Feature
    [ ] Breaking change

