### PR TITLE
standardise QSPI pin names

### DIFF
--- a/TESTS/mbed_hal/qspi/main.cpp
+++ b/TESTS/mbed_hal/qspi/main.cpp
@@ -66,12 +66,12 @@ uint8_t rx_buf[DATA_SIZE_1024];
 
 
 // some target defines QSPI pins as integers thus conversion needed
-#define QPIN_0 static_cast<PinName>(QSPI_PIN_IO0)
-#define QPIN_1 static_cast<PinName>(QSPI_PIN_IO1)
-#define QPIN_2 static_cast<PinName>(QSPI_PIN_IO2)
-#define QPIN_3 static_cast<PinName>(QSPI_PIN_IO3)
-#define QSCK   static_cast<PinName>(QSPI_PIN_SCK)
-#define QCSN   static_cast<PinName>(QSPI_PIN_CSN)
+#define QPIN_0 static_cast<PinName>(QSPI_FLASH1_IO0)
+#define QPIN_1 static_cast<PinName>(QSPI_FLASH1_IO1)
+#define QPIN_2 static_cast<PinName>(QSPI_FLASH1_IO2)
+#define QPIN_3 static_cast<PinName>(QSPI_FLASH1_IO3)
+#define QSCK   static_cast<PinName>(QSPI_FLASH1_SCK)
+#define QCSN   static_cast<PinName>(QSPI_FLASH1_CSN)
 
 
 static void log_data(const char *str, uint8_t *data, uint32_t size)

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/PinNames.h
@@ -227,12 +227,21 @@ typedef enum {
     A4 = p30,
     A5 = p31,
 
-    QSPI_FLASH_IO0 = P0_20,
-    QSPI_FLASH_IO1 = P0_21,
-    QSPI_FLASH_IO2 = P0_22,
-    QSPI_FLASH_IO3 = P0_23,
-    QSPI_FLASH_SCK = P0_19,
-    QSPI_FLASH_CSN = P0_17,
+    /**** QSPI pins ****/
+    QSPI1_IO0 = P0_20,
+    QSPI1_IO1 = P0_21,
+    QSPI1_IO2 = P0_22,
+    QSPI1_IO3 = P0_23,
+    QSPI1_SCK = P0_19,
+    QSPI1_CSN = P0_17,
+
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = QSPI1_IO0,
+    QSPI_FLASH1_IO1 = QSPI1_IO1,
+    QSPI_FLASH1_IO2 = QSPI1_IO2,
+    QSPI_FLASH1_IO3 = QSPI1_IO3,
+    QSPI_FLASH1_SCK = QSPI1_SCK,
+    QSPI_FLASH1_CSN = QSPI1_CSN,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_NUCLEO_F412ZG/PinNames.h
@@ -307,6 +307,14 @@ typedef enum {
     SYS_WKUP2 = PC_0,
     SYS_WKUP3 = PC_1,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PD_11,
+    QSPI1_IO1 = PD_12,
+    QSPI1_IO2 = PE_2,
+    QSPI1_IO3 = PD_13,
+    QSPI1_SCK = PB_2,
+    QSPI1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/PinNames.h
@@ -304,12 +304,12 @@ typedef enum {
     SYS_WKUP3 = PC_1,
 
     /**** QSPI FLASH pins ****/
-    QSPI_PIN_IO0 = PF_8,
-    QSPI_PIN_IO1 = PF_9,
-    QSPI_PIN_IO2 = PE_2,
-    QSPI_PIN_IO3 = PD_13,
-    QSPI_PIN_SCK = PB_2,
-    QSPI_PIN_CSN = PG_6,
+    QSPI_FLASH1_IO0 = PF_8,
+    QSPI_FLASH1_IO1 = PF_9,
+    QSPI_FLASH1_IO2 = PE_2,
+    QSPI_FLASH1_IO3 = PD_13,
+    QSPI_FLASH1_SCK = PB_2,
+    QSPI_FLASH1_CSN = PG_6,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_NUCLEO_F413ZH/PinNames.h
@@ -306,6 +306,14 @@ typedef enum {
     SYS_WKUP2 = PC_0,
     SYS_WKUP3 = PC_1,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PD_11,
+    QSPI1_IO1 = PD_12,
+    QSPI1_IO2 = PE_2,
+    QSPI1_IO3 = PD_13,
+    QSPI1_SCK = PB_2,
+    QSPI1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/TARGET_NUCLEO_F446ZE/PinNames.h
@@ -325,6 +325,14 @@ typedef enum {
     SYS_WKUP0 = PA_0,
     SYS_WKUP1 = PC_13,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PD_11,
+    QSPI1_IO1 = PD_12,
+    QSPI1_IO2 = PE_2,
+    QSPI1_IO3 = PD_13,
+    QSPI1_SCK = PB_2,
+    QSPI1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/TARGET_DISCO_F469NI/PinNames.h
@@ -406,12 +406,13 @@ typedef enum {
     SYS_TRACED3_ALT0 = PE_6,
     SYS_WKUP = PA_0,
 
-    QSPI_FLASH_IO0 = PF_8,
-    QSPI_FLASH_IO1 = PF_9,
-    QSPI_FLASH_IO2 = PF_7,
-    QSPI_FLASH_IO3 = PF_6,
-    QSPI_FLASH_SCK = PF_10,
-    QSPI_FLASH_CSN = PB_6,
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PF_8,
+    QSPI_FLASH1_IO1 = PF_9,
+    QSPI_FLASH1_IO2 = PF_7,
+    QSPI_FLASH1_IO3 = PF_6,
+    QSPI_FLASH1_SCK = PF_10,
+    QSPI_FLASH1_CSN = PB_6,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_DISCO_F746NG/PinNames.h
@@ -420,6 +420,14 @@ typedef enum {
     SYS_WKUP5 = PI_8,
     SYS_WKUP6 = PI_11,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PD_11,
+    QSPI_FLASH1_IO1 = PD_12,
+    QSPI_FLASH1_IO2 = PE_2,
+    QSPI_FLASH1_IO3 = PD_13,
+    QSPI_FLASH1_SCK = PB_2,
+    QSPI_FLASH1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/TARGET_NUCLEO_F746ZG/PinNames.h
@@ -354,6 +354,14 @@ typedef enum {
     SYS_WKUP3 = PC_1,
     SYS_WKUP4 = PC_13,
 
+    /**** QSPI pins ****/
+    QSPI_FLASH1_IO0 = PD_11,
+    QSPI_FLASH1_IO1 = PD_12,
+    QSPI_FLASH1_IO2 = PE_2,
+    QSPI_FLASH1_IO3 = PD_13,
+    QSPI_FLASH1_SCK = PB_2,
+    QSPI_FLASH1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/TARGET_NUCLEO_F756ZG/PinNames.h
@@ -354,6 +354,14 @@ typedef enum {
     SYS_WKUP3 = PC_1,
     SYS_WKUP4 = PC_13,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PD_11,
+    QSPI1_IO1 = PD_12,
+    QSPI1_IO2 = PE_2,
+    QSPI1_IO3 = PD_13,
+    QSPI1_SCK = PB_2,
+    QSPI1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/TARGET_NUCLEO_F767ZI/PinNames.h
@@ -359,6 +359,14 @@ typedef enum {
     SYS_WKUP3 = PC_1,
     SYS_WKUP4 = PC_13,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PD_11,
+    QSPI1_IO1 = PD_12,
+    QSPI1_IO2 = PE_2,
+    QSPI1_IO3 = PD_13,
+    QSPI1_SCK = PB_2,
+    QSPI1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/TARGET_DISCO_F769NI/PinNames.h
@@ -427,6 +427,14 @@ typedef enum {
     SYS_WKUP5 = PI_8,
     SYS_WKUP6 = PI_11,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PC_9,
+    QSPI_FLASH1_IO1 = PC_10,
+    QSPI_FLASH1_IO2 = PE_2,
+    QSPI_FLASH1_IO3 = PD_13,
+    QSPI_FLASH1_SCK = PB_2,
+    QSPI_FLASH1_CSN = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/TARGET_NUCLEO_L432KC/PinNames.h
@@ -159,6 +159,15 @@ typedef enum {
     SYS_WKUP1 = PA_0,
     SYS_WKUP4 = PA_2,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PB_1,
+    QSPI1_IO1 = PB_0,
+    QSPI1_IO2 = PA_7,
+    QSPI1_IO3 = PA_6,
+    QSPI1_SCK = PA_3,
+    QSPI1_CSN = PA_2,
+
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/TARGET_NUCLEO_L433RC_P/PinNames.h
@@ -236,6 +236,14 @@ typedef enum {
     SYS_WKUP2 = PC_13,
     SYS_WKUP4 = PA_2,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PB_1,
+    QSPI1_IO1 = PB_0,
+    QSPI1_IO2 = PA_7,
+    QSPI1_IO3 = PA_6,
+    QSPI1_SCK = PB_10,
+    QSPI1_CSN = PB_11,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
@@ -282,6 +282,14 @@ typedef enum {
     SYS_WKUP4 = PA_2,
     SYS_WKUP5 = PC_5,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PE_12,
+    QSPI_FLASH1_IO1 = PE_13,
+    QSPI_FLASH1_IO2 = PE_14,
+    QSPI_FLASH1_IO3 = PE_15,
+    QSPI_FLASH1_SCK = PE_10,
+    QSPI_FLASH1_CSN = PE_11,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_DISCO_L476VG/PinNames.h
@@ -258,6 +258,22 @@ typedef enum {
     SYS_WKUP4 = PA_2,
     SYS_WKUP5 = PC_5,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PE_12,
+    QSPI1_IO1 = PE_13,
+    QSPI1_IO2 = PE_14,
+    QSPI1_IO3 = PE_15,
+    QSPI1_SCK = PE_10,
+    QSPI1_CSN = PE_11,
+
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = QSPI1_IO0,
+    QSPI_FLASH1_IO1 = QSPI1_IO1,
+    QSPI_FLASH1_IO2 = QSPI1_IO2,
+    QSPI_FLASH1_IO3 = QSPI1_IO3,
+    QSPI_FLASH1_SCK = QSPI1_SCK,
+    QSPI_FLASH1_CSN = QSPI1_CSN,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_DISCO_L496AG/PinNames.h
@@ -341,6 +341,14 @@ typedef enum {
     SYS_WKUP4 = PA_2,
     SYS_WKUP5 = PC_5,
 
+    /**** QSPI FLASH pins ****/
+    QSPI_FLASH1_IO0 = PB_1,
+    QSPI_FLASH1_IO1 = PB_0,
+    QSPI_FLASH1_IO2 = PA_7,
+    QSPI_FLASH1_IO3 = PA_6,
+    QSPI_FLASH1_SCK = PB_11,
+    QSPI_FLASH1_CSN = PA_3,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/TARGET_NUCLEO_L496ZG/PinNames.h
@@ -317,6 +317,14 @@ typedef enum {
     SYS_WKUP4 = PA_2,
     SYS_WKUP5 = PC_5,
 
+    /**** QSPI pins ****/
+    QSPI1_IO0 = PE_12,
+    QSPI1_IO1 = PB_0,
+    QSPI1_IO2 = PE_14,
+    QSPI1_IO3 = PE_15,
+    QSPI1_SCK = PB_10,
+    QSPI1_CSN = PA_2,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
### Description

This PR is continuation of work on PR #7639

This PR try to standardise QSPI pin naming scheme to new format:
**QSPI_FLASHn_XXX**: for pins connected to the onboard flash
**QSPIn_XXX**: for pins available on external connector

Some targets support Dual-Flash, hence added port indexing (1, 2) to distinct which port is actually utilized

After more profound analysis of schematics and specs, it's not clear that any of targets allow to utilize two QSPI interfaces on external connectors. For all targets with dual-QSPI capable SoC (currently only STM platforms) specs clearly describes only one interface when it's routed to onboard flash or routed out to external connector.

@jeromecoutant @adustm  can you help to figure out which targets can utilize both QSPI interfaces ont external connectors (targets marked with `QSPI2???` on the list below)

@donatieng @bulislaw When it will be clear that any of targets support more then one QSPI interface on external connectors, then we could get back to discussion about `QSPI_COUNT/QSPI_FLASH_COUNT`

### NOTE
This PR is not ready and cannot be merge until PR #7783 will be merged

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change





### List of targets with QSPI interace 

- ARM_SSG
   - BEETLE - has  2MB of external QSPI flash (no pin definions) 	is this target actively supported ???
   - MUSCA - in development

- Freescale
   - K82F - in development
   - KL82Z - in development

- NXP
   - MIMXRT1050 - 64Mbit QSPI Flash; -	in development?
   - LPCXpresso54608 - 128 Mb Micron MT25QL128 Quad-SPI flash; - in development
   - LPC408X - in development?
	
- Silicon Labs
   - EFM32GG11_STK3701 Giant Gecko - in development?
	
- NORDIC
   - NRF52840 - QSPI1/QSPI_FLASH1

- STM
   - NUCLEO_F412ZG - QSPI1/QSPI2???
   - DISCO_F413ZH - QSPI_FLASH1
   - NUCLEO_F413ZH - QSPI1/QSPI2???
   - NUCLEO_F446RE - needs driver QSPI pins definion fix
   - NUCLEO_F446ZE - QSPI1/QSPI2???
   - DISCO_F469NI - QSPI_FLASH1/QSPI2???
   - DISCO_F746NG - QSPI_FLASH1
   - NUCLEO_F746ZG - QSPI1
   - NUCLEO_F756ZG - QSPI1
   - NUCLEO_F767ZI	 - QSPI1
   - DISCO_F769NI - QSPI_FLASH1
   - NUCLEO_L432KC - QSPI1
   - NUCLEO_L433RC_P - QSPI1
   - DISCO_L475VG_IOT01A - QSPI_FLASH1
   - DISCO_L476VG - QSPI1/QSPI_FLASH1
   - NUCLEO_L476RG - no pins available
   - NUCLEO_L486RG - no pins available???
   - DISCO_L496AG - QSPI_FLASH1/QSPI2??
   - NUCLEO_L496ZG - QSPI1/QSPI2???