### PR TITLE
Connectivity drivers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,7 +162,7 @@ matrix:
         - python tools/make.py -t GCC_ARM -m K64F --source=. --build=BUILD/K64F/GCC_ARM -j0
         # Check that example compiles without rtos
         - sed -n '/``` cpp/,/```/{/```$/Q;/```/d;p;}' $EVENTS/README.md > main.cpp
-        - rm -r rtos features/cellular features/netsocket features/nanostack features/lwipstack features/frameworks/greentea-client features/frameworks/utest features/frameworks/unity BUILD
+        - rm -r rtos features/cellular features/netsocket features/nanostack features/lwipstack features/frameworks/greentea-client features/frameworks/utest features/frameworks/unity components BUILD
         - python tools/make.py -t GCC_ARM -m DISCO_F401VC --source=. --build=BUILD/DISCO_F401VC/GCC_ARM -j0
         # Run local equeue tests
         - make -C $EVENTS/equeue test

--- a/components/802.15.4_RF/atmel-rf-driver/.gitignore
+++ b/components/802.15.4_RF/atmel-rf-driver/.gitignore
@@ -1,6 +1,0 @@
-*~
-*.swo
-*.swp
-build
-yotta_modules
-yotta_targets

--- a/components/802.15.4_RF/atmel-rf-driver/.gitignore
+++ b/components/802.15.4_RF/atmel-rf-driver/.gitignore
@@ -1,0 +1,6 @@
+*~
+*.swo
+*.swp
+build
+yotta_modules
+yotta_targets

--- a/components/802.15.4_RF/atmel-rf-driver/LICENSE
+++ b/components/802.15.4_RF/atmel-rf-driver/LICENSE
@@ -1,0 +1,2 @@
+Unless specifically indicated otherwise in a file, files are licensed
+under the Apache 2.0 license, as can be found in: apache-2.0.txt

--- a/components/802.15.4_RF/atmel-rf-driver/README.md
+++ b/components/802.15.4_RF/atmel-rf-driver/README.md
@@ -1,0 +1,7 @@
+# Example RF driver for Atmel 802.15.4 transceivers #
+
+Support for:
+ * AT86RF233
+ * AT86RF212B
+
+This driver is used with 6LoWPAN stack.

--- a/components/802.15.4_RF/atmel-rf-driver/apache-2.0.txt
+++ b/components/802.15.4_RF/atmel-rf-driver/apache-2.0.txt
@@ -1,0 +1,56 @@
+
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+    You must give any other recipients of the Work or Derivative Works a copy of this License; and
+    You must cause any modified files to carry prominent notices stating that You changed the files; and
+    You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+    If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -20,7 +20,7 @@
 #include "at24mac.h"
 #include "PinNames.h"
 
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 
 #include "NanostackRfPhy.h"
 

--- a/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NANOSTACK_RF_PHY_ATMEL_H_
+#define NANOSTACK_RF_PHY_ATMEL_H_
+
+#include "at24mac.h"
+#include "PinNames.h"
+
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+
+#include "NanostackRfPhy.h"
+
+// Arduino pin defaults for convenience
+#if !defined(ATMEL_SPI_MOSI)
+#define ATMEL_SPI_MOSI   D11
+#endif
+#if !defined(ATMEL_SPI_MISO)
+#define ATMEL_SPI_MISO   D12
+#endif
+#if !defined(ATMEL_SPI_SCLK)
+#define ATMEL_SPI_SCLK   D13
+#endif
+#if !defined(ATMEL_SPI_CS)
+#define ATMEL_SPI_CS     D10
+#endif
+#if !defined(ATMEL_SPI_RST)
+#define ATMEL_SPI_RST    D5
+#endif
+#if !defined(ATMEL_SPI_SLP)
+#define ATMEL_SPI_SLP    D7
+#endif
+#if !defined(ATMEL_SPI_IRQ)
+#define ATMEL_SPI_IRQ    D9
+#endif
+#if !defined(ATMEL_I2C_SDA)
+#define ATMEL_I2C_SDA    D14
+#endif
+#if !defined(ATMEL_I2C_SCL)
+#define ATMEL_I2C_SCL    D15
+#endif
+
+class RFBits;
+
+class NanostackRfPhyAtmel : public NanostackRfPhy {
+public:
+    NanostackRfPhyAtmel(PinName spi_mosi, PinName spi_miso,
+            PinName spi_sclk, PinName spi_cs,  PinName spi_rst, PinName spi_slp, PinName spi_irq,
+            PinName i2c_sda, PinName i2c_scl);
+    virtual ~NanostackRfPhyAtmel();
+    virtual int8_t rf_register();
+    virtual void rf_unregister();
+    virtual void get_mac_address(uint8_t *mac);
+    virtual void set_mac_address(uint8_t *mac);
+
+private:
+    AT24Mac _mac;
+    uint8_t _mac_addr[8];
+    RFBits *_rf;
+    bool _mac_set;
+
+    const PinName _spi_mosi;
+    const PinName _spi_miso;
+    const PinName _spi_sclk;
+    const PinName _spi_cs;
+    const PinName _spi_rst;
+    const PinName _spi_slp;
+    const PinName _spi_irq;
+};
+
+#endif /* MBED_CONF_NANOSTACK_CONFIGURATION */
+#endif /* NANOSTACK_RF_PHY_ATMEL_H_ */

--- a/components/802.15.4_RF/atmel-rf-driver/mbed_lib.json
+++ b/components/802.15.4_RF/atmel-rf-driver/mbed_lib.json
@@ -1,0 +1,34 @@
+{
+    "name": "atmel-rf",
+    "config": {
+        "full-spi-speed": {
+            "help": "Maximum SPI clock speed (Hz), as long as sufficient inter-byte spacing",
+            "value": 7500000
+        },
+        "full-spi-speed-byte-spacing": {
+            "help": "Required byte spacing in nanoseconds if full SPI speed is in use",
+            "value": 250
+        },
+        "low-spi-speed": {
+            "help": "Maximum SPI clock speed (Hz) if no inter-byte spacing",
+            "value": 3750000
+        },
+        "use-spi-spacing-api": {
+            "help": "Use SPI spacing API proposed in https://github.com/ARMmbed/mbed-os/pull/5353 to ensure spacing between bytes - either run at full speed with spacing, or low with no spacing",
+            "value": false
+        },
+        "assume-spaced-spi":  {
+            "help": "If not using SPI spacing API, assume platform has widely-spaced bytes in bursts, so use full clock speed rather than low.",
+            "value": false
+        },
+        "provide-default": {
+            "help": "Provide default NanostackRfpy. [true/false]",
+            "value": false
+        }
+    },
+    "target_overrides": {
+        "STM": {
+            "assume-spaced-spi": true
+        }
+    }
+}

--- a/components/802.15.4_RF/atmel-rf-driver/source/AT86RFReg.h
+++ b/components/802.15.4_RF/atmel-rf-driver/source/AT86RFReg.h
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef AT86RFREG_H_
+#define AT86RFREG_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*AT86RF212 PHY Modes*/
+#define BPSK_20                     0x00
+#define BPSK_40                     0x04
+#define BPSK_40_ALT                 0x14
+#define OQPSK_SIN_RC_100            0x08
+#define OQPSK_SIN_RC_200            0x09
+#define OQPSK_RC_100                0x18
+#define OQPSK_RC_200                0x19
+#define OQPSK_SIN_250               0x0c
+#define OQPSK_SIN_500               0x0d
+#define OQPSK_SIN_500_ALT           0x0f
+#define OQPSK_RC_250                0x1c
+#define OQPSK_RC_500                0x1d
+#define OQPSK_RC_500_ALT            0x1f
+#define OQPSK_SIN_RC_400_SCR_ON     0x2A
+#define OQPSK_SIN_RC_400_SCR_OFF    0x0A
+#define OQPSK_RC_400_SCR_ON         0x3A
+#define OQPSK_RC_400_SCR_OFF        0x1A
+#define OQPSK_SIN_1000_SCR_ON       0x2E
+#define OQPSK_SIN_1000_SCR_OFF      0x0E
+#define OQPSK_RC_1000_SCR_ON        0x3E
+#define OQPSK_RC_1000_SCR_OFF       0x1E
+
+/*Supported transceivers*/
+#define PART_AT86RF231              0x03
+#define PART_AT86RF212              0x07
+#define PART_AT86RF233              0x0B
+#define VERSION_AT86RF212           0x01
+#define VERSION_AT86RF212B          0x03
+
+/*RF Configuration Registers*/
+#define TRX_STATUS                  0x01
+#define TRX_STATE                   0x02
+#define TRX_CTRL_0                  0x03
+#define TRX_CTRL_1                  0x04
+#define PHY_TX_PWR                  0x05
+#define PHY_RSSI                    0x06
+#define PHY_ED_LEVEL                0x07
+#define PHY_CC_CCA                  0x08
+#define RX_CTRL                     0x0A
+#define SFD_VALUE                   0x0B
+#define TRX_CTRL_2                  0x0C
+#define ANT_DIV                     0x0D
+#define IRQ_MASK                    0x0E
+#define IRQ_STATUS                  0x0F
+#define VREG_CTRL                   0x10
+#define BATMON                      0x11
+#define XOSC_CTRL                   0x12
+#define CC_CTRL_0                   0x13
+#define CC_CTRL_1                   0x14
+#define RX_SYN                      0x15
+#define TRX_RPC                     0x16
+#define RF_CTRL_0                   0x16
+#define XAH_CTRL_1                  0x17
+#define FTN_CTRL                    0x18
+#define PLL_CF                      0x1A
+#define PLL_DCU                     0x1B
+#define PART_NUM                    0x1C
+#define VERSION_NUM                 0x1D
+#define MAN_ID_0                    0x1E
+#define MAN_ID_1                    0x1F
+#define SHORT_ADDR_0                0x20
+#define SHORT_ADDR_1                0x21
+#define PAN_ID_0                    0x22
+#define PAN_ID_1                    0x23
+#define IEEE_ADDR_0                 0x24
+#define IEEE_ADDR_1                 0x25
+#define IEEE_ADDR_2                 0x26
+#define IEEE_ADDR_3                 0x27
+#define IEEE_ADDR_4                 0x28
+#define IEEE_ADDR_5                 0x29
+#define IEEE_ADDR_6                 0x2A
+#define IEEE_ADDR_7                 0x2B
+#define XAH_CTRL_0                  0x2C
+#define CSMA_SEED_0                 0x2D
+#define CSMA_SEED_1                 0x2E
+#define CSMA_BE                     0x2F
+
+/* CSMA_SEED_1*/
+#define AACK_FVN_MODE1              7
+#define AACK_FVN_MODE0              6
+#define AACK_SET_PD                 5
+#define AACK_DIS_ACK                4
+#define AACK_I_AM_COORD             3
+#define CSMA_SEED_12                2
+#define CSMA_SEED_11                1
+#define CSMA_SEED_10                0
+
+/*TRX_STATUS bits*/
+#define CCA_STATUS                  0x40
+#define CCA_DONE                    0x80
+
+/*PHY_CC_CCA bits*/
+#define CCA_REQUEST                 0x80
+#define CCA_MODE_3A                 0x00
+#define CCA_MODE_1                  0x20
+#define CCA_MODE_2                  0x40
+#define CCA_MODE_3B                 0x60
+#define CCA_MODE_MASK               0x60
+#define CCA_CHANNEL_MASK            0x1F
+
+/*IRQ_MASK bits*/
+#define RX_START                    0x04
+#define TRX_END                     0x08
+#define CCA_ED_DONE                 0x10
+#define AMI                         0x20
+#define TRX_UR                      0x40
+
+/*ANT_DIV bits*/
+#define ANT_DIV_EN                  0x08
+#define ANT_EXT_SW_EN               0x04
+#define ANT_CTRL_DEFAULT            0x03
+
+/*TRX_CTRL_1 bits*/
+#define PA_EXT_EN                   0x80
+#define TX_AUTO_CRC_ON              0x20
+#define SPI_CMD_MODE_TRX_STATUS     0x04
+#define SPI_CMD_MODE_PHY_RSSI       0x08
+#define SPI_CMD_MODE_IRQ_STATUS     0x0C
+
+/*TRX_CTRL_2 bits*/
+#define RX_SAFE_MODE                0x80
+
+/*FTN_CTRL bits*/
+#define FTN_START                   0x80
+
+/*PHY_RSSI bits*/
+#define CRC_VALID                   0x80
+
+/*RX_SYN bits*/
+#define RX_PDT_DIS                  0x80
+
+/*TRX_RPC bits */
+#define RX_RPC_CTRL                 0xC0
+#define RX_RPC_EN                   0x20
+#define PDT_RPC_EN                  0x10
+#define PLL_RPC_EN                  0x08
+#define XAH_TX_RPC_EN               0x04
+#define IPAN_RPC_EN                 0x02
+#define TRX_RPC_RSVD_1              0x01
+
+/*XAH_CTRL_1 bits*/
+#define AACK_PROM_MODE              0x02
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* AT86RFREG_H_ */

--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -15,7 +15,7 @@
  */
 #include <string.h>
 
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 
 #include "platform/arm_hal_interrupt.h"
 #include "nanostack/platform/arm_hal_phy.h"

--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -321,6 +321,13 @@ __asm static void delay_loop(uint32_t count)
   BCS  %BT1
   BX   lr
 }
