### PR TITLE
Cellular: Allow cellular modules to override network registration mode

### DIFF
--- a/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellularnetwork/test_at_cellularnetwork.cpp
@@ -76,12 +76,12 @@ public:
             return _stack;
         }
     }
-    virtual bool has_registration(RegistrationType reg_type)
+    virtual AT_CellularNetwork::RegistrationMode has_registration(RegistrationType reg_type)
     {
         if (reg_type == C_GREG) {
-            return false;
+            return RegistrationModeDisable;
         }
-        return true;
+        return RegistrationModeLAC;
     }
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology op_rat)
     {
@@ -108,12 +108,12 @@ public:
             return _stack;
         }
     }
-    virtual bool has_registration(RegistrationType reg_type)
+    virtual AT_CellularNetwork::RegistrationMode has_registration(RegistrationType reg_type)
     {
         if (reg_type == C_GREG) {
-            return false;
+            return RegistrationModeDisable;
         }
-        return true;
+        return RegistrationModeLAC;
     }
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology op_rat)
     {

--- a/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/AT_CellularNetwork_stub.cpp
@@ -121,9 +121,9 @@ nsapi_error_t AT_CellularNetwork::get_cell_id(int &cell_id)
     return NSAPI_ERROR_OK;
 }
 
-bool AT_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode AT_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-    return false;
+    return RegistrationModeDisable;
 }
 
 nsapi_error_t AT_CellularNetwork::set_attach(int timeout)

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -55,7 +55,7 @@ AT_CellularNetwork::~AT_CellularNetwork()
 #endif // NSAPI_PPP_AVAILABLE
 
     for (int type = 0; type < CellularNetwork::C_MAX; type++) {
-        if (has_registration((RegistrationType)type)) {
+        if (has_registration((RegistrationType)type) != RegistrationModeDisable) {
             _at.remove_urc_handler(at_reg[type].urc_prefix, _urc_funcs[type]);
         }
     }
@@ -72,7 +72,7 @@ nsapi_error_t AT_CellularNetwork::init()
     _urc_funcs[C_REG] = callback(this, &AT_CellularNetwork::urc_creg);
 
     for (int type = 0; type < CellularNetwork::C_MAX; type++) {
-        if (has_registration((RegistrationType)type)) {
+        if (has_registration((RegistrationType)type) != RegistrationModeDisable) {
             if (_at.set_urc_handler(at_reg[type].urc_prefix, _urc_funcs[type]) != NSAPI_ERROR_OK) {
                 return NSAPI_ERROR_NO_MEMORY;
             }
@@ -703,13 +703,16 @@ nsapi_error_t AT_CellularNetwork::set_registration_urc(RegistrationType type, bo
     int index = (int)type;
     MBED_ASSERT(index >= 0 && index < C_MAX);
 
-    if (!has_registration(type)) {
+    RegistrationMode mode = has_registration(type);
+    if (mode == RegistrationModeDisable) {
         return NSAPI_ERROR_UNSUPPORTED;
     } else {
         _at.lock();
         if (urc_on) {
             _at.cmd_start(at_reg[index].cmd);
-            _at.write_string("=2", false);
+            const uint8_t ch_eq = '=';
+            _at.write_bytes(&ch_eq, 1);
+            _at.write_int((int)mode);
             _at.cmd_stop();
         } else {
             _at.cmd_start(at_reg[index].cmd);
@@ -801,7 +804,7 @@ nsapi_error_t AT_CellularNetwork::get_registration_status(RegistrationType type,
     int i = (int)type;
     MBED_ASSERT(i >= 0 && i < C_MAX);
 
-    if (!has_registration(at_reg[i].type)) {
+    if (has_registration(at_reg[i].type) == RegistrationModeDisable) {
         return NSAPI_ERROR_UNSUPPORTED;
     }
 
@@ -835,10 +838,10 @@ nsapi_error_t AT_CellularNetwork::get_cell_id(int &cell_id)
     return NSAPI_ERROR_OK;
 }
 
-bool AT_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode AT_CellularNetwork::has_registration(RegistrationType reg_type)
 {
     (void)reg_type;
-    return true;
+    return RegistrationModeLAC;
 }
 
 nsapi_error_t AT_CellularNetwork::set_attach(int /*timeout*/)

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -129,9 +129,14 @@ protected:
     /** Check if modem supports given registration type.
      *
      *  @param reg_type enum RegistrationType
-     *  @return         true if given registration type is supported by modem
+     *  @return         mode supported on given reg_type as per 3GPP TS 27.007, 0 when unsupported
      */
-    virtual bool has_registration(RegistrationType reg_type);
+    enum RegistrationMode {
+        RegistrationModeDisable = 0,
+        RegistrationModeEnable, // <stat>
+        RegistrationModeLAC, // <stat>[,<[lac>,]<[ci>],[<AcT>],[<rac>]]
+    };
+    virtual RegistrationMode has_registration(RegistrationType reg_type);
 
     /** Sets access technology to be scanned. Modem specific implementation.
      *

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.cpp
@@ -42,9 +42,9 @@ bool QUECTEL_BC95_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t request
     return requested_stack == IPV4_STACK ? true : false;
 }
 
-bool QUECTEL_BC95_CellularNetwork::has_registration(RegistrationType reg_tech)
+AT_CellularNetwork::RegistrationMode QUECTEL_BC95_CellularNetwork::has_registration(RegistrationType reg_tech)
 {
-    return (reg_tech == C_EREG);
+    return (reg_tech == C_EREG) ? RegistrationModeLAC : RegistrationModeDisable;
 }
 
 nsapi_error_t QUECTEL_BC95_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularNetwork.h
@@ -34,7 +34,7 @@ protected:
 
     virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
 
-    virtual bool has_registration(RegistrationType reg_type);
+    virtual RegistrationMode has_registration(RegistrationType reg_type);
 };
 } // namespace mbed
 #endif // QUECTEL_BC95_CELLULAR_NETWORK_H_

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96_CellularNetwork.cpp
@@ -32,9 +32,9 @@ bool QUECTEL_UG96_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t request
     return requested_stack == IPV4_STACK ? true : false;
 }
 
-bool QUECTEL_UG96_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode QUECTEL_UG96_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-    return (reg_type == C_REG || reg_type == C_GREG);
+    return (reg_type == C_REG || reg_type == C_GREG) ? RegistrationModeLAC : RegistrationModeDisable;
 }
 
 nsapi_error_t QUECTEL_UG96_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96_CellularNetwork.h
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96_CellularNetwork.h
@@ -30,7 +30,7 @@ public:
 protected:
     virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
 
-    virtual bool has_registration(RegistrationType rat);
+    virtual RegistrationMode has_registration(RegistrationType rat);
 
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology opRat);
 

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularNetwork.cpp
@@ -32,9 +32,9 @@ bool TELIT_HE910_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t requeste
     return requested_stack == IPV4_STACK ? true : false;
 }
 
-bool TELIT_HE910_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode TELIT_HE910_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-    return (reg_type == C_REG || reg_type == C_GREG);
+    return (reg_type == C_REG || reg_type == C_GREG) ? RegistrationModeLAC : RegistrationModeDisable;
 }
 
 nsapi_error_t TELIT_HE910_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularNetwork.h
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularNetwork.h
@@ -31,7 +31,7 @@ protected:
 
     virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
 
-    virtual bool has_registration(RegistrationType rat);
+    virtual RegistrationMode has_registration(RegistrationType rat);
 
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology opRat);
 };

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
@@ -47,9 +47,9 @@ bool UBLOX_AT_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t requested_s
     return requested_stack == IPV4_STACK ? true : false;
 }
 
-bool UBLOX_AT_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode UBLOX_AT_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-    return (reg_type == C_REG || reg_type == C_GREG);
+    return (reg_type == C_REG || reg_type == C_GREG) ? RegistrationModeLAC : RegistrationModeDisable;
 }
 
 nsapi_error_t UBLOX_AT_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.h
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.h
@@ -41,7 +41,7 @@ protected:
 
     virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
 
-    virtual bool has_registration(RegistrationType rat);
+    virtual RegistrationMode has_registration(RegistrationType rat);
 
 private:
 

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.cpp
@@ -32,9 +32,9 @@ bool UBLOX_PPP_CellularNetwork::get_modem_stack_type(nsapi_ip_stack_t requested_
     return requested_stack == IPV4_STACK ? true : false;
 }
 
-bool UBLOX_PPP_CellularNetwork::has_registration(RegistrationType reg_type)
+AT_CellularNetwork::RegistrationMode UBLOX_PPP_CellularNetwork::has_registration(RegistrationType reg_type)
 {
-    return (reg_type == C_REG || reg_type == C_GREG);
+    return (reg_type == C_REG || reg_type == C_GREG) ? RegistrationModeLAC : RegistrationModeDisable;
 }
 
 nsapi_error_t UBLOX_PPP_CellularNetwork::set_access_technology_impl(RadioAccessTechnology opRat)

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP_CellularNetwork.h
@@ -30,7 +30,7 @@ public:
 protected:
     virtual bool get_modem_stack_type(nsapi_ip_stack_t requested_stack);
 
-    virtual bool has_registration(RegistrationType rat);
+    virtual RegistrationMode has_registration(RegistrationType rat);
 
     virtual nsapi_error_t set_access_technology_impl(RadioAccessTechnology opRat);
 };


### PR DESCRIPTION
### Description

Cellular network registration is by default in mode 2, that is defined in 3GPP TS 27.007 as <stat>[,<[lac>,]<[ci>],[<AcT>],[<rac>]]

That value must be configurable because some modems support only certain modes on specific technologies and also in some cases it's required to support extended modes, such as requested in the issue https://github.com/ARMmbed/mbed-os/issues/7496

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
