### PR TITLE
Fix TCPSocket::accept()

### DIFF
--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -265,7 +265,7 @@ TCPSocket *TCPSocket::accept(nsapi_error_t *error)
         ret = _stack->socket_accept(_socket, &socket, &address);
 
         if (0 == ret) {
-            TCPSocket *connection = new TCPSocket();
+            connection = new TCPSocket();
             connection->_lock.lock();
             connection->_factory_allocated = true; // Destroy automatically on close()
             connection->_remote_peer = address;


### PR DESCRIPTION
### Description

TCPSocket::accept() was actually always return NULL, and unsted because we only
have tests with one device.

We will add the testcase for this soon.

This fixes #7936

@kjbracey-arm please review

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

