### PR TITLE
Fix is_valid_erase function to use get_erase_size with address

### DIFF
--- a/features/storage/blockdevice/BlockDevice.h
+++ b/features/storage/blockdevice/BlockDevice.h
@@ -226,8 +226,8 @@ public:
     bool is_valid_erase(bd_addr_t addr, bd_size_t size) const
     {
         return (
-            addr % get_erase_size() == 0 &&
-            size % get_erase_size() == 0 &&
+            addr % get_erase_size(addr) == 0 &&
+            (addr + size) % get_erase_size(addr + size - 1) == 0 &&
             addr + size <= this->size());
     }
 };


### PR DESCRIPTION
### Description
The base BlockDevice class includes the `is_valid_erase` function checking whether the address and size given to the `erase` API are valid. This function used to call the `get_erase_size` function without the address argument, but this was a bug, as it would have failed valid calls to `erase`. It now calls `get_erase_size` with the address argument.
Just to clarify - this will work also for classes that don't implement `get_erase_size` with the address parameter, as it defaults to the one that doesn't have the address in the base class.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

