### PR TITLE
Nuvoton: Fix GPIO mode mapping

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
@@ -94,15 +94,19 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    /* Input pull mode */
     PullNone = 0,
     PullDown,
     PullUp,
     
-    PushPull,
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
     OpenDrain,
-    Quasi,
+    QuasiBidirectional,
     
-    PullDefault = PullUp,
+    /* Default input pull mode */
+    PullDefault = PullUp
 } PinMode;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_M2351/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/gpio_api.c
@@ -51,6 +51,9 @@ void gpio_init(gpio_t *obj, PinName pin)
     }
 
     obj->mask = gpio_set(pin);
+    /* Default mode/direction */
+    obj->mode = PullUp;
+    obj->direction = PIN_INPUT;
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode)
@@ -58,8 +61,45 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    pin_mode(obj->pin, mode);
+
+    switch (mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            obj->mode = QuasiBidirectional;
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor I/O mode
+             * in the gpio_mode call here. */
+            if (mode == InputOnly) {
+                obj->direction = PIN_INPUT;
+                obj->mode = InputOnly;
+            } else {
+                obj->direction = PIN_OUTPUT;
+                obj->mode = PushPullOutput;
+            }
+            break;
+
+        default:
+            /* Allow for configuring other I/O modes directly */
+            obj->mode = mode;
+            break;
+    }
+
+    pin_mode(obj->pin, obj->mode);
 }
 
 void gpio_dir(gpio_t *obj, PinDirection direction)
@@ -67,25 +107,36 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    uint32_t pin_index = NU_PINNAME_TO_PIN(obj->pin);
-    uint32_t port_index = NU_PINNAME_TO_PORT(obj->pin);
-    GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
-    uint32_t mode_intern = GPIO_MODE_INPUT;
-    
-    switch (direction) {
-        case PIN_INPUT:
-            mode_intern = GPIO_MODE_INPUT;
-            break;
-        
-        case PIN_OUTPUT:
-            mode_intern = GPIO_MODE_OUTPUT;
+
+    obj->direction = direction;
+
+    switch (obj->mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
             break;
             
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor direction
+             * in the gpio_dir call here. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
         default:
-            return;
+            break;
     }
-    
-    GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    pin_mode(obj->pin, obj->mode);
 }

--- a/targets/TARGET_NUVOTON/TARGET_M2351/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/gpio_object.h
@@ -29,8 +29,10 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName  pin;
-    uint32_t mask;
+    PinName         pin;
+    uint32_t        mask;
+    PinDirection    direction;
+    PinMode         mode;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)

--- a/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/pinmap.c
@@ -41,31 +41,40 @@ void pin_mode(PinName pin, PinMode mode)
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     
     uint32_t mode_intern = GPIO_MODE_INPUT;
-    
+
     switch (mode) {
-        case PullUp:
+        case InputOnly:
             mode_intern = GPIO_MODE_INPUT;
             break;
-            
-        case PullDown:
-        case PullNone:
-            // NOTE: Not support
-            return;
-        
-        case PushPull:
+
+        case PushPullOutput:
             mode_intern = GPIO_MODE_OUTPUT;
             break;
-            
+
         case OpenDrain:
             mode_intern = GPIO_MODE_OPEN_DRAIN;
             break;
-            
-        case Quasi:
+
+        case QuasiBidirectional:
             mode_intern = GPIO_MODE_QUASI;
             break;
+
+        default:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We expect upper layer would have translated input pull mode/direction
+             * to I/O mode */
+            return;
     }
-    
+
     GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    /* Invalid combinations of PinMode/PinDirection
+     *
+     * We assume developer would avoid the following combinations of PinMode/PinDirection
+     * which are invalid:
+     * 1. InputOnly/PIN_OUTPUT
+     * 2. PushPullOutput/PIN_INPUT
+     */
 }
 
 #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)

--- a/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
@@ -55,15 +55,19 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    /* Input pull mode */
     PullNone = 0,
     PullDown,
     PullUp,
     
-    PushPull,
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
     OpenDrain,
-    Quasi,
+    QuasiBidirectional,
     
-    PullDefault = PullUp,
+    /* Default input pull mode */
+    PullDefault = PullUp
 } PinMode;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_M451/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/gpio_api.c
