### PR TITLE
Unittesting: Update mutex stub

### DIFF
--- a/UNITTESTS/stubs/Mutex_stub.cpp
+++ b/UNITTESTS/stubs/Mutex_stub.cpp
@@ -27,7 +27,12 @@ rtos::Mutex::~Mutex()
     return;
 }
 
-osStatus rtos::Mutex::lock(unsigned int)
+osStatus rtos::Mutex::lock(void)
+{
+    return osOK;
+}
+
+osStatus rtos::Mutex::lock(uint32_t millisec)
 {
     return osOK;
 }


### PR DESCRIPTION
### Description

Fix linker error by updating rtos::Mutex::lock() in `UNITTESTS/stubs/Mutex_stub.cpp`.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

