### PR TITLE
MIMXRT1050_EVK: Update the I2C driver

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
@@ -50,7 +50,6 @@ struct analogin_s {
 
 struct i2c_s {
     uint32_t instance;
-    uint8_t next_repeated_start;
 };
 
 struct spi_s {

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/pinmap.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/pinmap.c
@@ -54,7 +54,8 @@ void pin_function(PinName pin, int function)
     }
 
     /* Write to the mux register */
-    *((volatile uint32_t *)muxregister) = IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(function);
+    *((volatile uint32_t *)muxregister) = IOMUXC_SW_MUX_CTL_PAD_MUX_MODE(function) |
+                                          IOMUXC_SW_MUX_CTL_PAD_SION((function >> SION_BIT_SHIFT) & 0x1);
 
     /* If required write to the input daisy register */
     daisyregister = (function >> DAISY_REG_SHIFT) & 0xFFF;

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralNames.h
@@ -37,6 +37,7 @@ typedef enum {
 #define STDIO_UART_RX     USBRX
 #define STDIO_UART        UART_1
 
+#define SION_BIT_SHIFT        (3)
 #define DAISY_REG_SHIFT       (4)
 #define DAISY_REG_VALUE_SHIFT (16)
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralPins.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PeripheralPins.c
@@ -39,12 +39,12 @@ const PinMap PinMap_DAC[] = {
 
 /************I2C***************/
 const PinMap PinMap_I2C_SDA[] = {
-    {GPIO_AD_B1_01, I2C_1, ((1U << DAISY_REG_VALUE_SHIFT) | (0x4D0 << DAISY_REG_SHIFT) | 3)},
+    {GPIO_AD_B1_01, I2C_1, ((1U << DAISY_REG_VALUE_SHIFT) | (0x4D0 << DAISY_REG_SHIFT) | (1U << SION_BIT_SHIFT) | 3)},
     {NC   , NC   , 0}
 };
 
 const PinMap PinMap_I2C_SCL[] = {
-    {GPIO_AD_B1_00, I2C_1, ((1U << DAISY_REG_VALUE_SHIFT) | (0x4CC << DAISY_REG_SHIFT) | 3)},
+    {GPIO_AD_B1_00, I2C_1, ((1U << DAISY_REG_VALUE_SHIFT) | (0x4CC << DAISY_REG_SHIFT) | (1U << SION_BIT_SHIFT) | 3)},
     {NC   , NC   , 0}
 };
 


### PR DESCRIPTION
### Description
1. Remove the repeated_start flag and code as this is not needed
   for the LPI2C module
2. Enable the SION bit on the I2C pins
3. Enable 22K Pullup option of the I2C pins
4. Update the 0 byte write implementation to ensure the START command gets flushed out of the FIFO

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

