### PR TITLE
Disable MBEDTLS_HAVE_DATE_TIME as ARMCC does not support gmtime

### DIFF
--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -21,10 +21,6 @@
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
 #endif
 
-#if defined(DEVICE_RTC)
-#define MBEDTLS_HAVE_TIME_DATE
-#endif
-
 #if defined(MBEDTLS_CONFIG_HW_SUPPORT)
 #include "mbedtls_device.h"
 #endif


### PR DESCRIPTION
### Description
This PR reverts the change https://github.com/ARMmbed/mbed-os/pull/4846 which enabled the feature MBEDTLS_HAVE_DATE_TIME in Mbed TLS as the libc used by the ARM toolchain does not fully implement the gmtime() function that this feature relies on.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

