### PR TITLE
Removing default flow control for MTB_LAIRD_BL652

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/mbed_lib.json
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/mbed_lib.json
@@ -63,7 +63,7 @@
                 "NRF52_PAN_64"
             ],
             "target.lf_clock_src": "NRF_LF_SRC_RC",
-            "target.console-uart-flow-control": "RTSCTS"
+            "target.console-uart-flow-control": null
         },
         "MTB_UBLOX_NINA_B1": {
             "target.macros_add": [


### PR DESCRIPTION
### Description

Flow control is enabled by default for this target that derives from nRF52. It needs to be disabled for the MTB_LAIRD_BL652 module target since this module does not need flow control enabled.

Verified with printf() messages on the serial terminal. WIth FC = "RTSCTS" (i.e. default in Mbed OS today) there are no debug messages sent over the UART to terminal.

@cmonr or @0xc0170 : Please let me know what tests would be required for this. I can attach relevant logs. Thanks.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
