### PR TITLE
Add framework for configuring boot stack size

### DIFF
--- a/rtos/mbed_lib.json
+++ b/rtos/mbed_lib.json
@@ -3,5 +3,22 @@
     "config": {
         "present": 1
     },
-    "macros": ["_RTE_"]
+    "macros": ["_RTE_"],
+    "target_overrides": {
+        "*": {
+            "target.boot-stack-size": "0x400"
+        },
+	    "MCU_NRF51": {
+	        "target.boot-stack-size": "0x800"
+	    },
+	    "MCU_NRF52840": {
+	        "target.boot-stack-size": "0x800"
+	    },
+	    "MCU_NRF52832": {
+	        "target.boot-stack-size": "0x800"
+	    },
+	    "MCU_NRF51_UNIFIED": {
+	        "target.boot-stack-size": "0x800"
+	    }
+    }
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -64,6 +64,10 @@
   #define MBED_APP_SIZE 0x100000
 #endif
 
+#if !defined(MBED_BOOT_STACK_SIZE)
+  #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
 #define m_interrupts_start             MBED_APP_START
 #define m_interrupts_size              0x00000400
 
@@ -86,7 +90,7 @@
 #if (defined(__stack_size__))
   #define Stack_Size                   __stack_size__
 #else
-  #define Stack_Size                   0x0400
+  #define Stack_Size                   MBED_BOOT_STACK_SIZE
 #endif
 
 #if (defined(__heap_size__))
@@ -121,5 +125,7 @@ LR_IROM1 m_interrupts_start m_text_start+m_text_size-m_interrupts_start {   ; lo
     .ANY (+RW +ZI)
   }
   RW_IRAM1 ImageLimit(RW_m_data_2) { ; Heap region growing up
+  }
+  ARM_LIB_STACK m_data_2_start+m_data_2_size EMPTY -Stack_Size { ; Stack region growing down
   }
 }

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -53,12 +53,6 @@ ENTRY(Reset_Handler)
 
 __ram_vector_table__ = 1;
 
-/* With the RTOS in use, this does not affect the main stack size. The size of
- * the stack where main runs is determined via the RTOS. */
-__stack_size__ = 0x400;
-
-__heap_size__ = 0x6000;
-
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0
 #endif
@@ -66,6 +60,16 @@ __heap_size__ = 0x6000;
 #if !defined(MBED_APP_SIZE)
   #define MBED_APP_SIZE 0x100000
 #endif
+
+#if !defined(MBED_BOOT_STACK_SIZE)
+    #define MBED_BOOT_STACK_SIZE 0x400
+#endif
+
+/* With the RTOS in use, this does not affect the main stack size. The size of
+ * the stack where main runs is determined via the RTOS. */
+__stack_size__ = MBED_BOOT_STACK_SIZE;
+
+__heap_size__ = 0x6000;
 
 HEAP_SIZE  = DEFINED(__heap_size__)  ? __heap_size__  : 0x0400;
 STACK_SIZE = DEFINED(__stack_size__) ? __stack_size__ : 0x0400;
@@ -259,7 +263,7 @@ SECTIONS
     __end__ = .;
     PROVIDE(end = .);
     __HeapBase = .;
-    . += HEAP_SIZE;
+    . = ORIGIN(m_data_2) + LENGTH(m_data_2) - STACK_SIZE;
     __HeapLimit = .;
     __heap_limit = .; /* Add for _sbrk */
   } > m_data_2

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/device/TOOLCHAIN_IAR/MK64FN1M0xxx12.icf
@@ -49,10 +49,6 @@
 */
 define symbol __ram_vector_table__ = 1;
 
-/* Heap 1/4 of ram and stack 1/8 */
-define symbol __stack_size__=0x8000;
-define symbol __heap_size__=0x10000;
-
 if (!isdefinedsymbol(MBED_APP_START)) {
     define symbol MBED_APP_START = 0;
 }
@@ -60,6 +56,13 @@ if (!isdefinedsymbol(MBED_APP_START)) {
 if (!isdefinedsymbol(MBED_APP_SIZE)) {
     define symbol MBED_APP_SIZE = 0x100000;
 }
+
+if (!isdefinedsymbol(MBED_BOOT_STACK_SIZE)) {
+    define symbol MBED_BOOT_STACK_SIZE = 0x400;
+}
+
+define symbol __stack_size__=MBED_BOOT_STACK_SIZE;
+define symbol __heap_size__=0x10000;
 
 define symbol __ram_vector_table_size__ =  isdefinedsymbol(__ram_vector_table__) ? 0x00000400 : 0;
 define symbol __ram_vector_table_offset__ =  isdefinedsymbol(__ram_vector_table__) ? 0x000003FF : 0;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -20,6 +20,10 @@
             "network-default-interface-type": {
                 "help": "Default network interface type. Typical options: null, ETHERNET, WIFI, CELLULAR, MESH",
                 "value": null
+            },
+            "boot-stack-size": {
+                "help": "Define the boot stack size in bytes. This value must be a multiple of 8",
+                "value": "0x1000"
             }
         }
     },

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -742,12 +742,22 @@ class mbedToolchain:
         except ConfigException:
             pass
 
+    def add_linker_defines(self):
+        stack_param = "target.boot-stack-size"
+        params, _ = self.config_data
+
+        if stack_param in params:
+            define_string = self.make_ld_define("MBED_BOOT_STACK_SIZE", int(params[stack_param].value, 0))
+            self.ld.append(define_string)
+            self.flags["ld"].append(define_string)
+
     # Set the configuration data
     def set_config_data(self, config_data):
         self.config_data = config_data
         # new configuration data can change labels, so clear the cache
         self.labels = None
         self.add_regions()
+        self.add_linker_defines()
 
     # Creates the configuration header if needed:
     # - if there is no configuration data, "mbed_config.h" is not create (or deleted if it exists).


### PR DESCRIPTION
### Description

Add the target config option "boot-stack-size" which is passed to the linker as the define "MBED_BOOT_STACK_SIZE" so the linker can adjust the stack accordingly. On mbed 2 the boot stack becomes the main stack after boot.  On mbed 5 the boot stack becomes the ISR stack after boot. Because of these different uses  the stack size for mbed 2 is set to 4K by default while on mbed 5 it is set to 1k.

Additionally, the NRF5X family requires a larger interrupt stack sizedue to the softdevice so the size  is increased to 2k on mbed 5 builds.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

