### PR TITLE
Eventqueue Templatewall Doxygen Rework

### DIFF
--- a/events/Event.h
+++ b/events/Event.h
@@ -1890,6 +1890,7 @@ private:
     }
 
 public:
+#if !defined(DOXYGEN_ONLY)
     /** Create an event
      *  @param q                Event queue to dispatch on
      *  @param f                Function to execute when the event is dispatched
@@ -3619,7 +3620,7 @@ template <typename R, typename B0, typename B1, typename B2, typename B3, typena
 Event<void(A0, A1, A2, A3, A4)> EventQueue::event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4) {
     return Event<void(A0, A1, A2, A3, A4)>(this, cb, c0, c1, c2, c3, c4);
 }
-
+#endif
 }
 
 #endif

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -197,6 +197,21 @@ public:
      *                  enough memory to allocate the event.
      *                  Returned id will remain valid until event has finished
      *                  executing.
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename F, typename ...Args>
     int call(F f, Args ...args);
@@ -217,6 +232,21 @@ public:
      *                    enough memory to allocate the event.
      *                    Returned id will remain valid until event has finished
      *                    executing.
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename T, typename R, typename ...Args>
     int call(T *obj, R (T::*method)(Args ...args), Args ...args);
@@ -234,6 +264,21 @@ public:
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename F, typename ...Args>
     int call_in(int ms, Args ...args);
@@ -253,6 +298,21 @@ public:
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename T, typename R, typename ...Args>
     int call_in(int ms, T *obj, R (T::*method)(Args ...args), Args ...args);
@@ -274,6 +334,21 @@ public:
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename F, typename ...Args>
     int call_every(int ms, F f, Args ...args);
@@ -293,6 +368,21 @@ public:
      *  @param obj      Object to call with the member function
      *  @param method   Member function to execute in the context of the dispatch loop
      *  @param args     Arguments to pass to the callback
+     *
+     * @code
+     *     int main() {
+     *         // creates a queue with the default size
+     *         EventQueue queue;
+     *     
+     *         // events are simple callbacks
+     *         queue.call(printf, "called immediately\n");
+     *         queue.call_in(2000, printf, "called in 2 seconds\n");
+     *         queue.call_every(1000, printf, "called every 1 seconds\n");
+     *     
+     *         // events are executed by the dispatch method
+     *         queue.dispatch();
+     *     }
+     * @endcode
      */
     template <typename T, typename R, typename ...Args>
     int call_every(int ms, T *obj, R (T::*method)(Args ...args), Args ...args);
@@ -311,7 +401,26 @@ public:
      *  @return             Event that will dispatch on the specific queue
      *
      * @code
-     *     event(...TODO....);
+     *     #include "mbed.h"
+     *
+     *     void handler(int c) {
+     *         printf("Param: %d\r\n", c);
+     *     }
+     *
+     *     EventQueue q;
+     *
+     *     int main()
+     *     {
+     *         // Create event with parameter
+     *         Event<void()>    e  = q.event(handler, 1);
+     *         e();
+     *
+     *         // Create event and post parameter later
+     *         Event<void(int)> e2 = q.event(handler);
+     *         e2.post(2);
+     *
+     *         q.dispatch();
+     *     }
      * @endcode
      */
     template <typename R, typename ...BoundArgs, typename ...Args>
@@ -332,6 +441,33 @@ public:
      *  @param method          Member function to execute in the context of the dispatch loop
      *  @param context_args    TODO
      *  @return                Event that will dispatch on the specific queue
+     *
+     * @code
+     *     #include "mbed.h"
+     *
+     *     class Test {
+     *         int _id;
+     *
+     *     public:
+     *         Test(int id) : _id(id) { }
+     *
+     *         void handler(int c) {
+     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *         }
+     *     };
+     *
+     *     EventQueue q;
+     *
+     *     int main()
+     *     {
+     *         Test handler_cb(5);
+     *
+     *         // Create event on the eventqueue with a method callback
+     *         Event<void(int)> e = q.event(&handler_cb, &Test::handler);
+     *         e.post(1);
+     *         q.dispatch();
+     *     }
+     * @endcode
      */
     template <typename T, typename R, typename ...BoundArgs, typename ...ContextArgs, typename ...Args>
     Event<void(Args...)> event(T *obj, R (T::*method)(BoundArgs..., Args...), ContextArgs ...context_args);
