### PR TITLE
Fix pin names of MIMXRT1050 I2C pins

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
@@ -196,8 +196,8 @@ typedef enum {
     D14 = GPIO_AD_B0_01,
     D15 = GPIO_AD_B0_00,
 
-    I2C_SCL = D15,
-    I2C_SDA = D14,
+    I2C_SCL = A5,
+    I2C_SDA = A4,
 
     A0 = GPIO_AD_B1_10,
     A1 = GPIO_AD_B1_11,

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_MIMXRT1050/TARGET_EVK/PinNames.h
@@ -196,9 +196,6 @@ typedef enum {
     D14 = GPIO_AD_B0_01,
     D15 = GPIO_AD_B0_00,
 
-    I2C_SCL = A5,
-    I2C_SDA = A4,
-
     A0 = GPIO_AD_B1_10,
     A1 = GPIO_AD_B1_11,
     A2 = GPIO_AD_B1_04,
@@ -206,6 +203,9 @@ typedef enum {
     A4 = GPIO_AD_B1_01,
     A5 = GPIO_AD_B1_00,
 
+    I2C_SCL = A5,
+    I2C_SDA = A4,
+	
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Fixed the I2C pin mappings of MIMXRT1050 to the correct I/O pads.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

