### PR TITLE
Use high resolution time for Timer::read().

### DIFF
--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -79,7 +79,7 @@ int Timer::read_us()
 
 float Timer::read()
 {
-    return (float)read_us() / 1000000.0f;
+    return (float)read_high_resolution_us() / 1000000.0f;
 }
 
 int Timer::read_ms()


### PR DESCRIPTION
### Description

`float Timer::read()` delegates to `Timer::read_us()`, which returns an `int`, i.e. a signed 32-bit value capable of storing values up to 2147483647 us (the use of signed types in this interface has always bothered me, but that's outside the scope of this PR). Therefore, `Timer::read()` will return values up to  ~2147.5f seconds, or 35.8 minutes, even though the `float` return type could represent a much higher range (3.402823e+38 seconds, at reduced precision, of course).

By contrast, `int Timer::read_ms()` returns `read_high_resolution_us() / 1000`, so the maximum (signed) value is 2147483647 ms, or more than 24 days (if I haven't made a mistake).

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

