### PR TITLE
Error output improvements

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -135,7 +135,7 @@ void UARTSerial::sigio(Callback<void()> func)
 }
 
 /* Special synchronous write designed to work from critical section, such
- * as in mbed_error_vfprintf.
+ * as in mbed_error_vprintf.
  */
 ssize_t UARTSerial::write_unbuffered(const char *buf_ptr, size_t length)
 {

--- a/drivers/UARTSerial.h
+++ b/drivers/UARTSerial.h
@@ -238,6 +238,9 @@ private:
     /** Release mutex */
     virtual void api_unlock(void);
 
+    /** Unbuffered write - invoked when write called from critical section */
+    ssize_t write_unbuffered(const char *buf_ptr, size_t length);
+
     /** Software serial buffers
      *  By default buffer size is 256 for TX and 256 for RX. Configurable through mbed_app.json
      */

--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -56,25 +56,31 @@ void mbed_error_printf(const char *format, ...)
 
 void mbed_error_vprintf(const char *format, va_list arg)
 {
-#define ERROR_BUF_SIZE      (128)
     core_util_critical_section_enter();
-    char buffer[ERROR_BUF_SIZE];
-    int size = vsnprintf(buffer, ERROR_BUF_SIZE, format, arg);
-    if (size > 0) {
-#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES || MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES
-        char stdio_out_prev = '\0';
-        for (int i = 0; i < size; i++) {
-            if (buffer[i] == '\n' && stdio_out_prev != '\r') {
-                const char cr = '\r';
-                write(STDERR_FILENO, &cr, 1);
-            }
-            write(STDERR_FILENO, &buffer[i], 1);
-            stdio_out_prev = buffer[i];
-        }
-#else
-        write(STDERR_FILENO, buffer, size);
-#endif
+    char buffer[132];
+    int size = vsnprintf(buffer, sizeof buffer, format, arg);
+    if (size >= sizeof buffer) {
+        /* Output was truncated - indicate by overwriting last 4 bytes of buffer
+         * with ellipsis and newline.
+         * (Note that although vsnprintf always leaves a NUL terminator, we
+         * don't need a terminator and can use the entire buffer)
+         */
+        memcpy(&buffer[sizeof buffer - 4], "...\n", 4);
+        size = sizeof buffer;
     }
+#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES || MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES
+    char stdio_out_prev = '\0';
+    for (int i = 0; i < size; i++) {
+        if (buffer[i] == '\n' && stdio_out_prev != '\r') {
+            const char cr = '\r';
+            write(STDERR_FILENO, &cr, 1);
+        }
+        write(STDERR_FILENO, &buffer[i], 1);
+        stdio_out_prev = buffer[i];
+    }
+#else
+    write(STDERR_FILENO, buffer, size);
+#endif
     core_util_critical_section_exit();
 }
 

--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -18,13 +18,8 @@
 #include "platform/mbed_wait_api.h"
 #include "platform/mbed_toolchain.h"
 #include "platform/mbed_interface.h"
+#include "platform/mbed_retarget.h"
 #include "platform/mbed_critical.h"
-#include "hal/serial_api.h"
-
-#if DEVICE_SERIAL
-extern int stdio_uart_inited;
-extern serial_t stdio_uart;
-#endif
 
 WEAK void mbed_die(void)
 {
@@ -61,30 +56,24 @@ void mbed_error_printf(const char *format, ...)
 
 void mbed_error_vfprintf(const char *format, va_list arg)
 {
-#if DEVICE_SERIAL
 #define ERROR_BUF_SIZE      (128)
     core_util_critical_section_enter();
     char buffer[ERROR_BUF_SIZE];
     int size = vsnprintf(buffer, ERROR_BUF_SIZE, format, arg);
     if (size > 0) {
-        if (!stdio_uart_inited) {
-            serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
-        }
-#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES
+#if MBED_CONF_PLATFORM_STDIO_CONVERT_NEWLINES || MBED_CONF_PLATFORM_STDIO_CONVERT_TTY_NEWLINES
         char stdio_out_prev = '\0';
         for (int i = 0; i < size; i++) {
             if (buffer[i] == '\n' && stdio_out_prev != '\r') {
-                serial_putc(&stdio_uart, '\r');
+                const char cr = '\r';
+                write(STDERR_FILENO, &cr, 1);
             }
-            serial_putc(&stdio_uart, buffer[i]);
+            write(STDERR_FILENO, &buffer[i], 1);
             stdio_out_prev = buffer[i];
         }
 #else
-        for (int i = 0; i < size; i++) {
-            serial_putc(&stdio_uart, buffer[i]);
-        }
+        write(STDERR_FILENO, buffer, size);
 #endif
     }
     core_util_critical_section_exit();
-#endif
 }

--- a/platform/mbed_board.c
+++ b/platform/mbed_board.c
@@ -50,11 +50,11 @@ void mbed_error_printf(const char *format, ...)
 {
     va_list arg;
     va_start(arg, format);
-    mbed_error_vfprintf(format, arg);
+    mbed_error_vprintf(format, arg);
     va_end(arg);
 }
 
-void mbed_error_vfprintf(const char *format, va_list arg)
+void mbed_error_vprintf(const char *format, va_list arg)
 {
 #define ERROR_BUF_SIZE      (128)
     core_util_critical_section_enter();
@@ -76,4 +76,9 @@ void mbed_error_vfprintf(const char *format, va_list arg)
 #endif
     }
     core_util_critical_section_exit();
+}
+
+void mbed_error_vfprintf(const char *format, va_list arg)
+{
+    mbed_error_vprintf(format, arg);
 }

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -89,7 +89,7 @@ WEAK void error(const char *format, ...)
 #ifndef NDEBUG
     va_list arg;
     va_start(arg, format);
-    mbed_error_vfprintf(format, arg);
+    mbed_error_vprintf(format, arg);
     va_end(arg);
 #endif
     exit(1);

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -42,7 +42,7 @@ extern "C" {
 #else //MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN
 #if MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN > 64
 //We have to limit this to 64 bytes since we use mbed_error_printf for error reporting
-//and mbed_error_vfprintf uses 128bytes internal buffer which may not be sufficient for anything
+//and mbed_error_vprintf uses 128bytes internal buffer which may not be sufficient for anything
 //longer that 64 bytes with the current implementation.
 #error "Unsupported error filename buffer length detected, max supported length is 64 chars. Please change MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN or max-error-filename-len in configuration."
 #endif

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -26,6 +26,7 @@
 
 #include <stdarg.h>
 
+#include "mbed_toolchain.h"
 #include "device.h"
 
 /* Mbed interface mac address
@@ -146,8 +147,14 @@ void mbed_error_printf(const char *format, ...);
  * @param arg       Variable arguments list
  *
  */
+void mbed_error_vprintf(const char *format, va_list arg);
+
+/** @deprecated   Renamed to mbed_error_vprintf to match functionality */
+MBED_DEPRECATED_SINCE("mbed-os-5.11",
+                          "Renamed to mbed_error_vprintf to match functionality.")
 void mbed_error_vfprintf(const char *format, va_list arg);
 /** @}*/
+
 
 #ifdef __cplusplus
 }

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1250,6 +1250,8 @@ extern "C" void exit(int return_code)
 #if MBED_CONF_PLATFORM_STDIO_FLUSH_AT_EXIT
     fflush(stdout);
     fflush(stderr);
+    fsync(STDOUT_FILENO);
+    fsync(STDERR_FILENO);
 #endif
 #endif
 

--- a/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
+++ b/rtos/TARGET_CORTEX/TARGET_CORTEX_M/mbed_rtx_fault_handler.c
@@ -18,7 +18,6 @@
 #include "device.h"
 #include "platform/mbed_error.h"
 #include "platform/mbed_interface.h"
-#include "hal/serial_api.h"
 
 #ifndef MBED_FAULT_HANDLER_DISABLED
 #include "mbed_rtx_fault_handler.h"


### PR DESCRIPTION
### Description

* Make `mbed_error_printf` not serial specific
* Ensure serial buffer is flushed before error output
* `sync` output devices on exit, as well as `fflush`
* Rename `mbed_error_vfprintf` to `mbed_error_vprintf`
* <strike>Add format checking to `mbed_error_printf` et al</strike>
* Don't overrun in long error prints - indicate truncation
* <strike>Split up and tidy "assertation" message"</strike>

Fixes #7363 - possibly others I need to find.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

