### PR TITLE
Skip Greentea tests for Mbed OS code coverage on Fast Models

### DIFF
--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -104,10 +104,6 @@ void increment_multi_counter(void)
  */
 void test_case_1x_ticker()
 {
-#if defined(__ARM_FM)
-    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
-#endif
-
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;
@@ -339,8 +335,10 @@ Case cases[] = {
     Case("Test detach", test_detach),
     Case("Test multi call and time measure", test_multi_call_time),
     Case("Test multi ticker", test_multi_ticker),
+#if !defined(__ARM_FM)  //FastModels not support time drifting test
     Case("Test timers: 1x ticker", test_case_1x_ticker),
     Case("Test timers: 2x ticker", test_case_2x_ticker)
+#endif
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -145,10 +145,6 @@ void test_case_1x_ticker()
  */
 void test_case_2x_ticker()
 {
-#if defined(__ARM_FM)
-    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
-#endif
-
     char _key[11] = { };
     char _value[128] = { };
     int expected_key =  1;

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -104,6 +104,10 @@ void increment_multi_counter(void)
  */
 void test_case_1x_ticker()
 {
+#if defined(__ARM_FM)
+    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
+#endif
+
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;
@@ -145,6 +149,10 @@ void test_case_1x_ticker()
  */
 void test_case_2x_ticker()
 {
+#if defined(__ARM_FM)
+    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
+#endif
+
     char _key[11] = { };
     char _value[128] = { };
     int expected_key =  1;

--- a/TESTS/mbed_drivers/timeout/main.cpp
+++ b/TESTS/mbed_drivers/timeout/main.cpp
@@ -68,9 +68,10 @@ Case cases[] = {
     Case("1 s delay during sleep (attach_us)", test_sleep<AttachUSTester<Timeout>, 1000000, LONG_DELTA_US>,
          greentea_failure_handler),
 #endif
-
+#if !defined(__ARM_FM)  //FastModels not support time drifting test
     Case("Timing drift (attach)", test_drift<AttachTester<Timeout> >),
     Case("Timing drift (attach_us)", test_drift<AttachUSTester<Timeout> >),
+#endif
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -389,10 +389,6 @@ private:
 template<typename T>
 void test_drift(void)
 {
-#if defined(__ARM_FM)
-    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
-#endif
-
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbed_drivers/timeout/timeout_tests.h
+++ b/TESTS/mbed_drivers/timeout/timeout_tests.h
@@ -389,6 +389,10 @@ private:
 template<typename T>
 void test_drift(void)
 {
+#if defined(__ARM_FM)
+    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
+#endif
+
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbed_hal/common_tickers_freq/main.cpp
+++ b/TESTS/mbed_hal/common_tickers_freq/main.cpp
@@ -33,6 +33,11 @@
 #error [NOT_SUPPORTED] test not supported
 #endif
 
+//FastModels not support time drifting test
+#if defined(__ARM_FM)
+#error [NOT_SUPPORTED] test not supported
+#endif
+
 #define US_PER_S 1000000
 
 using namespace utest::v1;
@@ -62,10 +67,6 @@ void ticker_event_handler_stub(const ticker_data_t *const ticker)
 /* Test that the ticker is operating at the frequency it specifies. */
 void ticker_frequency_test()
 {
-#if defined(__ARM_FM)
-    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
-#endif
-
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbed_hal/common_tickers_freq/main.cpp
+++ b/TESTS/mbed_hal/common_tickers_freq/main.cpp
@@ -62,6 +62,10 @@ void ticker_event_handler_stub(const ticker_data_t *const ticker)
 /* Test that the ticker is operating at the frequency it specifies. */
 void ticker_frequency_test()
 {
+#if defined(__ARM_FM)
+    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
+#endif
+
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -27,11 +27,14 @@
 #error [NOT_SUPPORTED] test not supported
 #endif
 
+//FastModels not support time drifting test
+#if defined(__ARM_FM)
+#error [NOT_SUPPORTED] test not supported
+#endif
+
 using utest::v1::Case;
 
 #if defined(__CORTEX_M23) || defined(__CORTEX_M33)
-#define TEST_STACK_SIZE 512
-#elif defined(__ARM_FM)
 #define TEST_STACK_SIZE 512
 #else
 #define TEST_STACK_SIZE 256
@@ -67,10 +70,6 @@ void update_tick_thread(Mutex *mutex)
  */
 void test(void)
 {
-#if defined(__ARM_FM)
-    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
-#endif
-
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -65,6 +65,10 @@ void update_tick_thread(Mutex *mutex)
  */
 void test(void)
 {
+#if defined(__ARM_FM)
+    TEST_SKIP_MESSAGE("FastModels not support time drifting test")
+#endif
+
     char _key[11] = { };
     char _value[128] = { };
     int expected_key = 1;

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -31,6 +31,8 @@ using utest::v1::Case;
 
 #if defined(__CORTEX_M23) || defined(__CORTEX_M33)
 #define TEST_STACK_SIZE 512
+#elif defined(__ARM_FM)
+#define TEST_STACK_SIZE 512
 #else
 #define TEST_STACK_SIZE 256
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -31,6 +31,8 @@ using namespace utest::v1;
 
 #if defined(__CORTEX_M23) || defined(__CORTEX_M33)
 #define THREAD_STACK_SIZE   512
+#elif defined(__ARM_FM)
+#define THREAD_STACK_SIZE   512
 #else
 #define THREAD_STACK_SIZE   320 /* larger stack cause out of heap memory on some 16kB RAM boards in multi thread test*/
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -39,6 +39,8 @@ volatile bool thread_should_continue = true;
 #define THREAD_STACK_SIZE   512
 #elif defined(__CORTEX_M23) || defined(__CORTEX_M33)
 #define THREAD_STACK_SIZE   512
+#elif defined(__ARM_FM)
+#define THREAD_STACK_SIZE   512
 #else
 #define THREAD_STACK_SIZE   256
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -34,6 +34,8 @@
 #define PARALLEL_THREAD_STACK_SIZE 512
 #elif defined(__CORTEX_M23) || defined(__CORTEX_M33)
 #define PARALLEL_THREAD_STACK_SIZE 512
+#elif defined(__ARM_FM)
+#define PARALLEL_THREAD_STACK_SIZE 512
 #else
 #define PARALLEL_THREAD_STACK_SIZE 384
 #endif

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/MPS2.ld
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/MPS2.ld
@@ -69,7 +69,7 @@ ENTRY(Reset_Handler)
 STACK_SIZE = 0x400;
 
 /* Size of the vector table in SRAM */
-M_VECTOR_RAM_SIZE = 0x100;
+M_VECTOR_RAM_SIZE = NVIC_VECTORS_SIZE;
 
 SECTIONS
 {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4259,6 +4259,7 @@
     "ARM_FM": {
         "inherits": ["Target"],
         "public": false,
+        "macros": ["__ARM_FM"],
         "extra_labels": ["ARM_FM"]
     },
     "FVP_MPS2": {
@@ -4272,27 +4273,27 @@
     "FVP_MPS2_M0": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M0",
-        "macros": ["CMSDK_CM0"]
+        "macros_add": ["CMSDK_CM0"]
     },
     "FVP_MPS2_M0P": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M0+",
-        "macros": ["CMSDK_CM0plus"]
+        "macros_add": ["CMSDK_CM0plus"]
     },
     "FVP_MPS2_M3": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M3",
-        "macros": ["CMSDK_CM3"]
+        "macros_add": ["CMSDK_CM3"]
     },
     "FVP_MPS2_M4": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M4",
-        "macros": ["CMSDK_CM4"]
+        "macros_add": ["CMSDK_CM4"]
     },
     "FVP_MPS2_M7": {
         "inherits": ["FVP_MPS2"],
         "core": "Cortex-M7",
-        "macros": ["CMSDK_CM7"]
+        "macros_add": ["CMSDK_CM7"]
     },
     "NUMAKER_PFM_M2351": {
         "core": "Cortex-M23-NS",


### PR DESCRIPTION
### Description

This PR updated the Greentea tests which failed on code coverage testing on FastModels.
  
* Skip time drifting test on FastModels targets
FastModels targets are simulator running on the x86 hosts.
As the nature of non-RealTime x86 OS and FastModels, timing accuracy is not guaranteed
So skipping the time drifting tests on FastModel targets

* Increase the thread stack size on FastModel targets
The thread stack size was restricted due to some boards have really limited RAM sizes,
and out of heap memory on multiple threads tests.
The side effect was on the debug profile build, the tests will get stack overflow.
We need the build the test with debug profile in order to do the code coverage analysis.
So increased the thread stack size on FastModel targets.

This PR have a dependency on #7706 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Feature
    [ ] Breaking change

