### PR TITLE
Cellular: state machine and easycellular now return error fast if sim…

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -161,7 +161,15 @@ bool CellularConnectionFSM::open_sim()
     // here you could add wait(secs) if you know start delay of your SIM
     if (_sim->get_sim_state(state) != NSAPI_ERROR_OK) {
         tr_info("Waiting for SIM (err while reading)...");
+        if (_event_status_cb) {
+            _event_status_cb((nsapi_event_t)CellularSIMStatusChanged, state);
+        }
         return false;
+    }
+
+    // report current state so callback can set sim pin if needed
+    if (_event_status_cb) {
+        _event_status_cb((nsapi_event_t)CellularSIMStatusChanged, state);
     }
 
     if (state == CellularSIM::SimStatePinNeeded) {
@@ -172,12 +180,11 @@ bool CellularConnectionFSM::open_sim()
                 tr_error("SIM pin set failed with: %d, bailing out...", err);
             }
         } else {
-            tr_warn("PIN required but No SIM pin provided.");
+            // No sim pin provided even it's needed, stop state machine
+            tr_error("PIN required but No SIM pin provided.");
+            _retry_count = MAX_RETRY_ARRAY_SIZE;
+            return false;
         }
-    }
-
-    if (_event_status_cb) {
-        _event_status_cb((nsapi_event_t)CellularSIMStatusChanged, state);
     }
 
     return state == CellularSIM::SimStateReady;

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -168,6 +168,7 @@ private:
 
     bool _is_connected;
     bool _is_initialized;
+    bool _stm_error;
 #if USE_APN_LOOKUP
     bool _credentials_set;
 #endif // #if USE_APN_LOOKUP


### PR DESCRIPTION
… pin needed but not provided.

### Description

State machine and easycellular now return error fast if sim pin needed but not provided.
In earlier implementation state machine tried to enter pin multiple times even no pin was provided.

Internal ref to defect: IOTCELL-1320

@AriParkkila please review

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

