### PR TITLE
Update Greentea EMAC tests

### DIFF
--- a/TESTS/network/emac/emac_test_initialize.cpp
+++ b/TESTS/network/emac/emac_test_initialize.cpp
@@ -102,7 +102,7 @@ void test_emac_initialize()
 #endif
 
     // Power up the interface and emac driver
-    network_interface->connect();
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, network_interface->connect());
 
     worker_loop_link_up_wait();
 }

--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -56,7 +56,7 @@ using namespace utest::v1;
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
 #if !MBED_CONF_APP_ECHO_SERVER
-    GREENTEA_SETUP(600, "default_auto");
+    GREENTEA_SETUP(1200, "default_auto");
 #endif
     return verbose_test_setup_handler(number_of_cases);
 }


### PR DESCRIPTION
### Description
Increase timeout for EMAC tests. Old timeout (600 seconds) was not
enough for slower devices to complete the tests.

Check that connection was successful when running test case
emac_test_initialize.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

