### PR TITLE
Fix default Mbed OS error URI string

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -72,7 +72,7 @@
         },
         "error-decode-http-url-str": {
             "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
-            "value": "\"\\nFor more info, visit: https:/\\/armmbed.github.io/mbedos-error/?error=0x%08X\""
+            "value": "\"\\nFor more info, visit: https://armmbed.github.io/mbedos-error/?error=0x%08X\""
         }
     },
     "target_overrides": {


### PR DESCRIPTION
### Description

Build warnings about illegal escape sequences were being generated - remove a stray C `\` (escaped as JSON `\\`).

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

