### PR TITLE
Fix memory reservation for Softdevice in NRF52_DK

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_ARM_STD/nRF52832.sct
@@ -9,13 +9,13 @@
   #define MBED_APP_SIZE 0x80000
 #endif
 
-/* If app_start is 0, do not set aside space for the softdevice */
-#if MBED_APP_START == 0
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x10000
-#else
+/* If softdevice is present, set aside space for it */
+#if defined(SOFTDEVICE_PRESENT)
   #define MBED_RAM_START  0x200031D0
   #define MBED_RAM_SIZE   0xCE30
+#else
+  #define MBED_RAM_START  0x20000000
+  #define MBED_RAM_SIZE   0x10000
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_GCC_ARM/NRF52832.ld
@@ -25,13 +25,13 @@
   #define MBED_APP_SIZE 0x80000
 #endif
 
-/* If app_start is 0, do not set aside space for the softdevice */
-#if MBED_APP_START == 0
-  #define MBED_RAM_START  0x20000000
-  #define MBED_RAM_SIZE   0x10000
-#else
+/* If softdevice is present, set aside space for it */
+#if defined(SOFTDEVICE_PRESENT)
   #define MBED_RAM_START  0x200031D0
   #define MBED_RAM_SIZE   0xCE30
+#else
+  #define MBED_RAM_START  0x20000000
+  #define MBED_RAM_SIZE   0x10000
 #endif
 
 #define MBED_RAM0_START MBED_RAM_START

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52832/device/TOOLCHAIN_IAR/nRF52832.icf
@@ -11,13 +11,13 @@ if (!isdefinedsymbol(MBED_APP_SIZE)) {
     define symbol MBED_APP_SIZE = 0x80000;
 }
 
-/* If app_start is 0, do not set aside space for the softdevice */
-if (MBED_APP_START == 0) {
-  define symbol MBED_RAM_START = 0x20000000;
-  define symbol MBED_RAM_SIZE  = 0x10000;
-} else {
+/* If softdevice is present, set aside space for it */
+if (isdefinedsymbol(SOFTDEVICE_PRESENT)) {
   define symbol MBED_RAM_START = 0x200031D0;
   define symbol MBED_RAM_SIZE  = 0xCE30;
+} else {
+  define symbol MBED_RAM_START = 0x20000000;
+  define symbol MBED_RAM_SIZE  = 0x10000;
 }
 
 define symbol MBED_RAM0_START = MBED_RAM_START;

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -706,8 +706,8 @@ class mbedToolchain:
             self._add_defines_from_region(region)
             if region.active:
                 for define in [
-                        ("%s_START" % active_region_name, region.start),
-                        ("%s_SIZE" % active_region_name, region.size)
+                        ("%s_START" % active_region_name, "0x%x" % region.start),
+                        ("%s_SIZE" % active_region_name, "0x%x" % region.size)
                 ]:
                     define_string = self.make_ld_define(*define)
                     self.ld.append(define_string)
@@ -747,6 +747,11 @@ class mbedToolchain:
         self.config_data = config_data
         # new configuration data can change labels, so clear the cache
         self.labels = None
+        # pass info about softdevice presence to linker (see NRF52)
+        if "SOFTDEVICE_PRESENT" in config_data[1]:
+            define_string = self.make_ld_define("SOFTDEVICE_PRESENT", config_data[1]["SOFTDEVICE_PRESENT"].macro_value)
+            self.ld.append(define_string)
+            self.flags["ld"].append(define_string)
         self.add_regions()
 
     # Creates the configuration header if needed:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -325,7 +325,7 @@ class ARM(mbedToolchain):
 
     @staticmethod
     def make_ld_define(name, value):
-        return "--predefine=\"-D%s=0x%x\"" % (name, value)
+        return "--predefine=\"-D%s=%s\"" % (name, value)
 
     @staticmethod
     def redirect_symbol(source, sync, build_dir):
@@ -426,7 +426,7 @@ class ARMC6(ARM_STD):
             self.flags["ld"] += ["--import_cmse_lib_out=%s" % secure_file]
         # Add linking time preprocessor macro __DOMAIN_NS
         if target.core == "Cortex-M23-NS" or self.target.core == "Cortex-M33-NS":
-            define_string = self.make_ld_define("__DOMAIN_NS", 1)
+            define_string = self.make_ld_define("__DOMAIN_NS", "0x1")
             self.flags["ld"].append(define_string)
 
         asm_cpu = {

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -293,7 +293,7 @@ class GCC(mbedToolchain):
 
     @staticmethod
     def make_ld_define(name, value):
-        return "-D%s=0x%x" % (name, value)
+        return "-D%s=%s" % (name, value)
 
     @staticmethod
     def redirect_symbol(source, sync, build_dir):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -273,7 +273,7 @@ class IAR(mbedToolchain):
 
     @staticmethod
     def make_ld_define(name, value):
-        return "--config_def %s=0x%x" % (name, value)
+        return "--config_def %s=%s" % (name, value)
 
     @staticmethod
     def redirect_symbol(source, sync, build_dir):


### PR DESCRIPTION
### Description

The current system checks mbed app start trying to check whether softdevice is in use or not during linking. This doesn't work when bootloader is in use, so softdevice existence needs to be explicitly injected to linker scripts.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
