### PR TITLE
LoRaWAN: Restoring default RX2 data rate

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -522,8 +522,7 @@ void LoRaPHY::reset_to_default_values(loramac_protocol_params *params, bool init
 
     params->sys_params.rx2_channel.frequency = get_default_rx2_frequency();
 
-    // RX2 data rate should also start from the maximum
-    params->sys_params.rx2_channel.datarate = get_default_max_tx_datarate();
+    params->sys_params.rx2_channel.datarate = get_default_rx2_datarate();
 
     params->sys_params.uplink_dwell_time = phy_params.ul_dwell_time_setting;
 


### PR DESCRIPTION


### Description

In b0b0261 we changed the RX2 data rate to start from the highest data rate
available for the PHY rather than standard defined DR.
This introduced a regression, i.e., even when somebody changed the default RX2 data
rate to something usable for their environment, it didn't take any effect. As in
reset_mac_params() we override the data rate with max value possible for that PHY.
This commit restores the original behaviour and we always use standard defined
values.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

