### PR TITLE
Cellular: Fix Greentea tests for UBLOX_C027

### DIFF
--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -330,6 +330,7 @@ static void test_other()
 
     TEST_ASSERT(nw->set_blocking(true) == NSAPI_ERROR_OK);
 
+#ifndef TARGET_UBLOX_C027 // AT command is supported, but excluded as it runs out of memory easily (there can be very many operator names)
     if (strcmp(devi, "QUECTEL_BG96") != 0 && strcmp(devi, "SARA4_PPP") != 0) {
         // QUECTEL_BG96 timeouts with this one, tested with 3 minute timeout
         CellularNetwork::operator_names_list op_names;
@@ -346,6 +347,7 @@ static void test_other()
             TEST_ASSERT(strlen(opn->alpha) > 0);
         }
     }
+#endif
 
     // TELIT_HE910 and QUECTEL_BG96 just gives an error and no specific error number so we can't know is this real error or that modem/network does not support the command
     CellularNetwork::Supported_UE_Opt supported_opt = CellularNetwork::SUPPORTED_UE_OPT_MAX;


### PR DESCRIPTION
### Description

Excluded Greentea test for operator names query on SIM, due to there can be over a hundred operator names which causes  frequently out-of-memory problems on UBLOX_C027 (that has small memory).

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

