### PR TITLE
Reverting PinNames.h after PR #7774 changes

### DIFF
--- a/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_K20XX/TARGET_K20D50M/PinNames.h
@@ -236,11 +236,6 @@ typedef enum {
 
     TSI_ELEC0 = PTB16,
     TSI_ELEC1 = PTB17,
-    
-    SPI_MOSI = PTD2,
-    SPI_MISO = PTD3,
-    SPI_CLK  = PTD1,
-    SPI_PERSISTENT_MEM_CS = PTC2,
 
     // Not connected
     NC = (int)0xFFFFFFFF

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/PinNames.h
@@ -236,11 +236,6 @@ typedef enum {
     TSI_ELEC0 = PTB16,
     TSI_ELEC1 = PTB17,
 
-    SPI_MOSI    = PTD2,
-    SPI_MISO    = PTD3,
-    SPI_SCK     = PTD1,
-    SPI_PERSISTENT_MEM_CS = PTD0,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/PinNames.h
@@ -242,11 +242,6 @@ typedef enum {
     TSI_ELEC0 = PTB16,
     TSI_ELEC1 = PTB17,
 
-    SPI_MOSI    = PTD6,
-    SPI_MISO    = PTD7,
-    SPI_SCK     = PTD5,
-    SPI_PERSISTENT_MEM_CS = PTD4,
-    
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/PinNames.h
@@ -242,11 +242,6 @@ typedef enum {
 
     DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
 
-    SPI_MOSI    = PTE3,
-    SPI_MISO    = PTE1,
-    SPI_SCK     = PTE2,
-    SPI_PERSISTENT_MEM_CS = PTE4,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/PinNames.h
@@ -134,11 +134,6 @@ typedef enum {
     A4 = PTC2,
     A5 = PTC1,
 
-    SPI_MOSI    = PTD6,
-    SPI_MISO    = PTD7,
-    SPI_SCK     = PTD5,
-    SPI_PERSISTENT_MEM_CS = PTD4,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/PinNames.h
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/PinNames.h
@@ -243,11 +243,6 @@ typedef enum {
     
     DAC0_OUT = 0xFEFE, /* DAC does not have Pin Name in RM */
 
-    SPI_MOSI    = PTD6,
-    SPI_MISO    = PTD7,
-    SPI_SCK     = PTD5,
-    SPI_PERSISTENT_MEM_CS = PTD4,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/PinNames.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/TARGET_MCU_NRF52840/TARGET_NRF52840_DK/PinNames.h
@@ -197,11 +197,6 @@ typedef enum {
     SPIS_PSELMISO = P1_3,
     SPIS_PSELSS   = P1_1,
     SPIS_PSELSCK  = P1_4,
-    
-    SPI_MOSI   = p20,
-    SPI_MISO   = p21,
-    SPI_SCK    = p19,
-    SPI_PERSISTENT_MEM_CS = p17,
 
     I2C_SDA0 = p26,
     I2C_SCL0 = p27,

--- a/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M451/PinNames.h
@@ -128,11 +128,6 @@ typedef enum {
     SW2 = PA_15,
     SW3 = PA_14,
     
-    SPI_MOSI    = PD_13,
-    SPI_MISO    = PD_14,
-    SPI_SCK     = PD_15,
-    SPI_PERSISTENT_MEM_CS = PD_12,
-    
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -128,11 +128,6 @@ typedef enum {
     SW2 = PG_15,
     SW3 = PF_11,
     
-    SPI_MOSI    = D11,
-    SPI_MISO    = D12,
-    SPI_SCK     = D13,
-    SPI_PERSISTENT_MEM_CS = D10,
-    
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/PinNames.h
@@ -131,11 +131,6 @@ typedef enum {
     SW1 = PC_12,
     SW2 = PC_13,
     
-    SPI_MOSI    = PF_0,
-    SPI_MISO    = PD_15,
-    SPI_SCK     = PD_14,
-    SPI_PERSISTENT_MEM_CS = PD_13,
-    
 } PinName;
 
 #ifdef __cplusplus

--- a/targets/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
@@ -148,11 +148,6 @@ typedef enum {
     SDSCLK = P1_29,
     SDSSEL = P1_12,
     
-    SPI_MOSI    = SDMOSI,
-    SPI_MISO    = SDMISO,
-    SPI_SCK     = SDSCLK,
-    SPI_PERSISTENT_MEM_CS = SDSSEL,
-    
     // Not connected
     NC = (int)0xFFFFFFFF,
 } PinName;

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_MBED_LPC1768/PinNames.h
@@ -149,12 +149,6 @@ typedef enum {
     I2C_SDA2 = P0_10, // pin used by application board
     I2C_SCL = I2C_SCL2,
     I2C_SDA = I2C_SDA2,
-    
-    SPI_MOSI   = p5,
-    SPI_MISO   = p6,
-    SPI_SCK    = p7,
-    SPI_PERSISTENT_MEM_CS = p8
-    
 } PinName;
 
 typedef enum {

--- a/targets/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
@@ -117,11 +117,6 @@ typedef enum {
     I2C_SCL = D15,
     I2C_SDA = D14,
 
-    SPI_MOSI   = p5,
-    SPI_MISO   = p6,
-    SPI_SCK    = p7,
-    SPI_PERSISTENT_MEM_CS = p8,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/PinNames.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC54114/TARGET_LPCXpresso/PinNames.h
@@ -128,13 +128,7 @@ typedef enum {
     A2 = P1_8,
     A3 = P1_10,
     A4 = P1_4,
-    A5 = P1_5,
-    
-    SPI_MOSI   = P0_20,
-    SPI_MISO   = P0_18,
-    SPI_SCK    = P0_19,
-    SPI_PERSISTENT_MEM_CS = P1_2
-    
+    A5 = P1_5
 } PinName;
 
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/PinNames.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/PinNames.h
@@ -89,11 +89,6 @@ typedef enum {
     // Standardized button names
     BUTTON1 = USER_BUTTON0,
 
-    SPI_MOSI   = P5_6,
-    SPI_MISO   = P5_7,
-    SPI_SCK    = P5_4,
-    SPI_PERSISTENT_MEM_CS = P5_5,
-
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_RTL8195A/PinNames.h
@@ -216,9 +216,7 @@ typedef enum {
     D15         = PB_2,
     D16         = PA_1,
     D17         = PA_0,
-    D18         = PE_5,
-    
-    SPI_PERSISTENT_MEM_CS = D9
+    D18         = PE_5
 
 } PinName;
 

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/PinNames.h
@@ -228,7 +228,6 @@ typedef enum {
     SPI_MISO    = PA_6,
     SPI_SCK     = PA_5,
     SPI_CS      = PB_6,
-    SPI_PERSISTENT_MEM_CS = PB_6,
     PWM_OUT     = PB_3,
 
     /**** OSCILLATOR pins ****/

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/PinNames.h
@@ -186,12 +186,9 @@ typedef enum {
     SPI_MOSI    = SPI1_MOSI,
     SPI_MISO    = SPI1_MISO,
     SPI_SCK     = SPI1_SCK,
-    
     SPI_CS1     = PA_3, //LCD CS
     SPI_CS2     = PA_15, //SD Card CS
 
-    SPI_PERSISTENT_MEM_CS = SPI_CS2,
-    
     SERIAL_TX   = PA_2,
     SERIAL_RX   = PA_3,
     SERIAL_RTS  = PA_0,

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_MTB_MXCHIP_EMW3166/PinNames.h
@@ -219,7 +219,6 @@ typedef enum {
     SPI_MISO    = P_7,
     SPI_SCK     = P_6,
     SPI_CS      = P_5,
-    SPI_PERSISTENT_MEM_CS = P_33,
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/TARGET_USI_WM_BN_BM_22/PinNames.h
@@ -271,7 +271,6 @@ typedef enum {
     SPI_MISO    = P_25,
     SPI_SCK     = P_24,
     SPI_CS      = P_22,
-    SPI_PERSISTENT_MEM_CS = P_36,
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/TARGET_UBLOX_C030/PinNames.h
@@ -151,8 +151,6 @@ typedef enum {
     SPI_MISO    = D12,
     SPI_CLK     = D13,
     SPI_NSS     = D10,
-    SPI_PERSISTENT_MEM_CS = SPI_NSS,
-    
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_MTB_UBLOX_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_MTB_UBLOX_ODIN_W2/PinNames.h
@@ -176,7 +176,6 @@ typedef enum {
     SPI_MISO   = SPI0_MISO,
     SPI_SCK    = SPI0_SCK,
     SPI_CS     = SPI0_CS,
-    SPI_PERSISTENT_MEM_CS = PG_4,
 
     // STDIO for console print
 #ifdef MBED_CONF_TARGET_STDIO_UART_TX

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/TARGET_UBLOX_EVK_ODIN_W2/PinNames.h
@@ -167,13 +167,12 @@ typedef enum {
     SPI0_SCK     = D13,
     SPI0_CS      = D10,
     SPI1_CS      = D9,
-    
 
     SPI_MOSI   = SPI0_MOSI,
     SPI_MISO   = SPI0_MISO,
     SPI_SCK    = SPI0_SCK,
     SPI_CS     = SPI0_CS,
-    SPI_PERSISTENT_MEM_CS = SPI_CS,
+
 
     // Standardized button names
     BUTTON1    = SW0,

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
@@ -133,7 +133,6 @@ typedef enum {
     SPI_MISO    = PB_4,
     SPI_SCK     = PB_3,
     SPI_CS      = PA_11,
-    SPI_PERSISTENT_MEM_CS = PA_11,
     PWM_OUT     = PB_0,
 
     /**** OSCILLATOR pins ****/

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/TARGET_DISCO_L475VG_IOT01A/PinNames.h
@@ -239,7 +239,6 @@ typedef enum {
     SPI_MISO    = D12,
     SPI_SCK     = D13,
     SPI_CS      = D10,
-    SPI_PERSISTENT_MEM_CS = D10,
     PWM_OUT     = D9,
 #ifdef DEVICE_QSPI
     QSPI_PIN_IO0 = PE_12,

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/TARGET_NUCLEO_L476RG/PinNames.h
@@ -208,7 +208,6 @@ typedef enum {
     SPI_MISO    = PA_6,
     SPI_SCK     = PA_5,
     SPI_CS      = PB_6,
-    SPI_PERSISTENT_MEM_CS = PB_6,
     PWM_OUT     = PB_3,
 
     /**** USB pins ****/

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/TARGET_MTB_ADV_WISE_1570/PinNames.h
@@ -124,8 +124,7 @@ typedef enum {
     SPI_SCK         = PA_5,
     SPI_CS0         = PA_4,
     SPI_CS          = SPI_CS0,
-    SPI_PERSISTENT_MEM_CS = PB_12,
-    
+
     I2C1_SDA        = PB_11,
     I2C1_SCL        = PB_10,
 

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/TARGET_TB_SENSE_12/PinNames.h
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFR32MG12/TARGET_TB_SENSE_12/PinNames.h
@@ -74,13 +74,7 @@ typedef enum {
 
     /* Board Controller */
     STDIO_UART_TX = USBTX,
-    STDIO_UART_RX = USBRX,
-    
-    SPI_MOSI   = PC6,
-    SPI_MISO   = PC7,
-    SPI_SCK    = PC8,
-    SPI_PERSISTENT_MEM_CS = PC9
-    
+    STDIO_UART_RX = USBRX
 } PinName;
 
 #ifdef __cplusplus


### PR DESCRIPTION

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
In PR #7774 we have changed PinNames.h for various targets. Unfortunately, this was a mistake and those changes should not be done by us. Therefore this PR initiate a revert for those file. 
We will open a discussion with the relevant stakeholders to enable this change in the future.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

