### PR TITLE
 Add required header file and namespace element instead add all.

### DIFF
--- a/events/EventQueue.cpp
+++ b/events/EventQueue.cpp
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 #include "events/EventQueue.h"
-
 #include "events/mbed_events.h"
-#include "mbed.h"
 
+using mbed::Callback;
+
+namespace events {
 
 EventQueue::EventQueue(unsigned event_size, unsigned char *event_pointer)
 {
@@ -76,4 +77,5 @@ void EventQueue::chain(EventQueue *target)
     } else {
         equeue_chain(&_equeue, 0);
     }
+}
 }

--- a/events/equeue/equeue_mbed.cpp
+++ b/events/equeue/equeue_mbed.cpp
@@ -21,7 +21,16 @@
 #if defined(EQUEUE_PLATFORM_MBED)
 
 #include <stdbool.h>
-#include "mbed.h"
+#include <string.h>
+#include "platform/mbed_critical.h"
+#include "drivers/Timer.h"
+#include "drivers/Ticker.h"
+#include "drivers/Timeout.h"
+#include "drivers/LowPowerTimeout.h"
+#include "drivers/LowPowerTicker.h"
+#include "drivers/LowPowerTimer.h"
+
+using namespace mbed;
 
 // Ticker operations
 #if MBED_CONF_RTOS_PRESENT
@@ -33,6 +42,7 @@ unsigned equeue_tick() {
 #else
 
 #if MBED_CONF_EVENTS_USE_LOWPOWER_TIMER_TICKER
+
 #define ALIAS_TIMER      LowPowerTimer
 #define ALIAS_TICKER     LowPowerTicker
 #define ALIAS_TIMEOUT    LowPowerTimeout

--- a/events/mbed_shared_queues.cpp
+++ b/events/mbed_shared_queues.cpp
@@ -15,7 +15,11 @@
  */
 
 #include "events/mbed_shared_queues.h"
-#include "mbed.h"
+
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "rtos/Thread.h"
+using rtos::Thread;
+#endif
 
 using namespace events;
 

--- a/platform/ATCmdParser.cpp
+++ b/platform/ATCmdParser.cpp
@@ -39,6 +39,8 @@
 #define CR  13
 #endif
 
+namespace mbed {
+
 // getc/putc handling with timeouts
 int ATCmdParser::putc(char c)
 {
@@ -434,4 +436,5 @@ bool ATCmdParser::process_oob()
     }
 }
 
+}
 

--- a/platform/ATCmdParser.cpp
+++ b/platform/ATCmdParser.cpp
@@ -21,6 +21,9 @@
 #include "ATCmdParser.h"
 #include "mbed_poll.h"
 #include "mbed_debug.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef LF
 #undef LF
@@ -102,7 +105,7 @@ int ATCmdParser::read(char *data, int size)
 
 
 // printf/scanf handling
