### PR TITLE
Add overhead count in heap stats

### DIFF
--- a/TESTS/mbed_platform/stats_heap/main.cpp
+++ b/TESTS/mbed_platform/stats_heap/main.cpp
@@ -66,11 +66,13 @@ void test_case_malloc_free_size()
         TEST_ASSERT_EQUAL_UINT32(stats_start.total_size + ALLOCATION_SIZE_DEFAULT * (i + 1), stats_current.total_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt + 1, stats_current.alloc_cnt);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt, stats_current.alloc_fail_cnt);
-
+        // Library header 0x4-0x8, stats header 0x8 and alignment addition 0x4
+        TEST_ASSERT_INT_WITHIN(0x8, stats_start.overhead_size + 0xC , stats_current.overhead_size);
         // Free memory and assert back to starting size
         free(data);
         mbed_stats_heap_get(&stats_current);
         TEST_ASSERT_EQUAL_UINT32(stats_start.current_size, stats_current.current_size);
+        TEST_ASSERT_EQUAL_UINT32(stats_start.overhead_size, stats_current.overhead_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt, stats_current.alloc_cnt);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt, stats_current.alloc_fail_cnt);
     }
@@ -93,10 +95,14 @@ void test_case_allocate_zero()
         TEST_ASSERT_EQUAL_UINT32(stats_start.current_size, stats_current.current_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.total_size, stats_current.total_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt, stats_current.alloc_fail_cnt);
-
+        // Library header 0x4-0x8, stats header 0x8 and alignment addition 0x4
+        if (NULL != data) {
+            TEST_ASSERT_INT_WITHIN(0x8, stats_start.overhead_size + 0xC , stats_current.overhead_size);
+        }
         // Free memory and assert back to starting size
         free(data);
         mbed_stats_heap_get(&stats_current);
+        TEST_ASSERT_EQUAL_UINT32(stats_start.overhead_size, stats_current.overhead_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.current_size, stats_current.current_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt, stats_current.alloc_cnt);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt, stats_current.alloc_fail_cnt);
@@ -121,6 +127,7 @@ void test_case_allocate_fail()
         TEST_ASSERT_EQUAL_UINT32(stats_start.total_size, stats_current.total_size);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_cnt, stats_current.alloc_cnt);
         TEST_ASSERT_EQUAL_UINT32(stats_start.alloc_fail_cnt + i + 1, stats_current.alloc_fail_cnt);
+        TEST_ASSERT_EQUAL_UINT32(stats_start.overhead_size, stats_current.overhead_size);
     }
 }
 

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -48,6 +48,7 @@ typedef struct {
     uint32_t reserved_size;     /**< Current number of bytes allocated for the heap. */
     uint32_t alloc_cnt;         /**< Current number of allocations. */
     uint32_t alloc_fail_cnt;    /**< Number of failed allocations. */
+    uint32_t overhead_size;     /**< Overhead added to heap for stats. */
 } mbed_stats_heap_t;
 
 /**


### PR DESCRIPTION
### Description
Heap statistics are used for analyzing heap stats, but it doesn't tell anything about real heap usage or malloc overheads. Adding `overhead_size` element will help users to get the real heap usage.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

