### PR TITLE
LoRa: Stop processing MAC commands if command id is unknown

### DIFF
--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -304,7 +304,8 @@ lorawan_status_t LoRaMacCommand::process_mac_commands(const uint8_t *payload, ui
                 break;
             default:
                 // Unknown command. ABORT MAC commands processing
-                ret_value = LORAWAN_STATUS_UNSUPPORTED;
+                tr_error("Invalid MAC command (0x%X)!", payload[mac_index]);
+                return LORAWAN_STATUS_UNSUPPORTED;
         }
     }
     return ret_value;


### PR DESCRIPTION

### Description

The length of a MAC command is not explicitly given and must be
implicitly known by the MAC implementation. Therefore unknown MAC
commands cannot be skipped and the first unknown MAC command
terminates the processing of the MAC command sequence.

This commit fixes the bug where MAC command processing was not
terminated when unknown MAC command was received.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

