### PR TITLE
Add SPI_FREQ parameter to DATAFLASH block device configuration

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -74,7 +74,7 @@ public:
                          PinName miso,
                          PinName sclk,
                          PinName csel,
-                         int freq = 40000000,
+                         int freq = MBED_CONF_DATAFLASH_SPI_FREQ,
                          PinName nowp = NC);
 
     /** Initialize a block device

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
@@ -5,6 +5,7 @@
         "SPI_MISO": "NC",
         "SPI_CLK":  "NC",
         "SPI_CS":   "NC",
+        "SPI_FREQ": "40000000",
         "binary-size": {
             "help": "Configure device to use binary address space.",
             "value": "0"


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR adds the SPI_FREQ configuration parameter to the DATAFLASH block device component.
This addon will allow the application to change the frequency of the SPI storage from the configuration side without committing any code changes.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