-int ATCmdParser::vprintf(const char *format, va_list args)
+int ATCmdParser::vprintf(const char *format, std::va_list args)
 {
 
     if (vsprintf(_buffer, format, args) < 0) {
@@ -118,7 +121,7 @@ int ATCmdParser::vprintf(const char *format, va_list args)
     return i;
 }
 
-int ATCmdParser::vscanf(const char *format, va_list args)
+int ATCmdParser::vscanf(const char *format, std::va_list args)
 {
     // Since format is const, we need to copy it into our buffer to
     // add the line's null terminator and clobber value-matches with asterisks.
@@ -181,7 +184,7 @@ int ATCmdParser::vscanf(const char *format, va_list args)
 
 
 // Command parsing with line handling
-bool ATCmdParser::vsend(const char *command, va_list args)
+bool ATCmdParser::vsend(const char *command, std::va_list args)
 {
     // Create and send command
     if (vsprintf(_buffer, command, args) < 0) {
@@ -205,7 +208,7 @@ bool ATCmdParser::vsend(const char *command, va_list args)
     return true;
 }
 
-bool ATCmdParser::vrecv(const char *response, va_list args)
+bool ATCmdParser::vrecv(const char *response, std::va_list args)
 {
 restart:
     _aborted = false;
@@ -331,7 +334,7 @@ restart:
 // Mapping to vararg functions
 int ATCmdParser::printf(const char *format, ...)
 {
-    va_list args;
+    std::va_list args;
     va_start(args, format);
     int res = vprintf(format, args);
     va_end(args);
@@ -340,7 +343,7 @@ int ATCmdParser::printf(const char *format, ...)
 
 int ATCmdParser::scanf(const char *format, ...)
 {
-    va_list args;
+    std::va_list args;
     va_start(args, format);
     int res = vscanf(format, args);
     va_end(args);
@@ -349,7 +352,7 @@ int ATCmdParser::scanf(const char *format, ...)
 
 bool ATCmdParser::send(const char *command, ...)
 {
-    va_list args;
+    std::va_list args;
     va_start(args, command);
     bool res = vsend(command, args);
     va_end(args);
@@ -358,7 +361,7 @@ bool ATCmdParser::send(const char *command, ...)
 
 bool ATCmdParser::recv(const char *response, ...)
 {
-    va_list args;
+    std::va_list args;
     va_start(args, response);
     bool res = vrecv(response, args);
     va_end(args);

--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -202,7 +202,7 @@ public:
      */
     bool send(const char *command, ...) MBED_PRINTF_METHOD(1, 2);
 
-    bool vsend(const char *command, va_list args);
+    bool vsend(const char *command, std::va_list args);
 
     /**
      * Receive an AT response
@@ -220,7 +220,7 @@ public:
      */
     bool recv(const char *response, ...) MBED_SCANF_METHOD(1, 2);
 
-    bool vrecv(const char *response, va_list args);
+    bool vrecv(const char *response, std::va_list args);
 
     /**
      * Write a single byte to the underlying stream
@@ -265,7 +265,7 @@ public:
      */
     int printf(const char *format, ...) MBED_PRINTF_METHOD(1, 2);
 
-    int vprintf(const char *format, va_list args);
+    int vprintf(const char *format, std::va_list args);
 
     /**
      * Direct scanf on underlying stream
@@ -277,7 +277,7 @@ public:
      */
     int scanf(const char *format, ...) MBED_SCANF_METHOD(1, 2);
 
-    int vscanf(const char *format, va_list args);
+    int vscanf(const char *format, std::va_list args);
 
     /**
      * Attach a callback for out-of-band data

--- a/platform/ATCmdParser.h
+++ b/platform/ATCmdParser.h
@@ -20,9 +20,10 @@
 #ifndef MBED_ATCMDPARSER_H
 #define MBED_ATCMDPARSER_H
 
-#include "mbed.h"
 #include <cstdarg>
 #include "Callback.h"
+#include "NonCopyable.h"
+#include "FileHandle.h"
 
 namespace mbed {
 

--- a/platform/FileSystemHandle.cpp
+++ b/platform/FileSystemHandle.cpp
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
 #include "FileSystemHandle.h"
 #include <errno.h>
 
+namespace mbed {
 int FileSystemHandle::open(DirHandle **dir, const char *path)
 {
     return -ENOSYS;
@@ -46,4 +46,5 @@ int FileSystemHandle::mkdir(const char *path, mode_t mode)
 int FileSystemHandle::statvfs(const char *path, struct statvfs *buf)
 {
     return -ENOSYS;
+}
 }

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -20,7 +20,7 @@
 
 #include "platform/mbed_wait_api.h"
 #include "hal/us_ticker_api.h"
-#include "rtos/rtos.h"
+#include "rtos/ThisThread.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_power_mgmt.h"
 

--- a/rtos/Kernel.cpp
+++ b/rtos/Kernel.cpp
@@ -20,11 +20,11 @@
  * SOFTWARE.
  */
 
+#include "cmsis_os2.h"
 #include "rtos/Kernel.h"
-
-#include "mbed.h"
 #include "rtos/rtos_idle.h"
 #include "rtos/rtos_handlers.h"
+#include "platform/mbed_critical.h"
 
 namespace rtos {
 

--- a/rtos/RtosTimer.cpp
+++ b/rtos/RtosTimer.cpp
@@ -20,11 +20,11 @@
  * SOFTWARE.
  */
 #include "rtos/RtosTimer.h"
+#include "platform/Callback.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_assert.h"
 
 #include <string.h>
-
-#include "mbed.h"
-#include "platform/mbed_error.h"
 
 namespace rtos {
 
@@ -34,7 +34,7 @@ void RtosTimer::constructor(mbed::Callback<void()> func, os_timer_type type) {
     osTimerAttr_t attr = { 0 };
     attr.cb_mem = &_obj_mem;
     attr.cb_size = sizeof(_obj_mem);
-    _id = osTimerNew((void (*)(void *))Callback<void()>::thunk, type, &_function, &attr);
+    _id = osTimerNew((void (*)(void *))mbed::Callback<void()>::thunk, type, &_function, &attr);
     MBED_ASSERT(_id);
 }
 

--- a/rtos/ThisThread.cpp
+++ b/rtos/ThisThread.cpp
@@ -23,9 +23,9 @@
 #define __STDC_LIMIT_MACROS
 #include "rtos/ThisThread.h"
 
-#include "mbed.h"
+#include "rtos/Kernel.h"
 #include "rtos/rtos_idle.h"
-#include "mbed_assert.h"
+#include "platform/mbed_assert.h"
 
 namespace rtos {
 

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -21,11 +21,10 @@
  */
 #include "rtos/Thread.h"
 #include "rtos/ThisThread.h"
-
-#include "mbed.h"
 #include "rtos/rtos_idle.h"
 #include "rtos/rtos_handlers.h"
-#include "mbed_assert.h"
+#include "platform/mbed_assert.h"
+#include "platform/mbed_error.h"
 
 #define ALIGN_UP(pos, align) ((pos) % (align) ? (pos) +  ((align) - (pos) % (align)) : (pos))
 MBED_STATIC_ASSERT(ALIGN_UP(0, 8) == 0, "ALIGN_UP macro error");
@@ -68,7 +67,7 @@ void Thread::constructor(osPriority priority,
     constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
 }
 
-void Thread::constructor(Callback<void()> task,
+void Thread::constructor(mbed::Callback<void()> task,
                          osPriority priority, uint32_t stack_size, unsigned char *stack_mem, const char *name)
 {
     constructor(MBED_TZ_DEFAULT_ACCESS, priority, stack_size, stack_mem, name);
@@ -87,7 +86,7 @@ void Thread::constructor(Callback<void()> task,
     }
 }
 
-osStatus Thread::start(Callback<void()> task)
+osStatus Thread::start(mbed::Callback<void()> task)
 {
     _mutex.lock();
 


### PR DESCRIPTION
### Description

Source inside mbed-os should not be using "mbed.h" even in CPP files, instead required header file and namespace should be explicitly added inside `mbed-os`

With https://github.com/ARMmbed/mbed-os/pull/7760 PR, we will give an option to remove namespace. 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

