### PR TITLE
Fix: Restarting a terminated thread

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -141,6 +141,23 @@ void test_single_thread()
     TEST_ASSERT_EQUAL(counter, 1);
 }
 
+/** Test case to verify restart of thread which terminated successfully */
+template <void (*F)(counter_t *)>
+void test_single_thread_multiple_times()
+{
+    counter_t counter(0);
+    Thread thread(osPriorityNormal, THREAD_STACK_SIZE);
+    thread.start(callback(F, &counter));
+    thread.join();
+    TEST_ASSERT_EQUAL(counter, 1);
+    thread.start(callback(F, &counter));
+    thread.join();
+    TEST_ASSERT_EQUAL(counter, 2);
+    thread.start(callback(F, &counter));
+    thread.join();
+    TEST_ASSERT_EQUAL(counter, 3);
+}
+
 /** Template for tests: parallel threads, with yield, with wait, with child, with murder
 
     Testing parallel threads
@@ -747,7 +764,9 @@ static const case_t cases[] = {
     {"Testing thread states: wait message put", test_msg_put, DEFAULT_HANDLERS},
 
     {"Testing thread with external stack memory", test_thread_ext_stack, DEFAULT_HANDLERS},
-    {"Testing thread priority ops", test_thread_prio, DEFAULT_HANDLERS}
+    {"Testing thread priority ops", test_thread_prio, DEFAULT_HANDLERS},
+
+    {"Testing single thread multiple times", test_single_thread_multiple_times<increment>, DEFAULT_HANDLERS}
 
 };
 

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -167,8 +167,6 @@ osStatus Thread::join() {
     MBED_ASSERT(NULL == _tid);
     _mutex.unlock();
 
-    // Release sem so any other threads joining this thread wake up
-    _join_sem.release();
     return osOK;
 }
 

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -93,7 +93,12 @@ void Thread::constructor(Callback<void()> task,
 osStatus Thread::start(Callback<void()> task) {
     _mutex.lock();
 
-    if ((_tid != 0) || _finished) {
+    // Reset _finished, in case thread terminated successfully and was restarted
+    if ((true == _finished) && (_tid == 0)) {
+        _finished = false;
+    }
+
+    if (_tid != 0) {
         _mutex.unlock();
         return osErrorParameter;
     }

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -164,7 +164,6 @@ osStatus Thread::join() {
     // terminated or has been terminated. Once the mutex has
     // been locked it is ensured that the thread is deleted.
     _mutex.lock();
-    MBED_ASSERT(NULL == _tid);
     _mutex.unlock();
 
     return osOK;

--- a/rtos/Thread.cpp
+++ b/rtos/Thread.cpp
@@ -140,8 +140,8 @@ osStatus Thread::terminate() {
     // release the semaphore before terminating
     // since this thread could be terminating itself
     osThreadId_t local_id = _tid;
-    _join_sem.release();
     _tid = (osThreadId_t)NULL;
+    _join_sem.release();
     if (!_finished) {
         _finished = true;
         // if local_id == 0 Thread was not started in first place


### PR DESCRIPTION
### Description
Restarting a terminated thread is a valid use case and should be taken care of.

Resolves: https://github.com/ARMmbed/mbed-os/issues/6930

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

CC @0xc0170  @c1728p9 @geky 