### PR TITLE
corrected a typo in AT_CellularPower::opt_power_save_mode

### DIFF
--- a/features/cellular/framework/AT/AT_CellularPower.cpp
+++ b/features/cellular/framework/AT/AT_CellularPower.cpp
@@ -190,7 +190,7 @@ nsapi_error_t AT_CellularPower::opt_power_save_mode(int periodic_time, int activ
         }
 
         uint_to_binary_str(active_timer, &at[3], sizeof(at) - 3, PSMTimerBits);
-        pt[8] = '\0';
+        at[8] = '\0';
 
         // request for both GPRS and LTE
         _at.cmd_start("AT+CPSMS=");


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
The array should be `at` instead of `pt`

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

