### PR TITLE
Add greentea tests for network interface status and connect/disconnect

### DIFF
--- a/TESTS/network/interface/main.cpp
+++ b/TESTS/network/interface/main.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define WIFI 2
+#if !defined(MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE) || \
+    (MBED_CONF_TARGET_NETWORK_DEFAULT_INTERFACE_TYPE == WIFI && !defined(MBED_CONF_NSAPI_DEFAULT_WIFI_SSID))
+#error [NOT_SUPPORTED] No network configuration found for this target.
+#endif
+
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "unity/unity.h"
+#include "utest.h"
+#include "utest/utest_stack_trace.h"
+#include "networkinterface_tests.h"
+
+using namespace utest::v1;
+
+// Test setup
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(480, "default_auto");
+    return verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+        Case("NETWORKINTERFACE_STATUS", NETWORKINTERFACE_STATUS),
+        Case("NETWORKINTERFACE_STATUS_NONBLOCK", NETWORKINTERFACE_STATUS_NONBLOCK),
+        Case("NETWORKINTERFACE_STATUS_GET", NETWORKINTERFACE_STATUS_GET),
+        Case("NETWORKINTERFACE_CONN_DISC_REPEAT", NETWORKINTERFACE_CONN_DISC_REPEAT),
+};
+
+Specification specification(test_setup, cases);
+
+int main()
+{
+    return !Harness::run(specification);
+}

--- a/TESTS/network/interface/networkinterface_conn_disc_repeat.cpp
+++ b/TESTS/network/interface/networkinterface_conn_disc_repeat.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "networkinterface_tests.h"
+#include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+namespace
+{
+    NetworkInterface* net;
+    const int repeats = 5;
+}
+
+void NETWORKINTERFACE_CONN_DISC_REPEAT()
+{
+    net = NetworkInterface::get_default_instance();
+
+    for (int i = 0; i < repeats; i++) {
+        nsapi_error_t err = net->connect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+
+        err = net->disconnect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+    }
+}

--- a/TESTS/network/interface/networkinterface_status.cpp
+++ b/TESTS/network/interface/networkinterface_status.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "greentea-client/test_env.h"
+#include "networkinterface_tests.h"
+#include "unity/unity.h"
+#include "utest.h"
+
+using namespace utest::v1;
+
+namespace
+{
+    NetworkInterface* net;
+    rtos::Semaphore status_semaphore;
+    int status_write_counter = 0;
+    int status_read_counter = 0;
+    const int repeats = 5;
+    const int status_buffer_size = 100;
+    nsapi_connection_status_t current_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
+    nsapi_connection_status_t statuses[status_buffer_size];
+}
+
+void status_cb(nsapi_event_t event, intptr_t value)
+{
+    TEST_ASSERT_EQUAL(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, event);
+
+    statuses[status_write_counter] = static_cast<nsapi_connection_status_t>(value);
+    status_write_counter++;
+    if (status_write_counter >= status_buffer_size) {
+        TEST_ASSERT(0);
+    }
+
+    status_semaphore.release();
+}
+
+nsapi_connection_status_t wait_status_callback()
+{
+    nsapi_connection_status_t status;
+
+    while (true) {
+        status_semaphore.wait();
+
+        status = statuses[status_read_counter];
+        status_read_counter++;
+
+        if (status != current_status) {
+            current_status = status;
+            return status;
+        }
+    }
+}
+
+void NETWORKINTERFACE_STATUS()
+{
+    nsapi_connection_status_t status;
+
+    status_write_counter = 0;
+    status_read_counter = 0;
+    current_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
+
+    net = NetworkInterface::get_default_instance();
+    net->attach(status_cb);
+    net->set_blocking(true);
+
+    for (int i = 0; i < repeats; i++) {
+        nsapi_error_t err = net->connect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+
+        status = wait_status_callback();
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_CONNECTING, status);
+
+        status = wait_status_callback();
+        if (status == NSAPI_STATUS_LOCAL_UP) {
+            status = wait_status_callback();
+        }
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_GLOBAL_UP, status);
+
+        net->disconnect();
+
+        status = wait_status_callback();
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
+    }
+
+    net->attach(NULL);
+}
+
+void NETWORKINTERFACE_STATUS_NONBLOCK()
+{
+    nsapi_connection_status_t status;
+
+    status_write_counter = 0;
+    status_read_counter = 0;
+    current_status = NSAPI_STATUS_ERROR_UNSUPPORTED;
+
+    net = NetworkInterface::get_default_instance();
+    net->attach(status_cb);
+    net->set_blocking(false);
+
+    for (int i = 0; i < repeats; i++) {
+        nsapi_error_t err = net->connect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+
+        status = wait_status_callback();
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_CONNECTING, status);
+
+        status = wait_status_callback();
+        if (status == NSAPI_STATUS_LOCAL_UP) {
+            status = wait_status_callback();
+        }
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_GLOBAL_UP, status);
+
+        net->disconnect();
+
+        status = wait_status_callback();
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, status);
+    }
+
+    net->attach(NULL);
+    net->set_blocking(true);
+}
+
+void NETWORKINTERFACE_STATUS_GET()
+{
+    nsapi_connection_status_t status;
+
+    net = NetworkInterface::get_default_instance();
+    net->set_blocking(true);
+
+    TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, net->get_connection_status());
+
+    for (int i = 0; i < repeats; i++) {
+        nsapi_error_t err = net->connect();
+        TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, err);
+
+        while (net->get_connection_status() != NSAPI_STATUS_GLOBAL_UP) {
+            wait(0.5);
+        }
+
+        net->disconnect();
+
+        TEST_ASSERT_EQUAL(NSAPI_STATUS_DISCONNECTED, net->get_connection_status());
+    }
+
+    net->attach(NULL);
+}

--- a/TESTS/network/interface/networkinterface_tests.h
+++ b/TESTS/network/interface/networkinterface_tests.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef NETWORKINTERFACE_TESTS_H
+#define NETWORKINTERFACE_TESTS_H
+
+/*
+ * Test cases
+ */
+void NETWORKINTERFACE_STATUS();
+void NETWORKINTERFACE_STATUS_NONBLOCK();
+void NETWORKINTERFACE_STATUS_GET();
+void NETWORKINTERFACE_CONN_DISC_REPEAT();
+
+#endif //NETWORKINTERFACE_TESTS_H


### PR DESCRIPTION
### Description

Added following network interface status and connect/disconnect greentea tests:

NETWORKINTERFACE_STATUS
NETWORKINTERFACE_STATUS_NONBLOCK
NETWORKINTERFACE_STATUS_GET
NETWORKINTERFACE_CONN_DISC_REPEAT

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

