### PR TITLE
IOTCORE-389 - bring back legacy alignment for Arm C6

### DIFF
--- a/tools/profiles/debug.json
+++ b/tools/profiles/debug.json
@@ -23,7 +23,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--verbose", "--remove", "--show_full_path"]
+        "ld": ["--verbose", "--remove", "--show_full_path", "--legacyalign"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/develop.json
+++ b/tools/profiles/develop.json
@@ -22,7 +22,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--show_full_path"]
+        "ld": ["--show_full_path", "--legacyalign"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Otime", "--split_sections",

--- a/tools/profiles/release.json
+++ b/tools/profiles/release.json
@@ -22,7 +22,7 @@
         "asm": [],
         "c": ["-D__ASSERT_MSG", "-std=gnu99"],
         "cxx": ["-fno-rtti", "-std=gnu++98"],
-        "ld": ["--show_full_path"]
+        "ld": ["--show_full_path", "--legacyalign"]
     },
     "ARM": {
         "common": ["-c", "--gnu", "-Ospace", "--split_sections",


### PR DESCRIPTION
### Description

Quite a few of the scatter files are not (yet) aligned to 8-byte
boundaries and therefore the removal of legacy alignment feature
(which is under deprecation warning, but it actually not YET
deprecated) broke quite a few builds to this error:

Error: L6244E: Exec region RW_IRAM1 address (0x200001ac) not aligned on a 8 byte boundary.

We must bring this option now back to fix the builds.

This option to ld (--legacyalign) can only be removed once all of
the scatter files have been fixed.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