@@ -369,6 +505,21 @@ public:
      *                  enough memory to allocate the event.
      *                  Returned id will remain valid until event has finished
      *                  executing.
+     *
+     * @code
+     *     #include "mbed.h"
+     *
+     *     EventQueue q;
+     *
+     *     int main()
+     *     {
+     *         Callback<void(int)> cb(handler);
+     *         // Create event on the eventqueue with a separate callback object
+     *         Event<void(int)> e = q.event(cb);
+     *         e.post(1);
+     *         q.dispatch();
+     *     }
+     * @endcode
      */
     template <typename F>
     int call(F f) {

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -202,12 +202,10 @@ public:
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
+     *
      *         // events are simple callbacks
      *         queue.call(printf, "called immediately\n");
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -234,15 +232,27 @@ public:
      *                    executing.
      *
      * @code
+     *     class EventHandler {
+     *         int _id;
+     *     public:
+     *         EventHandler(int id) : _id(id) { }
+     *
+     *         void handler(int c) {
+     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *         }
+     *     };
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
-     *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
+     *         // Create EventHandler object with state
+     *         EventHandler handler_cb(1);
+     *
+     *         // events are simple callbacks, call object method
+     *         // with provided parameter
+     *         queue.call(&handler_cb, &EventHandler::handler, 2);
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -269,12 +279,10 @@ public:
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
+     *
      *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
      *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -300,15 +308,27 @@ public:
      *                  enough memory to allocate the event.
      *
      * @code
+     *     class EventHandler {
+     *         int _id;
+     *     public:
+     *         EventHandler(int id) : _id(id) { }
+     *
+     *         void handler(int c) {
+     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *         }
+     *     };
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
-     *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
+     *         // Create EventHandler object with state
+     *         EventHandler handler_cb(3);
+     *
+     *         // events are simple callbacks, call object method in 2 seconds
+     *         // with provided parameter
+     *         queue.call_in(2000, &handler_cb, &EventHandler::handler, 4);
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -336,15 +356,23 @@ public:
      *                  enough memory to allocate the event.
      *
      * @code
+     *     class EventHandler {
+     *         int _id;
+     *     public:
+     *         EventHandler(int id) : _id(id) { }
+     *
+     *         void handler(int c) {
+     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *         }
+     *     };
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
-     *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
+     *         // events are simple callbacks, call every 2 seconds
+     *         queue.call_every(2000, printf, "Calling every 2 seconds\n");
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -370,15 +398,27 @@ public:
      *  @param args     Arguments to pass to the callback
      *
      * @code
+     *     class EventHandler {
+     *         int _id;
+     *     public:
+     *         EventHandler(int id) : _id(id) { }
+     *
+     *         void handler(int c) {
+     *             printf("ID: %d Param: %d\r\n", _id, c);
+     *         }
+     *     };
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
-     *     
-     *         // events are simple callbacks
-     *         queue.call(printf, "called immediately\n");
-     *         queue.call_in(2000, printf, "called in 2 seconds\n");
-     *         queue.call_every(1000, printf, "called every 1 seconds\n");
-     *     
+     *
+     *         // Create EventHandler object with state
+     *         EventHandler handler_cb(5);
+     *
+     *         // events are simple callbacks, call object method every 2 seconds
+     *         // with provided parameter
+     *         queue.call_every(2000, &handler_cb, &EventHandler::handler, 6);
+     *
      *         // events are executed by the dispatch method
      *         queue.dispatch();
      *     }
@@ -407,19 +447,19 @@ public:
      *         printf("Param: %d\r\n", c);
      *     }
      *
-     *     EventQueue q;
-     *
      *     int main()
      *     {
+     *         EventQueue queue;
+     *
      *         // Create event with parameter
-     *         Event<void()>    e  = q.event(handler, 1);
+     *         Event<void()>    e  = queue.event(handler, 1);
      *         e();
      *
      *         // Create event and post parameter later
-     *         Event<void(int)> e2 = q.event(handler);
+     *         Event<void(int)> e2 = queue.event(handler);
      *         e2.post(2);
      *
-     *         q.dispatch();
+     *         queue.dispatch();
      *     }
      * @endcode
      */
@@ -445,27 +485,27 @@ public:
      * @code
      *     #include "mbed.h"
      *
