### PR TITLE
ESP8266: Fix compilation error when default interface is enabled

### DIFF
--- a/components/wifi/esp8266-driver/ESP8266Interface.cpp
+++ b/components/wifi/esp8266-driver/ESP8266Interface.cpp
@@ -579,7 +579,7 @@ nsapi_connection_status_t ESP8266Interface::get_connection_status() const
 #if MBED_CONF_ESP8266_PROVIDE_DEFAULT
 
 WiFiInterface *WiFiInterface::get_default_instance() {
-    static ESP8266Interface esp();
+    static ESP8266Interface esp;
     return &esp;
 }
 


### PR DESCRIPTION
### Description
Fixes below compilation error:

```
Compile [  1.3%]: ESP8266Interface.cpp
[Error] ESP8266Interface.cpp@582,33: cannot declare static function inside another function
[Error] ESP8266Interface.cpp@583,13: cannot convert 'ESP8266Interface (*)()' to 'WiFiInterface*' in return
Failed to build library
```

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

