### PR TITLE
Clean up include paths.

### DIFF
--- a/drivers/FlashIAP.cpp
+++ b/drivers/FlashIAP.cpp
@@ -24,7 +24,7 @@
 #include <string.h>
 #include <algorithm>
 #include "FlashIAP.h"
-#include "mbed_assert.h"
+#include "platform/mbed_assert.h"
 
 
 #ifdef DEVICE_FLASH

--- a/drivers/Serial.h
+++ b/drivers/Serial.h
@@ -20,10 +20,10 @@
 
 #if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
 
-#include "Stream.h"
+#include "platform/Stream.h"
 #include "SerialBase.h"
-#include "PlatformMutex.h"
-#include "serial_api.h"
+#include "platform/PlatformMutex.h"
+#include "hal/serial_api.h"
 #include "platform/NonCopyable.h"
 
 namespace mbed {

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -20,14 +20,14 @@
 
 #if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
 
-#include "Callback.h"
-#include "serial_api.h"
-#include "mbed_toolchain.h"
+#include "platform/Callback.h"
+#include "hal/serial_api.h"
+#include "platform/mbed_toolchain.h"
 #include "platform/NonCopyable.h"
 
 #if DEVICE_SERIAL_ASYNCH
-#include "CThunk.h"
-#include "dma_api.h"
+#include "platform/CThunk.h"
+#include "hal/dma_api.h"
 #endif
 
 namespace mbed {

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -21,12 +21,12 @@
 
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN) || defined(DOXYGEN_ONLY)
 
-#include "FileHandle.h"
+#include "platform/FileHandle.h"
 #include "SerialBase.h"
 #include "InterruptIn.h"
-#include "PlatformMutex.h"
-#include "serial_api.h"
-#include "CircularBuffer.h"
+#include "platform/PlatformMutex.h"
+#include "hal/serial_api.h"
+#include "platform/CircularBuffer.h"
 #include "platform/NonCopyable.h"
 
 #ifndef MBED_CONF_DRIVERS_UART_SERIAL_RXBUF_SIZE

--- a/hal/mbed_sleep_manager.c
+++ b/hal/mbed_sleep_manager.c
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-#include "mbed_assert.h"
-#include "mbed_power_mgmt.h"
-#include "mbed_critical.h"
+#include "platform/mbed_assert.h"
+#include "platform/mbed_power_mgmt.h"
+#include "platform/mbed_critical.h"
 #include "sleep_api.h"
-#include "mbed_error.h"
-#include "mbed_debug.h"
-#include "mbed_stats.h"
+#include "platform/mbed_error.h"
+#include "platform/mbed_debug.h"
+#include "platform/mbed_stats.h"
 #include "us_ticker_api.h"
 #include "lp_ticker_api.h"
 #include <limits.h>
 #include <stdio.h>
-#include "mbed_stats.h"
+#include "platform/mbed_stats.h"
 
 
 #if DEVICE_SLEEP

--- a/hal/mbed_ticker_api.c
+++ b/hal/mbed_ticker_api.c
@@ -17,7 +17,7 @@
 #include <stddef.h>
 #include "hal/ticker_api.h"
 #include "platform/mbed_critical.h"
-#include "mbed_assert.h"
+#include "platform/mbed_assert.h"
 
 static void schedule_interrupt(const ticker_data_t *const ticker);
 static void update_present_time(const ticker_data_t *const ticker);

--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -20,8 +20,8 @@
 #include "rtos/Thread.h"
 using namespace rtos;
 #else
-#include "Timer.h"
-#include "LowPowerTimer.h"
+#include "drivers/Timer.h"
+#include "drivers/LowPowerTimer.h"
 #endif
 
 namespace mbed {

--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -23,7 +23,7 @@
 #ifndef MBED_POWER_MGMT_H
 #define MBED_POWER_MGMT_H
 
-#include "sleep_api.h"
+#include "hal/sleep_api.h"
 #include "mbed_toolchain.h"
 #include "hal/ticker_api.h"
 #include <stdbool.h>


### PR DESCRIPTION
### Description

When studying the mbed source code,  I noticed `#include`s usually refer to files in other directories using double-quoted paths relative to the repository root `("platform/platform.h"`,` "hal/gpio_api.h"`, etc.). 
There are a few files where this is not the case, apparently relying on includes path implicitly set by the build environment. So this is not a real issue (until you change the build environment, of course), but simply something I'd suggest for consistency...

### Pull request type

Nothing's broken (for now), so I think "Refactor" describes this best (you may want to add "Code Cleanup" as an option some day).

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
