### PR TITLE
Cellular: add reconnect support to cellular statemachine

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -39,7 +39,9 @@ const int MAX_RETRY_ARRAY_SIZE = 10;
 
 /** CellularConnectionFSM class
  *
- *  Finite State Machine for connecting to cellular network
+ *  Finite State Machine for connecting to cellular network.
+ *  By default automatic reconnecting is on. This means that when FSM gets the disconnected callback
+ *  it will try to connect automatically. Application can toggle this behavior with method set_automatic_reconnect(...)
  */
 class CellularConnectionFSM {
 public:
@@ -59,7 +61,9 @@ public:
         STATE_ATTACHING_NETWORK,
         STATE_ACTIVATING_PDP_CONTEXT,
         STATE_CONNECTING_NETWORK,
-        STATE_CONNECTED
+        STATE_CONNECTED,
+        STATE_DISCONNECTING,
+        STATE_MAX_FSM_STATE
     };
 
 public:
@@ -68,6 +72,19 @@ public:
      *  @return see nsapi_error_t, 0 on success
      */
     nsapi_error_t init();
+
+    /** By default automatic reconnecting is on. This means that when FSM gets the disconnected callback
+     *  it will try to connect automatically. By this method application can toggle this behavior.
+     *
+     *  @param do_reconnect true for automatic reconnect, false to not reconnect automatically
+     */
+    void set_automatic_reconnect(bool do_reconnect);
+
+    /** Disconnects from the cellular network.
+     *
+     *  @return NSAPI_ERROR_OK on success, negative code in case of failure
+     */
+    nsapi_error_t disconnect();
 
     /** Set serial connection for cellular device
      *  @param serial UART driver
@@ -213,6 +230,7 @@ private:
     const char *_plmn;
     bool _command_success;
     bool _plmn_network_found;
+    bool _automatic_reconnect;
 };
 
 } // namespace

--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -83,6 +83,16 @@ EasyCellularConnection::~EasyCellularConnection()
     }
 }
 
+nsapi_error_t EasyCellularConnection::set_automatic_reconnect(bool do_reconnect)
+{
+    nsapi_error_t err = init();
+    if (err) {
+        return err;
+    }
+    _cellularConnectionFSM->set_automatic_reconnect(do_reconnect);
+    return NSAPI_ERROR_OK;
+}
+
 nsapi_error_t EasyCellularConnection::init()
 {
     nsapi_error_t err = NSAPI_ERROR_OK;
@@ -242,14 +252,12 @@ nsapi_error_t EasyCellularConnection::disconnect()
 #endif // #if USE_APN_LOOKUP
 
     nsapi_error_t err = NSAPI_ERROR_OK;
-    if (_cellularConnectionFSM && _cellularConnectionFSM->get_network()) {
-        err = _cellularConnectionFSM->get_network()->disconnect();
+    if (_cellularConnectionFSM) {
+        err = _cellularConnectionFSM->disconnect();
     }
 
-    if (err == NSAPI_ERROR_OK) {
-        delete _cellularConnectionFSM;
-        _cellularConnectionFSM = NULL;
-    }
+    delete _cellularConnectionFSM;
+    _cellularConnectionFSM = NULL;
 
     return err;
 }

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -37,6 +37,14 @@ public:
     EasyCellularConnection(bool debug = false);
     virtual ~EasyCellularConnection();
 
+    /** By default automatic reconnecting is on. This means that when we get disconnected callback
+     *  we will try to connect automatically. By this method application can toggle this behavior.
+     *
+     *  @param      do_reconnect true for automatic reconnect, false to not reconnect automatically
+     *  @return     NSAPI_ERROR_OK on success, or negative error code on failure
+     */
+    nsapi_error_t set_automatic_reconnect(bool do_reconnect);
+
 public:
     /** Set the Cellular network credentials
      *

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -165,10 +165,6 @@ public:
      */
     void process_oob();
 
