### PR TITLE
DISCO_L475VG_IOT01A remove old QSPI pins

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
@@ -240,14 +240,6 @@ typedef enum {
     SPI_SCK     = D13,
     SPI_CS      = D10,
     PWM_OUT     = D9,
-#ifdef DEVICE_QSPI
-    QSPI_PIN_IO0 = PE_12,
-    QSPI_PIN_IO1 = PE_13,
-    QSPI_PIN_IO2 = PE_14,
-    QSPI_PIN_IO3 = PE_15,
-    QSPI_PIN_SCK = PE_10,
-    QSPI_PIN_CSN = PE_11,
-#endif
 
     /**** USB pins ****/
     USB_OTG_FS_DM = PA_11,


### PR DESCRIPTION
### Description

clean up old QSPI pins names for DISCO_L475VG_IOT01A
QSPI_PIN_XXX was replaced by QSPI_FLASHn_XXX

### Pull request type

    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Breaking change

