### PR TITLE
Export, MCUXpresso: Avoid assigning self.libraries

### DIFF
--- a/tools/export/mcuxpresso/__init__.py
+++ b/tools/export/mcuxpresso/__init__.py
@@ -82,7 +82,6 @@ class MCUXpresso(GNUARMEclipse):
         for lib in self.libraries:
             l, _ = splitext(basename(lib))
             libraries.append(l[3:])
-        self.libraries = libraries
 
         self.system_libraries = [
             'stdc++', 'supc++', 'm', 'c', 'gcc', 'nosys'
@@ -156,7 +155,7 @@ class MCUXpresso(GNUARMEclipse):
             else:
                 opts['parent_id'] = 'release'
 
-            self.process_options(opts, flags)
+            self.process_options(opts, flags, libraries)
 
             opts['as']['defines'] = self.as_defines
             opts['c']['defines'] = self.c_defines
@@ -171,7 +170,7 @@ class MCUXpresso(GNUARMEclipse):
                 self.filter_dot(s) for s in self.resources.lib_dirs]
 
             opts['ld']['object_files'] = objects
-            opts['ld']['user_libraries'] = self.libraries
+            opts['ld']['user_libraries'] = libraries
             opts['ld']['system_libraries'] = self.system_libraries
             opts['ld']['script'] = "linker-script-%s.ld" % id
             opts['cpp_cmd'] = " ".join(toolchain.preproc)
@@ -305,7 +304,7 @@ class MCUXpresso(GNUARMEclipse):
 
     # -------------------------------------------------------------------------
 
-    def process_options(self, opts, flags_in):
+    def process_options(self, opts, flags_in, libraries):
         """
         CDT managed projects store lots of build options in separate
         variables, with separate IDs in the .cproject file.
@@ -701,7 +700,7 @@ class MCUXpresso(GNUARMEclipse):
             opts['ld'][
                 'other'] += ' '.join('-l' + s for s in self.system_libraries) + ' '
             opts['ld'][
-                'other'] += ' '.join('-l' + s for s in self.libraries)
+                'other'] += ' '.join('-l' + s for s in libraries)
             opts['ld']['other'] += ' -Wl,--end-group '
 
         # Strip all 'other' flags, since they might have leading spaces.


### PR DESCRIPTION
### Description

At some point in the past, self.libraries was changed from "assignable"
to not allowing assignment. This PR changes the MCUXpresso exporter to
avoid assigning this variable, and therefore fixes the exporter.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change