+#elif defined (__ARMCC_VERSION) /* ARMC6 */
+void delay_loop(uint32_t count)
+{
+    // TODO: This needs implementation
+    while(count--)
+        ;;
+}
 #elif defined (__ICCARM__)
 static void delay_loop(uint32_t count)
 {

--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -1,0 +1,2405 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <string.h>
+
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+
+#include "platform/arm_hal_interrupt.h"
+#include "nanostack/platform/arm_hal_phy.h"
+#include "ns_types.h"
+#include "NanostackRfPhyAtmel.h"
+#include "randLIB.h"
+#include "AT86RFReg.h"
+#include "nanostack/platform/arm_hal_phy.h"
+#include "mbed_trace.h"
+#include "mbed_toolchain.h"
+
+#define TRACE_GROUP "AtRF"
+
+/*Worst case sensitivity*/
+#define RF_DEFAULT_SENSITIVITY -88
+/*Run calibration every 5 minutes*/
+#define RF_CALIBRATION_INTERVAL 6000000
+/*Wait ACK for 2.5ms*/
+#define RF_ACK_WAIT_DEFAULT_TIMEOUT 50
+/*Base CCA backoff (50us units) - substitutes for Inter-Frame Spacing*/
+#define RF_CCA_BASE_BACKOFF 13 /* 650us */
+/*CCA random backoff (50us units)*/
+#define RF_CCA_RANDOM_BACKOFF 51 /* 2550us */
+
+#define RF_MTU 127
+
+#define RF_PHY_MODE OQPSK_SIN_250
+
+/*Radio RX and TX state definitions*/
+#define RFF_ON 0x01
+#define RFF_RX 0x02
+#define RFF_TX 0x04
+#define RFF_CCA 0x08
+
+typedef enum
+{
+    RF_MODE_NORMAL = 0,
+    RF_MODE_SNIFFER = 1,
+    RF_MODE_ED = 2
+}rf_mode_t;
+
+/*Atmel RF Part Type*/
+typedef enum
+{
+    ATMEL_UNKNOW_DEV = 0,
+    ATMEL_AT86RF212,
+    ATMEL_AT86RF231, // No longer supported (doesn't give ED+status on frame read)
+    ATMEL_AT86RF233
+}rf_trx_part_e;
+
+/*Atmel RF states*/
+typedef enum
+{
+    NOP = 0x00,
+    BUSY_RX = 0x01,
+    BUSY_TX = 0x02,
+    RF_TX_START = 0x02,
+    FORCE_TRX_OFF = 0x03,
+    FORCE_PLL_ON = 0x04,
+    RX_ON = 0x06,
+    TRX_OFF = 0x08,
+    PLL_ON = 0x09,
+    BUSY_RX_AACK = 0x11,
+    SLEEP = 0x0F,
+    RX_AACK_ON = 0x16,
+    TX_ARET_ON = 0x19,
+    STATE_TRANSITION_IN_PROGRESS = 0x1F
+}rf_trx_states_t;
+
+static const uint8_t *rf_tx_data; // Points to Nanostack's buffer
+static uint8_t rf_tx_length;
+/*ACK wait duration changes depending on data rate*/
+static uint16_t rf_ack_wait_duration = RF_ACK_WAIT_DEFAULT_TIMEOUT;
+
+static int8_t rf_sensitivity = RF_DEFAULT_SENSITIVITY;
+static rf_mode_t rf_mode = RF_MODE_NORMAL;
+static uint8_t radio_tx_power = 0x00;   // Default to +4dBm
+static uint8_t rf_phy_channel = 12;
+static uint8_t rf_tuned = 1;
+static uint8_t rf_use_antenna_diversity = 0;
+static int16_t expected_ack_sequence = -1;
+static uint8_t rf_rx_mode = 0;
+static uint8_t rf_flags = 0;
+static int8_t rf_radio_driver_id = -1;
+static phy_device_driver_s device_driver;
+static uint8_t mac_tx_handle = 0;
+static uint8_t xah_ctrl_1;
+
+/* Channel configurations for 2.4 and sub-GHz */
+static const phy_rf_channel_configuration_s phy_24ghz = {2405000000U, 5000000U, 250000U, 16U, M_OQPSK};
+static const phy_rf_channel_configuration_s phy_subghz = {868300000U, 2000000U, 250000U, 11U, M_OQPSK};
+
+static const phy_device_channel_page_s phy_channel_pages[] = {
+        { CHANNEL_PAGE_0, &phy_24ghz},
+        { CHANNEL_PAGE_2, &phy_subghz},
+        { CHANNEL_PAGE_0, NULL}
+};
+
+/**
+ *  RF output power write
+ *
+ * \brief TX power has to be set before network start.
+ *
+ * \param power
+ *              AT86RF233
+ *              0 = 4 dBm
+ *              1 = 3.7 dBm
+ *              2 = 3.4 dBm
+ *              3 = 3 dBm
+ *              4 = 2.5 dBm
+ *              5 = 2 dBm
+ *              6 = 1 dBm
+ *              7 = 0 dBm
+ *              8 = -1 dBm
+ *              9 = -2 dBm
+ *              10 = -3 dBm
+ *              11 = -4 dBm
+ *              12 = -6 dBm
+ *              13 = -8 dBm
+ *              14 = -12 dBm
+ *              15 = -17 dBm
+ *
+ *              AT86RF212B
+ *              See datasheet for TX power settings
+ *
+ * \return 0, Supported Value
+ * \return -1, Not Supported Value
+ */
+static rf_trx_part_e rf_radio_type_read(void);
+static void rf_ack_wait_timer_start(uint16_t slots);
+static void rf_handle_cca_ed_done(uint8_t full_trx_status);
+static void rf_handle_tx_end(rf_trx_states_t trx_status);
+static void rf_handle_rx_end(rf_trx_states_t trx_status);
+static void rf_on(void);
+static void rf_give_up_on_ack(void);
+static void rf_receive(rf_trx_states_t trx_status = STATE_TRANSITION_IN_PROGRESS);
+static rf_trx_states_t rf_poll_trx_state_change(rf_trx_states_t trx_state);
+static void rf_init(void);
+static int8_t rf_device_register(const uint8_t *mac_addr);
+static void rf_device_unregister(void);
+static int8_t rf_start_cca(uint8_t *data_ptr, uint16_t data_length, uint8_t tx_handle, data_protocol_e data_protocol );
+static void rf_cca_abort(void);
+static void rf_calibration_cb(void);
+static void rf_init_phy_mode(void);
+static void rf_ack_wait_timer_interrupt(void);
+static void rf_calibration_timer_interrupt(void);
+static void rf_calibration_timer_start(uint32_t slots);
+static void rf_cca_timer_interrupt(void);
+static void rf_cca_timer_start(uint32_t slots);
+static uint8_t rf_scale_lqi(int8_t rssi);
+
+static int8_t rf_interface_state_control(phy_interface_state_e new_state, uint8_t rf_channel);
+static int8_t rf_extension(phy_extension_type_e extension_type,uint8_t *data_ptr);
+static int8_t rf_address_write(phy_address_type_e address_type,uint8_t *address_ptr);
+
+static void rf_if_cca_timer_start(uint32_t slots);
+static void rf_if_enable_promiscuous_mode(void);
+static void rf_if_lock(void);
+static void rf_if_unlock(void);
+static uint8_t rf_if_read_rnd(void);
+static void rf_if_calibration_timer_start(uint32_t slots);
+static void rf_if_interrupt_handler(void);
+static void rf_if_ack_wait_timer_start(uint16_t slots);
+static void rf_if_ack_wait_timer_stop(void);
+static void rf_if_ack_pending_ctrl(uint8_t state);
+static void rf_if_calibration(void);
+static uint8_t rf_if_read_register(uint8_t addr);
+static void rf_if_set_bit(uint8_t addr, uint8_t bit, uint8_t bit_mask);
+static void rf_if_clear_bit(uint8_t addr, uint8_t bit);
+static void rf_if_write_register(uint8_t addr, uint8_t data);
+static void rf_if_reset_radio(void);
+static void rf_if_enable_ant_div(void);
+static void rf_if_disable_ant_div(void);
+static void rf_if_enable_slptr(void);
+static void rf_if_disable_slptr(void);
+static void rf_if_write_antenna_diversity_settings(void);
+static void rf_if_write_set_tx_power_register(uint8_t value);
+static void rf_if_write_rf_settings(void);
+static rf_trx_states_t rf_if_read_trx_state(void);
+static uint16_t rf_if_read_packet(uint8_t data[RF_MTU], uint8_t *lqi_out, uint8_t *ed_out, bool *crc_good);
+static void rf_if_write_short_addr_registers(uint8_t *short_address);
+static uint8_t rf_if_last_acked_pending(void);
+static void rf_if_write_pan_id_registers(uint8_t *pan_id);
+static void rf_if_write_ieee_addr_registers(uint8_t *address);
+static void rf_if_write_frame_buffer(const uint8_t *ptr, uint8_t length);
+static rf_trx_states_t rf_if_change_trx_state(rf_trx_states_t trx_state);
+static void rf_if_start_cca_process(void);
+static int8_t rf_if_scale_rssi(uint8_t ed_level);
+static void rf_if_set_channel_register(uint8_t channel);
+static void rf_if_enable_promiscuous_mode(void);
+static void rf_if_disable_promiscuous_mode(void);
+static uint8_t rf_if_read_part_num(void);
+static void rf_if_enable_irq(void);
+static void rf_if_disable_irq(void);
+static void rf_if_spi_exchange_n(const void *tx, size_t tx_len, void *rx, size_t rx_len);
+
+static inline rf_trx_states_t rf_if_trx_status_from_full(uint8_t full_trx_status)
+{
+    return (rf_trx_states_t) (full_trx_status & 0x1F);
+}
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "mbed.h"
+#include "rtos.h"
+
+static void rf_if_irq_task_process_irq();
+
+#define SIG_RADIO       1
+#define SIG_TIMER_ACK   2
+#define SIG_TIMER_CAL   4
+#define SIG_TIMER_CCA   8
+
+#define SIG_TIMERS (SIG_TIMER_ACK|SIG_TIMER_CAL|SIG_TIMER_CCA)
+#define SIG_ALL (SIG_RADIO|SIG_TIMERS)
+#endif
+
+// HW pins to RF chip
+
+class UnlockedSPI : public SPI {
+public:
+    UnlockedSPI(PinName mosi, PinName miso, PinName sclk) :
+        SPI(mosi, miso, sclk) { }
+    virtual void lock() { }
+    virtual void unlock() { }
+};
+
+class RFBits {
+public:
+    RFBits(PinName spi_mosi, PinName spi_miso,
+           PinName spi_sclk, PinName spi_cs,
+           PinName spi_rst, PinName spi_slp, PinName spi_irq);
+    UnlockedSPI spi;
+    DigitalOut CS;
+    DigitalOut RST;
+    DigitalOut SLP_TR;
+    InterruptIn IRQ;
+    Timeout ack_timer;
+    Timeout cal_timer;
+    Timeout cca_timer;
+#ifdef MBED_CONF_RTOS_PRESENT
+    Thread irq_thread;
+    Mutex mutex;
+    void rf_if_irq_task();
+#endif
+};
+
+RFBits::RFBits(PinName spi_mosi, PinName spi_miso,
+               PinName spi_sclk, PinName spi_cs,
+               PinName spi_rst, PinName spi_slp, PinName spi_irq)
+    :   spi(spi_mosi, spi_miso, spi_sclk),
+        CS(spi_cs),
+        RST(spi_rst),
+        SLP_TR(spi_slp),
+        IRQ(spi_irq)
+#ifdef MBED_CONF_RTOS_PRESENT
+,irq_thread(osPriorityRealtime, 1024)
+#endif
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+    irq_thread.start(mbed::callback(this, &RFBits::rf_if_irq_task));
+#endif
+}
+
+static RFBits *rf;
+static uint8_t rf_part_num = 0;
+/*TODO: RSSI Base value setting*/
+static int8_t rf_rssi_base_val = -91;
+
+static void rf_if_lock(void)
+{
+    platform_enter_critical();
+}
+
+static void rf_if_unlock(void)
+{
+    platform_exit_critical();
+}
+
+#ifdef MBED_CONF_RTOS_PRESENT
+static void rf_if_cca_timer_signal(void)
+{
+    rf->irq_thread.signal_set(SIG_TIMER_CCA);
+}
+
+static void rf_if_cal_timer_signal(void)
+{
+    rf->irq_thread.signal_set(SIG_TIMER_CAL);
+}
+
+static void rf_if_ack_timer_signal(void)
+{
+    rf->irq_thread.signal_set(SIG_TIMER_ACK);
+}
+#endif
+
+
+/* Delay functions for RF Chip SPI access */
+#ifdef __CC_ARM
+__asm static void delay_loop(uint32_t count)
+{
+1
+  SUBS a1, a1, #1
+  BCS  %BT1
+  BX   lr
+}
+#elif defined (__ICCARM__)
+static void delay_loop(uint32_t count)
+{
+  __asm volatile(
+    "loop: \n"
+    " SUBS %0, %0, #1 \n"
+    " BCS.n  loop\n"
+    : "+r" (count)
+    :
+    : "cc"
+  );
+}
+#else // GCC
+static void delay_loop(uint32_t count)
+{
+  __asm__ volatile (
+    "%=:\n\t"
+#if defined(__thumb__) && !defined(__thumb2__)
+    "SUB  %0, #1\n\t"
+#else
+    "SUBS %0, %0, #1\n\t"
+#endif
+    "BCS  %=b\n\t"
+    : "+l" (count)
+    :
+    : "cc"
+  );
+}
+#endif
+
+static void delay_ns(uint32_t ns)
+{
+  uint32_t cycles_per_us = SystemCoreClock / 1000000;
+  // Cortex-M0 takes 4 cycles per loop (SUB=1, BCS=3)
+  // Cortex-M3 and M4 takes 3 cycles per loop (SUB=1, BCS=2)
+  // Cortex-M7 - who knows?
+  // Cortex M3-M7 have "CYCCNT" - would be better than a software loop, but M0 doesn't
+  // Assume 3 cycles per loop for now - will be 33% slow on M0. No biggie,
+  // as original version of code was 300% slow on M4.
+  // [Note that this very calculation, plus call overhead, will take multiple
+  // cycles. Could well be 100ns on its own... So round down here, startup is
+  // worth at least one loop iteration.]
+  uint32_t count = (cycles_per_us * ns) / 3000;
+
+  delay_loop(count);
+}
+
+// t1 = 180ns, SEL falling edge to MISO active [SPI setup assumed slow enough to not need manual delay]
+#define CS_SELECT()  {rf->CS = 0; /* delay_ns(180); */}
+ // t9 = 250ns, last clock to SEL rising edge, t8 = 250ns, SPI idle time between consecutive access
+#define CS_RELEASE() {delay_ns(250); rf->CS = 1; delay_ns(250);}
+
+/*
+ * \brief Read connected radio part.
+ *
+ * This function only return valid information when rf_init() is called
+ *
+ * \return
+ */
+static rf_trx_part_e rf_radio_type_read(void)
+{
+  rf_trx_part_e ret_val = ATMEL_UNKNOW_DEV;
+
+  switch (rf_part_num)
+  {
+    case PART_AT86RF212:
+      ret_val = ATMEL_AT86RF212;
+      break;
+    case PART_AT86RF233:
+      ret_val = ATMEL_AT86RF233;
+      break;
+    default:
+      break;
+  }
+
+  return ret_val;
+}
+
+
+/*
+ * \brief Function starts the ACK wait timeout.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_if_ack_wait_timer_start(uint16_t slots)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+  rf->ack_timer.attach_us(rf_if_ack_timer_signal, slots*50);
+#else
+  rf->ack_timer.attach_us(rf_ack_wait_timer_interrupt, slots*50);
+#endif
+}
+
+/*
+ * \brief Function starts the calibration interval.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_if_calibration_timer_start(uint32_t slots)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+  rf->cal_timer.attach_us(rf_if_cal_timer_signal, slots*50);
+#else
+  rf->cal_timer.attach_us(rf_calibration_timer_interrupt, slots*50);
+#endif
+}
+
+/*
+ * \brief Function starts the CCA interval.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_if_cca_timer_start(uint32_t slots)
+{
+#ifdef MBED_CONF_RTOS_PRESENT
+  rf->cca_timer.attach_us(rf_if_cca_timer_signal, slots*50);
+#else
+  rf->cca_timer.attach_us(rf_cca_timer_interrupt, slots*50);
+#endif
+}
+
+/*
+ * \brief Function stops the CCA interval.
+ *
+ * \return none
+ */
+static void rf_if_cca_timer_stop(void)
+{
+  rf->cca_timer.detach();
+}
+
+/*
+ * \brief Function stops the ACK wait timeout.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_ack_wait_timer_stop(void)
+{
+  rf->ack_timer.detach();
+}
+
+/*
+ * \brief Function sets bit(s) in given RF register.
+ *
+ * \param addr Address of the register to set
+ * \param bit Bit(s) to set
+ * \param bit_mask Masks the field inside the register
+ *
+ * \return none
+ */
+static void rf_if_set_bit(uint8_t addr, uint8_t bit, uint8_t bit_mask)
+{
+  uint8_t reg = rf_if_read_register(addr);
+  reg &= ~bit_mask;
+  reg |= bit;
+  rf_if_write_register(addr, reg);
+}
+
+/*
+ * \brief Function clears bit(s) in given RF register.
+ *
+ * \param addr Address of the register to clear
+ * \param bit Bit(s) to clear
+ *
+ * \return none
+ */
+static void rf_if_clear_bit(uint8_t addr, uint8_t bit)
+{
+  rf_if_set_bit(addr, 0, bit);
+}
+
+/*
+ * \brief Function writes register in RF.
+ *
+ * \param addr Address on the RF
+ * \param data Written data
+ *
+ * \return none
+ */
+static void rf_if_write_register(uint8_t addr, uint8_t data)
+{
+  const uint8_t tx[2] = { static_cast<uint8_t>(0xC0 | addr), data };
+  uint8_t rx[2];
+  CS_SELECT();
+  rf_if_spi_exchange_n(tx, 2, rx, 2);
+  CS_RELEASE();
+}
+
+/*
+ * \brief Function reads RF register, and also outputs PHY_STATUS
+ *
+ * \param addr Address on the RF
+ * \param[out] status_out Pointer to store PHY_STATUS
+ *
+ * \return Read register data
+ */
+static uint8_t rf_if_read_register_with_status(uint8_t addr, uint8_t *status_out)
+{
+  const uint8_t tx[1] = { static_cast<uint8_t>(0x80 | addr) };
+  uint8_t rx[2];
+  CS_SELECT();
+  rf_if_spi_exchange_n(tx, 1, rx, 2);
+  CS_RELEASE();
+  if (status_out) {
+      *status_out = rx[0];
+  }
+  return rx[1];
+}
+
+/*
+ * \brief Function reads RF register.
+ *
+ * \param addr Address on the RF
+ *
+ * \return Read register data
+ */
+static uint8_t rf_if_read_register(uint8_t addr)
+{
+  return rf_if_read_register_with_status(addr, NULL);
+}
+
+/*
+ * \brief Function resets the RF.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_reset_radio(void)
+{
+#if MBED_CONF_ATMEL_RF_USE_SPI_SPACING_API
+  rf->spi.frequency(MBED_CONF_ATMEL_RF_FULL_SPI_SPEED);
+  int spacing = rf->spi.write_spacing(MBED_CONF_ATMEL_RF_FULL_SPI_SPEED_BYTE_SPACING);
+  if (spacing < MBED_CONF_ATMEL_RF_FULL_SPI_SPEED_BYTE_SPACING) {
+      rf->spi.frequency(MBED_CONF_ATMEL_RF_LOW_SPI_SPEED);
+      rf->spi.write_spacing(0);
+  }
+#elif MBED_CONF_ATMEL_RF_ASSUME_SPACED_SPI
+  rf->spi.frequency(MBED_CONF_ATMEL_RF_FULL_SPI_SPEED);
+#else
+  rf->spi.frequency(MBED_CONF_ATMEL_RF_LOW_SPI_SPEED);
+#endif
+  rf->IRQ.rise(0);
+  rf->RST = 1;
+  wait_ms(1);
+  rf->RST = 0;
+  wait_ms(10);
+  CS_RELEASE();
+  rf->SLP_TR = 0;
+  wait_ms(10);
+  rf->RST = 1;
+  wait_ms(10);
+
+  rf->IRQ.rise(&rf_if_interrupt_handler);
+}
+
+/*
+ * \brief Function enables the promiscuous mode.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_enable_promiscuous_mode(void)
+{
+  if (!(xah_ctrl_1 & AACK_PROM_MODE)) {
+    /*Set AACK_PROM_MODE to enable the promiscuous mode*/
+    rf_if_write_register(XAH_CTRL_1, xah_ctrl_1 |= AACK_PROM_MODE);
+  }
+}
+
+/*
+ * \brief Function disable the promiscuous mode.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_disable_promiscuous_mode(void)
+{
+  if (xah_ctrl_1 & AACK_PROM_MODE) {
+    /*Clear AACK_PROM_MODE to disable the promiscuous mode*/
+    rf_if_write_register(XAH_CTRL_1, xah_ctrl_1 &= ~AACK_PROM_MODE);
+  }
+}
+
+/*
+ * \brief Function enables the Antenna diversity usage.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_enable_ant_div(void)
+{
+  /*Set ANT_EXT_SW_EN to enable controlling of antenna diversity*/
+  rf_if_set_bit(ANT_DIV, ANT_EXT_SW_EN, ANT_EXT_SW_EN);
+}
+
+/*
+ * \brief Function disables the Antenna diversity usage.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_disable_ant_div(void)
+{
+  rf_if_clear_bit(ANT_DIV, ANT_EXT_SW_EN);
+}
+
+/*
+ * \brief Function sets the SLP TR pin.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_enable_slptr(void)
+{
+  rf->SLP_TR = 1;
+}
+
+/*
+ * \brief Function clears the SLP TR pin.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_disable_slptr(void)
+{
+  rf->SLP_TR = 0;
+}
+
+/*
+ * \brief Function writes the antenna diversity settings.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_write_antenna_diversity_settings(void)
+{
+  /*Recommended setting of PDT_THRES is 3 when antenna diversity is used*/
+  rf_if_set_bit(RX_CTRL, 0x03, 0x0f);
+  rf_if_write_register(ANT_DIV, ANT_DIV_EN | ANT_EXT_SW_EN | ANT_CTRL_DEFAULT);
+}
+
+/*
+ * \brief Function writes the TX output power register.
+ *
+ * \param value Given register value
+ *
+ * \return none
+ */
+static void rf_if_write_set_tx_power_register(uint8_t value)
+{
+  rf_if_write_register(PHY_TX_PWR, value);
+}
+
+/*
+ * \brief Function returns the RF part number.
+ *
+ * \param none
+ *
+ * \return part number
+ */
+static uint8_t rf_if_read_part_num(void)
+{
+  return rf_if_read_register(PART_NUM);
+}
+
+/*
+ * \brief Function writes the RF settings and initialises SPI interface.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_write_rf_settings(void)
+{
+  /*Reset RF module*/
+  rf_if_reset_radio();
+
+  rf_part_num = rf_if_read_part_num();
+
+  rf_if_write_register(XAH_CTRL_0,0);
+
+  /* Auto CRC on, IRQ status shows unmasked only, TRX_STATUS output on all accesses */
+  rf_if_write_register(TRX_CTRL_1, TX_AUTO_CRC_ON | SPI_CMD_MODE_TRX_STATUS);
+
+  rf_if_write_register(IRQ_MASK, CCA_ED_DONE | TRX_END | TRX_UR);
+
+  xah_ctrl_1 = rf_if_read_register(XAH_CTRL_1);
+
+  /*Read transceiver PART_NUM*/
+  rf_part_num = rf_if_read_register(PART_NUM);
+
+  /*Sub-GHz RF settings*/
+  if(rf_part_num == PART_AT86RF212)
+  {
+    /*GC_TX_OFFS mode-dependent setting - OQPSK*/
+    rf_if_write_register(RF_CTRL_0, 0x32);
+
+    if(rf_if_read_register(VERSION_NUM) == VERSION_AT86RF212B)
+    {
+      /*TX Output Power setting - 0 dBm North American Band*/
+      rf_if_write_register(PHY_TX_PWR, 0x03);
+    }
+    else
+    {
+      /*TX Output Power setting - 0 dBm North American Band*/
+      rf_if_write_register(PHY_TX_PWR, 0x24);
+    }
+
+    /*PHY Mode: IEEE 802.15.4-2006/2011 - OQPSK-SIN-250*/
+    rf_if_write_register(TRX_CTRL_2, RX_SAFE_MODE | RF_PHY_MODE);
+    /*Based on receiver Characteristics. See AT86RF212B Datasheet where RSSI BASE VALUE in range -97 - -100 dBm*/
+    rf_rssi_base_val = -98;
+  }
+  /*2.4GHz RF settings*/
+  else
+  {
+#if 0
+    /* Disable power saving functions for now - can only impact reliability,
+     * and don't have any users demanding it. */
+    /*Set RPC register*/
+    rf_if_write_register(TRX_RPC, RX_RPC_CTRL|RX_RPC_EN|PLL_RPC_EN|XAH_TX_RPC_EN|IPAN_RPC_EN|TRX_RPC_RSVD_1);
+#endif
+    /*PHY Mode: IEEE 802.15.4 - Data Rate 250 kb/s*/
+    rf_if_write_register(TRX_CTRL_2, RX_SAFE_MODE);
+    rf_rssi_base_val = -91;
+  }
+}
+
+/*
+ * \brief Function returns the RF state
+ *
+ * \param none
+ *
+ * \return RF state
+ */
+static rf_trx_states_t rf_if_read_trx_state(void)
+{
+  return rf_if_trx_status_from_full(rf_if_read_register(TRX_STATUS));
+}
+
+/*
+ * \brief Function reads packet buffer.
+ *
+ * \param data_out Output buffer
+ * \param lqi_out LQI output
+ * \param ed_out ED output
+ * \param crc_good CRC good indication
+ *
+ * \return PSDU length [0..RF_MTU]
+ */
+static uint16_t rf_if_read_packet(uint8_t data_out[RF_MTU], uint8_t *lqi_out, uint8_t *ed_out, bool *crc_good)
+{
+  CS_SELECT();
+  const uint8_t tx[1] = { 0x20 };
+  uint8_t rx[3];
+  rf_if_spi_exchange_n(tx, 1, rx, 2);
+  uint8_t len = rx[1] & 0x7F;
+  rf_if_spi_exchange_n(NULL, 0, data_out, len);
+  rf_if_spi_exchange_n(NULL, 0, rx, 3);
+  *lqi_out = rx[0];
+  *ed_out = rx[1];
+  *crc_good = rx[2] & 0x80;
+  CS_RELEASE();
+
+  return len;
+}
+
+/*
+ * \brief Function writes RF short address registers
+ *
+ * \param short_address Given short address
+ *
+ * \return none
+ */
+static void rf_if_write_short_addr_registers(uint8_t *short_address)
+{
+  rf_if_write_register(SHORT_ADDR_1, *short_address++);
+  rf_if_write_register(SHORT_ADDR_0, *short_address);
+}
+
+/*
+ * \brief Function sets the frame pending in ACK message
+ *
+ * \param state Given frame pending state
+ *
+ * \return none
+ */
+static void rf_if_ack_pending_ctrl(uint8_t state)
+{
+  rf_if_lock();
+  if(state)
+  {
+    rf_if_set_bit(CSMA_SEED_1, (1 << AACK_SET_PD), (1 << AACK_SET_PD));
+  }
+  else
+  {
+    rf_if_clear_bit(CSMA_SEED_1, (1 << AACK_SET_PD));
+  }
+  rf_if_unlock();
+}
+
+/*
+ * \brief Function returns the state of frame pending control
+ *
+ * \param none
+ *
+ * \return Frame pending state
+ */
+static uint8_t rf_if_last_acked_pending(void)
+{
+  uint8_t last_acked_data_pending;
+
+  rf_if_lock();
+  if(rf_if_read_register(CSMA_SEED_1) & (1 << AACK_SET_PD))
+    last_acked_data_pending = 1;
+  else
+    last_acked_data_pending = 0;
+  rf_if_unlock();
+
+  return last_acked_data_pending;
+}
+
+/*
+ * \brief Function calibrates the RF part.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_calibration(void)
+{
+  rf_if_set_bit(FTN_CTRL, FTN_START, FTN_START);
+  /*Wait while calibration is running*/
+  while(rf_if_read_register(FTN_CTRL) & FTN_START);
+}
+
+/*
+ * \brief Function writes RF PAN Id registers
+ *
+ * \param pan_id Given PAN Id
+ *
+ * \return none
+ */
+static void rf_if_write_pan_id_registers(uint8_t *pan_id)
+{
+  rf_if_write_register(PAN_ID_1, *pan_id++);
+  rf_if_write_register(PAN_ID_0, *pan_id);
+}
+
+/*
+ * \brief Function writes RF IEEE Address registers
+ *
+ * \param address Given IEEE Address
+ *
+ * \return none
+ */
+static void rf_if_write_ieee_addr_registers(uint8_t *address)
+{
+  uint8_t i;
+  uint8_t temp = IEEE_ADDR_0;
+
+  for(i=0; i<8; i++)
+    rf_if_write_register(temp++, address[7-i]);
+}
+
+/*
+ * \brief Function writes data in RF frame buffer.
+ *
+ * \param ptr Pointer to data (PSDU, except FCS)
+ * \param length Pointer to length (PSDU length, minus 2 for FCS)
+ *
+ * \return none
+ */
+static void rf_if_write_frame_buffer(const uint8_t *ptr, uint8_t length)
+{
+  const uint8_t cmd[2] = { 0x60, static_cast<uint8_t>(length + 2) };
+
+  CS_SELECT();
+  rf_if_spi_exchange_n(cmd, 2, NULL, 0);
+  rf_if_spi_exchange_n(ptr, length, NULL, 0);
+  CS_RELEASE();
+}
+
+/*
+ * \brief Function returns 8-bit random value.
+ *
+ * \param none
+ *
+ * \return random value
+ */
+static uint8_t rf_if_read_rnd(void)
+{
+  uint8_t temp;
+  uint8_t tmp_rpc_val = 0;
+  /*RPC must be disabled while reading the random number*/
+  if(rf_part_num == PART_AT86RF233)
+  {
+    tmp_rpc_val = rf_if_read_register(TRX_RPC);
+    rf_if_write_register(TRX_RPC, RX_RPC_CTRL|TRX_RPC_RSVD_1);
+  }
+
+  wait_ms(1);
+  temp = ((rf_if_read_register(PHY_RSSI)>>5) << 6);
+  wait_ms(1);
+  temp |= ((rf_if_read_register(PHY_RSSI)>>5) << 4);
+  wait_ms(1);
+  temp |= ((rf_if_read_register(PHY_RSSI)>>5) << 2);
+  wait_ms(1);
+  temp |= ((rf_if_read_register(PHY_RSSI)>>5));
+  wait_ms(1);
+  if(rf_part_num == PART_AT86RF233)
+    rf_if_write_register(TRX_RPC, tmp_rpc_val);
+  return temp;
+}
+
+/*
+ * \brief Function changes the state of the RF.
+ *
+ * \param trx_state Given RF state
+ *
+ * \return none
+ */
+static rf_trx_states_t rf_if_change_trx_state(rf_trx_states_t trx_state)
+{
+  rf_if_write_register(TRX_STATE, trx_state);
+  /*Wait while not in desired state*/
+  return rf_poll_trx_state_change(trx_state);
+}
+
+/*
+ * \brief Function starts the CCA process
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_start_cca_process(void)
+{
+  rf_if_write_register(PHY_CC_CCA, CCA_REQUEST | CCA_MODE_3A | rf_phy_channel);
+}
+
+/*
+ * \brief Function scales RSSI
+ *
+ * \param ed_level ED level read from chip
+ *
+ * \return appropriately scaled RSSI dBm
+ */
+static int8_t rf_if_scale_rssi(uint8_t ed_level)
+{
+  if (rf_part_num == PART_AT86RF212) {
+    /* Data sheet says to multiply by 1.03 - this is 1.03125, rounding down */
+    ed_level += ed_level >> 5;
+  }
+  return rf_rssi_base_val + ed_level;
+}
+
+/*
+ * \brief Function sets the RF channel field
+ *
+ * \param Given channel
+ *
+ * \return none
+ */
+static void rf_if_set_channel_register(uint8_t channel)
+{
+  rf_if_set_bit(PHY_CC_CCA, channel, CCA_CHANNEL_MASK);
+}
+
+/*
+ * \brief Function enables RF irq pin interrupts in RF interface.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_enable_irq(void)
+{
+  rf->IRQ.enable_irq();
+}
+
+/*
+ * \brief Function disables RF irq pin interrupts in RF interface.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_disable_irq(void)
+{
+  rf->IRQ.disable_irq();
+}
+
+#ifdef MBED_CONF_RTOS_PRESENT
+static void rf_if_interrupt_handler(void)
+{
+    rf->irq_thread.signal_set(SIG_RADIO);
+}
+
+// Started during construction of rf, so variable
+// rf isn't set at the start. Uses 'this' instead.
+void RFBits::rf_if_irq_task(void)
+{
+    for (;;) {
+        osEvent event = irq_thread.signal_wait(0);
+        if (event.status != osEventSignal) {
+            continue;
+        }
+        rf_if_lock();
+        if (event.value.signals & SIG_RADIO) {
+            rf_if_irq_task_process_irq();
+        }
+        if (event.value.signals & SIG_TIMER_ACK) {
+            rf_ack_wait_timer_interrupt();
+        }
+        if (event.value.signals & SIG_TIMER_CCA) {
+            rf_cca_timer_interrupt();
+        }
+        if (event.value.signals & SIG_TIMER_CAL) {
+            rf_calibration_timer_interrupt();
+        }
+        rf_if_unlock();
+    }
+}
+
+static void rf_if_irq_task_process_irq(void)
+#else
+/*
+ * \brief Function is a RF interrupt vector. End of frame in RX and TX are handled here as well as CCA process interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_if_interrupt_handler(void)
+#endif
+{
+  static uint8_t last_is, last_ts;
+  uint8_t irq_status, full_trx_status;
+  uint8_t orig_xah_ctrl_1 = xah_ctrl_1;
+
+  /*Read and clear interrupt flag, and pick up trx_status*/
+  irq_status = rf_if_read_register_with_status(IRQ_STATUS, &full_trx_status);
+  uint8_t orig_flags = rf_flags;
+
+  /*Frame end interrupt (RX and TX)*/
+  if(irq_status & TRX_END)
+  {
+    /*TX done interrupt*/
+    rf_trx_states_t trx_status = rf_if_trx_status_from_full(full_trx_status);
+    if(trx_status == PLL_ON || trx_status == TX_ARET_ON)
+    {
+      rf_handle_tx_end(trx_status);
+    }
+    /*Frame received interrupt*/
+    else
+    {
+      rf_handle_rx_end(trx_status);
+    }
+  }
+  if(irq_status & CCA_ED_DONE)
+  {
+    rf_handle_cca_ed_done(full_trx_status);
+  }
+  if (irq_status & TRX_UR)
+  {
+    tr_error("Radio underrun is %x->%x ts %x->%x fl %x->%x x1 %x", last_is, irq_status, last_ts, full_trx_status, orig_flags, rf_flags, orig_xah_ctrl_1);
+  }
+  last_is = irq_status;
+  last_ts = full_trx_status;
+}
+
+/*
+ * \brief Function writes/read data in SPI interface
+ */
+static void rf_if_spi_exchange_n(const void *tx, size_t tx_len, void *rx, size_t rx_len)
+{
+#if 1
+  rf->spi.write(static_cast<const char *>(tx), tx_len,
+                static_cast<char *>(rx), rx_len);
+#else
+  const uint8_t *txb = static_cast<const uint8_t *>(tx);
+  uint8_t *rxb = static_cast<uint8_t *>(rx);
+  while (tx_len > 0 || rx_len > 0) {
+      uint8_t b;
+      if (tx_len) {
+          tx_len--;
+          b = *txb++;
+      } else {
+          b = 0xFF;
+      }
+      b = rf->spi.write(b);
+      if (rx_len) {
+          rx_len--;
+          *rxb++ = b;
+      }
+  }
+#endif
+}
+
+/*
+ * \brief Function sets given RF flag on.
+ *
+ * \param x Given RF flag
+ *
+ * \return none
+ */
+static void rf_flags_set(uint8_t x)
+{
+    rf_flags |= x;
+}
+
+/*
+ * \brief Function clears given RF flag on.
+ *
+ * \param x Given RF flag
+ *
+ * \return none
+ */
+static void rf_flags_clear(uint8_t x)
+{
+    rf_flags &= ~x;
+}
+
+/*
+ * \brief Function checks if given RF flag is on.
+ *
+ * \param x Given RF flag
+ *
+ * \return states of the given flags
+ */
+static uint8_t rf_flags_check(uint8_t x)
+{
+    return (rf_flags & x);
+}
+
+/*
+ * \brief Function clears all RF flags.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_flags_reset(void)
+{
+    rf_flags = 0;
+}
+
+/*
+ * \brief Function initialises and registers the RF driver.
+ *
+ * \param none
+ *
+ * \return rf_radio_driver_id Driver ID given by NET library
+ */
+static int8_t rf_device_register(const uint8_t *mac_addr)
+{
+    rf_trx_part_e radio_type;
+
+    rf_init();
+
+    radio_type = rf_radio_type_read();
+    if(radio_type != ATMEL_UNKNOW_DEV)
+    {
+        /*Set pointer to MAC address*/
+        device_driver.PHY_MAC = (uint8_t *)mac_addr;
+        device_driver.driver_description = (char*)"ATMEL_MAC";
+        //Create setup Used Radio chips
+        if(radio_type == ATMEL_AT86RF212)
+        {
+            device_driver.link_type = PHY_LINK_15_4_SUBGHZ_TYPE;
+        }
+        else
+        {
+            device_driver.link_type = PHY_LINK_15_4_2_4GHZ_TYPE;
+        }
+        device_driver.phy_channel_pages = phy_channel_pages;
+        /*Maximum size of payload is 127*/
+        device_driver.phy_MTU = 127;
+        /*No header in PHY*/
+        device_driver.phy_header_length = 0;
+        /*No tail in PHY*/
+        device_driver.phy_tail_length = 0;
+        /*Set address write function*/
+        device_driver.address_write = &rf_address_write;
+        /*Set RF extension function*/
+        device_driver.extension = &rf_extension;
+        /*Set RF state control function*/
+        device_driver.state_control = &rf_interface_state_control;
+        /*Set transmit function*/
+        device_driver.tx = &rf_start_cca;
+        /*NULLIFY rx and tx_done callbacks*/
+        device_driver.phy_rx_cb = NULL;
+        device_driver.phy_tx_done_cb = NULL;
+        /*Register device driver*/
+        rf_radio_driver_id = arm_net_phy_register(&device_driver);
+    } else {
+        rf_if_disable_irq();
+    }
+    return rf_radio_driver_id;
+}
+
+/*
+ * \brief Function unregisters the RF driver.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_device_unregister()
+{
+    if (rf_radio_driver_id >= 0) {
+        arm_net_phy_unregister(rf_radio_driver_id);
+        rf_radio_driver_id = -1;
+    }
+}
+
+
+/*
+ * \brief Function is a call back for ACK wait timeout.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_ack_wait_timer_interrupt(void)
+{
+    rf_if_lock();
+    rf_give_up_on_ack();
+    rf_if_unlock();
+}
+
+/*
+ * \brief Function is a call back for calibration interval timer.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_calibration_timer_interrupt(void)
+{
+    /*Calibrate RF*/
+    rf_calibration_cb();
+    /*Start new calibration timeout*/
+    rf_calibration_timer_start(RF_CALIBRATION_INTERVAL);
+}
+
+/*
+ * \brief Function is a call back for cca interval timer.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_cca_timer_interrupt(void)
+{
+    rf_flags_set(RFF_CCA);
+    /*Start CCA process*/
+    rf_if_start_cca_process();
+}
+
+/*
+ * \brief Function starts the ACK wait timeout.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_ack_wait_timer_start(uint16_t slots)
+{
+    rf_if_ack_wait_timer_start(slots);
+}
+
+/*
+ * \brief Function starts the calibration interval.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_calibration_timer_start(uint32_t slots)
+{
+    rf_if_calibration_timer_start(slots);
+}
+
+/*
+ * \brief Function starts the CCA backoff.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_cca_timer_start(uint32_t slots)
+{
+    rf_if_cca_timer_start(slots);
+}
+
+/*
+ * \brief Function stops the CCA backoff.
+ *
+ * \return none
+ */
+static void rf_cca_timer_stop(void)
+{
+    rf_if_cca_timer_stop();
+}
+
+/*
+ * \brief Function writes various RF settings in startup.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_write_settings(void)
+{
+    rf_if_lock();
+    rf_if_write_rf_settings();
+    /*Set output power*/
+    rf_if_write_set_tx_power_register(radio_tx_power);
+    /*Initialise Antenna Diversity*/
+    if(rf_use_antenna_diversity)
+        rf_if_write_antenna_diversity_settings();
+    rf_if_unlock();
+}
+
+/*
+ * \brief Function writes 16-bit address in RF address filter.
+ *
+ * \param short_address Given short address
+ *
+ * \return none
+ */
+static void rf_set_short_adr(uint8_t * short_address)
+{
+    rf_if_lock();
+    /*Wake up RF if sleeping*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_disable_slptr();
+        rf_poll_trx_state_change(TRX_OFF);
+    }
+    /*Write address filter registers*/
+    rf_if_write_short_addr_registers(short_address);
+    /*RF back to sleep*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_enable_slptr();
+    }
+    rf_if_unlock();
+}
+
+/*
+ * \brief Function writes PAN Id in RF PAN Id filter.
+ *
+ * \param pan_id Given PAN Id
+ *
+ * \return none
+ */
+static void rf_set_pan_id(uint8_t *pan_id)
+{
+    rf_if_lock();
+    /*Wake up RF if sleeping*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_disable_slptr();
+        rf_poll_trx_state_change(TRX_OFF);
+    }
+    /*Write address filter registers*/
+    rf_if_write_pan_id_registers(pan_id);
+    /*RF back to sleep*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_enable_slptr();
+    }
+    rf_if_unlock();
+}
+
+/*
+ * \brief Function writes 64-bit address in RF address filter.
+ *
+ * \param address Given 64-bit address
+ *
+ * \return none
+ */
+static void rf_set_address(uint8_t *address)
+{
+    rf_if_lock();
+    /*Wake up RF if sleeping*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_disable_slptr();
+        rf_poll_trx_state_change(TRX_OFF);
+    }
+    /*Write address filter registers*/
+    rf_if_write_ieee_addr_registers(address);
+    /*RF back to sleep*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_enable_slptr();
+    }
+    rf_if_unlock();
+}
+
+/*
+ * \brief Function sets the RF channel.
+ *
+ * \param ch New channel
+ *
+ * \return none
+ */
+static void rf_channel_set(uint8_t ch)
+{
+    rf_if_lock();
+    rf_phy_channel = ch;
+    if(ch < 0x1f)
+        rf_if_set_channel_register(ch);
+    rf_if_unlock();
+}
+
+
+/*
+ * \brief Function initialises the radio driver and resets the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_init(void)
+{
+    rf_if_lock();
+
+    /*Write RF settings*/
+    rf_write_settings();
+    /*Initialise PHY mode*/
+    rf_init_phy_mode();
+    /*Clear RF flags*/
+    rf_flags_reset();
+    /*Set RF in TRX OFF state*/
+    rf_if_change_trx_state(TRX_OFF);
+    /*Set RF in PLL_ON state*/
+    rf_trx_states_t trx_status = rf_if_change_trx_state(PLL_ON);
+    /*Start receiver*/
+    rf_receive(trx_status);
+    /*Read randomness, and add to seed*/
+    randLIB_add_seed(rf_if_read_rnd());
+    /*Start RF calibration timer*/
+    rf_calibration_timer_start(RF_CALIBRATION_INTERVAL);
+
+    rf_if_unlock();
+}
+
+/**
+ * \brief Function gets called when MAC is setting radio off.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_off(void)
+{
+    if(rf_flags_check(RFF_ON))
+    {
+        rf_if_lock();
+        rf_cca_abort();
+        uint16_t while_counter = 0;
+        /*Wait while receiving*/
+        while(rf_if_read_trx_state() == BUSY_RX_AACK)
+        {
+            while_counter++;
+            if(while_counter == 0xffff)
+                break;
+        }
+        /*RF state change: RX_AACK_ON->PLL_ON->TRX_OFF->SLEEP*/
+        if(rf_if_read_trx_state() == RX_AACK_ON)
+        {
+            rf_if_change_trx_state(PLL_ON);
+        }
+        rf_if_change_trx_state(TRX_OFF);
+        rf_if_enable_slptr();
+
+        /*Disable Antenna Diversity*/
+        if(rf_use_antenna_diversity)
+            rf_if_disable_ant_div();
+        rf_if_unlock();
+    }
+
+    /*Clears all flags*/
+    rf_flags_reset();
+}
+
+/*
+ * \brief Function polls the RF state until it has changed to desired state.
+ *
+ * \param trx_state RF state
+ *
+ * \return none
+ */
+static rf_trx_states_t rf_poll_trx_state_change(rf_trx_states_t trx_state)
+{
+    uint16_t while_counter = 0;
+
+    if(trx_state == FORCE_PLL_ON)
+        trx_state = PLL_ON;
+    else if(trx_state == FORCE_TRX_OFF)
+        trx_state = TRX_OFF;
+
+    rf_trx_states_t state_out;
+    while((state_out = rf_if_read_trx_state()) != trx_state)
+    {
+        while_counter++;
+        if(while_counter == 0x1ff)
+            break;
+    }
+
+    return state_out;
+}
+
+/*
+ * \brief Function polls the RF state until it is no longer transitioning.
+ *
+ * \param trx_state RF state
+ *
+ * \return none
+ */
+static rf_trx_states_t rf_poll_for_state(void)
+{
+    rf_trx_states_t state_out;
+    while((state_out = rf_if_read_trx_state()) == STATE_TRANSITION_IN_PROGRESS)
+    {
+    }
+
+    return state_out;
+}
+
+/*
+ * \brief Function starts the CCA process before starting data transmission and copies the data to RF TX FIFO.
+ *
+ * \param data_ptr Pointer to TX data (excluding FCS)
+ * \param data_length Length of the TX data (excluding FCS)
+ * \param tx_handle Handle to transmission
+ * \return 0 Success
+ * \return -1 Busy
+ */
+static int8_t rf_start_cca(uint8_t *data_ptr, uint16_t data_length, uint8_t tx_handle, data_protocol_e data_protocol )
+{
+    (void)data_protocol;
+    rf_if_lock();
+    /*Check if transmitter is busy*/
+    rf_trx_states_t trx_state = rf_if_read_trx_state();
+    if(trx_state == BUSY_RX || trx_state == BUSY_RX_AACK || data_length > RF_MTU - 2)
+    {
+        rf_if_unlock();
+        /*Return busy*/
+        return -1;
+    }
+    else
+    {
+        rf_give_up_on_ack();
+
+        /*Nanostack has a static TX buffer, which will remain valid until we*/
+        /*generate a callback, so we just note the pointer for reading later.*/
+        rf_tx_data = data_ptr;
+        rf_tx_length = data_length;
+        /*Start CCA timeout*/
+        rf_cca_timer_start(RF_CCA_BASE_BACKOFF + randLIB_get_random_in_range(0, RF_CCA_RANDOM_BACKOFF));
+        /*Store TX handle*/
+        mac_tx_handle = tx_handle;
+        rf_if_unlock();
+    }
+
+    /*Return success*/
+    return 0;
+}
+
+/*
+ * \brief Function aborts CCA process.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_cca_abort(void)
+{
+    rf_cca_timer_stop();
+    rf_flags_clear(RFF_CCA);
+}
+
+/*
+ * \brief Function starts the transmission of the frame.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static bool rf_start_tx()
+{
+    /* Attempt change to PLL_ON */
+    rf_if_write_register(TRX_STATE, PLL_ON);
+
+    // It appears that if radio is busy, rather than ignoring the state change,
+    // the state change happens when it stops being busy - eg
+    // after address match fail or finishing reception. If this happens, we do
+    // not want to transmit - our channel clear check is stale (either someone is
+    // still transmitting, or it's a long time since we checked). So wait for the
+    // PLL_ON change and then go to receive mode without trying to transmit.
+    rf_trx_states_t state = rf_poll_for_state();
+    int poll_count = 0;
+    while (state != PLL_ON) {
+        /* Change didn't work (yet) - must be busy - assume it will eventually change */
+        state = rf_poll_for_state();
+        poll_count++;
+    }
+
+    rf_flags_clear(RFF_RX);
+    // Check whether we saw any delay in the PLL_ON transition.
+    if (poll_count > 0) {
+        tr_warning("PLL_ON delayed, retry count: %d", poll_count);
+        // let's get back to the receiving state.
+        rf_receive(state);
+        return false;
+    }
+
+    rf_flags_set(RFF_TX);
+    /*RF state change: SLP_TR pulse triggers PLL_ON->BUSY_TX*/
+    rf_if_enable_slptr();
+    /*Chip permits us to write frame buffer while it is transmitting*/
+    /*As long as first byte of data is in within 176us of TX start, we're good */
+    rf_if_write_frame_buffer(rf_tx_data, rf_tx_length);
+    rf_if_disable_slptr();
+    return true;
+}
+
+/*
+ * \brief Function sets the RF in RX state.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_receive(rf_trx_states_t trx_status)
+{
+    uint16_t while_counter = 0;
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_on();
+        rf_channel_set(rf_phy_channel);
+        trx_status = TRX_OFF;
+    }
+    /*If not yet in RX state set it*/
+    if(rf_flags_check(RFF_RX) == 0)
+    {
+        /*Wait while receiving data. Just making sure, usually this shouldn't happen. */
+        while(trx_status == BUSY_RX || trx_status == BUSY_RX_AACK || trx_status == STATE_TRANSITION_IN_PROGRESS)
+        {
+            while_counter++;
+            if(while_counter == 0xffff)
+            {
+                break;
+            }
+            trx_status = rf_if_read_trx_state();
+        }
+
+        if((rf_mode == RF_MODE_SNIFFER) || (rf_mode == RF_MODE_ED))
+        {
+            if (trx_status != RX_ON) {
+                trx_status = rf_if_change_trx_state(RX_ON);
+            }
+        }
+        else
+        {
+            /*ACK is always received in promiscuous mode to bypass address filters*/
+            if(rf_rx_mode)
+            {
+                rf_rx_mode = 0;
+                rf_if_enable_promiscuous_mode();
+            }
+            else
+            {
+                rf_if_disable_promiscuous_mode();
+            }
+            if (trx_status != RX_AACK_ON) {
+                trx_status = rf_if_change_trx_state(RX_AACK_ON);
+            }
+        }
+        /*If calibration timer was unable to calibrate the RF, run calibration now*/
+        if(!rf_tuned)
+        {
+            /*Start calibration. This can be done in states TRX_OFF, PLL_ON or in any receive state*/
+            rf_if_calibration();
+            /*RF is tuned now*/
+            rf_tuned = 1;
+        }
+
+        rf_flags_set(RFF_RX);
+    }
+}
+
+/*
+ * \brief Function calibrates the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_calibration_cb(void)
+{
+    /*clear tuned flag to start tuning in rf_receive*/
+    rf_tuned = 0;
+    /*If RF is in default receive state, start calibration*/
+    if(rf_if_read_trx_state() == RX_AACK_ON)
+    {
+        rf_if_lock();
+        /*Set RF in PLL_ON state*/
+        rf_if_change_trx_state(PLL_ON);
+        /*Set RF in TRX_OFF state to start PLL tuning*/
+        rf_if_change_trx_state(TRX_OFF);
+        /*Set RF in RX_ON state to calibrate*/
+        rf_trx_states_t trx_status = rf_if_change_trx_state(RX_ON);
+        /*Calibrate FTN*/
+        rf_if_calibration();
+        /*RF is tuned now*/
+        rf_tuned = 1;
+        /*Back to default receive state*/
+        rf_flags_clear(RFF_RX);
+        rf_receive(trx_status);
+        rf_if_unlock();
+    }
+}
+
+/*
+ * \brief Function sets RF_ON flag when radio is powered.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_on(void)
+{
+    /*Set RFF_ON flag*/
+    if(rf_flags_check(RFF_ON) == 0)
+    {
+        rf_if_lock();
+        rf_flags_set(RFF_ON);
+        /*Enable Antenna diversity*/
+        if(rf_use_antenna_diversity)
+            /*Set ANT_EXT_SW_EN to enable controlling of antenna diversity*/
+            rf_if_enable_ant_div();
+
+        /*Wake up from sleep state*/
+        rf_if_disable_slptr();
+        rf_poll_trx_state_change(TRX_OFF);
+        rf_if_unlock();
+    }
+}
+
+/*
+ * \brief Abandon waiting for an ack frame
+
+ * \return none
+ */
+static void rf_give_up_on_ack(void)
+{
+    if (expected_ack_sequence == -1) {
+        return;
+    }
+
+    rf_if_disable_promiscuous_mode();
+    rf_if_ack_wait_timer_stop();
+    expected_ack_sequence = -1;
+
+    if(device_driver.phy_tx_done_cb){
+        device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_FAIL, 0, 0);
+    }
+}
+
+/*
+ * \brief Function handles the received ACK frame.
+ *
+ * \param seq_number Sequence number of received ACK
+ * \param data_pending Pending bit state in received ACK
+ *
+ * \return none
+ */
+static void rf_handle_ack(uint8_t seq_number, uint8_t data_pending)
+{
+    phy_link_tx_status_e phy_status;
+    /*Received ACK sequence must be equal with transmitted packet sequence*/
+    if(expected_ack_sequence == seq_number)
+    {
+        rf_if_disable_promiscuous_mode();
+        rf_if_ack_wait_timer_stop();
+        expected_ack_sequence = -1;
+
+        /*When data pending bit in ACK frame is set, inform NET library*/
+        if(data_pending)
+            phy_status = PHY_LINK_TX_DONE_PENDING;
+        else
+            phy_status = PHY_LINK_TX_DONE;
+        /*Call PHY TX Done API*/
+        if(device_driver.phy_tx_done_cb){
+            device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle,phy_status, 0, 0);
+        }
+    } else {
+        rf_give_up_on_ack();
+    }
+}
+
+/*
+ * \brief Function is a call back for RX end interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_rx_end(rf_trx_states_t trx_status)
+{
+    /*Frame received interrupt*/
+    if(!rf_flags_check(RFF_RX)) {
+        return;
+    }
+
+    static uint8_t rf_buffer[RF_MTU];
+    uint8_t rf_lqi, rf_ed;
+    int8_t rf_rssi;
+    bool crc_good;
+
+    /*Read received packet*/
+    uint8_t len = rf_if_read_packet(rf_buffer, &rf_lqi, &rf_ed, &crc_good);
+
+    if (len < 5 || !crc_good) {
+        rf_give_up_on_ack();
+        return;
+    }
+
+    /* Convert raw ED to dBm value (chip-dependent) */
+    rf_rssi = rf_if_scale_rssi(rf_ed);
+
+    /* Create a virtual LQI using received RSSI, forgetting actual HW LQI */
+    /* (should be done through PHY_EXTENSION_CONVERT_SIGNAL_INFO) */
+    rf_lqi = rf_scale_lqi(rf_rssi);
+
+    /*Handle received ACK*/
+    if((rf_buffer[0] & 0x07) == 0x02 && rf_mode != RF_MODE_SNIFFER)
+    {
+        /*Check if data is pending*/
+        bool pending = (rf_buffer[0] & 0x10);
+
+        /*Send sequence number in ACK handler*/
+        rf_handle_ack(rf_buffer[2], pending);
+    } else {
+        rf_give_up_on_ack();
+        if( device_driver.phy_rx_cb ){
+            device_driver.phy_rx_cb(rf_buffer, len - 2, rf_lqi, rf_rssi, rf_radio_driver_id);
+        }
+    }
+}
+
+/*
+ * \brief Function is called when MAC is shutting down the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_shutdown(void)
+{
+    /*Call RF OFF*/
+    rf_off();
+}
+
+/*
+ * \brief Function is a call back for TX end interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_tx_end(rf_trx_states_t trx_status)
+{
+    rf_rx_mode = 0;
+    /*If ACK is needed for this transmission*/
+    if((rf_tx_data[0] & 0x20) && rf_flags_check(RFF_TX))
+    {
+        expected_ack_sequence = rf_tx_data[2];
+        rf_ack_wait_timer_start(rf_ack_wait_duration);
+        rf_rx_mode = 1;
+    }
+    rf_flags_clear(RFF_TX);
+    /*Start receiver*/
+    rf_receive(trx_status);
+
+    /*Call PHY TX Done API*/
+    if(device_driver.phy_tx_done_cb){
+        device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_SUCCESS, 0, 0);
+    }
+}
+
+/*
+ * \brief Function is a call back for CCA ED done interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_cca_ed_done(uint8_t full_trx_status)
+{
+    if (!rf_flags_check(RFF_CCA)) {
+        return;
+    }
+    rf_flags_clear(RFF_CCA);
+
+    bool success = false;
+
+    /*Check the result of CCA process*/
+    if((full_trx_status & CCA_STATUS) && rf_if_trx_status_from_full(full_trx_status) == RX_AACK_ON)
+    {
+        success = rf_start_tx();
+    }
+
+    if (!success)
+    {
+        /*Send CCA fail notification*/
+        if(device_driver.phy_tx_done_cb){
+            device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_CCA_FAIL, 0, 0);
+        }
+    }
+}
+
+/*
+ * \brief Function gives the control of RF states to MAC.
+ *
+ * \param new_state RF state
+ * \param rf_channel RF channel
+ *
+ * \return 0 Success
+ */
+static int8_t rf_interface_state_control(phy_interface_state_e new_state, uint8_t rf_channel)
+{
+    int8_t ret_val = 0;
+    switch (new_state)
+    {
+        /*Reset PHY driver and set to idle*/
+        case PHY_INTERFACE_RESET:
+            break;
+        /*Disable PHY Interface driver*/
+        case PHY_INTERFACE_DOWN:
+            rf_shutdown();
+            break;
+        /*Enable PHY Interface driver*/
+        case PHY_INTERFACE_UP:
+            rf_if_lock();
+            rf_mode = RF_MODE_NORMAL;
+            rf_channel_set(rf_channel);
+            rf_receive();
+            rf_if_enable_irq();
+            rf_if_unlock();
+            break;
+        /*Enable wireless interface ED scan mode*/
+        case PHY_INTERFACE_RX_ENERGY_STATE:
+            rf_mode = RF_MODE_ED;
+            rf_channel_set(rf_channel);
+            rf_receive();
+            rf_if_disable_irq();
+            // Read status to clear pending flags.
+            rf_if_read_register(IRQ_STATUS);
+            // ED can be initiated by writing arbitrary value to PHY_ED_LEVEL
+            rf_if_write_register(PHY_ED_LEVEL, 0xff);
+            break;
+        case PHY_INTERFACE_SNIFFER_STATE:             /**< Enable Sniffer state */
+            rf_mode = RF_MODE_SNIFFER;
+            rf_channel_set(rf_channel);
+            rf_flags_clear(RFF_RX);
+            rf_receive();
+            rf_if_enable_irq();
+            break;
+    }
+    return ret_val;
+}
+
+/*
+ * \brief Function controls the ACK pending, channel setting and energy detection.
+ *
+ * \param extension_type Type of control
+ * \param data_ptr Data from NET library
+ *
+ * \return 0 Success
+ */
+static int8_t rf_extension(phy_extension_type_e extension_type, uint8_t *data_ptr)
+{
+    switch (extension_type)
+    {
+        /*Control MAC pending bit for Indirect data transmission*/
+        case PHY_EXTENSION_CTRL_PENDING_BIT:
+            if(*data_ptr)
+            {
+                rf_if_ack_pending_ctrl(1);
+            }
+            else
+            {
+                rf_if_ack_pending_ctrl(0);
+            }
+            break;
+        /*Return frame pending status*/
+        case PHY_EXTENSION_READ_LAST_ACK_PENDING_STATUS:
+            *data_ptr = rf_if_last_acked_pending();
+            break;
+        /*Set channel*/
+        case PHY_EXTENSION_SET_CHANNEL:
+            break;
+        /*Read energy on the channel*/
+        case PHY_EXTENSION_READ_CHANNEL_ENERGY:
+            // End of the ED measurement is indicated by CCA_ED_DONE
+            while (!(rf_if_read_register(IRQ_STATUS) & CCA_ED_DONE));
+            // RF input power: RSSI base level + 1[db] * PHY_ED_LEVEL
+            *data_ptr = rf_sensitivity + rf_if_read_register(PHY_ED_LEVEL);
+            // Read status to clear pending flags.
+            rf_if_read_register(IRQ_STATUS);
+            // Next ED measurement is started, next PHY_EXTENSION_READ_CHANNEL_ENERGY call will return the result.
+            rf_if_write_register(PHY_ED_LEVEL, 0xff);
+            break;
+        /*Read status of the link*/
+        case PHY_EXTENSION_READ_LINK_STATUS:
+            break;
+        default:
+            break;
+    }
+    return 0;
+}
+
+/*
+ * \brief Function sets the addresses to RF address filters.
+ *
+ * \param address_type Type of address
+ * \param address_ptr Pointer to given address
+ *
+ * \return 0 Success
+ */
+static int8_t rf_address_write(phy_address_type_e address_type, uint8_t *address_ptr)
+{
+    int8_t ret_val = 0;
+    switch (address_type)
+    {
+        /*Set 48-bit address*/
+        case PHY_MAC_48BIT:
+            break;
+            /*Set 64-bit address*/
+        case PHY_MAC_64BIT:
+            rf_set_address(address_ptr);
+            break;
+        /*Set 16-bit address*/
+        case PHY_MAC_16BIT:
+            rf_set_short_adr(address_ptr);
+            break;
+        /*Set PAN Id*/
+        case PHY_MAC_PANID:
+            rf_set_pan_id(address_ptr);
+            break;
+    }
+    return ret_val;
+}
+
+/*
+ * \brief Function initialises the ACK wait time and returns the used PHY mode.
+ *
+ * \param none
+ *
+ * \return tmp Used PHY mode
+ */
+static void rf_init_phy_mode(void)
+{
+    uint8_t tmp = 0;
+    uint8_t part = rf_if_read_part_num();
+    /*Read used PHY Mode*/
+    tmp = rf_if_read_register(TRX_CTRL_2);
+    /*Set ACK wait time for used data rate*/
+    if(part == PART_AT86RF212)
+    {
+        if((tmp & 0x1f) == 0x00)
+        {
+            rf_sensitivity = -110;
+            rf_ack_wait_duration = 938;
+            tmp = BPSK_20;
+        }
+        else if((tmp & 0x1f) == 0x04)
+        {
+            rf_sensitivity = -108;
+            rf_ack_wait_duration = 469;
+            tmp = BPSK_40;
+        }
+        else if((tmp & 0x1f) == 0x14)
+        {
+            rf_sensitivity = -108;
+            rf_ack_wait_duration = 469;
+            tmp = BPSK_40_ALT;
+        }
+        else if((tmp & 0x1f) == 0x08)
+        {
+            rf_sensitivity = -101;
+            rf_ack_wait_duration = 50;
+            tmp = OQPSK_SIN_RC_100;
+        }
+        else if((tmp & 0x1f) == 0x09)
+        {
+            rf_sensitivity = -99;
+            rf_ack_wait_duration = 30;
+            tmp = OQPSK_SIN_RC_200;
+        }
+        else if((tmp & 0x1f) == 0x18)
+        {
+            rf_sensitivity = -102;
+            rf_ack_wait_duration = 50;
+            tmp = OQPSK_RC_100;
+        }
+        else if((tmp & 0x1f) == 0x19)
+        {
+            rf_sensitivity = -100;
+            rf_ack_wait_duration = 30;
+            tmp = OQPSK_RC_200;
+        }
+        else if((tmp & 0x1f) == 0x0c)
+        {
+            rf_sensitivity = -100;
+            rf_ack_wait_duration = 20;
+            tmp = OQPSK_SIN_250;
+        }
+        else if((tmp & 0x1f) == 0x0d)
+        {
+            rf_sensitivity = -98;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_SIN_500;
+        }
+        else if((tmp & 0x1f) == 0x0f)
+        {
+            rf_sensitivity = -98;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_SIN_500_ALT;
+        }
+        else if((tmp & 0x1f) == 0x1c)
+        {
+            rf_sensitivity = -101;
+            rf_ack_wait_duration = 20;
+            tmp = OQPSK_RC_250;
+        }
+        else if((tmp & 0x1f) == 0x1d)
+        {
+            rf_sensitivity = -99;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_RC_500;
+        }
+        else if((tmp & 0x1f) == 0x1f)
+        {
+            rf_sensitivity = -99;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_RC_500_ALT;
+        }
+        else if((tmp & 0x3f) == 0x2A)
+        {
+            rf_sensitivity = -91;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_SIN_RC_400_SCR_ON;
+        }
+        else if((tmp & 0x3f) == 0x0A)
+        {
+            rf_sensitivity = -91;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_SIN_RC_400_SCR_OFF;
+        }
+        else if((tmp & 0x3f) == 0x3A)
+        {
+            rf_sensitivity = -97;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_RC_400_SCR_ON;
+        }
+        else if((tmp & 0x3f) == 0x1A)
+        {
+            rf_sensitivity = -97;
+            rf_ack_wait_duration = 25;
+            tmp = OQPSK_RC_400_SCR_OFF;
+        }
+        else if((tmp & 0x3f) == 0x2E)
+        {
+            rf_sensitivity = -93;
+            rf_ack_wait_duration = 13;
+            tmp = OQPSK_SIN_1000_SCR_ON;
+        }
+        else if((tmp & 0x3f) == 0x0E)
+        {
+            rf_sensitivity = -93;
+            rf_ack_wait_duration = 13;
+            tmp = OQPSK_SIN_1000_SCR_OFF;
+        }
+        else if((tmp & 0x3f) == 0x3E)
+        {
+            rf_sensitivity = -95;
+            rf_ack_wait_duration = 13;
+            tmp = OQPSK_RC_1000_SCR_ON;
+        }
+        else if((tmp & 0x3f) == 0x1E)
+        {
+            rf_sensitivity = -95;
+            rf_ack_wait_duration = 13;
+            tmp = OQPSK_RC_1000_SCR_OFF;
+        }
+    }
+    else
+    {
+        rf_sensitivity = -101;
+        rf_ack_wait_duration = 20;
+    }
+    /*Board design might reduces the sensitivity*/
+    //rf_sensitivity += RF_SENSITIVITY_CALIBRATION;
+}
+
+
+static uint8_t rf_scale_lqi(int8_t rssi)
+{
+    uint8_t scaled_lqi;
+
+    /*rssi < RF sensitivity*/
+    if(rssi < rf_sensitivity)
+        scaled_lqi=0;
+    /*-91 dBm < rssi < -81 dBm (AT86RF233 XPro)*/
+    /*-90 dBm < rssi < -80 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 10))
+        scaled_lqi=31;
+    /*-81 dBm < rssi < -71 dBm (AT86RF233 XPro)*/
+    /*-80 dBm < rssi < -70 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 20))
+        scaled_lqi=207;
+    /*-71 dBm < rssi < -61 dBm (AT86RF233 XPro)*/
+    /*-70 dBm < rssi < -60 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 30))
+        scaled_lqi=255;
+    /*-61 dBm < rssi < -51 dBm (AT86RF233 XPro)*/
+    /*-60 dBm < rssi < -50 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 40))
+        scaled_lqi=255;
+    /*-51 dBm < rssi < -41 dBm (AT86RF233 XPro)*/
+    /*-50 dBm < rssi < -40 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 50))
+        scaled_lqi=255;
+    /*-41 dBm < rssi < -31 dBm (AT86RF233 XPro)*/
+    /*-40 dBm < rssi < -30 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 60))
+        scaled_lqi=255;
+    /*-31 dBm < rssi < -21 dBm (AT86RF233 XPro)*/
+    /*-30 dBm < rssi < -20 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 70))
+        scaled_lqi=255;
+    /*rssi > RF saturation*/
+    else if(rssi > (rf_sensitivity + 80))
+        scaled_lqi=111;
+    /*-21 dBm < rssi < -11 dBm (AT86RF233 XPro)*/
+    /*-20 dBm < rssi < -10 dBm (AT86RF212B XPro)*/
+    else
+        scaled_lqi=255;
+
+    return scaled_lqi;
+}
+
+NanostackRfPhyAtmel::NanostackRfPhyAtmel(PinName spi_mosi, PinName spi_miso,
+        PinName spi_sclk, PinName spi_cs,  PinName spi_rst, PinName spi_slp, PinName spi_irq,
+        PinName i2c_sda, PinName i2c_scl)
+    : _mac(i2c_sda, i2c_scl), _mac_addr(), _rf(NULL), _mac_set(false),
+      _spi_mosi(spi_mosi), _spi_miso(spi_miso), _spi_sclk(spi_sclk),
+      _spi_cs(spi_cs), _spi_rst(spi_rst), _spi_slp(spi_slp), _spi_irq(spi_irq)
+{
+    _rf = new RFBits(_spi_mosi, _spi_miso, _spi_sclk, _spi_cs, _spi_rst, _spi_slp, _spi_irq);
+}
+
+NanostackRfPhyAtmel::~NanostackRfPhyAtmel()
+{
+    delete _rf;
+}
+
+int8_t NanostackRfPhyAtmel::rf_register()
+{
+    if (NULL == _rf) {
+        return -1;
+    }
+
+    rf_if_lock();
+
+    if (rf != NULL) {
+        rf_if_unlock();
+        error("Multiple registrations of NanostackRfPhyAtmel not supported");
+        return -1;
+    }
+
+    // Read the mac address if it hasn't been set by a user
+    rf = _rf;
+    if (!_mac_set) {
+        int ret = _mac.read_eui64((void*)_mac_addr);
+        if (ret < 0) {
+            rf = NULL;
+            rf_if_unlock();
+            return -1;
+        }
+    }
+
+    int8_t radio_id = rf_device_register(_mac_addr);
+    if (radio_id < 0) {
+        rf = NULL;
+    }
+
+    rf_if_unlock();
+    return radio_id;
+}
+
+void NanostackRfPhyAtmel::rf_unregister()
+{
+    rf_if_lock();
+
+    if (NULL == rf) {
+        rf_if_unlock();
+        return;
+    }
+
+    rf_device_unregister();
+    rf = NULL;
+
+    rf_if_unlock();
+}
+
+void NanostackRfPhyAtmel::get_mac_address(uint8_t *mac)
+{
+    rf_if_lock();
+
+    if (NULL == rf) {
+        error("NanostackRfPhyAtmel Must be registered to read mac address");
+        rf_if_unlock();
+        return;
+    }
+    memcpy((void*)mac, (void*)_mac_addr, sizeof(_mac_addr));
+
+    rf_if_unlock();
+}
+
+void NanostackRfPhyAtmel::set_mac_address(uint8_t *mac)
+{
+    rf_if_lock();
+
+    if (NULL != rf) {
+        error("NanostackRfPhyAtmel cannot change mac address when running");
+        rf_if_unlock();
+        return;
+    }
+    memcpy((void*)_mac_addr, (void*)mac, sizeof(_mac_addr));
+    _mac_set = true;
+
+    rf_if_unlock();
+}
+
+#if MBED_CONF_ATMEL_RF_PROVIDE_DEFAULT
+
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+  static NanostackRfPhyAtmel rf_phy(ATMEL_SPI_MOSI, ATMEL_SPI_MISO, ATMEL_SPI_SCLK, ATMEL_SPI_CS,
+                           ATMEL_SPI_RST, ATMEL_SPI_SLP, ATMEL_SPI_IRQ, ATMEL_I2C_SDA, ATMEL_I2C_SCL);
+  return rf_phy;
+}
+
+#endif // MBED_CONF_ATMEL_RF_PROVIDE_DEFAULT
+
+#endif // MBED_CONF_NANOSTACK_CONFIGURATION

