### PR TITLE
Reorder members to resolve build warning

### DIFF
--- a/features/netsocket/InternetSocket.h
+++ b/features/netsocket/InternetSocket.h
@@ -233,8 +233,8 @@ protected:
     SocketAddress _remote_peer;
     uint8_t _readers;
     uint8_t _writers;
-    volatile unsigned _pending;
     bool _factory_allocated;
+    volatile unsigned _pending;
 
     // Event flags
     static const int READ_FLAG     = 0x1u;


### PR DESCRIPTION


### Description
Reorder fixes warning about ctor setup for member variables:

```
Compile [ 75.0%]: InternetSocket.cpp                                                                          
[Warning] InternetSocket.h@235,10: 'InternetSocket::_factory_allocated' will be initialized after [-Wreorder] 
[Warning] InternetSocket.h@234,23:   'volatile unsigned int InternetSocket::_pending' [-Wreorder]             
[Warning] InternetSocket.cpp@22,1:   when initialized here [-Wreorder]  
```                              

In response to: https://github.com/ARMmbed/mbed-os/issues/7885

Also related: https://github.com/ARMmbed/mbed-os/issues/7886        

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

