### PR TITLE
M2351: Fix STDIO_UART error

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PeripheralNames.h
@@ -163,7 +163,7 @@ typedef enum {
 #endif
 
     // NOTE: board-specific
-    STDIO_UART  = UART_3
+    STDIO_UART  = UART_0
 
 } UARTName;
 


### PR DESCRIPTION
### Description

This PR corrects **STDIO_UART** from **UART_3** to **UART_0**. With on-board ESP8266 module connection through **UART_3**,  program using on-board ESP8266 module would meet error with this issue.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

