### PR TITLE
Cellular: Decrease the stack size of cellular thread from 0x800 to 0x500

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -597,7 +597,7 @@ nsapi_error_t CellularConnectionFSM::start_dispatch()
 {
     MBED_ASSERT(!_queue_thread);
 
-    _queue_thread = new rtos::Thread(osPriorityNormal, 2048);
+    _queue_thread = new rtos::Thread(osPriorityNormal, 0x500, NULL, "cellular_thread");
     if (!_queue_thread) {
         stop();
         return NSAPI_ERROR_NO_MEMORY;


### PR DESCRIPTION
### Description

The stack size of cellular thread decreased from 0x800 to 0x500. Also added name to the cellular thread.

Fixes Arm internal ref IOTCELL-1087.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

