### PR TITLE
Changed the reported SNR from unsigned to signed.

### DIFF
--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -663,7 +663,7 @@ typedef struct {
     /**
      * The SNR for the received packet.
      */
-    uint8_t snr;
+    int8_t snr;
     /**
      * A boolean to mark if the meta data is stale
      */

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -666,7 +666,7 @@ typedef struct {
     /*!
      * The SNR of the received packet.
      */
-    uint8_t snr;
+    int8_t snr;
     /*!
      * The receive window.
      *


### PR DESCRIPTION
The rx metadata API returns the SNR of the received data. It's logically a signed value (since LoRa allows the signal to be below the noise floor, the SNR may be negative), and is signed within the stack.
But as it makes its way up the reporting chain, it becomes unsigned. I suspect this is not intentional, so I have simply changed the unsigned type to signed.

Aside: This is an unsolicited Pull Request without an associated Issue. I don't know whether this is acceptable etiquette, so please let me know if not.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

