### PR TITLE
Syncronize mbed-ls minimum version with icetea requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ IntelHex>=1.3
 junit-xml
 pyYAML
 requests
-mbed-ls>=1.4.2,==1.*
+mbed-ls>=1.5.1,==1.*
 mbed-host-tests>=1.1.2
 mbed-greentea>=0.2.24
 beautifulsoup4>=4


### PR DESCRIPTION
### Description

Fix for: https://github.com/ARMmbed/mbed-os/issues/8064

Root cause is that  icetea, mbed-flasher requires newer mbed-ls than mbed-os and mbed-cli install requirements based on mbed-os requirements

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