-     *     class Test {
+     *     class EventHandler {
      *         int _id;
      *
      *     public:
-     *         Test(int id) : _id(id) { }
+     *         EventHandler(int id) : _id(id) { }
      *
      *         void handler(int c) {
      *             printf("ID: %d Param: %d\r\n", _id, c);
      *         }
      *     };
      *
-     *     EventQueue q;
-     *
      *     int main()
      *     {
-     *         Test handler_cb(5);
+     *         EventQueue queue;
+     *
+     *         EventHandler handler_cb(5);
      *
      *         // Create event on the eventqueue with a method callback
-     *         Event<void(int)> e = q.event(&handler_cb, &Test::handler);
+     *         Event<void(int)> e = queue.event(&handler_cb, &EventHandler::handler);
      *         e.post(1);
-     *         q.dispatch();
+     *         queue.dispatch();
      *     }
      * @endcode
      */
@@ -509,15 +549,16 @@ public:
      * @code
      *     #include "mbed.h"
      *
-     *     EventQueue q;
-     *
      *     int main()
      *     {
+     *         EventQueue queue;
+     *
      *         Callback<void(int)> cb(handler);
+     *
      *         // Create event on the eventqueue with a separate callback object
-     *         Event<void(int)> e = q.event(cb);
+     *         Event<void(int)> e = queue.event(cb);
      *         e.post(1);
-     *         q.dispatch();
+     *         queue.dispatch();
      *     }
      * @endcode
      */

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -209,7 +209,7 @@ public:
      *         // events are simple callbacks
      *         queue.call(printf, "called immediately\n");
      *
-     *         // events are executed by the dispatch method
+     *         // the dispatch method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -219,19 +219,19 @@ public:
 
     /** Calls an event on the queue
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call function is irq safe and can act as a mechanism for moving
-     *  events out of irq contexts.
+     *  The call function is IRQ safe and can act as a mechanism for moving
+     *  events out of IRQ contexts.
      *
      *  @param obj        Object to call with the member function
      *  @param method     Member function to execute in the context of the dispatch loop
      *  @param args       Arguments to pass to the callback
-     *  @return           A unique id that represents the posted event and can
-     *                    be passed to cancel, or an id of 0 if there is not
+     *  @return           A unique ID that represents the posted event and can
+     *                    be passed to cancel, or an ID of 0 if there is not
      *                    enough memory to allocate the event.
-     *                    Returned id will remain valid until event has finished
+     *                    Returned ID remains valid until event has finished
      *                    executing.
      *
      * @code
@@ -258,7 +258,7 @@ public:
      *         // with provided parameter
      *         queue.call(&handler_cb, &EventHandler::handler, 2);
      *
-     *         // events are executed by the dispatch method
+     *         // the dispath method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -268,16 +268,16 @@ public:
 
     /** Calls an event on the queue after a specified delay
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call_in function is irq safe and can act as a mechanism for moving
-     *  events out of irq contexts.
+     *  The call_in function is IRQ safe and can act as a mechanism for moving
+     *  events out of IRQ contexts.
      *
      *  @param ms       Time to delay in milliseconds
      *  @param args     Arguments to pass to the callback
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to cancel, or an id of 0 if there is not
+     *  @return         A unique ID that represents the posted event and can
+     *                  be passed to cancel, or an ID of 0 if there is not
      *                  enough memory to allocate the event.
      *
      * @code
@@ -290,7 +290,7 @@ public:
      *         // events are simple callbacks
      *         queue.call_in(2000, printf, "called in 2 seconds\n");
      *
-     *         // events are executed by the dispatch method
+     *         // the dispatch methods executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -300,18 +300,18 @@ public:
 
     /** Calls an event on the queue after a specified delay
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call_in function is irq safe and can act as a mechanism for moving
-     *  events out of irq contexts.
+     *  The call_in function is IRQ safe and can act as a mechanism for moving
+     *  events out of IRQ contexts.
      *
      *  @param ms       Time to delay in milliseconds
      *  @param obj      Object to call with the member function
      *  @param method   Member function to execute in the context of the dispatch loop
      *  @param args     Arguments to pass to the callback
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to cancel, or an id of 0 if there is not
+     *  @return         A unique ID that represents the posted event and can
+     *                  be passed to cancel, or an ID of 0 if there is not
      *                  enough memory to allocate the event.
      *
      * @code
@@ -338,7 +338,7 @@ public:
      *         // with provided parameter
      *         queue.call_in(2000, &handler_cb, &EventHandler::handler, 4);
      *
-     *         // events are executed by the dispatch method
+     *         // the dispatch method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -351,17 +351,17 @@ public:
      *  @note The first call_every event occurs after the specified delay.
      *  To create a periodic event that fires immediately, @see Event.
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call_every function is irq safe and can act as a mechanism for
-     *  moving events out of irq contexts.
+     *  The call_every function is IRQ safe and can act as a mechanism for
+     *  moving events out of IRQ contexts.
      *
      *  @param ms       Period of the event in milliseconds
      *  @param f        Function to execute in the context of the dispatch loop
      *  @param args     Arguments to pass to the callback
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to cancel, or an id of 0 if there is not
+     *  @return         A unique ID that represents the posted event and can
+     *                  be passed to cancel, or an ID of 0 if there is not
      *                  enough memory to allocate the event.
      *
      * @code
@@ -384,7 +384,7 @@ public:
      *         // events are simple callbacks, call every 2 seconds
      *         queue.call_every(2000, printf, "Calling every 2 seconds\n");
      *
-     *         // events are executed by the dispatch method
+     *         // the dispatch method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -397,11 +397,11 @@ public:
      *  @note The first call_every event occurs after the specified delay.
      *  To create a periodic event that fires immediately, @see Event.
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call_every function is irq safe and can act as a mechanism for
-     *  moving events out of irq contexts.
+     *  The call_every function is IRQ safe and can act as a mechanism for
+     *  moving events out of IRQ contexts.
      *
      *  @param ms       Period of the event in milliseconds
      *  @param obj      Object to call with the member function
@@ -432,7 +432,7 @@ public:
      *         // with provided parameter
      *         queue.call_every(2000, &handler_cb, &EventHandler::handler, 6);
      *
-     *         // events are executed by the dispatch method
+     *         // the dispatch method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -448,7 +448,7 @@ public:
      *
      *  @param  func        Function to execute when the event is dispatched
      *  @param  args        Arguments to pass to the callback
-     *  @return             Event that will dispatch on the specific queue
+     *  @return             Event that dispatches on the specific queue
      *
      * @code
      *     #include "mbed.h"
@@ -471,7 +471,7 @@ public:
      *         // Post the event with paramter 8
      *         e.post(8);
      *
-     *         // Events are executed by the dispatch method
+     *         // The dispatch method executes events
      *         queue.dispatch();
      *
      *         e2.post(2);
@@ -492,7 +492,7 @@ public:
      *  @param obj             Object to call with the member function
      *  @param method          Member function to execute in the context of the dispatch loop
      *  @param context_args    Arguments to pass to the callback
-     *  @return                Event that will dispatch on the specific queue
+     *  @return                Event that dispatches on the specific queue
      *
      * @code
      *     #include "mbed.h"
@@ -520,7 +520,7 @@ public:
      *         // Post the event with paramter 8
      *         e.post(11);
      *
-     *         // Events are executed by the dispatch method
+     *         // The dispatch method executes events
      *         queue.dispatch();
      *     }
      * @endcode
@@ -536,7 +536,7 @@ public:
      *
      *  @param  cb             Callback object
      *  @param  context_args   Arguments to pass to the callback
-     *  @return                Event that will dispatch on the specific queue
+     *  @return                Event that dispatches on the specific queue
      *
      *  @code
      *     #include "mbed.h"
@@ -558,7 +558,7 @@ public:
      *         // Post the event with parameter 8
      *         e.post(9);
      *
-     *         // events are executed by the dispatch method
+     *         // The dispatch method executes events
      *         q.dispatch();
      *     }
      *  @endcode
@@ -570,17 +570,17 @@ public:
 
     /** Calls an event on the queue
      *
-     *  The specified callback will be executed in the context of the event
+     *  The specified callback is executed in the context of the event
      *  queue's dispatch loop.
      *
-     *  The call function is irq safe and can act as a mechanism for moving
-     *  events out of irq contexts.
+     *  The call function is IRQ safe and can act as a mechanism for moving
+     *  events out of IRQ contexts.
      *
      *  @param f        Function to execute in the context of the dispatch loop
-     *  @return         A unique id that represents the posted event and can
-     *                  be passed to cancel, or an id of 0 if there is not
+     *  @return         A unique ID that represents the posted event and can
+     *                  be passed to cancel, or an ID of 0 if there is not
      *                  enough memory to allocate the event.
-     *                  Returned id will remain valid until event has finished
+     *                  Returned ID remains valid until event has finished
      *                  executing.
      *
      * @code

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -84,7 +84,7 @@ public:
 
     /** Dispatch events without a timeout
      *
-     *  This is equivalent to EventQueue::dispatch with no arguments, but 
+     *  This is equivalent to EventQueue::dispatch with no arguments, but
      *  avoids overload ambiguities when passed as a callback.
      *
      *  @see EventQueue::dispatch
@@ -100,7 +100,7 @@ public:
 
     /** Millisecond counter
      *
-     *  Returns the underlying tick of the event queue represented as the 
+     *  Returns the underlying tick of the event queue represented as the
      *  number of milliseconds that have passed since an arbitrary point in
      *  time. Intentionally overflows to 0 after 2^32-1.
      *
@@ -180,6 +180,181 @@ public:
      */
     void chain(EventQueue *target);
 
+
+    #if defined(DOXYGEN_ONLY)
+    /** Calls an event on the queue
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param f        Function to execute in the context of the dispatch loop
+     *  @param args     Arguments to pass to the callback
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to cancel, or an id of 0 if there is not
+     *                  enough memory to allocate the event.
+     *                  Returned id will remain valid until event has finished
+     *                  executing.
+     */
+    template <typename F, typename ...Args>
+    int call(F f, Args ...args);
+
+    /** Calls an event on the queue
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param obj        Object to call with the member function
+     *  @param method     Member function to execute in the context of the dispatch loop
+     *  @param args       Arguments to pass to the callback
+     *  @return           A unique id that represents the posted event and can
+     *                    be passed to cancel, or an id of 0 if there is not
+     *                    enough memory to allocate the event.
+     *                    Returned id will remain valid until event has finished
+     *                    executing.
+     */
+    template <typename T, typename R, typename ...Args>
+    int call(T *obj, R (T::*method)(Args ...args), Args ...args);
+
+    /** Calls an event on the queue after a specified delay
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_in function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param ms       Time to delay in milliseconds
+     *  @param args     Arguments to pass to the callback
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to cancel, or an id of 0 if there is not
+     *                  enough memory to allocate the event.
+     */
+    template <typename F, typename ...Args>
+    int call_in(int ms, Args ...args);
+
+    /** Calls an event on the queue after a specified delay
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_in function is irq safe and can act as a mechanism for moving
+     *  events out of irq contexts.
+     *
+     *  @param ms       Time to delay in milliseconds
+     *  @param obj      Object to call with the member function
+     *  @param method   Member function to execute in the context of the dispatch loop
+     *  @param args     Arguments to pass to the callback
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to cancel, or an id of 0 if there is not
+     *                  enough memory to allocate the event.
+     */
+    template <typename T, typename R, typename ...Args>
+    int call_in(int ms, T *obj, R (T::*method)(Args ...args), Args ...args);
+
+    /** Calls an event on the queue periodically
+     *
+     *  @note The first call_every event occurs after the specified delay.
+     *  To create a periodic event that fires immediately, @see Event.
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_every function is irq safe and can act as a mechanism for
+     *  moving events out of irq contexts.
+     *
+     *  @param ms       Period of the event in milliseconds
+     *  @param f        Function to execute in the context of the dispatch loop
+     *  @param args     Arguments to pass to the callback
+     *  @return         A unique id that represents the posted event and can
+     *                  be passed to cancel, or an id of 0 if there is not
+     *                  enough memory to allocate the event.
+     */
+    template <typename F, typename ...Args>
+    int call_every(int ms, F f, Args ...args);
+
+    /** Calls an event on the queue periodically
+     *
+     *  @note The first call_every event occurs after the specified delay.
+     *  To create a periodic event that fires immediately, @see Event.
+     *
+     *  The specified callback will be executed in the context of the event
+     *  queue's dispatch loop.
+     *
+     *  The call_every function is irq safe and can act as a mechanism for
+     *  moving events out of irq contexts.
+     *
+     *  @param ms       Period of the event in milliseconds
+     *  @param obj      Object to call with the member function
+     *  @param method   Member function to execute in the context of the dispatch loop
+     *  @param args     Arguments to pass to the callback
+     */
+    template <typename T, typename R, typename ...Args>
+    int call_every(int ms, T *obj, R (T::*method)(Args ...args), Args ...args);
+
+    /** Creates an event bound to the event queue
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @tparam R           TODO
+     *  @tparam Args        TODO
+     *  @tparam BoundArgs   TODO
+     *  @param  func        Function to execute when the event is dispatched
+     *  @param  args        TODO
+     *  @return             Event that will dispatch on the specific queue
+     *
+     * @code
+     *     event(...TODO....);
+     * @endcode
+     */
+    template <typename R, typename ...BoundArgs, typename ...Args>
+    Event<void(Args...)> event(R (*func)(BoundArgs...), Args ...args);
+
+    /** Creates an event bound to the event queue
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @tparam T              TODO
+     *  @tparam R              TODO
+     *  @tparam BoundArgs      TODO
+     *  @tparam ContextArg     TODO
+     *  @tparam Args           TODO
+     *  @param obj             Object to call with the member function
+     *  @param method          Member function to execute in the context of the dispatch loop
+     *  @param context_args    TODO
+     *  @return                Event that will dispatch on the specific queue
+     */
+    template <typename T, typename R, typename ...BoundArgs, typename ...ContextArgs, typename ...Args>
+    Event<void(Args...)> event(T *obj, R (T::*method)(BoundArgs..., Args...), ContextArgs ...context_args);
+
+    /** Creates an event bound to the event queue
+     *
+     *  Constructs an event bound to the specified event queue. The specified
+     *  callback acts as the target for the event and is executed in the
+     *  context of the event queue's dispatch loop once posted.
+     *
+     *  @tparam templateArgs   TODO
+     *  @tparam R              TODO
+     *  @param  cb             TODO
+     *  @tparam Args           TODO
+     *  @tparam BoundArgs      TODO
+     *  @param  context_args   TODO
+     *  @return                Event that will dispatch on the specific queue
+     */
+    template <typename R, typename ...BoundArgs, typename ...ContextArgs, typename ...Args>
+    Event<void(Args...)> event(mbed::Callback<R(BoundArgs..., Args...)> cb, ContextArgs ...context_args);
+
+    #else
+
     /** Calls an event on the queue
      *
      *  The specified callback will be executed in the context of the event
@@ -206,6 +381,7 @@ public:
         equeue_event_dtor(e, &EventQueue::function_dtor<F>);
         return equeue_post(&_equeue, &EventQueue::function_call<F>, e);
     }
+
 
     /** Calls an event on the queue
      *  @see                    EventQueue::call
@@ -457,8 +633,8 @@ public:
      *  The call_in function is irq safe and can act as a mechanism for moving
      *  events out of irq contexts.
      *
-     *  @param f        Function to execute in the context of the dispatch loop
      *  @param ms       Time to delay in milliseconds
+     *  @param f        Function to execute in the context of the dispatch loop
      *  @return         A unique id that represents the posted event and can
      *                  be passed to cancel, or an id of 0 if there is not
      *                  enough memory to allocate the event.
@@ -2302,6 +2478,7 @@ public:
      */
     template <typename R, typename B0, typename B1, typename B2, typename B3, typename B4, typename C0, typename C1, typename C2, typename C3, typename C4, typename A0, typename A1, typename A2, typename A3, typename A4>
     Event<void(A0, A1, A2, A3, A4)> event(mbed::Callback<R(B0, B1, B2, B3, B4, A0, A1, A2, A3, A4)> cb, C0 c0, C1 c1, C2 c2, C3 c3, C4 c4);
+    #endif
 
 protected:
     template <typename F>

--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -181,6 +181,7 @@ public:
     void chain(EventQueue *target);
 
 
+
     #if defined(DOXYGEN_ONLY)
     /** Calls an event on the queue
      *
@@ -199,6 +200,8 @@ public:
      *                  executing.
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
@@ -232,6 +235,8 @@ public:
      *                    executing.
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     class EventHandler {
      *         int _id;
      *     public:
@@ -276,6 +281,8 @@ public:
      *                  enough memory to allocate the event.
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     int main() {
      *         // creates a queue with the default size
      *         EventQueue queue;
@@ -308,6 +315,8 @@ public:
      *                  enough memory to allocate the event.
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     class EventHandler {
      *         int _id;
      *     public:
@@ -356,6 +365,8 @@ public:
      *                  enough memory to allocate the event.
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     class EventHandler {
      *         int _id;
      *     public:
@@ -398,6 +409,8 @@ public:
      *  @param args     Arguments to pass to the callback
      *
      * @code
+     *     #include "mbed.h"
+     *
      *     class EventHandler {
      *         int _id;
      *     public:
@@ -433,11 +446,8 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
-     *  @tparam R           TODO
-     *  @tparam Args        TODO
-     *  @tparam BoundArgs   TODO
      *  @param  func        Function to execute when the event is dispatched
-     *  @param  args        TODO
+     *  @param  args        Arguments to pass to the callback
      *  @return             Event that will dispatch on the specific queue
      *
      * @code
@@ -457,6 +467,13 @@ public:
      *
      *         // Create event and post parameter later
      *         Event<void(int)> e2 = queue.event(handler);
+     *
+     *         // Post the event with paramter 8
+     *         e.post(8);
+     *
+     *         // Events are executed by the dispatch method
+     *         queue.dispatch();
+     *
      *         e2.post(2);
      *
      *         queue.dispatch();
@@ -472,14 +489,9 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
-     *  @tparam T              TODO
-     *  @tparam R              TODO
-     *  @tparam BoundArgs      TODO
-     *  @tparam ContextArg     TODO
-     *  @tparam Args           TODO
      *  @param obj             Object to call with the member function
      *  @param method          Member function to execute in the context of the dispatch loop
-     *  @param context_args    TODO
+     *  @param context_args    Arguments to pass to the callback
      *  @return                Event that will dispatch on the specific queue
      *
      * @code
@@ -500,11 +512,15 @@ public:
      *     {
      *         EventQueue queue;
      *
-     *         EventHandler handler_cb(5);
+     *         EventHandler handler_cb(10);
      *
      *         // Create event on the eventqueue with a method callback
      *         Event<void(int)> e = queue.event(&handler_cb, &EventHandler::handler);
-     *         e.post(1);
+     *
+     *         // Post the event with paramter 8
+     *         e.post(11);
+     *
+     *         // Events are executed by the dispatch method
      *         queue.dispatch();
      *     }
      * @endcode
@@ -518,13 +534,34 @@ public:
      *  callback acts as the target for the event and is executed in the
      *  context of the event queue's dispatch loop once posted.
      *
-     *  @tparam templateArgs   TODO
-     *  @tparam R              TODO
-     *  @param  cb             TODO
-     *  @tparam Args           TODO
-     *  @tparam BoundArgs      TODO
-     *  @param  context_args   TODO
+     *  @param  cb             Callback object
+     *  @param  context_args   Arguments to pass to the callback
      *  @return                Event that will dispatch on the specific queue
+     *
+     *  @code
+     *     #include "mbed.h"
+     *
+     *     void handler(int c) {
+     *         printf("Param: %d\r\n", c);
+     *     }
+     *
+     *     int main()
+     *     {
+     *         EventQueue queue;
+     *         // Create callback object acting as a function
+     *         // pointer to handler
+     *         Callback<void(int)> cb(handler);
+     *
+     *         // Pass the callback object to the eventqueue
+     *         Event<void(int)> e = queue.event(cb);
+     *
+     *         // Post the event with parameter 8
+     *         e.post(9);
+     *
+     *         // events are executed by the dispatch method
+     *         q.dispatch();
+     *     }
+     *  @endcode
      */
     template <typename R, typename ...BoundArgs, typename ...ContextArgs, typename ...Args>
     Event<void(Args...)> event(mbed::Callback<R(BoundArgs..., Args...)> cb, ContextArgs ...context_args);


### PR DESCRIPTION
### Description
The doxygen for the EventQueue API (and Callback class but that's not covered in this PR) are illegible due to how the classes are implemented/doxygen-ified before. Chris and Vincent set up this solution a while back, just implementing the rest of their work: https://github.com/ARMmbed/mbed-os/pull/7303 

Additionally added some inline examples on how to setup/call the different overloaded methods in EventQueue. **NOTE**:  Will squash the commit history following any feedback

# Before
![image](https://user-images.githubusercontent.com/1060940/44238194-3a896e00-a179-11e8-8b72-96069820dc40.png)

# After
![image](https://user-images.githubusercontent.com/1060940/44238099-d8306d80-a178-11e8-9142-8bb5305920a2.png)
________________________
## Example of expanded function doc
![image](https://user-images.githubusercontent.com/1060940/44238380-1da16a80-a17a-11e8-9cd1-fe758e93815c.png)

@geky Lot of copy and pasting, so may have borked one of the comment headers or examples in the new vararg function declarations.
@AnotherButler 

Feel free to add anyone else to the review.
### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

