### PR TITLE
Clarify test configuration in Socket/Networking test document

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -234,6 +234,16 @@ content at minimum:
 
 ```
 {
+    "config": {
+        "echo-server-addr" : {
+            "help" : "IP address of echo server",
+            "value" : "\"echo.mbedcloudtesting.com\""
+        },
+        "echo-server-port" : {
+            "help" : "Port of echo server",
+            "value" : "7"
+        }
+    },
     "macros": ["MBED_EXTENDED_TESTS"]
 }
 ```
@@ -257,7 +267,7 @@ the `mbed_app.json` might look like this:
             "value": "\"password\""
         },
         "wifi-secure-protocol": {
-            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA/WPA2",
+            "help": "WiFi security protocol, valid values are WEP, WPA, WPA2, WPA_WPA2",
             "value": "\"WPA2\""
         },
         "wifi-ch-secure": {
@@ -280,17 +290,6 @@ the `mbed_app.json` might look like this:
             "help": "How many networks may appear in Wifi scan result",
             "value": 30
         },
-        "header-file": {
-            "help" : "String for including your driver header file",
-            "value" : "\"MyWifiInterface.h\""
-        },
-        "object-construction" : {
-            "value" : "new MyWifiInterface()"
-        },
-        "connect-statement" : {
-            "help" : "Must use 'net' variable name",
-            "value" : "net->wifiInterface()->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, NSAPI_SECURITY_WPA_WPA2)"
-        },
         "echo-server-addr" : {
             "help" : "IP address of echo server",
             "value" : "\"echo.mbedcloudtesting.com\""
@@ -300,9 +299,18 @@ the `mbed_app.json` might look like this:
             "value" : "7"
         }
     },
-    "macros": ["MBED_EXTENDED_TESTS"]
+    "macros": ["MBED_EXTENDED_TESTS"],
+    "target_overrides": {
+        "*": {
+            "target.network-default-interface-type": "WIFI",
+            "nsapi.default-wifi-ssid": "\"WIFI_SSID\"",
+            "nsapi.default-wifi-password": "\"WIFI_PASSWORD\"",
+            "nsapi.default-wifi-security": "WPA_WPA2"
+        }
+    }
 }
 ```
+See `mbed-os/tools/test_configs` folder for examples.
 
 Now build test binaries:
 


### PR DESCRIPTION
### Description

Clarify test configuration in Socket/Networking test document.
Current documentation instructs user to supply `mbed_app.json` and rely content of `tools/test_configuration` to be appended. However, this is not working.
Full `mbed_app.json` needs to be provided.

Fixes #8055 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

