### PR TITLE
Removing feature names from the "allowed feature" config list.

### DIFF
--- a/TEST_APPS/device/socket_app/mbed_app.json
+++ b/TEST_APPS/device/socket_app/mbed_app.json
@@ -7,7 +7,6 @@
     ],
     "target_overrides": {
         "*": {
-            "target.features_add": ["LWIP", "COMMON_PAL"],
             "mbed-trace.enable": 1,
             "platform.stdio-baud-rate": 115200,
             "platform.stdio-convert-newlines": true,

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -63,12 +63,7 @@ BOOTLOADER_OVERRIDES = ROM_OVERRIDES | RAM_OVERRIDES
 
 
 ALLOWED_FEATURES = [
-    "BOOTLOADER","UVISOR", "BLE", "CLIENT", "IPV4", "LWIP", "COMMON_PAL", "STORAGE",
-    "NANOSTACK","CRYPTOCELL310",
-    # Nanostack configurations
-    "LOWPAN_BORDER_ROUTER", "LOWPAN_HOST", "LOWPAN_ROUTER", "NANOSTACK_FULL",
-    "THREAD_BORDER_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER",
-    "ETHERNET_HOST",
+    "BOOTLOADER", "BLE", "LWIP", "STORAGE", "NANOSTACK", "CRYPTOCELL310",
 ]
 
 # Base class for all configuration exceptions
@@ -749,7 +744,7 @@ class Config(object):
         if start > rom_start + rom_size:
             raise ConfigException("Not enough memory on device to fit all "
                                   "application regions")
-    
+
     @staticmethod
     def _find_sector(address, sectors):
         target_size = -1
@@ -762,13 +757,13 @@ class Config(object):
         if (target_size < 0):
             raise ConfigException("No valid sector found")
         return target_start, target_size
-        
+
     @staticmethod
     def _align_floor(address, sectors):
         target_start, target_size = Config._find_sector(address, sectors)
         sector_num = (address - target_start) // target_size
         return target_start + (sector_num * target_size)
-    
+
     @staticmethod
     def _align_ceiling(address, sectors):
         target_start, target_size = Config._find_sector(address, sectors)


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
I was going through the OS source and noticed this list still references a bunch of `FEATURE_*` folders that don't exist anymore. Currently, these are the only `FEATURE_*` folders that I see in the Mbed OS tree:

```
$ cd mbed-os
$ find features -regextype sed -regex "^.*/FEATURE_[^/]*$"
features/cryptocell/FEATURE_CRYPTOCELL310
features/deprecated_warnings/FEATURE_NANOSTACK
features/deprecated_warnings/FEATURE_LWIP
features/FEATURE_UVISOR
features/FEATURE_BLE
features/storage/FEATURE_STORAGE
```

This change only leaves the above features enabled. The following features have been removed from the whitelist:

```
"CLIENT",
"IPV4",
"COMMON_PAL",
"LOWPAN_BORDER_ROUTER",
"LOWPAN_HOST",
"LOWPAN_ROUTER",
"NANOSTACK_FULL",
"THREAD_BORDER_ROUTER",
"THREAD_END_DEVICE",
"THREAD_ROUTER",
"ETHERNET_HOST"
```

I don't believe this is a breaking change, but it'd be good to hear from @theotherjimmy.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