@@ -51,6 +51,9 @@ void gpio_init(gpio_t *obj, PinName pin)
     }
 
     obj->mask = gpio_set(pin);
+    /* Default mode/direction */
+    obj->mode = PullUp;
+    obj->direction = PIN_INPUT;
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode)
@@ -58,8 +61,45 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    pin_mode(obj->pin, mode);
+
+    switch (mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            obj->mode = QuasiBidirectional;
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor I/O mode
+             * in the gpio_mode call here. */
+            if (mode == InputOnly) {
+                obj->direction = PIN_INPUT;
+                obj->mode = InputOnly;
+            } else {
+                obj->direction = PIN_OUTPUT;
+                obj->mode = PushPullOutput;
+            }
+            break;
+
+        default:
+            /* Allow for configuring other I/O modes directly */
+            obj->mode = mode;
+            break;
+    }
+
+    pin_mode(obj->pin, obj->mode);
 }
 
 void gpio_dir(gpio_t *obj, PinDirection direction)
@@ -67,25 +107,36 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    uint32_t pin_index = NU_PINNAME_TO_PIN(obj->pin);
-    uint32_t port_index = NU_PINNAME_TO_PORT(obj->pin);
-    GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
-    uint32_t mode_intern = GPIO_MODE_INPUT;
-    
-    switch (direction) {
-        case PIN_INPUT:
-            mode_intern = GPIO_MODE_INPUT;
-            break;
-        
-        case PIN_OUTPUT:
-            mode_intern = GPIO_MODE_OUTPUT;
+
+    obj->direction = direction;
+
+    switch (obj->mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
             break;
             
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor direction
+             * in the gpio_dir call here. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
         default:
-            return;
+            break;
     }
-    
-    GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    pin_mode(obj->pin, obj->mode);
 }

--- a/targets/TARGET_NUVOTON/TARGET_M451/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/gpio_object.h
@@ -28,8 +28,10 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName  pin;
-    uint32_t mask;
+    PinName         pin;
+    uint32_t        mask;
+    PinDirection    direction;
+    PinMode         mode;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)

--- a/targets/TARGET_NUVOTON/TARGET_M451/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/pinmap.c
@@ -55,29 +55,38 @@ void pin_mode(PinName pin, PinMode mode)
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     
     uint32_t mode_intern = GPIO_MODE_INPUT;
-    
+
     switch (mode) {
-        case PullUp:
+        case InputOnly:
             mode_intern = GPIO_MODE_INPUT;
             break;
-            
-        case PullDown:
-        case PullNone:
-            // NOTE: Not support
-            return;
-        
-        case PushPull:
+
+        case PushPullOutput:
             mode_intern = GPIO_MODE_OUTPUT;
             break;
-            
+
         case OpenDrain:
             mode_intern = GPIO_MODE_OPEN_DRAIN;
             break;
-            
-        case Quasi:
+
+        case QuasiBidirectional:
             mode_intern = GPIO_MODE_QUASI;
             break;
+
+        default:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We expect upper layer would have translated input pull mode/direction
+             * to I/O mode */
+            return;
     }
-    
+
     GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    /* Invalid combinations of PinMode/PinDirection
+     *
+     * We assume developer would avoid the following combinations of PinMode/PinDirection
+     * which are invalid:
+     * 1. InputOnly/PIN_OUTPUT
+     * 2. PushPullOutput/PIN_INPUT
+     */
 }

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -55,15 +55,19 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    /* Input pull mode */
     PullNone = 0,
     PullDown,
     PullUp,
     
-    PushPull,
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
     OpenDrain,
-    Quasi,
+    QuasiBidirectional,
     
-    PullDefault = PullUp,
+    /* Default input pull mode */
+    PullDefault = PullUp
 } PinMode;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_M480/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/gpio_object.h
@@ -28,8 +28,10 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName  pin;
-    uint32_t mask;
+    PinName         pin;
+    uint32_t        mask;
+    PinDirection    direction;
+    PinMode         mode;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)

