### PR TITLE
Allow ThreadInterface::device_eui64_get() before connect()

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/LoWPANNDInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/LoWPANNDInterface.h
@@ -37,9 +37,10 @@ public:
      */
     LoWPANNDInterface(NanostackRfPhy *phy) : MeshInterfaceNanostack(phy) { }
 
-    virtual int connect();
-    virtual int disconnect();
     bool getRouterIpAddress(char *address, int8_t len);
+protected:
+    Nanostack::LoWPANNDInterface *get_interface() const;
+    virtual nsapi_error_t do_initialize();
 };
 
 #endif

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -67,6 +67,18 @@ protected:
 
 class InterfaceNanostack : public virtual NetworkInterface {
 public:
+    /** Start the interface
+     *
+     *  @return     0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t connect();
+
+    /** Stop the interface
+     *
+     *  @return     0 on success, negative error code on failure
+     */
+    virtual nsapi_error_t disconnect();
+
     /** Get the internally stored IP address
     /return     IP address of the interface or null if not yet connected
     */
@@ -109,6 +121,7 @@ protected:
     InterfaceNanostack();
     virtual Nanostack *get_stack(void);
     Nanostack::Interface *get_interface() const { return _interface; }
+    virtual nsapi_error_t do_initialize() = 0;
 
     Nanostack::Interface *_interface;
 

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/NanostackEthernetInterface.h
@@ -49,20 +49,9 @@ public:
 
     nsapi_error_t initialize(NanostackEthernetPhy *phy);
 
-    /** Start the interface
-     *
-     *  @return     0 on success, negative on failure
-     */
-    virtual nsapi_error_t connect();
-
-    /** Stop the interface
-     *
-     *  @return     0 on success, negative on failure
-     */
-    virtual nsapi_error_t disconnect();
-
 protected:
     Nanostack::EthernetInterface *get_interface() const { return static_cast<Nanostack::EthernetInterface *>(_interface); }
+    virtual nsapi_error_t do_initialize();
 
 };
 

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/ThreadInterface.h
@@ -62,10 +62,9 @@ public:
 
     mesh_error_t device_pskd_set(const char *pskd);
 
-    virtual int connect();
-    virtual int disconnect();
 protected:
     Nanostack::ThreadInterface *get_interface() const;
+    virtual nsapi_error_t do_initialize();
 };
 
 #endif // THREADINTERFACE_H

--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -27,7 +27,12 @@ private:
     mesh_error_t mesh_disconnect();
 };
 
-int LoWPANNDInterface::connect()
+Nanostack::LoWPANNDInterface *LoWPANNDInterface::get_interface() const
+{
+    return static_cast<Nanostack::LoWPANNDInterface*>(_interface);
+}
+
+nsapi_error_t LoWPANNDInterface::do_initialize()
 {
     if (!_interface) {
         _interface = new (nothrow) Nanostack::LoWPANNDInterface(*_phy);
@@ -36,9 +41,7 @@ int LoWPANNDInterface::connect()
         }
         _interface->attach(_connection_status_cb);
     }