--- a/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2016-2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "at24mac.h"
+
+/* Device addressing */
+#define AT24MAC_EEPROM_ADDRESS		(0x0A<<4)
+#define AT24MAC_RW_PROTECT_ADDRESS	(0x06<<4)
+#define AT24MAC_SERIAL_ADDRESS		(0x0B<<4)
+
+/* Known memory blocks */
+#define AT24MAC_SERIAL_OFFSET	(0x80)
+#define AT24MAC_EUI64_OFFSET	(0x98)
+#define AT24MAC_EUI48_OFFSET	(0x9A)
+
+#define SERIAL_LEN 16
+#define EUI64_LEN 8
+#define EUI48_LEN 6
+
+AT24Mac::I2CReset::I2CReset(PinName sda, PinName scl)
+{
+    mbed::DigitalInOut SDA(sda, PIN_OUTPUT, PullUp, 1);
+    mbed::DigitalInOut SCL(scl, PIN_OUTPUT, PullUp, 0);
+    //generate 9 clocks for worst-case scenario
+    for (int i = 0; i < 10; ++i) {
+        SCL = 1;
+        wait_us(5);
+        SCL = 0;
+        wait_us(5);
+    }
+    //generate a STOP condition
+    SDA = 0;
+    wait_us(5);
+    SCL = 1;
+    wait_us(5);
+    SDA = 1;
+    wait_us(5);
+}
+
+/*I2C needs to be reset before constructing the I2C object (in case I2C is stuck)
+  because they use the same pins, therefore i2c_reset has to be before _i2c
+  in the initializer list*/
+AT24Mac::AT24Mac(PinName sda, PinName scl) : i2c_reset(sda, scl), _i2c(sda, scl)
+{
+    // Do nothing
+}
+
+int AT24Mac::read_serial(void *buf)
+{
+    char offset = AT24MAC_SERIAL_OFFSET;
+    if (_i2c.write(AT24MAC_SERIAL_ADDRESS, &offset, 1, true))
+        return -1; //No ACK
+    return _i2c.read(AT24MAC_SERIAL_ADDRESS, (char*)buf, SERIAL_LEN);
+}
+
+int AT24Mac::read_eui64(void *buf)
+{
+    char offset = AT24MAC_EUI64_OFFSET;
+    if (_i2c.write(AT24MAC_SERIAL_ADDRESS, &offset, 1, true))
+        return -1; //No ACK
+    return _i2c.read(AT24MAC_SERIAL_ADDRESS, (char*)buf, EUI64_LEN);
+}
+
+int AT24Mac::read_eui48(void *buf)
+{
+    char offset = AT24MAC_EUI48_OFFSET;
+    if (_i2c.write(AT24MAC_SERIAL_ADDRESS, &offset, 1, true))
+        return -1; //No ACK
+    return _i2c.read(AT24MAC_SERIAL_ADDRESS, (char*)buf, EUI48_LEN);
+}

--- a/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
@@ -31,21 +31,21 @@
 
 AT24Mac::I2CReset::I2CReset(PinName sda, PinName scl)
 {
-    mbed::DigitalInOut SDA(sda, PIN_OUTPUT, PullUp, 1);
-    mbed::DigitalInOut SCL(scl, PIN_OUTPUT, PullUp, 0);
+    mbed::DigitalInOut pin_sda(sda, PIN_OUTPUT, PullUp, 1);
+    mbed::DigitalInOut pin_scl(scl, PIN_OUTPUT, PullUp, 0);
     //generate 9 clocks for worst-case scenario
     for (int i = 0; i < 10; ++i) {
-        SCL = 1;
+        pin_scl = 1;
         wait_us(5);
-        SCL = 0;
+        pin_scl = 0;
         wait_us(5);
     }
     //generate a STOP condition
-    SDA = 0;
+    pin_sda = 0;
     wait_us(5);
-    SCL = 1;
+    pin_scl = 1;
     wait_us(5);
-    SDA = 1;
+    pin_sda = 1;
     wait_us(5);
 }
 

--- a/components/802.15.4_RF/atmel-rf-driver/source/at24mac.h
+++ b/components/802.15.4_RF/atmel-rf-driver/source/at24mac.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef AT24MAC_H
+#define AT24MAC_H
+
+#include "PinNames.h"
+#include "I2C.h"
+#include "drivers/DigitalInOut.h"
+#include "platform/mbed_wait_api.h"
+
+/*
+ * AT24MAC drivers.
+ *
+ * This is a EEPROM chip designed to contain factory programmed read-only EUI-64 or EUI-48,
+ * a 128bit serial number and some user programmable EEPROM.
+ *
+ * AT24MAC602 contains EUI-64, use read_eui64()
+ * AT24MAC402 contains EUI-64, use read_eui48()
+ *
+ * NOTE: You cannot use both EUI-64 and EUI-48. Chip contains only one of those.
+ */
+
+class AT24Mac {
+public:
+    AT24Mac(PinName sda, PinName scl);
+
+    /**
+     * Read unique serial number from chip.
+     * \param buf pointer to write serial number to. Must have space for 16 bytes.
+     * \return zero on success, negative number on failure
+     */
+    int read_serial(void *buf);
+
+    /**
+     * Read EUI-64 from chip.
+     * \param buf pointer to write EUI-64 to. Must have space for 8 bytes.
+     * \return zero on success, negative number on failure
+     */
+    int read_eui64(void *buf);
+
+    /**
+     * Read EUI-48 from chip.
+     * \param buf pointer to write EUI-48 to. Must have space for 6 bytes.
+     * \return zero on success, negative number on failure
+     */
+    int read_eui48(void *buf);
+
+private:
+    /*
+     * Dummy class to allow us to reset I2C before the I2C constructor is called in
+     * the initializer list of AT24Mac's constructor
+     */
+    class I2CReset {
+    public:
+        I2CReset(PinName sda, PinName scl);
+    };
+    I2CReset i2c_reset;
+    mbed::I2C _i2c;
+};
+
+#endif /* AT24MAC_H */

--- a/components/802.15.4_RF/mcr20a-rf-driver/.gitignore
+++ b/components/802.15.4_RF/mcr20a-rf-driver/.gitignore
@@ -1,6 +1,0 @@
-*~
-*.swo
-*.swp
-build
-yotta_modules
-yotta_targets

--- a/components/802.15.4_RF/mcr20a-rf-driver/.gitignore
+++ b/components/802.15.4_RF/mcr20a-rf-driver/.gitignore
@@ -1,0 +1,6 @@
+*~
+*.swo
+*.swp
+build
+yotta_modules
+yotta_targets

--- a/components/802.15.4_RF/mcr20a-rf-driver/LICENSE
+++ b/components/802.15.4_RF/mcr20a-rf-driver/LICENSE
@@ -1,0 +1,2 @@
+Unless specifically indicated otherwise in a file, files are licensed
+under the Apache 2.0 license, as can be found in: apache-2.0.txt

--- a/components/802.15.4_RF/mcr20a-rf-driver/README.md
+++ b/components/802.15.4_RF/mcr20a-rf-driver/README.md
@@ -1,0 +1,6 @@
+# Example RF driver for Freescale 802.15.4 transceivers #
+
+Support for:
+ * MCR20A
+
+This driver is used with 6LoWPAN stack.

--- a/components/802.15.4_RF/mcr20a-rf-driver/apache-2.0.txt
+++ b/components/802.15.4_RF/mcr20a-rf-driver/apache-2.0.txt
@@ -1,0 +1,56 @@
+
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+    You must give any other recipients of the Work or Derivative Works a copy of this License; and
+    You must cause any modified files to carry prominent notices stating that You changed the files; and
+    You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+    If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/components/802.15.4_RF/mcr20a-rf-driver/mbed_lib.json
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mbed_lib.json
@@ -1,0 +1,9 @@
+{
+    "name": "mcr20a",
+    "config": {
+        "provide-default": {
+            "help": "Provide default NanostackRfpy. [true/false]",
+            "value": false
+        }
+    }
+}

--- a/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -19,7 +19,7 @@
 
 #include "mbed.h"
 
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 
 #include "NanostackRfPhy.h"
 

--- a/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NANOSTACK_PHY_MCR20A_H_
+#define NANOSTACK_PHY_MCR20A_H_
+
+#include "mbed.h"
+
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+
+#include "NanostackRfPhy.h"
+
+// Arduino pin defaults for convenience
+#if !defined(MCR20A_SPI_MOSI)
+#define MCR20A_SPI_MOSI   D11
+#endif
+#if !defined(MCR20A_SPI_MISO)
+#define MCR20A_SPI_MISO   D12
+#endif
+#if !defined(MCR20A_SPI_SCLK)
+#define MCR20A_SPI_SCLK   D13
+#endif
+#if !defined(MCR20A_SPI_CS)
+#define MCR20A_SPI_CS     D10
+#endif
+#if !defined(MCR20A_SPI_RST)
+#define MCR20A_SPI_RST    D5
+#endif
+#if !defined(MCR20A_SPI_IRQ)
+#define MCR20A_SPI_IRQ    D2
+#endif
+
+class NanostackRfPhyMcr20a : public NanostackRfPhy {
+public:
+    NanostackRfPhyMcr20a(PinName spi_mosi, PinName spi_miso,
+                         PinName spi_sclk, PinName spi_cs,  PinName spi_rst,
+                         PinName spi_irq);
+    virtual ~NanostackRfPhyMcr20a();
+    virtual int8_t rf_register();
+    virtual void rf_unregister();
+    virtual void get_mac_address(uint8_t *mac);
+    virtual void set_mac_address(uint8_t *mac);
+
+private:
+    SPI _spi;
+    DigitalOut _rf_cs;
+    DigitalOut _rf_rst;
+    InterruptIn _rf_irq;
+    DigitalIn _rf_irq_pin;
+    Thread _irq_thread;
+
+    void _pins_set();
+    void _pins_clear();
+};
+
+#endif /* MBED_CONF_NANOSTACK_CONFIGURATION */
+#endif /* NANOSTACK_PHY_MCR20A_H_ */

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
@@ -42,7 +42,7 @@
 #include "MCR20Reg.h"
 #include "XcvrSpi.h"
 
