### PR TITLE
Fix overflow in disk_get_sector_size()

### DIFF
--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -166,12 +166,12 @@ void ff_memfree(void *p)
 }
 
 // Implementation of diskio functions (see ChaN/diskio.h)
-static DWORD disk_get_sector_size(BYTE pdrv)
+static WORD disk_get_sector_size(BYTE pdrv)
 {
     bd_size_t sector_size = _ffs[pdrv]->get_erase_size();
-    MBED_ASSERT(sector_size <= DWORD(-1));
+    MBED_ASSERT(sector_size <= WORD(-1));
 
-    DWORD ssize = sector_size;
+    WORD ssize = sector_size;
     if (ssize < 512) {
         ssize = 512;
     }
@@ -251,7 +251,7 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
             if (_ffs[pdrv] == NULL) {
                 return RES_NOTRDY;
             } else {
-                *((DWORD*)buff) = disk_get_sector_size(pdrv);
+                *((WORD*)buff) = disk_get_sector_size(pdrv);
                 return RES_OK;
             }
         case GET_BLOCK_SIZE:

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -166,9 +166,12 @@ void ff_memfree(void *p)
 }
 
 // Implementation of diskio functions (see ChaN/diskio.h)
-static WORD disk_get_sector_size(BYTE pdrv)
+static DWORD disk_get_sector_size(BYTE pdrv)
 {
-    WORD ssize = _ffs[pdrv]->get_erase_size();
+    bd_size_t sector_size = _ffs[pdrv]->get_erase_size();
+    MBED_ASSERT(sector_size <= DWORD(-1));
+
+    DWORD ssize = sector_size;
     if (ssize < 512) {
         ssize = 512;
     }
@@ -248,7 +251,7 @@ DRESULT disk_ioctl(BYTE pdrv, BYTE cmd, void *buff)
             if (_ffs[pdrv] == NULL) {
                 return RES_NOTRDY;
             } else {
-                *((WORD*)buff) = disk_get_sector_size(pdrv);
+                *((DWORD*)buff) = disk_get_sector_size(pdrv);
                 return RES_OK;
             }
         case GET_BLOCK_SIZE:


### PR DESCRIPTION
### Fix overflow in FAT

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
disk_get_sector_size() was returning a WORD but could have recieved up to a QWORD from get_erase_size()



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

