### PR TITLE
Update linker files for NUCLEO_F207ZG and enable bootloader functionality

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/startup_stm32f207xx.S
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/startup_stm32f207xx.S
@@ -3,7 +3,7 @@
 ;* Author             : MCD Application Team
 ;* Version            : V2.1.1
 ;* Date               : 20-November-2015
-;* Description        : STM32F207xx devices vector table for MDK-ARM_STD toolchain. 
+;* Description        : STM32F207xx devices vector table for MDK-ARM_STD toolchain.
 ;*                      This module performs:
 ;*                      - Set the initial SP
 ;*                      - Set the initial PC == Reset_Handler
@@ -13,7 +13,7 @@
 ;*                      After Reset the CortexM3 processor is in Thread mode,
 ;*                      priority is Privileged, and the Stack is set to Main.
 ;*******************************************************************************
-; 
+;
 ;* Redistribution and use in source and binary forms, with or without modification,
 ;* are permitted provided that the following conditions are met:
 ;*   1. Redistributions of source code must retain the above copyright notice,
@@ -35,32 +35,10 @@
 ;* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 ;* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 ;* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-; 
+;
 ;*******************************************************************************
 
-; Amount of memory (in bytes) allocated for Stack
-; Tailor this value to your application needs
-; <h> Stack Configuration
-;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Stack_Size      EQU     0x00000400
-
-                AREA    STACK, NOINIT, READWRITE, ALIGN=3
-Stack_Mem       SPACE   Stack_Size
 __initial_sp    EQU     0x20020000
-
-
-; <h> Heap Configuration
-;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
-; </h>
-
-Heap_Size       EQU     0x00000200
-
-                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
-__heap_base
-Heap_Mem        SPACE   Heap_Size
-__heap_limit
 
                 PRESERVE8
                 THUMB
@@ -404,33 +382,6 @@ HASH_RNG_IRQHandler
                 ENDP
 
                 ALIGN
-
-;*******************************************************************************
-; User Stack and Heap initialization
-;*******************************************************************************
-                 IF      :DEF:__MICROLIB
-                
-                 EXPORT  __initial_sp
-                 EXPORT  __heap_base
-                 EXPORT  __heap_limit
-                
-                 ELSE
-                
-                 IMPORT  __use_two_region_memory
-                 EXPORT  __user_initial_stackheap
-                 
-__user_initial_stackheap
-
-                 LDR     R0, =  Heap_Mem
-                 LDR     R1, =(Stack_Mem + Stack_Size)
-                 LDR     R2, = (Heap_Mem +  Heap_Size)
-                 LDR     R3, = Stack_Mem
-                 BX      LR
-
-                 ALIGN
-
-                 ENDIF
-
-                 END
+                END
 
 ;************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE*****

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/stm32f207xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/stm32f207xx.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2016, STMicroelectronics
@@ -27,8 +28,16 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-LR_IROM1 0x08000000 0x00100000  {    ; load region size_region
-  ER_IROM1 0x08000000 0x00100000  {  ; load address = execution address
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x100000
+#endif
+
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/STM32F207ZGTx_FLASH.ld
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/STM32F207ZGTx_FLASH.ld
@@ -1,8 +1,16 @@
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x8000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 1024k
+#endif
+
 /* Linker script to configure memory regions. */
 /* 97 vectors * 4 bytes = 388 bytes to reserve (0x184) */
 MEMORY
-{ 
-  FLASH (rx) : ORIGIN = 0x8000000, LENGTH = 1024K
+{
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   RAM (rwx) : ORIGIN = 0x20000184, LENGTH = 128K - 0x184
 }
 
@@ -10,7 +18,7 @@ MEMORY
  * with other linker script that defines memory regions FLASH and RAM.
  * It references following symbols, which must be defined in code:
  *   Reset_Handler : Entry of reset handler
- * 
+ *
  * It defines following symbols, which code can use without definition:
  *   __exidx_start
  *   __exidx_end

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
@@ -1,7 +1,10 @@
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x100000; }
+
 /* [ROM = 1024kb = 0x100000] */
-define symbol __intvec_start__     = 0x08000000;
+define symbol __intvec_start__     = MBED_APP_START;
 define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x080FFFFF;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 128kb = 0x20000] Vector table dynamic copy: 97 vectors = 388 bytes (0x184) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
@@ -15,9 +18,10 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
-define symbol __size_cstack__ = 0x4000;
-define symbol __size_heap__   = 0x8000;
+/* Stack: 4kB - 408B for vector table */
+/* Heap: 64kB */
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x10000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
@@ -18,7 +18,7 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-/* Stack: 4kB - 408B for vector table */
+/* Stack: 1024B */
 /* Heap: 64kB */
 define symbol __size_cstack__ = 0x400;
 define symbol __size_heap__   = 0x10000;

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/system_clock.c
@@ -30,6 +30,7 @@
 **/
 
 #include "stm32f2xx.h"
+#include "nvic_addr.h"
 #include "mbed_error.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
@@ -88,7 +89,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -979,6 +979,7 @@
         "device_has_remove": ["LPTICKER"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F207ZG",
+        "bootloader_supported": true,
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         }
@@ -4461,7 +4462,7 @@
         "mbed_rom_start":   "0x10040000",
         "mbed_rom_size":    "0x40000",
         "mbed_ram_start":   "0x30008000",
-        "mbed_ram_size":    "0x10000", 
+        "mbed_ram_size":    "0x10000",
         "inherits": ["Target"],
         "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "STDIO_MESSAGES", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "TRNG", "FLASH"],
         "detect_code": ["1305"],


### PR DESCRIPTION
### Description
Updated linker and startup files for target
- ARM_STD startup file cleanup; removed stack & heap configuration section which seemed like leftovers from somewhere. As far as I can tell they had no function.
- ARM_STD linker file to support MBED_APP_START
- GCC_ARM linker file to support MBED_APP_START
- IAR linker file to support MBED_APP_START
- IAR linker file stack configured to 1kB and heap 64kB
Bootloader support
- Add bootloader_supported to targets.json
- Update vector table with application start address

Tested with MCC internal version on all three compilers, with and without MBED_APP_START. Bootloader not tested.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

