### PR TITLE
introduce core_util_atomic_exchange_bool

### DIFF
--- a/TESTS/mbed_platform/critical_section/main.cpp
+++ b/TESTS/mbed_platform/critical_section/main.cpp
@@ -24,7 +24,7 @@ using utest::v1::Case;
 
 volatile bool callback_called;
 
-void tiemout_callback(void)
+void timeout_callback(void)
 {
     callback_called = true;
 }
@@ -45,7 +45,7 @@ void critical_section_raii_recursive(Timeout &timeout)
         const us_timestamp_t timeout_time_us = 1;
         const int wait_time_us = timeout_time_us * 100;
 
-        timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+        timeout.attach_us(callback(timeout_callback), timeout_time_us);
         wait_us(wait_time_us);
     }
     TEST_ASSERT_TRUE(core_util_in_critical_section());
@@ -83,7 +83,7 @@ void test_C_API(void)
     TEST_ASSERT_FALSE(core_util_in_critical_section());
 
     callback_called = false;
-    timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+    timeout.attach_us(callback(timeout_callback), timeout_time_us);
     wait_us(wait_time_us);
     TEST_ASSERT_TRUE(callback_called);
 
@@ -93,7 +93,7 @@ void test_C_API(void)
     }
 
     callback_called = false;
-    timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+    timeout.attach_us(callback(timeout_callback), timeout_time_us);
     wait_us(wait_time_us);
     TEST_ASSERT_FALSE(callback_called);
     TEST_ASSERT_TRUE(core_util_in_critical_section());
@@ -139,7 +139,7 @@ void test_CPP_API_constructor_destructor(void)
     TEST_ASSERT_FALSE(core_util_in_critical_section());
 
     callback_called = false;
-    timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+    timeout.attach_us(callback(timeout_callback), timeout_time_us);
     wait_us(wait_time_us);
     TEST_ASSERT_TRUE(callback_called);
 
@@ -180,7 +180,7 @@ void test_CPP_API_enable_disable(void)
     TEST_ASSERT_FALSE(core_util_in_critical_section());
 
     callback_called = false;
-    timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+    timeout.attach_us(callback(timeout_callback), timeout_time_us);
     wait_us(wait_time_us);
     TEST_ASSERT_TRUE(callback_called);
 
@@ -190,7 +190,7 @@ void test_CPP_API_enable_disable(void)
     }
 
     callback_called = false;
-    timeout.attach_us(callback(tiemout_callback), timeout_time_us);
+    timeout.attach_us(callback(timeout_callback), timeout_time_us);
     wait_us(wait_time_us);
     TEST_ASSERT_FALSE(callback_called);
     TEST_ASSERT_TRUE(core_util_in_critical_section());

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -110,6 +110,13 @@ void core_util_critical_section_exit(void)
 }
 
 #if MBED_EXCLUSIVE_ACCESS
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value) {
+    bool old;
+    do {
+        old = __LDREX(ptr);
+    } while (__STREX(ptr, value));
+    return old;
+}
 
 /* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
 #if defined (__CC_ARM)
@@ -212,6 +219,13 @@ uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 }
 
 #else
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value) {
+    bool old;
+    core_util_critical_section_enter();
+    old = *ptr;
+    core_util_critical_section_exit();
+    return old;
+}
 
 bool core_util_atomic_cas_u8(volatile uint8_t *ptr, uint8_t *expectedCurrentValue, uint8_t desiredValue)
 {

--- a/platform/mbed_critical.c
+++ b/platform/mbed_critical.c
@@ -110,11 +110,11 @@ void core_util_critical_section_exit(void)
 }
 
 #if MBED_EXCLUSIVE_ACCESS
-bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value) {
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool desiredValue) {
     bool old;
     do {
-        old = __LDREX(ptr);
-    } while (__STREX(ptr, value));
+        old = __LDREXB((volatile uint8_t *)ptr);
+    } while (__STREXB((volatile uint8_t *)ptr, (uint8_t)desiredValue));
     return old;
 }
 
@@ -219,10 +219,11 @@ uint32_t core_util_atomic_decr_u32(volatile uint32_t *valuePtr, uint32_t delta)
 }
 
 #else
-bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value) {
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool desiredValue) {
     bool old;
     core_util_critical_section_enter();
     old = *ptr;
+    *ptr = desiredValue;
     core_util_critical_section_exit();
     return old;
 }

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -90,6 +90,25 @@ void core_util_critical_section_exit(void);
 bool core_util_in_critical_section(void);
 
 /**
+ * Atomic exchange. It fetches the content of a memory location and modifies the content of that
+ * memory location to a given new value. This is done as a single atomic operation.
+ * The atomicity guarantees that the returned value was in the memory at the time the write occured.
+ *
+ * @param   ptr                 The target memory location.
+ * @param[in] value             The new value.
+ *
+ * @return The value contained in *ptr when the set occured.
+ *
+ * pseudocode:
+ * function exchange(p : pointer to bool, new : bool) returns bool {
+ *    old = *p
+ *    *p = new
+ *    return old
+ * }
+ */
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value);
+
+/**
  * Atomic compare and set. It compares the contents of a memory location to a
  * given value and, only if they are the same, modifies the contents of that
  * memory location to a given new value. This is done as a single atomic

--- a/platform/mbed_critical.h
+++ b/platform/mbed_critical.h
@@ -95,7 +95,7 @@ bool core_util_in_critical_section(void);
  * The atomicity guarantees that the returned value was in the memory at the time the write occured.
  *
  * @param   ptr                 The target memory location.
- * @param[in] value             The new value.
+ * @param[in] desiredValue      The new value.
  *
  * @return The value contained in *ptr when the set occured.
  *
@@ -106,7 +106,7 @@ bool core_util_in_critical_section(void);
  *    return old
  * }
  */
-bool core_util_atomic_exchange_bool(volatile bool *ptr, bool value);
+bool core_util_atomic_exchange_bool(volatile bool *ptr, bool desiredValue);
 
 /**
  * Atomic compare and set. It compares the contents of a memory location to a


### PR DESCRIPTION
### Description
This introduces the `bool core_util_atomic_exchange_bool(volatile bool *ptr, bool new)` method.

#### Example use case : Managing activity state in asynchronous applications.

```c
if (core_util_atomic_exchange_bool(&_is_busy, true)) {
    // resource was already busy, queue the action
    queue(action);
} else {
    // resource is now marked as busy
    start_processing(action);
}
```

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

