### PR TITLE
Timer:read_us() should return 64-bit value

### DIFF
--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -72,7 +72,7 @@ void Timer::stop()
     core_util_critical_section_exit();
 }
 
-int Timer::read_us()
+us_timestamp_t Timer::read_us()
 {
     return read_high_resolution_us();
 }

--- a/drivers/Timer.h
+++ b/drivers/Timer.h
@@ -85,7 +85,7 @@ public:
      *
      *  @returns    Time passed in micro seconds
      */
-    int read_us();
+    us_timestamp_t read_us();
 
     /** An operator shorthand for read()
      */


### PR DESCRIPTION

### Description

This PR addresses https://github.com/ARMmbed/mbed-os/issues/7836.

Timer::read_us() should return the full 64-bits returned from
read_high_resolution_us() or bad things can happen given enough time.

I tested this overnight and observed proper output at the critical
first rollover (at ~ 23:26:47) and also the day rollover.

Cleaner test and result follow:

```
#include "mbed.h"

#define START_VALUE 1534460461 // comes from Thu Aug 16 23:01:01 2018

int main()
{
    int break_count;
    time_t seconds, new_time;

    printf("resetting time...\n");
    struct tm t
    {
    };
    t.tm_year = 2018 - 1900;
    t.tm_mon = 8 - 1;
    t.tm_mday = 16;
    t.tm_hour = 23;
    t.tm_min = 1;
    t.tm_sec = 1;
    new_time = mktime(&t);
    printf ("setting time to %ld\r\n", new_time);
    set_time(new_time);

    for (unsigned long long c = 0; c < 10000000000; c++)
    {
        seconds = time(NULL);
        printf("time read = %ld sec %s", seconds, ctime(&seconds));
        if (seconds == START_VALUE)
        {
           // time has wrapped back to set_time() value
           break_count +=1;
        }

        // wait for 1 second
        wait_ms(1000);

    }  // for (c)

    return (0);
}
```


Program output:

```
time read = 1534462598 sec Thu Aug 16 23:36:38 2018
time read = 1534462599 sec Thu Aug 16 23:36:39 2018
time read = 1534462600 sec Thu Aug 16 23:36:40 2018
time read = 1534462601 sec Thu Aug 16 23:36:41 2018
time read = 1534462602 sec Thu Aug 16 23:36:42 2018
time read = 1534462603 sec Thu Aug 16 23:36:43 2018
time read = 1534462604 sec Thu Aug 16 23:36:44 2018
time read = 1534462606 sec Thu Aug 16 23:36:46 2018
time read = 1534462607 sec Thu Aug 16 23:36:47 2018
time read = 1534462608 sec Thu Aug 16 23:36:48 2018
time read = 1534462609 sec Thu Aug 16 23:36:49 2018
time read = 1534462610 sec Thu Aug 16 23:36:50 2018
time read = 1534462611 sec Thu Aug 16 23:36:51 2018
time read = 1534462612 sec Thu Aug 16 23:36:52 2018
time read = 1534462613 sec Thu Aug 16 23:36:53 2018
```



### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

