### PR TITLE
Change mbedtls_platform_context parameter to NULL

### DIFF
--- a/TESTS/mbedtls/multi/main.cpp
+++ b/TESTS/mbedtls/multi/main.cpp
@@ -188,15 +188,14 @@ int main()
 {
     int ret = 0;
 #if defined(MBEDTLS_PLATFORM_C)
-    mbedtls_platform_context platform_ctx;
-    if ((ret = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if ((ret = mbedtls_platform_setup(NULL)) != 0) {
         mbedtls_printf("Mbed TLS multitest failed! mbedtls_platform_setup returned %d\n", ret);
         return 1;
     }
 #endif
     ret = (Harness::run(specification) ? 0 : 1);
 #if defined(MBEDTLS_PLATFORM_C)
-    mbedtls_platform_teardown(&platform_ctx);
+    mbedtls_platform_teardown(NULL);
 #endif
     return ret;
 }

--- a/TESTS/mbedtls/selftest/main.cpp
+++ b/TESTS/mbedtls/selftest/main.cpp
@@ -96,15 +96,14 @@ int main()
 {
     int ret = 0;
 #if defined(MBEDTLS_PLATFORM_C)
-    mbedtls_platform_context platform_ctx;
-    if ((ret = mbedtls_platform_setup(&platform_ctx)) != 0) {
+    if ((ret = mbedtls_platform_setup(NULL)) != 0) {
         mbedtls_printf("Mbed TLS selftest failed! mbedtls_platform_setup returned %d\n", ret);
         return 1;
     }
 #endif
     ret = (Harness::run(specification) ? 0 : 1);
 #if defined(MBEDTLS_PLATFORM_C)
-    mbedtls_platform_teardown(&platform_ctx);
+    mbedtls_platform_teardown(NULL);
 #endif
     return ret;
 }

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.cpp
@@ -47,7 +47,7 @@ namespace vendor {
 namespace nordic {
 
 CryptoToolbox::CryptoToolbox() : _initialized(false) {
-    mbedtls_platform_setup(&_platform_context);
+    mbedtls_platform_setup(NULL);
     mbedtls_entropy_init(&_entropy_context);
     mbedtls_ecp_group_init(&_group);
     int err = mbedtls_ecp_group_load(
@@ -60,7 +60,7 @@ CryptoToolbox::CryptoToolbox() : _initialized(false) {
 CryptoToolbox::~CryptoToolbox() {
     mbedtls_ecp_group_free(&_group);
     mbedtls_entropy_free(&_entropy_context);
-    mbedtls_platform_teardown(&_platform_context);
+    mbedtls_platform_teardown(NULL);
 }
 
 bool CryptoToolbox::generate_keys(

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/nRF5xCrypto.h
@@ -132,7 +132,6 @@ private:
     void swap_endian(uint8_t* buf, size_t len);
 
     bool _initialized;
-    mbedtls_platform_context _platform_context;
     mbedtls_entropy_context _entropy_context;
     mbedtls_ecp_group _group;
 };


### PR DESCRIPTION
### Description
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
`mbedtls_platform_setup()` and `mbedtls_platform_teardown()` now ignore the context parameter, since #7099 was merged. Changing the sent parameter to NULL, to avoid misleading.
This PR continues #7099

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

