### PR TITLE
nrf_ble: Expose configuration of max characteristics and descriptors

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xGattServer.h
@@ -43,8 +43,8 @@ public:
 
 
 private:
-    const static unsigned BLE_TOTAL_CHARACTERISTICS = 20;
-    const static unsigned BLE_TOTAL_DESCRIPTORS     = 8;
+    const static unsigned BLE_TOTAL_CHARACTERISTICS = NRF_SDH_BLE_TOTAL_CHARACTERISTICS;
+    const static unsigned BLE_TOTAL_DESCRIPTORS     = NRF_SDH_BLE_TOTAL_DESCRIPTORS;
     const static unsigned TOTAL_CONCURRENT_LONG_WRITE_REQUESTS = 3;
 
 private:

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/mbed_lib.json
@@ -25,6 +25,16 @@
             "help": "select whether to include the Service Changed characteristic in the GATT Server",
             "value": "1",
             "macro_name": "NRF_SDH_BLE_SERVICE_CHANGED"
+        },
+        "max_characteristics": {
+            "help": "Sets the maximum number of characteristics that can be registered",
+            "value": "20",
+            "macro_name": "NRF_SDH_BLE_TOTAL_CHARACTERISTICS"
+        },
+        "max_descriptors": {
+            "help": "Sets the maximum number of descriptors that can be registered",
+            "value": "8",
+            "macro_name": "NRF_SDH_BLE_TOTAL_DESCRIPTORS"
         }
     }
 }


### PR DESCRIPTION
### Description

This PR simply exposes a couple of hard defined BLE limits in the config system. 
These defines restrict the configuration of larger BLE projects and can't be worked around without changing this file in mbed-os.

This PR does not change the default behavior of these defines, just allows them to be changed by an end-user project.

* `BLE_TOTAL_CHARACTERISTICS`
Limits the maximum number of characteristics that can be configured on the BLE stack

* `BLE_TOTAL_DESCRIPTORS`
Limits the maximum number of descriptors that can be configured on the BLE stack

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