-#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 
 #include "platform/arm_hal_interrupt.h"
 

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
@@ -1,0 +1,683 @@
+/*!
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* \file MCR20Drv.c
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+
+/*****************************************************************************
+*                               INCLUDED HEADERS                            *
+*---------------------------------------------------------------------------*
+* Add to this section all the headers that this module needs to include.    *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+
+#include "MCR20Drv.h"
+#include "MCR20Reg.h"
+#include "XcvrSpi.h"
+
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+
+#include "platform/arm_hal_interrupt.h"
+
+/*****************************************************************************
+*                               PRIVATE VARIABLES                           *
+*---------------------------------------------------------------------------*
+* Add to this section all the variables and constants that have local       *
+* (file) scope.                                                             *
+* Each of this declarations shall be preceded by the 'static' keyword.      *
+* These variables / constants cannot be accessed outside this module.       *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+uint32_t mPhyIrqDisableCnt = 1;
+
+/*****************************************************************************
+*                               PUBLIC VARIABLES                            *
+*---------------------------------------------------------------------------*
+* Add to this section all the variables and constants that have global      *
+* (project) scope.                                                          *
+* These variables / constants can be accessed outside this module.          *
+* These variables / constants shall be preceded by the 'extern' keyword in  *
+* the interface header.                                                     *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+
+/*****************************************************************************
+*                           PRIVATE FUNCTIONS PROTOTYPES                    *
+*---------------------------------------------------------------------------*
+* Add to this section all the functions prototypes that have local (file)   *
+* scope.                                                                    *
+* These functions cannot be accessed outside this module.                   *
+* These declarations shall be preceded by the 'static' keyword.             *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+
+/*****************************************************************************
+*                                PRIVATE FUNCTIONS                          *
+*---------------------------------------------------------------------------*
+* Add to this section all the functions that have local (file) scope.       *
+* These functions cannot be accessed outside this module.                   *
+* These definitions shall be preceded by the 'static' keyword.              *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+
+
+/*****************************************************************************
+*                             PUBLIC FUNCTIONS                              *
+*---------------------------------------------------------------------------*
+* Add to this section all the functions that have global (project) scope.   *
+* These functions can be accessed outside this module.                      *
+* These functions shall have their declarations (prototypes) within the     *
+* interface header file and shall be preceded by the 'extern' keyword.      *
+*---------------------------------------------------------------------------*
+*****************************************************************************/
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_Init
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_Init
+(
+void
+)
+{
+    xcvr_spi_init(gXcvrSpiInstance_c);
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrDeassertCS_d();
+    #if !defined(TARGET_KW24D)
+      MCR20Drv_RST_B_Deassert();
+    #endif
+    RF_IRQ_Init();
+    RF_IRQ_Disable();
+    mPhyIrqDisableCnt = 1;
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_DirectAccessSPIWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_DirectAccessSPIWrite
+(
+uint8_t address,
+uint8_t value
+)
+{
+    uint16_t txData;
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData = (address & TransceiverSPI_DirectRegisterAddressMask);
+    txData |= value << 8;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t *)&txData, 0, sizeof(txData));
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_DirectAccessSPIMultiByteWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_DirectAccessSPIMultiByteWrite
+(
+uint8_t startAddress,
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint8_t txData;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData = (startAddress & TransceiverSPI_DirectRegisterAddressMask);
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, &txData, 0, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, byteArray, 0, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_PB_SPIByteWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_PB_SPIByteWrite
+(
+uint8_t address,
+uint8_t value
+)
+{
+    uint32_t txData;
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData  = TransceiverSPI_WriteSelect            |
+        TransceiverSPI_PacketBuffAccessSelect |
+            TransceiverSPI_PacketBuffByteModeSelect;
+    txData |= (address) << 8;
+    txData |= (value)   << 16;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)&txData, 0, 3);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_PB_SPIBurstWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_PB_SPIBurstWrite
+(
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint8_t txData;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData = TransceiverSPI_WriteSelect            |
+        TransceiverSPI_PacketBuffAccessSelect |
+            TransceiverSPI_PacketBuffBurstModeSelect;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, &txData, 0, 1);
+    xcvr_spi_transfer(gXcvrSpiInstance_c, byteArray, 0, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_DirectAccessSPIRead
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+
+uint8_t MCR20Drv_DirectAccessSPIRead
+(
+uint8_t address
+)
+{
+    uint8_t txData;
+    uint8_t rxData;
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrAssertCS_d();
+
+    txData = (address & TransceiverSPI_DirectRegisterAddressMask) |
+        TransceiverSPI_ReadSelect;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, &txData, 0, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, 0, &rxData, sizeof(rxData));
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+
+    return rxData;
+
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_DirectAccessSPIMultyByteRead
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_DirectAccessSPIMultiByteRead
+(
+uint8_t startAddress,
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint8_t  txData;
+    uint8_t  phyIRQSTS1;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return 0;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrAssertCS_d();
+
+    txData = (startAddress & TransceiverSPI_DirectRegisterAddressMask) |
+        TransceiverSPI_ReadSelect;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, &txData, &phyIRQSTS1, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, 0, byteArray, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+
+    return phyIRQSTS1;
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_PB_SPIBurstRead
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_PB_SPIBurstRead
+(
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint8_t  txData;
+    uint8_t  phyIRQSTS1;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return 0;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrAssertCS_d();
+
+    txData = TransceiverSPI_ReadSelect |
+        TransceiverSPI_PacketBuffAccessSelect |
+            TransceiverSPI_PacketBuffBurstModeSelect;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, &txData, &phyIRQSTS1, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, 0, byteArray, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+
+    return phyIRQSTS1;
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IndirectAccessSPIWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIWrite
+(
+uint8_t address,
+uint8_t value
+)
+{
+    uint32_t  txData;
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData = TransceiverSPI_IARIndexReg;
+    txData |= (address) << 8;
+    txData |= (value)   << 16;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)&txData, 0, 3);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IndirectAccessSPIMultiByteWrite
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIMultiByteWrite
+(
+uint8_t startAddress,
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint16_t  txData;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 16000000);
+
+    gXcvrAssertCS_d();
+
+    txData = TransceiverSPI_IARIndexReg;
+    txData |= (startAddress)  << 8;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)&txData, 0, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)byteArray, 0, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IndirectAccessSPIRead
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_IndirectAccessSPIRead
+(
+uint8_t address
+)
+{
+    uint16_t  txData;
+    uint8_t   rxData;
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrAssertCS_d();
+
+    txData = TransceiverSPI_IARIndexReg | TransceiverSPI_ReadSelect;
+    txData |= (address) << 8;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)&txData, 0, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, 0, &rxData, sizeof(rxData));
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+
+    return rxData;
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IndirectAccessSPIMultiByteRead
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIMultiByteRead
+(
+uint8_t startAddress,
+uint8_t * byteArray,
+uint8_t numOfBytes
+)
+{
+    uint16_t  txData;
+
+    if( (numOfBytes == 0) || (byteArray == 0) )
+    {
+        return;
+    }
+
+    ProtectFromMCR20Interrupt();
+
+    xcvr_spi_configure_speed(gXcvrSpiInstance_c, 8000000);
+
+    gXcvrAssertCS_d();
+
+    txData = (TransceiverSPI_IARIndexReg | TransceiverSPI_ReadSelect);
+    txData |= (startAddress) << 8;
+
+    xcvr_spi_transfer(gXcvrSpiInstance_c, (uint8_t*)&txData, 0, sizeof(txData));
+    xcvr_spi_transfer(gXcvrSpiInstance_c, 0, byteArray, numOfBytes);
+
+    gXcvrDeassertCS_d();
+    UnprotectFromMCR20Interrupt();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IsIrqPending
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+uint32_t  MCR20Drv_IsIrqPending
+(
+void
+)
+{
+    return RF_isIRQ_Pending();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IRQ_Disable
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_IRQ_Disable
+(
+void
+)
+{
+    platform_enter_critical();
+
+    if( mPhyIrqDisableCnt == 0 )
+    {
+        RF_IRQ_Disable();
+    }
+
+    mPhyIrqDisableCnt++;
+
+    platform_exit_critical();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_IRQ_Enable
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_IRQ_Enable
+(
+void
+)
+{
+    platform_enter_critical();
+
+    if( mPhyIrqDisableCnt )
+    {
+        mPhyIrqDisableCnt--;
+
+        if( mPhyIrqDisableCnt == 0 )
+        {
+            RF_IRQ_Enable();
+        }
+    }
+
+    platform_exit_critical();
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_RST_Assert
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_RST_B_Assert
+(
+void
+)
+{
+    RF_RST_Set(0);
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_RST_Deassert
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_RST_B_Deassert
+(
+void
+)
+{
+    RF_RST_Set(1);
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_SoftRST_Assert
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_SoftRST_Assert
+(
+void
+)
+{
+    MCR20Drv_IndirectAccessSPIWrite(SOFT_RESET, (0x80));
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_SoftRST_Deassert
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_SoftRST_Deassert
+(
+void
+)
+{
+    MCR20Drv_IndirectAccessSPIWrite(SOFT_RESET, (0x00));
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_Soft_RESET
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_Soft_RESET
+(
+void
+)
+{
+    //assert SOG_RST
+    MCR20Drv_IndirectAccessSPIWrite(SOFT_RESET, (0x80));
+
+    //deassert SOG_RST
+    MCR20Drv_IndirectAccessSPIWrite(SOFT_RESET, (0x00));
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_RESET
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_RESET
+(
+void
+)
+{
+  #if !defined(TARGET_KW24D)
+    volatile uint32_t delay = 1000;
+    //assert RST_B
+    MCR20Drv_RST_B_Assert();
+
+    while(delay--);
+
+    //deassert RST_B
+    MCR20Drv_RST_B_Deassert();
+  #endif
+}
+
+/*---------------------------------------------------------------------------
+* Name: MCR20Drv_Set_CLK_OUT_Freq
+* Description: -
+* Parameters: -
+* Return: -
+*---------------------------------------------------------------------------*/
+void MCR20Drv_Set_CLK_OUT_Freq
+(
+uint8_t freqDiv
+)
+{
+    uint8_t clkOutCtrlReg = (freqDiv & cCLK_OUT_DIV_Mask) | cCLK_OUT_EN | cCLK_OUT_EXTEND;
+
+    if(freqDiv == gCLK_OUT_FREQ_DISABLE)
+    {
+        clkOutCtrlReg = (cCLK_OUT_EXTEND | gCLK_OUT_FREQ_4_MHz); //reset value with clock out disabled
+    }
+
+    MCR20Drv_DirectAccessSPIWrite((uint8_t) CLK_OUT_CTRL, clkOutCtrlReg);
+}
+
+#endif /* MBED_CONF_NANOSTACK_CONFIGURATION */

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.h
@@ -1,0 +1,373 @@
+/*!
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* \file MCR20Drv.h
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __MCR20_DRV_H__
+#define __MCR20_DRV_H__
+
+#include <stdint.h>
+
+/*****************************************************************************
+ *                               INCLUDED HEADERS                            *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the headers that this module needs to include.    *
+ * Note that it is not a good practice to include header files into header   *
+ * files, so use this section only if there is no other better solution.     *
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+
+/*****************************************************************************
+ *                             PRIVATE MACROS                                *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the access macros, registers mappings, bit access *
+ * macros, masks, flags etc ...
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+
+/* Disable XCVR clock output by default, to reduce power consumption */
+#ifndef gMCR20_ClkOutFreq_d 
+#define gMCR20_ClkOutFreq_d gCLK_OUT_FREQ_DISABLE
+#endif
+
+/*****************************************************************************
+ *                            PUBLIC FUNCTIONS                               *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the global functions prototype preceded (as a     *
+ * good practice) by the keyword 'extern'                                    *
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_Init
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+extern void MCR20Drv_Init
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_SPI_DMA_Init
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_SPI_DMA_Init
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_Start_PB_DMA_SPI_Write
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_Start_PB_DMA_SPI_Write
+(
+  uint8_t * srcAddress,
+  uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_Start_PB_DMA_SPI_Read
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_Start_PB_DMA_SPI_Read
+(
+  uint8_t * dstAddress,
+  uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_DirectAccessSPIWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_DirectAccessSPIWrite
+(
+ uint8_t address,
+ uint8_t value
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_DirectAccessSPIMultiByteWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_DirectAccessSPIMultiByteWrite
+(
+ uint8_t startAddress,
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_PB_SPIBurstWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_PB_SPIBurstWrite
+(
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_DirectAccessSPIRead
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_DirectAccessSPIRead
+(
+ uint8_t address
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_DirectAccessSPIMultyByteRead
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+
+uint8_t MCR20Drv_DirectAccessSPIMultiByteRead
+(
+ uint8_t startAddress,
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_PB_SPIByteWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_PB_SPIByteWrite
+(
+ uint8_t address,
+ uint8_t value
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_PB_SPIBurstRead
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_PB_SPIBurstRead
+(
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IndirectAccessSPIWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIWrite
+(
+ uint8_t address,
+ uint8_t value
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IndirectAccessSPIMultiByteWrite
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIMultiByteWrite
+(
+ uint8_t startAddress,
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IndirectAccessSPIRead
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+uint8_t MCR20Drv_IndirectAccessSPIRead
+(
+ uint8_t address
+);
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IndirectAccessSPIMultiByteRead
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_IndirectAccessSPIMultiByteRead
+(
+ uint8_t startAddress,
+ uint8_t * byteArray,
+ uint8_t numOfBytes
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IsIrqPending
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+uint32_t MCR20Drv_IsIrqPending
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IRQ_Disable
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_IRQ_Disable
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_IRQ_Enable
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_IRQ_Enable
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_RST_PortConfig
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_RST_B_PortConfig
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_RST_Assert
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_RST_B_Assert
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_RST_Deassert
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_RST_B_Deassert
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_SoftRST_Assert
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_SoftRST_Assert
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_SoftRST_Deassert
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_SoftRST_Deassert
+(
+  void
+);
+
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_RESET
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_RESET
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_Soft_RESET
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_Soft_RESET
+(
+  void
+);
+
+/*---------------------------------------------------------------------------
+ * Name: MCR20Drv_Set_CLK_OUT_Freq
+ * Description: -
+ * Parameters: -
+ * Return: -
+ *---------------------------------------------------------------------------*/
+void MCR20Drv_Set_CLK_OUT_Freq
+(
+  uint8_t freqDiv
+);
+
+#define ProtectFromMCR20Interrupt()   MCR20Drv_IRQ_Disable()
+#define UnprotectFromMCR20Interrupt() MCR20Drv_IRQ_Enable()
+
+#endif /* __MCR20_DRV_H__ */

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Overwrites.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Overwrites.h
@@ -1,0 +1,309 @@
+/*!
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* \file MCR20Overwrites.h
+* Description: Overwrites header file for MCR20 Register values
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef OVERWRITES_H_
+#define OVERWRITES_H_
+
+typedef struct overwrites_tag {
+ char address;
+ char data;
+}overwrites_t;
+
+
+/*****************************************************************************************************************/
+//         This file is created exclusively for use with the transceiver 2.0 silicon
+//         and is provided for the world to use. It contains a list of all
+//         known overwrite values. Overwrite values are non-default register
+//         values that configure the transceiver device to a more optimally performing
+//         posture. It is expected that low level software (i.e. PHY) will
+//         consume this file as a #include, and transfer the contents to the
+//         the indicated addresses in the transceiver's memory space. This file has
+//         at least one required entry, that being its own version current version
+//         number, to be stored at transceiver's location 0x3B the
+//         OVERWRITES_VERSION_NUMBER register. The RAM register is provided in
+//         the transceiver address space to assist in future debug efforts. The
+//         analyst may read this location (once device has been booted with
+//         mysterious software) and have a good indication of what register
+//         overwrites were performed (with all versions of the overwrites.h file
+//         being archived forever at the Compass location shown above.
+//
+//     The transceiver has an indirect register (IAR) space. Write access to this space
+//         requires 3 or more writes:
+//         1st) the first write is an index value to the indirect (write Bit7=0, register access Bit 6=0) + 0x3E
+//         2nd) IAR Register #0x00 - 0xFF.
+//     3rd) The data to write
+//         nth) Burst mode additional data if required.
+//
+//     Write access to direct space requires only a single address, data pair.
+
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x0C}, //version 0C: new value for ACKDELAY targeting 198us (23 May, 2013, Larry Roshak)
+{0x23, 0x17}  //PA_PWR new default Power Step is "23"  
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}, //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}, //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}, //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}, //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}, //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}, //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}, //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}, //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}, //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}, //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}, //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}, //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}, //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28}, //PA_CAL_DIS=1  Disabled PA calibration 
+{0x52, 0x55}, //AGC_THR1 RSSI tune up 
+{0x53, 0x2D}, //AGC_THR2 RSSI tune up 
+{0x66, 0x5F}, //ATT_RSSI1 tune up     
+{0x67, 0x8F}, //ATT_RSSI2 tune up     
+{0x68, 0x61}, //RSSI_OFFSET 
+{0x78, 0x03}, //CHF_PMAGAIN 
+{0x22, 0x50}, //CCA1_THRESH 
+{0x4D, 0x13}, //CORR_NVAL moved from 0x14 to 0x13 for 0.5 dB improved Rx Sensitivity 
+{0x39, 0x3D}  //ACKDELAY new value targeting a delay of 198us (23 May, 2013, Larry Roshak)
+};
+
+
+/* begin of deprecated versions
+
+==VERSION 1==
+(version 1 is empty)
+
+==VERSION 2==
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}  //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+};
+
+==VERSION 3==
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1: override VCOALC_REF_TX to 3 
+{0x92, 0x07}  //VCO_CTRL2: override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+};
+
+==VERSION 4==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x04}  //version 04 is the current version: update PA_COILTUNING default 
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1: override VCOALC_REF_TX to 3 
+{0x92, 0x07}  //VCO_CTRL2: override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}  //PA_TUNING: override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+};
+
+==VERSION 5==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x05}  //version 05: updates Channel Filter Register set (21 Dec 2012, on behalf of S. Soca)
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}  //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}  //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}  //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}  //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}  //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}  //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}  //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}  //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}  //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}  //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}  //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}  //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}  //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+};
+
+==VERSION 6==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x06}  //version 06: disable PA calibration 
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}  //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}  //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}  //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}  //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}  //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}  //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}  //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}  //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}  //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}  //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}  //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}  //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}  //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28}  //PA_CAL_DIS=1  Disabled PA calibration 
+};
+
+==VERSION 7==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x07}  //version 07: updated registers for ED/RSSI 
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07},  //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71},  //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F},  //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F},  //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24},  //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24},  //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24},  //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24},  //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24},  //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24},  //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}, //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D},  //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D},  //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28},  //PA_CAL_DIS=1  Disabled PA calibration 
+{0x52, 0x73},  //AGC_THR1 RSSI tune up 
+{0x53, 0x2D}, //AGC_THR2 RSSI tune up 
+{0x66, 0x5F}, //ATT_RSSI1 tune up 
+{0x67, 0x8F}, //ATT_RSSI2 tune up 
+{0x68, 0x60}, //RSSI_OFFSET 
+{0x69, 0x65}  //RSSI_SLOPE 
+};
+
+
+==VERSION 8==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x08}  //version 08: updated registers for ED/RSSI 
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}, //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}, //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}, //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}, //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}, //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}, //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}, //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}, //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}, //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}, //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}, //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}, //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}, //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28}, //PA_CAL_DIS=1  Disabled PA calibration 
+{0x52, 0x73}, //AGC_THR1 RSSI tune up 
+{0x53, 0x2D}, //AGC_THR2 RSSI tune up 
+{0x66, 0x5F}, //ATT_RSSI1 tune up     
+{0x67, 0x8F}, //ATT_RSSI2 tune up     
+{0x69, 0x65}  //RSSI_SLOPE            
+{0x68, 0x61}, //RSSI_OFFSET 
+{0x78, 0x03}  //CHF_PMAGAIN 
+};
+
+
+==VERSION 9==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x09}  //version 09: updated registers for ED/RSSI and PowerStep 
+{0x23, 0x17}  //PA_PWR new default value                                
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}, //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}, //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}, //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}, //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}, //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}, //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}, //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}, //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}, //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}, //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}, //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}, //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}, //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28}, //PA_CAL_DIS=1  Disabled PA calibration 
+{0x52, 0x55}, //AGC_THR1 RSSI tune up 
+{0x53, 0x2D}, //AGC_THR2 RSSI tune up 
+{0x66, 0x5F}, //ATT_RSSI1 tune up     
+{0x67, 0x8F}, //ATT_RSSI2 tune up     
+{0x68, 0x61}, //RSSI_OFFSET 
+{0x78, 0x03}  //CHF_PMAGAIN 
+};
+
+==VERSION A==
+overwrites_t const overwrites_direct[] ={
+{0x3B, 0x0A}  //version 0A: updated registers for CCA 
+{0x23, 0x17}  //PA_PWR new default Power Step is "23"  
+};
+
+overwrites_t const overwrites_indirect[] ={
+{0x31, 0x02}, //clear MISO_HIZ_EN (for single SPI master/slave pair) and SPI_PUL_EN (minimize HIB currents) 
+{0x91, 0xB3}, //VCO_CTRL1 override VCOALC_REF_TX to 3                         
+{0x92, 0x07}, //VCO_CTRL2 override VCOALC_REF_RX to 3, keep VCO_BUF_BOOST = 1 
+{0x8A, 0x71}, //PA_TUNING override PA_COILTUNING to 001 (27 Nov 2012, D. Brown, on behalf of S. Eid)
+{0x79, 0x2F}, //CHF_IBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7A, 0x2F}, //CHF_QBUF  Adjust the gm-C filter gain (+/- 6dB)         (21 Dec, 2012, on behalf of S. Soca)
+{0x7B, 0x24}, //CHF_IRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7C, 0x24}, //CHF_QRIN  Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7D, 0x24}, //CHF_IL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7E, 0x24}, //CHF_QL    Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x7F, 0x32}, //CHF_CC1   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x80, 0x1D}, //CHF_CCL   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x81, 0x2D}, //CHF_CC2   Adjust the filter center frequency (+/- 1MHz) (21 Dec, 2012, on behalf of S. Soca)
+{0x82, 0x24}, //CHF_IROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x83, 0x24}, //CHF_QROUT Adjust the filter bandwidth (+/- 0.5MHz)      (21 Dec, 2012, on behalf of S. Soca)
+{0x64, 0x28}, //PA_CAL_DIS=1  Disabled PA calibration 
+{0x52, 0x55}, //AGC_THR1 RSSI tune up 
+{0x53, 0x2D}, //AGC_THR2 RSSI tune up 
+{0x66, 0x5F}, //ATT_RSSI1 tune up     
+{0x67, 0x8F}, //ATT_RSSI2 tune up     
+{0x68, 0x61}, //RSSI_OFFSET 
+{0x78, 0x03}  //CHF_PMAGAIN 
+{0x22, 0x50}  //CCA1_THRESH 
+};
+
+end of deprecated versions */
+
+
+#endif  //OVERWRITES_H_
+

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Reg.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Reg.h
@@ -1,0 +1,730 @@
+/*!
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* \file MCR20reg.h
+* MCR20 Registers
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __MCR20_REG_H__
+#define __MCR20_REG_H__
+/*****************************************************************************
+ *                               INCLUDED HEADERS                            *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the headers that this module needs to include.    *
+ * Note that it is not a good practice to include header files into header   *
+ * files, so use this section only if there is no other better solution.     *
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+
+/****************************************************************************/
+/* Transceiver SPI Registers */
+/****************************************************************************/
+
+#define TransceiverSPI_IARIndexReg                  (0x3E)
+
+#define TransceiverSPI_ReadSelect                   (1<<7)
+#define TransceiverSPI_WriteSelect                  (0<<7)
+#define TransceiverSPI_RegisterAccessSelect         (0<<6)
+#define TransceiverSPI_PacketBuffAccessSelect       (1<<6)
+#define TransceiverSPI_PacketBuffBurstModeSelect    (0<<5)
+#define TransceiverSPI_PacketBuffByteModeSelect     (1<<5)
+
+#define TransceiverSPI_DirectRegisterAddressMask    (0x3F)
+
+#define IRQSTS1             0x00
+#define IRQSTS2             0x01
+#define IRQSTS3             0x02
+#define PHY_CTRL1           0x03
+#define PHY_CTRL2           0x04
+#define PHY_CTRL3           0x05
+#define RX_FRM_LEN          0x06
+#define PHY_CTRL4           0x07
+#define SRC_CTRL            0x08
+#define SRC_ADDRS_SUM_LSB   0x09
+#define SRC_ADDRS_SUM_MSB   0x0A
+#define CCA1_ED_FNL         0x0B
+#define EVENT_TMR_LSB       0x0C
+#define EVENT_TMR_MSB       0x0D
+#define EVENT_TMR_USB       0x0E
+#define TIMESTAMP_LSB       0x0F
+#define TIMESTAMP_MSB       0x10
+#define TIMESTAMP_USB       0x11
+#define T3CMP_LSB           0x12
+#define T3CMP_MSB           0x13
+#define T3CMP_USB           0x14
+#define T2PRIMECMP_LSB      0x15
+#define T2PRIMECMP_MSB      0x16
+#define T1CMP_LSB           0x17
+#define T1CMP_MSB           0x18
+#define T1CMP_USB           0x19
+#define T2CMP_LSB           0x1A
+#define T2CMP_MSB           0x1B
+#define T2CMP_USB           0x1C
+#define T4CMP_LSB           0x1D
+#define T4CMP_MSB           0x1E
+#define T4CMP_USB           0x1F
+#define PLL_INT0            0x20
+#define PLL_FRAC0_LSB       0x21
+#define PLL_FRAC0_MSB       0x22
+#define PA_PWR              0x23
+#define SEQ_STATE           0x24
+#define LQI_VALUE           0x25
+#define RSSI_CCA_CONT       0x26
+//--------------            0x27
+#define ASM_CTRL1           0x28
+#define ASM_CTRL2           0x29
+#define ASM_DATA_0          0x2A
+#define ASM_DATA_1          0x2B
+#define ASM_DATA_2          0x2C
+#define ASM_DATA_3          0x2D
+#define ASM_DATA_4          0x2E
+#define ASM_DATA_5          0x2F
+#define ASM_DATA_6          0x30
+#define ASM_DATA_7          0x31
+#define ASM_DATA_8          0x32
+#define ASM_DATA_9          0x33
+#define ASM_DATA_A          0x34
+#define ASM_DATA_B          0x35
+#define ASM_DATA_C          0x36
+#define ASM_DATA_D          0x37
+#define ASM_DATA_E          0x38
+#define ASM_DATA_F          0x39
+//-------------------       0x3A
+#define OVERWRITE_VER       0x3B
+#define CLK_OUT_CTRL        0x3C
+#define PWR_MODES           0x3D
+#define IAR_INDEX           0x3E
+#define IAR_DATA            0x3F
+
+
+#define PART_ID             0x00
+#define XTAL_TRIM           0x01
+#define PMC_LP_TRIM         0x02
+#define MACPANID0_LSB       0x03
+#define MACPANID0_MSB       0x04
+#define MACSHORTADDRS0_LSB  0x05
+#define MACSHORTADDRS0_MSB  0x06
+#define MACLONGADDRS0_0     0x07
+#define MACLONGADDRS0_8     0x08
+#define MACLONGADDRS0_16    0x09
+#define MACLONGADDRS0_24    0x0A
+#define MACLONGADDRS0_32    0x0B
+#define MACLONGADDRS0_40    0x0C
+#define MACLONGADDRS0_48    0x0D
+#define MACLONGADDRS0_56    0x0E
+#define RX_FRAME_FILTER     0x0F
+#define PLL_INT1            0x10
+#define PLL_FRAC1_LSB       0x11
+#define PLL_FRAC1_MSB       0x12
+#define MACPANID1_LSB       0x13
+#define MACPANID1_MSB       0x14
+#define MACSHORTADDRS1_LSB  0x15
+#define MACSHORTADDRS1_MSB  0x16
+#define MACLONGADDRS1_0     0x17
+#define MACLONGADDRS1_8     0x18
+#define MACLONGADDRS1_16    0x19
+#define MACLONGADDRS1_24    0x1A
+#define MACLONGADDRS1_32    0x1B
+#define MACLONGADDRS1_40    0x1C
+#define MACLONGADDRS1_48    0x1D
+#define MACLONGADDRS1_56    0x1E
+#define DUAL_PAN_CTRL       0x1F
+#define DUAL_PAN_DWELL      0x20
+#define DUAL_PAN_STS        0x21
+#define CCA1_THRESH         0x22
+#define CCA1_ED_OFFSET_COMP 0x23
+#define LQI_OFFSET_COMP     0x24
+#define CCA_CTRL            0x25
+#define CCA2_CORR_PEAKS     0x26
+#define CCA2_CORR_THRESH    0x27
+#define TMR_PRESCALE        0x28
+//----------------          0x29
+#define GPIO_DATA           0x2A
+#define GPIO_DIR            0x2B
+#define GPIO_PUL_EN         0x2C
+#define GPIO_PUL_SEL        0x2D
+#define GPIO_DS             0x2E
+//--------------            0x2F
+#define ANT_PAD_CTRL        0x30
+#define MISC_PAD_CTRL       0x31
+#define BSM_CTRL            0x32
+//---------------           0x33
+#define _RNG                0x34
+#define RX_BYTE_COUNT       0x35
+#define RX_WTR_MARK         0x36
+#define SOFT_RESET          0x37
+#define TXDELAY             0x38
+#define ACKDELAY            0x39
+#define SEQ_MGR_CTRL        0x3A
+#define SEQ_MGR_STS         0x3B
+#define SEQ_T_STS           0x3C
+#define ABORT_STS           0x3D
+#define CCCA_BUSY_CNT       0x3E
+#define SRC_ADDR_CHECKSUM1  0x3F
+#define SRC_ADDR_CHECKSUM2  0x40
+#define SRC_TBL_VALID1      0x41
+#define SRC_TBL_VALID2      0x42
+#define FILTERFAIL_CODE1    0x43
+#define FILTERFAIL_CODE2    0x44
+#define SLOT_PRELOAD        0x45
+//----------------          0x46
+#define CORR_VT             0x47
+#define SYNC_CTRL           0x48
+#define PN_LSB_0            0x49
+#define PN_LSB_1            0x4A
+#define PN_MSB_0            0x4B
+#define PN_MSB_1            0x4C
+#define CORR_NVAL           0x4D
+#define TX_MODE_CTRL        0x4E
+#define SNF_THR             0x4F
+#define FAD_THR             0x50
+#define ANT_AGC_CTRL        0x51
+#define AGC_THR1            0x52
+#define AGC_THR2            0x53
+#define AGC_HYS             0x54
+#define AFC                 0x55
+//---------------           0x56
+//---------------           0x57
+#define PHY_STS             0x58
+#define RX_MAX_CORR         0x59
+#define RX_MAX_PREAMBLE     0x5A
+#define RSSI                0x5B
+//---------------           0x5C
+//---------------           0x5D
+#define PLL_DIG_CTRL        0x5E
+#define VCO_CAL             0x5F
+#define VCO_BEST_DIFF       0x60
+#define VCO_BIAS            0x61
+#define KMOD_CTRL           0x62
+#define KMOD_CAL            0x63
+#define PA_CAL              0x64
+#define PA_PWRCAL           0x65
+#define ATT_RSSI1           0x66
+#define ATT_RSSI2           0x67
+#define RSSI_OFFSET         0x68
+#define RSSI_SLOPE          0x69
+#define RSSI_CAL1           0x6A
+#define RSSI_CAL2           0x6B
+//---------------           0x6C
+//---------------           0x6D
+#define XTAL_CTRL           0x6E
+#define XTAL_COMP_MIN       0x6F
+#define XTAL_COMP_MAX       0x70
+#define XTAL_GM             0x71
+//---------------           0x72
+//---------------           0x73
+#define LNA_TUNE            0x74
+#define LNA_AGCGAIN         0x75
+//---------------           0x76
+//---------------           0x77
+#define CHF_PMA_GAIN        0x78
+#define CHF_IBUF            0x79
+#define CHF_QBUF            0x7A
+#define CHF_IRIN            0x7B
+#define CHF_QRIN            0x7C
+#define CHF_IL              0x7D
+#define CHF_QL              0x7E
+#define CHF_CC1             0x7F
+#define CHF_CCL             0x80
+#define CHF_CC2             0x81
+#define CHF_IROUT           0x82
+#define CHF_QROUT           0x83
+//---------------           0x84
+//---------------           0x85
+#define RSSI_CTRL           0x86
+//---------------           0x87
+//---------------           0x88
+#define PA_BIAS             0x89
+#define PA_TUNING           0x8A
+//---------------           0x8B
+//---------------           0x8C
+#define PMC_HP_TRIM         0x8D
+#define VREGA_TRIM          0x8E
+//---------------           0x8F
+//---------------           0x90
+#define VCO_CTRL1           0x91
+#define VCO_CTRL2           0x92
+//---------------           0x93
+//---------------           0x94
+#define ANA_SPARE_OUT1      0x95
+#define ANA_SPARE_OUT2      0x96
+#define ANA_SPARE_IN        0x97
+#define MISCELLANEOUS       0x98
+//---------------           0x99
+#define SEQ_MGR_OVRD0       0x9A
+#define SEQ_MGR_OVRD1       0x9B
+#define SEQ_MGR_OVRD2       0x9C
+#define SEQ_MGR_OVRD3       0x9D
+#define SEQ_MGR_OVRD4       0x9E
+#define SEQ_MGR_OVRD5       0x9F
+#define SEQ_MGR_OVRD6       0xA0
+#define SEQ_MGR_OVRD7       0xA1
+//---------------           0xA2
+#define TESTMODE_CTRL       0xA3
+#define DTM_CTRL1           0xA4
+#define DTM_CTRL2           0xA5
+#define ATM_CTRL1           0xA6
+#define ATM_CTRL2           0xA7
+#define ATM_CTRL3           0xA8
+//---------------           0xA9
+#define LIM_FE_TEST_CTRL    0xAA
+#define CHF_TEST_CTRL       0xAB
+#define VCO_TEST_CTRL       0xAC
+#define PLL_TEST_CTRL       0xAD
+#define PA_TEST_CTRL        0xAE
+#define PMC_TEST_CTRL       0xAF
+#define SCAN_DTM_PROTECT_1  0xFE
+#define SCAN_DTM_PROTECT_0  0xFF
+
+// IRQSTS1 bits
+#define cIRQSTS1_RX_FRM_PEND         (1<<7)
+#define cIRQSTS1_PLL_UNLOCK_IRQ      (1<<6)
+#define cIRQSTS1_FILTERFAIL_IRQ      (1<<5)
+#define cIRQSTS1_RXWTRMRKIRQ         (1<<4)
+#define cIRQSTS1_CCAIRQ              (1<<3)
+#define cIRQSTS1_RXIRQ               (1<<2)
+#define cIRQSTS1_TXIRQ               (1<<1)
+#define cIRQSTS1_SEQIRQ              (1<<0)
+
+typedef union regIRQSTS1_tag{
+  uint8_t byte;
+  struct{
+    uint8_t SEQIRQ:1;
+    uint8_t TXIRQ:1;
+    uint8_t RXIRQ:1;
+    uint8_t CCAIRQ:1;
+    uint8_t RXWTRMRKIRQ:1;
+    uint8_t FILTERFAIL_IRQ:1;
+    uint8_t PLL_UNLOCK_IRQ:1;
+    uint8_t RX_FRM_PEND:1;
+  }bit;
+} regIRQSTS1_t;
+
+// IRQSTS2 bits
+#define cIRQSTS2_CRCVALID            (1<<7)
+#define cIRQSTS2_CCA                 (1<<6)
+#define cIRQSTS2_SRCADDR             (1<<5)
+#define cIRQSTS2_PI                  (1<<4)
+#define cIRQSTS2_TMRSTATUS           (1<<3)
+#define cIRQSTS2_ASM_IRQ             (1<<2)
+#define cIRQSTS2_PB_ERR_IRQ          (1<<1)
+#define cIRQSTS2_WAKE_IRQ            (1<<0)
+
+typedef union regIRQSTS2_tag{
+  uint8_t byte;
+  struct{
+    uint8_t WAKE_IRQ:1;
+    uint8_t PB_ERR_IRQ:1;
+    uint8_t ASM_IRQ:1;
+    uint8_t TMRSTATUS:1;
+    uint8_t PI_:1;
+    uint8_t SRCADDR:1;
+    uint8_t CCA:1;
+    uint8_t CRCVALID:1;
+  }bit;
+} regIRQSTS2_t;
+
+// IRQSTS3 bits
+#define cIRQSTS3_TMR4MSK             (1<<7)
+#define cIRQSTS3_TMR3MSK             (1<<6)
+#define cIRQSTS3_TMR2MSK             (1<<5)
+#define cIRQSTS3_TMR1MSK             (1<<4)
+#define cIRQSTS3_TMR4IRQ             (1<<3)
+#define cIRQSTS3_TMR3IRQ             (1<<2)
+#define cIRQSTS3_TMR2IRQ             (1<<1)
+#define cIRQSTS3_TMR1IRQ             (1<<0)
+
+typedef union regIRQSTS3_tag{
+  uint8_t byte;
+  struct{
+    uint8_t TMR1IRQ:1;
+    uint8_t TMR2IRQ:1;
+    uint8_t TMR3IRQ:1;
+    uint8_t TMR4IRQ:1;
+    uint8_t TMR1MSK:1;
+    uint8_t TMR2MSK:1;
+    uint8_t TMR3MSK:1;
+    uint8_t TMR4MSK:1;
+  }bit;
+} regIRQSTS3_t;
+
+// PHY_CTRL1 bits
+#define cPHY_CTRL1_TMRTRIGEN           (1<<7)
+#define cPHY_CTRL1_SLOTTED             (1<<6)
+#define cPHY_CTRL1_CCABFRTX            (1<<5)
+#define cPHY_CTRL1_RXACKRQD            (1<<4)
+#define cPHY_CTRL1_AUTOACK             (1<<3)
+#define cPHY_CTRL1_XCVSEQ              (7<<0)
+
+typedef union regPHY_CTRL1_tag{
+  uint8_t byte;
+  struct{
+    uint8_t XCVSEQ:3;
+    uint8_t AUTOACK:1;
+    uint8_t RXACKRQD:1;
+    uint8_t CCABFRTX:1;
+    uint8_t SLOTTED:1;
+    uint8_t TMRTRIGEN:1;
+  }bit;
+} regPHY_CTRL1_t; 
+
+// PHY_CTRL2 bits
+#define cPHY_CTRL2_CRC_MSK             (1<<7)
+#define cPHY_CTRL2_PLL_UNLOCK_MSK      (1<<6)
+#define cPHY_CTRL2_FILTERFAIL_MSK      (1<<5)
+#define cPHY_CTRL2_RX_WMRK_MSK         (1<<4)
+#define cPHY_CTRL2_CCAMSK              (1<<3)
+#define cPHY_CTRL2_RXMSK               (1<<2)
+#define cPHY_CTRL2_TXMSK               (1<<1)
+#define cPHY_CTRL2_SEQMSK              (1<<0)
+
+typedef union regPHY_CTRL2_tag{
+  uint8_t byte;
+  struct{
+    uint8_t SEQMSK:1;
+    uint8_t TXMSK:1;
+    uint8_t RXMSK:1;
+    uint8_t CCAMSK:1;
+    uint8_t RX_WMRK_MSK:1;
+    uint8_t FILTERFAIL_MSK:1;
+    uint8_t PLL_UNLOCK_MSK:1;
+    uint8_t CRC_MSK:1;
+  }bit;
+} regPHY_CTRL2_t; 
+
+// PHY_CTRL3 bits
+#define cPHY_CTRL3_TMR4CMP_EN          (1<<7)
+#define cPHY_CTRL3_TMR3CMP_EN          (1<<6)
+#define cPHY_CTRL3_TMR2CMP_EN          (1<<5)
+#define cPHY_CTRL3_TMR1CMP_EN          (1<<4)
+#define cPHY_CTRL3_ASM_MSK             (1<<2)
+#define cPHY_CTRL3_PB_ERR_MSK          (1<<1)
+#define cPHY_CTRL3_WAKE_MSK            (1<<0)
+
+typedef union regPHY_CTRL3_tag{
+  uint8_t byte;
+  struct{
+    uint8_t WAKE_MSK:1;
+    uint8_t PB_ERR_MSK:1;
+    uint8_t ASM_MSK:1;
+    uint8_t RESERVED:1;
+    uint8_t TMR1CMP_EN:1;
+    uint8_t TMR2CMP_EN:1;
+    uint8_t TMR3CMP_EN:1;
+    uint8_t TMR4CMP_EN:1;
+  }bit;
+} regPHY_CTRL3_t;
+
+// RX_FRM_LEN bits
+#define cRX_FRAME_LENGTH               (0x7F)
+
+// PHY_CTRL4 bits
+#define cPHY_CTRL4_TRCV_MSK            (1<<7)
+#define cPHY_CTRL4_TC3TMOUT            (1<<6)
+#define cPHY_CTRL4_PANCORDNTR0         (1<<5)
+#define cPHY_CTRL4_CCATYPE             (3<<0)
+#define cPHY_CTRL4_CCATYPE_Shift_c     (3)
+#define cPHY_CTRL4_TMRLOAD             (1<<2)
+#define cPHY_CTRL4_PROMISCUOUS         (1<<1)
+#define cPHY_CTRL4_TC2PRIME_EN         (1<<0)
+
+typedef union regPHY_CTRL4_tag{
+  uint8_t byte;
+  struct{
+    uint8_t TC2PRIME_EN:1;
+    uint8_t PROMISCUOUS:1;
+    uint8_t TMRLOAD:1;
+    uint8_t CCATYPE:2;
+    uint8_t PANCORDNTR0:1;
+    uint8_t TC3TMOUT:1;
+    uint8_t TRCV_MSK:1;
+  }bit;
+} regPHY_CTRL4_t;
+
+// SRC_CTRL bits
+#define cSRC_CTRL_INDEX               (0x0F)
+#define cSRC_CTRL_INDEX_Shift_c       (4)
+#define cSRC_CTRL_ACK_FRM_PND         (1<<3)
+#define cSRC_CTRL_SRCADDR_EN          (1<<2)
+#define cSRC_CTRL_INDEX_EN            (1<<1)
+#define cSRC_CTRL_INDEX_DISABLE       (1<<0)
+
+typedef union regSRC_CTRL_tag{
+  uint8_t byte;
+  struct{
+    uint8_t INDEX_DISABLE:1;
+    uint8_t INDEX_EN:1;
+    uint8_t SRCADDR_EN:1;
+    uint8_t ACK_FRM_PND:1;
+    uint8_t INDEX:4;
+  }bit;
+} regSRC_CTRL_t;
+
+// ASM_CTRL1 bits
+#define cASM_CTRL1_CLEAR               (1<<7)
+#define cASM_CTRL1_START               (1<<6)
+#define cASM_CTRL1_SELFTST             (1<<5)
+#define cASM_CTRL1_CTR                 (1<<4)
+#define cASM_CTRL1_CBC                 (1<<3)
+#define cASM_CTRL1_AES                 (1<<2)
+#define cASM_CTRL1_LOAD_MAC            (1<<1)
+
+// ASM_CTRL2 bits
+#define cASM_CTRL2_DATA_REG_TYPE_SEL          (7)
+#define cASM_CTRL2_DATA_REG_TYPE_SEL_Shift_c  (5)
+#define cASM_CTRL2_TSTPAS                     (1<<1)
+
+// CLK_OUT_CTRL bits
+#define cCLK_OUT_CTRL_EXTEND           (1<<7)
+#define cCLK_OUT_CTRL_HIZ              (1<<6)
+#define cCLK_OUT_CTRL_SR               (1<<5)
+#define cCLK_OUT_CTRL_DS               (1<<4)
+#define cCLK_OUT_CTRL_EN               (1<<3)
+#define cCLK_OUT_CTRL_DIV              (7)
+
+// PWR_MODES bits
+#define cPWR_MODES_XTAL_READY          (1<<5)
+#define cPWR_MODES_XTALEN              (1<<4)
+#define cPWR_MODES_ASM_CLK_EN          (1<<3)
+#define cPWR_MODES_AUTODOZE            (1<<1)
+#define cPWR_MODES_PMC_MODE            (1<<0)
+
+// RX_FRAME_FILTER bits
+#define cRX_FRAME_FLT_FRM_VER             (0xC0)
+#define cRX_FRAME_FLT_FRM_VER_Shift_c     (6)
+#define cRX_FRAME_FLT_ACTIVE_PROMISCUOUS  (1<<5)
+#define cRX_FRAME_FLT_NS_FT               (1<<4)
+#define cRX_FRAME_FLT_CMD_FT              (1<<3)
+#define cRX_FRAME_FLT_ACK_FT              (1<<2)
+#define cRX_FRAME_FLT_DATA_FT             (1<<1)
+#define cRX_FRAME_FLT_BEACON_FT           (1<<0)
+
+typedef union regRX_FRAME_FILTER_tag{
+  uint8_t byte;
+  struct{
+    uint8_t FRAME_FLT_BEACON_FT:1;
+    uint8_t FRAME_FLT_DATA_FT:1;
+    uint8_t FRAME_FLT_ACK_FT:1;
+    uint8_t FRAME_FLT_CMD_FT:1;
+    uint8_t FRAME_FLT_NS_FT:1;
+    uint8_t FRAME_FLT_ACTIVE_PROMISCUOUS:1;
+    uint8_t FRAME_FLT_FRM_VER:2;
+  }bit;
+} regRX_FRAME_FILTER_t; 
+
+// DUAL_PAN_CTRL bits
+#define cDUAL_PAN_CTRL_DUAL_PAN_SAM_LVL_MSK       (0xF0)
+#define cDUAL_PAN_CTRL_DUAL_PAN_SAM_LVL_Shift_c   (4)
+#define cDUAL_PAN_CTRL_CURRENT_NETWORK            (1<<3)
+#define cDUAL_PAN_CTRL_PANCORDNTR1                (1<<2)
+#define cDUAL_PAN_CTRL_DUAL_PAN_AUTO              (1<<1)
+#define cDUAL_PAN_CTRL_ACTIVE_NETWORK             (1<<0)
+
+// DUAL_PAN_STS bits
+#define cDUAL_PAN_STS_RECD_ON_PAN1        (1<<7)
+#define cDUAL_PAN_STS_RECD_ON_PAN0        (1<<6)
+#define cDUAL_PAN_STS_DUAL_PAN_REMAIN     (0x3F)
+
+// CCA_CTRL bits
+#define cCCA_CTRL_AGC_FRZ_EN          (1<<6)
+#define cCCA_CTRL_CONT_RSSI_EN        (1<<5)
+#define cCCA_CTRL_LQI_RSSI_NOT_CORR   (1<<4)
+#define cCCA_CTRL_CCA3_AND_NOT_OR     (1<<3)
+#define cCCA_CTRL_POWER_COMP_EN_LQI   (1<<2)
+#define cCCA_CTRL_POWER_COMP_EN_ED    (1<<1)
+#define cCCA_CTRL_POWER_COMP_EN_CCA1  (1<<0)
+
+// GPIO_DATA bits
+#define cGPIO_DATA_7        (1<<7)
+#define cGPIO_DATA_6        (1<<6)
+#define cGPIO_DATA_5        (1<<5)
+#define cGPIO_DATA_4        (1<<4)
+#define cGPIO_DATA_3        (1<<3)
+#define cGPIO_DATA_2        (1<<2)
+#define cGPIO_DATA_1        (1<<1)
+#define cGPIO_DATA_0        (1<<0)
+
+// GPIO_DIR bits
+#define cGPIO_DIR_7         (1<<7)
+#define cGPIO_DIR_6         (1<<6)
+#define cGPIO_DIR_5         (1<<5)
+#define cGPIO_DIR_4         (1<<4)
+#define cGPIO_DIR_3         (1<<3)
+#define cGPIO_DIR_2         (1<<2)
+#define cGPIO_DIR_1         (1<<1)
+#define cGPIO_DIR_0         (1<<0)
+
+// GPIO_PUL_EN bits
+#define cGPIO_PUL_EN_7      (1<<7)
+#define cGPIO_PUL_EN_6      (1<<6)
+#define cGPIO_PUL_EN_5      (1<<5)
+#define cGPIO_PUL_EN_4      (1<<4)
+#define cGPIO_PUL_EN_3      (1<<3)
+#define cGPIO_PUL_EN_2      (1<<2)
+#define cGPIO_PUL_EN_1      (1<<1)
+#define cGPIO_PUL_EN_0      (1<<0)
+
+// GPIO_PUL_SEL bits
+#define cGPIO_PUL_SEL_7     (1<<7)
+#define cGPIO_PUL_SEL_6     (1<<6)
+#define cGPIO_PUL_SEL_5     (1<<5)
+#define cGPIO_PUL_SEL_4     (1<<4)
+#define cGPIO_PUL_SEL_3     (1<<3)
+#define cGPIO_PUL_SEL_2     (1<<2)
+#define cGPIO_PUL_SEL_1     (1<<1)
+#define cGPIO_PUL_SEL_0     (1<<0)
+
+// GPIO_DS bits
+#define cGPIO_DS_7          (1<<7)
+#define cGPIO_DS_6          (1<<6)
+#define cGPIO_DS_5          (1<<5)
+#define cGPIO_DS_4          (1<<4)
+#define cGPIO_DS_3          (1<<3)
+#define cGPIO_DS_2          (1<<2)
+#define cGPIO_DS_1          (1<<1)
+#define cGPIO_DS_0          (1<<0)
+
+// SPI_CTRL bits
+//#define cSPI_CTRL_MISO_HIZ_EN        (1<<1)
+//#define cSPI_CTRL_PB_PROTECT         (1<<0)
+
+// ANT_PAD_CTRL bits
+#define cANT_PAD_CTRL_ANTX_POL           (0x0F)
+#define cANT_PAD_CTRL_ANTX_POL_Shift_c   (4)
+#define cANT_PAD_CTRL_ANTX_CTRLMODE      (1<<3)
+#define cANT_PAD_CTRL_ANTX_HZ            (1<<2)
+#define cANT_PAD_CTRL_ANTX_EN            (3)
+
+// MISC_PAD_CTRL bits
+#define cMISC_PAD_CTRL_MISO_HIZ_EN        (1<<3)
+#define cMISC_PAD_CTRL_IRQ_B_OD           (1<<2)
+#define cMISC_PAD_CTRL_NON_GPIO_DS        (1<<1)
+#define cMISC_PAD_CTRL_ANTX_CURR          (1<<0)
+
+// ANT_AGC_CTRL bits
+#define cANT_AGC_CTRL_FAD_EN_Shift_c    (0)
+#define cANT_AGC_CTRL_FAD_EN_Mask_c     (1<<cANT_AGC_CTRL_FAD_EN_Shift_c)
+#define cANT_AGC_CTRL_ANTX_Shift_c      (1)
+#define cANT_AGC_CTRL_ANTX_Mask_c       (1<<cANT_AGC_CTRL_ANTX_Shift_c)
+
+// BSM_CTRL bits
+#define cBSM_CTRL_BSM_EN                  (1<<0)
+
+// SOFT_RESET bits
+#define cSOFT_RESET_SOG_RST            (1<<7)
+#define cSOFT_RESET_REGS_RST           (1<<4)
+#define cSOFT_RESET_PLL_RST            (1<<3)
+#define cSOFT_RESET_TX_RST             (1<<2)
+#define cSOFT_RESET_RX_RST             (1<<1)
+#define cSOFT_RESET_SEQ_MGR_RST        (1<<0)
+
+// SEQ_MGR_CTRL bits
+#define cSEQ_MGR_CTRL_SEQ_STATE_CTRL          (3)
+#define cSEQ_MGR_CTRL_SEQ_STATE_CTRL_Shift_c  (6)
+#define cSEQ_MGR_CTRL_NO_RX_RECYCLE           (1<<5)
+#define cSEQ_MGR_CTRL_LATCH_PREAMBLE          (1<<4)
+#define cSEQ_MGR_CTRL_EVENT_TMR_DO_NOT_LATCH  (1<<3)
+#define cSEQ_MGR_CTRL_CLR_NEW_SEQ_INHIBIT     (1<<2)
+#define cSEQ_MGR_CTRL_PSM_LOCK_DIS            (1<<1)
+#define cSEQ_MGR_CTRL_PLL_ABORT_OVRD          (1<<0)
+
+// SEQ_MGR_STS bits
+#define cSEQ_MGR_STS_TMR2_SEQ_TRIG_ARMED (1<<7)
+#define cSEQ_MGR_STS_RX_MODE             (1<<6)
+#define cSEQ_MGR_STS_RX_TIMEOUT_PENDING  (1<<5)
+#define cSEQ_MGR_STS_NEW_SEQ_INHIBIT     (1<<4)
+#define cSEQ_MGR_STS_SEQ_IDLE            (1<<3)
+#define cSEQ_MGR_STS_XCVSEQ_ACTUAL       (7)
+
+// ABORT_STS bits
+#define cABORT_STS_PLL_ABORTED        (1<<2)
+#define cABORT_STS_TC3_ABORTED        (1<<1)
+#define cABORT_STS_SW_ABORTED         (1<<0)
+
+// FILTERFAIL_CODE2 bits
+#define cFILTERFAIL_CODE2_PAN_SEL  (1<<7)
+#define cFILTERFAIL_CODE2_9_8      (3)
+
+// PHY_STS bits
+#define cPHY_STS_PLL_UNLOCK  (1<<7)
+#define cPHY_STS_PLL_LOCK_ERR        (1<<6)
+#define cPHY_STS_PLL_LOCK            (1<<5)
+#define cPHY_STS_CRCVALID            (1<<3)
+#define cPHY_STS_FILTERFAIL_FLAG_SEL (1<<2)
+#define cPHY_STS_SFD_DET             (1<<1)
+#define cPHY_STS_PREAMBLE_DET        (1<<0)
+
+// TESTMODE_CTRL bits
+#define cTEST_MODE_CTRL_HOT_ANT            (1<<4)
+#define cTEST_MODE_CTRL_IDEAL_RSSI_EN      (1<<3)
+#define cTEST_MODE_CTRL_IDEAL_PFC_EN       (1<<2)
+#define cTEST_MODE_CTRL_CONTINUOUS_EN      (1<<1)
+#define cTEST_MODE_CTRL_FPGA_EN            (1<<0)
+
+// DTM_CTRL1 bits
+#define cDTM_CTRL1_ATM_LOCKED  (1<<7)
+#define cDTM_CTRL1_DTM_EN      (1<<6)
+#define cDTM_CTRL1_PAGE5       (1<<5)
+#define cDTM_CTRL1_PAGE4       (1<<4)
+#define cDTM_CTRL1_PAGE3       (1<<3)
+#define cDTM_CTRL1_PAGE2       (1<<2)
+#define cDTM_CTRL1_PAGE1       (1<<1)
+#define cDTM_CTRL1_PAGE0       (1<<0)
+
+// TX_MODE_CTRL
+#define cTX_MODE_CTRL_TX_INV   (1<<4)
+#define cTX_MODE_CTRL_BT_EN    (1<<3)
+#define cTX_MODE_CTRL_DTS2     (1<<2)
+#define cTX_MODE_CTRL_DTS1     (1<<1)
+#define cTX_MODE_CTRL_DTS0     (1<<0)
+
+#define cTX_MODE_CTRL_DTS_MASK (7)
+
+// CLK_OUT_CTRL bits
+#define cCLK_OUT_EXTEND        (1<<7)
+#define cCLK_OUT_HIZ           (1<<6)
+#define cCLK_OUT_SR            (1<<5)
+#define cCLK_OUT_DS            (1<<4)
+#define cCLK_OUT_EN            (1<<3)
+#define cCLK_OUT_DIV_Mask      (7<<0)
+
+#define gCLK_OUT_FREQ_32_MHz      (0)
+#define gCLK_OUT_FREQ_16_MHz      (1)
+#define gCLK_OUT_FREQ_8_MHz       (2)
+#define gCLK_OUT_FREQ_4_MHz       (3)
+#define gCLK_OUT_FREQ_1_MHz       (4)
+#define gCLK_OUT_FREQ_250_KHz     (5)
+#define gCLK_OUT_FREQ_62_5_KHz    (6)
+#define gCLK_OUT_FREQ_32_78_KHz   (7)
+#define gCLK_OUT_FREQ_DISABLE     (8)
+
+
+
+
+#endif /* __MCR20_REG_H__ */

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -1,0 +1,1826 @@
+/*
+ * Copyright (c) 2014-2015 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "NanostackRfPhyMcr20a.h"
+
+#ifdef MBED_CONF_NANOSTACK_CONFIGURATION
+
+#include "ns_types.h"
+#include "platform/arm_hal_interrupt.h"
+#include "nanostack/platform/arm_hal_phy.h"
+#include <string.h>
+#include "rtos.h"
+
+/* Freescale headers which are for C files */
+extern "C" {
+#include "MCR20Drv.h"
+#include "MCR20Reg.h"
+#include "MCR20Overwrites.h"
+}
+
+
+#define RF_BUFFER_SIZE 128
+
+/*Radio RX and TX state definitions*/
+#define RFF_ON 0x01
+#define RFF_RX 0x02
+#define RFF_TX 0x04
+#define RFF_CCA 0x08
+
+#define RF_MODE_NORMAL  0
+#define RF_MODE_SNIFFER 1
+
+#define RF_CCA_THRESHOLD 75 /* -75 dBm */
+
+#define RF_TX_POWER_MAX 0
+
+/* PHY constants in symbols */
+#define gPhyWarmUpTime_c       9
+#define gPhySHRDuration_c     10
+#define gPhySymbolsPerOctet_c  2
+#define gPhyAckWaitDuration_c 54
+
+#define gCcaED_c               0
+#define gCcaCCA_MODE1_c        1
+
+#define gXcvrRunState_d       gXcvrPwrAutodoze_c
+#if !defined(TARGET_KW24D)
+  #define gXcvrLowPowerState_d  gXcvrPwrHibernate_c
+#else 
+  #define gXcvrLowPowerState_d  gXcvrPwrAutodoze_c
+#endif
+
+/* MCR20A XCVR states */
+typedef enum xcvrState_tag{
+  gIdle_c,
+  gRX_c,
+  gTX_c,
+  gCCA_c,
+  gTR_c,
+  gCCCA_c,
+}xcvrState_t;
+
+/* MCR20A XCVR low power states */
+typedef enum xcvrPwrMode_tag{
+    gXcvrPwrIdle_c,
+    gXcvrPwrAutodoze_c,
+    gXcvrPwrDoze_c,
+    gXcvrPwrHibernate_c
+}xcvrPwrMode_t;
+
+
+/*RF Part Type*/
+typedef enum
+{
+    FREESCALE_UNKNOW_DEV = 0,
+    FREESCALE_MCR20A
+}rf_trx_part_e;
+
+/*Atmel RF states*/
+typedef enum
+{
+    NOP = 0x00,
+    BUSY_RX = 0x01,
+    RF_TX_START = 0x02,
+    FORCE_TRX_OFF = 0x03,
+    FORCE_PLL_ON = 0x04,
+    RX_ON = 0x06,
+    TRX_OFF = 0x08,
+    PLL_ON = 0x09,
+    BUSY_RX_AACK = 0x11,
+    SLEEP = 0x0F,
+    RX_AACK_ON = 0x16,
+    TX_ARET_ON = 0x19
+}rf_trx_states_t;
+
+/*RF receive buffer*/
+static uint8_t rf_buffer[RF_BUFFER_SIZE];
+
+/* TX info */
+static uint8_t  radio_tx_power = 0x17; /* 0 dBm */
+static uint8_t  mac_tx_handle = 0;
+static uint8_t  need_ack = 0;
+static uint16_t tx_len = 0;
+
+/* RF driver data */
+static xcvrState_t mPhySeqState;
+static xcvrPwrMode_t mPwrState;
+static phy_device_driver_s device_driver;
+static uint8_t mStatusAndControlRegs[8];
+static uint8_t rf_rnd = 0;
+static int8_t  rf_radio_driver_id = -1;
+static uint8_t MAC_address[8];
+
+/* Driver instance handle and hardware */
+static NanostackRfPhyMcr20a *rf = NULL;
+static SPI *spi = NULL;
+static DigitalOut *cs = NULL;
+static DigitalOut *rst = NULL;
+static InterruptIn *irq = NULL;
+static DigitalIn *irq_pin = NULL;
+static Thread *irq_thread = NULL;
+
+/* Channel info */                 /* 2405    2410    2415    2420    2425    2430    2435    2440    2445    2450    2455    2460    2465    2470    2475    2480 */
+static const uint8_t  pll_int[16] =  {0x0B,   0x0B,   0x0B,   0x0B,   0x0B,   0x0B,   0x0C,   0x0C,   0x0C,   0x0C,   0x0C,   0x0C,   0x0D,   0x0D,   0x0D,   0x0D};
+static const uint16_t pll_frac[16] = {0x2800, 0x5000, 0x7800, 0xA000, 0xC800, 0xF000, 0x1800, 0x4000, 0x6800, 0x9000, 0xB800, 0xE000, 0x0800, 0x3000, 0x5800, 0x8000};
+
+/* Channel configurations for 2.4 */
+static const phy_rf_channel_configuration_s phy_24ghz = {2405000000U, 5000000U, 250000U, 16U, M_OQPSK};
+
+static const phy_device_channel_page_s phy_channel_pages[] = {
+        { CHANNEL_PAGE_0, &phy_24ghz},
+        { CHANNEL_PAGE_0, NULL}
+};
+
+
+static rf_trx_part_e rf_radio_type_read(void);
+
+MBED_UNUSED static void rf_ack_wait_timer_start(uint16_t slots);
+MBED_UNUSED static void rf_ack_wait_timer_stop(void);
+MBED_UNUSED static void rf_handle_cca_ed_done(void);
+MBED_UNUSED static void rf_handle_tx_end(void);
+MBED_UNUSED static void rf_handle_rx_end(void);
+MBED_UNUSED static void rf_on(void);
+MBED_UNUSED static void rf_receive(void);
+MBED_UNUSED static void rf_poll_trx_state_change(rf_trx_states_t trx_state);
+MBED_UNUSED static void rf_init(void);
+MBED_UNUSED static void rf_set_mac_address(const uint8_t *ptr);
+MBED_UNUSED static int8_t rf_device_register(void);
+MBED_UNUSED static void rf_device_unregister(void);
+MBED_UNUSED static int8_t rf_start_cca(uint8_t *data_ptr, uint16_t data_length, uint8_t tx_handle, data_protocol_e data_protocol );
+MBED_UNUSED static void rf_cca_abort(void);
+MBED_UNUSED static void rf_read_mac_address(uint8_t *ptr);
+MBED_UNUSED static int8_t rf_read_random(void);
+MBED_UNUSED static void rf_calibration_cb(void);
+MBED_UNUSED static void rf_init_phy_mode(void);
+MBED_UNUSED static void rf_ack_wait_timer_interrupt(void);
+MBED_UNUSED static void rf_calibration_timer_interrupt(void);
+MBED_UNUSED static void rf_calibration_timer_start(uint32_t slots);
+MBED_UNUSED static void rf_cca_timer_interrupt(void);
+MBED_UNUSED static void rf_cca_timer_start(uint32_t slots);
+MBED_UNUSED static uint16_t rf_get_phy_mtu_size(void);
+MBED_UNUSED static uint8_t rf_scale_lqi(int8_t rssi);
+
+/**
+ *  RF output power write
+ *
+ * \brief TX power has to be set before network start.
+ *
+ * \param power
+ *              See datasheet for TX power settings
+ *
+ * \return 0, Supported Value
+ * \return -1, Not Supported Value
+ */
+MBED_UNUSED static int8_t rf_tx_power_set(uint8_t power);
+MBED_UNUSED static uint8_t rf_tx_power_get(void);
+MBED_UNUSED static int8_t rf_enable_antenna_diversity(void);
+
+/* Private functions */
+MBED_UNUSED static void    rf_abort(void);
+MBED_UNUSED static void    rf_promiscuous(uint8_t mode);
+MBED_UNUSED static void    rf_get_timestamp(uint32_t *pRetClk);
+MBED_UNUSED static void    rf_set_timeout(uint32_t *pEndTime);
+MBED_UNUSED static void    rf_set_power_state(xcvrPwrMode_t newState);
+MBED_UNUSED static uint8_t rf_if_read_rnd(void);
+MBED_UNUSED static uint8_t rf_convert_LQI(uint8_t hwLqi);
+MBED_UNUSED static uint8_t rf_get_channel_energy(void);
+MBED_UNUSED static uint8_t rf_convert_energy_level(uint8_t energyLevel);
+MBED_UNUSED static int8_t  rf_convert_LQI_to_RSSI(uint8_t lqi);
+MBED_UNUSED static int8_t  rf_interface_state_control(phy_interface_state_e new_state, uint8_t rf_channel);
+MBED_UNUSED static int8_t  rf_extension(phy_extension_type_e extension_type,uint8_t *data_ptr);
+MBED_UNUSED static int8_t  rf_address_write(phy_address_type_e address_type,uint8_t *address_ptr);
+static void PHY_InterruptThread(void);
+static void handle_interrupt(void);
+
+
+/*
+ * \brief Read connected radio part.
+ *
+ * This function only return valid information when rf_init() is called
+ *
+ * \return
+ */
+static rf_trx_part_e rf_radio_type_read(void)
+{
+    return FREESCALE_MCR20A;
+}
+
+/*
+ * \brief Function initialises and registers the RF driver.
+ *
+ * \param none
+ *
+ * \return rf_radio_driver_id Driver ID given by NET library
+ */
+static int8_t rf_device_register(void)
+{
+    rf_trx_part_e radio_type;
+
+    rf_init();
+
+
+
+    radio_type = rf_radio_type_read();
+    if(radio_type == FREESCALE_MCR20A)
+    {
+        /*Set pointer to MAC address*/
+        device_driver.PHY_MAC = MAC_address;
+        device_driver.driver_description = (char*)"FREESCALE_MAC";
+
+        //Create setup Used Radio chips
+        /*Type of RF PHY is SubGHz*/
+        device_driver.link_type = PHY_LINK_15_4_2_4GHZ_TYPE;
+
+        device_driver.phy_channel_pages = phy_channel_pages;
+        /*Maximum size of payload is 127*/
+        device_driver.phy_MTU = 127;
+        /*No header in PHY*/
+        device_driver.phy_header_length = 0;
+        /*No tail in PHY*/
+        device_driver.phy_tail_length = 0;
+        /*Set address write function*/
+        device_driver.address_write = &rf_address_write;
+        /*Set RF extension function*/
+        device_driver.extension = &rf_extension;
+        /*Set RF state control function*/
+        device_driver.state_control = &rf_interface_state_control;
+        /*Set transmit function*/
+        device_driver.tx = &rf_start_cca;
+        /*Upper layer callbacks init to NULL*/
+        device_driver.phy_rx_cb = NULL;
+        device_driver.phy_tx_done_cb = NULL;
+        /*Virtual upper data callback init to NULL*/
+        device_driver.arm_net_virtual_rx_cb = NULL;
+        device_driver.arm_net_virtual_tx_cb = NULL;
+
+        /*Register device driver*/
+        rf_radio_driver_id = arm_net_phy_register(&device_driver);
+    }
+
+    return rf_radio_driver_id;
+}
+
+/*
+ * \brief Function unregisters the RF driver.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_device_unregister(void)
+{
+    arm_net_phy_unregister(rf_radio_driver_id);
+}
+
+/*
+ * \brief Function returns the generated 8-bit random value for seeding Pseudo-random generator.
+ *
+ * \param none
+ *
+ * \return random value
+ */
+static int8_t rf_read_random(void)
+{
+    return rf_rnd;
+}
+
+/*
+ * \brief Function is a call back for ACK wait timeout.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_ack_wait_timer_interrupt(void)
+{
+    /* The packet was transmitted successfully, but no ACK was received */
+    if (device_driver.phy_tx_done_cb) {
+        device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_SUCCESS, 1, 1);
+    }
+    rf_receive();
+}
+
+/*
+ * \brief Function is a call back for calibration interval timer.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_calibration_timer_interrupt(void)
+{
+}
+
+/*
+ * \brief Function is a call back for cca interval timer.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_cca_timer_interrupt(void)
+{
+    /* CCA time-out handled by Hardware */
+}
+
+
+/*
+ * \brief Function starts the ACK wait time-out.
+ *
+ * \param slots The ACK wait time-out in [symbols]
+ *
+ * \return none
+ */
+static void rf_ack_wait_timer_start(uint16_t time)
+{
+    uint32_t timeout;
+
+    rf_get_timestamp(&timeout);
+    timeout += time;
+    rf_set_timeout(&timeout);
+}
+
+/*
+ * \brief Function starts the calibration interval.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_calibration_timer_start(uint32_t slots)
+{
+    (void)slots;
+}
+
+/*
+ * \brief Function starts the CCA timout.
+ *
+ * \param slots Given slots, resolution 50us
+ *
+ * \return none
+ */
+static void rf_cca_timer_start(uint32_t slots)
+{
+    (void)slots;
+}
+
+/*
+ * \brief Function stops the ACK wait timeout.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_ack_wait_timer_stop(void)
+{
+}
+
+/*
+ * \brief Function reads the MAC address array.
+ *
+ * \param ptr Pointer to read array
+ *
+ * \return none
+ */
+static void rf_read_mac_address(uint8_t *ptr)
+{
+    memcpy(ptr, MAC_address, 8);
+}
+
+/*
+ * \brief Function sets the MAC address array.
+ *
+ * \param ptr Pointer to given MAC address array
+ *
+ * \return none
+ */
+static void rf_set_mac_address(const uint8_t *ptr)
+{
+    memcpy(MAC_address, ptr, 8);
+}
+
+static uint16_t rf_get_phy_mtu_size(void)
+{
+    return device_driver.phy_MTU;
+}
+
+/*
+ * \brief Function writes 16-bit address in RF address filter.
+ *
+ * \param short_address Given short address
+ *
+ * \return none
+ */
+static void rf_set_short_adr(uint8_t * short_address)
+{
+    /* Write one register at a time to be accessible from hibernate mode */
+    MCR20Drv_IndirectAccessSPIWrite(MACSHORTADDRS0_MSB, short_address[0]);
+    MCR20Drv_IndirectAccessSPIWrite(MACSHORTADDRS0_LSB, short_address[1]);
+}
+
+/*
+ * \brief Function writes PAN Id in RF PAN Id filter.
+ *
+ * \param pan_id Given PAN Id
+ *
+ * \return none
+ */
+static void rf_set_pan_id(uint8_t *pan_id)
+{
+    /* Write one register at a time to be accessible from hibernate mode */
+    MCR20Drv_IndirectAccessSPIWrite(MACPANID0_MSB, pan_id[0]);
+    MCR20Drv_IndirectAccessSPIWrite(MACPANID0_LSB, pan_id[1]);
+}
+
+/*
+ * \brief Function writes 64-bit address in RF address filter.
+ *
+ * \param address Given 64-bit address
+ *
+ * \return none
+ */
+static void rf_set_address(uint8_t *address)
+{
+    /* Write one register at a time to be accessible from hibernate mode */
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_0,  address[7]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_8,  address[6]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_16, address[5]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_24, address[4]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_32, address[3]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_40, address[2]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_48, address[1]);
+    MCR20Drv_IndirectAccessSPIWrite(MACLONGADDRS0_56, address[0]);
+}
+
+/*
+ * \brief Function sets the RF channel.
+ *
+ * \param ch New channel
+ *
+ * \return none
+ */
+static void rf_channel_set(uint8_t channel)
+{
+    MCR20Drv_DirectAccessSPIWrite(PLL_INT0, pll_int[channel - 11]);
+    MCR20Drv_DirectAccessSPIMultiByteWrite(PLL_FRAC0_LSB, (uint8_t *) &pll_frac[channel - 11], 2);
+}
+
+
+/*
+ * \brief Function initialises the radio driver and resets the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_init(void)
+{
+    uint32_t index;
+    mPhySeqState = gIdle_c;
+    mPwrState = gXcvrPwrIdle_c;
+    /*Reset RF module*/
+    MCR20Drv_RESET();
+    /* Initialize the transceiver SPI driver */
+    MCR20Drv_Init();
+    /* Disable Tristate on MISO for SPI reads */
+    MCR20Drv_IndirectAccessSPIWrite(MISC_PAD_CTRL, 0x02);
+    /* Set XCVR clock output settings */
+    #if !defined(TARGET_KW24D)
+      MCR20Drv_Set_CLK_OUT_Freq(gMCR20_ClkOutFreq_d);
+    #endif
+    /* Set default XCVR power state */
+    rf_set_power_state(gXcvrRunState_d);
+
+    /* PHY_CTRL1 default HW settings  + AUTOACK enabled */
+    mStatusAndControlRegs[PHY_CTRL1] = cPHY_CTRL1_AUTOACK;
+    /* PHY_CTRL2 : mask all PP interrupts */
+    mStatusAndControlRegs[PHY_CTRL2] = cPHY_CTRL2_CRC_MSK | \
+                                       cPHY_CTRL2_PLL_UNLOCK_MSK | \
+                                       /*cPHY_CTRL2_FILTERFAIL_MSK | */ \
+                                       cPHY_CTRL2_RX_WMRK_MSK | \
+                                       cPHY_CTRL2_CCAMSK | \
+                                       cPHY_CTRL2_RXMSK | \
+                                       cPHY_CTRL2_TXMSK | \
+                                       cPHY_CTRL2_SEQMSK;
+    /* PHY_CTRL3 : enable timer 3 and disable remaining interrupts */
+    mStatusAndControlRegs[PHY_CTRL3] = cPHY_CTRL3_ASM_MSK    | \
+                                       cPHY_CTRL3_PB_ERR_MSK | \
+                                       cPHY_CTRL3_WAKE_MSK   | \
+                                       cPHY_CTRL3_TMR3CMP_EN;
+    /* PHY_CTRL4 unmask global TRX interrupts, enable 16 bit mode for TC2 - TC2 prime EN */
+    mStatusAndControlRegs[PHY_CTRL4] = cPHY_CTRL4_TC2PRIME_EN | (gCcaCCA_MODE1_c << cPHY_CTRL4_CCATYPE_Shift_c);
+    /* Clear all PP IRQ bits to avoid unexpected interrupts immediately after initialization */
+    mStatusAndControlRegs[IRQSTS1] = cIRQSTS1_PLL_UNLOCK_IRQ | \
+                                     cIRQSTS1_FILTERFAIL_IRQ | \
+                                     cIRQSTS1_RXWTRMRKIRQ | \
+                                     cIRQSTS1_CCAIRQ | \
+                                     cIRQSTS1_RXIRQ | \
+                                     cIRQSTS1_TXIRQ | \
+                                     cIRQSTS1_SEQIRQ;
+    
+    mStatusAndControlRegs[IRQSTS2] = cIRQSTS2_ASM_IRQ | cIRQSTS2_PB_ERR_IRQ | cIRQSTS2_WAKE_IRQ;
+    /* Mask and clear all TMR IRQs */
+    mStatusAndControlRegs[IRQSTS3] = cIRQSTS3_TMR4MSK | cIRQSTS3_TMR3MSK | cIRQSTS3_TMR2MSK | cIRQSTS3_TMR1MSK | \
+                                     cIRQSTS3_TMR4IRQ | cIRQSTS3_TMR3IRQ | cIRQSTS3_TMR2IRQ | cIRQSTS3_TMR1IRQ;
+    /* Write settings to XCVR */
+    MCR20Drv_DirectAccessSPIMultiByteWrite(PHY_CTRL1, &mStatusAndControlRegs[PHY_CTRL1], 5);
+    /* Clear all interrupts */
+    MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, &mStatusAndControlRegs[IRQSTS1], 3);
+    
+    /*  RX_FRAME_FILTER. Accept FrameVersion 0 and 1 packets, reject all others */
+    MCR20Drv_IndirectAccessSPIWrite(RX_FRAME_FILTER, (cRX_FRAME_FLT_FRM_VER | \
+                                                      cRX_FRAME_FLT_BEACON_FT | \
+                                                      cRX_FRAME_FLT_DATA_FT | \
+                                                      cRX_FRAME_FLT_CMD_FT ));
+    /* Direct register overwrites */
+    for (index = 0; index < sizeof(overwrites_direct)/sizeof(overwrites_t); index++)
+        MCR20Drv_DirectAccessSPIWrite(overwrites_direct[index].address, overwrites_direct[index].data);
+    /* Indirect register overwrites */
+    for (index = 0; index < sizeof(overwrites_indirect)/sizeof(overwrites_t); index++)
+        MCR20Drv_IndirectAccessSPIWrite(overwrites_indirect[index].address, overwrites_indirect[index].data);
+
+    /* Set the CCA energy threshold value */
+    MCR20Drv_IndirectAccessSPIWrite(CCA1_THRESH, RF_CCA_THRESHOLD);
+    /* Set prescaller to obtain 1 symbol (16us) timebase */
+    MCR20Drv_IndirectAccessSPIWrite(TMR_PRESCALE, 0x05);
+
+    MCR20Drv_IRQ_Enable();
+
+    /*Read random variable. This will be used when seeding pseudo-random generator*/
+    rf_rnd = rf_if_read_rnd();
+    /*Write initial eui64*/
+    rf_set_address(MAC_address);
+    /*set default channel to 11*/
+    rf_channel_set(11);
+    /*Start receiver*/
+    rf_receive();
+}
+
+/**
+ * \brief Function gets called when MAC is setting radio off.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_off(void)
+{
+    /* Abort any ongoing sequences */
+    rf_abort();
+    /* Set XCVR in a low power state */
+    rf_set_power_state(gXcvrLowPowerState_d);
+}
+
+/*
+ * \brief Function polls the RF state until it has changed to desired state.
+ *
+ * \param trx_state RF state
+ *
+ * \return none
+ */
+static void rf_poll_trx_state_change(rf_trx_states_t trx_state)
+{
+    (void)trx_state;
+}
+
+/*
+ * \brief Function starts the CCA process before starting data transmission and copies the data to RF TX FIFO.
+ *
+ * \param data_ptr Pointer to TX data
+ * \param data_length Length of the TX data
+ * \param tx_handle Handle to transmission
+ * \return 0 Success
+ * \return -1 Busy
+ */
+static int8_t rf_start_cca(uint8_t *data_ptr, uint16_t data_length, uint8_t tx_handle, data_protocol_e data_protocol )
+{
+    uint8_t ccaMode;
+
+    /* Parameter validation */
+    if( !data_ptr || (data_length > 125) || (PHY_LAYER_PAYLOAD != data_protocol) )
+    {
+        return -1;
+    }
+
+    if( mPhySeqState == gRX_c )
+    {
+        uint8_t phyReg = MCR20Drv_DirectAccessSPIRead(SEQ_STATE) & 0x1F;
+        /* Check for an Rx in progress. */
+        if((phyReg <= 0x06) || (phyReg == 0x15) || (phyReg == 0x16))
+        {
+            if (device_driver.phy_tx_done_cb) {
+                device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_CCA_FAIL, 1, 1);
+            }
+            return -1;
+        }
+        rf_abort();
+    }
+
+    /*Check if transmitter is busy*/
+    if( mPhySeqState != gIdle_c )
+    {
+        /*Return busy*/
+        return -1;
+    }
+
+    /*Store TX handle*/
+    mac_tx_handle = tx_handle;
+    /*Check if transmitted data needs to be acked*/
+    need_ack = (*data_ptr & 0x20) == 0x20;
+
+    /* Set XCVR power state in run mode */
+    rf_set_power_state(gXcvrRunState_d);
+    /* Load data into XCVR */
+    tx_len = data_length + 2;
+    MCR20Drv_PB_SPIBurstWrite(data_ptr - 1, data_length + 1);
+    MCR20Drv_PB_SPIByteWrite(0,tx_len);
+    
+    /* Set CCA mode 1 */
+    ccaMode = (mStatusAndControlRegs[PHY_CTRL4] >> cPHY_CTRL4_CCATYPE_Shift_c) & cPHY_CTRL4_CCATYPE;
+    if( ccaMode != gCcaCCA_MODE1_c )
+    {
+        mStatusAndControlRegs[PHY_CTRL4] &= ~(cPHY_CTRL4_CCATYPE << cPHY_CTRL4_CCATYPE_Shift_c);
+        mStatusAndControlRegs[PHY_CTRL4] |= gCcaCCA_MODE1_c << cPHY_CTRL4_CCATYPE_Shift_c;
+        MCR20Drv_DirectAccessSPIWrite(PHY_CTRL4, mStatusAndControlRegs[PHY_CTRL4]);
+    }
+
+    /* Read XCVR registers */
+    mStatusAndControlRegs[0] = MCR20Drv_DirectAccessSPIMultiByteRead(IRQSTS2, &mStatusAndControlRegs[1], 4);
+    mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+    mStatusAndControlRegs[PHY_CTRL1] |= gCCA_c;
+    mPhySeqState = gCCA_c;
+
+    /* Ensure that no spurious interrupts are raised */
+    mStatusAndControlRegs[IRQSTS3] &= 0xF0; /* do not change other IRQ status */
+    mStatusAndControlRegs[IRQSTS3] |= (cIRQSTS3_TMR3MSK | cIRQSTS3_TMR3IRQ);
+    MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 3);
+
+    /* Write XCVR settings */
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+    
+    /* Unmask SEQ interrupt */
+    mStatusAndControlRegs[PHY_CTRL2] &= ~(cPHY_CTRL2_SEQMSK);
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL2, mStatusAndControlRegs[PHY_CTRL2]);
+
+    /*Return success*/
+    return 0;
+}
+
+/*
+ * \brief Function aborts CCA process.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_cca_abort(void)
+{
+    rf_abort();
+}
+
+/*
+ * \brief Function starts the transmission of the frame. Called from ISR context!
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_start_tx(void)
+{
+    /* Perform TxRxAck sequence if required by phyTxMode */
+    if( need_ack )
+    {
+        mStatusAndControlRegs[PHY_CTRL1] |= cPHY_CTRL1_RXACKRQD;
+        mPhySeqState = gTR_c;
+    }
+    else
+    {
+        mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_RXACKRQD);
+        mPhySeqState = gTX_c;
+    }
+
+    mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+    mStatusAndControlRegs[PHY_CTRL1] |= mPhySeqState;
+    
+    /* Unmask SEQ interrupt */
+    mStatusAndControlRegs[PHY_CTRL2] &= ~(cPHY_CTRL2_SEQMSK);
+
+    /* Start the sequence immediately */
+    MCR20Drv_DirectAccessSPIMultiByteWrite(PHY_CTRL1, &mStatusAndControlRegs[PHY_CTRL1], 2);
+
+    if( need_ack )
+    {
+        rf_ack_wait_timer_start(gPhyWarmUpTime_c + gPhySHRDuration_c + tx_len * gPhySymbolsPerOctet_c + gPhyAckWaitDuration_c);
+    }
+}
+
+/*
+ * \brief Function sets the RF in RX state. Called from ISR context!
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_receive(void)
+{
+    uint8_t phyRegs[5];
+
+    /* RX can start only from Idle state */
+    if( mPhySeqState != gIdle_c )
+    {
+        return;
+    }
+
+    /* Set XCVR power state in run mode */
+    rf_set_power_state(gXcvrRunState_d);
+    /* read XVCR settings */
+    phyRegs[IRQSTS1] = MCR20Drv_DirectAccessSPIMultiByteRead(IRQSTS2, &phyRegs[IRQSTS2], 4);
+    /* unmask SEQ interrupt */
+    phyRegs[PHY_CTRL2] &= ~(cPHY_CTRL2_SEQMSK);
+    /* set XcvrSeq to RX */
+    phyRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+    phyRegs[PHY_CTRL1] |=  gRX_c;
+    mPhySeqState = gRX_c;
+    /* Ensure that no spurious interrupts are raised */
+    phyRegs[IRQSTS3] &= 0xF0; /* do not change other IRQ status */
+    phyRegs[IRQSTS3] |= cIRQSTS3_TMR3MSK | cIRQSTS3_TMR3IRQ;
+    /* sync settings with XCVR */
+    MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, phyRegs, 5);
+}
+
+/*
+ * \brief Function calibrates the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_calibration_cb(void)
+{
+}
+
+/*
+ * \brief Function sets RF_ON flag when radio is powered.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_on(void)
+{
+}
+
+/*
+ * \brief Function is a call back for RX end interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_rx_end(void)
+{
+    uint8_t rf_lqi = MCR20Drv_DirectAccessSPIRead(LQI_VALUE);
+    int8_t rf_rssi = 0;
+    uint8_t len = mStatusAndControlRegs[RX_FRM_LEN] - 2;
+    
+
+    /*Start receiver*/
+    rf_receive();
+
+    /*Check the length is valid*/
+    if(len > 1 && len < RF_BUFFER_SIZE)
+    {
+        rf_lqi  = rf_convert_LQI(rf_lqi);
+        rf_rssi = rf_convert_LQI_to_RSSI(rf_lqi);
+        /*gcararu: Scale LQI using received RSSI, to match the LQI reported by the ATMEL radio */
+        rf_lqi  = rf_scale_lqi(rf_rssi);
+
+        /*Read received packet*/
+        MCR20Drv_PB_SPIBurstRead(rf_buffer, len);
+        if (device_driver.phy_rx_cb) {
+            device_driver.phy_rx_cb(rf_buffer, len, rf_lqi, rf_rssi, rf_radio_driver_id);
+        }
+    }
+}
+
+/*
+ * \brief Function is called when MAC is shutting down the radio.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_shutdown(void)
+{
+    /*Call RF OFF*/
+    rf_off();
+}
+
+/*
+ * \brief Function is a call back for TX end interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_tx_end(void)
+{
+    uint8_t rx_frame_pending = mStatusAndControlRegs[IRQSTS1] & cIRQSTS1_RX_FRM_PEND;
+
+    /*Start receiver*/
+    rf_receive();
+
+    if (!device_driver.phy_tx_done_cb) {
+        return;
+    }
+
+    /*Call PHY TX Done API*/
+    if( need_ack )
+    {
+        if( rx_frame_pending )
+        {
+            device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_DONE_PENDING, 1, 1);
+        }
+        else
+        {
+            // arm_net_phy_tx_done(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_SUCCESS, 1, 1);
+            device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_DONE, 1, 1);
+        }
+    }
+    else
+    {
+        device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_TX_SUCCESS, 1, 1);
+    }
+}
+
+/*
+ * \brief Function is a call back for CCA ED done interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_handle_cca_ed_done(void)
+{
+    /*Check the result of CCA process*/
+    if( !(mStatusAndControlRegs[IRQSTS2] & cIRQSTS2_CCA) ) 
+    {
+        rf_start_tx();
+    }
+    else if (device_driver.phy_tx_done_cb)
+    {
+        /*Send CCA fail notification*/
+        device_driver.phy_tx_done_cb(rf_radio_driver_id, mac_tx_handle, PHY_LINK_CCA_FAIL, 1, 1);
+    }
+}
+
+/*
+ * \brief Function sets the TX power variable.
+ *
+ * \param power TX power setting
+ *
+ * \return 0 Success
+ * \return -1 Fail
+ */
+static int8_t rf_tx_power_set(uint8_t power)
+{
+    /* gcapraru: Map MCR20A Tx power levels over ATMEL values */
+    static uint8_t pwrLevelMapping[16] = {25,25,25,24,24,24,23,23,22,22,21,20,19,18,17,14};
+
+    if( power > 15 )
+    {
+        return -1;
+    }
+
+    radio_tx_power = power;
+    MCR20Drv_DirectAccessSPIWrite(PA_PWR, pwrLevelMapping[power]);
+    return 0;
+}
+
+/*
+ * \brief Function returns the TX power variable.
+ *
+ * \param none
+ *
+ * \return radio_tx_power TX power variable
+ */
+static uint8_t rf_tx_power_get(void)
+{
+    return radio_tx_power;
+}
+
+/*
+ * \brief Function enables the usage of Antenna diversity.
+ *
+ * \param none
+ *
+ * \return 0 Success
+ */
+static int8_t rf_enable_antenna_diversity(void)
+{
+    uint8_t phyReg;
+
+    phyReg = MCR20Drv_IndirectAccessSPIRead(ANT_AGC_CTRL);
+    phyReg |= cANT_AGC_CTRL_FAD_EN_Mask_c;
+    MCR20Drv_IndirectAccessSPIWrite(ANT_AGC_CTRL, phyReg);
+
+    phyReg = MCR20Drv_IndirectAccessSPIRead(ANT_PAD_CTRL);
+    phyReg |= 0x02;
+    MCR20Drv_IndirectAccessSPIWrite(ANT_PAD_CTRL, phyReg);
+    
+    return 0;
+}
+
+/*
+ * \brief Function gives the control of RF states to MAC.
+ *
+ * \param new_state RF state
+ * \param rf_channel RF channel
+ *
+ * \return 0 Success
+ */
+static int8_t rf_interface_state_control(phy_interface_state_e new_state, uint8_t rf_channel)
+{
+    int8_t ret_val = 0;
+    switch (new_state)
+    {
+        /*Reset PHY driver and set to idle*/
+        case PHY_INTERFACE_RESET:
+            break;
+        /*Disable PHY Interface driver*/
+        case PHY_INTERFACE_DOWN:
+            rf_shutdown();
+            break;
+        /*Enable PHY Interface driver*/
+        case PHY_INTERFACE_UP:
+            rf_channel_set(rf_channel);
+            rf_receive();
+            break;
+        /*Enable wireless interface ED scan mode*/
+        case PHY_INTERFACE_RX_ENERGY_STATE:
+            rf_abort();
+            rf_channel_set(rf_channel);
+            break;
+        case PHY_INTERFACE_SNIFFER_STATE:             /**< Enable Sniffer state */
+            rf_promiscuous(1);
+            rf_channel_set(rf_channel);
+            rf_receive();
+            break;
+    }
+    return ret_val;
+}
+
+/*
+ * \brief Function controls the ACK pending, channel setting and energy detection.
+ *
+ * \param extension_type Type of control
+ * \param data_ptr Data from NET library
+ *
+ * \return 0 Success
+ */
+static int8_t rf_extension(phy_extension_type_e extension_type, uint8_t *data_ptr)
+{
+    switch (extension_type)
+    {
+        /*Control MAC pending bit for Indirect data transmission*/
+        case PHY_EXTENSION_CTRL_PENDING_BIT:
+        {
+            uint8_t reg = MCR20Drv_DirectAccessSPIRead(SRC_CTRL);
+
+            if(*data_ptr)
+            {
+                reg |= cSRC_CTRL_ACK_FRM_PND;
+            }
+            else
+            {
+                reg &= ~cSRC_CTRL_ACK_FRM_PND;
+            }
+            
+            MCR20Drv_DirectAccessSPIWrite(SRC_CTRL, reg);
+            break;
+            
+        }
+        /*Return frame Auto Ack frame pending status*/
+        case PHY_EXTENSION_READ_LAST_ACK_PENDING_STATUS: {
+            uint8_t reg = MCR20Drv_DirectAccessSPIRead(SRC_CTRL);
+            if (reg & cSRC_CTRL_ACK_FRM_PND) {
+                *data_ptr = 1;
+            } else {
+                *data_ptr  = 0;
+            }
+            break;
+        }
+        /*Set channel*/
+        case PHY_EXTENSION_SET_CHANNEL:
+            break;
+        /*Read energy on the channel*/
+        case PHY_EXTENSION_READ_CHANNEL_ENERGY:
+            *data_ptr = rf_get_channel_energy();
+            break;
+        /*Read status of the link*/
+        case PHY_EXTENSION_READ_LINK_STATUS:
+            break;
+        case PHY_EXTENSION_CONVERT_SIGNAL_INFO:
+            break;
+        case PHY_EXTENSION_ACCEPT_ANY_BEACON:
+            break;
+    }
+    return 0;
+}
+
+/*
+ * \brief Function sets the addresses to RF address filters.
+ *
+ * \param address_type Type of address
+ * \param address_ptr Pointer to given address
+ *
+ * \return 0 Success
+ */
+static int8_t rf_address_write(phy_address_type_e address_type, uint8_t *address_ptr)
+{
+    int8_t ret_val = 0;
+    switch (address_type)
+    {
+        /*Set 48-bit address*/
+        case PHY_MAC_48BIT:
+            break;
+            /*Set 64-bit address*/
+        case PHY_MAC_64BIT:
+            rf_set_address(address_ptr);
+            break;
+        /*Set 16-bit address*/
+        case PHY_MAC_16BIT:
+            rf_set_short_adr(address_ptr);
+            break;
+        /*Set PAN Id*/
+        case PHY_MAC_PANID:
+            rf_set_pan_id(address_ptr);
+            break;
+    }
+    return ret_val;
+}
+
+/*
+ * \brief Function initialises the ACK wait time and returns the used PHY mode.
+ *
+ * \param none
+ *
+ * \return tmp Used PHY mode
+ */
+static void rf_init_phy_mode(void)
+{
+}
+
+/*
+ * \brief Function is a RF interrupt vector. End of frame in RX and TX are handled here as well as CCA process interrupt.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void PHY_InterruptHandler(void)
+{
+    /* Disable and clear transceiver(IRQ_B) interrupt */
+    MCR20Drv_IRQ_Disable();
+    irq_thread->signal_set(1);
+}
+
+static void PHY_InterruptThread(void)
+{
+    for (;;) {
+        osEvent event = irq_thread->signal_wait(0);
+        if (event.status != osEventSignal) {
+            continue;
+        }
+        handle_interrupt();
+    }
+}
+
+static void handle_interrupt(void)
+{
+    uint8_t xcvseqCopy;
+
+    //MCR20Drv_IRQ_Clear();
+
+    /* Read transceiver interrupt status and control registers */
+    mStatusAndControlRegs[IRQSTS1] =
+        MCR20Drv_DirectAccessSPIMultiByteRead(IRQSTS2, &mStatusAndControlRegs[IRQSTS2], 7);
+
+    xcvseqCopy = mStatusAndControlRegs[PHY_CTRL1] & cPHY_CTRL1_XCVSEQ;
+    
+    /* Flter Fail IRQ */
+    if( (mStatusAndControlRegs[IRQSTS1] & cIRQSTS1_FILTERFAIL_IRQ) &&
+       !(mStatusAndControlRegs[PHY_CTRL2] & cPHY_CTRL2_FILTERFAIL_MSK) )
+    {
+        if( xcvseqCopy == gRX_c )
+        {
+            /* Abort current SEQ */
+            mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+            MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+            /* Wait for Sequence Idle */
+            while ((MCR20Drv_DirectAccessSPIRead(SEQ_STATE) & 0x1F) != 0);
+            /* Clear IRQ flags: */
+            MCR20Drv_DirectAccessSPIWrite(IRQSTS1, cIRQSTS1_SEQIRQ);
+            /* Restart Rx asap */
+            mStatusAndControlRegs[PHY_CTRL1] |= gRX_c;
+            MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+        }
+    }
+    
+    /* TMR3 IRQ: ACK wait time-out */
+    if( (mStatusAndControlRegs[IRQSTS3] & cIRQSTS3_TMR3IRQ) &&
+       !(mStatusAndControlRegs[IRQSTS3] & cIRQSTS3_TMR3MSK) )
+    {
+        /* Disable TMR3 IRQ */
+        mStatusAndControlRegs[IRQSTS3] |= cIRQSTS3_TMR3MSK;
+
+        if( xcvseqCopy == gTR_c )
+        {
+            /* Set XCVR to Idle */
+            mPhySeqState = gIdle_c;
+            mStatusAndControlRegs[PHY_CTRL1] &=  ~( cPHY_CTRL1_XCVSEQ );
+            /* Mask interrupts */
+            mStatusAndControlRegs[PHY_CTRL2] |= cPHY_CTRL2_CCAMSK | cPHY_CTRL2_RXMSK | cPHY_CTRL2_TXMSK | cPHY_CTRL2_SEQMSK;
+            /* Sync settings with XCVR */
+            MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 5);
+            
+            rf_ack_wait_timer_interrupt();
+            MCR20Drv_IRQ_Enable();
+            return;
+        }
+    }
+
+    /* Sequencer interrupt, the autosequence has completed */
+    if( (mStatusAndControlRegs[IRQSTS1] & cIRQSTS1_SEQIRQ) && 
+       !(mStatusAndControlRegs[PHY_CTRL2] & cPHY_CTRL2_SEQMSK) )
+    {
+        /* Set XCVR to Idle */
+        mPhySeqState = gIdle_c;
+        mStatusAndControlRegs[PHY_CTRL1] &=  ~( cPHY_CTRL1_XCVSEQ );
+        /* Mask interrupts */
+        mStatusAndControlRegs[PHY_CTRL2] |= cPHY_CTRL2_CCAMSK | cPHY_CTRL2_RXMSK | cPHY_CTRL2_TXMSK | cPHY_CTRL2_SEQMSK;
+        /* Sync settings with XCVR */
+        MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 5);
+                                                               
+        /* PLL unlock, the autosequence has been aborted due to PLL unlock */
+        if( mStatusAndControlRegs[IRQSTS1] & cIRQSTS1_PLL_UNLOCK_IRQ )
+        {
+            if(xcvseqCopy == gRX_c)
+            {
+                rf_receive();
+            }
+            MCR20Drv_IRQ_Enable();
+            return;
+        }
+
+        switch(xcvseqCopy)
+        {
+        case gTX_c:
+        case gTR_c:
+            rf_handle_tx_end();
+            break;
+
+        case gRX_c:
+            rf_handle_rx_end();
+            break;
+
+        case gCCA_c:
+            rf_handle_cca_ed_done();
+            break;
+
+        default:
+            break;
+        }
+        
+        MCR20Drv_IRQ_Enable();
+        return;
+    }
+    /* Other IRQ. Clear XCVR interrupt flags */
+    MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 3);
+    MCR20Drv_IRQ_Enable();
+}
+
+/*
+ * \brief Function forces the XCVR to Idle state.
+ *
+ * \param none
+ *
+ * \return none
+ */
+static void rf_abort(void)
+{
+    /* Mask XCVR irq */
+    MCR20Drv_IRQ_Disable();
+
+    mPhySeqState = gIdle_c;
+
+    mStatusAndControlRegs[IRQSTS1] = MCR20Drv_DirectAccessSPIMultiByteRead(IRQSTS2, &mStatusAndControlRegs[IRQSTS2], 5);
+    
+    /* Mask SEQ interrupt */
+    mStatusAndControlRegs[PHY_CTRL2] |= cPHY_CTRL2_SEQMSK;
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL2, mStatusAndControlRegs[PHY_CTRL2]);
+
+    if( (mStatusAndControlRegs[PHY_CTRL1] & cPHY_CTRL1_XCVSEQ) != gIdle_c )
+    {
+        /* Abort current SEQ */
+        mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+        MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+        
+        /* Wait for Sequence Idle (if not already) */
+        while ((MCR20Drv_DirectAccessSPIRead(SEQ_STATE) & 0x1F) != 0);
+        //while ( !(MCR20Drv_DirectAccessSPIRead(IRQSTS1) & cIRQSTS1_SEQIRQ));
+        mStatusAndControlRegs[IRQSTS1] |= cIRQSTS1_SEQIRQ;
+    }
+
+    /* Clear all PP IRQ bits to avoid unexpected interrupts and mask TMR3 interrupt.
+       Do not change TMR IRQ status. */
+    mStatusAndControlRegs[IRQSTS3] &= 0xF0;
+    mStatusAndControlRegs[IRQSTS3] |= (cIRQSTS3_TMR3MSK | cIRQSTS3_TMR3IRQ);
+    MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 3);
+
+    /* Unmask XCVR irq */
+    MCR20Drv_IRQ_Enable();
+}
+
+/*
+ * \brief Function reads a time-stamp value from XCVR [symbols]
+ *
+ * \param pEndTime pointer to location where time-stamp will be stored
+ *
+ * \return none
+ */
+static void rf_get_timestamp(uint32_t *pRetClk)
+{
+    if(NULL == pRetClk)
+    {
+        return;
+    }
+
+    platform_enter_critical();
+
+    *pRetClk = 0;
+    MCR20Drv_DirectAccessSPIMultiByteRead(EVENT_TMR_LSB, (uint8_t *) pRetClk, 3);
+
+    platform_exit_critical();
+}
+
+/*
+ * \brief Function set a time-out to an XCVR sequence.
+ *
+ * \param pEndTime pointer to the sequence time-out value [symbols]
+ *
+ * \return none
+ */
+static void rf_set_timeout(uint32_t *pEndTime)
+{
+    uint8_t phyReg;
+    
+    if(NULL == pEndTime)
+    {
+        return;
+    }
+    
+    platform_enter_critical();
+    
+    phyReg = MCR20Drv_DirectAccessSPIRead(IRQSTS3);
+    phyReg &= 0xF0;                    /* do not change IRQ status */
+    phyReg |= (cIRQSTS3_TMR3MSK);      /* mask TMR3 interrupt */
+    MCR20Drv_DirectAccessSPIWrite(IRQSTS3, phyReg);
+    
+    MCR20Drv_DirectAccessSPIMultiByteWrite(T3CMP_LSB, (uint8_t *) pEndTime, 3);
+    
+    phyReg &= ~(cIRQSTS3_TMR3MSK);      /* unmask TMR3 interrupt */
+    phyReg |= (cIRQSTS3_TMR3IRQ);       /* aknowledge TMR3 IRQ */
+    MCR20Drv_DirectAccessSPIWrite(IRQSTS3, phyReg);
+    
+    platform_exit_critical();
+}
+
+/*
+ * \brief Function reads a random number from RF.
+ *
+ * \param none 
+ *
+ * \return 8-bit random number
+ */
+static uint8_t rf_if_read_rnd(void)
+{
+    uint8_t phyReg;
+
+    MCR20Drv_IRQ_Disable();
+    /* Check if XCVR is idle */
+    phyReg = MCR20Drv_DirectAccessSPIRead(PHY_CTRL1);
+
+    if( (phyReg & cPHY_CTRL1_XCVSEQ) == gIdle_c )
+    {
+        /* Program a new sequence */
+        MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, phyReg | gCCA_c);
+        /* Wait for sequence to finish */
+        while( !(MCR20Drv_DirectAccessSPIRead(IRQSTS1) & cIRQSTS1_SEQIRQ) );
+        /* Clear interrupt flag */
+        MCR20Drv_DirectAccessSPIWrite(IRQSTS1, cIRQSTS1_SEQIRQ);
+    }
+
+    MCR20Drv_IRQ_Enable();
+
+    return MCR20Drv_IndirectAccessSPIRead(_RNG);
+}
+
+/*
+ * \brief Function converts LQI into RSSI.
+ *
+ * \param LQI 
+ *
+ * \return RSSI
+ */
+static int8_t rf_convert_LQI_to_RSSI(uint8_t lqi)
+{
+    int32_t rssi = (50*lqi - 16820) / 163;
+    return (int8_t)rssi;
+}
+
+/*
+ * \brief Function scale the LQI value reported by RF into a 0-255 value.
+ *
+ * \param hwLqi - the LQI value reported by RF
+ *
+ * \return scaled LQI
+ */
+static uint8_t rf_convert_LQI(uint8_t hwLqi)
+{
+    uint32_t tmpLQI;
+
+    /* LQI Saturation Level */
+    if (hwLqi >= 230)
+    {
+        return 0xFF;
+    }
+    else if (hwLqi <= 9)
+    {
+        return 0;
+    }
+    else
+    {
+        /* Rescale the LQI values from min to saturation to the 0x00 - 0xFF range */
+        /* The LQI value mst be multiplied by ~1.1087 */
+        /* tmpLQI =  hwLqi * 7123 ~= hwLqi * 65536 * 0.1087 = hwLqi * 2^16 * 0.1087*/
+        tmpLQI = ((uint32_t)hwLqi * (uint32_t)7123 );
+        /* tmpLQI =  (tmpLQI / 2^16) + hwLqi */
+        tmpLQI = (uint32_t)(tmpLQI >> 16) + (uint32_t)hwLqi;
+
+        return (uint8_t)tmpLQI;
+    }
+}
+
+/*
+ * \brief Function enables/disables Rx promiscuous mode.
+ *
+ * \param state of XCVR promiscuous mode
+ *
+ * \return none
+ */
+static void rf_promiscuous(uint8_t state)
+{
+    uint8_t rxFrameFltReg, phyCtrl4Reg;
+
+    rxFrameFltReg = MCR20Drv_IndirectAccessSPIRead(RX_FRAME_FILTER);
+    phyCtrl4Reg = MCR20Drv_DirectAccessSPIRead(PHY_CTRL4);
+
+    if( state )
+    {
+        /* FRM_VER[1:0] = b00. 00: Any FrameVersion accepted (0,1,2 & 3) */
+        /* All frame types accepted*/
+        phyCtrl4Reg   |= cPHY_CTRL4_PROMISCUOUS;
+        rxFrameFltReg &= ~(cRX_FRAME_FLT_FRM_VER);
+        rxFrameFltReg |=  (cRX_FRAME_FLT_ACK_FT | cRX_FRAME_FLT_NS_FT);
+    }
+    else
+    {
+        phyCtrl4Reg   &= ~cPHY_CTRL4_PROMISCUOUS;
+        /* FRM_VER[1:0] = b11. Accept FrameVersion 0 and 1 packets, reject all others */
+        /* Beacon, Data and MAC command frame types accepted */
+        rxFrameFltReg &= ~(cRX_FRAME_FLT_FRM_VER);
+        rxFrameFltReg |= (0x03 << cRX_FRAME_FLT_FRM_VER_Shift_c);
+        rxFrameFltReg &= ~(cRX_FRAME_FLT_ACK_FT | cRX_FRAME_FLT_NS_FT);
+    }
+
+    MCR20Drv_IndirectAccessSPIWrite(RX_FRAME_FILTER, rxFrameFltReg);
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL4, phyCtrl4Reg);
+}
+
+/*
+ * \brief Function used to switch XCVR power state.
+ *
+ * \param state The XCVR power mode
+ *
+ * \return none
+ */
+static void rf_set_power_state(xcvrPwrMode_t newState)
+{
+    uint8_t pwrMode;
+    uint8_t xtalState;
+
+    if( mPwrState == newState )
+    {
+        return;
+    }
+
+    /* Read power settings from RF */
+    pwrMode = MCR20Drv_DirectAccessSPIRead(PWR_MODES);
+    xtalState = pwrMode & cPWR_MODES_XTALEN;
+    
+    switch( newState )
+    {
+    case gXcvrPwrIdle_c:
+        pwrMode &= ~(cPWR_MODES_AUTODOZE);
+        pwrMode |= (cPWR_MODES_XTALEN | cPWR_MODES_PMC_MODE);
+        break;
+    case gXcvrPwrAutodoze_c:
+        pwrMode |= (cPWR_MODES_XTALEN | cPWR_MODES_AUTODOZE | cPWR_MODES_PMC_MODE);
+        break;
+    case gXcvrPwrDoze_c:
+        pwrMode &= ~(cPWR_MODES_AUTODOZE | cPWR_MODES_PMC_MODE);
+        pwrMode |= cPWR_MODES_XTALEN;
+        break;
+    case gXcvrPwrHibernate_c:
+        pwrMode &= ~(cPWR_MODES_XTALEN | cPWR_MODES_AUTODOZE | cPWR_MODES_PMC_MODE);
+        break;
+    default:
+        return;
+    }
+    
+    mPwrState = newState;
+    MCR20Drv_DirectAccessSPIWrite(PWR_MODES, pwrMode);
+    
+    if( !xtalState && (pwrMode & cPWR_MODES_XTALEN))
+    {
+        /* wait for crystal oscillator to complet its warmup */
+        while( ( MCR20Drv_DirectAccessSPIRead(PWR_MODES) & cPWR_MODES_XTAL_READY ) != cPWR_MODES_XTAL_READY);
+        /* wait for radio wakeup from hibernate interrupt */
+        while( ( MCR20Drv_DirectAccessSPIRead(IRQSTS2) & (cIRQSTS2_WAKE_IRQ | cIRQSTS2_TMRSTATUS) ) != (cIRQSTS2_WAKE_IRQ | cIRQSTS2_TMRSTATUS) );
+
+        MCR20Drv_DirectAccessSPIWrite(IRQSTS2, cIRQSTS2_WAKE_IRQ);
+    }
+}
+
+/*
+ * \brief Function reads the energy level on the preselected channel.
+ *
+ * \return energy level
+ */
+static uint8_t rf_get_channel_energy(void)
+{
+    uint8_t ccaMode;
+
+    MCR20Drv_IRQ_Disable();
+    /* RX can start only from Idle state */
+    if( mPhySeqState != gIdle_c )
+    {
+        MCR20Drv_IRQ_Enable();
+        return 0;
+    }
+
+    /* Set XCVR power state in run mode */
+    rf_set_power_state(gXcvrRunState_d);
+
+    /* Switch to ED mode */
+    ccaMode = (mStatusAndControlRegs[PHY_CTRL4] >> cPHY_CTRL4_CCATYPE_Shift_c) & cPHY_CTRL4_CCATYPE;
+    if( ccaMode != gCcaED_c )
+    {
+        mStatusAndControlRegs[PHY_CTRL4] &= ~(cPHY_CTRL4_CCATYPE << cPHY_CTRL4_CCATYPE_Shift_c);
+        mStatusAndControlRegs[PHY_CTRL4] |= gCcaED_c << cPHY_CTRL4_CCATYPE_Shift_c;
+        MCR20Drv_DirectAccessSPIWrite(PHY_CTRL4, mStatusAndControlRegs[PHY_CTRL4]);
+    }
+    
+    /* Start ED sequence */
+    mStatusAndControlRegs[PHY_CTRL1] |= gCCA_c;
+    MCR20Drv_DirectAccessSPIWrite(IRQSTS1, cIRQSTS1_CCAIRQ | cIRQSTS1_SEQIRQ);
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+    /* Wait for sequence to finish */
+    while ( !(MCR20Drv_DirectAccessSPIRead(IRQSTS1) & cIRQSTS1_SEQIRQ));
+    /* Set XCVR to Idle */
+    mStatusAndControlRegs[PHY_CTRL1] &= ~(cPHY_CTRL1_XCVSEQ);
+    MCR20Drv_DirectAccessSPIWrite(PHY_CTRL1, mStatusAndControlRegs[PHY_CTRL1]);
+    MCR20Drv_DirectAccessSPIWrite(IRQSTS1, cIRQSTS1_CCAIRQ | cIRQSTS1_SEQIRQ);
+    
+    MCR20Drv_IRQ_Enable();
+    
+    return rf_convert_energy_level(MCR20Drv_DirectAccessSPIRead(CCA1_ED_FNL));
+}
+
+/*
+ * \brief Function converts the energy level from dBm to a 0-255 value.
+ *
+ * \param energyLevel in dBm
+ *
+ * \return energy level (0-255)
+ */
+static uint8_t rf_convert_energy_level(uint8_t energyLevel)
+{
+    if(energyLevel >= 90)
+    {
+        /* ED value is below minimum. Return 0x00. */
+        energyLevel = 0x00;
+    }
+    else if(energyLevel <= 26)
+    {
+        /* ED value is above maximum. Return 0xFF. */
+        energyLevel = 0xFF;
+    }
+    else
+    {
+        /* Energy level (-90 dBm to -26 dBm ) --> varies form 0 to 64 */
+        energyLevel = (90 - energyLevel);
+        /* Rescale the energy level values to the 0x00-0xff range (0 to 64 translates in 0 to 255) */
+        /* energyLevel * 3.9844 ~= 4 */
+        /* Multiply with 4=2^2 by shifting left.
+        The multiplication will not overflow beacause energyLevel has values between 0 and 63 */
+        energyLevel <<= 2;
+    }
+
+    return energyLevel;
+}
+
+static uint8_t rf_scale_lqi(int8_t rssi)
+{
+    uint8_t scaled_lqi;
+    /*Worst case sensitivity*/
+    const int8_t rf_sensitivity = -98;
+
+    /*rssi < RF sensitivity*/
+    if(rssi < rf_sensitivity)
+        scaled_lqi=0;
+    /*-91 dBm < rssi < -81 dBm (AT86RF233 XPro)*/
+    /*-90 dBm < rssi < -80 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 10))
+        scaled_lqi=31;
+    /*-81 dBm < rssi < -71 dBm (AT86RF233 XPro)*/
+    /*-80 dBm < rssi < -70 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 20))
+        scaled_lqi=207;
+    /*-71 dBm < rssi < -61 dBm (AT86RF233 XPro)*/
+    /*-70 dBm < rssi < -60 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 30))
+        scaled_lqi=255;
+    /*-61 dBm < rssi < -51 dBm (AT86RF233 XPro)*/
+    /*-60 dBm < rssi < -50 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 40))
+        scaled_lqi=255;
+    /*-51 dBm < rssi < -41 dBm (AT86RF233 XPro)*/
+    /*-50 dBm < rssi < -40 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 50))
+        scaled_lqi=255;
+    /*-41 dBm < rssi < -31 dBm (AT86RF233 XPro)*/
+    /*-40 dBm < rssi < -30 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 60))
+        scaled_lqi=255;
+    /*-31 dBm < rssi < -21 dBm (AT86RF233 XPro)*/
+    /*-30 dBm < rssi < -20 dBm (AT86RF212B XPro)*/
+    else if(rssi < (rf_sensitivity + 70))
+        scaled_lqi=255;
+    /*rssi > RF saturation*/
+    else if(rssi > (rf_sensitivity + 80))
+        scaled_lqi=111;
+    /*-21 dBm < rssi < -11 dBm (AT86RF233 XPro)*/
+    /*-20 dBm < rssi < -10 dBm (AT86RF212B XPro)*/
+    else
+        scaled_lqi=255;
+
+    return scaled_lqi;
+}
+
+
+/*****************************************************************************/
+/*              Layer porting to the Freescale driver                        */
+/*****************************************************************************/
+extern "C" void xcvr_spi_init(uint32_t instance)
+{
+    (void)instance;
+}
+
+extern "C" void RF_IRQ_Init(void) {
+    MBED_ASSERT(irq != NULL);
+    irq->mode(PullUp);
+    irq->fall(&PHY_InterruptHandler);
+}
+
+extern "C" void RF_IRQ_Enable(void) {
+    MBED_ASSERT(irq != NULL);
+    irq->enable_irq();
+}
+
+extern "C" void RF_IRQ_Disable(void) {
+    MBED_ASSERT(irq != NULL);
+    irq->disable_irq();
+}
+
+extern "C" uint8_t RF_isIRQ_Pending(void) {
+    MBED_ASSERT(rf != NULL);
+    return !irq_pin->read();
+}
+
+extern "C" void RF_RST_Set(int state) {
+    MBED_ASSERT(rst != NULL);
+    *rst = state;
+}
+
+extern "C" void gXcvrAssertCS_d(void)
+{
+    MBED_ASSERT(cs != NULL);
+    *cs = 0;
+}
+
+extern "C" void gXcvrDeassertCS_d(void)
+{
+    MBED_ASSERT(cs != NULL);
+    *cs = 1;
+}
+
+extern "C" void xcvr_spi_configure_speed(uint32_t instance, uint32_t freq)
+{
+    MBED_ASSERT(spi != NULL);
+    (void)instance;
+    spi->frequency(freq);
+}
+
+extern "C" void xcvr_spi_transfer(uint32_t instance,
+                         uint8_t * sendBuffer,
+                         uint8_t * receiveBuffer,
+                         size_t transferByteCount)
+{
+    MBED_ASSERT(spi != NULL);
+    (void)instance;
+    volatile uint8_t dummy;
+
+    if( !transferByteCount )
+        return;
+
+    if( !sendBuffer && !receiveBuffer )
+        return;
+
+    while( transferByteCount-- )
+    {
+        if( sendBuffer )
+        {
+            dummy = *sendBuffer;
+            sendBuffer++;
+        }
+        else
+        {
+            dummy = 0xFF;
+        }
+
+        dummy = spi->write(dummy);
+
+        if( receiveBuffer )
+        {
+            *receiveBuffer = dummy;
+            receiveBuffer++;
+        }
+    }
+}
+
+/*****************************************************************************/
+/*****************************************************************************/
+
+static void rf_if_lock(void)
+{
+    platform_enter_critical();
+}
+
+static void rf_if_unlock(void)
+{
+    platform_exit_critical();
+}
+
+NanostackRfPhyMcr20a::NanostackRfPhyMcr20a(PinName spi_mosi, PinName spi_miso,
+        PinName spi_sclk, PinName spi_cs,  PinName spi_rst, PinName spi_irq)
+    : _spi(spi_mosi, spi_miso, spi_sclk), _rf_cs(spi_cs), _rf_rst(spi_rst, 1),
+      _rf_irq(spi_irq), _rf_irq_pin(spi_irq),
+      _irq_thread(osPriorityRealtime, 1024)
+{
+    char mac48[6];
+    mbed_mac_address(mac48);
+
+    MAC_address[0] = mac48[0];
+    MAC_address[1] = mac48[1];
+    MAC_address[2] = mac48[2];
+    MAC_address[3] = 0xFF;
+    MAC_address[4] = 0xFF;
+    MAC_address[5] = mac48[3];
+    MAC_address[6] = mac48[4];
+    MAC_address[7] = mac48[5];
+}
+
+NanostackRfPhyMcr20a::~NanostackRfPhyMcr20a()
+{
+    // Do nothing
+}
+
+int8_t NanostackRfPhyMcr20a::rf_register()
+{
+
+    rf_if_lock();
+
+    if (rf != NULL) {
+        rf_if_unlock();
+        error("Multiple registrations of NanostackRfPhyMcr20a not supported");
+        return -1;
+    }
+
+    _irq_thread.start(mbed::callback(PHY_InterruptThread));
+
+    _pins_set();
+    int8_t radio_id = rf_device_register();
+    if (radio_id < 0) {
+        _pins_clear();
+        rf = NULL;
+    }
+
+    rf_if_unlock();
+    return radio_id;
+}
+
+void NanostackRfPhyMcr20a::rf_unregister()
+{
+    rf_if_lock();
+
+    if (rf != this) {
+        rf_if_unlock();
+        return;
+    }
+
+    rf_device_unregister();
+    rf = NULL;
+    _pins_clear();
+
+    rf_if_unlock();
+}
+
+void NanostackRfPhyMcr20a::get_mac_address(uint8_t *mac)
+{
+    rf_if_lock();
+
+    memcpy((void*)mac, (void*)MAC_address, sizeof(MAC_address));
+
+    rf_if_unlock();
+}
+
+void NanostackRfPhyMcr20a::set_mac_address(uint8_t *mac)
+{
+    rf_if_lock();
+
+    if (NULL != rf) {
+        error("NanostackRfPhyAtmel cannot change mac address when running");
+        rf_if_unlock();
+        return;
+    }
+    memcpy((void*)MAC_address, (void*)mac, sizeof(MAC_address));
+
+    rf_if_unlock();
+}
+
+void NanostackRfPhyMcr20a::_pins_set()
+{
+    spi = &_spi;
+    cs = &_rf_cs;
+    rst = &_rf_rst;
+    irq = &_rf_irq;
+    irq_pin = &_rf_irq_pin;
+    irq_thread = &_irq_thread;
+}
+
+void NanostackRfPhyMcr20a::_pins_clear()
+{
+    spi = NULL;
+    cs = NULL;
+    rst = NULL;
+    irq = NULL;
+    irq_pin = NULL;
+    irq_thread = NULL;
+}
+
+#if MBED_CONF_MCR20A_PROVIDE_DEFAULT || TARGET_KW24D
+
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+    static NanostackRfPhyMcr20a rf_phy(MCR20A_SPI_MOSI, MCR20A_SPI_MISO, MCR20A_SPI_SCLK, MCR20A_SPI_CS, MCR20A_SPI_RST, MCR20A_SPI_IRQ);
+    return rf_phy;
+}
+
+#endif // MBED_CONF_MCR20A_PROVIDE_DEFAULT
+
+#endif // MBED_CONF_NANOSTACK_CONFIGURATION

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/XcvrSpi.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/XcvrSpi.h
@@ -1,0 +1,89 @@
+/*!
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* All rights reserved.
+*
+* \file XcvrSpi.h
+*
+* Redistribution and use in source and binary forms, with or without modification,
+* are permitted provided that the following conditions are met:
+*
+* o Redistributions of source code must retain the above copyright notice, this list
+*   of conditions and the following disclaimer.
+*
+* o Redistributions in binary form must reproduce the above copyright notice, this
+*   list of conditions and the following disclaimer in the documentation and/or
+*   other materials provided with the distribution.
+*
+* o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+*   contributors may be used to endorse or promote products derived from this
+*   software without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef __XCVR_SPI_H__
+#define __XCVR_SPI_H__
+
+
+/*****************************************************************************
+ *                               INCLUDED HEADERS                            *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the headers that this module needs to include.    *
+ * Note that it is not a good practice to include header files into header   *
+ * files, so use this section only if there is no other better solution.     *
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+ 
+
+/*****************************************************************************
+ *                             PUBLIC MACROS                                 *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the access macros, registers mappings, bit access *
+ * macros, masks, flags etc ...
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+#define gXcvrSpiInstance_c              0
+
+/*****************************************************************************
+ *                            PUBLIC FUNCTIONS                               *
+ *---------------------------------------------------------------------------*
+ * Add to this section all the global functions prototype preceded (as a     *
+ * good practice) by the keyword 'extern'                                    *
+ *---------------------------------------------------------------------------*
+ *****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C" {
+#endif /* __cplusplus */
+
+void RF_RST_Set(int state);
+void RF_CS_Set(int state);
+void RF_IRQ_Init(void);
+void RF_IRQ_Disable(void);
+void RF_IRQ_Enable(void);
+uint8_t RF_isIRQ_Pending(void);
+
+void gXcvrAssertCS_d(void);
+void gXcvrDeassertCS_d(void);
+
+void xcvr_spi_init(uint32_t instance);
+void xcvr_spi_configure_speed(uint32_t instance, uint32_t freq);
+void xcvr_spi_transfer(uint32_t instance,
+                         uint8_t * sendBuffer,
+                         uint8_t * receiveBuffer,
+                         uint32_t transferByteCount);
+                         
+#if defined(__cplusplus)
+}
+#endif /* __cplusplus */
+
+#endif /* __XCVR_SPI_H__ */

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -1,0 +1,670 @@
+/* ESP8266 Example
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ESP8266.h"
+#include "mbed_debug.h"
+#include "nsapi_types.h"
+
+#include <cstring>
+
+#define ESP8266_DEFAULT_BAUD_RATE   115200
+#define ESP8266_ALL_SOCKET_IDS      -1
+
+ESP8266::ESP8266(PinName tx, PinName rx, bool debug)
+    : _serial(tx, rx, ESP8266_DEFAULT_BAUD_RATE), 
+      _parser(&_serial), 
+      _packets(0), 
+      _packets_end(&_packets),
+      _connect_error(0),
+      _fail(false),
+      _closed(false),
+      _socket_open(),
+      _connection_status(NSAPI_STATUS_DISCONNECTED)
+{
+    _serial.set_baud( ESP8266_DEFAULT_BAUD_RATE );
+    _parser.debug_on(debug);
+    _parser.set_delimiter("\r\n");
+    _parser.oob("+IPD", callback(this, &ESP8266::_packet_handler));
+    //Note: espressif at command document says that this should be +CWJAP_CUR:<error code>
+    //but seems that at least current version is not sending it
+    //https://www.espressif.com/sites/default/files/documentation/4a-esp8266_at_instruction_set_en.pdf
+    //Also seems that ERROR is not sent, but FAIL instead
+    _parser.oob("+CWJAP:", callback(this, &ESP8266::_connect_error_handler));
+    _parser.oob("0,CLOSED", callback(this, &ESP8266::_oob_socket0_closed_handler));
+    _parser.oob("1,CLOSED", callback(this, &ESP8266::_oob_socket1_closed_handler));
+    _parser.oob("2,CLOSED", callback(this, &ESP8266::_oob_socket2_closed_handler));
+    _parser.oob("3,CLOSED", callback(this, &ESP8266::_oob_socket3_closed_handler));
+    _parser.oob("4,CLOSED", callback(this, &ESP8266::_oob_socket4_closed_handler));
+    _parser.oob("WIFI ", callback(this, &ESP8266::_connection_status_handler));
+    _parser.oob("UNLINK", callback(this, &ESP8266::_oob_socket_close_error));
+}
+
+int ESP8266::get_firmware_version()
+{
+    int version;
+
+    _smutex.lock();
+    bool done = _parser.send("AT+GMR")
+           && _parser.recv("SDK version:%d", &version)
+           && _parser.recv("OK\n");
+    _smutex.unlock();
+
+    if(done) {
+        return version;
+    } else { 
+        // Older firmware versions do not prefix the version with "SDK version: "
+        return -1;
+    }
+}
+
+bool ESP8266::startup(int mode)
+{
+    if (!(mode == WIFIMODE_STATION || mode == WIFIMODE_SOFTAP
+        || mode == WIFIMODE_STATION_SOFTAP)) {
+        return false;
+    }
+
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+    bool done = _parser.send("AT+CWMODE_CUR=%d", mode)
+            && _parser.recv("OK\n")
+            &&_parser.send("AT+CIPMUX=1")
+            && _parser.recv("OK\n");
+    setTimeout(); //Restore default
+    _smutex.unlock();
+
+    return done;
+}
+
+bool ESP8266::reset(void)
+{
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+
+    for (int i = 0; i < 2; i++) {
+        if (_parser.send("AT+RST")
+            && _parser.recv("OK\n")
+            && _parser.recv("ready")) {
+            _clear_socket_packets(ESP8266_ALL_SOCKET_IDS);
+            _smutex.unlock();
+            return true;
+        }
+    }
+    setTimeout();
+    _smutex.unlock();
+
+    return false;
+}
+
+bool ESP8266::dhcp(bool enabled, int mode)
+{
+    //only 3 valid modes
+    if (mode < 0 || mode > 2) {
+        return false;
+    }
+
+    _smutex.lock();
+    bool done = _parser.send("AT+CWDHCP_CUR=%d,%d", mode, enabled?1:0)
+                && _parser.recv("OK\n");
+    _smutex.unlock();
+
+    return done;
+}
+
+nsapi_error_t ESP8266::connect(const char *ap, const char *passPhrase)
+{
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+    _connection_status = NSAPI_STATUS_CONNECTING;
+    if(_connection_status_cb)
+        _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
+
+    _parser.send("AT+CWJAP_CUR=\"%s\",\"%s\"", ap, passPhrase);
+    if (!_parser.recv("OK\n")) {
+        if (_fail) {
+            _smutex.unlock();
+            nsapi_error_t ret;
+            if (_connect_error == 1)
+                ret = NSAPI_ERROR_CONNECTION_TIMEOUT;
+            else if (_connect_error == 2)
+                ret = NSAPI_ERROR_AUTH_FAILURE;
+            else if (_connect_error == 3)
+                ret = NSAPI_ERROR_NO_SSID;
+            else
+                ret = NSAPI_ERROR_NO_CONNECTION;
+
+            _fail = false;
+            _connect_error = 0;
+            return ret;
+        }
+    }
+    setTimeout();
+    _smutex.unlock();
+
+    return NSAPI_ERROR_OK;
+}
+
+bool ESP8266::disconnect(void)
+{
+    _smutex.lock();
+    bool done = _parser.send("AT+CWQAP") && _parser.recv("OK\n");
+    _smutex.unlock();
+
+    return done;
+}
+
+const char *ESP8266::getIPAddress(void)
+{
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+    if (!(_parser.send("AT+CIFSR")
+        && _parser.recv("+CIFSR:STAIP,\"%15[^\"]\"", _ip_buffer)
+        && _parser.recv("OK\n"))) {
+        _smutex.unlock();
+        return 0;
+    }
+    setTimeout();
+    _smutex.unlock();
+
+    return _ip_buffer;
+}
+
+const char *ESP8266::getMACAddress(void)
+{
+    _smutex.lock();
+    if (!(_parser.send("AT+CIFSR")
+        && _parser.recv("+CIFSR:STAMAC,\"%17[^\"]\"", _mac_buffer)
+        && _parser.recv("OK\n"))) {
+        _smutex.unlock();
+        return 0;
+    }
+    _smutex.unlock();
+
+    return _mac_buffer;
+}
+
+const char *ESP8266::getGateway()
+{
+    _smutex.lock();
+    if (!(_parser.send("AT+CIPSTA_CUR?")
+        && _parser.recv("+CIPSTA_CUR:gateway:\"%15[^\"]\"", _gateway_buffer)
+        && _parser.recv("OK\n"))) {
+        _smutex.unlock();
+        return 0;
+    }
+    _smutex.unlock();
+
+    return _gateway_buffer;
+}
+
+const char *ESP8266::getNetmask()
+{
+    _smutex.lock();
+    if (!(_parser.send("AT+CIPSTA_CUR?")
+        && _parser.recv("+CIPSTA_CUR:netmask:\"%15[^\"]\"", _netmask_buffer)
+        && _parser.recv("OK\n"))) {
+        _smutex.unlock();
+        return 0;
+    }
+    _smutex.unlock();
+
+    return _netmask_buffer;
+}
+
+int8_t ESP8266::getRSSI()
+{
+    int8_t rssi;
+    char bssid[18];
+
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+    if (!(_parser.send("AT+CWJAP_CUR?")
+        && _parser.recv("+CWJAP_CUR:\"%*[^\"]\",\"%17[^\"]\"", bssid)
+        && _parser.recv("OK\n"))) {
+       _smutex.unlock();
+        return 0;
+    }
+    setTimeout();
+   _smutex.unlock();
+
+   _smutex.lock();
+   setTimeout(ESP8266_CONNECT_TIMEOUT);
+    if (!(_parser.send("AT+CWLAP=\"\",\"%s\",", bssid)
+        && _parser.recv("+CWLAP:(%*d,\"%*[^\"]\",%hhd,", &rssi)
+        && _parser.recv("OK\n"))) {
+        _smutex.unlock();
+        return 0;
+    }
+    setTimeout();
+    _smutex.unlock();
+
+    return rssi;
+}
+
+int ESP8266::scan(WiFiAccessPoint *res, unsigned limit)
+{
+    unsigned cnt = 0;
+    nsapi_wifi_ap_t ap;
+
+    _smutex.lock();
+    setTimeout(ESP8266_CONNECT_TIMEOUT);
+
+    if (!_parser.send("AT+CWLAP")) {
+        _smutex.unlock();
+        return NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    while (recv_ap(&ap)) {
+        if (cnt < limit) {
+            res[cnt] = WiFiAccessPoint(ap);
+        }
+
+        cnt++;
+        if (limit != 0 && cnt >= limit) {
+            break;
+        }
+    }
+    setTimeout();
+    _smutex.unlock();
+
+    return cnt;
+}
+
+nsapi_error_t ESP8266::open_udp(int id, const char* addr, int port, int local_port)
+{
+    static const char *type = "UDP";
+    bool done = false;
+
+    if (id >= SOCKET_COUNT) {
+        return NSAPI_ERROR_PARAMETER;
+    } else if (_socket_open[id]) {
+        return NSAPI_ERROR_IS_CONNECTED;
+    }
+
+    _smutex.lock();
+    if(local_port) {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d,%d", id, type, addr, port, local_port)
+                && _parser.recv("OK\n");
+    } else {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
+               && _parser.recv("OK\n");
+    }
+
+    if (done) {
+        _socket_open[id] = 1;
+    }
+
+    _clear_socket_packets(id);
+
+    _smutex.unlock();
+
+    return done ? NSAPI_ERROR_OK : NSAPI_ERROR_DEVICE_ERROR;
+}
+
+bool ESP8266::open_tcp(int id, const char* addr, int port, int keepalive)
+{
+    static const char *type = "TCP";
+    bool done = false;
+
+    if (id >= SOCKET_COUNT || _socket_open[id]) {
+        return false;
+    }
+
+    _smutex.lock();
+    if(keepalive) {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d,%d", id, type, addr, port, keepalive)
+                && _parser.recv("OK\n");
+    } else {
+        done = _parser.send("AT+CIPSTART=%d,\"%s\",\"%s\",%d", id, type, addr, port)
+               && _parser.recv("OK\n");
+    }
+
+    if (done) {
+        _socket_open[id] = 1;
+    }
+
+    _clear_socket_packets(id);
+
+    _smutex.unlock();
+
+    return done;
+}
+
+bool ESP8266::dns_lookup(const char* name, char* ip)
+{
+    _smutex.lock();
+    bool done = _parser.send("AT+CIPDOMAIN=\"%s\"", name) && _parser.recv("+CIPDOMAIN:%s%*[\r]%*[\n]", ip);
+    _smutex.unlock();
+
+    return done;
+}
+
+nsapi_error_t ESP8266::send(int id, const void *data, uint32_t amount)
+{
+    //May take a second try if device is busy
+    for (unsigned i = 0; i < 2; i++) {
+        _smutex.lock();
+        setTimeout(ESP8266_SEND_TIMEOUT);
+        if (_parser.send("AT+CIPSEND=%d,%lu", id, amount)
+            && _parser.recv(">")
+            && _parser.write((char*)data, (int)amount) >= 0) {
+            while (_parser.process_oob()); // multiple sends in a row require this
+            _smutex.unlock();
+            return NSAPI_ERROR_OK;
+        }
+        setTimeout();
+        _smutex.unlock();
+    }
+
+    return NSAPI_ERROR_DEVICE_ERROR;
+}
+
+void ESP8266::_packet_handler()
+{
+    int id;
+    int amount;
+
+    // parse out the packet
+    if (!_parser.recv(",%d,%d:", &id, &amount)) {
+        return;
+    }
+
+    struct packet *packet = (struct packet*)malloc(
+            sizeof(struct packet) + amount);
+    if (!packet) {
+        debug("ESP8266: could not allocate memory for RX data\n");
+        return;
+    }
+
+    packet->id = id;
+    packet->len = amount;
+    packet->next = 0;
+
+    if (_parser.read((char*)(packet + 1), amount) < amount) {
+        free(packet);
+        return;
+    }
+
+    // append to packet list
+    *_packets_end = packet;
+    _packets_end = &packet->next;
+}
+
+int32_t ESP8266::recv_tcp(int id, void *data, uint32_t amount, uint32_t timeout)
+{
+    _smutex.lock();
+    setTimeout(timeout);
+
+    // Poll for inbound packets
+    while (_parser.process_oob()) {
+    }
+
+    setTimeout();
+
+    // check if any packets are ready for us
+    for (struct packet **p = &_packets; *p; p = &(*p)->next) {
+        if ((*p)->id == id) {
+            struct packet *q = *p;
+
+            if (q->len <= amount) { // Return and remove full packet
+                memcpy(data, q+1, q->len);
+
+                if (_packets_end == &(*p)->next) {
+                    _packets_end = p;
+                }
+                *p = (*p)->next;
+                _smutex.unlock();
+
+                uint32_t len = q->len;
+                free(q);
+                return len;
+            } else { // return only partial packet
+                memcpy(data, q+1, amount);
+
+                q->len -= amount;
+                memmove(q+1, (uint8_t*)(q+1) + amount, q->len);
+
+                _smutex.unlock();
+                return amount;
+            }
+        }
+    }
+    if(!_socket_open[id]) {
+        _smutex.unlock();
+        return 0;
+    }
+    _smutex.unlock();
+
+    return NSAPI_ERROR_WOULD_BLOCK;
+}
+
+int32_t ESP8266::recv_udp(int id, void *data, uint32_t amount, uint32_t timeout)
+{
+    _smutex.lock();
+    setTimeout(timeout);
+
+    // Poll for inbound packets
+    while (_parser.process_oob()) {
+    }
+
+    setTimeout();
+
+    // check if any packets are ready for us
+    for (struct packet **p = &_packets; *p; p = &(*p)->next) {
+        if ((*p)->id == id) {
+            struct packet *q = *p;
+
+            // Return and remove packet (truncated if necessary)
+            uint32_t len = q->len < amount ? q->len : amount;
+            memcpy(data, q+1, len);
+
+            if (_packets_end == &(*p)->next) {
+                _packets_end = p;
+            }
+            *p = (*p)->next;
+            _smutex.unlock();
+
+            free(q);
+            return len;
+        }
+    }
+    _smutex.unlock();
+
+    return NSAPI_ERROR_WOULD_BLOCK;
+}
+
+void ESP8266::_clear_socket_packets(int id)
+{
+    struct packet **p = &_packets;
+
+    while (*p) {
+        if ((*p)->id == id || id == ESP8266_ALL_SOCKET_IDS) {
+            struct packet *q = *p;
+
+            if (_packets_end == &(*p)->next) {
+                _packets_end = p; // Set last packet next field/_packets
+            }
+            *p = (*p)->next;
+
+            free(q);
+        } else {
+            // Point to last packet next field
+            p = &(*p)->next;
+        }
+    }
+}
+
+bool ESP8266::close(int id)
+{
+    //May take a second try if device is busy
+    for (unsigned i = 0; i < 2; i++) {
+        _smutex.lock();
+        if (_parser.send("AT+CIPCLOSE=%d", id)) {
+            if (!_parser.recv("OK\n")) {
+                if (_closed) { // UNLINK ERROR
+                    _closed = false;
+                    _socket_open[id] = 0;
+                    _clear_socket_packets(id);
+                    _smutex.unlock();
+                    // ESP8266 has a habit that it might close a socket on its own.
+                    //debug("ESP8266: socket %d already closed when calling close\n", id);
+                    return true;
+                }
+            } else {
+                _clear_socket_packets(id);
+                _smutex.unlock();
+                return true;
+            }
+        }
+        _smutex.unlock();
+    }
+
+    return false;
+}
+
+void ESP8266::setTimeout(uint32_t timeout_ms)
+{
+    _parser.set_timeout(timeout_ms);
+}
+
+bool ESP8266::readable()
+{
+    return _serial.FileHandle::readable();
+}
+
+bool ESP8266::writeable()
+{
+    return _serial.FileHandle::writable();
+}
+
+void ESP8266::sigio(Callback<void()> func)
+{
+    _serial.sigio(func);
+}
+
+void ESP8266::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+{
+    _connection_status_cb = status_cb;
+}
+
+bool ESP8266::recv_ap(nsapi_wifi_ap_t *ap)
+{
+    int sec;
+    int dummy;
+    bool ret = _parser.recv("+CWLAP:(%d,\"%32[^\"]\",%hhd,\"%hhx:%hhx:%hhx:%hhx:%hhx:%hhx\",%hhu,%d,%d)\n",
+            &sec,
+            ap->ssid,
+            &ap->rssi,
+            &ap->bssid[0], &ap->bssid[1], &ap->bssid[2], &ap->bssid[3], &ap->bssid[4], &ap->bssid[5],
+            &ap->channel,
+            &dummy,
+            &dummy);
+
+    ap->security = sec < 5 ? (nsapi_security_t)sec : NSAPI_SECURITY_UNKNOWN;
+
+    return ret;
+}
+
+void ESP8266::_connect_error_handler()
+{
+    _fail = false;
+    _connect_error = 0;
+
+    if (_parser.recv("%d", &_connect_error) && _parser.recv("FAIL")) {
+        _fail = true;
+        _parser.abort();
+    }
+}
+
+void ESP8266::_oob_socket_close_error()
+{
+    if (_parser.recv("ERROR\n")) {
+        _closed = true; // Not possible to pinpoint to a certain socket
+        _parser.abort();
+    }
+}
+
+void ESP8266::_oob_socket0_closed_handler()
+{
+    _socket_open[0] = 0;
+}
+
+void ESP8266::_oob_socket1_closed_handler()
+{
+    _socket_open[1] = 0;
+}
+
+void ESP8266::_oob_socket2_closed_handler()
+{
+    _socket_open[2] = 0;
+}
+
+void ESP8266::_oob_socket3_closed_handler()
+{
+    _socket_open[3] = 0;
+}
+
+void ESP8266::_oob_socket4_closed_handler()
+{
+    _socket_open[4] = 0;
+}
+
+void ESP8266::_connection_status_handler()
+{
+    char status[13];
+    if (_parser.recv("%12[^\"]\n", status)) {
+        if (strcmp(status, "GOT IP\n") == 0)
+            _connection_status = NSAPI_STATUS_GLOBAL_UP;
+        else if (strcmp(status, "DISCONNECT\n") == 0)
+            _connection_status = NSAPI_STATUS_DISCONNECTED;
+        else
+            return;
+
+        if(_connection_status_cb)
+            _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connection_status);
+    }
+}
+
+int8_t ESP8266::get_default_wifi_mode()
+{
+    int8_t mode;
+
+    _smutex.lock();
+    if (_parser.send("AT+CWMODE_DEF?")
+        && _parser.recv("+CWMODE_DEF:%hhd", &mode)
+        && _parser.recv("OK\n")) {
+        _smutex.unlock();
+        return mode;
+    }
+    _smutex.unlock();
+
+    return 0;
+}
+
+bool ESP8266::set_default_wifi_mode(const int8_t mode)
+{
+    _smutex.lock();
+    bool done = _parser.send("AT+CWMODE_DEF=%hhd", mode)
+                && _parser.recv("OK\n");
+    _smutex.unlock();
+
+    return done;
+}
+
+nsapi_connection_status_t ESP8266::get_connection_status() const
+{
+    return _connection_status;
+}

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -1,0 +1,309 @@
+/* ESP8266Interface Example
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ESP8266_H
+#define ESP8266_H
+
+#include "ATCmdParser.h"
+#include "nsapi_types.h"
+#include "rtos.h"
+
+// Various timeouts for different ESP8266 operations
+#ifndef ESP8266_CONNECT_TIMEOUT
+#define ESP8266_CONNECT_TIMEOUT 15000
+#endif
+#ifndef ESP8266_SEND_TIMEOUT
+#define ESP8266_SEND_TIMEOUT    2000
+#endif
+#ifndef ESP8266_RECV_TIMEOUT
+#define ESP8266_RECV_TIMEOUT    2000
+#endif
+#ifndef ESP8266_MISC_TIMEOUT
+#define ESP8266_MISC_TIMEOUT    2000
+#endif
+
+/** ESP8266Interface class.
+    This is an interface to a ESP8266 radio.
+ */
+class ESP8266
+{
+public:
+    ESP8266(PinName tx, PinName rx, bool debug=false);
+
+    /**
+    * Check firmware version of ESP8266
+    *
+    * @return integer firmware version or -1 if firmware query command gives outdated response
+    */
+    int get_firmware_version(void);
+    
+    /**
+    * Startup the ESP8266
+    *
+    * @param mode mode of WIFI 1-client, 2-host, 3-both
+    * @return true only if ESP8266 was setup correctly
+    */
+    bool startup(int mode);
+
+    /**
+    * Reset ESP8266
+    *
+    * @return true only if ESP8266 resets successfully
+    */
+    bool reset(void);
+
+    /**
+    * Enable/Disable DHCP
+    *
+    * @param enabled DHCP enabled when true
+    * @param mode mode of DHCP 0-softAP, 1-station, 2-both
+    * @return true only if ESP8266 enables/disables DHCP successfully
+    */
+    bool dhcp(bool enabled, int mode);
+
+    /**
+    * Connect ESP8266 to AP
+    *
+    * @param ap the name of the AP
+    * @param passPhrase the password of AP
+    * @return NSAPI_ERROR_OK only if ESP8266 is connected successfully
+    */
+    nsapi_error_t connect(const char *ap, const char *passPhrase);
+
+    /**
+    * Disconnect ESP8266 from AP
+    *
+    * @return true only if ESP8266 is disconnected successfully
+    */
+    bool disconnect(void);
+
+    /**
+    * Get the IP address of ESP8266
+    *
+    * @return null-teriminated IP address or null if no IP address is assigned
+    */
+    const char *getIPAddress(void);
+
+    /**
+    * Get the MAC address of ESP8266
+    *
+    * @return null-terminated MAC address or null if no MAC address is assigned
+    */
+    const char *getMACAddress(void);
+
+     /** Get the local gateway
+     *
+     *  @return         Null-terminated representation of the local gateway
+     *                  or null if no network mask has been recieved
+     */
+    const char *getGateway();
+
+    /** Get the local network mask
+     *
+     *  @return         Null-terminated representation of the local network mask 
+     *                  or null if no network mask has been recieved
+     */
+    const char *getNetmask();
+
+    /* Return RSSI for active connection
+     *
+     * @return      Measured RSSI
+     */
+    int8_t getRSSI();
+
+    /** Scan for available networks
+     *
+     * @param  ap    Pointer to allocated array to store discovered AP
+     * @param  limit Size of allocated @a res array, or 0 to only count available AP
+     * @return       Number of entries in @a res, or if @a count was 0 number of available networks, negative on error
+     *               see @a nsapi_error
+     */
+    int scan(WiFiAccessPoint *res, unsigned limit);
+    
+    /**Perform a dns query
+    *
+    * @param name Hostname to resolve
+    * @param ip   Buffer to store IP address
+    * @return 0 true on success, false on failure
+    */
+    bool dns_lookup(const char *name, char *ip);
+
+    /**
+    * Open a socketed connection
+    *
+    * @param type the type of socket to open "UDP" or "TCP"
+    * @param id id to give the new socket, valid 0-4
+    * @param port port to open connection with
+    * @param addr the IP address of the destination
+    * @param port the port on the destination
+    * @param local_port UDP socket's local port, zero means any
+    * @return true only if socket opened successfully
+    */
+    nsapi_error_t open_udp(int id, const char* addr, int port, int local_port = 0);
+
+    /**
+    * Open a socketed connection
+    *
+    * @param type the type of socket to open "UDP" or "TCP"
+    * @param id id to give the new socket, valid 0-4
+    * @param port port to open connection with
+    * @param addr the IP address of the destination
+    * @param port the port on the destination
+    * @param tcp_keepalive TCP connection's keep alive time, zero means disabled
+    * @return true only if socket opened successfully
+    */
+    bool open_tcp(int id, const char* addr, int port, int keepalive = 0);
+
+    /**
+    * Sends data to an open socket
+    *
+    * @param id id of socket to send to
+    * @param data data to be sent
+    * @param amount amount of data to be sent - max 1024
+    * @return NSAPI_ERROR_OK in success, negative error code in failure
+    */
+    nsapi_error_t send(int id, const void *data, uint32_t amount);
+
+    /**
+    * Receives datagram from an open UDP socket
+    *
+    * @param id id to receive from
+    * @param data placeholder for returned information
+    * @param amount number of bytes to be received
+    * @return the number of bytes received
+    */
+    int32_t recv_udp(int id, void *data, uint32_t amount, uint32_t timeout=ESP8266_RECV_TIMEOUT);
+
+    /**
+    * Receives stream data from an open TCP socket
+    *
+    * @param id id to receive from
+    * @param data placeholder for returned information
+    * @param amount number of bytes to be received
+    * @return the number of bytes received
+    */
+    int32_t recv_tcp(int id, void *data, uint32_t amount, uint32_t timeout=ESP8266_RECV_TIMEOUT);
+
+    /**
+    * Closes a socket
+    *
+    * @param id id of socket to close, valid only 0-4
+    * @return true only if socket is closed successfully
+    */
+    bool close(int id);
+
+    /**
+    * Allows timeout to be changed between commands
+    *
+    * @param timeout_ms timeout of the connection
+    */
+    void setTimeout(uint32_t timeout_ms=ESP8266_MISC_TIMEOUT);
+
+    /**
+    * Checks if data is available
+    */
+    bool readable();
+
+    /**
+    * Checks if data can be written
+    */
+    bool writeable();
+
+    /**
+    * Attach a function to call whenever sigio happens in the serial
+    *
+    * @param func A pointer to a void function, or 0 to set as none
+    */
+    void sigio(Callback<void()> func);
+
+    /**
+    * Attach a function to call whenever sigio happens in the serial
+    *
+    * @param obj pointer to the object to call the member function on
+    * @param method pointer to the member function to call
+    */
+    template <typename T, typename M>
+    void sigio(T *obj, M method) {
+        sigio(Callback<void()>(obj, method));
+    }
+
+    /**
+    * Attach a function to call whenever network state has changed
+    *
+    * @param func A pointer to a void function, or 0 to set as none
+    */
+    void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+
+    /**
+     * Read default Wifi mode from flash
+     *
+     * return Station, SoftAP or SoftAP+Station - 0 on failure
+     */
+    int8_t get_default_wifi_mode();
+
+    /**
+     * Write default Wifi mode to flash
+     */
+    bool set_default_wifi_mode(const int8_t mode);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    nsapi_connection_status_t get_connection_status() const;
+
+    static const int8_t WIFIMODE_STATION = 1;
+    static const int8_t WIFIMODE_SOFTAP = 2;
+    static const int8_t WIFIMODE_STATION_SOFTAP = 3;
+    static const int8_t SOCKET_COUNT = 5;
+
+private:
+    UARTSerial _serial;
+    ATCmdParser _parser;
+    Mutex _smutex; // Protect serial port access
+
+    struct packet {
+        struct packet *next;
+        int id;
+        uint32_t len;
+        // data follows
+    } *_packets, **_packets_end;
+    void _packet_handler();
+    void _connect_error_handler();
+    bool recv_ap(nsapi_wifi_ap_t *ap);
+    void _oob_socket0_closed_handler();
+    void _oob_socket1_closed_handler();
+    void _oob_socket2_closed_handler();
+    void _oob_socket3_closed_handler();
+    void _oob_socket4_closed_handler();
+    void _connection_status_handler();
+    void _oob_socket_close_error();
+    void _clear_socket_packets(int id);
+
+    char _ip_buffer[16];
+    char _gateway_buffer[16];
+    char _netmask_buffer[16];
+    char _mac_buffer[18];
+
+    int _connect_error;
+    bool _fail;
+    bool _closed;
+    int _socket_open[SOCKET_COUNT];
+    nsapi_connection_status_t _connection_status;
+    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+};
+
+#endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -1,0 +1,586 @@
+/* ESP8266 implementation of NetworkInterfaceAPI
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cstring>
+#include "ESP8266.h"
+#include "ESP8266Interface.h"
+#include "mbed_debug.h"
+#include "nsapi_types.h"
+
+
+#ifndef MBED_CONF_ESP8266_TX
+#ifdef TARGET_FF_ARDUINO
+#define MBED_CONF_ESP8266_TX D1
+#else
+#define MBED_CONF_ESP8266_TX NC
+#endif
+#endif
+
+#ifndef MBED_CONF_ESP8266_RX
+#ifdef TARGET_FF_ARDUINO
+#define MBED_CONF_ESP8266_RX D0
+#else
+#define MBED_CONF_ESP8266_RX NC
+#endif
+#endif
+
+// Firmware version
+#define ESP8266_VERSION 2
+
+ESP8266Interface::ESP8266Interface()
+    : _esp(MBED_CONF_ESP8266_TX, MBED_CONF_ESP8266_RX, MBED_CONF_ESP8266_DEBUG),
+      _initialized(false),
+      _started(false)
+{
+    memset(_ids, 0, sizeof(_ids));
+    memset(_cbs, 0, sizeof(_cbs));
+    memset(ap_ssid, 0, sizeof(ap_ssid));
+    memset(ap_pass, 0, sizeof(ap_pass));
+    memset(_local_ports, 0, sizeof(_local_ports));
+    ap_sec = NSAPI_SECURITY_UNKNOWN;
+
+    _esp.sigio(this, &ESP8266Interface::event);
+    _esp.setTimeout();
+}
+
+// ESP8266Interface implementation
+ESP8266Interface::ESP8266Interface(PinName tx, PinName rx, bool debug)
+    : _esp(tx, rx, debug),
+      _initialized(false),
+      _started(false)
+{
+    memset(_ids, 0, sizeof(_ids));
+    memset(_cbs, 0, sizeof(_cbs));
+    memset(ap_ssid, 0, sizeof(ap_ssid));
+    memset(ap_pass, 0, sizeof(ap_pass));
+    memset(_local_ports, 0, sizeof(_local_ports));
+    ap_sec = NSAPI_SECURITY_UNKNOWN;
+
+    _esp.sigio(this, &ESP8266Interface::event);
+    _esp.setTimeout();
+}
+
+int ESP8266Interface::connect(const char *ssid, const char *pass, nsapi_security_t security,
+                                        uint8_t channel)
+{
+    if (channel != 0) {
+        return NSAPI_ERROR_UNSUPPORTED;
+    }
+
+    int err = set_credentials(ssid, pass, security);
+    if(err) {
+        return err;
+    }
+
+    return connect();
+}
+
+int ESP8266Interface::connect()
+{
+    nsapi_error_t status;
+
+    if (strlen(ap_ssid) == 0) {
+        return NSAPI_ERROR_NO_SSID;
+    }
+
+    if (ap_sec != NSAPI_SECURITY_NONE) {
+        if (strlen(ap_pass) < ESP8266_PASSPHRASE_MIN_LENGTH) {
+            return NSAPI_ERROR_PARAMETER;
+        }
+    }
+
+    status = _init();
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+
+    if(get_ip_address()) {
+        return NSAPI_ERROR_IS_CONNECTED;
+    }
+
+    status = _startup(ESP8266::WIFIMODE_STATION);
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+    _started = true;
+
+    if (!_esp.dhcp(true, 1)) {
+        return NSAPI_ERROR_DHCP_FAILURE;
+    }
+
+    int connect_error = _esp.connect(ap_ssid, ap_pass);
+    if (connect_error) {
+        return connect_error;
+    }
+
+    if (!get_ip_address()) {
+        return NSAPI_ERROR_DHCP_FAILURE;
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+int ESP8266Interface::set_credentials(const char *ssid, const char *pass, nsapi_security_t security)
+{
+    ap_sec = security;
+
+    if (!ssid) {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    int ssid_length = strlen(ssid);
+
+    if (ssid_length > 0
+        && ssid_length <= ESP8266_SSID_MAX_LENGTH) {
+        memset(ap_ssid, 0, sizeof(ap_ssid));
+        strncpy(ap_ssid, ssid, sizeof(ap_ssid));
+    } else {
+        return NSAPI_ERROR_PARAMETER;
+    }
+
+    if (ap_sec != NSAPI_SECURITY_NONE) {
+
+        if (!pass) {
+            return NSAPI_ERROR_PARAMETER;
+        }
+
+        int pass_length = strlen(pass);
+        if (pass_length >= ESP8266_PASSPHRASE_MIN_LENGTH
+            && pass_length <= ESP8266_PASSPHRASE_MAX_LENGTH ) {
+            memset(ap_pass, 0, sizeof(ap_pass));
+            strncpy(ap_pass, pass, sizeof(ap_pass));
+        } else {
+            return NSAPI_ERROR_PARAMETER;
+        }
+    } else {
+        memset(ap_pass, 0, sizeof(ap_pass));
+    }
+
+    return NSAPI_ERROR_OK;
+}
+
+int ESP8266Interface::set_channel(uint8_t channel)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+
+int ESP8266Interface::disconnect()
+{
+    _started = false;
+    _initialized = false;
+
+    return _esp.disconnect() ? NSAPI_ERROR_OK : NSAPI_ERROR_DEVICE_ERROR;
+}
+
+const char *ESP8266Interface::get_ip_address()
+{
+    if(!_started) {
+        return NULL;
+    }
+
+    const char *ip_buff = _esp.getIPAddress();
+    if(!ip_buff || std::strcmp(ip_buff, "0.0.0.0") == 0) {
+        return NULL;
+    }
+
+    return ip_buff;
+}
+
+const char *ESP8266Interface::get_mac_address()
+{
+    return _esp.getMACAddress();
+}
+
+const char *ESP8266Interface::get_gateway()
+{
+    return _started ? _esp.getGateway() : NULL;
+}
+
+const char *ESP8266Interface::get_netmask()
+{
+    return _started ? _esp.getNetmask() : NULL;
+}
+
+int8_t ESP8266Interface::get_rssi()
+{
+    return _started ? _esp.getRSSI() : 0;
+}
+
+int ESP8266Interface::scan(WiFiAccessPoint *res, unsigned count)
+{
+    nsapi_error_t status;
+
+    status = _init();
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+
+    status = _startup(ESP8266::WIFIMODE_STATION);
+    if(status != NSAPI_ERROR_OK) {
+        return status;
+    }
+
+    return _esp.scan(res, count);
+}
+
+bool ESP8266Interface::_get_firmware_ok()
+{
+    if (_esp.get_firmware_version() != ESP8266_VERSION) {
+        debug("ESP8266: ERROR: Firmware incompatible with this driver.\
+               \r\nUpdate to v%d - https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update\r\n",ESP8266_VERSION);
+        return false;
+    }
+
+    return true;
+}
+
+bool ESP8266Interface::_disable_default_softap()
+{
+    static int disabled = false;
+
+    if (disabled || _esp.get_default_wifi_mode() == ESP8266::WIFIMODE_STATION) {
+        disabled = true;
+        return true;
+    }
+    if (_esp.set_default_wifi_mode(ESP8266::WIFIMODE_STATION)) {
+        disabled = true;
+        return true;
+    }
+
+    return false;
+}
+
+nsapi_error_t ESP8266Interface::_init(void)
+{
+    if (!_initialized) {
+        if (!_esp.reset()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        if (!_get_firmware_ok()) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        if (_disable_default_softap() == false) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        _initialized = true;
+    }
+    return NSAPI_ERROR_OK;
+}
+
+nsapi_error_t ESP8266Interface::_startup(const int8_t wifi_mode)
+{
+    if (!_started) {
+        if (!_esp.startup(wifi_mode)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+    }
+    return NSAPI_ERROR_OK;
+}
+
+struct esp8266_socket {
+    int id;
+    nsapi_protocol_t proto;
+    bool connected;
+    SocketAddress addr;
+    int keepalive; // TCP
+};
+
+int ESP8266Interface::socket_open(void **handle, nsapi_protocol_t proto)
+{
+    // Look for an unused socket
+    int id = -1;
+
+    for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
+        if (!_ids[i]) {
+            id = i;
+            _ids[i] = true;
+            break;
+        }
+    }
+
+    if (id == -1) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    struct esp8266_socket *socket = new struct esp8266_socket;
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    socket->id = id;
+    socket->proto = proto;
+    socket->connected = false;
+    socket->keepalive = 0;
+    *handle = socket;
+    return 0;
+}
+
+int ESP8266Interface::socket_close(void *handle)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+    int err = 0;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (socket->connected && !_esp.close(socket->id)) {
+        err = NSAPI_ERROR_DEVICE_ERROR;
+    }
+
+    socket->connected = false;
+    _ids[socket->id] = false;
+    _local_ports[socket->id] = 0;
+    delete socket;
+    return err;
+}
+
+int ESP8266Interface::socket_bind(void *handle, const SocketAddress &address)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (socket->proto == NSAPI_UDP) {
+        if(address.get_addr().version != NSAPI_UNSPEC) {
+            return NSAPI_ERROR_UNSUPPORTED;
+        }
+
+        for(int id = 0; id < ESP8266_SOCKET_COUNT; id++) {
+            if(_local_ports[id] == address.get_port() && id != socket->id) { // Port already reserved by another socket
+                return NSAPI_ERROR_PARAMETER;
+            } else if (id == socket->id && socket->connected) {
+                return NSAPI_ERROR_PARAMETER;
+            }
+        }
+        _local_ports[socket->id] = address.get_port();
+        return 0;
+    }
+
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+int ESP8266Interface::socket_listen(void *handle, int backlog)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+int ESP8266Interface::socket_connect(void *handle, const SocketAddress &addr)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+    nsapi_error_t ret;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (socket->proto == NSAPI_UDP) {
+        ret = _esp.open_udp(socket->id, addr.get_ip_address(), addr.get_port(), _local_ports[socket->id]);
+        if (ret != NSAPI_ERROR_OK) {
+            return ret;
+        }
+    } else {
+        if (!_esp.open_tcp(socket->id, addr.get_ip_address(), addr.get_port(), socket->keepalive)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+    }
+
+    socket->connected = true;
+    return 0;
+}
+
+int ESP8266Interface::socket_accept(void *server, void **socket, SocketAddress *addr)
+{
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+int ESP8266Interface::socket_send(void *handle, const void *data, unsigned size)
+{
+    nsapi_error_t status;
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    status = _esp.send(socket->id, data, size);
+
+    return status != NSAPI_ERROR_OK ? status : size;
+}
+
+int ESP8266Interface::socket_recv(void *handle, void *data, unsigned size)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    int32_t recv;
+    if (socket->proto == NSAPI_TCP) {
+        recv = _esp.recv_tcp(socket->id, data, size);
+        if (recv <= 0 && recv != NSAPI_ERROR_WOULD_BLOCK) {
+            socket->connected = false;
+        }
+    } else {
+        recv = _esp.recv_udp(socket->id, data, size);
+    }
+
+    return recv;
+}
+
+int ESP8266Interface::socket_sendto(void *handle, const SocketAddress &addr, const void *data, unsigned size)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if((strcmp(addr.get_ip_address(), "0.0.0.0") == 0) || !addr.get_port())  {
+        return NSAPI_ERROR_DNS_FAILURE;
+    }
+
+    if (socket->connected && socket->addr != addr) {
+        if (!_esp.close(socket->id)) {
+            return NSAPI_ERROR_DEVICE_ERROR;
+        }
+        socket->connected = false;
+    }
+
+    if (!socket->connected) {
+        int err = socket_connect(socket, addr);
+        if (err < 0) {
+            return err;
+        }
+        socket->addr = addr;
+    }
+
+    return socket_send(socket, data, size);
+}
+
+int ESP8266Interface::socket_recvfrom(void *handle, SocketAddress *addr, void *data, unsigned size)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    int ret = socket_recv(socket, data, size);
+    if (ret >= 0 && addr) {
+        *addr = socket->addr;
+    }
+
+    return ret;
+}
+
+void ESP8266Interface::socket_attach(void *handle, void (*callback)(void *), void *data)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+    _cbs[socket->id].callback = callback;
+    _cbs[socket->id].data = data;
+}
+
+nsapi_error_t ESP8266Interface::setsockopt(nsapi_socket_t handle, int level,
+        int optname, const void *optval, unsigned optlen)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!optlen) {
+        return NSAPI_ERROR_PARAMETER;
+    } else if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (level == NSAPI_SOCKET && socket->proto == NSAPI_TCP) {
+        switch (optname) {
+            case NSAPI_KEEPALIVE: {
+                if(socket->connected) {// ESP8266 limitation, keepalive needs to be given before connecting
+                    return NSAPI_ERROR_UNSUPPORTED;
+                }
+
+                if (optlen == sizeof(int)) {
+                    int secs = *(int *)optval;
+                    if (secs  >= 0 && secs <= 7200) {
+                        socket->keepalive = secs;
+                        return NSAPI_ERROR_OK;
+                    }
+                }
+                return NSAPI_ERROR_PARAMETER;
+            }
+        }
+    }
+
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+nsapi_error_t ESP8266Interface::getsockopt(nsapi_socket_t handle, int level, int optname, void *optval, unsigned *optlen)
+{
+    struct esp8266_socket *socket = (struct esp8266_socket *)handle;
+
+    if (!optval || !optlen) {
+        return NSAPI_ERROR_PARAMETER;
+    } else if (!socket) {
+        return NSAPI_ERROR_NO_SOCKET;
+    }
+
+    if (level == NSAPI_SOCKET && socket->proto == NSAPI_TCP) {
+        switch (optname) {
+            case NSAPI_KEEPALIVE: {
+                if(*optlen > sizeof(int)) {
+                    *optlen = sizeof(int);
+                }
+                memcpy(optval, &(socket->keepalive), *optlen);
+                return NSAPI_ERROR_OK;
+            }
+        }
+    }
+
+    return NSAPI_ERROR_UNSUPPORTED;
+}
+
+
+void ESP8266Interface::event()
+{
+    for (int i = 0; i < ESP8266_SOCKET_COUNT; i++) {
+        if (_cbs[i].callback) {
+            _cbs[i].callback(_cbs[i].data);
+        }
+    }
+}
+
+void ESP8266Interface::attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
+{
+    _esp.attach(status_cb);
+}
+
+nsapi_connection_status_t ESP8266Interface::get_connection_status() const
+{
+    return _esp.get_connection_status();
+}
+
+#if MBED_CONF_ESP8266_PROVIDE_DEFAULT
+
+WiFiInterface *WiFiInterface::get_default_instance() {
+    static ESP8266Interface esp();
+    return &esp;
+}
+
+#endif

--- a/components/wifi/esp8266-driver/ESP8266Interface.h
+++ b/components/wifi/esp8266-driver/ESP8266Interface.h
@@ -1,0 +1,346 @@
+/* ESP8266 implementation of NetworkInterfaceAPI
+ * Copyright (c) 2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ESP8266_INTERFACE_H
+#define ESP8266_INTERFACE_H
+
+#include "mbed.h"
+#include "ESP8266.h"
+
+
+#define ESP8266_SOCKET_COUNT 5
+
+/** ESP8266Interface class
+ *  Implementation of the NetworkStack for the ESP8266
+ */
+class ESP8266Interface : public NetworkStack, public WiFiInterface
+{
+public:
+    /**
+     * @brief ESP8266Interface default constructor
+     *        Will use values defined in mbed_lib.json
+     */
+    ESP8266Interface();
+
+    /** ESP8266Interface lifetime
+     * @param tx        TX pin
+     * @param rx        RX pin
+     * @param debug     Enable debugging
+     */
+    ESP8266Interface(PinName tx, PinName rx, bool debug = false);
+
+    /** Start the interface
+     *
+     *  Attempts to connect to a WiFi network. Requires ssid and passphrase to be set.
+     *  If passphrase is invalid, NSAPI_ERROR_AUTH_ERROR is returned.
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int connect();
+
+    /** Start the interface
+     *
+     *  Attempts to connect to a WiFi network.
+     *
+     *  @param ssid      Name of the network to connect to
+     *  @param pass      Security passphrase to connect to the network
+     *  @param security  Type of encryption for connection (Default: NSAPI_SECURITY_NONE)
+     *  @param channel   This parameter is not supported, setting it to anything else than 0 will result in NSAPI_ERROR_UNSUPPORTED
+     *  @return          0 on success, or error code on failure
+     */
+    virtual int connect(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE,
+                                  uint8_t channel = 0);
+
+    /** Set the WiFi network credentials
+     *
+     *  @param ssid      Name of the network to connect to
+     *  @param pass      Security passphrase to connect to the network
+     *  @param security  Type of encryption for connection
+     *                   (defaults to NSAPI_SECURITY_NONE)
+     *  @return          0 on success, or error code on failure
+     */
+    virtual int set_credentials(const char *ssid, const char *pass, nsapi_security_t security = NSAPI_SECURITY_NONE);
+
+    /** Set the WiFi network channel - NOT SUPPORTED
+     *
+     * This function is not supported and will return NSAPI_ERROR_UNSUPPORTED
+     *
+     *  @param channel   Channel on which the connection is to be made, or 0 for any (Default: 0)
+     *  @return          Not supported, returns NSAPI_ERROR_UNSUPPORTED
+     */
+    virtual int set_channel(uint8_t channel);
+
+    /** Stop the interface
+     *  @return             0 on success, negative on failure
+     */
+    virtual int disconnect();
+
+    /** Get the internally stored IP address
+     *  @return             IP address of the interface or null if not yet connected
+     */
+    virtual const char *get_ip_address();
+
+    /** Get the internally stored MAC address
+     *  @return             MAC address of the interface
+     */
+    virtual const char *get_mac_address();
+
+     /** Get the local gateway
+     *
+     *  @return         Null-terminated representation of the local gateway
+     *                  or null if no network mask has been recieved
+     */
+    virtual const char *get_gateway();
+
+    /** Get the local network mask
+     *
+     *  @return         Null-terminated representation of the local network mask
+     *                  or null if no network mask has been recieved
+     */
+    virtual const char *get_netmask();
+
+    /** Gets the current radio signal strength for active connection
+     *
+     * @return          Connection strength in dBm (negative value)
+     */
+    virtual int8_t get_rssi();
+
+    /** Scan for available networks
+     *
+     * This function will block.
+     *
+     * @param  ap       Pointer to allocated array to store discovered AP
+     * @param  count    Size of allocated @a res array, or 0 to only count available AP
+     * @param  timeout  Timeout in milliseconds; 0 for no timeout (Default: 0)
+     * @return          Number of entries in @a, or if @a count was 0 number of available networks, negative on error
+     *                  see @a nsapi_error
+     */
+    virtual int scan(WiFiAccessPoint *res, unsigned count);
+
+    /** Translates a hostname to an IP address with specific version
+     *
+     *  The hostname may be either a domain name or an IP address. If the
+     *  hostname is an IP address, no network transactions will be performed.
+     *
+     *  If no stack-specific DNS resolution is provided, the hostname
+     *  will be resolve using a UDP socket on the stack.
+     *
+     *  @param address  Destination for the host SocketAddress
+     *  @param host     Hostname to resolve
+     *  @param version  IP version of address to resolve, NSAPI_UNSPEC indicates
+     *                  version is chosen by the stack (defaults to NSAPI_UNSPEC)
+     *  @return         0 on success, negative error code on failure
+     */
+    using NetworkInterface::gethostbyname;
+
+    /** Add a domain name server to list of servers to query
+     *
+     *  @param addr     Destination for the host address
+     *  @return         0 on success, negative error code on failure
+     */
+    using NetworkInterface::add_dns_server;
+
+    /** Set socket options
+     *
+     *  The setsockopt allow an application to pass stack-specific hints
+     *  to the underlying stack. For unsupported options,
+     *  NSAPI_ERROR_UNSUPPORTED is returned and the socket is unmodified.
+     *
+     *  @param handle   Socket handle
+     *  @param level    Stack-specific protocol level
+     *  @param optname  Stack-specific option identifier
+     *  @param optval   Option value
+     *  @param optlen   Length of the option value
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t setsockopt(nsapi_socket_t handle, int level,
+            int optname, const void *optval, unsigned optlen);
+
+    /** Get socket options
+     *
+     *  getsockopt allows an application to retrieve stack-specific options
+     *  from the underlying stack using stack-specific level and option names,
+     *  or to request generic options using levels from nsapi_socket_level_t.
+     *
+     *  For unsupported options, NSAPI_ERROR_UNSUPPORTED is returned
+     *  and the socket is unmodified.
+     *
+     *  @param level    Stack-specific protocol level or nsapi_socket_level_t
+     *  @param optname  Level-specific option name
+     *  @param optval   Destination for option value
+     *  @param optlen   Length of the option value
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t getsockopt(nsapi_socket_t handle, int level, int optname,
+            void *optval, unsigned *optlen);
+
+    /** Register callback for status reporting
+     *
+     *  The specified status callback function will be called on status changes
+     *  on the network. The parameters on the callback are the event type and
+     *  event-type dependent reason parameter.
+     *
+     *  In ESP8266 the callback will be called when processing OOB-messages via
+     *  AT-parser. Do NOT call any ESP8266Interface -functions or do extensive
+     *  processing in the callback.
+     *
+     *  @param status_cb The callback for status changes
+     */
+    virtual void attach(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb);
+
+    /** Get the connection status
+     *
+     *  @return         The connection status according to ConnectionStatusType
+     */
+    virtual nsapi_connection_status_t get_connection_status() const;
+
+protected:
+    /** Open a socket
+     *  @param handle       Handle in which to store new socket
+     *  @param proto        Type of socket to open, NSAPI_TCP or NSAPI_UDP
+     *  @return             0 on success, negative on failure
+     */
+    virtual int socket_open(void **handle, nsapi_protocol_t proto);
+
+    /** Close the socket
+     *  @param handle       Socket handle
+     *  @return             0 on success, negative on failure
+     *  @note On failure, any memory associated with the socket must still
+     *        be cleaned up
+     */
+    virtual int socket_close(void *handle);
+
+    /** Bind a server socket to a specific port
+     *  @param handle       Socket handle
+     *  @param address      Local address to listen for incoming connections on
+     *  @return             0 on success, negative on failure.
+     */
+    virtual int socket_bind(void *handle, const SocketAddress &address);
+
+    /** Start listening for incoming connections
+     *  @param handle       Socket handle
+     *  @param backlog      Number of pending connections that can be queued up at any
+     *                      one time [Default: 1]
+     *  @return             0 on success, negative on failure
+     */
+    virtual int socket_listen(void *handle, int backlog);
+
+    /** Connects this TCP socket to the server
+     *  @param handle       Socket handle
+     *  @param address      SocketAddress to connect to
+     *  @return             0 on success, negative on failure
+     */
+    virtual int socket_connect(void *handle, const SocketAddress &address);
+
+    /** Accept a new connection.
+     *  @param handle       Handle in which to store new socket
+     *  @param server       Socket handle to server to accept from
+     *  @return             0 on success, negative on failure
+     *  @note This call is not-blocking, if this call would block, must
+     *        immediately return NSAPI_ERROR_WOULD_WAIT
+     */
+    virtual int socket_accept(void *handle, void **socket, SocketAddress *address);
+
+    /** Send data to the remote host
+     *  @param handle       Socket handle
+     *  @param data         The buffer to send to the host
+     *  @param size         The length of the buffer to send
+     *  @return             Number of written bytes on success, negative on failure
+     *  @note This call is not-blocking, if this call would block, must
+     *        immediately return NSAPI_ERROR_WOULD_WAIT
+     */
+    virtual int socket_send(void *handle, const void *data, unsigned size);
+
+    /** Receive data from the remote host
+     *  @param handle       Socket handle
+     *  @param data         The buffer in which to store the data received from the host
+     *  @param size         The maximum length of the buffer
+     *  @return             Number of received bytes on success, negative on failure
+     *  @note This call is not-blocking, if this call would block, must
+     *        immediately return NSAPI_ERROR_WOULD_WAIT
+     */
+    virtual int socket_recv(void *handle, void *data, unsigned size);
+
+    /** Send a packet to a remote endpoint
+     *  @param handle       Socket handle
+     *  @param address      The remote SocketAddress
+     *  @param data         The packet to be sent
+     *  @param size         The length of the packet to be sent
+     *  @return             The number of written bytes on success, negative on failure
+     *  @note This call is not-blocking, if this call would block, must
+     *        immediately return NSAPI_ERROR_WOULD_WAIT
+     */
+    virtual int socket_sendto(void *handle, const SocketAddress &address, const void *data, unsigned size);
+
+    /** Receive a packet from a remote endpoint
+     *  @param handle       Socket handle
+     *  @param address      Destination for the remote SocketAddress or null
+     *  @param buffer       The buffer for storing the incoming packet data
+     *                      If a packet is too long to fit in the supplied buffer,
+     *                      excess bytes are discarded
+     *  @param size         The length of the buffer
+     *  @return             The number of received bytes on success, negative on failure
+     *  @note This call is not-blocking, if this call would block, must
+     *        immediately return NSAPI_ERROR_WOULD_WAIT
+     */
+    virtual int socket_recvfrom(void *handle, SocketAddress *address, void *buffer, unsigned size);
+
+    /** Register a callback on state change of the socket
+     *  @param handle       Socket handle
+     *  @param callback     Function to call on state change
+     *  @param data         Argument to pass to callback
+     *  @note Callback may be called in an interrupt context.
+     */
+    virtual void socket_attach(void *handle, void (*callback)(void *), void *data);
+
+    /** Provide access to the NetworkStack object
+     *
+     *  @return The underlying NetworkStack object
+     */
+    virtual NetworkStack *get_stack()
+    {
+        return this;
+    }
+
+private:
+    static const int ESP8266_SSID_MAX_LENGTH = 32; /* 32 is what 802.11 defines as longest possible name */
+    static const int ESP8266_PASSPHRASE_MAX_LENGTH = 63; /* The longest allowed passphrase */
+    static const int ESP8266_PASSPHRASE_MIN_LENGTH = 8; /* The shortest allowed passphrase */
+
+    ESP8266 _esp;
+    bool _ids[ESP8266_SOCKET_COUNT];
+    int _initialized;
+    int _started;
+
+    char ap_ssid[ESP8266_SSID_MAX_LENGTH + 1]; /* 32 is what 802.11 defines as longest possible name; +1 for the \0 */
+    nsapi_security_t ap_sec;
+    uint8_t ap_ch;
+    char ap_pass[ESP8266_PASSPHRASE_MAX_LENGTH + 1];
+    uint16_t _local_ports[ESP8266_SOCKET_COUNT];
+
+    bool _disable_default_softap();
+    void event();
+    bool _get_firmware_ok();
+    nsapi_error_t _init(void);
+    nsapi_error_t _startup(const int8_t wifi_mode);
+
+    struct {
+        void (*callback)(void *);
+        void *data;
+    } _cbs[ESP8266_SOCKET_COUNT];
+};
+
+#endif

