### PR TITLE
Cellular: Support for GPRS dial-up

### DIFF
--- a/features/cellular/framework/AT/AT_CellularBase.h
+++ b/features/cellular/framework/AT/AT_CellularBase.h
@@ -50,6 +50,7 @@ public:
      */
     enum SupportedFeature {
         AT_CGSN_WITH_TYPE, // AT+CGSN without type is likely always supported similar to AT+GSN
+        AT_CGDATA, // alternative is to support only ATD*99***<cid>#
         SUPPORTED_FEATURE_END_MARK // must be last element in the array of features
     };
     static void set_unsupported_features(const SupportedFeature *unsupported_features);

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -381,8 +381,15 @@ nsapi_error_t AT_CellularNetwork::open_data_channel()
 {
 #if NSAPI_PPP_AVAILABLE
     tr_info("Open data channel in PPP mode");
-    _at.cmd_start("AT+CGDATA=\"PPP\",");
-    _at.write_int(_cid);
+    if (is_supported(AT_CGDATA)) {
+        _at.cmd_start("AT+CGDATA=\"PPP\",");
+        _at.write_int(_cid);
+    } else {
+        MBED_ASSERT(_cid >= 0 && _cid <= 99);
+        char cmd_buf[sizeof("ATD*99***xx#")];
+        std::sprintf(cmd_buf, "ATD*99***%d#", _cid);
+        _at.cmd_start(cmd_buf);
+    }
     _at.cmd_stop();
 
     _at.resp_start("CONNECT", true);


### PR DESCRIPTION
### Description

Data state may be entered by issuing a 3GPP TS 27.007 command AT+CGDATA or a GPRS dial-up command ATD*99***<cid>#.

This PR adds support for GPRS dial-up command on AT cellular network. This PR does not change any functionality until modem defines AT_CGDATA as unsupported feature.

Requested in Issue #7682 and PR #7304.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

