### PR TITLE
Cellular: Fix Greentea test for network attach

### DIFF
--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -184,6 +184,7 @@ static void test_network_registration()
 
 static void test_attach()
 {
+    wait(10);
     TEST_ASSERT(nw->set_attach() == NSAPI_ERROR_OK);
 
     CellularNetwork::AttachStatus status;


### PR DESCRIPTION
### Description

Added 10 seconds wait in Greentea test before trying to attach after network registration test. Cellular network attach can't be done before DUT is registered to a network.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

