### PR TITLE
Realtek: fix gpio is connected

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/gpio_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/gpio_api.c
@@ -199,4 +199,13 @@ void gpio_deinit(gpio_t *obj)
     HAL_GPIO_DeInit(&obj->hal_pin);
 }
 
+int gpio_is_connected(const gpio_t *obj)
+{
+    if(obj->pin != (PinName)NC){
+        return 1;
+    } else {
+        return 0;
+    }
+}
+
 #endif


### PR DESCRIPTION
### Description

Met linking issue when try to compile the mbed-cloud-client-example for REALTEK_RTL8195AM platform using ARM toolchain.

mbed compile -t ARM -m REALTEK_RTL8195AM
.....
.....
Link: mbed-cloud-client-example
Error: L6218E: Undefined symbol gpio_is_connected (referred from ../BUILD/REALTEK_RTL8195AM/ARM/storage-selector/dataflash-driver/DataFlashBlockDevice.o).
Finished: 0 information, 0 warning and 1 error messages.
[ERROR] Error: L6218E: Undefined symbol gpio_is_connected (referred from ../BUILD/REALTEK_RTL8195AM/ARM/storage-selector/dataflash-driver/DataFlashBlockDevice.o).
Finished: 0 information, 0 warning and 1 error messages.

[mbed] ERROR: "c:\python27\python.exe" returned error code 1.


### Pull request type

    [X ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

