### PR TITLE
BLE: fix missing updates sent callback in GattServer using Cordio stack

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -624,6 +624,8 @@ ble_error_t GattServer::write(
     // successful
     uint16_t conn_id = 0;
     uint16_t conn_found = 0;
+    size_t updates_sent = 0;
+
     while((conn_found < DM_CONN_MAX) && (conn_id < CONNECTION_ID_LIMIT)) {
         if (DmConnInUse(conn_id) == true) {
             ++conn_found;
@@ -631,13 +633,19 @@ ble_error_t GattServer::write(
                 uint16_t cccd_config = AttsCccEnabled(conn_id, cccd_index);
                 if (cccd_config & ATT_CLIENT_CFG_NOTIFY) {
                     AttsHandleValueNtf(conn_id, att_handle, len, (uint8_t*)buffer);
+                    updates_sent++;
                 }
                 if (cccd_config & ATT_CLIENT_CFG_INDICATE) {
                     AttsHandleValueInd(conn_id, att_handle, len, (uint8_t*)buffer);
+                    updates_sent++;
                 }
             }
         }
         ++conn_id;
+    }
+
+    if (updates_sent) {
+        handleDataSentEvent(updates_sent);
     }
 
     return BLE_ERROR_NONE;

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -682,14 +682,22 @@ ble_error_t GattServer::write(
     }
 
     // This characteristic has a CCCD attribute. Handle notifications and indications.
+    size_t updates_sent = 0;
+
     if (is_update_authorized(connection, att_handle)) {
         uint16_t cccEnabled = AttsCccEnabled(connection, cccd_index);
         if (cccEnabled & ATT_CLIENT_CFG_NOTIFY) {
             AttsHandleValueNtf(connection, att_handle, len, (uint8_t*)buffer);
+            updates_sent++;
         }
         if (cccEnabled & ATT_CLIENT_CFG_INDICATE) {
             AttsHandleValueInd(connection, att_handle, len, (uint8_t*)buffer);
+            updates_sent++;
         }
+    }
+
+    if (updates_sent) {
+        handleDataSentEvent(updates_sent);
     }
 
     return BLE_ERROR_NONE;


### PR DESCRIPTION
### Description

Calling onDataSent registers a callback to be notified of updates sent. Cordio implementation of the GattServer doesn't call this callback. This adds the call.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

