### PR TITLE
Add * operator to SingletonPtr

### DIFF
--- a/platform/SingletonPtr.h
+++ b/platform/SingletonPtr.h
@@ -113,6 +113,16 @@ struct SingletonPtr {
         return get();
     }
 
+    /** Get a reference to the underlying singleton
+     *
+     * @returns
+     *   A reference to the singleton
+     */
+    T &operator*()
+    {
+        return *get();
+    }
+
     // This is zero initialized when in global scope
     T *_ptr;
     // Force data to be 4 byte aligned


### PR DESCRIPTION
### Description

Sometimes you want don't want to directly call a method on your `SingletonPtr`-wrapped object, but you want to pass it to something else.

For example

    SingletonPtr<PlatformMutex> mutex;
    mutex->lock();

is fine, but what about

    SingletonPtr<PlatformMutex> mutex;
    ScopedLock<PlatformMutex> lock(*mutex.get());

Add an overload for `operator*` to make this more elegant:

    SingletonPtr<PlatformMutex> mutex;
    ScopedLock<PlatformMutex> lock(*mutex);

This addition is consistent with standard C++ classes such as `unique_ptr` and `shared_ptr`, which likewise have `get`, `operator->` and `operator*`.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

Change originally proposed and discussed as part of #7924, now separated out.