### PR TITLE
Fix uvisor ticker issue on K64F

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -120,8 +120,10 @@ void lp_ticker_clear_interrupt(void)
 
 void lp_ticker_free(void)
 {
+#ifndef  FEATURE_UVISOR
     LPTMR_DisableInterrupts(LPTMR0, kLPTMR_TimerInterruptEnable);
     NVIC_DisableIRQ(LPTMR0_IRQn);
+#endif
 }
 
 #endif /* DEVICE_LPTICKER */


### PR DESCRIPTION
### Description
Restore lp_ticker_free to previous implementation
This fixes uvisor tests on K64F
This is a temporary patch until uvisor is removed




### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

