### PR TITLE
nrf5x: ram start address fix

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -60,6 +60,7 @@ OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
  *   __exidx_start
  *   __exidx_end
  *   __etext
+ *   __ram_start__
  *   __data_start__
  *   __preinit_array_start
  *   __preinit_array_end
@@ -203,6 +204,7 @@ SECTIONS
 
     .nvictable (NOLOAD) :
     {
+      __ram_start__ = .;
       PROVIDE(__start_nvictable = .);
       KEEP(*(.nvictable))
       PROVIDE(__stop_nvictable = .);

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/device/TOOLCHAIN_GCC_ARM/NRF52840.ld
@@ -60,6 +60,7 @@ OUTPUT_FORMAT ("elf32-littlearm", "elf32-bigarm", "elf32-littlearm")
  *   __exidx_start
  *   __exidx_end
  *   __etext
+ *   __ram_start__
  *   __data_start__
  *   __preinit_array_start
  *   __preinit_array_end
@@ -202,6 +203,7 @@ SECTIONS
 
     .nvictable (NOLOAD) :
     {
+      __ram_start__ = .;
       PROVIDE(__start_nvictable = .);
       KEEP(*(.nvictable))
       PROVIDE(__stop_nvictable = .);

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/README.md
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/README.md
@@ -6,6 +6,10 @@ components/libraries/fstorage/nrf_fstorage_sd.*
 
 # Modifications
 
+The linker definitions for the start of ram in `softdevice/common/nrf_sdh_ble.c` 
+have been updated to the start of the mbed nvic section in ram as this 
+equals the end of softdevice ram.
+
 Removed:
  * common/nrf_sdh_freertos.c
  * common/nrf_sdh_freertos.h

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/TARGET_SOFTDEVICE_COMMON/softdevice/common/nrf_sdh_ble.c
@@ -66,17 +66,17 @@ NRF_SECTION_SET_DEF(sdh_ble_observers, nrf_sdh_ble_evt_observer_t, NRF_SDH_BLE_O
 
 //lint -save -e10 -e19 -e40 -e27 Illegal character (0x24)
 #if defined(__CC_ARM)
-    extern uint32_t  Image$$RW_IRAM1$$Base;
-    uint32_t const * const m_ram_start = &Image$$RW_IRAM1$$Base;
+    extern uint32_t  Image$$RW_IRAM0$$Base;
+    uint32_t const * const m_ram_start = &Image$$RW_IRAM0$$Base;
 #elif defined(__ICCARM__)
-    extern uint32_t  __ICFEDIT_region_RAM_start__;
-    uint32_t const * const m_ram_start = &__ICFEDIT_region_RAM_start__;
+    extern uint32_t  __ICFEDIT_region_RAM_NVIC_start__;
+    uint32_t const * const m_ram_start = &__ICFEDIT_region_RAM_NVIC_start__;
 #elif defined(__SES_ARM)
     extern uint32_t  __app_ram_start__;
     uint32_t const * const m_ram_start = &__app_ram_start__;
 #elif defined(__GNUC__)
-    extern uint32_t  __data_start__;
-    uint32_t const * const m_ram_start = &__data_start__;
+    extern uint32_t  __ram_start__;
+    uint32_t const * const m_ram_start = &__ram_start__;
 #endif
 //lint -restore
 


### PR DESCRIPTION
### Description

In all nordic targets the start of application ram is needed by the softdevice to know where the end of its ram space is.

This is currently determined by checking the location of `__data_start__` (for gcc, different name on other compilers) which is traditionally at the start of the volatile ram block. 

In mbed however there is the extra small nvic block before this.
As it stands, if the softdevice uses all it's declared available ram it will overwrite this nvic block, breaking the application.

With this PR the start of ram is now pointing to the mbeds nvic section.

This does require editing the one Nordic SDK file which controls this. 
This modification is noted in the associated readme.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

