### PR TITLE
LPC1768: Enable RTC

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -243,7 +243,7 @@
         "extra_labels": ["NXP", "LPC176X", "MBED_LPC1768", "NXP_EMAC"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
         "detect_code": ["1010"],
-        "device_has": ["USTICKER", "ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "EMAC", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
+        "device_has": ["RTC", "USTICKER", "ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "EMAC", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
         "device_name": "LPC1768",
         "bootloader_supported": true,


### PR DESCRIPTION
### Description
Enable RTC on LPC1768. Passed the RTC tests, results below:

mbedgt: greentea test automation tool ver. 1.4.0
mbedgt: test specification file '.\BUILD\tests\LPC1768\IAR\test_spec.json' (specified with --test-spec option)
mbedgt: using '.\BUILD\tests\LPC1768\IAR\test_spec.json' from current directory!
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 2 devices
mbedgt: processing target 'LPC1768' toolchain 'IAR' compatible platforms... (note: switch set to --parallel 1)
mbedgt: test case filter (specified with -n option)
        mbed-os-tests-mbed_hal-rtc*
        test filtered in 'mbed-os-tests-mbed_hal-rtc_time_conv'
        test filtered in 'mbed-os-tests-mbed_hal-rtc_reset'
        test filtered in 'mbed-os-tests-mbed_hal-rtc'
        test filtered in 'mbed-os-tests-mbed_hal-rtc_time'
mbedgt: running 4 tests for platform 'LPC1768' and toolchain 'IAR'
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 101000000000000000000002F7F2171F717c989aaee5786d06004ba75cb79c0b
mbedgt: test suite 'mbed-os-tests-mbed_hal-rtc_time_conv' ............................................ OK in 41.54 sec
        test case: 'test make time and local time - RTC leap years full support' ..................... OK in 11.93 sec
        test case: 'test make time and local time - RTC leap years partial support' .................. OK in 11.62 sec
mbedgt: test case summary: 2 passes, 0 failures
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test case summary event not found
        no test case report present, assuming test suite to be a single test case!
        test suite: mbed-os-tests-mbed_hal-rtc_reset
        test case: mbed-os-tests-mbed_hal-rtc_reset
mbedgt: test on hardware with target id: 101000000000000000000002F7F2171F717c989aaee5786d06004ba75cb79c0b
mbedgt: test suite 'mbed-os-tests-mbed_hal-rtc_reset' ................................................ OK in 23.06 sec
        test case: 'mbed-os-tests-mbed_hal-rtc_reset' ................................................ OK in 23.06 sec
mbedgt: test case summary: 1 pass, 0 failures
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 101000000000000000000002F7F2171F717c989aaee5786d06004ba75cb79c0b
mbedgt: test suite 'mbed-os-tests-mbed_hal-rtc' ...................................................... OK in 53.04 sec
        test case: 'RTC - accuracy' .................................................................. OK in 10.03 sec
        test case: 'RTC - enabled' ................................................................... OK in 0.05 sec
        test case: 'RTC - glitch' .................................................................... OK in 4.03 sec
        test case: 'RTC - init' ...................................................................... OK in 0.05 sec
        test case: 'RTC - persist' ................................................................... OK in 4.04 sec
        test case: 'RTC - range' ..................................................................... OK in 16.05 sec
        test case: 'RTC - write/read' ................................................................ OK in 0.04 sec
mbedgt: test case summary: 7 passes, 0 failures
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 101000000000000000000002F7F2171F717c989aaee5786d06004ba75cb79c0b
mbedgt: test suite 'mbed-os-tests-mbed_hal-rtc_time' ................................................. OK in 53.33 sec
        test case: 'RTC - accuracy' .................................................................. OK in 10.03 sec
        test case: 'RTC - enabled' ................................................................... OK in 0.05 sec
        test case: 'RTC - glitch' .................................................................... OK in 4.03 sec
        test case: 'RTC - init' ...................................................................... OK in 0.04 sec
        test case: 'RTC - persist' ................................................................... OK in 4.05 sec
        test case: 'RTC - range' ..................................................................... OK in 16.04 sec
        test case: 'RTC - write/read' ................................................................ OK in 0.05 sec
mbedgt: test case summary: 7 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.9782313111
mbedgt: test suite report:
+-------------+---------------+--------------------------------------+--------+--------------------+-------------+
| target      | platform_name | test suite                           | result | elapsed_time (sec) | copy_method |
+-------------+---------------+--------------------------------------+--------+--------------------+-------------+
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | OK     | 53.04              | default     |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_reset     | OK     | 23.06              | default     |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | OK     | 53.33              | default     |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time_conv | OK     | 41.54              | default     |
+-------------+---------------+--------------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 4 OK
mbedgt: test case report:
+-------------+---------------+--------------------------------------+--------------------------------------------------
--------------+--------+--------+--------+--------------------+
| target      | platform_name | test suite                           | test case
              | passed | failed | result | elapsed_time (sec) |
+-------------+---------------+--------------------------------------+--------------------------------------------------
--------------+--------+--------+--------+--------------------+
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - accuracy
              | 1      | 0      | OK     | 10.03              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - enabled
              | 1      | 0      | OK     | 0.05               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - glitch
              | 1      | 0      | OK     | 4.03               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - init
              | 1      | 0      | OK     | 0.05               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - persist
              | 1      | 0      | OK     | 4.04               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - range
              | 1      | 0      | OK     | 16.05              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc           | RTC - write/read
              | 1      | 0      | OK     | 0.04               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_reset     | mbed-os-tests-mbed_hal-rtc_reset
              | 1      | 0      | OK     | 23.06              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - accuracy
              | 1      | 0      | OK     | 10.03              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - enabled
              | 1      | 0      | OK     | 0.05               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - glitch
              | 1      | 0      | OK     | 4.03               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - init
              | 1      | 0      | OK     | 0.04               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - persist
              | 1      | 0      | OK     | 4.05               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - range
              | 1      | 0      | OK     | 16.04              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time      | RTC - write/read
              | 1      | 0      | OK     | 0.05               |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time_conv | test make time and local time - RTC leap years fu
ll support    | 1      | 0      | OK     | 11.93              |
| LPC1768-IAR | LPC1768       | mbed-os-tests-mbed_hal-rtc_time_conv | test make time and local time - RTC leap years pa
rtial support | 1      | 0      | OK     | 11.62              |
+-------------+---------------+--------------------------------------+--------------------------------------------------
--------------+--------+--------+--------+--------------------+
mbedgt: test case results: 17 OK


### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

