### PR TITLE
Fix error decode link

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -72,7 +72,7 @@
         },
         "error-decode-http-url-str": {
             "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
-            "value": "\"\\nFor more info, visit: https:/\\/armmbed.github.io/mbedos-error/?error=0x%08X\""
+            "value": "\"\\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X\""
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Description

The Mbed error decode microsite link string currently causes compile warnings. @SenRamakri were the slashes I removed necessary? They seem like they'd print the string out wrong in addition to causing the compile warning. The print logic isn't the same as standard printf though due to the context so deferring to you.

https://github.com/ARMmbed/mbed-os/pull/7662 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

