### PR TITLE
netsocket: Fix compiler warning

### DIFF
--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -21,8 +21,8 @@ using namespace mbed;
 
 InternetSocket::InternetSocket()
     : _stack(0), _socket(0), _timeout(osWaitForever),
-      _readers(0), _writers(0), _factory_allocated(false),
-      _pending(0)
+      _readers(0), _writers(0), _pending(0),
+      _factory_allocated(false)
 {
 }
 


### PR DESCRIPTION
### Description
Fixes below warning from GCC_ARM compiler:
[Warning] InternetSocket.h@237,10: 'InternetSocket::_factory_allocated' will be initialized after [-Wreorder]
[Warning] InternetSocket.h@236,23:   'volatile unsigned int InternetSocket::_pending' [-Wreorder]
[Warning] InternetSocket.cpp@22,1:   when initialized here [-Wreorder]


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

