### PR TITLE
Lora: Remove duplicate LinkCheckReq MAC command

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -306,7 +306,7 @@ int16_t LoRaWANStack::handle_tx(const uint8_t port, const uint8_t *data,
     // add a link check request with normal data, until the application
     // explicitly removes it.
     if (_link_check_requested) {
-        set_link_check_request();
+        _loramac.setup_link_check_request();
     }
 
     if (!_lw_session.active) {
@@ -442,13 +442,12 @@ lorawan_status_t LoRaWANStack::set_link_check_request()
         return LORAWAN_STATUS_NOT_INITIALIZED;
     }
 
-    _link_check_requested = true;
     if (!_callbacks.link_check_resp) {
         tr_error("Must assign a callback function for link check request. ");
         return LORAWAN_STATUS_PARAMETER_INVALID;
     }
 
-    _loramac.setup_link_check_request();
+    _link_check_requested = true;
     return LORAWAN_STATUS_OK;
 }
 


### PR DESCRIPTION
### Description

When application requests link check request with add_link_check_request()
it was added to MAC command buffer. Again when actual TX was started,
stack cherry-picked the request into MAC buffer again resulting in a duplicate
entry in the buffer.

Functionality is changed now so that add_link_check_request() does not add
the request into MAC command buffer but it is cherry-picked into the buffer when
TX is issued.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

