### PR TITLE
Cellular: CellularDevice:get_default_instance() implemented

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -15,8 +15,8 @@
  * limitations under the License.
  */
 
-#ifndef _CELLULAR_CONNECTION_UTIL_H
-#define _CELLULAR_CONNECTION_UTIL_H
+#ifndef _CELLULAR_CONNECTION_FSM_H
+#define _CELLULAR_CONNECTION_FSM_H
 
 #include "CellularTargets.h"
 #if defined(CELLULAR_DEVICE) || defined(DOXYGEN_ONLY)
@@ -29,12 +29,10 @@
 #include "CellularNetwork.h"
 #include "CellularPower.h"
 #include "CellularSIM.h"
-#include "CellularUtil.h"
-
-// modem type is defined as CELLULAR_DEVICE macro
-#include CELLULAR_STRINGIFY(CELLULAR_DEVICE.h)
 
 namespace mbed {
+
+class CellularDevice;
 
 const int PIN_SIZE = 8;
 const int MAX_RETRY_ARRAY_SIZE = 10;
@@ -209,7 +207,7 @@ private:
 
     uint16_t _retry_timeout_array[MAX_RETRY_ARRAY_SIZE];
     int _retry_array_length;
-    events::EventQueue _at_queue;
+    events::EventQueue *_at_queue;
     char _st_string[20];
     int _event_id;
     const char *_plmn;
@@ -221,4 +219,4 @@ private:
 
 #endif // CELLULAR_DEVICE || DOXYGEN
 
-#endif /* _CELLULAR_CONNECTION_UTIL_H */
+#endif // _CELLULAR_CONNECTION_FSM_H

--- a/features/cellular/easy_cellular/EasyCellularConnection.cpp
+++ b/features/cellular/easy_cellular/EasyCellularConnection.cpp
@@ -23,7 +23,7 @@
 #endif
 
 #include "CellularConnectionFSM.h"
-#include "CellularUtil.h"
+#include "CellularDevice.h"
 
 #include "EasyCellularConnection.h"
 #include "CellularLog.h"

--- a/features/cellular/framework/API/CellularDevice.h
+++ b/features/cellular/framework/API/CellularDevice.h
@@ -18,16 +18,21 @@
 #ifndef CELLULAR_DEVICE_H_
 #define CELLULAR_DEVICE_H_
 
-#include "FileHandle.h"
+#include "CellularTargets.h"
+#include "EventQueue.h"
+#include "nsapi_types.h"
+#include "PlatformMutex.h"
 
-#include "CellularSIM.h"
-#include "CellularNetwork.h"
-#include "CellularSMS.h"
-#include "CellularPower.h"
-#include "CellularInformation.h"
-#include "NetworkStack.h"
+class NetworkStack;
 
 namespace mbed {
+
+class CellularPower;
+class CellularSMS;
+class CellularSIM;
+class CellularInformation;
+class CellularNetwork;
+class FileHandle;
 
 /**
  *  Class CellularDevice
@@ -37,6 +42,24 @@ namespace mbed {
  */
 class CellularDevice {
 public:
+
+    /** Return singleton instance of CellularDevice if CELLULAR_DEVICE is defined. If CELLULAR_DEVICE is not
+     *  defined then returns NULL. Implementation is marked as weak.
+     *
+     *  @return CellularDevice* instance if any
+     */
+    static CellularDevice *get_default_instance();
+
+    /** Get event queue that can be chained to main event queue. EventQueue is created in get_default_instance() or
+     *  given to CELLULAR_DEVICE (for example TELIT_HE910 class).
+     *  @return event queue
+     */
+    virtual events::EventQueue *get_queue() const;
+
+    /** Default constructor
+     */
+    CellularDevice();
+
     /** virtual Destructor
      */
     virtual ~CellularDevice() {}
@@ -124,6 +147,13 @@ public:
      *  @return 0 on success
      */
     virtual nsapi_error_t init_module(FileHandle *fh) = 0;
+
+protected:
+    int _network_ref_count;
+    int _sms_ref_count;
+    int _power_ref_count;
+    int _sim_ref_count;
+    int _info_ref_count;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/AT_CellularDevice.h
+++ b/features/cellular/framework/AT/AT_CellularDevice.h
@@ -20,15 +20,14 @@
 
 #include "CellularDevice.h"
 
-#include "AT_CellularNetwork.h"
-#include "AT_CellularSIM.h"
-#include "AT_CellularSMS.h"
-#include "AT_CellularPower.h"
-#include "AT_CellularInformation.h"
-
-#include "ATHandler.h"
-
 namespace mbed {
+
+class ATHandler;
+class AT_CellularInformation;
+class AT_CellularNetwork;
+class AT_CellularPower;
+class AT_CellularSIM;
+class AT_CellularSMS;
 
 /**
  *  Class AT_CellularDevice
@@ -53,6 +52,9 @@ protected:
     void release_at_handler(ATHandler *at_handler);
 
 public: // CellularDevice
+
+    virtual events::EventQueue *get_queue() const;
+
     virtual CellularNetwork *open_network(FileHandle *fh);
 
     virtual CellularSMS *open_sms(FileHandle *fh);
@@ -84,6 +86,41 @@ public: // CellularDevice
     virtual nsapi_error_t init_module(FileHandle *fh);
 
 protected:
+    /** Create new instance of AT_CellularNetwork or if overridden, modem specific implementation.
+     *
+     *  @param at   ATHandler reference for communication with the modem.
+     *  @return new instance of class AT_CellularNetwork
+     */
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+
+    /** Create new instance of AT_CellularSMS or if overridden, modem specific implementation.
+     *
+     *  @param at   ATHandler reference for communication with the modem.
+     *  @return new instance of class AT_CellularSMS
+     */
+    virtual AT_CellularSMS *open_sms_impl(ATHandler &at);
+
+    /** Create new instance of AT_CellularPower or if overridden, modem specific implementation.
+     *
+     *  @param at   ATHandler reference for communication with the modem.
+     *  @return new instance of class AT_CellularPower
+     */
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
+
+    /** Create new instance of AT_CellularSIM or if overridden, modem specific implementation.
+     *
+     *  @param at   ATHandler reference for communication with the modem.
+     *  @return new instance of class AT_CellularSIM
+     */
+    virtual AT_CellularSIM *open_sim_impl(ATHandler &at);
+
+    /** Create new instance of AT_CellularInformation or if overridden, modem specific implementation.
+     *
+     *  @param at   ATHandler reference for communication with the modem.
+     *  @return new instance of class AT_CellularInformation
+     */
+    virtual AT_CellularInformation *open_information_impl(ATHandler &at);
+
     AT_CellularNetwork *_network;
     AT_CellularSMS *_sms;
     AT_CellularSIM *_sim;

--- a/features/cellular/framework/device/CellularDevice.cpp
+++ b/features/cellular/framework/device/CellularDevice.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CellularDevice.h"
+#include "EventQueue.h"
+#include "CellularUtil.h"
+
+#ifdef CELLULAR_DEVICE
+#include CELLULAR_STRINGIFY(CELLULAR_DEVICE.h)
+#endif // CELLULAR_DEVICE
+
+namespace mbed {
+
+#ifdef CELLULAR_DEVICE
+MBED_WEAK CellularDevice *CellularDevice::get_default_instance()
+{
+    static events::EventQueue event_queue(4 * EVENTS_EVENT_SIZE);
+    static CELLULAR_DEVICE device(event_queue);
+    return &device;
+}
+#else
+MBED_WEAK CellularDevice *CellularDevice::get_default_instance()
+{
+    return NULL;
+}
+#endif // CELLULAR_DEVICE
+
+CellularDevice::CellularDevice() : _network_ref_count(0), _sms_ref_count(0), _power_ref_count(0), _sim_ref_count(0),
+        _info_ref_count(0)
+{
+}
+
+events::EventQueue *CellularDevice::get_queue() const
+{
+    return NULL;
+}
+
+}

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.cpp
@@ -32,18 +32,9 @@ GEMALTO_CINTERION::~GEMALTO_CINTERION()
 {
 }
 
-CellularNetwork *GEMALTO_CINTERION::open_network(FileHandle *fh)
+AT_CellularNetwork *GEMALTO_CINTERION::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new GEMALTO_CINTERION_CellularNetwork(*get_at_handler(fh));
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new GEMALTO_CINTERION_CellularNetwork(at);
 }
 
 nsapi_error_t GEMALTO_CINTERION::init_module(FileHandle *fh)

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.h
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION.h
@@ -28,8 +28,9 @@ public:
     GEMALTO_CINTERION(events::EventQueue &queue);
     virtual ~GEMALTO_CINTERION();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+public:
     virtual nsapi_error_t init_module(FileHandle *fh);
 };
 

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.cpp
@@ -39,44 +39,17 @@ QUECTEL_BC95::~QUECTEL_BC95()
 {
 }
 
-CellularNetwork *QUECTEL_BC95::open_network(FileHandle *fh)
+AT_CellularNetwork *QUECTEL_BC95::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new QUECTEL_BC95_CellularNetwork(*atHandler);
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new QUECTEL_BC95_CellularNetwork(at);
 }
 
-CellularPower *QUECTEL_BC95::open_power(FileHandle *fh)
+AT_CellularPower *QUECTEL_BC95::open_power_impl(ATHandler &at)
 {
-    if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = new QUECTEL_BC95_CellularPower(*atHandler);
-            if (!_power) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _power;
+    return new QUECTEL_BC95_CellularPower(at);
 }
 
-CellularSIM *QUECTEL_BC95::open_sim(FileHandle *fh)
+AT_CellularSIM *QUECTEL_BC95::open_sim_impl(ATHandler &at)
 {
-    if (!_sim) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _sim = new QUECTEL_BC95_CellularSIM(*atHandler);
-            if (!_sim) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _sim;
+    return new QUECTEL_BC95_CellularSIM(at);
 }

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.h
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95.h
@@ -24,14 +24,13 @@ namespace mbed {
 
 class QUECTEL_BC95 : public AT_CellularDevice {
 public:
-
     QUECTEL_BC95(events::EventQueue &queue);
     virtual ~QUECTEL_BC95();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
-    virtual CellularSIM *open_sim(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
+    virtual AT_CellularSIM *open_sim_impl(ATHandler &at);
 
 public: // NetworkInterface
     void handle_urc(FileHandle *fh);

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.cpp
@@ -43,16 +43,7 @@ QUECTEL_BG96::~QUECTEL_BG96()
 {
 }
 
-CellularNetwork *QUECTEL_BG96::open_network(FileHandle *fh)
+AT_CellularNetwork *QUECTEL_BG96::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new QUECTEL_BG96_CellularNetwork(*atHandler);
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new QUECTEL_BG96_CellularNetwork(at);
 }

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96.h
@@ -24,12 +24,11 @@ namespace mbed {
 
 class QUECTEL_BG96 : public AT_CellularDevice {
 public:
-
     QUECTEL_BG96(events::EventQueue &queue);
     virtual ~QUECTEL_BG96();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
 
 public: // NetworkInterface
     void handle_urc(FileHandle *fh);

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.cpp
@@ -37,24 +37,12 @@ QUECTEL_UG96::~QUECTEL_UG96()
 {
 }
 
-CellularNetwork *QUECTEL_UG96::open_network(FileHandle *fh)
+AT_CellularNetwork *QUECTEL_UG96::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        _network = new QUECTEL_UG96_CellularNetwork(*get_at_handler(fh));
-    }
-    return _network;
+    return new QUECTEL_UG96_CellularNetwork(at);
 }
 
-CellularPower *QUECTEL_UG96::open_power(FileHandle *fh)
+AT_CellularPower *QUECTEL_UG96::open_power_impl(ATHandler &at)
 {
-    if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = new QUECTEL_UG96_CellularPower(*atHandler);
-            if (!_power) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _power;
+    return new QUECTEL_UG96_CellularPower(at);
 }

--- a/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.h
+++ b/features/cellular/framework/targets/QUECTEL/UG96/QUECTEL_UG96.h
@@ -32,13 +32,12 @@ namespace mbed {
 
 class QUECTEL_UG96 : public AT_CellularDevice {
 public:
-
     QUECTEL_UG96(events::EventQueue &queue);
     virtual ~QUECTEL_UG96();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
 
 public: // NetworkInterface
     void handle_urc(FileHandle *fh);

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.cpp
@@ -36,32 +36,14 @@ TELIT_HE910::~TELIT_HE910()
 {
 }
 
-CellularPower *TELIT_HE910::open_power(FileHandle *fh)
+AT_CellularNetwork *TELIT_HE910::open_network_impl(ATHandler &at)
 {
-    if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = new TELIT_HE910_CellularPower(*atHandler);
-            if (!_power) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _power;
+    return new TELIT_HE910_CellularNetwork(at);
 }
 
-CellularNetwork *TELIT_HE910::open_network(FileHandle *fh)
+AT_CellularPower *TELIT_HE910::open_power_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new TELIT_HE910_CellularNetwork(*atHandler);
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new TELIT_HE910_CellularPower(at);
 }
 
 uint16_t TELIT_HE910::get_send_delay()

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.h
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910.h
@@ -26,14 +26,15 @@
 namespace mbed {
 
 class TELIT_HE910 : public AT_CellularDevice {
-
 public:
     TELIT_HE910(events::EventQueue &queue);
     virtual ~TELIT_HE910();
 
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
+
 public: // from CellularDevice
-    virtual CellularPower *open_power(FileHandle *fh);
-    virtual CellularNetwork *open_network(FileHandle *fh);
     virtual uint16_t get_send_delay();
 };
 } // namespace mbed

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.cpp
@@ -30,30 +30,12 @@ UBLOX_AT::~UBLOX_AT()
 {
 }
 
-CellularNetwork *UBLOX_AT::open_network(FileHandle *fh)
+AT_CellularNetwork *UBLOX_AT::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new UBLOX_AT_CellularNetwork(*atHandler);
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new UBLOX_AT_CellularNetwork(at);
 }
 
-CellularPower *UBLOX_AT::open_power(FileHandle *fh)
+AT_CellularPower *UBLOX_AT::open_power_impl(ATHandler &at)
 {
-    if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = new UBLOX_AT_CellularPower(*atHandler);
-            if (!_power) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _power;
+    return new UBLOX_AT_CellularPower(at);
 }

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.h
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT.h
@@ -23,16 +23,14 @@
 namespace mbed
 {
 
-class UBLOX_AT : public AT_CellularDevice
-{
-
+class UBLOX_AT : public AT_CellularDevice {
 public:
     UBLOX_AT(events::EventQueue &queue);
     virtual ~UBLOX_AT();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
 
 public: // NetworkInterface
     void handle_urc(FileHandle *fh);

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.cpp
@@ -30,30 +30,12 @@ UBLOX_PPP::~UBLOX_PPP()
 {
 }
 
-CellularNetwork *UBLOX_PPP::open_network(FileHandle *fh)
+AT_CellularNetwork *UBLOX_PPP::open_network_impl(ATHandler &at)
 {
-    if (!_network) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _network = new UBLOX_PPP_CellularNetwork(*atHandler);
-            if (!_network) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _network;
+    return new UBLOX_PPP_CellularNetwork(at);
 }
 
-CellularPower *UBLOX_PPP::open_power(FileHandle *fh)
+AT_CellularPower *UBLOX_PPP::open_power_impl(ATHandler &at)
 {
-    if (!_power) {
-        ATHandler *atHandler = get_at_handler(fh);
-        if (atHandler) {
-            _power = new UBLOX_PPP_CellularPower(*get_at_handler(fh));
-            if (!_power) {
-                release_at_handler(atHandler);
-            }
-        }
-    }
-    return _power;
+    return new UBLOX_PPP_CellularPower(at);
 }

--- a/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
+++ b/features/cellular/framework/targets/UBLOX/PPP/UBLOX_PPP.h
@@ -23,14 +23,13 @@
 namespace mbed {
 
 class UBLOX_PPP : public AT_CellularDevice {
-
 public:
     UBLOX_PPP(events::EventQueue &queue);
     virtual ~UBLOX_PPP();
 
-public: // CellularDevice
-    virtual CellularNetwork *open_network(FileHandle *fh);
-    virtual CellularPower *open_power(FileHandle *fh);
+protected: // AT_CellularDevice
+    virtual AT_CellularNetwork *open_network_impl(ATHandler &at);
+    virtual AT_CellularPower *open_power_impl(ATHandler &at);
 };
 
 MBED_DEPRECATED_SINCE("mbed-os-5.9", "This API will be deprecated, Use UBLOX_PPP instead of UBLOX_LISA_U.")


### PR DESCRIPTION
### Description

Implemented CellularDevice:get_default_instance().
Removed copy-paste code from targets by creating implementation methods to override.

Internal ref to defect: IOTCELL-1284

@AriParkkila @kjbracey-arm please review.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

