### PR TITLE
Storage: Add required header file and namespace element instead add all

### DIFF
--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "BufferedBlockDevice.h"
-#include "mbed_assert.h"
-#include "mbed_critical.h"
+#include "platform/mbed_assert.h"
+#include "platform/mbed_critical.h"
 #include <algorithm>
 #include <string.h>
 

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "ChainingBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
 
 
 ChainingBlockDevice::ChainingBlockDevice(BlockDevice **bds, size_t bd_count)

--- a/features/storage/blockdevice/ChainingBlockDevice.h
+++ b/features/storage/blockdevice/ChainingBlockDevice.h
@@ -23,8 +23,8 @@
 #define MBED_CHAINING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
-
+#include "platform/mbed_assert.h"
+#include <stdlib.h>
 
 /** Block device for chaining multiple block devices
  *  with the similar block sizes at sequential addresses
@@ -45,8 +45,7 @@
  *  ChainingBlockDevice chainmem(bds);
  *  @endcode
  */
-class ChainingBlockDevice : public BlockDevice
-{
+class ChainingBlockDevice : public BlockDevice {
 public:
     /** Lifetime of the memory block device
      *
@@ -178,6 +177,5 @@ protected:
     uint32_t _init_ref_count;
     bool _is_initialized;
 };
-
 
 #endif

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -15,9 +15,8 @@
  */
 
 #include "ExhaustibleBlockDevice.h"
-#include "mbed.h"
-#include "mbed_critical.h"
-
+#include "platform/mbed_critical.h"
+#include "platform/mbed_assert.h"
 
 ExhaustibleBlockDevice::ExhaustibleBlockDevice(BlockDevice *bd, uint32_t erase_cycles)
     : _bd(bd), _erase_array(NULL), _erase_cycles(erase_cycles), _init_ref_count(0), _is_initialized(false)

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -15,8 +15,8 @@
  */
 
 #include "FlashSimBlockDevice.h"
-#include "mbed_assert.h"
-#include "mbed_critical.h"
+#include "platform/mbed_assert.h"
+#include "platform/mbed_critical.h"
 #include <algorithm>
 #include <stdlib.h>
 #include <string.h>

--- a/features/storage/blockdevice/HeapBlockDevice.cpp
+++ b/features/storage/blockdevice/HeapBlockDevice.cpp
@@ -15,7 +15,7 @@
  */
 
 #include "HeapBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
 
 
 HeapBlockDevice::HeapBlockDevice(bd_size_t size, bd_size_t block)

--- a/features/storage/blockdevice/HeapBlockDevice.h
+++ b/features/storage/blockdevice/HeapBlockDevice.h
@@ -23,8 +23,9 @@
 #define MBED_MEM_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
-
+#include "platform/mbed_assert.h"
+#include <string.h>
+#include <stdlib.h>
 
 /** Lazily allocated heap-backed block device
  *

--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -15,9 +15,11 @@
  */
 
 #include "MBRBlockDevice.h"
-#include "mbed_critical.h"
+#include "platform/mbed_critical.h"
+#include "platform/mbed_toolchain.h"
+#include "platform/mbed_assert.h"
 #include <algorithm>
-
+#include <string.h>
 
 // On disk structures, all entries are little endian
 MBED_PACKED(struct) mbr_entry {

--- a/features/storage/blockdevice/MBRBlockDevice.h
+++ b/features/storage/blockdevice/MBRBlockDevice.h
@@ -23,7 +23,6 @@
 #define MBED_MBR_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
 
 
 /** Additional error codes used for MBR records

--- a/features/storage/blockdevice/ObservingBlockDevice.cpp
+++ b/features/storage/blockdevice/ObservingBlockDevice.cpp
@@ -22,7 +22,6 @@
 
 #include "ObservingBlockDevice.h"
 #include "ReadOnlyBlockDevice.h"
-#include "mbed.h"
 
 
 ObservingBlockDevice::ObservingBlockDevice(BlockDevice *bd)
@@ -36,7 +35,7 @@ ObservingBlockDevice::~ObservingBlockDevice()
     // Does nothing
 }
 
-void ObservingBlockDevice::attach(Callback<void(BlockDevice *)> cb)
+void ObservingBlockDevice::attach(mbed::Callback<void(BlockDevice *)> cb)
 {
     _change = cb;
 }

--- a/features/storage/blockdevice/ObservingBlockDevice.h
+++ b/features/storage/blockdevice/ObservingBlockDevice.h
@@ -23,8 +23,8 @@
 #define MBED_OBSERVING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "PlatformMutex.h"
-#include "Callback.h"
+#include "platform/PlatformMutex.h"
+#include "platform/Callback.h"
 
 
 class ObservingBlockDevice : public BlockDevice

--- a/features/storage/blockdevice/ProfilingBlockDevice.h
+++ b/features/storage/blockdevice/ProfilingBlockDevice.h
@@ -23,7 +23,6 @@
 #define MBED_PROFILING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
 
 
 /** Block device for measuring storage operations of another block device

--- a/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
+++ b/features/storage/blockdevice/ReadOnlyBlockDevice.cpp
@@ -23,7 +23,6 @@
 #include "ReadOnlyBlockDevice.h"
 #include "mbed_error.h"
 
-
 ReadOnlyBlockDevice::ReadOnlyBlockDevice(BlockDevice *bd)
     : _bd(bd)
 {

--- a/features/storage/blockdevice/SlicingBlockDevice.h
+++ b/features/storage/blockdevice/SlicingBlockDevice.h
@@ -23,8 +23,7 @@
 #define MBED_SLICING_BLOCK_DEVICE_H
 
 #include "BlockDevice.h"
-#include "mbed.h"
-
+#include "platform/mbed_assert.h"
 
 /** Block device for mapping to a slice of another block device
  *

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -29,6 +29,8 @@
 #include <errno.h>
 ////// Error handling /////
 
+using namespace mbed;
+
 static int fat_error_remap(FRESULT res)
 {
     switch(res) {

--- a/features/storage/filesystem/littlefs/LittleFileSystem.cpp
+++ b/features/storage/filesystem/littlefs/LittleFileSystem.cpp
@@ -20,6 +20,8 @@
 #include "lfs_util.h"
 #include "MbedCRC.h"
 
+using namespace mbed;
+
 extern "C" void lfs_crc(uint32_t *crc, const void *buffer, size_t size)
 {
     uint32_t initial_xor = *crc;    

--- a/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
+++ b/features/storage/nvstore/TESTS/nvstore/functionality/main.cpp
@@ -510,7 +510,7 @@ static void nvstore_multi_thread_test()
         if (!threads[i]) {
             goto mem_fail;
         }
-        threads[i]->start(callback(thread_test_worker));
+        threads[i]->start(mbed::callback(thread_test_worker));
     }
 
     wait_ms(thr_test_num_secs * 1000);
@@ -635,7 +635,7 @@ static void nvstore_race_test()
         }
         delete[] dummy;
 
-        threads[i]->start(callback(race_test_worker, (void *) buffs[i]));
+        threads[i]->start(mbed::callback(race_test_worker, (void *) buffs[i]));
         threads[i]->join();
     }
 


### PR DESCRIPTION
### Description

Source inside mbed-os should not be using "mbed.h" even in CPP files, instead required header file and namespace should be explicitly added inside mbed-os

With #7760 PR, we will give an option to remove namespace.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

