### PR TITLE
FileBase: Fix unsetting of default when destroyed

### DIFF
--- a/platform/FileBase.cpp
+++ b/platform/FileBase.cpp
@@ -57,7 +57,7 @@ FileBase::~FileBase()
     }
 
     if (_default == this) {
-        _default == NULL;
+        _default = NULL;
     }
 
     _mutex->unlock();


### PR DESCRIPTION
### Description

Code that should unset a FileBase from being the default when it is destroyed was broken by a `==` instead of `=` typo.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

