### PR TITLE
SD - Add required header file and namespace element instead add all

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -142,15 +142,6 @@
 #include "mbed_debug.h"
 #include <errno.h>
 
-/* Required version: 5.9.0 and above */
-#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5
-#if (MBED_VERSION < MBED_ENCODE_VERSION(5,9,0))
-#error "Incompatible mbed-os version detected! Required 5.9.0 and above"
-#endif
-#else
-#warning "mbed-os version 5.9.0 or above required"
-#endif
-
 #ifndef MBED_CONF_SD_CMD_TIMEOUT
 #define MBED_CONF_SD_CMD_TIMEOUT                 5000   /*!< Timeout in ms for response */
 #endif

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -139,7 +139,8 @@
 #ifdef DEVICE_SPI
 
 #include "SDBlockDevice.h"
-#include "mbed_debug.h"
+#include "platform/mbed_debug.h"
+#include "platform/mbed_wait_api.h"
 #include <errno.h>
 
 #ifndef MBED_CONF_SD_CMD_TIMEOUT

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -21,7 +21,11 @@
 #ifdef DEVICE_SPI
 
 #include "BlockDevice.h"
-#include "mbed.h"
+#include "drivers/SPI.h"
+#include "drivers/Timer.h"
+#include "drivers/MbedCRC.h"
+#include "drivers/DigitalOut.h"
+#include "platform/platform.h"
 #include "platform/PlatformMutex.h"
 
 /** SDBlockDevice class
@@ -177,10 +181,10 @@ private:
     bool _is_valid_trim(bd_addr_t addr, bd_size_t size);
 
     /* SPI functions */
-    Timer _spi_timer;               /**< Timer Class object used for busy wait */
+    mbed::Timer _spi_timer;               /**< Timer Class object used for busy wait */
     uint32_t _init_sck;             /**< Intial SPI frequency */
     uint32_t _transfer_sck;         /**< SPI frequency during data transfer/after initialization */
-    SPI _spi;                       /**< SPI Class object */
+    mbed::SPI _spi;                       /**< SPI Class object */
 
     /* SPI initialization function */
     void _spi_init();
@@ -195,7 +199,7 @@ private:
     int _freq(void);
 
     /* Chip Select and SPI mode select */
-    DigitalOut _cs;
+    mbed::DigitalOut _cs;
     void _select();
     void _deselect();
 
@@ -217,8 +221,8 @@ private:
     bool _crc_on;
     uint32_t _init_ref_count;
 
-    MbedCRC<POLY_7BIT_SD, 7> _crc7;
-    MbedCRC<POLY_16BIT_CCITT, 16> _crc16;
+    mbed::MbedCRC<POLY_7BIT_SD, 7> _crc7;
+    mbed::MbedCRC<POLY_16BIT_CCITT, 16> _crc16;
 };
 
 #endif  /* DEVICE_SPI */


### PR DESCRIPTION
### Description

Source inside mbed-os should not be using "mbed.h" even in CPP files, instead required header file and namespace should be explicitly added inside mbed-os

With #7760 PR, we will give an option to remove namespace.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

