### PR TITLE
`mbed dm`: Accept api key and host on the command line

### DIFF
--- a/tools/device_management.py
+++ b/tools/device_management.py
@@ -80,10 +80,23 @@ def wrap_payload(func):
 
 def wrap_init(func):
     def inner(options):
-        accounts = AccountManagementAPI()
-        certs = CertificatesAPI()
+        if getattr(options, 'api_key', None):
+            api_key = options.api_key
+        else:
+            api_key = getenv("MBED_CLOUD_SDK_API_KEY")
+        if getattr(options, 'server_address', None):
+            host_addr = options.server_address
+        else:
+            host_addr = getenv("MBED_CLOUD_SDK_HOST",
+                               "https://api.us-east-1.mbedcloud.com/")
+        config = {
+            "api_key": api_key,
+            "host": host_addr,
+        }
+        accounts = AccountManagementAPI(config)
+        certs = CertificatesAPI(config)
         api_key = accounts.list_api_keys(filter={
-            'key': getenv("MBED_CLOUD_SDK_API_KEY")
+            'key': api_key
         }).next()
         user = accounts.get_user(api_key.owner_id)
         certificates_owned = list(certs.list_certificates())


### PR DESCRIPTION
### Description

`mbed dm` will now accept the Pelion Device Management API Key and 
Host on the command line with the following switches:
 * `-a`, `--api-key` accepts the API Key
 * `-S` (note capitol), `--server-address` accepts the Host

 This is consistant with manifest tool parameters
 Resolves https://github.com/ARMmbed/mbed-cli/issues/745

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change