### PR TITLE
Remove unused cmsis includes.

### DIFF
--- a/drivers/CAN.cpp
+++ b/drivers/CAN.cpp
@@ -17,7 +17,6 @@
 
 #if DEVICE_CAN
 
-#include "cmsis.h"
 #include "platform/mbed_power_mgmt.h"
 
 namespace mbed {

--- a/drivers/TimerEvent.cpp
+++ b/drivers/TimerEvent.cpp
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 #include "drivers/TimerEvent.h"
-#include "cmsis.h"
 
 #include <stddef.h>
 #include "hal/ticker_api.h"


### PR DESCRIPTION
### Description

Remove unused "cmsis.h" includes from CAN and TimerEvent drivers.
AFAICS those files do not use any CMSIS functionality, and I guess code in "drivers" shouldn't use CMSIS directly, anyway.
Since this is not really a "Fix" (nothing's broken, actually), I'll go with "Refactor" as Pull request type (maybe you want to add "Cleanup" to that list).

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

