### PR TITLE
IAR: Fix for #7662, only massage the error decode URL for the IAR .xcl

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -72,7 +72,7 @@
         },
         "error-decode-http-url-str": {
             "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
-            "value": "\"\\nFor more info, visit: https:/\\/armmbed.github.io/mbedos-error/?error=0x%08X\""
+            "value": "\"\\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X\""
         }
     },
     "target_overrides": {

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -167,7 +167,7 @@ class IAR(mbedToolchain):
         opts = ['-D%s' % d for d in defines]
         if for_asm:
             config_macros = self.config.get_config_data_macros()
-            macros_cmd = ['"-D%s"' % d.replace('"', '') for d in config_macros]
+            macros_cmd = ['"-D%s"' % d.replace('"', '').replace('//','/\/') for d in config_macros]
             if self.RESPONSE_FILES:
                 via_file = self.make_option_file(
                     macros_cmd, "asm_macros_{}.xcl")


### PR DESCRIPTION

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
tools/toolchains/iar.py:
Replace "//" sequence in get_compile_options() for_asm when generating the .xcl file.
This eliminates the need to escape this sequence in the .json files, which upsets other toolchains.

Tested with IAR and GCC_ARM toolchains with the mbed-os-example-blinky example.

platform/mbed_lib.json:
Removed the "\\" escape sequence

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