-
-    return _interface->bringup(false, NULL, NULL, NULL, IPV6_STACK, _blocking);
-
+    return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t Nanostack::LoWPANNDInterface::bringup(bool dhcp, const char *ip,
@@ -82,11 +85,6 @@ nsapi_error_t Nanostack::LoWPANNDInterface::bringup(bool dhcp, const char *ip,
     }
     return 0;
 
-}
-
-int LoWPANNDInterface::disconnect()
-{
-    return _interface->bringdown();
 }
 
 nsapi_error_t Nanostack::LoWPANNDInterface::bringdown()

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -102,14 +102,19 @@ int InterfaceNanostack::disconnect()
 
 nsapi_error_t MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
 {
-    if (_phy) {
+    if (_phy && phy && _phy != phy) {
         error("Phy already set");
         return NSAPI_ERROR_IS_CONNECTED;
     }
-    _phy = phy;
-    return NSAPI_ERROR_OK;
+    if (phy) {
+        _phy = phy;
+    }
+    if (_phy) {
+        return do_initialize();
+    } else {
+        return NSAPI_ERROR_PARAMETER;
+    }
 }
-
 
 void Nanostack::Interface::network_handler(mesh_connection_status_t status)
 {
@@ -148,7 +153,9 @@ nsapi_error_t Nanostack::Interface::register_phy()
 {
     NanostackLockGuard lock;
 
-    _device_id = interface_phy.phy_register();
+    if (_device_id < 0) {
+        _device_id = interface_phy.phy_register();
+    }
     if (_device_id < 0) {
         return NSAPI_ERROR_DEVICE_ERROR;
     }

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -82,6 +82,24 @@ InterfaceNanostack::InterfaceNanostack()
     // Nothing to do
 }
 
+int InterfaceNanostack::connect()
+{
+    nsapi_error_t error = do_initialize();
+    if (error) {
+        return error;
+    }
+
+    return _interface->bringup(false, NULL, NULL, NULL, IPV6_STACK, _blocking);
+}
+
+int InterfaceNanostack::disconnect()
+{
+    if (!_interface) {
+        return NSAPI_ERROR_NO_CONNECTION;
+    }
+    return _interface->bringdown();
+}
+
 nsapi_error_t MeshInterfaceNanostack::initialize(NanostackRfPhy *phy)
 {
     if (_phy) {

--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -87,25 +87,16 @@ nsapi_error_t Nanostack::EthernetInterface::bringup(bool dhcp, const char *ip,
     return 0;
 }
 
-int NanostackEthernetInterface::connect()
+nsapi_error_t NanostackEthernetInterface::do_initialize()
 {
     if (!_interface) {
         return NSAPI_ERROR_PARAMETER;
     }
-    return _interface->bringup(false, NULL, NULL, NULL, IPV6_STACK, _blocking);
+    return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t Nanostack::EthernetInterface::bringdown()
 {
     enet_tasklet_disconnect();
     return 0;
-}
-
-
-int NanostackEthernetInterface::disconnect()
-{
-    if (!_interface) {
-        return NSAPI_ERROR_NO_CONNECTION;
-    }
-    return _interface->bringdown();
 }

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -213,6 +213,10 @@ void ThreadInterface::device_eui64_set(const uint8_t *eui64)
 
 void ThreadInterface::device_eui64_get(uint8_t *eui64)
 {
+    memset(eui64, 0, 8);
+    if (!get_interface()) {
+        return;
+    }
     get_interface()->device_eui64_get(eui64);
 }
 
@@ -226,6 +230,9 @@ void Nanostack::ThreadInterface::device_eui64_get(uint8_t *eui64)
 {
     if (!eui64_set) {
         uint8_t eui64_buf[8];
+        if (register_phy() < 0) {
+            return;
+        }
         get_phy().get_mac_address(eui64_buf);
         device_eui64_set(eui64_buf);
     }

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -76,7 +76,7 @@ Nanostack::ThreadInterface *ThreadInterface::get_interface() const
     return static_cast<Nanostack::ThreadInterface*>(_interface);
 }
 
-int ThreadInterface::connect()
+nsapi_error_t ThreadInterface::do_initialize()
 {
     if (!_interface) {
         _interface = new (nothrow) Nanostack::ThreadInterface(*_phy);
@@ -85,8 +85,7 @@ int ThreadInterface::connect()
         }
         _interface->attach(_connection_status_cb);
     }
-
-    return _interface->bringup(false, NULL, NULL, NULL, IPV6_STACK, _blocking);
+    return NSAPI_ERROR_OK;
 }
 
 nsapi_error_t Nanostack::ThreadInterface::bringup(bool dhcp, const char *ip,
@@ -144,11 +143,6 @@ nsapi_error_t Nanostack::ThreadInterface::bringup(bool dhcp, const char *ip,
         }
     }
     return 0;
-}
-
-int ThreadInterface::disconnect()
-{
-    return _interface->bringdown();
 }
 
 nsapi_error_t Nanostack::ThreadInterface::bringdown()


### PR DESCRIPTION
### Description

Perform necessary driver initialisation so that we can read the EUI-64 before connecting.

Fixes #7391.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

Marked as refactor as it's a non-trivial initialisation rework, and it wasn't necessarily intended to permit this ordering originally, although it makes sense.