### PR TITLE
Cellular: Make AT_CellularStack socket array multi-thread safe

### DIFF
--- a/features/cellular/framework/AT/AT_CellularStack.cpp
+++ b/features/cellular/framework/AT/AT_CellularStack.cpp
@@ -95,14 +95,18 @@ nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protoc
 
     int max_socket_count = get_max_socket_count();
 
+    _socket_mutex.lock();
+
     if (!_socket) {
         if (socket_stack_init() != NSAPI_ERROR_OK) {
+            _socket_mutex.unlock();
             return NSAPI_ERROR_NO_SOCKET;
         }
 
         _socket = new CellularSocket*[max_socket_count];
         if (!_socket) {
             tr_error("No memory to open socket!");
+            _socket_mutex.unlock();
             return NSAPI_ERROR_NO_SOCKET;
         }
         _socket_count = max_socket_count;
@@ -121,6 +125,7 @@ nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protoc
 
     if (index == -1) {
         tr_error("No socket found!");
+        _socket_mutex.unlock();
         return NSAPI_ERROR_NO_SOCKET;
     }
 
@@ -135,6 +140,8 @@ nsapi_error_t AT_CellularStack::socket_open(nsapi_socket_t *handle, nsapi_protoc
     psock->localAddress = addr;
     psock->proto = proto;
     *handle = psock;
+
+    _socket_mutex.unlock();
 
     return NSAPI_ERROR_OK;
 }
@@ -166,8 +173,6 @@ nsapi_error_t AT_CellularStack::socket_close(nsapi_socket_t handle)
         return err;
     }
 
-    _socket[index] = NULL;
-    delete socket;
     err = NSAPI_ERROR_OK;
 
     // Close the socket on the modem if it was created
@@ -175,6 +180,10 @@ nsapi_error_t AT_CellularStack::socket_close(nsapi_socket_t handle)
     if (sock_created) {
         err = socket_close_impl(sock_id);
     }
+
+    _socket[index] = NULL;
+    delete socket;
+
     _at.unlock();
 
     return err;

--- a/features/cellular/framework/AT/AT_CellularStack.h
+++ b/features/cellular/framework/AT/AT_CellularStack.h
@@ -165,6 +165,10 @@ protected:
 
     // stack type from PDP context
     nsapi_ip_stack_t _stack_type;
+
+private:
+    // mutex for write/read to a _socket array, needed when multiple threads may open sockets simultaneously
+    PlatformMutex _socket_mutex;
 };
 
 } // namespace mbed


### PR DESCRIPTION
### Description

The socket array `_sockets` was not multi-thread safe. That could be a problem if two threads try to open socket at the same.

In socket_close() was  `delete socket` called erroneously before calling `socket_close_impl`, that may still use that socket.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

