### PR TITLE
Lora: Change visibility of LoRaMac internal methods as private

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -97,30 +97,10 @@ public:
     void disconnect(void);
 
     /**
-     * @brief   Queries the LoRaMAC the maximum possible FRMPayload size to send.
-     *          The LoRaMAC takes the scheduled MAC commands into account and returns
-     *          corresponding value.
-     *
-     * @param   fopts_len     [in]    Number of mac commands in the queue pending.
-     *
-     * @return  Size of the biggest packet that can be sent.
-     *          Please note that if the size of the MAC commands in the queue do
-     *          not fit into the payload size on the related datarate, the LoRaMAC will
-     *          omit the MAC commands.
-     */
-    uint8_t get_max_possible_tx_size(uint8_t fopts_len);
-
-    /**
      * @brief nwk_joined Checks if device has joined to network
      * @return True if joined to network, false otherwise
      */
     bool nwk_joined();
-
-    /**
-     * @brief set_nwk_joined This is used for ABP mode for which real joining does not happen
-     * @param joined True if device has joined in network, false otherwise
-     */
-    void set_nwk_joined(bool joined);
 
     /**
      * @brief   Adds a channel plan to the system.
@@ -220,12 +200,6 @@ public:
     void bind_phy(LoRaPHY &phy);
 
     /**
-     * @brief Configures the events to trigger an MLME-Indication with
-     *        a MLME type of MLME_SCHEDULE_UPLINK.
-     */
-    void set_mlme_schedule_ul_indication(void);
-
-    /**
      * @brief Schedules the frame for sending.
      *
      * @details Prepares a full MAC frame and schedules it for physical
@@ -242,37 +216,6 @@ public:
      */
     lorawan_status_t send(loramac_mhdr_t *mac_hdr, const uint8_t fport,
                           const void *fbuffer, uint16_t fbuffer_size);
-
-    /**
-     * @brief Puts the system in continuous transmission mode
-     *
-     * @remark Uses the radio parameters set on the previous transmission.
-     *
-     * @param [in] timeout    Time in seconds while the radio is kept in continuous wave mode
-     *
-     * @return status          Status of the operation. LORAWAN_STATUS_OK in case
-     *                         of success and a negative error code in case of
-     *                         failure.
-     */
-    lorawan_status_t set_tx_continuous_wave(uint16_t timeout);
-
-    /**
-     * @brief Puts the system in continuous transmission mode
-     *
-     * @param [in] timeout     Time in seconds while the radio is kept in continuous wave mode
-     * @param [in] frequency   RF frequency to be set.
-     * @param [in] power       RF output power to be set.
-     *
-     * @return status          Status of the operation. LORAWAN_STATUS_OK in case
-     *                         of success and a negative error code in case of
-     *                         failure.
-     */
-    lorawan_status_t set_tx_continuous_wave1(uint16_t timeout, uint32_t frequency, uint8_t power);
-
-    /**
-     * @brief Resets MAC specific parameters to default
-     */
-    void reset_mac_parameters(void);
 
     /**
      * @brief get_default_tx_datarate Gets the default TX datarate
@@ -356,11 +299,6 @@ public:
      */
     void set_device_class(const device_class_t &device_class,
                           mbed::Callback<void(void)>ack_expiry_handler);
-
-    /**
-     * @brief opens a continuous RX2 window for Class C devices
-     */
-    void open_continuous_rx_window(void);
 
     /**
      * @brief setup_link_check_request Adds link check request command
@@ -487,10 +425,36 @@ public:
 #endif
 
 private:
-    typedef mbed::ScopedLock<LoRaMac> Lock;
-#if MBED_CONF_RTOS_PRESENT
-    rtos::Mutex _mutex;
-#endif
+    /**
+     * @brief   Queries the LoRaMAC the maximum possible FRMPayload size to send.
+     *          The LoRaMAC takes the scheduled MAC commands into account and returns
+     *          corresponding value.
+     *
+     * @param   fopts_len     [in]    Number of mac commands in the queue pending.
+     *
+     * @return  Size of the biggest packet that can be sent.
+     *          Please note that if the size of the MAC commands in the queue do
+     *          not fit into the payload size on the related datarate, the LoRaMAC will
+     *          omit the MAC commands.
+     */
+    uint8_t get_max_possible_tx_size(uint8_t fopts_len);
+
+    /**
+     * @brief set_nwk_joined This is used for ABP mode for which real joining does not happen
+     * @param joined True if device has joined in network, false otherwise
+     */
+    void set_nwk_joined(bool joined);
+
+    /**
+     * @brief Configures the events to trigger an MLME-Indication with
+     *        a MLME type of MLME_SCHEDULE_UPLINK.
+     */
+    void set_mlme_schedule_ul_indication(void);
+
+    /**
+     * @brief Resets MAC specific parameters to default
+     */
+    void reset_mac_parameters(void);
 
     /**
      * Handles a Join Accept frame
@@ -628,6 +592,11 @@ private:
                                 float max_eirp, float antenna_gain, uint16_t timeout);
 
 private:
+    typedef mbed::ScopedLock<LoRaMac> Lock;
+#if MBED_CONF_RTOS_PRESENT
+    rtos::Mutex _mutex;
+#endif
+
     /**
      * Timer subsystem handle
      */


### PR DESCRIPTION

### Description

Some LoRaMac methods were defined as public even though there were used only
internally.

Also removed definition of some methods which were not even implemented nor used.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

