### PR TITLE
LoRaWAN: Memory overrun correction

### DIFF
--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -220,7 +220,7 @@ LoRaPHYCN470::LoRaPHYCN470()
     }
 
     // Initialize the channels default mask
-    for (uint8_t i = 0; i < CN470_MAX_NB_CHANNELS; i++) {
+    for (uint8_t i = 0; i < CN470_CHANNEL_MASK_SIZE; i++) {
         default_channel_mask[i] = 0xFFFF & fsb_mask[i];
     }
 


### PR DESCRIPTION


### Description

A typo in LoRaPHYCN470 is causing memory overrun.
We were supposed to fill-in default channel mask and iterate over CN470_CHANNEL_MASK_SIZE times.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

