### PR TITLE
NXP: Update serial driver's parity handling

### DIFF
--- a/targets/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11U6X/serial_api.c
@@ -266,7 +266,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
                     (parity == ParityForced1) || (parity == ParityForced0));
         data_bits -= 5;
     
-        int parity_enable, parity_select;
+        int parity_enable = 0, parity_select = 0;
         switch (parity) {
             case ParityNone: parity_enable = 0; parity_select = 0; break;
             case ParityOdd : parity_enable = 1; parity_select = 0; break;
@@ -274,7 +274,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
             case ParityForced1: parity_enable = 1; parity_select = 2; break;
             case ParityForced0: parity_enable = 1; parity_select = 3; break;
             default:
-                return;
+                break;
         }
         
         obj->uart->LCR = data_bits       << 0

--- a/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC11XX_11CXX/serial_api.c
@@ -193,7 +193,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;
@@ -201,7 +201,6 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         case ParityForced1: parity_enable = 1; parity_select = 2; break;
         case ParityForced0: parity_enable = 1; parity_select = 3; break;
         default:
-            parity_enable = 0, parity_select = 0;
             break;
     }
     

--- a/targets/TARGET_NXP/TARGET_LPC13XX/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC13XX/serial_api.c
@@ -196,7 +196,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;

--- a/targets/TARGET_NXP/TARGET_LPC15XX/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC15XX/serial_api.c
@@ -203,7 +203,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 7;
     
-    int paritysel;
+    int paritysel = 0;
     switch (parity) {
         case ParityNone: paritysel = 0; break;
         case ParityEven: paritysel = 2; break;

--- a/targets/TARGET_NXP/TARGET_LPC176X/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/serial_api.c
@@ -256,7 +256,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;
@@ -264,7 +264,6 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         case ParityForced1: parity_enable = 1; parity_select = 2; break;
         case ParityForced0: parity_enable = 1; parity_select = 3; break;
         default:
-            parity_enable = 0, parity_select = 0;
             break;
     }
 

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/serial_api.c
@@ -219,7 +219,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;

--- a/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/serial_api.c
@@ -206,7 +206,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;

--- a/targets/TARGET_NXP/TARGET_LPC43XX/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC43XX/serial_api.c
@@ -264,7 +264,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     }
     data_bits -= 5;
 
-    int parity_enable, parity_select;
+    int parity_enable = 0, parity_select = 0;
     switch (parity) {
         case ParityNone: parity_enable = 0; parity_select = 0; break;
         case ParityOdd : parity_enable = 1; parity_select = 0; break;
@@ -272,8 +272,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         case ParityForced1: parity_enable = 1; parity_select = 2; break;
         case ParityForced0: parity_enable = 1; parity_select = 3; break;
         default:
-            error("Invalid serial parity setting");
-            return;
+            break;
     }
     
     obj->uart->LCR = data_bits            << 0

--- a/targets/TARGET_NXP/TARGET_LPC81X/serial_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC81X/serial_api.c
@@ -188,7 +188,7 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
     stop_bits -= 1;
     data_bits -= 7;
     
-    int paritysel;
+    int paritysel = 0;
     switch (parity) {
         case ParityNone: paritysel = 0; break;
         case ParityEven: paritysel = 2; break;


### PR DESCRIPTION
### Description
This is a fix for issue 6305. This fix set the default parity value to NONE.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

