### PR TITLE
Fix memory allocation on STM32L4 devices

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
@@ -38,8 +38,6 @@
 extern uint32_t __mbed_sbrk_start;
 extern uint32_t __mbed_krbs_start;
 
-#define STM32L4_HEAP_ALIGN               32
-#define STM32L4_ALIGN_UP(X, ALIGN)       (((X) + (ALIGN) - 1) & ~((ALIGN) - 1))
 /**
  * The default implementation of _sbrk() (in platform/mbed_retarget.cpp) for GCC_ARM requires one-region model (heap and
  * stack share one region), which doesn't fit two-region model (heap and stack are two distinct regions), for example,
@@ -50,8 +48,8 @@ extern uint32_t __mbed_krbs_start;
 void *__wrap__sbrk(int incr)
 {
     static uint32_t heap_ind = (uint32_t) &__mbed_sbrk_start;
-    uint32_t heap_ind_old = STM32L4_ALIGN_UP(heap_ind, STM32L4_HEAP_ALIGN);
-    uint32_t heap_ind_new = STM32L4_ALIGN_UP(heap_ind_old + incr, STM32L4_HEAP_ALIGN);
+    uint32_t heap_ind_old = heap_ind;
+    uint32_t heap_ind_new = heap_ind_old + incr;
 
     if (heap_ind_new > &__mbed_krbs_start) {
         errno = ENOMEM;

--- a/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/l4_retarget.c
@@ -51,7 +51,7 @@ void *__wrap__sbrk(int incr)
     uint32_t heap_ind_old = heap_ind;
     uint32_t heap_ind_new = heap_ind_old + incr;
 
-    if (heap_ind_new > &__mbed_krbs_start) {
+    if (heap_ind_new > (uint32_t)&__mbed_krbs_start) {
         errno = ENOMEM;
         return (void *) - 1;
     }


### PR DESCRIPTION
### Description

Depending on initial size allocated on STM32L4 devices with TWO_RAM_REGIONS  set a crash may occur. This is because there is a mismatch between the size newlib is expecting and the size actually returned by _sbrk. This is because the STM32L4 implementation of _sbrk is performing alignment internally.

This patch fixes this problem by removing the code in __wrap__sbrk which performs the alignment.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

