### PR TITLE
Fix EFM32 pwmout hal function pwmout_period

### DIFF
--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
@@ -302,7 +302,7 @@ void pwmout_period(pwmout_t *obj, float seconds)
     }
 
     //Check if anything changed
-    if(((PWM_TIMER->CTRL & ~_TIMER_CTRL_PRESC_MASK) == (pwm_prescaler_div << _TIMER_CTRL_PRESC_SHIFT)) && (TIMER_TopGet(PWM_TIMER) == cycles)) return;
+    if(((PWM_TIMER->CTRL & _TIMER_CTRL_PRESC_MASK) == (pwm_prescaler_div << _TIMER_CTRL_PRESC_SHIFT)) && (TIMER_TopGet(PWM_TIMER) == cycles)) return;
 
     //Save previous period for recalculation of duty cycles
     uint32_t previous_period_cycles = PWM_TIMER->TOPB;


### PR DESCRIPTION
### Description

In pwmout_period() of the EFM32 pwmout_api.c is a check for changed values, which is not working correctly because of a wrongly used bitmask. This has been fixed.

With the wrong bitmask, it was not possible to do things like...:

pwmout_init(PB11);
pwmout_period_us(100);
--- use of pwm channel ---
pwm_free();
--- we want to use another pin now ---
pwmout_init(PB12);
pwmout_period_us(100);

The Problem occurs on the second call of pwmout_period_us() ... the check for changed values would evaluate to TRUE, and the frequency would not be changed to 10kHz ... instead the standard frequency of 50Hz would be effective.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

