### PR TITLE
nRF5x: pass ram linker start/length from config system

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -10,12 +10,14 @@
 #endif
 
 /* If softdevice is present, set aside space for it */
-#if defined(SOFTDEVICE_PRESENT)
-  #define MBED_RAM_START  0x200031D0
-  #define MBED_RAM_SIZE   0xCE30
-#else
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x10000
+#if !defined(MBED_RAM_START)
+  #if defined(SOFTDEVICE_PRESENT)
+    #define MBED_RAM_START  0x200031D0
+    #define MBED_RAM_SIZE   0xCE30
+  #else
+    #define MBED_RAM_START  0x20000000
+    #define MBED_RAM_SIZE   0x10000
+  #endif
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -26,12 +26,14 @@
 #endif
 
 /* If softdevice is present, set aside space for it */
-#if defined(SOFTDEVICE_PRESENT)
-  #define MBED_RAM_START  0x200031D0
-  #define MBED_RAM_SIZE   0xCE30
-#else
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x10000
+#if !defined(MBED_RAM_START)
+  #if defined(SOFTDEVICE_PRESENT)
+    #define MBED_RAM_START  0x200031D0
+    #define MBED_RAM_SIZE   0xCE30
+  #else
+    #define MBED_RAM_START  0x20000000
+    #define MBED_RAM_SIZE   0x10000
+  #endif
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START
@@ -189,7 +191,7 @@ SECTIONS
         PROVIDE(__start_fs_data = .);
         KEEP(*(.fs_data))
         PROVIDE(__stop_fs_data = .);
-        
+
         *(.jcr)
         . = ALIGN(4);
         /* All data end */

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -12,12 +12,14 @@ if (!isdefinedsymbol(MBED_APP_SIZE)) {
 }
 
 /* If softdevice is present, set aside space for it */
-if (isdefinedsymbol(SOFTDEVICE_PRESENT)) {
-  define symbol MBED_RAM_START = 0x200031D0;
-  define symbol MBED_RAM_SIZE  = 0xCE30;
-} else {
-  define symbol MBED_RAM_START = 0x20000000;
-  define symbol MBED_RAM_SIZE  = 0x10000;
+if (!isdefinedsymbol(MBED_RAM_START)) {
+  if (isdefinedsymbol(SOFTDEVICE_PRESENT)) {
+    define symbol MBED_RAM_START = 0x200031D0;
+    define symbol MBED_RAM_SIZE  = 0xCE30;
+  } else {
+    define symbol MBED_RAM_START = 0x20000000;
+    define symbol MBED_RAM_SIZE  = 0x10000;
+  }
 }
 
 define symbol MBED_RAM0_START = MBED_RAM_START;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_ARM_STD/nRF52840.sct
@@ -9,13 +9,15 @@
   #define MBED_APP_SIZE 0x100000
 #endif
 
-/* If app_start is 0, do not set aside space for the softdevice */
-#if MBED_APP_START == 0
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x40000
-#else
-  #define MBED_RAM_START  0x20003188
-  #define MBED_RAM_SIZE   0x3CE78
+/* If softdevice is present, set aside space for it */
+#if !defined(MBED_RAM_START)
+  #if defined(SOFTDEVICE_PRESENT)
+    #define MBED_RAM_START  0x20003188
+    #define MBED_RAM_SIZE   0x3CE78
+  #else
+    #define MBED_RAM_START  0x20000000
+    #define MBED_RAM_SIZE   0x40000
+  #endif
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -25,13 +25,15 @@
   #define MBED_APP_SIZE 0x100000
 #endif
 
-/* If app_start is 0, do not set aside space for the softdevice */
-#if MBED_APP_START == 0
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x40000
-#else
-  #define MBED_RAM_START  0x20003188
-  #define MBED_RAM_SIZE   0x3CE78
+/* If softdevice is present, set aside space for it */
+#if !defined(MBED_RAM_START)
+  #if defined(SOFTDEVICE_PRESENT)
+    #define MBED_RAM_START  0x20003188
+    #define MBED_RAM_SIZE   0x3CE78
+  #else
+    #define MBED_RAM_START  0x20000000
+    #define MBED_RAM_SIZE   0x40000
+  #endif
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_IAR/nRF52840.icf
@@ -11,13 +11,15 @@ if (!isdefinedsymbol(MBED_APP_SIZE)) {
     define symbol MBED_APP_SIZE = 0x100000;
 }
 
-/* If app_start is 0, do not set aside space for the softdevice */
-if (MBED_APP_START == 0) {
-  define symbol MBED_RAM_START = 0x20000000;
-  define symbol MBED_RAM_SIZE  = 0x40000;
-} else {
-  define symbol MBED_RAM_START = 0x20003188;
-  define symbol MBED_RAM_SIZE  = 0x3CE78;
+/* If softdevice is present, set aside space for it */
+if (!isdefinedsymbol(MBED_RAM_START)) {
+  if (isdefinedsymbol(SOFTDEVICE_PRESENT)) {
+    define symbol MBED_RAM_START = 0x20003188;
+    define symbol MBED_RAM_SIZE  = 0x3CE78;
+  } else {
+    define symbol MBED_RAM_START = 0x20000000;
+    define symbol MBED_RAM_SIZE  = 0x40000;
+  }
 }
 
 define symbol MBED_RAM0_START = MBED_RAM_START;

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -495,7 +495,8 @@ class Config(object):
         self.target_labels = self.target.labels
         for override in BOOTLOADER_OVERRIDES:
             _, attr = override.split(".")
-            setattr(self.target, attr, None)
+            if not hasattr(self.target, attr):
+                setattr(self.target, attr, None)
 
         self.cumulative_overrides = {key: ConfigCumulativeOverride(key)
                                      for key in CUMULATIVE_ATTRIBUTES}


### PR DESCRIPTION
### Description

The ram start and length settings can already be defined in `targets.json` with `mbed_ram_start` and `mbed_ram_size` etc.

These are supposed to be used in nrf5x targets to specify in the linker how much ram is set aside for the softdevice. Unfortunately the linker files have these values defined in directly so they can't be overridden by the target settings.
This PR fixes the problem by simply checking if the defines are already set before setting them in the linker scripts.

There was also a minor bug in the python config handler where these boot-loader target settings in were being overridden by a later part of the config system with `None`. This is also fixed.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