--- a/components/wifi/esp8266-driver/README.md
+++ b/components/wifi/esp8266-driver/README.md
@@ -1,0 +1,13 @@
+# ESP8266 WiFi driver for Mbed OS
+
+The Mbed OS driver for the ESP8266 WiFi module.
+
+## Firmware version
+
+ESP8266 modules come in different shapes and formats, but the most important factor is the firmware version in it. To make sure that the firmware in your module is compatible with Mbed OS, follow the [Update guide](https://developer.mbed.org/teams/ESP8266/wiki/Firmware-Update).
+
+## Restrictions
+
+- The ESP8266 WiFi module does not allow the TCP client to bind on a specific port.
+- Setting up a UDP server is not possible.
+- The serial port does not have hardware flow control enabled. The AT command set does not either have a way to limit the download rate. Therefore, downloading anything larger than the serial port input buffer is unreliable. An application should be able to read fast enough to stay ahead of the network. This affects mostly the TCP protocol where data would be lost with no notification. On UDP, this would lead to only packet losses which the higher layer protocol should recover from.

--- a/components/wifi/esp8266-driver/mbed_lib.json
+++ b/components/wifi/esp8266-driver/mbed_lib.json
@@ -1,0 +1,35 @@
+{
+    "name": "esp8266",
+    "config": {
+        "tx": {
+            "help": "TX pin for serial connection",
+            "value": null
+        },
+        "rx": {
+            "help": "RX pin for serial connection",
+            "value": null
+        },
+        "debug": {
+            "help": "Enable debug logs",
+            "value": false
+        },
+        "provide-default": {
+            "help": "Provide default WifiInterface. [true/false]",
+            "value": false
+        }
+    },
+    "target_overrides": {
+         "HEXIWEAR": {
+            "tx": "PTD3",
+            "rx": "PTD2"
+        },
+        "NUCLEO_F401RE": {
+            "tx": "D8",
+            "rx": "D2"
+        },
+        "NUCLEO_F411RE": {
+            "tx": "D8",
+            "rx": "D2"
+        }
+    }
+}

--- a/doxyfile_options
+++ b/doxyfile_options
@@ -855,6 +855,7 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */nanostack/sal-stack-nanostack-eventloop/* \
                          */ble/generic/* \
                          */ble/pal/* \
+                         */components/* \
                          */UNITTESTS/*
 
 # The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -10,5 +10,5 @@
     "EXPAND_AS_DEFINED": "",
     "SKIP_FUNCTION_MACROS": "NO",
     "STRIP_CODE_COMMENTS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */features/nfc/stack/*"
+    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */components/* */features/nfc/stack/*"
 }

--- a/features/nanostack/mbed-mesh-api/mbed_lib.json
+++ b/features/nanostack/mbed-mesh-api/mbed_lib.json
@@ -109,5 +109,14 @@
             "help": "Commissioning security policy bits [0-0xFF]",
             "value": 255
         }
+    },
+    "target_overrides": {
+        "KW24D": {
+            "mbed-mesh-api.use-malloc-for-heap": true,
+            "mbed-mesh-api.heap-size": 14000
+        },
+        "NCS36510": {
+            "mbed-mesh-api.heap-size": 14000
+        }
     }
 }

--- a/features/nanostack/sal-stack-nanostack/mbed_lib.json
+++ b/features/nanostack/sal-stack-nanostack/mbed_lib.json
@@ -6,5 +6,13 @@
             "value": "nanostack_full"
         }
     },
-    "macros": ["NS_USE_EXTERNAL_MBED_TLS"]
+    "macros": ["NS_USE_EXTERNAL_MBED_TLS"],
+    "target_overrides": {
+        "KW24D": {
+            "nanostack.configuration": "lowpan_router"
+        },
+        "NCS36510": {
+            "nanostack.configuration": "lowpan_router"
+        }
+    }
 }

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -29,5 +29,13 @@
             "help": "Number of cached host name resolutions",
             "value": 3
         }
+    },
+    "target_overrides": {
+        "KW24D": {
+            "nsapi.default-mesh-type": "LOWPAN"
+        },
+        "NCS36510": {
+            "nsapi.default-mesh-type": "LOWPAN"
+        }
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1723,7 +1723,6 @@
     },
     "MTB_ADV_WISE_1510": {
         "inherits": ["FAMILY_STM32"],
-        "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L443xC", "STM32L443RC"],
         "config": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -644,6 +644,7 @@
         "extra_labels_add": ["K64F"],
         "extra_labels_remove": ["FRDM"],
         "components_remove": ["SD"],
+        "supported_form_factors": [],
         "detect_code": ["3105"]
     },
     "EV_COG_AD4050LZ": {

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -582,10 +582,13 @@
         "macros": ["CPU_MKW24D512VHA5", "FSL_RTOS_MBED"],
         "inherits": ["Target"],
         "detect_code": ["0250"],
-        "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
+        "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH", "802_15_4_PHY"],
         "release_versions": ["2", "5"],
         "device_name": "MKW24D512xxx5",
-        "bootloader_supported": true
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "MESH"
+        }
     },
     "KW41Z": {
         "supported_form_factors": ["ARDUINO"],

--- a/tools/test/examples/examples.json
+++ b/tools/test/examples/examples.json
@@ -29,8 +29,8 @@
       "targets" : ["K64F", "NUCLEO_F429ZI"],
       "toolchains" : ["GCC_ARM", "ARM"],
       "exporters": [],
-      "compile" : true,
-      "export": true,
+      "compile" : false,
+      "export": false,
       "auto-update" : true
     },
     {

--- a/tools/test_configs/config_paths.json
+++ b/tools/test_configs/config_paths.json
@@ -9,5 +9,6 @@
     "6LOWPAN_HOST" : "6lowpanInterface_host.json",
     "6LOWPAN_ROUTER" : "6lowpanInterface_router.json",
     "THREAD_END_DEVICE" : "ThreadInterface_end_device.json",
-    "THREAD_ROUTER" : "ThreadInterface_router.json"
+    "THREAD_ROUTER" : "ThreadInterface_router.json",
+    "NO_NETWORK": "no_network.json"
 }

--- a/tools/test_configs/no_network.json
+++ b/tools/test_configs/no_network.json
@@ -1,0 +1,17 @@
+{
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : null
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : null
+        }
+    },
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": null
+        }
+    }
+}

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -44,7 +44,7 @@
         "test_configurations": ["IDW0XX1_WIFI"]
     },
     "KW24D": {
-        "default_test_configuration": "6LOWPAN_HOST",
+        "default_test_configuration": "NO_NETWORK",
         "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
     }
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -42,5 +42,9 @@
     "NUCLEO_F401RE": {
         "default_test_configuration": "NONE",
         "test_configurations": ["IDW0XX1_WIFI"]
+    },
+    "KW24D": {
+        "default_test_configuration": "6LOWPAN_HOST",
+        "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
     }
 }


### PR DESCRIPTION
### Description

Import connectivity drivers into Mbed OS.
* ESP8266 (Wifi)
* Atmel AT86RF233/AT86RF212 (IEEE 802.15.4)
* MCR20A (IEEE 802.15.4)

After this change, any of those driver can be selected as a default driver. This allows building connectivity examples for applications without connectivity.
This allows us to migrate away from easy-connect dependency.

Documentation how default network interfaces work, please see:
* https://github.com/ARMmbed/mbed-os-5-docs/pull/660

This PR depends on https://github.com/ARMmbed/mbed-os/pull/7778

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

