### PR TITLE
BLE: fix whitelist generation (set correct address type)

### DIFF
--- a/features/FEATURE_BLE/ble/generic/SecurityDb.h
+++ b/features/FEATURE_BLE/ble/generic/SecurityDb.h
@@ -603,7 +603,7 @@ public:
                 sizeof(BLEProtocol::AddressBytes_t)
             );
 
-            if (flags->peer_address_is_public) {
+            if (identity->identity_address_is_public) {
                 whitelist->addresses[whitelist->size].type = BLEProtocol::AddressType::PUBLIC;
             } else {
                 whitelist->addresses[whitelist->size].type = BLEProtocol::AddressType::RANDOM_STATIC;


### PR DESCRIPTION
### Description

Whitelist generation creates a list of addresses based on the existing bonds. The addresses can be of different types but the only way to identify a random address from a public address is through a separate bit of information (not contained in the address). During whitelist generation the wrong address type was read and creating the whitelist resulted in the wrong type of address being written.

Was read:
type of address connected to
should be read:
type of *identity* address

Bug was detected by existing test SM_whitelist_generation_test_01 (which are not yet part of CI).

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

