### PR TITLE
Cellular: CellularDevice unittests fix initialization

### DIFF
--- a/features/cellular/UNITTESTS/at/at_cellulardevice/test_at_cellulardevice.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellulardevice/test_at_cellulardevice.cpp
@@ -118,10 +118,11 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_network()
     ATHandler_stub::ref_count = 0;
 
     CHECK(dev.open_network(&fh1));
+    AT_CellularBase_stub::handler_value = AT_CellularBase_stub::handler_at_constructor_value;
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_network();
-    CHECK(ATHandler_stub::ref_count == 0);
+    CHECK(ATHandler_stub::ref_count == -909);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_sms()
@@ -132,10 +133,11 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_sms()
     ATHandler_stub::ref_count = 0;
 
     CHECK(dev.open_sms(&fh1));
+    AT_CellularBase_stub::handler_value = AT_CellularBase_stub::handler_at_constructor_value;
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_sms();
-    CHECK(ATHandler_stub::ref_count == 0);
+    CHECK(ATHandler_stub::ref_count == -909);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_power()
@@ -146,10 +148,11 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_power()
     ATHandler_stub::ref_count = 0;
 
     CHECK(dev.open_power(&fh1));
+    AT_CellularBase_stub::handler_value = AT_CellularBase_stub::handler_at_constructor_value;
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_power();
-    CHECK(ATHandler_stub::ref_count == 0);
+    CHECK(ATHandler_stub::ref_count == -909);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_sim()
@@ -161,11 +164,13 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_sim()
 
 
     CHECK(dev.open_sim(&fh1));
+    AT_CellularBase_stub::handler_value = AT_CellularBase_stub::handler_at_constructor_value;
+
     dev.close_sms(); // this should not affect to refcount as it's not opened
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_sim();
-    CHECK(ATHandler_stub::ref_count == 0);
+    CHECK(ATHandler_stub::ref_count == -909);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_information()
@@ -174,21 +179,28 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_information()
     AT_CellularDevice dev(que);
     FileHandle_stub fh1;
     ATHandler_stub::int_value = 0;
-
-    CHECK(dev.open_information(&fh1));
-
+    ATHandler_stub::ref_count = 0;
     ATHandler_stub::fh_value = NULL;
     AT_CellularBase_stub::handler_value = NULL;
-    dev.close_information();
 
+    CHECK(dev.open_information(&fh1));
+    CHECK(ATHandler_stub::ref_count == 1);
+
+    // at handler is not found as it's NULL (e.g. AT_CellularBase_stub::handler_value is NULL)
+    dev.close_information();
+    CHECK(ATHandler_stub::ref_count == 1);
+
+    // same filehandle but different at
     ATHandler_stub::fh_value = &fh1;
     ATHandler at(&fh1, que, 0, ",");
     AT_CellularBase_stub::handler_value = &at;
 
     CHECK(dev.open_information(&fh1));
-    AT_CellularBase_stub::handler_value = AT_CellularBase_stub::handler_at_constructor_value;
+    // refcount is two it's one when we create athandler and then in open_information it's incremented by one
+    CHECK(ATHandler_stub::ref_count == 2);
 
     dev.close_information();
+    CHECK(ATHandler_stub::ref_count == 1);
 
     ATHandler_stub::fh_value = NULL;
 }

--- a/features/cellular/UNITTESTS/at/at_cellulardevice/test_at_cellulardevice.cpp
+++ b/features/cellular/UNITTESTS/at/at_cellulardevice/test_at_cellulardevice.cpp
@@ -122,7 +122,7 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_network()
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_network();
-    CHECK(ATHandler_stub::ref_count == -909);
+    CHECK(ATHandler_stub::ref_count == kATHandler_destructor_ref_ount);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_sms()
@@ -137,7 +137,7 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_sms()
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_sms();
-    CHECK(ATHandler_stub::ref_count == -909);
+    CHECK(ATHandler_stub::ref_count == kATHandler_destructor_ref_ount);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_power()
@@ -152,7 +152,7 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_power()
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_power();
-    CHECK(ATHandler_stub::ref_count == -909);
+    CHECK(ATHandler_stub::ref_count == kATHandler_destructor_ref_ount);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_sim()
@@ -170,7 +170,7 @@ void Test_AT_CellularDevice::test_AT_CellularDevice_close_sim()
     CHECK(ATHandler_stub::ref_count == 1);
 
     dev.close_sim();
-    CHECK(ATHandler_stub::ref_count == -909);
+    CHECK(ATHandler_stub::ref_count == kATHandler_destructor_ref_ount);
 }
 
 void Test_AT_CellularDevice::test_AT_CellularDevice_close_information()

--- a/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -68,7 +68,7 @@ void ATHandler::set_debug(bool debug_on)
 
 ATHandler::~ATHandler()
 {
-    ATHandler_stub::ref_count = -909;
+    ATHandler_stub::ref_count = kATHandler_destructor_ref_ount;
 }
 
 void ATHandler::inc_ref_count()

--- a/features/cellular/UNITTESTS/stubs/ATHandler_stub.h
+++ b/features/cellular/UNITTESTS/stubs/ATHandler_stub.h
@@ -26,6 +26,8 @@
 static const int kRead_string_table_size = 100;
 static const int kRead_int_table_size = 100;
 static const int kResp_stop_count_default = 100;
+// set reference count to -909 to separate it from zero so we can test that ATHandler is really deleted.
+static const int kATHandler_destructor_ref_ount = -909;
 
 namespace ATHandler_stub {
 extern nsapi_error_t nsapi_error_value;


### PR DESCRIPTION
…ons between tests.

### Description

Fixed CellularDevice unittests by doing proper initializations. 
AT_CellularBase_stub was returning a wrong reference to ATHandler_stub.

Only unit tests changed, no code changes.

Internal ref to defect: IOTCELL-1275

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

