### PR TITLE
Add required header file and namespace element instead add all

### DIFF
--- a/TESTS/lorawan/loraradio/main.cpp
+++ b/TESTS/lorawan/loraradio/main.cpp
@@ -38,6 +38,7 @@
 
 
 using namespace utest::v1;
+using namespace mbed;
 
 static LoRaRadio *radio = NULL;
 rtos::Semaphore event_sem(0);

--- a/TESTS/mbed_platform/FileHandle/TestFile.h
+++ b/TESTS/mbed_platform/FileHandle/TestFile.h
@@ -18,14 +18,13 @@
 
 #include "platform/FileHandle.h"
 
-
 #define POS_IS_VALID(pos) (pos >= 0 && pos < _end)
 #define NEW_POS_IS_VALID(pos) (pos >= 0 && pos < (int32_t)FILE_SIZE)
 #define SEEK_POS_IS_VALID(pos) (pos >= 0 && pos <= _end)
 #define INVALID_POS (-1)
 
 template<uint32_t FILE_SIZE>
-class TestFile : public FileHandle {
+class TestFile : public mbed::FileHandle {
 public:
     TestFile(): _pos(0), _end(0) {}
     ~TestFile() {}

--- a/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
@@ -18,6 +18,7 @@
 #include "utest.h"
 #include "SPIFBlockDevice.h"
 #include "mbed_trace.h"
+#include "rtos/Thread.h"
 #include <stdlib.h>
 
 using namespace utest::v1;

--- a/features/device_key/TESTS/device_key/functionality/main.cpp
+++ b/features/device_key/TESTS/device_key/functionality/main.cpp
@@ -25,6 +25,7 @@
 #endif
 
 using namespace utest::v1;
+using namespace mbed;
 
 #define MSG_VALUE_DUMMY "0"
 #define MSG_VALUE_LEN 32

--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -36,6 +36,7 @@ typedef struct {
 
 #include "rtos/Mutex.h"
 #include "rtos/Thread.h"
+#include "rtos/Kernel.h"
 #include "mbed_stats.h"
 #include "cmsis_os2.h"
 #include "platform/SingletonPtr.h"

--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -15,8 +15,6 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
-#include "rtos.h"
 #include "mbed_stats.h"
 #include "cmsis_os2.h"
 #include "greentea-client/test_env.h"

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -18,7 +18,6 @@
 #include <ctype.h>
 #include <cstdio>
 #include <string.h>
-#include "mbed.h"
 #include "greentea-client/test_env.h"
 #include "greentea-client/greentea_serial.h"
 #include "greentea-client/greentea_metrics.h"

--- a/features/frameworks/utest/mbed-utest-shim.cpp
+++ b/features/frameworks/utest/mbed-utest-shim.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include "mbed.h"
 #include "mbed_critical.h"
 #include "utest/utest.h"
 

--- a/features/frameworks/utest/source/utest_shim.cpp
+++ b/features/frameworks/utest/source/utest_shim.cpp
@@ -58,7 +58,9 @@ utest_v1_scheduler_t utest_v1_get_scheduler()
 #ifdef YOTTA_MBED_HAL_VERSION_STRING
 #   include "mbed-hal/us_ticker_api.h"
 #else
-#   include "mbed.h"
+#include "platform/SingletonPtr.h"
+#include "Timeout.h"
+using mbed::Timeout;
 #endif
 
 // only one callback is active at any given time

--- a/features/frameworks/utest/source/utest_stack_trace.cpp
+++ b/features/frameworks/utest/source/utest_stack_trace.cpp
@@ -17,7 +17,6 @@
 #ifdef UTEST_STACK_TRACE
  
 #include "greentea-client/test_env.h"
-#include "mbed.h"
 #include "utest/utest.h"
 #include "unity/unity.h"
 #include "utest/utest_stack_trace.h"

--- a/features/frameworks/utest/utest/utest_scheduler.h
+++ b/features/frameworks/utest/utest/utest_scheduler.h
@@ -22,7 +22,7 @@
 #ifndef UTEST_SCHEDULER_H
 #define UTEST_SCHEDULER_H
 
-#include "mbed.h"
+#include "hal/ticker_api.h"
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdio.h>

--- a/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/LoWPANNDInterface.cpp
@@ -35,7 +35,7 @@ Nanostack::LoWPANNDInterface *LoWPANNDInterface::get_interface() const
 nsapi_error_t LoWPANNDInterface::do_initialize()
 {
     if (!_interface) {
-        _interface = new (nothrow) Nanostack::LoWPANNDInterface(*_phy);
+        _interface = new (std::nothrow) Nanostack::LoWPANNDInterface(*_phy);
         if (!_interface) {
             return NSAPI_ERROR_NO_MEMORY;
         }

--- a/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
@@ -138,7 +138,7 @@ int8_t EMACPhy::phy_register()
         phy.phy_tx_done_cb = NULL;
 
         emac.set_memory_manager(memory_manager);
-        emac.set_link_input_cb(callback(this, &EMACPhy::emac_phy_rx));
+        emac.set_link_input_cb(mbed::callback(this, &EMACPhy::emac_phy_rx));
 
         if (!emac.power_up()) {
             return -1;
@@ -183,7 +183,7 @@ nsapi_error_t Nanostack::add_ethernet_interface(EMAC &emac, bool default_if, Nan
         return NSAPI_ERROR_DEVICE_ERROR;
     }
 
-    single_phy = new (nothrow) EMACPhy(this->memory_manager, emac);
+    single_phy = new (std::nothrow) EMACPhy(this->memory_manager, emac);
     if (!single_phy) {
         return NSAPI_ERROR_NO_MEMORY;
     }
@@ -194,7 +194,7 @@ nsapi_error_t Nanostack::add_ethernet_interface(EMAC &emac, bool default_if, Nan
 
     Nanostack::EthernetInterface *interface;
 
-    interface = new (nothrow) Nanostack::EthernetInterface(*single_phy);
+    interface = new (std::nothrow) Nanostack::EthernetInterface(*single_phy);
     if (!interface) {
         return NSAPI_ERROR_NO_MEMORY;
     }

--- a/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEMACInterface.cpp
@@ -2,12 +2,11 @@
  * Copyright (c) 2017 ARM Limited. All rights reserved.
  */
 
-#include "Nanostack.h"
 #include "NanostackEthernetInterface.h"
 #include "NanostackEthernetPhy.h"
-#include "EMAC.h"
 #include "nsdynmemLIB.h"
 #include "arm_hal_phy.h"
+#include "EMAC.h"
 
 class EMACPhy : public NanostackEthernetPhy
 {

--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -38,7 +38,7 @@ nsapi_error_t NanostackEthernetInterface::initialize(NanostackEthernetPhy *phy)
         return NSAPI_ERROR_PARAMETER;
     }
 
-    _interface = new (nothrow) Nanostack::EthernetInterface(*phy);
+    _interface = new (std::nothrow) Nanostack::EthernetInterface(*phy);
     if (!_interface) {
         return NSAPI_ERROR_NO_MEMORY;
     }

--- a/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/ThreadInterface.cpp
@@ -79,7 +79,7 @@ Nanostack::ThreadInterface *ThreadInterface::get_interface() const
 nsapi_error_t ThreadInterface::do_initialize()
 {
     if (!_interface) {
-        _interface = new (nothrow) Nanostack::ThreadInterface(*_phy);
+        _interface = new (std::nothrow) Nanostack::ThreadInterface(*_phy);
         if (!_interface) {
             return NSAPI_ERROR_NO_MEMORY;
         }

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
@@ -17,11 +17,17 @@
 // Include before mbed.h to properly get UINT*_C()
 #include "ns_types.h"
 
-#include "mbed.h"
 #include "platform/SingletonPtr.h"
 #include "platform/arm_hal_timer.h"
 #include "platform/arm_hal_interrupt.h"
-#include <mbed_assert.h>
+#include "platform/mbed_assert.h"
+#include "Timeout.h"
+#include "Timer.h"
+#include "events/Event.h"
+#include "events/mbed_shared_queues.h"
+
+using namespace mbed;
+using namespace events;
 
 static SingletonPtr<Timer> timer;
 static SingletonPtr<Timeout> timeout;

--- a/features/nanostack/nanostack-interface/Nanostack.cpp
+++ b/features/nanostack/nanostack-interface/Nanostack.cpp
@@ -17,8 +17,6 @@
 
 /* Nanostack implementation of NetworkSocketAPI */
 
-#include "mbed.h"
-#include "rtos.h"
 #include "Nanostack.h"
 #include "NanostackLockGuard.h"
 

--- a/features/nanostack/nanostack-interface/Nanostack.h
+++ b/features/nanostack/nanostack-interface/Nanostack.h
@@ -18,7 +18,6 @@
 #ifndef NANOSTACK_H_
 #define NANOSTACK_H_
 
-#include "mbed.h"
 #include "OnboardNetworkStack.h"
 #include "NanostackMemoryManager.h"
 #include "MeshInterface.h"

--- a/features/netsocket/EMACInterface.cpp
+++ b/features/netsocket/EMACInterface.cpp
@@ -15,6 +15,7 @@
  */
 
 #include "EMACInterface.h"
+using namespace mbed;
 
 /* Interface implementation */
 EMACInterface::EMACInterface(EMAC &emac, OnboardNetworkStack &stack) :

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -18,7 +18,6 @@
 #define EMAC_INTERFACE_H
 
 #include "nsapi.h"
-#include "rtos.h"
 #include "EMAC.h"
 #include "OnboardNetworkStack.h"
 

--- a/features/netsocket/EthernetInterface.h
+++ b/features/netsocket/EthernetInterface.h
@@ -18,7 +18,6 @@
 #define ETHERNET_INTERFACE_H
 
 #include "nsapi.h"
-#include "rtos.h"
 #include "EMACInterface.h"
 
 

--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -15,7 +15,8 @@
  */
 
 #include "TCPServer.h"
-#include "mbed.h"
+
+using mbed::Callback;
 
 TCPServer::TCPServer()
 {

--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -18,6 +18,8 @@
 #include "utest/utest.h"
 #include "BlockDevice.h"
 #include "FileSystem.h"
+
+#include <stdlib.h>
 #if COMPONENT_SPIF
 #include "SPIFBlockDevice.h"
 #include "LittleFileSystem.h"
@@ -32,6 +34,7 @@
 #endif
 
 using namespace utest::v1;
+using namespace mbed;
 
 static const size_t small_buf_size = 10;
 static const size_t medium_buf_size = 250;


### PR DESCRIPTION
### Description

Source inside mbed-os should not be using "mbed.h" even in CPP files, instead required header file and namespace should be explicitly added inside mbed-os

With #7760 PR, we will give an option to remove namespace.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

