### PR TITLE
STM32: Fix alignment of execute region to 8byte boundary

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/STM32F0xx.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/device/TOOLCHAIN_GCC_ARM/STM32F0xx.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
 		_edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
 		_sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
 		_ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_ARM_MICRO/stm32f0xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_ARM_MICRO/stm32f0xx.sct
@@ -36,8 +36,8 @@
    .ANY (+RO)
   }
 
-  ; 45 vectors = 180 bytes (0xB4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0xB4) (0x2000-0xB4)  {  ; RW data
+  ; 45 vectors = 180 bytes (0xB4) 8-byte aligned = 0xB8 (0xB4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xB8) (0x2000-0xB8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_ARM_STD/stm32f0xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_ARM_STD/stm32f0xx.sct
@@ -36,8 +36,8 @@
    .ANY (+RO)
   }
 
-  ; 45 vectors = 180 bytes (0xB4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0xB4) (0x2000-0xB4)  {  ; RW data
+  ; 45 vectors = 180 bytes (0xB4); 8-byte aligned = 0xB8 (0xB4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xB8) (0x2000-0xB8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/STM32F030X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/device/TOOLCHAIN_GCC_ARM/STM32F030X8.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/STM32F031X6.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/device/TOOLCHAIN_GCC_ARM/STM32F031X6.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/STM32F042X6.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/device/TOOLCHAIN_GCC_ARM/STM32F042X6.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F070XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/device/TOOLCHAIN_GCC_ARM/STM32F070XB.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F072XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/device/TOOLCHAIN_GCC_ARM/STM32F072XB.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_GCC_ARM/STM32F091XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/device/TOOLCHAIN_GCC_ARM/STM32F091XC.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/TOOLCHAIN_GCC_ARM/STM32F103XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/device/TOOLCHAIN_GCC_ARM/STM32F103XB.ld
@@ -1,8 +1,9 @@
 /* Linker script to configure memory regions. */
+/* 0xEC reserved for vectors - 8byte aligned = 0xF0 */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 64K
-  RAM (rwx) : ORIGIN = 0x200000EC, LENGTH = 20K - 0xEC
+  RAM (rwx) : ORIGIN = 0x200000F0, LENGTH = 20K - (0xEC+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_ARM_MICRO/stm32f100xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_ARM_MICRO/stm32f100xb.sct
@@ -35,8 +35,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region (128K)
    .ANY (+RO)
   }
 
-  ; 77 vectors (16 core + 61 peripheral) * 4 bytes = 308 bytes to reserve (0x134)
-  RW_IRAM1 (0x20000000+0x134) (0x2000-0x134)  {  ; RW data
+  ; 77 vectors (16 core + 61 peripheral) * 4 bytes = 308 bytes to reserve (0x134) 8-byte aligned = 0x138
+  RW_IRAM1 (0x20000000+0x138) (0x2000-0x138)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_ARM_STD/stm32f100xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_ARM_STD/stm32f100xb.sct
@@ -35,8 +35,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region (128K)
    .ANY (+RO)
   }
 
-  ; 77 vectors (16 core + 61 peripheral) * 4 bytes = 308 bytes to reserve (0x134)
-  RW_IRAM1 (0x20000000+0x134) (0x2000-0x134)  {  ; RW data
+  ; 77 vectors (16 core + 61 peripheral) * 4 bytes = 308 bytes to reserve (0x134) 8-byte aligned = 0x138
+  RW_IRAM1 (0x20000000+0x138) (0x2000-0x138)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_GCC_ARM/STM32F100.ld
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/device/TOOLCHAIN_GCC_ARM/STM32F100.ld
@@ -86,13 +86,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -100,7 +100,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -108,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
 		_edata = .;
@@ -117,12 +117,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
 		_sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
 		_ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_ARM_MICRO/stm32f103xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_ARM_MICRO/stm32f103xb.sct
@@ -35,8 +35,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region (128K)
    .ANY (+RO)
   }
 
-  ; 59 vectors (16 core + 43 peripheral) * 4 bytes = 236 bytes to reserve (0xEC)
-  RW_IRAM1 (0x20000000+0xEC) (0x5000-0xEC)  {  ; RW data
+  ; 59 vectors (16 core + 43 peripheral) * 4 bytes = 236 bytes to reserve (0xEC) 8-byte aligned = 0xF0
+  RW_IRAM1 (0x20000000+0xF0) (0x5000-0xF0)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_ARM_STD/stm32f103xb.sct
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_ARM_STD/stm32f103xb.sct
@@ -35,8 +35,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region (128K)
    .ANY (+RO)
   }
 
-  ; 59 vectors (16 core + 43 peripheral) * 4 bytes = 236 bytes to reserve (0xEC)
-  RW_IRAM1 (0x20000000+0xEC) (0x5000-0xEC)  {  ; RW data
+  ; 59 vectors (16 core + 43 peripheral) * 4 bytes = 236 bytes to reserve (0xEC) 8-byte aligned = 0xF0
+  RW_IRAM1 (0x20000000+0xF0) (0x5000-0xF0)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_GCC_ARM/STM32F103XB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_GCC_ARM/STM32F103XB.ld
@@ -1,8 +1,9 @@
 /* Linker script to configure memory regions. */
+/* 0xEC reserved for vectors; 8-byte aligned = 0xF0 */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 128K
-  RAM (rwx) : ORIGIN = 0x200000EC, LENGTH = 20K - 0xEC
+  RAM (rwx) : ORIGIN = 0x200000F0, LENGTH = 20K - (0xEC+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_IAR/stm32f103xb.icf
+++ b/targets/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/device/TOOLCHAIN_IAR/stm32f103xb.icf
@@ -7,8 +7,8 @@ define symbol __ICFEDIT_intvec_start__ = 0x08000000;
 define symbol __ICFEDIT_region_ROM_start__ = 0x08000000;
 define symbol __ICFEDIT_region_ROM_end__   = 0x0801FFFF;
 define symbol __ICFEDIT_region_NVIC_start__   = 0x20000000;
-define symbol __ICFEDIT_region_NVIC_end__   = 0x200000EB;
-define symbol __ICFEDIT_region_RAM_start__ = 0x200000EC;
+define symbol __ICFEDIT_region_NVIC_end__   = 0x200000F0 - 0x1;
+define symbol __ICFEDIT_region_RAM_start__ = 0x200000F0; /* 8-byte aligned (0xEC) = 0xF0 */
 define symbol __ICFEDIT_region_RAM_end__   = 0x20004FFF;
 /*-Sizes-*/
 /*Heap 1/4 of ram and stack 1/8*/

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_MICRO/stm32f207xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_MICRO/stm32f207xx.sct
@@ -34,8 +34,8 @@ LR_IROM1 0x08000000 0x00100000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 97 vectors * 4 bytes = 388 bytes to reserve (0x184)
-  RW_IRAM1 (0x20000000+0x184) (0x00020000-0x184)  {  ; RW data
+  ; 97 vectors * 4 bytes = 388 bytes to reserve (0x184) 8-byte aligned = 0x188
+  RW_IRAM1 (0x20000000+0x188) (0x00020000-0x188)  {  ; RW data
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/stm32f207xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_ARM_STD/stm32f207xx.sct
@@ -43,8 +43,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 97 vectors * 4 bytes = 388 bytes to reserve (0x184)
-  RW_IRAM1 (0x20000000+0x184) (0x00020000-0x184)  {  ; RW data
+  ; 97 vectors * 4 bytes = 388 bytes to reserve (0x184) 8-byte aligned = 0x188 (0x184 + 0x4)
+  RW_IRAM1 (0x20000000+0x188) (0x00020000-0x188)  {  ; RW data
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/STM32F207ZGTx_FLASH.ld
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_GCC_ARM/STM32F207ZGTx_FLASH.ld
@@ -8,10 +8,11 @@
 
 /* Linker script to configure memory regions. */
 /* 97 vectors * 4 bytes = 388 bytes to reserve (0x184) */
+/* 8-byte aligned(0x184) = 0x188 */
 MEMORY
 {
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx) : ORIGIN = 0x20000184, LENGTH = 128K - 0x184
+  RAM (rwx) : ORIGIN = 0x20000188, LENGTH = 128K - 0x188
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -93,13 +94,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +116,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +125,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/TOOLCHAIN_GCC_ARM/STM32F302X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F302x8/device/TOOLCHAIN_GCC_ARM/STM32F302X8.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_GCC_ARM/STM32F303X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303x8/device/TOOLCHAIN_GCC_ARM/STM32F303X8.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/TOOLCHAIN_GCC_ARM/STM32F303XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xC/device/TOOLCHAIN_GCC_ARM/STM32F303XC.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_MICRO/stm32f303xe.sct
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_MICRO/stm32f303xe.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 101 vectors = 404 bytes (0x194) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x194) (0x10000-0x194)  {  ; RW data
+  ; 101 vectors = 404 bytes (0x194) 8-byte aligned = 0x198 (0x194 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x198) (0x10000-0x198)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_STD/stm32f303xe.sct
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_ARM_STD/stm32f303xe.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 101 vectors = 404 bytes (0x194) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x194) (0x10000-0x194)  {  ; RW data
+  ; 101 vectors = 404 bytes (0x194) 8-byte aligned = 0x198 (0x194 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x198) (0x10000-0x198)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_GCC_ARM/STM32F303XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F303xE/device/TOOLCHAIN_GCC_ARM/STM32F303XE.ld
@@ -1,4 +1,5 @@
 /* Linker script to configure memory regions. */
+/* 0x194 resevered for vectors; 8-byte aligned = 0x198 (0x194 + 0x4)*/
 #ifndef MBED_APP_START
 #define MBED_APP_START 0x08000000
 #endif
@@ -11,7 +12,7 @@ MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 16K
-  RAM (rwx) : ORIGIN = 0x20000194, LENGTH = 64K - 0x194
+  RAM (rwx) : ORIGIN = 0x20000198, LENGTH = 64K - (0x194+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -93,13 +94,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +116,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +125,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/TOOLCHAIN_GCC_ARM/STM32F334X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32F3/TARGET_STM32F334x8/device/TOOLCHAIN_GCC_ARM/STM32F334X8.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/device/TOOLCHAIN_GCC_ARM/NUCLEO_F411RE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTB_MTS_DRAGONFLY/device/TOOLCHAIN_GCC_ARM/NUCLEO_F411RE.ld
@@ -87,13 +87,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -101,7 +101,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -109,7 +109,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
 
@@ -117,11 +117,11 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
     } > RAM
     

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/TOOLCHAIN_GCC_ARM/NUCLEO_F411RE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device/TOOLCHAIN_GCC_ARM/NUCLEO_F411RE.ld
@@ -87,13 +87,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -101,7 +101,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -109,7 +109,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
 
@@ -117,11 +117,11 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
     } > RAM
     

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/TOOLCHAIN_GCC_ARM/STM32F405.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device/TOOLCHAIN_GCC_ARM/STM32F405.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
 
@@ -115,11 +115,11 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
     } > RAM
     

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
@@ -86,13 +86,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -100,7 +100,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -108,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -117,12 +117,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/device/TOOLCHAIN_GCC_ARM/STM32F401XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xC/device/TOOLCHAIN_GCC_ARM/STM32F401XC.ld
@@ -2,7 +2,7 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 256K
-  RAM (rwx)  : ORIGIN = 0x20000194, LENGTH = 64k - 0x194
+  RAM (rwx)  : ORIGIN = 0x20000198, LENGTH = 64k - 0x198
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_ARM_MICRO/stm32f401xe.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_ARM_MICRO/stm32f401xe.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 101 vectors = 404 bytes (0x194) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x194) (0x18000-0x194)  {  ; RW data
+  ; Total: 101 vectors = 404 bytes (0x194) 8-byte aligned = 0x198 (0x194 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x198) (0x18000-0x198)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_ARM_STD/stm32f401xe.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_ARM_STD/stm32f401xe.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 101 vectors = 404 bytes (0x194) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x194) (0x18000-0x194)  {  ; RW data
+  ; Total: 101 vectors = 404 bytes (0x194) 8-byte aligned = 0x198 (0x194 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x198) (0x18000-0x198)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_GCC_ARM/STM32F401XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F401xE/device/TOOLCHAIN_GCC_ARM/STM32F401XE.ld
@@ -1,8 +1,9 @@
 /* Linker script to configure memory regions. */
+/* 0x194 reserved for vectors 8-byte aligned = 0x198 (0x194 + 0x4) */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512K
-  RAM (rwx)  : ORIGIN = 0x20000194, LENGTH = 96k - 0x194
+  RAM (rwx)  : ORIGIN = 0x20000198, LENGTH = 96k - (0x194+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/device/TOOLCHAIN_GCC_ARM/STM32F407XG.ld
@@ -85,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -99,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -116,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_GCC_ARM/STM32F410xB.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F410xB/device/TOOLCHAIN_GCC_ARM/STM32F410xB.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F411xE/device/TOOLCHAIN_GCC_ARM/STM32F411XE.ld
@@ -92,13 +92,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -114,7 +114,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -123,12 +123,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_ARM_MICRO/stm32f412xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_ARM_MICRO/stm32f412xg.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 113 vectors = 452 bytes (0x1C4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C4) (0x40000-0x1C4)  {  ; RW data
+  ; Total: 113 vectors = 452 bytes (0x1C4) 8-byte aligned = 0x1C8 (0x1C4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x40000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_ARM_STD/stm32f412xg.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_ARM_STD/stm32f412xg.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 113 vectors = 452 bytes (0x1C4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C4) (0x40000-0x1C4)  {  ; RW data
+  ; Total: 113 vectors = 452 bytes (0x1C4) 8-byte aligned = 0x1C8 (0x1C4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x40000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_GCC_ARM/STM32F412xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_GCC_ARM/STM32F412xG.ld
@@ -6,10 +6,11 @@
   #define MBED_APP_SIZE 1024K
 #endif
 /* Linker script to configure memory regions. */
+/* 0x1C4 reserved for vectors; 8-byte aligned = 0x1C8 (0x1C4 + 0x4) */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001C4, LENGTH = 256K - 0x1C4
+  RAM (rwx)  : ORIGIN = 0x200001C8, LENGTH = 256K - (0x1C4+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -91,13 +92,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -105,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -113,7 +114,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -122,12 +123,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_MICRO/stm32f429xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_MICRO/stm32f429xx.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x20000-0x1AC)  {  ; RW data
+  ; Total: 107 vectors = 428 bytes (0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x20000-0x1B0)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_STD/stm32f429xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_ARM_STD/stm32f429xx.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x30000-0x1AC)  {  ; RW data
+  ; Total: 107 vectors = 428 bytes (0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x30000-0x1B0)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_GCC_ARM/STM32F429xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F429xI/device/TOOLCHAIN_GCC_ARM/STM32F429xI.ld
@@ -58,7 +58,7 @@ SECTIONS
     {
         __vector_table = .;
         KEEP(*(.isr_vector))
-         . = ALIGN(4);
+         . = ALIGN(8);
     } > VECTORS
 
     .text :
@@ -106,12 +106,12 @@ SECTIONS
 
     .interrupts_ram :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __VECTOR_RAM__ = .;
         __interrupts_ram_start__ = .; /* Create a global symbol at data start */
         *(.m_interrupts_ram)     /* This is a user defined section */
         . += M_VECTOR_RAM_SIZE;
-        . = ALIGN(4);
+        . = ALIGN(8);
         __interrupts_ram_end__ = .; /* Define a global symbol at data end */
     } > RAM
 
@@ -125,13 +125,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -139,7 +139,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -147,7 +147,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -170,12 +170,12 @@ SECTIONS
 
     .bss (NOLOAD):
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_ARM_STD/stm32f437xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_ARM_STD/stm32f437xx.sct
@@ -46,8 +46,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x30000-0x1AC)  {  ; RW data
+  ; Total: 107 vectors = 428 bytes (0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x30000-0x1B0)  {  ; RW data
    .ANY (+RW +ZI)
   }
   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_GCC_ARM/STM32F437xx.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/device/TOOLCHAIN_GCC_ARM/STM32F437xx.ld
@@ -7,9 +7,10 @@
 #endif
 
 /* Linker script to configure memory regions. */
+/* 0x1AC resevered for vectors; 8-byte aligned = 0x1B0 (0x1AC + 0x4)*/
 MEMORY
 { 
-RAM (xrw)        : ORIGIN = 0x200001AC, LENGTH = 192K - 0x1AC /* 0x1AC is to leave room for vectors */
+RAM (xrw)        : ORIGIN = 0x200001B0, LENGTH = 192K - 0x1B0 /* 0x1AC+0x4 is to leave room for vectors */
 CCM_RAM (rw)     : ORIGIN = 0x10000000, LENGTH = 64K
 BACKUP_SRAM (rw) : ORIGIN = 0x40024000, LENGTH = 4096
 FLASH (rx)       : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
@@ -94,13 +95,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -108,7 +109,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -116,7 +117,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -125,12 +126,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_ARM_MICRO/stm32f439xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_ARM_MICRO/stm32f439xx.sct
@@ -45,9 +45,9 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be used
+  ; Total: 107 vectors = 428 bytes (0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be used
   ; should match ER_IROM1::RESET/4 and cmsis_nvic.h::NVIC_NUM_VECTORS
-  RW_IRAM1 (0x20000000 + (107*4)) (0x30000 - (107*4))  {  ; RW data
+  RW_IRAM1 (0x20000000 + 0x1B0) (0x30000 - 0x1B0)  {  ; RW data
    .ANY (+RW +ZI)
   }
   RW_IRAM2 (0x10000000) 0x10000 { 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_ARM_STD/stm32f439xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_ARM_STD/stm32f439xx.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x30000-0x1AC)  {  ; RW data
+  ; Total: 107 vectors = 428 bytes(0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x30000-0x1B0)  {  ; RW data
    .ANY (+RW +ZI)
   }
   

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_GCC_ARM/STM32F439ZI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/device/TOOLCHAIN_GCC_ARM/STM32F439ZI.ld
@@ -7,11 +7,12 @@
 #endif
 
 /* Linker script to configure memory regions. */
+/* 0x1AC resevered for vectors; 8-byte aligned = 0x1B0 (0x1AC + 0x4)*/
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   CCM (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
-  RAM (rwx) : ORIGIN = 0x200001AC, LENGTH = 192k - 0x1AC 
+  RAM (rwx) : ORIGIN = 0x200001B0, LENGTH = 192k - (0x1AC+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -93,13 +94,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +116,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +125,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_ARM_MICRO/stm32f446xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_ARM_MICRO/stm32f446xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 113 vectors = 452 bytes (0x1C4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C4) (0x20000-0x1C4)  {  ; RW data
+  ; Total: 113 vectors = 452 bytes (0x1C4) 8-byte aligned = 0x1C8 (0x1C4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x20000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_ARM_STD/stm32f446xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_ARM_STD/stm32f446xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 113 vectors = 452 bytes (0x1C4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1C4) (0x20000-0x1C4)  {  ; RW data
+  ; Total: 113 vectors = 452 bytes (0x1C4) 8-byte aligned = 0x1C8 (0x1C4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C8) (0x20000-0x1C8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_GCC_ARM/STM32F446XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_GCC_ARM/STM32F446XE.ld
@@ -7,10 +7,11 @@
 #endif
 
 /* Linker script to configure memory regions. */
+/* 0x1C4 resevered for vectors; 8-byte aligned = 0x1C8 (0x1C4 + 0x4)*/
 MEMORY
 {
   FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx)  : ORIGIN = 0x200001C4, LENGTH = 128k - 0x1C4
+  RAM (rwx)  : ORIGIN = 0x200001C8, LENGTH = 128k - (0x1C4+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -92,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -114,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -123,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_IAR/stm32f446xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F446xE/device/TOOLCHAIN_IAR/stm32f446xx.icf
@@ -3,10 +3,10 @@ define symbol __intvec_start__     = 0x08000000;
 define symbol __region_ROM_start__ = 0x08000000;
 define symbol __region_ROM_end__   = 0x0807FFFF;
 
-/* [RAM = 128kb = 0x20000] Vector table dynamic copy: 113 vectors = 452 bytes (0x1C4) to be reserved in RAM */
+/* [RAM = 128kb = 0x20000] Vector table dynamic copy: 113 vectors * 4= 452 bytes (0x1C4) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001C3; /* Aligned on 8 bytes */
-define symbol __region_RAM_start__    = 0x200001C4;
+define symbol __NVIC_end__            = 0x200001C7; /* Add 4 more bytes to be aligned on 8 bytes */
+define symbol __region_RAM_start__    = 0x200001C8;
 define symbol __region_RAM_end__      = 0x2001FFFF;
 
 /* Memory regions */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_ARM_MICRO/stm32f469xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_ARM_MICRO/stm32f469xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 109 vectors = 436 bytes (0x1B4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1B4) (0x50000-0x1B4)  {  ; RW data
+  ; Total: 109 vectors = 436 bytes (0x1B4) 8-byte aligned = 0x1B8 (0x1B4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B8) (0x50000-0x1B8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_ARM_STD/stm32f469xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_ARM_STD/stm32f469xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x200000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 109 vectors = 436 bytes (0x1B4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1B4) (0x50000-0x1B4)  {  ; RW data
+  ; Total: 109 vectors = 436 bytes (0x1B4) 8-byte aligned = 0x1B8 (0x1B4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B8) (0x50000-0x1B8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_GCC_ARM/STM32F469XI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_GCC_ARM/STM32F469XI.ld
@@ -1,8 +1,9 @@
 /* Linker script to configure memory regions. */
+/* 0x1B4 resevered for vectors; 8-byte aligned = 0x1B8 (0x1B4 + 0x4)*/
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 2M
-  RAM (rwx)  : ORIGIN = 0x200001B4, LENGTH = 320k - 0x1B4
+  RAM (rwx)  : ORIGIN = 0x200001B8, LENGTH = 320k - (0x1B4+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F469xI/device/TOOLCHAIN_IAR/stm32f469xx.icf
@@ -3,10 +3,10 @@ define symbol __intvec_start__     = 0x08000000;
 define symbol __region_ROM_start__ = 0x08000000;
 define symbol __region_ROM_end__   = 0x081FFFFF;
 
-/* [RAM = 384kb = 0x60000] Vector table dynamic copy: 109 vectors = 436 bytes (0x1B4) to be reserved in RAM */
+/* [RAM = 384kb = 0x60000] Vector table dynamic copy: 109 vectors * 4 = 436 bytes (0x1B4) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001B3; /* Aligned on 8 bytes */
-define symbol __region_RAM_start__    = 0x200001B4;
+define symbol __NVIC_end__            = 0x200001B7; /* Add 4 more bytes to be aligned on 8 bytes */
+define symbol __region_RAM_start__    = 0x200001B8;
 define symbol __region_RAM_end__      = 0x2004FFFF;
 
 /* Memory regions */

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F746xG/device/TOOLCHAIN_GCC_ARM/STM32F746xG.ld
@@ -93,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_GCC_ARM/STM32F756xG.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F756xG/device/TOOLCHAIN_GCC_ARM/STM32F756xG.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F767xI/device/TOOLCHAIN_GCC_ARM/STM32F767xI.ld
@@ -93,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_GCC_ARM/STM32F769xI.ld
+++ b/targets/TARGET_STM/TARGET_STM32F7/TARGET_STM32F769xI/device/TOOLCHAIN_GCC_ARM/STM32F769xI.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_GCC_ARM/STM32L031K6.ld
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/device/TOOLCHAIN_GCC_ARM/STM32L031K6.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_GCC_ARM/STM32L073XZ.ld
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/device/TOOLCHAIN_GCC_ARM/STM32L073XZ.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/device/TOOLCHAIN_GCC_ARM/STM32L053X8.ld
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L053x8/device/TOOLCHAIN_GCC_ARM/STM32L053X8.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/device/TOOLCHAIN_GCC_ARM/STM32L072XZ.ld
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L072xZ/device/TOOLCHAIN_GCC_ARM/STM32L072XZ.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/device/TOOLCHAIN_GCC_ARM/STM32L082xZ.ld
+++ b/targets/TARGET_STM/TARGET_STM32L0/TARGET_STM32L0x2xZ/device/TOOLCHAIN_GCC_ARM/STM32L082xZ.ld
@@ -84,13 +84,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +98,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +115,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_MICRO/stm32l152rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_MICRO/stm32l152rc.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/stm32l152rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_ARM_STD/stm32l152rc.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/STM32L152XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device/TOOLCHAIN_GCC_ARM/STM32L152XC.ld
@@ -3,9 +3,10 @@ MEMORY
 {
   /* 256KB FLASH, 32KB RAM, Reserve up till 0x13C. There are 0x73 vectors = 292
    * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138
+   * 8-byte aligned (0x13C) = 0x140
    */
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 256k
-  RAM (rwx) : ORIGIN = 0x2000013C, LENGTH = 0x8000-0x13C
+  RAM (rwx) : ORIGIN = 0x20000140, LENGTH = 0x8000-(0x13C+0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -87,13 +88,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -101,7 +102,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -109,7 +110,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -118,12 +119,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
@@ -46,8 +46,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
@@ -46,8 +46,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) + 0x4(8-byte aligned) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_MTS_XDOT/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
@@ -10,9 +10,10 @@ MEMORY
 {
   /* 256KB FLASH, 32KB RAM, Reserve up till 0x13C. There are 0x73 vectors = 292
    * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138
+   * 8-byte aligned(0x13C) = 0x140
    */
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx) : ORIGIN = 0x2000013C, LENGTH = 0x8000-0x13C
+  RAM (rwx) : ORIGIN = 0x20000140, LENGTH = 0x8000-0x140
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -94,13 +95,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -108,7 +109,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -116,7 +117,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -125,12 +126,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_ARM_MICRO/stm32l151cba.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_ARM_MICRO/stm32l151cba.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 61 vectors = 244 bytes (0xF4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0xF4) (0x8000-0xF4)  {  ; RW data
+  ; 61 vectors = 244 bytes (0xF4) 8-byte aligned = 0xF8 (0xF4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xF8) (0x8000-0xF8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_ARM_STD/stm32l151cba.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_ARM_STD/stm32l151cba.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x20000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 61 vectors = 244 bytes (0xF4) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0xF4) (0x8000-0xF4)  {  ; RW data
+  ; 61 vectors = 244 bytes (0xF4) 8-byte aligned = 0xF8 (0xF4 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0xF8) (0x8000-0xF8)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_GCC_ARM/STM32L151XB-A.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_GCC_ARM/STM32L151XB-A.ld
@@ -3,10 +3,10 @@
 MEMORY
 {
   /* 128KB FLASH, 32KB RAM, Reserve up till 0xF4. There are 61 vectors = 244
-   * bytes (0xF4) in RAM.
+   * bytes (0xF4) in RAM. 8-byte aligned(0xF4) = 0xF8
    */
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 128k
-  RAM (rwx) : ORIGIN = 0x200000F4, LENGTH = 0x8000-0xF4
+  RAM (rwx) : ORIGIN = 0x200000F8, LENGTH = 0x8000-0xF8
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -88,13 +88,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -102,7 +102,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -110,7 +110,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -119,12 +119,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_IAR/stm32l152xba.icf
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_MTB_RAK811/device/TOOLCHAIN_IAR/stm32l152xba.icf
@@ -7,8 +7,8 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 32kb = 0x8000] Vector table dynamic copy: 61 vectors = 244 bytes (0xF4) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200000F3;
-define symbol __region_RAM_start__    = 0x200000F4;
+define symbol __NVIC_end__            = 0x200000F7; /* Add 4 more bytes to be aligned on 8 bytes */
+define symbol __region_RAM_start__    = 0x200000F8;
 define symbol __region_RAM_end__      = 0x20007FFF;
 
 /* Memory regions */

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/stm32l152re.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_MICRO/stm32l152re.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x14000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x14000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/stm32l152re.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_ARM_STD/stm32l152re.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x80000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x14000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4)to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x14000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/STM32L152XE.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device/TOOLCHAIN_GCC_ARM/STM32L152XE.ld
@@ -3,9 +3,10 @@ MEMORY
 {
   /* 512KB FLASH, 80KB RAM, Reserve up till 0x13C. There are 0x73 vectors = 292
    * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138
+   * 8-byte aligned(0x13C) = 0x140
    */
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 512k
-  RAM (rwx) : ORIGIN = 0x2000013C, LENGTH = 0x14000-0x13C
+  RAM (rwx) : ORIGIN = 0x20000140, LENGTH = 0x14000-0x140
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -87,13 +88,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -101,7 +102,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -109,7 +110,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -118,12 +119,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x40000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes(0x124) 8-byte aligned = 0x128 (0x124 + 0x4)to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
@@ -4,9 +4,10 @@ MEMORY
 {
   /* 256KB FLASH, 32KB RAM, Reserve up till 0x13C. There are 0x73 vectors = 292
    * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138
+   * 8-byte aligned(0x13C) = 0x140
    */
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 256k
-  RAM (rwx) : ORIGIN = 0x2000013C, LENGTH = 0x8000-0x13C
+  RAM (rwx) : ORIGIN = 0x20000140, LENGTH = 0x8000-0x140
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -88,13 +89,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -102,7 +103,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -110,7 +111,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -119,12 +120,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_MICRO/stm32l151rc.sct
@@ -46,8 +46,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_ARM_STD/stm32l151rc.sct
@@ -46,8 +46,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; 73 vectors = 292 bytes (0x124) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x124) (0x8000-0x124)  {  ; RW data
+  ; 73 vectors = 292 bytes (0x124) 8-byte aligned = 0x128 (0x124 + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x128) (0x8000-0x128)  {  ; RW data
    .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
+++ b/targets/TARGET_STM/TARGET_STM32L1/TARGET_XDOT_L151CC/device/TOOLCHAIN_GCC_ARM/STM32L151XC.ld
@@ -9,10 +9,11 @@
 MEMORY
 {
   /* 256KB FLASH, 32KB RAM, Reserve up till 0x13C. There are 0x73 vectors = 292
-   * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138
+   * bytes (0x124) in RAM. But all GCC scripts seem to require BootRAM @0x138\
+   * 8-byte aligned(0x13C) = 0x140
    */
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  RAM (rwx) : ORIGIN = 0x2000013C, LENGTH = 0x8000-0x13C
+  RAM (rwx) : ORIGIN = 0x20000140, LENGTH = 0x8000-0x140
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -94,13 +95,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -108,7 +109,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -116,7 +117,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -125,12 +126,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > RAM

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_GCC_ARM/STM32L432XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_GCC_ARM/STM32L432XX.ld
@@ -92,13 +92,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -114,7 +114,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -123,12 +123,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L432xC/device/TOOLCHAIN_IAR/stm32l432xx.icf
@@ -9,7 +9,7 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* [RAM = 48kb + 16kb = 0x10000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 98 x 4) */
 define symbol __region_SRAM1_start__  = 0x20000188;
 define symbol __region_SRAM1_end__    = 0x2000FFFF;
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_GCC_ARM/STM32L433XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_GCC_ARM/STM32L433XX.ld
@@ -92,13 +92,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -106,7 +106,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -114,7 +114,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -123,12 +123,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_IAR/stm32l433xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L433xC/device/TOOLCHAIN_IAR/stm32l433xx.icf
@@ -9,7 +9,7 @@ define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 /* [RAM = 48kb + 16kb = 0x10000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 98 x 4) */
 define symbol __region_SRAM1_start__  = 0x20000188;
 define symbol __region_SRAM1_end__    = 0x2000FFFF;
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_ARM_STD/stm32l443xx.sct
@@ -49,8 +49,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
   .ANY (+RW +ZI)
   }
 
-  ; Total: 99 vectors = 396 bytes (0x18C) to be reserved in RAM
-  RW_IRAM2 (0x10000000+0x18C) (0x04000-0x18C)  {  ; RW data 16k L4-ECC-SRAM2 retained in standby
+  ; Total: 99 vectors = 396 bytes (0x18C+0x4) to be reserved in RAM
+  RW_IRAM2 (0x10000000+0x190) (0x04000-0x190)  {  ; RW data 16k L4-ECC-SRAM2 retained in standby
   .ANY (+RW +ZI)
   }
 

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_GCC_ARM/STM32L443XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_GCC_ARM/STM32L443XX.ld
@@ -7,10 +7,11 @@
 #endif
 
 /* Linker script to configure memory regions. */
+/* 0x18C resevered for vectors; 8-byte aligned = 0x190 (0x18C + 0x4)*/
 MEMORY
 {
   FLASH (rx)   : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  SRAM2 (rwx)  : ORIGIN = 0x1000018C, LENGTH = 16k - 0x18C
+  SRAM2 (rwx)  : ORIGIN = 0x10000190, LENGTH = 16k - (0x18C+0x4)
   SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 48k
 }
 
@@ -93,13 +94,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +108,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +116,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +125,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L443xC/device/TOOLCHAIN_IAR/stm32l443xx.icf
@@ -7,9 +7,9 @@ define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 48kb + 16kb = 0xC000] */
-/* Vector table dynamic copy: Total: 99 vectors = 396 bytes (0x18C) to be reserved in RAM */
+/* Vector table dynamic copy: Total: 99 vectors * 4 = 396 bytes (0x18C) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x1000018F; /* Aligned on 8 bytes (400 = 50 x 8) */
+define symbol __NVIC_end__            = 0x1000018F; /* Add 4 more bytes to be aligned on 8 bytes */
 define symbol __region_SRAM2_start__  = 0x10000190;
 define symbol __region_SRAM2_end__    = 0x10003FFF;
 define symbol __region_SRAM1_start__  = 0x20000000;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_GCC_ARM/STM32L475XX.ld
@@ -93,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L475xG/device/TOOLCHAIN_IAR/stm32l475xx.icf
@@ -7,9 +7,9 @@ define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 96kb + 32kb = 0x20000] */
-/* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
+/* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __NVIC_end__            = 0x10000187;
 define symbol __region_SRAM2_start__  = 0x10000188;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_SRAM1_start__  = 0x20000000;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -93,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L476xG/device/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -7,9 +7,9 @@ define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 96kb + 32kb = 0x20000] */
-/* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
+/* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __NVIC_end__            = 0x10000187;
 define symbol __region_SRAM2_start__  = 0x10000188;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_SRAM1_start__  = 0x20000000;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_GCC_ARM/STM32L486XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_GCC_ARM/STM32L486XX.ld
@@ -93,13 +93,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -107,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -115,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -124,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L486xG/device/TOOLCHAIN_IAR/stm32l486xx.icf
@@ -7,9 +7,9 @@ define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 96kb + 32kb = 0x20000] */
-/* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
+/* Vector table dynamic copy: Total: 98 vectors * 4 = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
-define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __NVIC_end__            = 0x10000187;
 define symbol __region_SRAM2_start__  = 0x10000188;
 define symbol __region_SRAM2_end__    = 0x10007FFF;
 define symbol __region_SRAM1_start__  = 0x20000000;

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_MICRO/stm32l496xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_MICRO/stm32l496xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x50000-0x1AC)  { ; RW data 320k L4-SRAM1
+  ; Total: 107 vectors = 428 bytes (0x1AC) 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x50000-0x1B0)  { ; RW data 320k L4-SRAM1
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_STD/stm32l496xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_ARM_STD/stm32l496xx.sct
@@ -36,8 +36,8 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1AC) (0x50000-0x1AC)  { ; RW data 320k L4-SRAM1
+  ; Total: 107 vectors = 428 bytes (0x1AC); 8-byte aligned = 0x1B0 (0x1AC + 0x4) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1B0) (0x50000-0x1B0)  { ; RW data 320k L4-SRAM1
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_GCC_ARM/STM32L496XX.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_GCC_ARM/STM32L496XX.ld
@@ -1,8 +1,9 @@
 /* Linker script to configure memory regions. */
+/* 0x1AC resevered for vectors; 8-byte aligned = 0x1B0 (0x1AC + 0x4)*/
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  SRAM1 (rwx)  : ORIGIN = 0x200001AC, LENGTH = 320k - 0x1AC
+  SRAM1 (rwx)  : ORIGIN = 0x200001B0, LENGTH = 320k - (0x1AC +0x4)
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -84,13 +85,13 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
@@ -98,7 +99,7 @@ SECTIONS
         PROVIDE_HIDDEN (__init_array_end = .);
 
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -106,7 +107,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -115,12 +116,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L496xG/device/TOOLCHAIN_IAR/stm32l496xx.icf
@@ -4,10 +4,10 @@ define symbol __region_ROM_start__ = 0x08000000;
 define symbol __region_ROM_end__   = 0x08000000 + 0x100000 - 1;
 
 /* [RAM = 0x50000] */
-/* Vector table dynamic copy: Total: 107 vectors = 428 bytes (0x1AC) to be reserved in RAM */
+/* Vector table dynamic copy: Total: 107 vectors * 4 = 428 bytes (0x1AC) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x200001AC - 1;
-define symbol __region_SRAM1_start__  = 0x200001AC; /* Aligned on 8 bytes (428 = 53 x 8) */
+define symbol __NVIC_end__            = 0x200001AF; /* Add 4 more bytes to be aligned on 8 bytes */
+define symbol __region_SRAM1_start__  = 0x200001B0;
 define symbol __region_SRAM1_end__    = 0x2004FFFF;
 
 /* Memory regions */


### PR DESCRIPTION
### Description

Resolves https://github.com/ARMmbed/mbed-os/issues/8004


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

