### PR TITLE
Improve the config ajustment script of TLS for ENTROPY_NV_SEED

### DIFF
--- a/features/mbedtls/importer/adjust-config.sh
+++ b/features/mbedtls/importer/adjust-config.sh
@@ -37,38 +37,39 @@ add_code() {
 
 # add an #ifndef to include config-no-entropy.h when the target does not have
 # an entropy source we can use.
-add_code                                                                                  \
-    "#ifndef MBEDTLS_CONFIG_H\n"                                                          \
-    "\n"                                                                                  \
-    "#include \"platform\/inc\/platform_mbed.h\"\n"                                       \
-    "\n"                                                                                  \
-    "\/*\n"                                                                               \
-    " * Only use features that do not require an entropy source when\n"                   \
-    " * DEVICE_ENTROPY_SOURCE is not defined in mbed OS.\n"                               \
-    " *\/\n"                                                                              \
-    "#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_TEST_NULL_ENTROPY)\n" \
-    "#include \"mbedtls\/config-no-entropy.h\"\n"                                         \
-    "\n"                                                                                  \
-    "#if defined(MBEDTLS_USER_CONFIG_FILE)\n"                                             \
-    "#include MBEDTLS_USER_CONFIG_FILE\n"                                                 \
-    "#endif\n"                                                                            \
-    "\n"                                                                                  \
+add_code                                                                                          \
+    "#ifndef MBEDTLS_CONFIG_H\n"                                                                  \
+    "\n"                                                                                          \
+    "#include \"platform\/inc\/platform_mbed.h\"\n"                                               \
+    "\n"                                                                                          \
+    "\/*\n"                                                                                       \
+    " * Only use features that do not require an entropy source when\n"                           \
+    " * DEVICE_ENTROPY_SOURCE is not defined in mbed OS.\n"                                       \
+    " *\/\n"                                                                                      \
+    "#if !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n" \
+    "    !defined(MBEDTLS_ENTROPY_NV_SEED)\n"                                                     \
+    "#include \"mbedtls\/config-no-entropy.h\"\n"                                                 \
+    "\n"                                                                                          \
+    "#if defined(MBEDTLS_USER_CONFIG_FILE)\n"                                                     \
+    "#include MBEDTLS_USER_CONFIG_FILE\n"                                                         \
+    "#endif\n"                                                                                    \
+    "\n"                                                                                          \
     "#else\n"
 
-add_code                                                                                \
-    "#include \"check_config.h\"\n"                                                     \
-    "\n"                                                                                \
-    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY *\/\n"      \
-    "\n"                                                                                \
-    "#if defined(MBEDTLS_TEST_NULL_ENTROPY)\n"                                          \
-    "#warning \"MBEDTLS_TEST_NULL_ENTROPY has been enabled. This \" \\\\\n"             \
-    "    \"configuration is not secure and is not suitable for production use\"\n"      \
-    "#endif\n"                                                                          \
-    "\n"                                                                                \
-    "#if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n"   \
-    "    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_ENTROPY_NV_SEED)\n" \
-    "#error \"No entropy source was found at build time, so TLS \" \\\\\n"              \
-    "    \"functionality is not available\"\n"                                          \
+add_code                                                                                                       \
+    "#include \"check_config.h\"\n"                                                                            \
+    "\n"                                                                                                       \
+    "#endif \/* !MBEDTLS_ENTROPY_HARDWARE_ALT && !MBEDTLS_TEST_NULL_ENTROPY && !MBEDTLS_ENTROPY_NV_SEED *\/\n" \
+    "\n"                                                                                                       \
+    "#if defined(MBEDTLS_TEST_NULL_ENTROPY)\n"                                                                 \
+    "#warning \"MBEDTLS_TEST_NULL_ENTROPY has been enabled. This \" \\\\\n"                                    \
+    "    \"configuration is not secure and is not suitable for production use\"\n"                             \
+    "#endif\n"                                                                                                 \
+    "\n"                                                                                                       \
+    "#if defined(MBEDTLS_SSL_TLS_C) && !defined(MBEDTLS_TEST_NULL_ENTROPY) && \\\\\n"                          \
+    "    !defined(MBEDTLS_ENTROPY_HARDWARE_ALT) && !defined(MBEDTLS_ENTROPY_NV_SEED)\n"                        \
+    "#error \"No entropy source was found at build time, so TLS \" \\\\\n"                                     \
+    "    \"functionality is not available\"\n"                                                                 \
     "#endif\n"
 
 # not supported on mbed OS, nor used by mbed Client


### PR DESCRIPTION
### Description
I think that **ENTROPY_NV_SEED** is one of "entropy", but it doesn't included to the "!defined" lineup in the following config file.
`mbed-os\features\mbedtls\inc\mbedtls\config.h`
Therefore, when `MBEDTLS_ENTROPY_NV_SEED` is defined, it is accidently invoked `mbedtls/config-no-entropy.h` at [line 40](https://github.com/TomoYamanaka/mbed-os/blob/improve_nv_seed_of_tls/features/mbedtls/inc/mbedtls/config.h#L40).

I think that it should go through [line 47](https://github.com/TomoYamanaka/mbed-os/blob/improve_nv_seed_of_tls/features/mbedtls/inc/mbedtls/config.h#L47) in the case of `MBEDTLS_ENTROPY_NV_SEED`.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
