### PR TITLE
Move unittest paths to hyphens

### DIFF
--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -225,7 +225,7 @@ For example to create a unit test for `rtos/Semaphore.cpp`:
 1. Create a directory for unit test files in `UNITTESTS/rtos/Semaphore`.
 2. Create a test definition file `UNITTESTS/rtos/Semaphore/unittest.cmake` with the following content:
 ```
-set(TEST_SUITE_NAME "rtos_Semaphore")
+set(TEST_SUITE_NAME "rtos-Semaphore")
 
 set(unittest-sources
 	stubs/mbed_assert.c

--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -79,7 +79,7 @@ mbed test --unittests
 
 A subset of tests can be run by providing `-r` flag for the tool which runs tests matching a regular expression.
 
-e.g. `mbed test --unittests --run -r features_netsocket`
+e.g. `mbed test --unittests --run -r features-netsocket`
 
 ### Build manually without Python tools
 
@@ -105,7 +105,7 @@ mingw32-make
 
 #### Custom CMake variables
 
-Usage: 
+Usage:
 `cmake [RELATIVE PATH TO UNITTESTS DIR] [OPTIONS]`
 
 Keyword variables (usage `cmake -D<VARIABLE>(:<TYPE>)=<value>`:
@@ -157,8 +157,8 @@ mkdir UNITTESTS/build
 cd UNITTESTS/build
 cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE:STRING=html  ..
 make
-./features_netsocket_InternetSocket
-gcovr -r ../.. --html --html-detail -o ./index.html ./CMakeFiles/features_netsocket_InternetSocket.MbedOS.dir/
+./features-netsocket-InternetSocket
+gcovr -r ../.. --html --html-detail -o ./index.html ./CMakeFiles/features-netsocket-InternetSocket.MbedOS.dir/
 ```
 Windows:
 ```
@@ -166,8 +166,8 @@ mkdir UNITTESTS/build
 cd UNITTESTS/build
 cmake -DCMAKE_BUILD_TYPE=Debug -DCOVERAGE:STRING=html -g "MinGW Makefiles" ..
 mingw32-make
-features_netsocket_InternetSocket.exe
-gcovr -r ..\.. --html --html-detail -o .\index.html .\CMakeFiles\features_netsocket_InternetSocket.MbedOS.dir\
+features-netsocket-InternetSocket.exe
+gcovr -r ..\.. --html --html-detail -o .\index.html .\CMakeFiles\features-netsocket-InternetSocket.MbedOS.dir\
 ```
 
 ## The structure of unit tests
@@ -203,7 +203,7 @@ Each class to be tested requires two files for unit testing:
 
 A unit test definition file `unittest.cmake` requires variables to be set for a test to be configured. File source paths in `unittest.cmake` files need to be relative to the unit test folder and `CMakeLists.txt`.
 
-* **TEST_SUITE_NAME** - Identifier for the test suite. Use naming convention *PATH_TO_THE_TESTABLE_FILE* e.g. *features_netsocket_InternetSocket*
+* **TEST_SUITE_NAME** - Identifier for the test suite. Use naming convention *PATH_TO_THE_TESTABLE_FILE* e.g. *features-netsocket-InternetSocket*
 * **unittest-includes** - Include paths for headers needed to build the tests in addition to the base include paths listed in [CMakeLists.txt](CMakeLists.txt). Optional.
 * **unittest-sources** - Mbed OS source files and stubs included for the build.
 * **unittest-test-sources** - Unit test source files.

--- a/UNITTESTS/features/cellular/framework/AT/AT_CellularBase/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/AT_CellularBase/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "cellular_framework_AT_AT_CellularBase")
+set(TEST_SUITE_NAME "cellular-framework-AT-AT_CellularBase")
 
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}

--- a/UNITTESTS/features/cellular/framework/common/util/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/common/util/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "cellular_framework_common_util")
+set(TEST_SUITE_NAME "cellular-framework-common-util")
 
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}

--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "features_netsocket_InternetSocket")
+set(TEST_SUITE_NAME "features-netsocket-InternetSocket")
 
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp

--- a/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "features_netsocket_NetworkInterface")
+set(TEST_SUITE_NAME "features-netsocket-NetworkInterface")
 
 # Source files
 set(unittest-sources

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "features_netsocket_TCPSocket")
+set(TEST_SUITE_NAME "features-netsocket-TCPSocket")
 
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "features_netsocket_UDPSocket")
+set(TEST_SUITE_NAME "features-netsocket-UDPSocket")
 
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp

--- a/UNITTESTS/platform/CircularBuffer/unittest.cmake
+++ b/UNITTESTS/platform/CircularBuffer/unittest.cmake
@@ -4,7 +4,7 @@
 ####################
 
 # Unit test suite name
-set(TEST_SUITE_NAME "platform_CircularBuffer")
+set(TEST_SUITE_NAME "platform-CircularBuffer")
 
 set(unittest-sources
 )


### PR DESCRIPTION
### Description

This PR is part of the 5.10 OOB process.

This PR proposes to move the naming convention for unittests to be consistent with the naming convention for greentea and icetea tests. Currently, unittests name test suites by separating directory names by underscores. So for example, a test contained in `features/netsocket/NetworkInterface` would be named `features_netsocket_NetworkInterface`. However, the existing test frameworks for greentea and icetea uses hyphens, so it would be named `features-netsocket-NetworkInterface`. This PR moves the naming to use hyphens to be inline with the current frameworks.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

