### PR TITLE
Fix stack size for LwIP on EFM32GG11

### DIFF
--- a/features/lwipstack/mbed_lib.json
+++ b/features/lwipstack/mbed_lib.json
@@ -125,7 +125,7 @@
         "LPC546XX": {
             "mem-size": 36496
         },
-        "EFM32GG11-STK3701": {
+        "EFM32GG11_STK3701": {
             "mem-size": 36560
         },
         "RZ_A1_EMAC": {

--- a/features/netsocket/emac-drivers/TARGET_Silicon_Labs/sl_emac_config.h
+++ b/features/netsocket/emac-drivers/TARGET_Silicon_Labs/sl_emac_config.h
@@ -34,7 +34,12 @@
 /** Timeout in milliseconds for polling the PHY link status */
 #define SL_ETH_LINK_POLL_PERIOD_MS    (500)
 /** Default Ethernet worker thread stack size in bytes */
+#include "mbed_trace.h"
+#if MBED_CONF_MBED_TRACE_ENABLE == 1
+#define SL_ETH_THREAD_STACKSIZE       (768)
+#else
 #define SL_ETH_THREAD_STACKSIZE       (512)
+#endif
 /** Default Ethernet worker thread stack priority */
 #define SL_ETH_THREAD_PRIORITY        (osPriorityHigh)
 /** Name of interface */


### PR DESCRIPTION
### Description

Typo in the config file made the LwIP stack way too small on EFM32GG11 STK3701 target. Additionally, the EMAC thread stack was slightly too small when debug printing is on.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

