### PR TITLE
Adjust STMF411xE IAR linker file to mbed-os memory needs.

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_IAR/stm32f411xe.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_IAR/stm32f411xe.icf
@@ -18,9 +18,9 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-/*Heap 1/4 of ram and stack 1/8*/
-define symbol __size_cstack__ = 0x4000;
-define symbol __size_heap__   = 0x8000;
+/*Heap 84kB and stack 1kB */
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x15000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION

### Description
mbed cloud client needs more heap, so heap size increased.
8k is enough for stack, so stack size decreased.
New linker file configuration tested with HW, mbed cloud client is able to register to cloud

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

