### PR TITLE
nrf52-ble: fix total links count

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.h
@@ -35,7 +35,7 @@ extern "C" {
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_PERIPHERAL_LINKS was used, ram settings are adjusted by the yotta target module. */
 #define PERIPHERAL_LINK_COUNT   NRF_SDH_BLE_PERIPHERAL_LINK_COUNT    /**<number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_CENTRAL_LINKS was used, ram settings are adjusted by the yotta target module. */
-#define TOTAL_LINK_COUNT        NRF_SDH_BLE_TOTAL_LINK_COUNT          /**<number of total links used by the application. When changing this number remember to adjust the RAM settings */                                                             
+#define TOTAL_LINK_COUNT        (CENTRAL_LINK_COUNT+PERIPHERAL_LINK_COUNT) /**<number of total links used by the application. When changing this number remember to adjust the RAM settings */                                                             
 #define GATTS_ATTR_TAB_SIZE     NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE /**< GATTS attribite table size. */
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF52/source/btle/btle.h
@@ -35,7 +35,7 @@ extern "C" {
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_PERIPHERAL_LINKS was used, ram settings are adjusted by the yotta target module. */
 #define PERIPHERAL_LINK_COUNT   NRF_SDH_BLE_PERIPHERAL_LINK_COUNT    /**<number of peripheral links used by the application. When changing this number remember to adjust the RAM settings*/
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_CENTRAL_LINKS was used, ram settings are adjusted by the yotta target module. */
-#define TOTAL_LINK_COUNT        (CENTRAL_LINK_COUNT+PERIPHERAL_LINK_COUNT) /**<number of total links used by the application. When changing this number remember to adjust the RAM settings */                                                             
+#define TOTAL_LINK_COUNT        NRF_SDH_BLE_TOTAL_LINK_COUNT          /**<number of total links used by the application. When changing this number remember to adjust the RAM settings */                                                             
 #define GATTS_ATTR_TAB_SIZE     NRF_SDH_BLE_GATTS_ATTR_TAB_SIZE /**< GATTS attribite table size. */
                                                                        /** If value for YOTTA_CFG_NORDIC_BLE_GATTS_ATTR_TAB_SIZE was used, ram settings are adjusted by the yotta target module. */
 

--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/mbed_lib.json
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/mbed_lib.json
@@ -11,6 +11,11 @@
             "value": "1",
             "macro_name": "NRF_SDH_BLE_PERIPHERAL_LINK_COUNT"
         },
+        "total_link_count": {
+            "help": "How many concurrent connections the system support.",
+            "value": "(NRF_SDH_BLE_CENTRAL_LINK_COUNT + NRF_SDH_BLE_PERIPHERAL_LINK_COUNT)",
+            "macro_name": "NRF_SDH_BLE_TOTAL_LINK_COUNT"
+        },
         "gatt_attr_tab_size": {
             "help": "The size of the table used to hold gatts. Can be adjusted by trial and error",
             "value": "0x600",


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

I think I found a bug about the NRF52 series. The `NRF_SDH_BLE_TOTAL_LINK_COUNT` is NOT defined in any configuration file except `sdk_config.h`. This causes the actual number of total links to be inconsistent with the definition when `central_link_count` or `peripheral_link_count` is configured via `features/FEATURE_BLE/targets/TARGET_NORDIC/mbed_lib.json`.

This PR fixes this bug and I think this is a good way. Please review.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

