### PR TITLE
Re-add Shared Pointer Class into platform features

### DIFF
--- a/TESTS/mbed_platform/SharedPtr/main.cpp
+++ b/TESTS/mbed_platform/SharedPtr/main.cpp
@@ -1,0 +1,128 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+
+#include "platform/SharedPtr.h"
+
+using utest::v1::Case;
+
+struct TestStruct {
+    TestStruct()
+    {
+        s_count++;
+        value = 42;
+    }
+
+    ~TestStruct()
+    {
+        s_count--;
+        value = 0;
+    }
+
+    int value;
+    static int s_count;
+};
+
+int TestStruct::s_count = 0;
+
+/**
+ * Test that a shared pointer correctly manages the lifetime of the underlying raw pointer
+ */
+void test_single_sharedptr_lifetime()
+{
+    // Sanity-check value of counter
+    TEST_ASSERT_EQUAL(0, TestStruct::s_count);
+
+    // Create and destroy shared pointer in given scope
+    {
+        SharedPtr<TestStruct> s_ptr(new TestStruct);
+        TEST_ASSERT_EQUAL(1, TestStruct::s_count);
+    }
+
+    // Destroy shared pointer
+    TEST_ASSERT_EQUAL(0, TestStruct::s_count);
+}
+
+/**
+ * Test that multiple instances of shared pointers correctly manage the reference count
+ * to release the object at the correct point
+ */
+void test_instance_sharing()
+{
+    SharedPtr<TestStruct> s_ptr1(NULL);
+
+    // Sanity-check value of counter
+    TEST_ASSERT_EQUAL(0, TestStruct::s_count);
+
+    // Create and destroy shared pointer in given scope
+    {
+        SharedPtr<TestStruct> s_ptr2(new TestStruct);
+        TEST_ASSERT_EQUAL(1, TestStruct::s_count);
+        s_ptr1 = s_ptr2;
+        TEST_ASSERT_EQUAL(1, TestStruct::s_count);
+    }
+
+    TEST_ASSERT_EQUAL(1, TestStruct::s_count);
+
+    s_ptr1 = NULL;
+
+    // Destroy shared pointer
+    TEST_ASSERT_EQUAL(0, TestStruct::s_count);
+}
+
+/**
+ * Test whether comparison operators operate as expected, both between
+ * shared pointers managing the same object,
+ * and a shared pointer and underlying raw pointer
+ */
+void test_equality_comparators()
+{
+    TestStruct *raw_ptr1 = new TestStruct;
+    TestStruct *raw_ptr2 = new TestStruct;
+    SharedPtr<TestStruct> s_ptr1_1(raw_ptr1);
+    SharedPtr<TestStruct> s_ptr1_2 = s_ptr1_1;
+    SharedPtr<TestStruct> s_ptr2(raw_ptr2);
+
+    // Pointers that should be deemed equal
+    TEST_ASSERT_TRUE(s_ptr1_1 == raw_ptr1); // Shared pointer / Raw pointer
+    TEST_ASSERT_TRUE(s_ptr1_1 == s_ptr1_2); // Shared pointer / Shared pointer
+
+    // Pointers that should be deemed different
+    TEST_ASSERT_TRUE(s_ptr1_1 != raw_ptr2); // Shared pointer / Raw pointer
+    TEST_ASSERT_TRUE(s_ptr1_1 != s_ptr2); // Shared pointer / Shared pointer
+}
+
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10, "default_auto");
+    return utest::v1::verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Test single shared pointer instance", test_single_sharedptr_lifetime),
+    Case("Test instance sharing across multiple shared pointers", test_instance_sharing),
+    Case("Test equality comparators", test_equality_comparators)
+};
+
+utest::v1::Specification specification(test_setup, cases);
+
+int main()
+{
+    return !utest::v1::Harness::run(specification);
+}

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -175,8 +175,9 @@ public:
     {
         if (_ptr != NULL) {
             core_util_critical_section_enter();
-            return *_counter;
+            uint32_t current_counter = *_counter;
             core_util_critical_section_exit();
+            return current_counter;
         } else {
             return 0;
         }

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -1,0 +1,215 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __SHAREDPTR_H__
+#define __SHAREDPTR_H__
+
+#include <stdlib.h>
+
+#include <stdint.h>
+#include <stddef.h>
+
+/** Shared pointer class.
+  *
+  * Similar to std::shared_ptr in C++11.
+  *
+  * Usage: SharedPtr<class> POINTER(new class())
+  *
+  * When POINTER is passed around by value the copy constructor and
+  * destructor counts the number of references to the original object.
+  * If the counter reaches zero, delete is called on the object pointed to.
+  *
+  * To avoid loops, "weak" references should be used by calling the original
+  * pointer directly through POINTER.get().
+  */
+
+template <class T>
+class SharedPtr {
+public:
+    /**
+     * @brief Create empty SharedPtr not pointing to anything.
+     * @details Used for variable declaration.
+     */
+    SharedPtr(): pointer(NULL), counter(NULL) {
+    }
+
+    /**
+     * @brief Create new SharedPtr
+     * @param _pointer Pointer to take control over
+     */
+    SharedPtr(T* _pointer): pointer(_pointer) {
+        // allocate counter on the heap so it can be shared
+        counter = (uint32_t*) malloc(sizeof(uint32_t));
+        *counter = 1;
+    }
+
+    /**
+     * @brief Destructor.
+     * @details Decrement reference counter and delete object if no longer pointed to.
+     */
+    ~SharedPtr() {
+        decrementCounter();
+    }
+
+    /**
+     * @brief Copy constructor.
+     * @details Create new SharePointer from other SharedPtr by
+     *          copying pointer to original object and pointer to counter.
+     * @param source Object being copied from.
+     */
+    SharedPtr(const SharedPtr& source): pointer(source.pointer), counter(source.counter) {
+        // increment reference counter
+        if (counter) {
+            (*counter)++;
+        }
+    }
+
+    /**
+     * @brief Assignment operator.
+     * @details Cleanup previous reference and assign new pointer and counter.
+     * @param source Object being assigned from.
+     * @return Object being assigned.
+     */
+    SharedPtr operator=(const SharedPtr& source) {
+        if (this != &source) {
+            // clean up by decrementing counter
+            decrementCounter();
+
+            // assign new values
+            pointer = source.get();
+            counter = source.getCounter();
+
+            // increment new counter
+            if (counter) {
+                (*counter)++;
+            }
+        }
+
+        return *this;
+    }
+
+    /**
+     * @brief Raw pointer accessor.
+     * @details Get raw pointer to object pointed to.
+     * @return Pointer.
+     */
+    T* get() const {
+        return pointer;
+    }
+
+    /**
+     * @brief Reference count accessor.
+     * @return Reference count.
+     */
+    uint32_t use_count() const {
+        if (counter) {
+            return *counter;
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * @brief Dereference object operator.
+     * @details Override to return the object pointed to.
+     */
+    T& operator*() const {
+        return *pointer;
+    }
+
+    /**
+     * @brief Dereference object member operator.
+     * @details Override to return return member in object pointed to.
+     */
+    T* operator->() const {
+        return pointer;
+    }
+
+    /**
+     * @brief Boolean conversion operator.
+     * @return Whether or not the pointer is NULL.
+     */
+    operator bool() const {
+        return (pointer != 0);
+    }
+
+private:
+    /**
+     * @brief Get pointer to reference counter.
+     * @return Pointer to reference counter.
+     */
+    uint32_t* getCounter() const {
+        return counter;
+    }
+
+    /**
+     * @brief Decrement reference counter.
+     * @details If count reaches zero, free counter and delete object pointed to.
+     */
+    void decrementCounter() {
+        if (counter) {
+            if (*counter == 1) {
+                free(counter);
+                delete pointer;
+            } else {
+                (*counter)--;
+            }
+        }
+    }
+
+private:
+    // pointer to shared object
+    T* pointer;
+
+    // pointer to shared reference counter
+    uint32_t* counter;
+};
+
+/** Non-member relational operators.
+  */
+template <class T, class U>
+bool operator== (const SharedPtr<T>& lhs, const SharedPtr<U>& rhs) {
+    return (lhs.get() == rhs.get());
+}
+
+template <class T, typename U>
+bool operator== (const SharedPtr<T>& lhs, U rhs) {
+    return (lhs.get() == (T*) rhs);
+}
+
+template <class T, typename U>
+bool operator== (U lhs, const SharedPtr<T>& rhs) {
+    return ((T*) lhs == rhs.get());
+}
+
+/** Non-member relational operators.
+  */
+template <class T, class U>
+bool operator!= (const SharedPtr<T>& lhs, const SharedPtr<U>& rhs) {
+    return (lhs.get() != rhs.get());
+}
+
+template <class T, typename U>
+bool operator!= (const SharedPtr<T>& lhs, U rhs) {
+    return (lhs.get() != (T*) rhs);
+}
+
+template <class T, typename U>
+bool operator!= (U lhs, const SharedPtr<T>& rhs) {
+    return ((T*) lhs != rhs.get());
+}
+
+#endif // __SHAREDPTR_H__

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -48,16 +48,16 @@
   * @endcode
   *
   *
-  * It is similar to the std::shared_ptr class introduced in C++11,
-  * however this is not a compatible implementation (no weak pointer, no make_shared, no custom deleters, etc.)
+  * It is similar to the std::shared_ptr class introduced in C++11;
+  * however, this is not a compatible implementation (no weak pointer, no make_shared, no custom deleters and so on.)
   *
   * Usage: SharedPtr<Class> ptr(new Class())
   *
-  * When ptr is passed around by value the copy constructor and
+  * When ptr is passed around by value, the copy constructor and
   * destructor manages the reference count of the raw pointer.
   * If the counter reaches zero, delete is called on the raw pointer.
   *
-  * To avoid loops, "weak" references should be used by calling the original
+  * To avoid loops, use "weak" references by calling the original
   * pointer directly through ptr.get().
   */
 
@@ -78,7 +78,7 @@ public:
      */
     SharedPtr(T *ptr): _ptr(ptr), _counter(NULL)
     {
-        // allocate counter on the heap so it can be shared
+        // Allocate counter on the heap, so it can be shared
         if (_ptr != NULL) {
             _counter = new uint32_t;
             *_counter = 1;
@@ -87,7 +87,7 @@ public:
 
     /**
      * @brief Destructor.
-     * @details Decrement reference counter and delete object if no longer pointed to.
+     * @details Decrement reference counter, and delete object if no longer pointed to.
      */
     ~SharedPtr()
     {
@@ -102,7 +102,7 @@ public:
      */
     SharedPtr(const SharedPtr &source): _ptr(source._ptr), _counter(source._counter)
     {
-        // increment reference counter
+        // Increment reference counter
         if (_ptr != NULL) {
             core_util_atomic_incr_u32(_counter, 1);
         }
@@ -117,14 +117,14 @@ public:
     SharedPtr operator=(const SharedPtr &source)
     {
         if (this != &source) {
-            // clean up by decrementing counter
+            // Clean up by decrementing counter
             decrement_counter();
 
-            // assign new values
+            // Assign new values
             _ptr = source.get();
             _counter = source.get_counter();
 
-            // increment new counter
+            // Increment new counter
             if (_ptr != NULL) {
                 core_util_atomic_incr_u32(_counter, 1);
             }
@@ -139,11 +139,11 @@ public:
      */
     void reset(T *ptr)
     {
-        // clean up by decrementing counter
+        // Clean up by decrementing counter
         decrement_counter();
 
         if (ptr != NULL) {
-            // allocate counter on the heap so it can be shared
+            // Allocate counter on the heap, so it can be shared
             _counter = new uint32_t;
             *_counter = 1;
         }
@@ -237,10 +237,10 @@ private:
     }
 
 private:
-    // pointer to shared object
+    // Pointer to shared object
     T *_ptr;
 
-    // pointer to shared reference counter
+    // Pointer to shared reference counter
     uint32_t *_counter;
 };
 

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -32,31 +32,33 @@
   * @code
   * #include "platform/SharedPtr.h"
   * 
-  * struct MyStruct { int a; };
+  * void test() {
+  *     struct MyStruct { int a; };
   * 
-  * // Create shared pointer
-  * SharedPtr<MyStruct> ptr( new MyStruct );
+  *     // Create shared pointer
+  *     SharedPtr<MyStruct> ptr( new MyStruct );
   * 
-  * // Increase reference count
-  * SharedPtr<MyStruct> ptr2( ptr );
+  *     // Increase reference count
+  *     SharedPtr<MyStruct> ptr2( ptr );
   * 
-  * ptr = NULL; // Reference to the struct instance is still held by ptr2
+  *     ptr = NULL; // Reference to the struct instance is still held by ptr2
   * 
-  * ptr2 = NULL; // The raw pointer is freed
+  *     ptr2 = NULL; // The raw pointer is freed
+  * }
   * @endcode
   * 
   * 
   * It is similar to the std::shared_ptr class introduced in C++11, 
   * however this is not a compatible implementation (no weak pointer, no make_shared, no custom deleters, etc.)
   *
-  * Usage: SharedPtr<class> POINTER(new class())
+  * Usage: SharedPtr<Class> ptr(new Class())
   *
-  * When POINTER is passed around by value the copy constructor and
-  * destructor counts the number of references to the original object.
-  * If the counter reaches zero, delete is called on the object pointed to.
+  * When ptr is passed around by value the copy constructor and
+  * destructor manages the reference count of the raw pointer.
+  * If the counter reaches zero, delete is called on the raw pointer.
   *
   * To avoid loops, "weak" references should be used by calling the original
-  * pointer directly through POINTER.get().
+  * pointer directly through ptr.get().
   */
 
 template <class T>


### PR DESCRIPTION
### Description

This PR re-adds a shared pointer class to mbed OS (similar to the `std::shared_ptr` class introduced in C++11). This class (or a variation of) is used by different projects and used to be part of the "core-util" classes. The only change from this previous revision is the name: `SharedPtr` (to avoid any clashes with existing projects and be consistent with the `SingletonPtr` class).

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change
