### PR TITLE
NRF52: Ensure that we configure hardware after flow control changes

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/serial_api.c
@@ -1257,6 +1257,7 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
 
     /* Force reconfiguration next time object is owner. */
     uart_object->update = true;
+    nordic_nrf5_serial_configure(obj);
 }
 
 /** Clear the serial peripheral


### PR DESCRIPTION
Call the routines to program the hardware to reflect the updates made to
flow control so that the object and hardware are in synch.

### Description

During the initialization of the UART, when the flow control is set on the object, it is possible that the change does not get reflected in hardware. See attached screenshot. This change makes sure that we update the hardware registers.

![discrepancy_in_settings](https://user-images.githubusercontent.com/39923816/45308669-a1374880-b4e7-11e8-9fab-b5284fb4b2ba.PNG)



### Pull request type

    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

