### PR TITLE
platform: error: fix bogus usage of memset()

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -120,7 +120,7 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
     error_count++;
 
     //Clear the context capturing buffer
-    memset(&current_error_ctx, sizeof(mbed_error_ctx), 0);
+    memset(&current_error_ctx, 0, sizeof(mbed_error_ctx));
     //Capture error information
     current_error_ctx.error_status = error_status;
     current_error_ctx.error_address = (uint32_t)caller;
@@ -279,7 +279,7 @@ mbed_error_status_t mbed_clear_all_errors(void)
     //Make sure we dont multiple clients resetting
     core_util_critical_section_enter();
     //Clear the error and context capturing buffer
-    memset(&last_error_ctx, sizeof(mbed_error_ctx), 0);
+    memset(&last_error_ctx, 0, sizeof(mbed_error_ctx));
     //reset error count to 0
     error_count = 0;
 #if MBED_CONF_PLATFORM_ERROR_HIST_ENABLED


### PR DESCRIPTION
### Description

Code had mixed up order of 'c' and 'n' arguments to memset().
Fix this.

Spotted-by: kjbracey-arm & a GCC profile without "-fno-builtin"

Related GCC warnings:
---8<---8<----
[Warning] mbed_error.c@123,5: 'memset' used with constant zero length parameter; this could be due to transposed parameters [-Wmemset-transposed-args]
[Warning] mbed_error.c@282,5: 'memset' used with constant zero length parameter; this could be due to transposed parameters [-Wmemset-transposed-args]

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

