### PR TITLE
Hotfix for PR #7778 on Silicon Labs targets

### DIFF
--- a/features/nanostack/sal-stack-nanostack/mbed_lib.json
+++ b/features/nanostack/sal-stack-nanostack/mbed_lib.json
@@ -13,6 +13,9 @@
         },
         "NCS36510": {
             "nanostack.configuration": "lowpan_router"
+        },
+        "TB_SENSE_12": {
+            "nanostack.configuration": "lowpan_router"
         }
     }
 }

--- a/features/nanostack/targets/TARGET_Silicon_Labs/TARGET_SL_RAIL/NanostackRfPhyEfr32.cpp
+++ b/features/nanostack/targets/TARGET_Silicon_Labs/TARGET_SL_RAIL/NanostackRfPhyEfr32.cpp
@@ -1275,3 +1275,9 @@ static void radioEventHandler(RAIL_Handle_t railHandle,
     }
     while (events != 0);
 }
+
+NanostackRfPhy &NanostackRfPhy::get_default_instance()
+{
+    static NanostackRfPhyEfr32 rf_phy;
+    return rf_phy;
+}

--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -36,6 +36,9 @@
         },
         "NCS36510": {
             "nsapi.default-mesh-type": "LOWPAN"
+        },
+        "TB_SENSE_12": {
+            "nsapi.default-mesh-type": "LOWPAN"
         }
     }
 }

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3443,7 +3443,7 @@
     },
     "EFR32MG1_BRD4150": {
         "inherits": ["EFR32MG1P132F256GM48"],
-        "device_has": ["ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "FLASH"],
+        "device_has": ["802_15_4_PHY", "ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "FLASH"],
         "forced_reset_timeout": 2,
         "config": {
             "hf_clock_src": {
@@ -3482,11 +3482,14 @@
                 "macro_name": "EFM_BC_EN"
             }
         },
+        "overrides": {
+            "network-default-interface-type": "MESH"
+        },
         "public": false
     },
     "TB_SENSE_1": {
         "inherits": ["EFR32MG1P233F256GM48"],
-        "device_has": ["ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "FLASH"],
+        "device_has": ["802_15_4_PHY", "ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {
@@ -3519,6 +3522,9 @@
                 "value": "cmuHFRCOFreq_32M0Hz",
                 "macro_name": "HFRCO_FREQUENCY_ENUM"
             }
+        },
+        "overrides": {
+            "network-default-interface-type": "MESH"
         }
     },
     "EFM32PG12B500F1024GL125": {
@@ -3588,7 +3594,7 @@
     "TB_SENSE_12": {
         "inherits": ["EFR32MG12P332F1024GL125"],
         "device_name": "EFR32MG12P332F1024GL125",
-        "device_has": ["ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "TRNG", "FLASH"],
+        "device_has": ["802_15_4_PHY", "ANALOGIN", "CRC", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES", "USTICKER", "TRNG", "FLASH"],
         "forced_reset_timeout": 5,
         "config": {
             "hf_clock_src": {
@@ -3621,6 +3627,9 @@
                 "value": "cmuHFRCOFreq_32M0Hz",
                 "macro_name": "HFRCO_FREQUENCY_ENUM"
             }
+        },
+        "overrides": {
+            "network-default-interface-type": "MESH"
         }
     },
     "EFM32GG11B820F2048GL192": {
@@ -3680,6 +3689,9 @@
                 "value": "PG13",
                 "macro_name": "QSPI_FLASH_EN"
             }
+        },
+        "overrides": {
+            "network-default-interface-type": "ETHERNET"
         }
     },
     "WIZWIKI_W7500": {

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -46,5 +46,9 @@
     "KW24D": {
         "default_test_configuration": "NO_NETWORK",
         "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
+    },
+    "TB_SENSE_12": {
+        "default_test_configuration": "NO_NETWORK",
+        "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
     }
 }

--- a/tools/test_configs/target_configs.json
+++ b/tools/test_configs/target_configs.json
@@ -50,5 +50,9 @@
     "TB_SENSE_12": {
         "default_test_configuration": "NO_NETWORK",
         "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
+    },
+    "TB_SENSE_1": {
+        "default_test_configuration": "NO_NETWORK",
+        "test_configurations": ["6LOWPAN_HOST", "6LOWPAN_ROUTER", "THREAD_END_DEVICE", "THREAD_ROUTER"]
     }
 }

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -167,7 +167,7 @@ class IAR(mbedToolchain):
         opts = ['-D%s' % d for d in defines]
         if for_asm:
             config_macros = self.config.get_config_data_macros()
-            macros_cmd = ['"-D%s"' % d.replace('"', '').replace('//','/\/') for d in config_macros]
+            macros_cmd = ['"-D%s"' % d for d in config_macros if not '"' in d]
             if self.RESPONSE_FILES:
                 via_file = self.make_option_file(
                     macros_cmd, "asm_macros_{}.xcl")


### PR DESCRIPTION
### Description

TB_SENSE_12 was left behind by the changes in #7778. As discussed with @SeppoTakalo over email, this commit implements the changes required to allow TB_SENSE_12 to provide a default network interface for Silicon Labs targets. This was done by mimicking the changes that were put in place by @SeppoTakalo for NCS36510/KW24D.

Considering #7778 made it in for 5.10.0-rc1, I strongly suggest you pull in this PR for the same release to keep continuity. CC @0xc0170 @kjbracey-arm @screamerbg 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

