### PR TITLE
Platform: Add C++ Span class.

### DIFF
--- a/platform/Span.h
+++ b/platform/Span.h
@@ -109,7 +109,8 @@ namespace mbed {
        size_t payload_size;
     }
 
-    parsed_value_t parse(uint8_t *buffer, size_t buffer_size) {
+    parsed_value_t parse(uint8_t *buffer, size_t buffer_size)
+    {
        parsed_value_t parsed_value { 0 };
 
        if (buffer != NULL && buffer_size <= MINIMAL_BUFFER_SIZE) {
@@ -139,7 +140,8 @@ namespace mbed {
        Span<uint8_t> payload;
     }
 
-    parsed_value_t parse(const Span<uint8_t> &buffer) {
+    parsed_value_t parse(const Span<uint8_t> &buffer)
+    {
        parsed_value_t parsed_value;
 
        if (buffer.size() <= MINIMAL_BUFFER_SIZE) {
@@ -208,7 +210,9 @@ struct Span {
      * @note This function is not accessible if Extent != SPAN_DYNAMIC_EXTENT or
      * Extent != 0 .
      */
-    Span() : _data(NULL) {
+    Span() :
+        _data(NULL)
+    {
         MBED_STATIC_ASSERT(
             Extent == 0,
             "Cannot default construct a static-extent Span (unless Extent is 0)"
@@ -228,7 +232,8 @@ struct Span {
      * @post a call to size() will return Extent and data() will return @p ptr.
      */
     Span(pointer ptr, index_type count) :
-        _data(ptr) {
+        _data(ptr)
+    {
         MBED_ASSERT(count == Extent);
         MBED_ASSERT(Extent == 0 || ptr != NULL);
     }
@@ -246,7 +251,8 @@ struct Span {
      * @post a call to size() will return Extent and data() will return @p first.
      */
     Span(pointer first, pointer last) :
-        _data(first) {
+        _data(first)
+    {
         MBED_ASSERT(first <= last);
         MBED_ASSERT((last - first) == Extent);
         MBED_ASSERT(Extent == 0 || first != NULL);
@@ -321,7 +327,8 @@ struct Span {
      * @pre Count >= 0 && Count <= size().
      */
     template<ptrdiff_t Count>
-    Span<element_type, Count> first() const {
+    Span<element_type, Count> first() const
+    {
         MBED_STATIC_ASSERT(
             (0 <= Count) && (Count <= Extent),
             "Invalid subspan extent"
@@ -339,7 +346,8 @@ struct Span {
      * @pre Count >= 0 && Count <= size().
      */
     template<ptrdiff_t Count>
-    Span<element_type, Count> last() const {
+    Span<element_type, Count> last() const
+    {
         MBED_STATIC_ASSERT(
             (0 <= Count) && (Count <= Extent),
             "Invalid subspan extent"
@@ -361,7 +369,8 @@ struct Span {
      */
     template<std::ptrdiff_t Offset, std::ptrdiff_t Count>
     Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count>
-    subspan() const {
+    subspan() const
+    {
         MBED_STATIC_ASSERT(
             0 <= Offset && Offset <= Extent,
             "Invalid subspan offset"
@@ -384,7 +393,8 @@ struct Span {
      *
      * @return A new Span over the first @p count elements.
      */
-    Span<element_type, SPAN_DYNAMIC_EXTENT> first(index_type count) const {
+    Span<element_type, SPAN_DYNAMIC_EXTENT> first(index_type count) const
+    {
         MBED_ASSERT(0 <= count && count <= Extent);
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(_data, count);
     }
@@ -396,7 +406,8 @@ struct Span {
      *
      * @return A new Span over the last @p count elements.
      */
-    Span<element_type, SPAN_DYNAMIC_EXTENT> last(index_type count) const {
+    Span<element_type, SPAN_DYNAMIC_EXTENT> last(index_type count) const
+    {
         MBED_ASSERT(0 <= count && count <= Extent);
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(
             _data + (Extent - count),
@@ -418,7 +429,8 @@ struct Span {
      */
     Span<element_type, SPAN_DYNAMIC_EXTENT> subspan(
         index_type offset, index_type count = SPAN_DYNAMIC_EXTENT
-    ) const {
+    ) const
+    {
         MBED_ASSERT(0 <= offset && offset <= Extent);
         MBED_ASSERT(
             (count == SPAN_DYNAMIC_EXTENT) ||
@@ -473,7 +485,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @note This function is not accessible if Extent != SPAN_DYNAMIC_EXTENT or
      * Extent != 0 .
      */
-    Span() : _data(NULL), _size(0) { }
+    Span() :
+        _data(NULL), _size(0) { }
 
     /**
      * Construct a Span from a pointer to a buffer and its size.
@@ -488,7 +501,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @post a call to size() will return count and data() will return @p ptr.
      */
     Span(pointer ptr, index_type count) :
-        _data(ptr), _size(count) {
+        _data(ptr), _size(count)
+    {
         MBED_ASSERT(count >= 0);
         MBED_ASSERT(ptr != NULL || count == 0);
     }
@@ -506,7 +520,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * data() will return @p first.
      */
     Span(pointer first, pointer last) :
-        _data(first), _size(last - first) {
+        _data(first), _size(last - first)
+    {
         MBED_ASSERT(first <= last);
         MBED_ASSERT(first != NULL  || (last - first) == 0);
     }
@@ -594,7 +609,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @pre Count >= 0 && Count <= size().
      */
     template<ptrdiff_t Count>
-    Span<element_type, Count> first() const {
+    Span<element_type, Count> first() const
+    {
         MBED_ASSERT((Count >= 0) && (Count <= _size));
         return Span<element_type, Count>(_data, Count);
     }
@@ -609,7 +625,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @pre Count >= 0 && Count <= size().
      */
     template<ptrdiff_t Count>
-    Span<element_type, Count> last() const {
+    Span<element_type, Count> last() const
+    {
         MBED_ASSERT((0 <= Count) && (Count <= _size));
         return Span<element_type, Count>(_data + (_size - Count), Count);
     }
@@ -628,7 +645,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      */
     template<std::ptrdiff_t Offset, std::ptrdiff_t Count>
     Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? SPAN_DYNAMIC_EXTENT : Count>
-    subspan() const {
+    subspan() const
+    {
         MBED_ASSERT(0 <= Offset && Offset <= _size);
         MBED_ASSERT(
             (Count == SPAN_DYNAMIC_EXTENT) ||
@@ -647,7 +665,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @return A new Span over the first @p count elements.
      */
-    Span<element_type, SPAN_DYNAMIC_EXTENT> first(index_type count) const {
+    Span<element_type, SPAN_DYNAMIC_EXTENT> first(index_type count) const
+    {
         MBED_ASSERT(0 <= count && count <= _size);
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(_data, count);
     }
@@ -659,7 +678,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @return A new Span over the last @p count elements.
      */
-    Span<element_type, SPAN_DYNAMIC_EXTENT> last(index_type count) const {
+    Span<element_type, SPAN_DYNAMIC_EXTENT> last(index_type count) const
+    {
         MBED_ASSERT(0 <= count && count <= _size);
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(
             _data + (_size - count),
@@ -681,7 +701,8 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      */
     Span<element_type, SPAN_DYNAMIC_EXTENT> subspan(
         index_type offset, index_type count = SPAN_DYNAMIC_EXTENT
-    ) const {
+    ) const
+    {
         MBED_ASSERT(0 <= offset && offset <= _size);
         MBED_ASSERT(
             (count == SPAN_DYNAMIC_EXTENT) ||

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -26,7 +26,7 @@
 namespace mbed {
 
 /**
- * Special value for the Size parameter of Span.
+ * Special value for the Extent parameter of Span.
  * If the type use this value then the size of the array is stored in the object
  * at runtime.
  */
@@ -47,18 +47,18 @@ namespace mbed {
  * @note You can create Span instances with the help of the function
  * template make_Span() and make_const_Span().
  *
- * @note Span<T, Size> objects can be implicitly converted to Span<T> objects
+ * @note Span<T, Extent> objects can be implicitly converted to Span<T> objects
  * where required.
  *
  * @tparam T type of objects held by the array.
- * @tparam Size The size of the array viewed. The default value
+ * @tparam Extent The size of the array viewed. The default value
  * SPAN_DYNAMIC_SIZE  is special as it allows construction of Span objects of
  * any size (set at runtime).
  */
-template<typename T, ptrdiff_t Size = SPAN_DYNAMIC_EXTENT>
+template<typename T, ptrdiff_t Extent = SPAN_DYNAMIC_EXTENT>
 struct Span {
 
-    MBED_STATIC_ASSERT(Size >= 0, "Invalid size for a Span");
+    MBED_STATIC_ASSERT(Extent >= 0, "Invalid extent for a Span");
 
     /**
      * Construct a view to an empty array.
@@ -78,7 +78,7 @@ struct Span {
      */
     Span(T *array_ptr, size_t array_size) :
         _array(array_ptr) {
-        MBED_ASSERT(array_size >= (size_t) Size);
+        MBED_ASSERT(array_size >= (size_t) Extent);
     }
 
     /**
@@ -86,12 +86,10 @@ struct Span {
      *
      * @param elements Reference to the array viewed.
      *
-     * @tparam Size Number of elements of T presents in the array.
-     *
-     * @post a call to size() will return Size, and data() will return
+     * @post a call to size() will return Extent, and data() will return
      * a pointer to elements.
      */
-    Span(T (&elements)[Size]):
+    Span(T (&elements)[Extent]):
         _array(elements) { }
 
     /**
@@ -101,7 +99,7 @@ struct Span {
      */
     size_t size() const
     {
-        return _array ? Size : 0;
+        return _array ? Extent : 0;
     }
 
     /**
@@ -170,7 +168,7 @@ struct Span {
      * @return A new Span over the first @p count elements.
      */
     Span<T> first(std::size_t count) const {
-        MBED_ASSERT(count <= Size);
+        MBED_ASSERT(count <= Extent);
         return Span<T>(_array, count);
     }
 
@@ -183,7 +181,7 @@ struct Span {
      */
     template<std::ptrdiff_t Count>
     Span<T, Count> first() const {
-        MBED_ASSERT(Count <= Size);
+        MBED_ASSERT(Count <= Extent);
         return Span<T, Count>(_array);
     }
 
@@ -195,8 +193,8 @@ struct Span {
      * @return A new Span over the last @p count elements.
      */
     Span<T> last(std::size_t count) const {
-        MBED_ASSERT(count <= Size);
-        return Span<T>(_array + (Size - count), count);
+        MBED_ASSERT(count <= Extent);
+        return Span<T>(_array + (Extent - count), count);
     }
 
     /**
@@ -208,8 +206,8 @@ struct Span {
      */
     template<std::ptrdiff_t Count>
     Span<T, Count> last() const {
-        MBED_ASSERT(Count <= Size);
-        return Span<T, Count>(_array + (Size - Count));
+        MBED_ASSERT(Count <= Extent);
+        return Span<T, Count>(_array + (Extent - Count));
     }
 
 private:
@@ -261,8 +259,8 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      * static size.
      * @param other The Span object used to construct this.
      */
-    template<size_t Size>
-    Span(const Span<T, Size> &other):
+    template<size_t Extent>
+    Span(const Span<T, Extent> &other):
         _array(other.data()), _size(other.size()) { }
 
     /**
@@ -370,8 +368,8 @@ private:
  * @return True if arrays in input have the same size and the same content
  * and false otherwise.
  */
-template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
+template<typename T, typename U, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator==(const Span<T, LhsExtent> &lhs, const Span<U, RhsExtent> &rhs)
 {
     if (lhs.size() != rhs.size()) {
         return false;
@@ -393,8 +391,8 @@ bool operator==(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
  * @return True if arrays in input have the same size and the same content
  * and false otherwise.
  */
-template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
+template<typename T, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator==(const Span<T, LhsExtent> &lhs, T (&rhs)[RhsExtent])
 {
     return lhs == Span<T>(rhs);
 }
@@ -408,8 +406,8 @@ bool operator==(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
  * @return True if arrays in input have the same size and the same content
  * and false otherwise.
  */
-template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
+template<typename T, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator==(T (&lhs)[LhsExtent], const Span<T, RhsExtent> &rhs)
 {
     return Span<T>(lhs) == rhs;
 }
@@ -423,8 +421,8 @@ bool operator==(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
  * @return True if arrays in input do not have the same size or the same
  * content and false otherwise.
  */
-template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
+template<typename T, typename U, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator!=(const Span<T, LhsExtent> &lhs, const Span<U, RhsExtent> &rhs)
 {
     return !(lhs == rhs);
 }
@@ -438,10 +436,10 @@ bool operator!=(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
  * @return True if arrays in input have the same size and the same content
  * and false otherwise.
  */
-template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
+template<typename T, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator!=(const Span<T, LhsExtent> &lhs, T (&rhs)[RhsExtent])
 {
-    return !(lhs == Span<T, RhsSize>(rhs));
+    return !(lhs == Span<T, RhsExtent>(rhs));
 }
 
 /**
@@ -453,17 +451,17 @@ bool operator!=(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
  * @return True if arrays in input have the same size and the same content
  * and false otherwise.
  */
-template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
+template<typename T, ptrdiff_t LhsExtent, ptrdiff_t RhsExtent>
+bool operator!=(T (&lhs)[LhsExtent], const Span<T, RhsExtent> &rhs)
 {
-    return !(Span<T, LhsSize>(lhs) == rhs);
+    return !(Span<T, LhsExtent>(lhs) == rhs);
 }
 
 /**
  * Generate a Span from a reference to a C/C++ array.
  *
  * @tparam T Type of elements held in elements.
- * @tparam Size Number of items held in elements.
+ * @tparam Extent Number of items held in elements.
  *
  * @param elements The reference to the array viewed.
  *
@@ -472,16 +470,16 @@ bool operator!=(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
  * @note This helper avoids the typing of template parameter when Span is
  * created 'inline'.
  */
-template<typename T, size_t Size>
-Span<T, Size> make_Span(T (&elements)[Size])
+template<typename T, size_t Extent>
+Span<T, Extent> make_Span(T (&elements)[Extent])
 {
-    return Span<T, Size>(elements);
+    return Span<T, Extent>(elements);
 }
 
 /**
  * Generate a Span from a pointer to a C/C++ array.
  *
- * @tparam Size Number of items held in elements.
+ * @tparam Extent Number of items held in elements.
  * @tparam T Type of elements held in elements.
  *
  * @param elements The reference to the array viewed.
@@ -491,10 +489,10 @@ Span<T, Size> make_Span(T (&elements)[Size])
  * @note This helper avoids the typing of template parameter when Span is
  * created 'inline'.
  */
-template<size_t Size, typename T>
-Span<T, Size> make_Span(T *elements)
+template<size_t Extent, typename T>
+Span<T, Extent> make_Span(T *elements)
 {
-    return Span<T, Size>(elements, Size);
+    return Span<T, Extent>(elements, Extent);
 }
 
 /**
@@ -520,7 +518,7 @@ Span<T> make_Span(T *array_ptr, size_t array_size)
  * Generate a Span to a const content from a reference to a C/C++ array.
  *
  * @tparam T Type of elements held in elements.
- * @tparam Size Number of items held in elements.
+ * @tparam Extent Number of items held in elements.
  *
  * @param elements The array viewed.
  * @return The Span to elements.
@@ -528,16 +526,16 @@ Span<T> make_Span(T *array_ptr, size_t array_size)
  * @note This helper avoids the typing of template parameter when Span is
  * created 'inline'.
  */
-template<typename T, size_t Size>
-Span<const T, Size> make_const_Span(const T (&elements)[Size])
+template<typename T, size_t Extent>
+Span<const T, Extent> make_const_Span(const T (&elements)[Extent])
 {
-    return Span<const T, Size>(elements);
+    return Span<const T, Extent>(elements);
 }
 
 /**
  * Generate a Span to a const content from a pointer to a C/C++ array.
  *
- * @tparam Size Number of items held in elements.
+ * @tparam Extent Number of items held in elements.
  * @tparam T Type of elements held in elements.
  *
  * @param elements The reference to the array viewed.
@@ -547,10 +545,10 @@ Span<const T, Size> make_const_Span(const T (&elements)[Size])
  * @note This helper avoids the typing of template parameter when Span is
  * created 'inline'.
  */
-template<size_t Size, typename T>
-Span<const T, Size> make_const_Span(const T *elements)
+template<size_t Extent, typename T>
+Span<const T, Extent> make_const_Span(const T *elements)
 {
-    return Span<const T, Size>(elements, Size);
+    return Span<const T, Extent>(elements, Extent);
 }
 
 /**

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -111,7 +111,7 @@ struct Span {
      */
     bool empty() const
     {
-        return size() ? false : true;
+        return size() == 0;
     }
 
     /**
@@ -281,7 +281,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      */
     bool empty() const
     {
-        return size() ? false : true;
+        return size() == 0;
     }
 
     /**

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -181,7 +181,7 @@ struct Span {
      *
      * @return A new Span over the first @p Count elements.
      */
-    template<std::size_t Count>
+    template<std::ptrdiff_t Count>
     Span<T, Count> first() const {
         MBED_ASSERT(Count <= Size);
         return Span<T, Count>(_array);
@@ -194,7 +194,7 @@ struct Span {
      *
      * @return A new Span over the last @p count elements.
      */
-    Span<T> last(std::ptrdiff_t count) const {
+    Span<T> last(std::size_t count) const {
         MBED_ASSERT(count <= Size);
         return Span<T>(_array + (Size - count), count);
     }
@@ -339,7 +339,7 @@ struct Span<T, SPAN_DYNAMIC_SIZE> {
      *
      * @return A new Span over the first @p count elements.
      */
-    Span<T> first(std::ptrdiff_t count) const {
+    Span<T> first(std::size_t count) const {
         MBED_ASSERT(count <= _size);
         return Span<T>(_array, count);
     }
@@ -351,7 +351,7 @@ struct Span<T, SPAN_DYNAMIC_SIZE> {
      *
      * @return A new Span over the last @p count elements.
      */
-    Span<T> last(std::ptrdiff_t count) const {
+    Span<T> last(std::size_t count) const {
         MBED_ASSERT(count <= _size);
         return Span<T>(_array + (_size - count), count);
     }

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -76,7 +76,7 @@ struct Span {
      * @post a call to size() will return array_size and data() will return
      * @p array_ptr.
      */
-    Span(T* array_ptr, size_t array_size) :
+    Span(T *array_ptr, size_t array_size) :
         _array(array_ptr) {
         MBED_ASSERT(array_size >= (size_t) Size);
     }
@@ -123,7 +123,7 @@ struct Span {
      *
      * @pre index shall be less than size().
      */
-    T& operator[](size_t index)
+    T &operator[](size_t index)
     {
         return _array[index];
     }
@@ -137,7 +137,7 @@ struct Span {
      *
      * @pre index shall be less than size().
      */
-    const T& operator[](size_t index) const
+    const T &operator[](size_t index) const
     {
         return _array[index];
     }
@@ -147,7 +147,7 @@ struct Span {
      *
      * @return The raw pointer to the array.
      */
-    T* data()
+    T *data()
     {
         return _array;
     }
@@ -157,7 +157,7 @@ struct Span {
      *
      * @return The raw pointer to the array.
      */
-    const T* data() const
+    const T *data() const
     {
         return _array;
     }
@@ -213,7 +213,7 @@ struct Span {
     }
 
 private:
-    T* _array;
+    T *_array;
 };
 
 /**
@@ -238,7 +238,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      * @post a call to size() will return array_size and data() will return
      * @p array_ptr.
      */
-    Span(T* array_ptr, size_t array_size) :
+    Span(T *array_ptr, size_t array_size) :
         _array(array_ptr), _size(array_size) { }
 
     /**
@@ -262,7 +262,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      * @param other The Span object used to construct this.
      */
     template<size_t Size>
-    Span(const Span<T, Size>& other):
+    Span(const Span<T, Size> &other):
         _array(other.data()), _size(other.size()) { }
 
     /**
@@ -293,7 +293,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      *
      * @pre index shall be less than size().
      */
-    T& operator[](size_t index)
+    T &operator[](size_t index)
     {
         return _array[index];
     }
@@ -307,7 +307,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      *
      * @pre index shall be less than size().
      */
-    const T& operator[](size_t index) const
+    const T &operator[](size_t index) const
     {
         return _array[index];
     }
@@ -317,7 +317,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      *
      * @return The raw pointer to the array.
      */
-    T* data()
+    T *data()
     {
         return _array;
     }
@@ -327,7 +327,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      *
      * @return The raw pointer to the array.
      */
-    const T* data() const
+    const T *data() const
     {
         return _array;
     }
@@ -357,7 +357,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
     }
 
 private:
-    T* _array;
+    T *_array;
     size_t _size;
 };
 
@@ -371,7 +371,7 @@ private:
  * and false otherwise.
  */
 template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
+bool operator==(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
 {
     if (lhs.size() != rhs.size()) {
         return false;
@@ -394,7 +394,7 @@ bool operator==(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
  * and false otherwise.
  */
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
+bool operator==(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
 {
     return lhs == Span<T>(rhs);
 }
@@ -409,7 +409,7 @@ bool operator==(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
  * and false otherwise.
  */
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator==(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
+bool operator==(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
 {
     return Span<T>(lhs) == rhs;
 }
@@ -424,7 +424,7 @@ bool operator==(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
  * content and false otherwise.
  */
 template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
+bool operator!=(const Span<T, LhsSize> &lhs, const Span<U, RhsSize> &rhs)
 {
     return !(lhs == rhs);
 }
@@ -439,7 +439,7 @@ bool operator!=(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
  * and false otherwise.
  */
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
+bool operator!=(const Span<T, LhsSize> &lhs, T (&rhs)[RhsSize])
 {
     return !(lhs == Span<T, RhsSize>(rhs));
 }
@@ -454,7 +454,7 @@ bool operator!=(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
  * and false otherwise.
  */
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
-bool operator!=(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
+bool operator!=(T (&lhs)[LhsSize], const Span<T, RhsSize> &rhs)
 {
     return !(Span<T, LhsSize>(lhs) == rhs);
 }
@@ -492,7 +492,7 @@ Span<T, Size> make_Span(T (&elements)[Size])
  * created 'inline'.
  */
 template<size_t Size, typename T>
-Span<T, Size> make_Span(T* elements)
+Span<T, Size> make_Span(T *elements)
 {
     return Span<T, Size>(elements, Size);
 }
@@ -511,7 +511,7 @@ Span<T, Size> make_Span(T* elements)
  * created 'inline'.
  */
 template<typename T>
-Span<T> make_Span(T* array_ptr, size_t array_size)
+Span<T> make_Span(T *array_ptr, size_t array_size)
 {
     return Span<T>(array_ptr, array_size);
 }
@@ -548,7 +548,7 @@ Span<const T, Size> make_const_Span(const T (&elements)[Size])
  * created 'inline'.
  */
 template<size_t Size, typename T>
-Span<const T, Size> make_const_Span(const T* elements)
+Span<const T, Size> make_const_Span(const T *elements)
 {
     return Span<const T, Size>(elements, Size);
 }
@@ -568,7 +568,7 @@ Span<const T, Size> make_const_Span(const T* elements)
  * created 'inline'.
  */
 template<typename T>
-Span<const T> make_const_Span(T* array_ptr, size_t array_size)
+Span<const T> make_const_Span(T *array_ptr, size_t array_size)
 {
     return Span<const T>(array_ptr, array_size);
 }

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -25,12 +25,12 @@
 
 namespace mbed {
 
-// Internal details of span
-// It is used construct span from span of convertible types (non const -> const)
+// Internal details of Span
+// It is used construct Span from Span of convertible types (non const -> const)
 namespace span_detail {
 
-// If From type is convertible to To type then the compilation constant value is
-// true otherwise it is false.
+// If From type is convertible to To type, then the compilation constant value is
+// true; otherwise, it is false.
 template<typename From, typename To>
 class is_convertible
 {
@@ -49,29 +49,29 @@ public:
 
 /**
  * Special value for the Extent parameter of Span.
- * If the type use this value then the size of the array is stored in the object
+ * If the type uses this value, then the size of the array is stored in the object
  * at runtime.
  */
 #define SPAN_DYNAMIC_EXTENT -1
 
 /**
- * Non owning view to a sequence of contiguous elements.
+ * Nonowning view to a sequence of contiguous elements.
  *
  * Spans encapsulate a pointer to a sequence of contiguous elements and its size
  * into a single object. Span can replace the traditional pair of pointer and
- * size arguments passed as array definition in function calls.
+ * size arguments passed as array definitions in function calls.
  *
  * @par Operations
  *
  * Span objects can be copied and assigned like regular value types with the help
- * of copy constructor and copy assignment (=) operator.
+ * of copy constructor and copy assignment (=) operators.
  *
- * Elements of the object can be retrieved with the subscript ([]) operator. The
- * pointer to the first element of the sequence viewed can be accessed with data()
- * while the function size() returns the number of elements in the sequence and
- * empty() informs if the there is any element in the sequence.
+ * You can retrieve elements of the object with the subscript ([]) operator. You can access the
+ * pointer to the first element of the sequence viewed with data().
+ * The function size() returns the number of elements in the sequence, and
+ * empty() informs whether there is any element in the sequence.
  *
- * Span can be sliced from the beginning of the sequence (first()), from the end
+ * You can splice Span from the beginning of the sequence (first()), from the end
  * of the sequence (last()) or from an arbitrary point of the sequence (subspan()).
  *
  * @par Size encoding
@@ -83,18 +83,18 @@ public:
  *   - Span<uint8_t>: Span over an arbitrary long sequence.
  *
  * When the size is encoded in the type itself, it is guaranteed that the Span
- * view a valid sequence (not empty() and not NULL) - unless Extent equals 0.
+ * view is a valid sequence (not empty() and not NULL) - unless Extent equals 0.
  * The type system also prevents automatic conversion from Span of different
  * sizes. Finally, the Span object is internally represented as a single pointer.
  *
  * When the size of the sequence viewed is encoded in the Span value, Span
  * instances can view an empty sequence. The function empty() helps client code
- * to decide if valid content is being viewed or not.
+ * decide whether Span is viewing valid content or not.
  *
  * @par Example
  *
  * - Encoding fixed size array: Array values in parameter decays automatically
- * to pointer which leaves room for subtitle bugs:
+ * to pointer, which leaves room for subtitle bugs:
  *
  * @code
     typedef uint8_t mac_address_t[6];
@@ -155,7 +155,7 @@ public:
     }
 
 
-    //with span
+    //with Span
     struct parsed_value_t {
        Span<uint8_t> header;
        Span<uint8_t> options;
@@ -188,10 +188,10 @@ public:
  * @note Span<T, Extent> objects can be implicitly converted to Span<T> objects
  * where required.
  *
- * @tparam ElementType type of objects viewed by the Span.
+ * @tparam ElementType type of objects the Span views.
  *
  * @tparam Extent The size of the contiguous sequence viewed. The default value
- * SPAN_DYNAMIC_SIZE  is special as it allows construction of Span objects of
+ * SPAN_DYNAMIC_SIZE  is special because it allows construction of Span objects of
  * any size (set at runtime).
  */
 template<typename ElementType, ptrdiff_t Extent = SPAN_DYNAMIC_EXTENT>
@@ -227,7 +227,7 @@ struct Span {
     /**
      * Construct an empty Span.
      *
-     * @post a call to size() will return 0, and data() will return NULL.
+     * @post a call to size() returns 0, and data() returns NULL.
      *
      * @note This function is not accessible if Extent != SPAN_DYNAMIC_EXTENT or
      * Extent != 0 .
@@ -251,7 +251,7 @@ struct Span {
      * @pre [ptr, ptr + count) must be be a valid range.
      * @pre count must be equal to Extent.
      *
-     * @post a call to size() will return Extent and data() will return @p ptr.
+     * @post a call to size() returns Extent, and data() returns @p ptr.
      */
     Span(pointer ptr, index_type count) :
         _data(ptr)
@@ -261,16 +261,16 @@ struct Span {
     }
 
     /**
-     * Construct a Span from the range [first, last)
+     * Construct a Span from the range [first, last).
      *
      * @param first Pointer to the beginning of the data viewed.
      * @param last End of the range (element after the last element).
      *
      * @pre [first, last) must be be a valid range.
-     * @pre first <= last
+     * @pre first <= last.
      * @pre last - first must be equal to Extent.
      *
-     * @post a call to size() will return Extent and data() will return @p first.
+     * @post a call to size() returns Extent, and data() returns @p first.
      */
     Span(pointer first, pointer last) :
         _data(first)
@@ -285,7 +285,7 @@ struct Span {
      *
      * @param elements Reference to the array viewed.
      *
-     * @post a call to size() will return Extent, and data() will return a
+     * @post a call to size() returns Extent, and data() returns a
      * pointer to elements.
      */
     Span(element_type (&elements)[Extent]):
@@ -296,9 +296,9 @@ struct Span {
      *
      * @param other The Span object used to construct this.
      *
-     * @note For span with a positive extent, this function is not accessible.
+     * @note For Span with a positive extent, this function is not accessible.
      *
-     * @note OtherElementType(*)[] should be convertible to ElementType(*)[].
+     * @note OtherElementType(*)[] is convertible to ElementType(*)[].
      */
     template<typename OtherElementType>
     Span(const Span<OtherElementType, Extent> &other):
@@ -323,7 +323,7 @@ struct Span {
     /**
      * Return if the sequence is empty or not.
      *
-     * @return true if the sequence is empty and false otherwise
+     * @return true if the sequence is empty and false otherwise.
      */
     bool empty() const
     {
@@ -331,13 +331,13 @@ struct Span {
     }
 
     /**
-     * Returns a reference to the element at position @p index
+     * Returns a reference to the element at position @p index.
      *
      * @param index Index of the element to access.
      *
      * @return A reference to the element at the index specified in input.
      *
-     * @pre 0 <= index < Extent
+     * @pre 0 <= index < Extent.
      */
     reference operator[](index_type index) const
     {
@@ -359,7 +359,7 @@ struct Span {
     }
 
     /**
-     * Create a new span over the first @p Count elements of the existing view.
+     * Create a new Span over the first @p Count elements of the existing view.
      *
      * @tparam Count The number of element viewed by the new Span
      *
@@ -378,9 +378,9 @@ struct Span {
     }
 
     /**
-     * Create a new span over the last @p Count elements of the existing view.
+     * Create a new Span over the last @p Count elements of the existing view.
      *
-     * @tparam Count The number of element viewed by the new Span
+     * @tparam Count The number of element viewed by the new Span.
      *
      * @return A new Span over the last @p Count elements.
      *
@@ -397,13 +397,13 @@ struct Span {
     }
 
     /**
-     * Create a subspan that is a view other Count elements; the view starts at
+     * Create a subspan that is a view of other Count elements; the view starts at
      * element Offset.
      *
      * @tparam Offset The offset of the first element viewed by the subspan.
      *
      * @tparam Count The number of elements present in the subspan. If Count
-     * is equal to SPAN_DYNAMIC_EXTENT then a span starting at offset and
+     * is equal to SPAN_DYNAMIC_EXTENT, then a Span starting at offset and
      * containing the rest of the elements is returned.
      *
      * @return A subspan of this starting at Offset and Count long.
@@ -430,7 +430,7 @@ struct Span {
     /**
      * Create a new Span over the first @p count elements of the existing view.
      *
-     * @param count The number of element viewed by the new Span
+     * @param count The number of element viewed by the new Span.
      *
      * @return A new Span over the first @p count elements.
      */
@@ -441,9 +441,9 @@ struct Span {
     }
 
     /**
-     * Create a new span over the last @p count elements of the existing view.
+     * Create a new Span over the last @p count elements of the existing view.
      *
-     * @param count The number of element viewed by the new Span
+     * @param count The number of elements viewed by the new Span.
      *
      * @return A new Span over the last @p count elements.
      */
@@ -457,13 +457,13 @@ struct Span {
     }
 
     /**
-     * Create a subspan that is a view other count elements; the view starts at
+     * Create a subspan that is a view of other count elements; the view starts at
      * element offset.
      *
      * @param offset The offset of the first element viewed by the subspan.
      *
      * @param count The number of elements present in the subspan. If Count
-     * is equal to SPAN_DYNAMIC_EXTENT then a span starting at offset and
+     * is equal to SPAN_DYNAMIC_EXTENT, then a span starting at offset and
      * containing the rest of the elements is returned.
      *
      * @return
@@ -488,12 +488,12 @@ private:
 };
 
 /**
- * Span specialisation that handle dynamic size.
+ * Span specialization that handle dynamic size.
  */
 template<typename ElementType>
 struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
-     * Type of the element contained
+     * Type of the element contained.
      */
     typedef ElementType element_type;
 
@@ -503,12 +503,12 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     typedef ptrdiff_t index_type;
 
     /**
-     * Pointer to an ElementType
+     * Pointer to an ElementType.
      */
     typedef element_type *pointer;
 
     /**
-     * Reference to an ElementType
+     * Reference to an ElementType.
      */
     typedef element_type &reference;
 
@@ -520,7 +520,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Construct an empty Span.
      *
-     * @post a call to size() will return 0, and data() will return NULL.
+     * @post a call to size() returns 0, and data() returns NULL.
      *
      * @note This function is not accessible if Extent != SPAN_DYNAMIC_EXTENT or
      * Extent != 0 .
@@ -538,7 +538,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @pre [ptr, ptr + count) must be be a valid range.
      * @pre count must be equal to extent.
      *
-     * @post a call to size() will return count and data() will return @p ptr.
+     * @post a call to size() returns count, and data() returns @p ptr.
      */
     Span(pointer ptr, index_type count) :
         _data(ptr), _size(count)
@@ -548,16 +548,16 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     }
 
     /**
-     * Construct a Span from the range [first, last)
+     * Construct a Span from the range [first, last).
      *
      * @param first Pointer to the beginning of the data viewed.
      * @param last End of the range (element after the last element).
      *
      * @pre [first, last) must be be a valid range.
-     * @pre first <= last
+     * @pre first <= last.
      *
-     * @post a call to size() will return the result of (last - first) and
-     * data() will return @p first.
+     * @post a call to size() returns the result of (last - first), and
+     * data() returns @p first.
      */
     Span(pointer first, pointer last) :
         _data(first), _size(last - first)
@@ -573,7 +573,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @tparam Count Number of elements of T presents in the array.
      *
-     * @post a call to size() will return Count, and data() will return a
+     * @post a call to size() returns Count, and data() returns a
      * pointer to elements.
      */
     template<size_t Count>
@@ -585,9 +585,9 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @param other The Span object used to construct this.
      *
-     * @note For span with a positive extent, this function is not accessible.
+     * @note For Span with a positive extent, this function is not accessible.
      *
-     * @note OtherElementType(*)[] should be convertible to ElementType(*)[].
+     * @note OtherElementType(*)[] is convertible to ElementType(*)[].
      */
     template<typename OtherElementType, ptrdiff_t OtherExtent>
     Span(const Span<OtherElementType, OtherExtent> &other):
@@ -612,7 +612,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Return if the sequence viewed is empty or not.
      *
-     * @return true if the sequence is empty and false otherwise
+     * @return true if the sequence is empty and false otherwise.
      */
     bool empty() const
     {
@@ -626,7 +626,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @return A reference to the element at the index specified in input.
      *
-     * @pre index shall be less than size().
+     * @pre index is less than size().
      */
     reference operator[](index_type index) const
     {
@@ -649,7 +649,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Create a new Span over the first @p Count elements of the existing view.
      *
-     * @tparam Count The number of element viewed by the new Span
+     * @tparam Count The number of elements viewed by the new Span.
      *
      * @return A new Span over the first @p Count elements.
      *
@@ -665,7 +665,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Create a new Span over the last @p Count elements of the existing view.
      *
-     * @tparam Count The number of element viewed by the new Span
+     * @tparam Count The number of elements viewed by the new Span.
      *
      * @return A new Span over the last @p Count elements.
      *
@@ -685,7 +685,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @tparam Offset The offset of the first element viewed by the subspan.
      *
      * @tparam Count The number of elements present in the subspan. If Count
-     * is equal to SPAN_DYNAMIC_EXTENT then a span starting at offset and
+     * is equal to SPAN_DYNAMIC_EXTENT, then a Span starting at offset and
      * containing the rest of the elements is returned.
      *
      * @return A subspan of this starting at Offset and Count long.
@@ -708,7 +708,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Create a new Span over the first @p count elements of the existing view.
      *
-     * @param count The number of element viewed by the new Span
+     * @param count The number of elements viewed by the new Span.
      *
      * @return A new Span over the first @p count elements.
      */
@@ -721,7 +721,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     /**
      * Create a new Span over the last @p count elements of the existing view.
      *
-     * @param count The number of element viewed by the new Span
+     * @param count The number of elements viewed by the new Span.
      *
      * @return A new Span over the last @p count elements.
      */
@@ -735,13 +735,13 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
     }
 
     /**
-     * Create a subspan that is a view other count elements; the view starts at
+     * Create a subspan that is a view of other count elements; the view starts at
      * element offset.
      *
      * @param offset The offset of the first element viewed by the subspan.
      *
      * @param count The number of elements present in the subspan. If Count
-     * is equal to SPAN_DYNAMIC_EXTENT then a span starting at offset and
+     * is equal to SPAN_DYNAMIC_EXTENT, then a Span starting at offset and
      * containing the rest of the elements is returned.
      *
      * @return A subspan of this starting at offset and count long.
@@ -769,8 +769,8 @@ private:
 /**
  * Equality operator between two Span objects.
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if Spans in input have the same size and the same content and
  * false otherwise.
@@ -790,10 +790,10 @@ bool operator==(const Span<T, LhsExtent> &lhs, const Span<U, RhsExtent> &rhs)
 }
 
 /**
- * Equality operation between a span and a reference to a C++ array.
+ * Equality operation between a Span and a reference to a C++ array.
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if elements in input have the same size and the same content and
  * false otherwise.
@@ -807,8 +807,8 @@ bool operator==(const Span<T, LhsExtent> &lhs, T (&rhs)[RhsExtent])
 /**
  * Equality operation between a Span and a reference to a C++ array.
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if elements in input have the same size and the same content
  * and false otherwise.
@@ -822,8 +822,8 @@ bool operator==(T (&lhs)[LhsExtent], const Span<T, RhsExtent> &rhs)
 /**
  * Not equal operator
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if arrays in input do not have the same size or the same content
  * and false otherwise.
@@ -837,8 +837,8 @@ bool operator!=(const Span<T, LhsExtent> &lhs, const Span<U, RhsExtent> &rhs)
 /**
  * Not Equal operation between a Span and a reference to a C++ array.
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if elements in input have the same size and the same content
  * and false otherwise.
@@ -852,8 +852,8 @@ bool operator!=(const Span<T, LhsExtent> &lhs, T (&rhs)[RhsExtent])
 /**
  * Not Equal operation between a Span and a reference to a C++ array.
  *
- * @param lhs Left hand side of the binary operation.
- * @param rhs Right hand side of the binary operation.
+ * @param lhs Left side of the binary operation.
+ * @param rhs Right side of the binary operation.
  *
  * @return True if elements in input have the same size and the same content
  * and false otherwise.

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -183,6 +183,9 @@ struct Span {
      */
     reference operator[](index_type index) const
     {
+#ifdef MBED_DEBUG
+        MBED_ASSERT(0 <= index && index < Extent);
+#endif
         return _data[index];
     }
 
@@ -454,6 +457,9 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      */
     reference operator[](index_type index) const
     {
+#ifdef MBED_DEBUG
+        MBED_ASSERT(0 <= index && index < _size);
+#endif
         return _data[index];
     }
 

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -39,7 +39,7 @@ namespace mbed {
  * into a single object. Span can replace the traditional pair of pointer and
  * size arguments passed as array definition in function calls.
  *
- * @paragraph Operations
+ * @par Operations
  *
  * Span objects can be copied and assigned like regular value types with the help
  * of copy constructor and copy assignment (=) operator.
@@ -52,7 +52,7 @@ namespace mbed {
  * Span can be sliced from the beginning of the sequence (first()), from the end
  * of the sequence (last()) or from an arbitrary point of the sequence (subspan()).
  *
- * @paragraph Size encoding
+ * @par Size encoding
  *
  * The size of the sequence can be encoded in the type itself or in the value of
  * the instance with the help of the template parameter Extent:
@@ -69,7 +69,7 @@ namespace mbed {
  * instances can view invalid sequence (empty and NULL pointer). The function
  * empty() helps client code to decide if valid content is being viewed or not.
  *
- * @paragraph Example
+ * @par Example
  *
  * - Encoding fixed size array: Array values in parameter decays automatically
  * to pointer which leaves room for subtitle bugs:

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -64,14 +64,14 @@ public:
  * @par Operations
  *
  * Span objects can be copied and assigned like regular value types with the help
- * of copy constructor and copy assignment (=) operators.
+ * of the copy constructor or the copy assignment (=) operator.
  *
  * You can retrieve elements of the object with the subscript ([]) operator. You can access the
  * pointer to the first element of the sequence viewed with data().
  * The function size() returns the number of elements in the sequence, and
  * empty() informs whether there is any element in the sequence.
  *
- * You can splice Span from the beginning of the sequence (first()), from the end
+ * You can slice Span from the beginning of the sequence (first()), from the end
  * of the sequence (last()) or from an arbitrary point of the sequence (subspan()).
  *
  * @par Size encoding
@@ -298,7 +298,7 @@ struct Span {
      *
      * @note For Span with a positive extent, this function is not accessible.
      *
-     * @note OtherElementType(*)[] is convertible to ElementType(*)[].
+     * @note OtherElementType(*)[] must be convertible to ElementType(*)[].
      */
     template<typename OtherElementType>
     Span(const Span<OtherElementType, Extent> &other):
@@ -587,7 +587,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      *
      * @note For Span with a positive extent, this function is not accessible.
      *
-     * @note OtherElementType(*)[] is convertible to ElementType(*)[].
+     * @note OtherElementType(*)[] must be convertible to ElementType(*)[].
      */
     template<typename OtherElementType, ptrdiff_t OtherExtent>
     Span(const Span<OtherElementType, OtherExtent> &other):

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -206,7 +206,7 @@ struct Span {
     template<ptrdiff_t Count>
     Span<element_type, Count> first() const {
         MBED_STATIC_ASSERT(
-            (Count >= 0) && (Count <= Extent),
+            (0 <= Count) && (Count <= Extent),
             "Invalid subspan extent"
         );
         return Span<element_type, Count>(_data, Count);
@@ -224,7 +224,7 @@ struct Span {
     template<ptrdiff_t Count>
     Span<element_type, Count> last() const {
         MBED_STATIC_ASSERT(
-            (Count >= 0) && (Count <= Extent),
+            (0 <= Count) && (Count <= Extent),
             "Invalid subspan extent"
         );
         return Span<element_type, Count>(_data + (Extent - Count), Count);
@@ -246,12 +246,12 @@ struct Span {
     Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count>
     subspan() const {
         MBED_STATIC_ASSERT(
-            Offset == 0 || (Offset > 0 && Offset < Extent),
+            0 <= Offset && Offset <= Extent,
             "Invalid subspan offset"
         );
         MBED_STATIC_ASSERT(
             (Count == SPAN_DYNAMIC_EXTENT) ||
-            (Count >= 0 && Offset + Count <= Extent),
+            (0 <= Count && (Count + Offset) <= Extent),
             "Invalid subspan count"
         );
         return Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count>(
@@ -305,7 +305,7 @@ struct Span {
         MBED_ASSERT(0 <= offset && offset <= Extent);
         MBED_ASSERT(
             (count == SPAN_DYNAMIC_EXTENT) ||
-            (count >= 0 && (offset + count <= Extent))
+            (0 <= count && (count + offset) <= Extent)
         );
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(
             _data + offset,
@@ -490,7 +490,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      */
     template<ptrdiff_t Count>
     Span<element_type, Count> last() const {
-        MBED_ASSERT((Count >= 0) && (Count <= _size));
+        MBED_ASSERT((0 <= Count) && (Count <= _size));
         return Span<element_type, Count>(_data + (_size - Count), Count);
     }
 
@@ -512,7 +512,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
         MBED_ASSERT(0 <= Offset && Offset <= _size);
         MBED_ASSERT(
             (Count == SPAN_DYNAMIC_EXTENT) ||
-            (Count >= 0 && Offset + Count <= _size)
+            (0 <= Count && (Count + Offset) <= _size)
         );
         return Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? SPAN_DYNAMIC_EXTENT : Count>(
             _data + Offset,
@@ -565,7 +565,7 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
         MBED_ASSERT(0 <= offset && offset <= _size);
         MBED_ASSERT(
             (count == SPAN_DYNAMIC_EXTENT) ||
-            (count >= 0 && (offset + count <= _size))
+            (0 <= count && (count + offset) <= _size)
         );
         return Span<element_type, SPAN_DYNAMIC_EXTENT>(
             _data + offset,

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -79,7 +79,7 @@ namespace mbed {
     void process_mac(mac_address_t);
 
     // compile just fine
-    uint8_t* invalid_value = NULL;
+    uint8_t *invalid_value = NULL;
     process_mac(invalid_value);
 
 
@@ -88,7 +88,7 @@ namespace mbed {
     void process_mac(mac_address_t);
 
     // compilation error
-    uint8_t* invalid_value = NULL;
+    uint8_t *invalid_value = NULL;
     process_mac(invalid_value);
 
     // compilation ok
@@ -103,13 +103,13 @@ namespace mbed {
     const uint8_t options_tag[OPTIONS_TAG_SIZE];
 
     struct parsed_value_t {
-       uint8_t* header;
-       uint8_t* options;
-       uint8_t* payload;
+       uint8_t *header;
+       uint8_t *options;
+       uint8_t *payload;
        size_t payload_size;
     }
 
-    parsed_value_t parse(uint8_t* buffer, size_t buffer_size) {
+    parsed_value_t parse(uint8_t *buffer, size_t buffer_size) {
        parsed_value_t parsed_value { 0 };
 
        if (buffer != NULL && buffer_size <= MINIMAL_BUFFER_SIZE) {
@@ -139,7 +139,7 @@ namespace mbed {
        Span<uint8_t> payload;
     }
 
-    parsed_value_t parse(Span<uint8_t> buffer) {
+    parsed_value_t parse(const Span<uint8_t> &buffer) {
        parsed_value_t parsed_value;
 
        if (buffer.size() <= MINIMAL_BUFFER_SIZE) {

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -98,7 +98,10 @@ struct Span {
      * Extent != 0 .
      */
     Span() : _data(NULL) {
-        MBED_STATIC_ASSERT(Extent == 0, "Invalid extent for a Span");
+        MBED_STATIC_ASSERT(
+            Extent == 0,
+            "Cannot default construct a static-extent Span (unless Extent is 0)"
+        );
     }
 
     /**

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -45,14 +45,6 @@ public:
     static const bool value = sizeof(true_type) == sizeof(sink(generator()));
 };
 
-template<bool Condition, typename ResultType = void>
-struct enable_if;
-
-template<typename ResultType>
-struct enable_if<true, ResultType> {
-    typedef ResultType type;
-};
-
 }
 
 /**
@@ -309,13 +301,14 @@ struct Span {
      * @note OtherElementType(*)[] should be convertible to ElementType(*)[].
      */
     template<typename OtherElementType>
-    Span(
-        const Span<OtherElementType, Extent> &other,
-        typename span_detail::enable_if<
-            span_detail::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value
-        >::type* = 0
-    ):
-        _data(other.data()) { }
+    Span(const Span<OtherElementType, Extent> &other):
+        _data(other.data())
+    {
+        MBED_STATIC_ASSERT(
+            (span_detail::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value),
+            "OtherElementType(*)[] should be convertible to ElementType (*)[]"
+        );
+    }
 
     /**
      * Return the size of the sequence viewed.
@@ -499,7 +492,6 @@ private:
  */
 template<typename ElementType>
 struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
-
     /**
      * Type of the element contained
      */
@@ -598,13 +590,14 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @note OtherElementType(*)[] should be convertible to ElementType(*)[].
      */
     template<typename OtherElementType, ptrdiff_t OtherExtent>
-    Span(
-        const Span<OtherElementType, OtherExtent> &other,
-        typename span_detail::enable_if<
-            span_detail::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value
-        >::type* = NULL
-    ):
-        _data(other.data()), _size(other.size()) { }
+    Span(const Span<OtherElementType, OtherExtent> &other):
+        _data(other.data()), _size(other.size())
+    {
+        MBED_STATIC_ASSERT(
+            (span_detail::is_convertible<OtherElementType (*)[], ElementType (*)[]>::value),
+            "OtherElementType(*)[] should be convertible to ElementType (*)[]"
+        );
+    }
 
     /**
      * Return the size of the array viewed.

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -30,7 +30,7 @@ namespace mbed {
  * If the type use this value then the size of the array is stored in the object
  * at runtime.
  */
-#define SPAN_DYNAMIC_SIZE -1
+#define SPAN_DYNAMIC_EXTENT -1
 
 /**
  * View to an array.
@@ -55,7 +55,7 @@ namespace mbed {
  * SPAN_DYNAMIC_SIZE  is special as it allows construction of Span objects of
  * any size (set at runtime).
  */
-template<typename T, ptrdiff_t Size = SPAN_DYNAMIC_SIZE>
+template<typename T, ptrdiff_t Size = SPAN_DYNAMIC_EXTENT>
 struct Span {
 
     MBED_STATIC_ASSERT(Size >= 0, "Invalid size for an ArrayView");
@@ -220,7 +220,7 @@ private:
  * Span specialisation that handle dynamic array size.
  */
 template<typename T>
-struct Span<T, SPAN_DYNAMIC_SIZE> {
+struct Span<T, SPAN_DYNAMIC_EXTENT> {
 
     /**
      * Construct a view to an empty array.

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -441,7 +441,7 @@ bool operator!=(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
 bool operator!=(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
 {
-    return !(lhs == Span<T>(rhs));
+    return !(lhs == Span<T, RhsSize>(rhs));
 }
 
 /**
@@ -456,7 +456,7 @@ bool operator!=(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
 template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
 bool operator!=(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
 {
-    return !(Span<T>(lhs) == rhs);
+    return !(Span<T, LhsSize>(lhs) == rhs);
 }
 
 /**

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -243,7 +243,8 @@ struct Span {
      * @return
      */
     template<std::ptrdiff_t Offset, std::ptrdiff_t Count>
-    Span<element_type, Count> subspan() const {
+    Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count>
+    subspan() const {
         MBED_STATIC_ASSERT(
             Offset == 0 || (Offset > 0 && Offset < Extent),
             "Invalid subspan offset"
@@ -253,7 +254,7 @@ struct Span {
             (Count >= 0 && Offset + Count <= Extent),
             "Invalid subspan count"
         );
-        return Span<element_type, Count>(
+        return Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count>(
             _data + Offset,
             Count == SPAN_DYNAMIC_EXTENT ? Extent - Offset : Count
         );
@@ -506,13 +507,14 @@ struct Span<ElementType, SPAN_DYNAMIC_EXTENT> {
      * @return
      */
     template<std::ptrdiff_t Offset, std::ptrdiff_t Count>
-    Span<element_type, Count> subspan() const {
-        MBED_ASSERT(Offset == 0 || (Offset > 0 && Offset < _size));
+    Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? SPAN_DYNAMIC_EXTENT : Count>
+    subspan() const {
+        MBED_ASSERT(0 <= Offset && Offset <= _size);
         MBED_ASSERT(
             (Count == SPAN_DYNAMIC_EXTENT) ||
             (Count >= 0 && Offset + Count <= _size)
         );
-        return Span<element_type, Count>(
+        return Span<element_type, Count == SPAN_DYNAMIC_EXTENT ? SPAN_DYNAMIC_EXTENT : Count>(
             _data + Offset,
             Count == SPAN_DYNAMIC_EXTENT ? _size - Offset : Count
         );

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -1,0 +1,578 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018-2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef MBED_PLATFORM_SPAN_H_
+#define MBED_PLATFORM_SPAN_H_
+
+#include <algorithm>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "platform/mbed_assert.h"
+
+namespace mbed {
+
+/**
+ * Special value for the Size parameter of Span.
+ * If the type use this value then the size of the array is stored in the object
+ * at runtime.
+ */
+#define SPAN_DYNAMIC_SIZE -1
+
+/**
+ * View to an array.
+ *
+ * Spans encapsulate the pointer to an array and its size into a single object
+ * or type; however, it does not manage the lifetime of the array viewed.
+ * You can use instances of Span to replace the traditional pair of pointer and
+ * size arguments in function calls.
+ *
+ * You can use the size member function to query the number of elements present
+ * in the array, and overloads of the subscript operator allow code using
+ * this object to access to the content of the array viewed.
+ *
+ * @note You can create Span instances with the help of the function
+ * template make_Span() and make_const_Span().
+ *
+ * @note Span<T, Size> objects can be implicitly converted to Span<T> objects
+ * where required.
+ *
+ * @tparam T type of objects held by the array.
+ * @tparam Size The size of the array viewed. The default value
+ * SPAN_DYNAMIC_SIZE  is special as it allows construction of Span objects of
+ * any size (set at runtime).
+ */
+template<typename T, ptrdiff_t Size = SPAN_DYNAMIC_SIZE>
+struct Span {
+
+    MBED_STATIC_ASSERT(Size >= 0, "Invalid size for an ArrayView");
+
+    /**
+     * Construct a view to an empty array.
+     *
+     * @post a call to size() will return 0, and data() will return NULL.
+     */
+    Span() : _array(NULL) { }
+
+    /**
+     * Construct a Span from a pointer to a buffer.
+     *
+     * @param array_ptr Pointer to the array data
+     * @param array_size Number of elements of T present in the array.
+     *
+     * @post a call to size() will return array_size and data() will return
+     * array_tpr.
+     */
+    Span(T* array_ptr, size_t array_size) :
+        _array(array_ptr) {
+        MBED_ASSERT(array_size >= (size_t) Size);
+    }
+
+    /**
+     * Construct a Span from the reference to an array.
+     *
+     * @param elements Reference to the array viewed.
+     *
+     * @tparam Size Number of elements of T presents in the array.
+     *
+     * @post a call to size() will return Size, and data() will return
+     * a pointer to elements.
+     */
+    Span(T (&elements)[Size]):
+        _array(elements) { }
+
+    /**
+     * Return the size of the array viewed.
+     *
+     * @return The number of elements present in the array viewed.
+     */
+    size_t size() const
+    {
+        return _array ? Size : 0;
+    }
+
+    /**
+     * Return if the array is empty or not.
+     *
+     * @return true if the array is empty and false otherwise
+     */
+    bool empty() const
+    {
+        return size() ? false : true;
+    }
+
+    /**
+     * Access to a mutable element of the array.
+     *
+     * @param index Element index to access.
+     *
+     * @return A reference to the element at the index specified in input.
+     *
+     * @pre index shall be less than size().
+     */
+    T& operator[](size_t index)
+    {
+        return _array[index];
+    }
+
+    /**
+     * Access to an immutable element of the array.
+     *
+     * @param index Element index to access.
+     *
+     * @return A const reference to the element at the index specified in input.
+     *
+     * @pre index shall be less than size().
+     */
+    const T& operator[](size_t index) const
+    {
+        return _array[index];
+    }
+
+    /**
+     * Get the raw pointer to the array.
+     *
+     * @return The raw pointer to the array.
+     */
+    T* data()
+    {
+        return _array;
+    }
+
+    /**
+     * Get the raw const pointer to the array.
+     *
+     * @return The raw pointer to the array.
+     */
+    const T* data() const
+    {
+        return _array;
+    }
+
+    /**
+     * Create a new Span over the first @p count elements of the existing view.
+     *
+     * @param count The number of element viewed by the new Span
+     *
+     * @return A new Span over the first @p count elements.
+     */
+    Span<T> first(std::size_t count) const {
+        MBED_ASSERT(count <= Size);
+        return Span<T>(_array, count);
+    }
+
+    /**
+     * Create a new span over the first @p Count elements of the existing view.
+     *
+     * @tparam Count The number of element viewed by the new Span
+     *
+     * @return A new Span over the first @p Count elements.
+     */
+    template<std::size_t Count>
+    Span<T, Count> first() const {
+        MBED_ASSERT(Count <= Size);
+        return Span<T, Count>(_array);
+    }
+
+    /**
+     * Create a new span over the last @p count elements of the existing view.
+     *
+     * @param count The number of element viewed by the new Span
+     *
+     * @return A new Span over the last @p count elements.
+     */
+    Span<T> last(std::ptrdiff_t count) const {
+        MBED_ASSERT(count <= Size);
+        return Span<T>(_array + (Size - count), count);
+    }
+
+    /**
+     * Create a new span over the last @p Count elements of the existing view.
+     *
+     * @tparam Count The number of element viewed by the new Span
+     *
+     * @return A new Span over the last @p Count elements.
+     */
+    template<std::ptrdiff_t Count>
+    Span<T, Count> last() const {
+        MBED_ASSERT(Count <= Size);
+        return Span<T, Count>(_array + (Size - Count));
+    }
+
+private:
+    T* _array;
+};
+
+/**
+ * Span specialisation that handle dynamic array size.
+ */
+template<typename T>
+struct Span<T, SPAN_DYNAMIC_SIZE> {
+
+    /**
+     * Construct a view to an empty array.
+     *
+     * @post a call to size() will return 0, and data() will return NULL.
+     */
+    Span() : _array(0), _size(0) { }
+
+    /**
+     * Construct a Span from a pointer to a buffer and its size.
+     *
+     * @param array_ptr Pointer to the array data
+     * @param array_size Number of elements of T present in the array.
+     *
+     * @post a call to size() will return array_size and data() will return
+     * array_tpr.
+     */
+    Span(T* array_ptr, size_t array_size) :
+        _array(array_ptr), _size(array_size) { }
+
+    /**
+     * Construct a Span from the reference to an array.
+     *
+     * @param elements Reference to the array viewed.
+     *
+     * @tparam Size Number of elements of T presents in the array.
+     *
+     * @post a call to size() will return Size, and data() will return
+     * a pointer to elements.
+     */
+    template<size_t Size>
+    Span(T (&elements)[Size]):
+        _array(elements), _size(Size) { }
+
+
+    /**
+     * Construct a Span object with a dynamic size from a Span object with a
+     * static size.
+     * @param other The Span object used to construct this.
+     */
+    template<size_t Size>
+    Span(const Span<T, Size>& other):
+        _array(other.data()), _size(other.size()) { }
+
+    /**
+     * Return the size of the array viewed.
+     *
+     * @return The number of elements present in the array viewed.
+     */
+    size_t size() const
+    {
+        return _size;
+    }
+
+    /**
+     * Return if the array is empty or not
+     * @return true if the array is empty and false otherwise
+     */
+    bool empty() const
+    {
+        return size() ? false : true;
+    }
+
+    /**
+     * Access to a mutable element of the array.
+     *
+     * @param index Element index to access.
+     *
+     * @return A reference to the element at the index specified in input.
+     *
+     * @pre index shall be less than size().
+     */
+    T& operator[](size_t index)
+    {
+        return _array[index];
+    }
+
+    /**
+     * Access to an immutable element of the array.
+     *
+     * @param index Element index to access.
+     *
+     * @return A const reference to the element at the index specified in input.
+     *
+     * @pre index shall be less than size().
+     */
+    const T& operator[](size_t index) const
+    {
+        return _array[index];
+    }
+
+    /**
+     * Get the raw pointer to the array.
+     *
+     * @return The raw pointer to the array.
+     */
+    T* data()
+    {
+        return _array;
+    }
+
+    /**
+     * Get the raw const pointer to the array.
+     *
+     * @return The raw pointer to the array.
+     */
+    const T* data() const
+    {
+        return _array;
+    }
+
+    /**
+     * Create a new Span over the first @p count elements of the existing view.
+     *
+     * @param count The number of element viewed by the new Span
+     *
+     * @return A new Span over the first @p count elements.
+     */
+    Span<T> first(std::ptrdiff_t count) const {
+        MBED_ASSERT(count <= _size);
+        return Span<T>(_array, count);
+    }
+
+    /**
+     * Create a new span over the last @p count elements of the existing view.
+     *
+     * @param count The number of element viewed by the new Span
+     *
+     * @return A new Span over the last @p count elements.
+     */
+    Span<T> last(std::ptrdiff_t count) const {
+        MBED_ASSERT(count <= _size);
+        return Span<T>(_array + (_size - count), count);
+    }
+
+private:
+    T* _array;
+    size_t _size;
+};
+
+/**
+ * Equality operator between two Span objects.
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input have the same size and the same content
+ * and false otherwise.
+ */
+template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator==(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
+{
+    if (lhs.size() != rhs.size()) {
+        return false;
+    }
+
+    if (lhs.data() == rhs.data()) {
+        return true;
+    }
+
+    return std::equal(lhs.data(), lhs.data() + lhs.size(), rhs.data());
+}
+
+/**
+ * Equality operation between a span and a reference to a C++ array.
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input have the same size and the same content
+ * and false otherwise.
+ */
+template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator==(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
+{
+    return lhs == Span<T>(rhs);
+}
+
+/**
+ * Equality operation between a span and a reference to a C++ array.
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input have the same size and the same content
+ * and false otherwise.
+ */
+template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator==(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
+{
+    return Span<T>(lhs) == rhs;
+}
+
+/**
+ * Not equal operator
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input do not have the same size or the same
+ * content and false otherwise.
+ */
+template<typename T, typename U, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator!=(const Span<T, LhsSize>& lhs, const Span<U, RhsSize>& rhs)
+{
+    return !(lhs == rhs);
+}
+
+/**
+ * Not Equal operation between a span and a reference to a C++ array.
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input have the same size and the same content
+ * and false otherwise.
+ */
+template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator!=(const Span<T, LhsSize>& lhs, T (&rhs)[RhsSize])
+{
+    return !(lhs == Span<T>(rhs));
+}
+
+/**
+ * Not Equal operation between a span and a reference to a C++ array.
+ *
+ * @param lhs Left hand side of the binary operation.
+ * @param rhs Right hand side of the binary operation.
+ *
+ * @return True if arrays in input have the same size and the same content
+ * and false otherwise.
+ */
+template<typename T, ptrdiff_t LhsSize, ptrdiff_t RhsSize>
+bool operator!=(T (& lhs)[LhsSize], const Span<T, RhsSize>& rhs)
+{
+    return !(Span<T>(lhs) == rhs);
+}
+
+/**
+ * Generate a Span from a reference to a C/C++ array.
+ *
+ * @tparam T Type of elements held in elements.
+ * @tparam Size Number of items held in elements.
+ *
+ * @param elements The reference to the array viewed.
+ *
+ * @return The Span to elements.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<typename T, size_t Size>
+Span<T, Size> make_Span(T (&elements)[Size])
+{
+    return Span<T, Size>(elements);
+}
+
+/**
+ * Generate a Span from a pointer to a C/C++ array.
+ *
+ * @tparam Size Number of items held in elements.
+ * @tparam T Type of elements held in elements.
+ *
+ * @param elements The reference to the array viewed.
+ *
+ * @return The Span to elements.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<size_t Size, typename T>
+Span<T, Size> make_Span(T* elements)
+{
+    return Span<T, Size>(elements, Size);
+}
+
+/**
+ * Generate a Span from a C/C++ pointer and the size of the array.
+ *
+ * @tparam T Type of elements held in array_ptr.
+ *
+ * @param array_ptr The pointer to the array to viewed.
+ * @param array_size The number of T elements in the array.
+ *
+ * @return The Span to array_ptr with a size of array_size.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<typename T>
+Span<T> make_Span(T* array_ptr, size_t array_size)
+{
+    return Span<T>(array_ptr, array_size);
+}
+
+/**
+ * Generate a Span to a const content from a reference to a C/C++ array.
+ *
+ * @tparam T Type of elements held in elements.
+ * @tparam Size Number of items held in elements.
+ *
+ * @param elements The array viewed.
+ * @return The Span to elements.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<typename T, size_t Size>
+Span<const T, Size> make_const_Span(const T (&elements)[Size])
+{
+    return Span<const T, Size>(elements);
+}
+
+/**
+ * Generate a Span to a const content from a pointer to a C/C++ array.
+ *
+ * @tparam Size Number of items held in elements.
+ * @tparam T Type of elements held in elements.
+ *
+ * @param elements The reference to the array viewed.
+ *
+ * @return The Span to elements.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<size_t Size, typename T>
+Span<const T, Size> make_const_Span(const T* elements)
+{
+    return Span<const T, Size>(elements, Size);
+}
+
+/**
+ * Generate a Span to a const content from a C/C++ pointer and the size of the
+ * array.
+ *
+ * @tparam T Type of elements held in array_ptr.
+ *
+ * @param array_ptr The pointer to the array to viewed.
+ * @param array_size The number of T elements in the array.
+ *
+ * @return The Span to array_ptr with a size of array_size.
+ *
+ * @note This helper avoids the typing of template parameter when Span is
+ * created 'inline'.
+ */
+template<typename T>
+Span<const T> make_const_Span(T* array_ptr, size_t array_size)
+{
+    return Span<const T>(array_ptr, array_size);
+}
+
+} // namespace mbed
+
+#endif /* MBED_PLATFORM_SPAN_H_ */

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -58,7 +58,7 @@ namespace mbed {
 template<typename T, ptrdiff_t Size = SPAN_DYNAMIC_EXTENT>
 struct Span {
 
-    MBED_STATIC_ASSERT(Size >= 0, "Invalid size for an ArrayView");
+    MBED_STATIC_ASSERT(Size >= 0, "Invalid size for a Span");
 
     /**
      * Construct a view to an empty array.
@@ -74,7 +74,7 @@ struct Span {
      * @param array_size Number of elements of T present in the array.
      *
      * @post a call to size() will return array_size and data() will return
-     * array_tpr.
+     * @p array_ptr.
      */
     Span(T* array_ptr, size_t array_size) :
         _array(array_ptr) {
@@ -236,7 +236,7 @@ struct Span<T, SPAN_DYNAMIC_EXTENT> {
      * @param array_size Number of elements of T present in the array.
      *
      * @post a call to size() will return array_size and data() will return
-     * array_tpr.
+     * @p array_ptr.
      */
     Span(T* array_ptr, size_t array_size) :
         _array(array_ptr), _size(array_size) { }

--- a/platform/Span.h
+++ b/platform/Span.h
@@ -73,7 +73,7 @@ struct Span {
      * @param array_ptr Pointer to the array data
      * @param array_size Number of elements of T present in the array.
      *
-     * @post a call to size() will return array_size and data() will return
+     * @post a call to size() will return Extent and data() will return
      * @p array_ptr.
      */
     Span(T *array_ptr, size_t array_size) :


### PR DESCRIPTION
### Description

The Span class allows the creation of views over contiguous memory. The view
do not own memory, is typed and has a length. It can be used as a replacement of
the traditional pair of pointer and size in parameters or class fields.

Main operations:
- size(): return the lenght of the memory viewed
- empty(): return if the memory viewed is empty
- [index]: access elements viewed
- data(): return a pointer to the memory viewed.
- first(count): Create a subview from the first count elements.
- last(count): Create a subview from the last count elements.
- == and !=: compare two views or a view to array and return if they are equal or
not.

The Span class came in two flavors:
- Static size: The size is encoded in the Span type and it is as lightweitgh as
a single pointer,
- Dynamic size: The object can store arbitrary views and it costs one pointer
and the size of the view.

### Pull request type


    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

