### PR TITLE
Increase the timeout for rtostimer test to 10s

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/rtostimer/main.cpp
@@ -334,7 +334,7 @@ void test_isr_calls_fail()
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(5, "default_auto");
+    GREENTEA_SETUP(10, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 


### PR DESCRIPTION
### Description

Increase the timeout for `mbedmicro-rtos-mbed-rtostimer` test from 5s to 10s.

In some of the case, while running this test on a VM, the tests was running a bit slow and exceeded the timeout limit. this is just increased the timeout keep the test running to the end

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

