### PR TITLE
NFC: fix reading from NFC EEPROM

### DIFF
--- a/features/nfc/source/nfc/NFCEEPROM.cpp
+++ b/features/nfc/source/nfc/NFCEEPROM.cpp
@@ -397,6 +397,7 @@ void NFCEEPROM::continue_read()
         _driver->read_bytes(_eeprom_address, ac_buffer_builder_write_position(buffer_builder), _ndef_buffer_read_sz - _eeprom_address);
     } else {
         // Done, close session
+        _current_op = nfc_eeprom_read_end_session;
         _operation_result = NFC_OK;
         _driver->end_session();
     }


### PR DESCRIPTION
### Description

Reading operation returns failure despite succeeding because the closing of the session fails. This happens because it's not setting the current operation at the end of reading so when session is ended successfully the event is unexpected (since it's missing the current op set correctly) and hence returns a failure despite just succeeding. This fix adds that missing assignment to the current op.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

