### PR TITLE
Changed routing error cause ERR_RTE to convert to NSAPI_ERROR_NO_ADDRESS 

### DIFF
--- a/features/lwipstack/lwip_tools.cpp
+++ b/features/lwipstack/lwip_tools.cpp
@@ -39,8 +39,9 @@ nsapi_error_t LWIP::err_remap(err_t err) {
         case ERR_RST:
         case ERR_ABRT:
             return NSAPI_ERROR_NO_CONNECTION;
-        case ERR_TIMEOUT:
         case ERR_RTE:
+            return NSAPI_ERROR_NO_ADDRESS;
+        case ERR_TIMEOUT:
         case ERR_WOULDBLOCK:
             return NSAPI_ERROR_WOULD_BLOCK;
         case ERR_VAL:


### PR DESCRIPTION
### Description

Changed routing error cause ERR_RTE to convert to NSAPI_ERROR_NO_ADDRESS instead of would block error. 

Do not merge: this needs further study, might need to work differently with different socket operations (tcp/udp)

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