-    /** Set sigio for the current file handle. Sigio event goes through eventqueue so that it's handled in current thread.
-     */
-    void set_filehandle_sigio();
-
     /** Set file handle, which is used for reading AT responses and writing AT commands
      *
      *  @param fh file handle used for reading AT responses and writing AT commands
@@ -211,8 +207,6 @@ private:
 
     uint16_t _at_send_delay;
     uint64_t _last_response_stop;
-
-    bool _fh_sigio_set;
 
     bool _processing;
     int32_t _ref_count;

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -62,6 +62,14 @@ AT_CellularNetwork::~AT_CellularNetwork()
 
     _at.remove_urc_handler("NO CARRIER", callback(this, &AT_CellularNetwork::urc_no_carrier));
     _at.remove_urc_handler("+CGEV:", callback(this, &AT_CellularNetwork::urc_cgev));
+
+    _at.lock();
+    _at.cmd_start("AT+CGEREP=0");
+    _at.cmd_stop();
+    _at.resp_start();
+    _at.resp_stop();
+    _at.unlock();
+
     free_credentials();
 }
 
@@ -79,6 +87,16 @@ nsapi_error_t AT_CellularNetwork::init()
         }
     }
 
+    // additional urc to get better disconnect info for application. Not critical so not returning an error in case of failure
+    nsapi_error_t err = _at.set_urc_handler("+CGEV:", callback(this, &AT_CellularNetwork::urc_cgev));
+    if (err == NSAPI_ERROR_OK) {
+        _at.lock();
+        _at.cmd_start("AT+CGEREP=1");
+        _at.cmd_stop();
+        _at.resp_start();
+        _at.resp_stop();
+        _at.unlock();
+    }
     return _at.set_urc_handler("NO CARRIER", callback(this, &AT_CellularNetwork::urc_no_carrier));
 }
 
@@ -168,6 +186,13 @@ void AT_CellularNetwork::read_reg_params_and_compare(RegistrationType type)
         if (reg_status != _reg_status) {
             _reg_status = reg_status;
             _connection_status_cb((nsapi_event_t)CellularRegistrationStatusChanged, _reg_status);
+            // Call network callback if we think we are connected and we get some other registration status than
+            // "registered"
+            if (_connect_status == NSAPI_STATUS_GLOBAL_UP && (_reg_status != RegisteredHomeNetwork &&
+                    _reg_status != RegisteredRoaming)) {
+                tr_info("AT_CellularNetwork, calling disconnected after registration change!");
+                call_network_cb(NSAPI_STATUS_DISCONNECTED);
+            }
         }
         if (cell_id != -1 && cell_id != _cell_id) {
             _cell_id = cell_id;
@@ -360,17 +385,6 @@ nsapi_error_t AT_CellularNetwork::connect()
         return err;
     }
 #else
-    // additional urc to get better disconnect info for application. Not critical so not returning an error in case of failure
-    err = _at.set_urc_handler("+CGEV:", callback(this, &AT_CellularNetwork::urc_cgev));
-    if (err == NSAPI_ERROR_OK) {
-        _at.lock();
-        _at.cmd_start("AT+CGEREP=1");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
-        _at.unlock();
-    }
-
     call_network_cb(NSAPI_STATUS_GLOBAL_UP);
 #endif
 

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -24,8 +24,6 @@
 
 namespace mbed {
 
-#define AT_NETWORK_TRIALS 5
-
 /**
  *  Class AT_CellularNetwork
  *

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.cpp
@@ -34,3 +34,26 @@ void QUECTEL_BG96_CellularPower::remove_device_ready_urc_cb(mbed::Callback<void(
 {
     _at.remove_urc_handler(DEVICE_READY_URC, callback);
 }
+
+nsapi_error_t QUECTEL_BG96_CellularPower::set_power_level(int func_level, int do_reset0)
+{
+    nsapi_error_t err = AT_CellularPower::set_at_mode();
+    if (err) {
+        return err;
+    }
+
+    _at.lock();
+    _at.cmd_start("AT+QURCCFG=");
+    _at.write_string("urcport");
+    _at.write_string("uart1");
+#ifndef NDEBUG
+    _at.write_string("usbat");
+    _at.write_string("usbmodem");
+#endif // NDEBUG
+    _at.cmd_stop();
+    _at.resp_start();
+    _at.resp_stop();
+    return _at.unlock_return_error();
+}
+
+

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.h
@@ -29,6 +29,7 @@ public:
 public: //from CellularPower
     virtual nsapi_error_t set_device_ready_urc_cb(mbed::Callback<void()> callback);
     virtual void remove_device_ready_urc_cb(mbed::Callback<void()> callback);
+    virtual nsapi_error_t set_power_level(int func_level, int do_reset = 0);
 };
 
 } // namespace mbed

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -69,6 +69,7 @@ typedef enum nsapi_connection_status {
     NSAPI_STATUS_GLOBAL_UP          = 1,        /*!< global IP address set */
     NSAPI_STATUS_DISCONNECTED       = 2,        /*!< no connection to network */
     NSAPI_STATUS_CONNECTING         = 3,        /*!< connecting to network */
+    NSAPI_STATUS_RECONNECTING       = 4,        /*!< reconnecting to network */
     NSAPI_STATUS_ERROR_UNSUPPORTED  = NSAPI_ERROR_UNSUPPORTED
 } nsapi_connection_status_t;
 


### PR DESCRIPTION
### Description

If cellular state machine notices that device is disconnected from the network it will no try to automatically do a reconnect.

Internal ref to defect: IOTCELL-1287

@AriParkkila please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

