### PR TITLE
Lora: Refactor duty-cycle configuration and introduce config for JOIN request

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1069,11 +1069,16 @@ lorawan_status_t LoRaMac::schedule_tx()
         _params.timers.aggregated_timeoff = 0;
     }
 
+    if (MBED_CONF_LORA_DUTY_CYCLE_ON && _lora_phy->verify_duty_cycle(true)) {
+        _params.is_dutycycle_on = true;
+    } else {
+        _params.is_dutycycle_on = false;
+    }
+
     calculate_backOff(_params.last_channel_idx);
 
     next_channel.aggregate_timeoff = _params.timers.aggregated_timeoff;
     next_channel.current_datarate = _params.sys_params.channel_data_rate;
-    _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
     next_channel.dc_enabled = _params.is_dutycycle_on;
     next_channel.joined = _is_nwk_joined;
     next_channel.last_aggregate_tx_time = _params.timers.aggregated_last_tx_time;
@@ -1157,9 +1162,6 @@ lorawan_status_t LoRaMac::schedule_tx()
 void LoRaMac::calculate_backOff(uint8_t channel)
 {
     lorawan_time_t elapsed_time = _lora_time.get_elapsed_time(_params.timers.mac_init_time);
-
-    _params.is_dutycycle_on = MBED_CONF_LORA_DUTY_CYCLE_ON;
-
     _lora_phy->calculate_backoff(_is_nwk_joined, _params.is_last_tx_join_request, _params.is_dutycycle_on,
                                 channel, elapsed_time, _params.timers.tx_toa);
 

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -270,8 +270,7 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
 
     // Update bands Time OFF
     for (uint8_t i = 0; i < nb_bands; i++) {
-
-        if (joined == false) {
+        if (MBED_CONF_LORA_DUTY_CYCLE_ON_JOIN && joined == false) {
             uint32_t txDoneTime =  MAX(_lora_time->get_elapsed_time(bands[i].last_join_tx_time),
                                        (duty_cycle == true) ?
                                        _lora_time->get_elapsed_time(bands[i].last_tx_time) : 0);
@@ -283,7 +282,6 @@ lorawan_time_t LoRaPHY::update_band_timeoff(bool joined, bool duty_cycle,
             if (bands[i].off_time != 0) {
                 next_tx_delay = MIN(bands[i].off_time - txDoneTime, next_tx_delay);
             }
-
         } else {
             // if network has been joined
             if (duty_cycle == true) {
@@ -451,7 +449,7 @@ uint8_t LoRaPHY::get_bandwidth(uint8_t dr)
     }
 }
 
-uint8_t LoRaPHY::enabled_channel_count(bool joined, uint8_t datarate,
+uint8_t LoRaPHY::enabled_channel_count(uint8_t datarate,
                                        const uint16_t *channel_mask,
                                        uint8_t *channel_indices,
                                        uint8_t *delayTx)
@@ -1183,7 +1181,7 @@ void LoRaPHY::calculate_backoff(bool joined, bool last_tx_was_join_req, bool dc_
     // Reset time-off to initial value.
     band_table[band_idx].off_time = 0;
 
-    if (joined == false) {
+    if (MBED_CONF_LORA_DUTY_CYCLE_ON_JOIN && joined == false) {
         // Get the join duty cycle
         if (elapsed_time < 3600000) {
             join_duty_cycle = BACKOFF_DC_1_HOUR;
@@ -1246,7 +1244,7 @@ lorawan_status_t LoRaPHY::set_next_channel(channel_selection_params_t *params,
                                             band_table, phy_params.bands.size);
 
         // Search how many channels are enabled
-        channel_count = enabled_channel_count(params->joined, params->current_datarate,
+        channel_count = enabled_channel_count(params->current_datarate,
                                               phy_params.channels.mask,
                                               enabled_channels, &delay_tx);
     } else {

--- a/features/lorawan/lorastack/phy/LoRaPHY.h
+++ b/features/lorawan/lorastack/phy/LoRaPHY.h
@@ -632,7 +632,7 @@ protected:
      */
     uint8_t get_bandwidth(uint8_t dr_index);
 
-    uint8_t enabled_channel_count(bool joined, uint8_t datarate,
+    uint8_t enabled_channel_count(uint8_t datarate,
                                   const uint16_t *mask, uint8_t* enabledChannels,
                                   uint8_t* delayTx);
 

--- a/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAS923.cpp
@@ -361,8 +361,7 @@ lorawan_status_t LoRaPHYAS923::set_next_channel(channel_selection_params_t* next
                                             bands, AS923_MAX_NB_BANDS);
 
         // Search how many channels are enabled
-        nb_enabled_channels = enabled_channel_count(next_channel_prams->joined,
-                                                    next_channel_prams->current_datarate,
+        nb_enabled_channels = enabled_channel_count(next_channel_prams->current_datarate,
                                                     channel_mask,
                                                     enabled_channels, &delay_tx);
     }  else {

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -593,10 +593,9 @@ lorawan_status_t LoRaPHYAU915::set_next_channel(channel_selection_params_t* next
                                             bands, AU915_MAX_NB_BANDS);
 
         // Search how many channels are enabled
-        nb_enabled_channels = enabled_channel_count(next_chan_params->joined,
-                                                     next_chan_params->current_datarate,
-                                                     current_channel_mask,
-                                                     enabled_channels, &delay_tx);
+        nb_enabled_channels = enabled_channel_count(next_chan_params->current_datarate,
+                                                    current_channel_mask,
+                                                    enabled_channels, &delay_tx);
     } else {
         delay_tx++;
         next_tx_delay = next_chan_params->aggregate_timeoff - _lora_time->get_elapsed_time(next_chan_params->last_aggregate_tx_time);

--- a/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYKR920.cpp
@@ -430,9 +430,9 @@ lorawan_status_t LoRaPHYKR920::set_next_channel(channel_selection_params_t* para
                                           bands, KR920_MAX_NB_BANDS);
 
         // Search how many channels are enabled
-        nb_enabled_channels = enabled_channel_count(params->joined, params->current_datarate,
-                                                     channel_mask,
-                                                     enabled_channels, &delay_tx);
+        nb_enabled_channels = enabled_channel_count(params->current_datarate,
+                                                    channel_mask,
+                                                    enabled_channels, &delay_tx);
     } else {
         delay_tx++;
         nextTxDelay = params->aggregate_timeoff - _lora_time->get_elapsed_time(params->last_aggregate_tx_time);

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -631,8 +631,7 @@ lorawan_status_t LoRaPHYUS915::set_next_channel(channel_selection_params_t* para
         next_tx_delay = update_band_timeoff(params->joined, params->dc_enabled, bands, US915_MAX_NB_BANDS);
 
         // Search how many channels are enabled
-        nb_enabled_channels = enabled_channel_count(params->joined,
-                                                    params->current_datarate,
+        nb_enabled_channels = enabled_channel_count(params->current_datarate,
                                                     current_channel_mask,
                                                     enabled_channels, &delay_tx);
     } else {

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915Hybrid.cpp
@@ -631,8 +631,7 @@ lorawan_status_t LoRaPHYUS915Hybrid::set_next_channel(channel_selection_params_t
                                             US915_HYBRID_MAX_NB_BANDS);
 
         // Search how many channels are enabled
-        nb_enabled_channels = enabled_channel_count(params->joined,
-                                                    params->current_datarate,
+        nb_enabled_channels = enabled_channel_count(params->current_datarate,
                                                     current_channel_mask,
                                                     enabled_channels, &delay_tx);
     } else {

--- a/features/lorawan/mbed_lib.json
+++ b/features/lorawan/mbed_lib.json
@@ -57,6 +57,10 @@
             "help": "Enables/disables duty cycling. NOTE: Disable only for testing. Mandatory in many regions.",
             "value": true
         },
+        "duty-cycle-on-join": {
+            "help": "Enables/disables duty cycling for JOIN requests (disabling requires duty-cycle-on to be disabled). NOTE: Disable only for testing!",
+            "value": true
+        },
         "lbt-on": {
             "help": "Enables/disables LBT. NOTE: [This feature is not yet integrated].",
             "value": false


### PR DESCRIPTION
### Description

- Duty cycle can be now only disabled with duty-cycle-on flag if region supports duty-cycle.
  If region does not support duty-cycle, this flag has no effect and duty cycle is always
  disabled.

- Also introduced a new flag (duty-cycle-on-join) to disable duty cycle for JOIN requests.
  This flag can be used for testing only and is used to speed up JOIN request testing as
  backoff times for JOIN request are really long (easily several minutes per attempt).
  This flag works in conjunction with main duty cycle setting. Disabling duty-cycle-on-join
  works only if duty-cycle-on is disabled (or region settings have duty cycle disabled).


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