--- a/targets/TARGET_NUVOTON/TARGET_M480/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/pinmap.c
@@ -47,27 +47,36 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t mode_intern = GPIO_MODE_INPUT;
 
     switch (mode) {
-    case PullUp:
-        mode_intern = GPIO_MODE_INPUT;
-        break;
+        case InputOnly:
+            mode_intern = GPIO_MODE_INPUT;
+            break;
 
-    case PullDown:
-    case PullNone:
-        // NOTE: Not support
-        return;
+        case PushPullOutput:
+            mode_intern = GPIO_MODE_OUTPUT;
+            break;
 
-    case PushPull:
-        mode_intern = GPIO_MODE_OUTPUT;
-        break;
+        case OpenDrain:
+            mode_intern = GPIO_MODE_OPEN_DRAIN;
+            break;
 
-    case OpenDrain:
-        mode_intern = GPIO_MODE_OPEN_DRAIN;
-        break;
+        case QuasiBidirectional:
+            mode_intern = GPIO_MODE_QUASI;
+            break;
 
-    case Quasi:
-        mode_intern = GPIO_MODE_QUASI;
-        break;
+        default:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We expect upper layer would have translated input pull mode/direction
+             * to I/O mode */
+            return;
     }
 
     GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    /* Invalid combinations of PinMode/PinDirection
+     *
+     * We assume developer would avoid the following combinations of PinMode/PinDirection
+     * which are invalid:
+     * 1. InputOnly/PIN_OUTPUT
+     * 2. PushPullOutput/PIN_INPUT
+     */
 }

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/PinNames.h
@@ -55,15 +55,18 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    /* Input pull mode */
     PullNone = 0,
     PullDown,
     PullUp,
     
-    PushPull,
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
     OpenDrain,
-    Quasi,
     
-    PullDefault = PullUp,
+    /* Default input pull mode */
+    PullDefault = PullUp
 } PinMode;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/gpio_object.h
@@ -28,8 +28,10 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName  pin;
-    uint32_t mask;
+    PinName         pin;
+    uint32_t        mask;
+    PinDirection    direction;
+    PinMode         mode;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/pinmap.c
@@ -44,30 +44,35 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     
-    uint32_t mode_intern = GPIO_PMD_INPUT;
-    
+    uint32_t mode_intern;
+
     switch (mode) {
-        case PullUp:
+        case InputOnly:
             mode_intern = GPIO_PMD_INPUT;
             break;
-            
-        case PullDown:
-        case PullNone:
-            // NOTE: Not support
-            return;
-        
-        case PushPull:
+
+        case PushPullOutput:
             mode_intern = GPIO_PMD_OUTPUT;
             break;
-            
+
         case OpenDrain:
             mode_intern = GPIO_PMD_OPEN_DRAIN;
             break;
             
-        case Quasi:
-            // NOTE: Not support
-            break;
+        default:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We expect upper layer would have translated input pull mode/direction
+             * to I/O mode */
+            return;
     }
-    
+
     GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    /* Invalid combinations of PinMode/PinDirection
+     *
+     * We assume developer would avoid the following combinations of PinMode/PinDirection
+     * which are invalid:
+     * 1. InputOnly/PIN_OUTPUT
+     * 2. PushPullOutput/PIN_INPUT
+     */
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
@@ -55,15 +55,19 @@ typedef enum {
 } PinDirection;
 
 typedef enum {
+    /* Input pull mode */
     PullNone = 0,
     PullDown,
     PullUp,
     
-    PushPull,
+    /* I/O mode */
+    InputOnly,
+    PushPullOutput,
     OpenDrain,
-    Quasi,
+    QuasiBidirectional,
     
-    PullDefault = PullUp,
+    /* Default input pull mode */
+    PullDefault = PullUp
 } PinMode;
 
 typedef enum {

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_api.c
@@ -51,6 +51,9 @@ void gpio_init(gpio_t *obj, PinName pin)
     }
 
     obj->mask = gpio_set(pin);
+    /* Default mode/direction */
+    obj->mode = PullUp;
+    obj->direction = PIN_INPUT;
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode)
@@ -58,8 +61,45 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    pin_mode(obj->pin, mode);
+
+    switch (mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            obj->mode = QuasiBidirectional;
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor I/O mode
+             * in the gpio_mode call here. */
+            if (mode == InputOnly) {
+                obj->direction = PIN_INPUT;
+                obj->mode = InputOnly;
+            } else {
+                obj->direction = PIN_OUTPUT;
+                obj->mode = PushPullOutput;
+            }
+            break;
+
+        default:
+            /* Allow for configuring other I/O modes directly */
+            obj->mode = mode;
+            break;
+    }
+
+    pin_mode(obj->pin, obj->mode);
 }
 
 void gpio_dir(gpio_t *obj, PinDirection direction)
