### PR TITLE
NRF52 serial: Fix UART console RX

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -113,6 +113,7 @@ void nrf_reloc_vector_table(void)
 #endif
 }
 
+#if (STDIO_UART_RTS != NC)
 void mbed_sdk_init(void)
 {
 	gpio_t rts;
@@ -120,3 +121,4 @@ void mbed_sdk_init(void)
 	/* Set STDIO_UART_RTS as gpio driven low */
 	gpio_write(&rts, 0);
 }
+#endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -39,6 +39,8 @@
 #include "nrf.h"
 #include "cmsis_nvic.h"
 #include "stdint.h"
+#include "PinNames.h"
+#include "hal/gpio_api.h"
 
 #if defined(SOFTDEVICE_PRESENT)
 #include "nrf_sdm.h"
@@ -109,4 +111,12 @@ void nrf_reloc_vector_table(void)
     /* No SoftDevice is present. Set all interrupts to vector table in RAM. */
     SCB->VTOR = (uint32_t) nrf_dispatch_vector;    
 #endif
+}
+
+void mbed_sdk_init(void)
+{
+	gpio_t rts;
+	gpio_init_out(&rts, STDIO_UART_RTS);
+	/* Set STDIO_UART_RTS as gpio driven low */
+	gpio_write(&rts, 0);
 }


### PR DESCRIPTION
While investigating the RX issue on NRF52_DK after SDK 14 updates,
it is observed that the RX FIFO doesn't get filled up, when the
flow control is disabled. Hence the readable never returns true.
If using Serial interface, the stdio file handles (0, 1, 2) get opened.
This results in configuring the flow control for STDIO, and it is observed
that the RX FIFO gets filled.

However, if RawSerial is used, the STDIO file handles
don't get opened. During the debug process it was observed that if the
flow control is configured once and then set to disabled, RX worked
as expected.

Alternative to this approach is that user application specifically
enables flow control as done in mbed's Greentea test suite. See https://goo.gl/r8nBYH

See https://goo.gl/8VB2qg step 14 for _initio's description.
See test code to reproduce the issue and test fix here: https://goo.gl/AQU1xG

### Description

The change in behavior with NRF52's UART RX is documented here. https://github.com/ARMmbed/mbed-os/issues/6891
This change is a fix for the above issue.

### Pull request type
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

