### PR TITLE
Nuvoton: Fix Greentea test common_tickers failed

### DIFF
--- a/TESTS/mbed_hal/common_tickers/main.cpp
+++ b/TESTS/mbed_hal/common_tickers/main.cpp
@@ -473,11 +473,14 @@ void ticker_speed_test(void)
 
     /* ---- Test fire_interrupt function. ---- */
     counter = NUM_OF_CALLS;
+    /* Disable ticker interrupt which would interfere with speed test */
+    core_util_critical_section_enter();
     start = us_ticker_read();
     while (counter--) {
         intf->fire_interrupt();
     }
     stop = us_ticker_read();
+    core_util_critical_section_exit();
 
     TEST_ASSERT(diff_us(start, stop, us_ticker_info) < (NUM_OF_CALLS * (MAX_FUNC_EXEC_TIME_US + DELTA_FUNC_EXEC_TIME_US)));
 
@@ -569,7 +572,7 @@ utest::v1::status_t lp_ticker_teardown(const Case *const source, const size_t pa
 
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
-    GREENTEA_SETUP(30, "default_auto");
+    GREENTEA_SETUP(80, "default_auto");
     return verbose_test_setup_handler(number_of_cases);
 }
 

--- a/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
@@ -160,23 +160,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
-    /* Disable wakeup */
-    TIMER_DisableWakeup(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock

--- a/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/lp_ticker.c
@@ -101,8 +101,6 @@ void lp_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         lp_ticker_disable_interrupt();
-        lp_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -203,6 +201,10 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    lp_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
@@ -123,16 +123,7 @@ void us_ticker_init(void)
 
 void us_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock

--- a/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/us_ticker.c
@@ -75,8 +75,6 @@ void us_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         us_ticker_disable_interrupt();
-        us_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -159,6 +157,10 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    us_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
@@ -126,23 +126,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
-    /* Disable wakeup */
-    TIMER_DisableWakeup(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/lp_ticker.c
@@ -76,8 +76,6 @@ void lp_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         lp_ticker_disable_interrupt();
-        lp_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -166,6 +164,10 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    lp_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
@@ -52,8 +52,6 @@ void us_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         us_ticker_disable_interrupt();
-        us_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -124,6 +122,10 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    us_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M451/us_ticker.c
@@ -91,16 +91,7 @@ void us_ticker_init(void)
 
 void us_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -126,23 +126,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
-    /* Disable wakeup */
-    TIMER_DisableWakeup(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/lp_ticker.c
@@ -76,8 +76,6 @@ void lp_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         lp_ticker_disable_interrupt();
-        lp_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -166,6 +164,10 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    lp_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -52,8 +52,6 @@ void us_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         us_ticker_disable_interrupt();
-        us_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -124,6 +122,10 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    us_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_M480/us_ticker.c
@@ -91,16 +91,7 @@ void us_ticker_init(void)
 
 void us_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
@@ -78,8 +78,6 @@ void lp_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         lp_ticker_disable_interrupt();
-        lp_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -170,6 +168,10 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    lp_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/lp_ticker.c
@@ -130,23 +130,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_TMR_ACT_Msk));
-
-    /* Disable wakeup */
-    TIMER_DisableWakeup(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
@@ -54,8 +54,6 @@ void us_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         us_ticker_disable_interrupt();
-        us_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -126,6 +124,10 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    us_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NANO100/us_ticker.c
@@ -93,16 +93,7 @@ void us_ticker_init(void)
 
 void us_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_TMR_ACT_Msk));
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
@@ -125,23 +125,7 @@ void lp_ticker_init(void)
 
 void lp_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
-    /* Disable wakeup */
-    TIMER_DisableWakeup(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
-    wait_us((NU_US_PER_SEC / NU_TMRCLK_PER_SEC) * 3);
-
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/lp_ticker.c
@@ -76,8 +76,6 @@ void lp_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         lp_ticker_disable_interrupt();
-        lp_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -165,6 +163,10 @@ timestamp_t lp_ticker_read()
 
 void lp_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    lp_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
@@ -90,16 +90,7 @@ void us_ticker_init(void)
 
 void us_ticker_free(void)
 {
-    TIMER_T *timer_base = (TIMER_T *) NU_MODBASE(TIMER_MODINIT.modname);
-
-    /* Stop counting */
-    TIMER_Stop(timer_base);
-
-    /* Wait for timer to stop counting and unset active flag */
-    while((timer_base->CTL & TIMER_CTL_ACTSTS_Msk));
-
     /* Disable interrupt */
-    TIMER_DisableInt(timer_base);
     NVIC_DisableIRQ(TIMER_MODINIT.irq_n);
 
     /* Disable IP clock */

--- a/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
+++ b/targets/TARGET_NUVOTON/TARGET_NUC472/us_ticker.c
@@ -52,8 +52,6 @@ void us_ticker_init(void)
         /* By HAL spec, ticker_init allows the ticker to keep counting and disables the
          * ticker interrupt. */
         us_ticker_disable_interrupt();
-        us_ticker_clear_interrupt();
-        NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
         return;
     }
     ticker_inited = 1;
@@ -123,6 +121,10 @@ uint32_t us_ticker_read()
 
 void us_ticker_set_interrupt(timestamp_t timestamp)
 {
+    /* Clear any previously pending interrupts */
+    us_ticker_clear_interrupt();
+    NVIC_ClearPendingIRQ(TIMER_MODINIT.irq_n);
+
     /* In continuous mode, counter will be reset to zero with the following sequence: 
      * 1. Stop counting
      * 2. Configure new CMP value


### PR DESCRIPTION
### Description

This PR tries to fix `mbed-os-tests-mbed_hal-common_tickers` test failed, especially on Nuvoton targets:
1. Redeem from missing go-off ticker interrupt when us/lp ticker layers are uninstalled
1. Disable ticker interrupt which would interfere with fire_interrupt speed test
1. Enlarge test period to avoid timeout error

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