@@ -67,25 +107,36 @@ void gpio_dir(gpio_t *obj, PinDirection direction)
     if (obj->pin == (PinName) NC) {
         return;
     }
-    
-    uint32_t pin_index = NU_PINNAME_TO_PIN(obj->pin);
-    uint32_t port_index = NU_PINNAME_TO_PORT(obj->pin);
-    GPIO_T *gpio_base = NU_PORT_BASE(port_index);
-    
-    uint32_t mode_intern = GPIO_MODE_INPUT;
-    
-    switch (direction) {
-        case PIN_INPUT:
-            mode_intern = GPIO_MODE_INPUT;
-            break;
-        
-        case PIN_OUTPUT:
-            mode_intern = GPIO_MODE_OUTPUT;
+
+    obj->direction = direction;
+
+    switch (obj->mode) {
+        case PullNone:
+        case PullDown:
+        case PullUp:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We translate to input-only/push-pull output I/O mode dependent on direction. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
             break;
             
+        case QuasiBidirectional:
+            /* With quasi-bidirectional I/O mode, before digital input function is performed,
+             * the corresponding bit in GPIOx_DOUT must be set to 1. */
+            if (obj->direction == PIN_INPUT) {
+                gpio_write(obj, 1);
+            }
+            break;
+
+        case InputOnly:
+        case PushPullOutput:
+            /* We may meet contradictory I/O mode/direction configuration. Favor direction
+             * in the gpio_dir call here. */
+            obj->mode = (obj->direction == PIN_INPUT) ? InputOnly : PushPullOutput;
+            break;
+
         default:
-            return;
+            break;
     }
-    
-    GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    pin_mode(obj->pin, obj->mode);
 }

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_object.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/gpio_object.h
@@ -28,8 +28,10 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName  pin;
-    uint32_t mask;
+    PinName         pin;
+    uint32_t        mask;
+    PinDirection    direction;
+    PinMode         mode;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/pinmap.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/pinmap.c
@@ -54,30 +54,39 @@ void pin_mode(PinName pin, PinMode mode)
     uint32_t port_index = NU_PINNAME_TO_PORT(pin);
     GPIO_T *gpio_base = NU_PORT_BASE(port_index);
     
-    uint32_t mode_intern = GPIO_MODE_INPUT;
-    
+    uint32_t mode_intern;
+
     switch (mode) {
-        case PullUp:
+        case InputOnly:
             mode_intern = GPIO_MODE_INPUT;
             break;
-            
-        case PullDown:
-        case PullNone:
-            // NOTE: Not support
-            return;
-        
-        case PushPull:
+
+        case PushPullOutput:
             mode_intern = GPIO_MODE_OUTPUT;
             break;
-            
+
         case OpenDrain:
             mode_intern = GPIO_MODE_OPEN_DRAIN;
             break;
-            
-        case Quasi:
+
+        case QuasiBidirectional:
             mode_intern = GPIO_MODE_QUASI;
             break;
+
+        default:
+            /* H/W doesn't support separate configuration for input pull mode/direction.
+             * We expect upper layer would have translated input pull mode/direction
+             * to I/O mode */
+            return;
     }
-    
+
     GPIO_SetMode(gpio_base, 1 << pin_index, mode_intern);
+
+    /* Invalid combinations of PinMode/PinDirection
+     *
+     * We assume developer would avoid the following combinations of PinMode/PinDirection
+     * which are invalid:
+     * 1. InputOnly/PIN_OUTPUT
+     * 2. PushPullOutput/PIN_INPUT
+     */
 }


### PR DESCRIPTION
### Description

Nuvoton's GPIO H/W doesn't support separate configuration for input pull mode (`PinMode`)/direction (`PinDirection`). It supports 3~4 GPIO I/O modes which include the above configurations. This PR tries to give a better mode mapping between input pull mode/direction and GPIO I/O mode in the functions `gpio_mode`/`gpio_dir`/`pin_mode`.

- NUMAKER_PFM_NUC472
- NUMAKER_PFM_M453
- NUMAKER_PFM_M487
- NUMAKER_PFM_NANO130
- NUMAKER_PFM_M2351

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
