### PR TITLE
Using SPI_ macros from PinNames in SPIF and SD config files.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
@@ -1,10 +1,10 @@
 {
     "name": "dataflash",
     "config": {
-        "SPI_MOSI": "NC",
-        "SPI_MISO": "NC",
-        "SPI_CLK":  "NC",
-        "SPI_CS":   "NC",
+        "SPI_MOSI": "SPI_MOSI",
+        "SPI_MISO": "SPI_MISO",
+        "SPI_CLK":  "SPI_SCK",
+        "SPI_CS":   "SPI_PERSISTENT_MEM_CS",
         "SPI_FREQ": "40000000",
         "binary-size": {
             "help": "Configure device to use binary address space.",

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/mbed_lib.json
@@ -4,7 +4,7 @@
         "SPI_MOSI": "SPI_MOSI",
         "SPI_MISO": "SPI_MISO",
         "SPI_CLK":  "SPI_SCK",
-        "SPI_CS":   "SPI_PERSISTENT_MEM_CS",
+        "SPI_CS":   "SPI_CS",
         "SPI_FREQ": "40000000",
         "binary-size": {
             "help": "Configure device to use binary address space.",

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -1,7 +1,7 @@
 {
     "name": "sd",
     "config": {
-        "SPI_CS": "SPI_PERSISTENT_MEM_CS",
+        "SPI_CS": "SPI_CS",
         "SPI_MOSI": "SPI_MOSI",
         "SPI_MISO": "SPI_MISO",
         "SPI_CLK": "SPI_SCK",

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -1,11 +1,10 @@
 {
     "name": "sd",
     "config": {
-        "SPI_CS": "NC",
-        "SPI_MOSI": "NC",
-        "SPI_MISO": "NC",
-        "SPI_CLK": "NC",
-        "DEVICE_SPI": 1,
+        "SPI_CS": "SPI_PERSISTENT_MEM_CS",
+        "SPI_MOSI": "SPI_MOSI",
+        "SPI_MISO": "SPI_MISO",
+        "SPI_CLK": "SPI_SCK",
         "FSFAT_SDCARD_INSTALLED": 1,
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
@@ -59,12 +58,6 @@
              "SPI_MISO": "PTD7",
              "SPI_CLK":  "PTD5",
              "SPI_CS":   "PTD4"
-        },
-        "K64F": {
-             "SPI_MOSI": "PTE3",
-             "SPI_MISO": "PTE1",
-             "SPI_CLK":  "PTE2",
-             "SPI_CS":   "PTE4"
         },
         "K66F": {
              "SPI_MOSI": "PTE3",
@@ -216,5 +209,6 @@
              "SPI_CLK":  "PC_10",
              "SPI_CS":   "PA_15"
         }
+        
     }
 }

--- a/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
@@ -1,19 +1,13 @@
 {
     "name": "spif-driver",
     "config": {
-        "SPI_MOSI": "NC",
-        "SPI_MISO": "NC",
-        "SPI_CLK":  "NC",
-        "SPI_CS":   "NC",
+        "SPI_MOSI": "SPI_MOSI",
+        "SPI_MISO": "SPI_MISO",
+        "SPI_CLK":  "SPI_SCK",
+        "SPI_CS":   "SPI_PERSISTENT_MEM_CS",
         "SPI_FREQ": "40000000"
     },
     "target_overrides": {
-        "K82F": {
-            "SPI_MOSI": "PTE2",
-            "SPI_MISO": "PTE4",
-            "SPI_CLK":  "PTE1",
-            "SPI_CS":   "PTE5"
-        },
         "LPC54114": {
             "SPI_MOSI": "P0_20",
             "SPI_MISO": "P0_18",

--- a/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SPIF/mbed_lib.json
@@ -4,7 +4,7 @@
         "SPI_MOSI": "SPI_MOSI",
         "SPI_MISO": "SPI_MISO",
         "SPI_CLK":  "SPI_SCK",
-        "SPI_CS":   "SPI_PERSISTENT_MEM_CS",
+        "SPI_CS":   "SPI_CS",
         "SPI_FREQ": "40000000"
     },
     "target_overrides": {

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/PinNames.h
@@ -176,7 +176,7 @@ typedef enum {
     SPI_MOSI    = PTE2,
     SPI_MISO    = PTE4,
     SPI_SCK     = PTE1,
-    SPI_PERSISTENT_MEM_CS = PTE5,
+    SPI_CS      = PTE5,
 
     /**** QSPI FLASH pins ****/
     QSPI_FLASH1_IO0 = PTE2,

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PinNames.h
@@ -246,7 +246,7 @@ typedef enum {
     SPI_MOSI    = PTE3,
     SPI_MISO    = PTE1,
     SPI_SCK     = PTE2,
-    SPI_PERSISTENT_MEM_CS = PTE4,
+    SPI_CS      = PTE4,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/PinNames.h
@@ -218,7 +218,7 @@ typedef enum {
     SPI_MOSI   = PTE3,
     SPI_MISO   = PTE1,
     SPI_SCK    = PTE2,
-    SPI_PERSISTENT_MEM_CS = PTE4,
+    SPI_CS     = PTE4,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_RAPIDIOT/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_RAPIDIOT/PinNames.h
@@ -227,7 +227,7 @@ typedef enum {
     SPI_MOSI    = PTC6,
     SPI_MISO    = PTC7,
     SPI_SCK     = PTC5,
-    SPI_PERSISTENT_MEM_CS = PTC4,
+    SPI_CS      = PTC4,
 
     DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
     // Not connected


### PR DESCRIPTION


### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Now after PR #7774 merged the following pins add been added to mbed-os:
SPI_MOSI
SPI_MISO
SPI_SCK
SPI_PERSISTENT_MEM_CS

This PR is created in order to start using them in the new components block devices configuration file.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

