### PR TITLE
Tools: Modified version mismatch msg to be warning instead of error

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -121,7 +121,7 @@ class ARM(mbedToolchain):
                 "file": "",
                 "line": "",
                 "col": "",
-                "severity": "ERROR",
+                "severity": "WARNING",
             })
 
     def _get_toolchain_labels(self):

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -140,7 +140,7 @@ class GCC(mbedToolchain):
                 "file": "",
                 "line": "",
                 "col": "",
-                "severity": "ERROR",
+                "severity": "Warning",
             })
 
     def is_not_supported_error(self, output):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -112,7 +112,7 @@ class IAR(mbedToolchain):
                 "file": "",
                 "line": "",
                 "col": "",
-                "severity": "ERROR",
+                "severity": "Warning",
             })
 
 


### PR DESCRIPTION
### Description

It was mientioned, but slipped in the original PR that the version mismatch message be a warning instead of an error. The current mesasge is prefixed with `[Error]` which appears to be confusing users since the build continues (sometimes just fine).

This PR changes `[Error]` to `[Warning]`

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

