### PR TITLE
Export, Embitz: Avoid assigning `self.resources.linker_script`

### DIFF
--- a/tools/export/embitz/__init__.py
+++ b/tools/export/embitz/__init__.py
@@ -64,17 +64,13 @@ class EmBitz(Exporter):
             l, _ = splitext(basename(lib))
             libraries.append(l[3:])
 
-
-        if self.resources.linker_script is None:
-            self.resources.linker_script = ''
-
         ctx = {
             'name': self.project_name,
             'target': self.target,
             'toolchain': self.toolchain.name,
             'source_files': source_files,
             'include_paths': self.resources.inc_dirs,
-            'script_file': self.resources.linker_script,
+            'script_file': self.resources.linker_script or '',
             'library_paths': self.resources.lib_dirs,
             'libraries': libraries,
             'symbols': self.toolchain.get_symbols(),


### PR DESCRIPTION
### Description

At some point in the past, `self.linker_script` was changed from 
"assignable" to not allowing assignment. This PR changes the Embitz
exporter to avoid assigning this variable, and therefore fixes the 
exporter. This change also simplifies the expoter code

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] New target
    [ ] Feature
    [ ] Breaking change