### PR TITLE
NRF52: serial_api: Use polling for putc

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/hal/nrf_uarte.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_14_2/drivers_nrf/hal/nrf_uarte.h
@@ -229,6 +229,25 @@ __STATIC_INLINE void nrf_uarte_event_clear(NRF_UARTE_Type * p_reg, nrf_uarte_eve
 __STATIC_INLINE bool nrf_uarte_event_check(NRF_UARTE_Type * p_reg, nrf_uarte_event_t event);
 
 /**
+ * @brief Function for checking the state of a specific extra UARTE event.
+ *
+ * @param[in] p_reg  Pointer to the peripheral registers structure.
+ * @param[in] event  Event to check.
+ *
+ * @retval True if event is set, False otherwise.
+ */
+__STATIC_INLINE bool nrf_uarte_event_extra_check(NRF_UARTE_Type * p_reg, uint32_t event);
+
+/**
+ * @brief Function for clearing a specific extra UARTE event.
+ *
+ * @param[in] p_reg  Pointer to the peripheral registers structure.
+ * @param[in] event  Extra event to clear.
+ */
+
+__STATIC_INLINE void nrf_uarte_event_extra_clear(NRF_UARTE_Type * p_reg, uint32_t event);
+
+/**
  * @brief Function for returning the address of a specific UARTE event register.
  *
  * @param[in] p_reg  Pointer to the peripheral registers structure.
@@ -456,7 +475,21 @@ __STATIC_INLINE void nrf_uarte_event_clear(NRF_UARTE_Type * p_reg, nrf_uarte_eve
 
 }
 
+__STATIC_INLINE void nrf_uarte_event_extra_clear(NRF_UARTE_Type * p_reg, uint32_t event)
+{
+    *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event)) = 0x0UL;
+#if __CORTEX_M == 0x04
+    volatile uint32_t dummy = *((volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event));
+    (void)dummy;
+#endif
+
+}
 __STATIC_INLINE bool nrf_uarte_event_check(NRF_UARTE_Type * p_reg, nrf_uarte_event_t event)
+{
+    return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
+}
+
+__STATIC_INLINE bool nrf_uarte_event_extra_check(NRF_UARTE_Type * p_reg, uint32_t event)
 {
     return (bool)*(volatile uint32_t *)((uint8_t *)p_reg + (uint32_t)event);
 }


### PR DESCRIPTION
There are scenarios where putc is called within a critical section, e.g
to log ASSERTs in early initialization code. The interrupts being
disabled here prevents the handlers for the UARTE from executing.
This breaks the tx_in_progress flag based approach. The tx_in_progress
never gets reset. Poll on the TXDRDY instead.

It can be recreated with a simple program as shown here: https://goo.gl/kLiAQF

*************** Current Behavior ****************
++ MbedOS Error Info ++
Error Status: 0x80FF0100 Code: 256 Module: 255
Error Message: F

************** With Fix *************************

++ MbedOS Error Info ++
Error Status: 0x80FF0100 Code: 256 Module: 255
Error Message: Fatal Run-time error
Location: 0x2C0A9
Error Value: 0x0
Current Thread: Id: 0x20005520 Entry: 0x30EBF StackSize: 0x1000 StackMem: 0x20004520 SP: 0x20005490
For more info, visit: https://armmbed.github.io/mbedos-error/?error=0x80FF0100
-- MbedOS Error Info --
nrf failure at .\main.cpp:22
***************************************************

### Description

When in a critical section, the interrupts are disabled and hence the tx_in_progress will never get cleared
leading to an infinite wait.

### Pull request type

Fix UART TX that is based on tx_in_progress variable. This may not get reset when in critical section.
Hence use polling.

    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

