### PR TITLE
MIMXRT1050: Fix I2C Byte transfer functions

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_IMX/objects.h
@@ -50,6 +50,7 @@ struct analogin_s {
 
 struct i2c_s {
     uint32_t instance;
+    uint8_t address_set;
 };
 
 struct spi_s {


### PR DESCRIPTION
### Description
1. Added a flag to issue START command
2. Do not send START command inside i2c_start function as the LPI2C hardware will issue a STOP on reception of a NACK
3. Remove the i2c_address global variable, this is not required

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

