### PR TITLE
STM32 RTC : start LSI clock (for targets without LSE)

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F0/common_objects.h
@@ -148,7 +148,6 @@ struct flash_s {
 #endif
 
 /* STM32F0 HAL doesn't provide this API called in rtc_api.c */
-#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__)
 #define RTC_WKUP_IRQn RTC_IRQn
 
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F1/common_objects.h
@@ -137,8 +137,4 @@ struct flash_s {
 }
 #endif
 
-/* STM32F1 HAL doesn't provide this API called in rtc_api.c */
-#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__)
-
 #endif
-

--- a/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F3/common_objects.h
@@ -145,8 +145,4 @@ struct flash_s {
 }
 #endif
 
-/* STM32F3 HAL doesn't provide this API called in rtc_api.c */
-#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__)
-
 #endif
-

--- a/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/common_objects.h
@@ -143,8 +143,4 @@ struct can_s {
 };
 #endif
 
-/* STM32L4 HAL doesn't provide this API called in rtc_api.c */
-#define __HAL_RCC_RTC_CLKPRESCALER(__RTCCLKSource__)
-
 #endif
-

--- a/targets/TARGET_STM/mbed_overrides.c
+++ b/targets/TARGET_STM/mbed_overrides.c
@@ -54,5 +54,21 @@ void mbed_sdk_init()
     SetSysClock();
     SystemCoreClockUpdate();
 
+    /* Start LSI clock for RTC */
+#if DEVICE_RTC
+#if !MBED_CONF_TARGET_LSE_AVAILABLE
+    RCC_OscInitTypeDef RCC_OscInitStruct = {0};
+
+    if (__HAL_RCC_GET_RTC_SOURCE() != RCC_RTCCLKSOURCE_NO_CLK) {
+        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
+        RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
+        RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
+        if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+            error("Init : cannot initialize LSI\n");
+        }
+    }
+#endif /* ! MBED_CONF_TARGET_LSE_AVAILABLE */
+#endif /* DEVICE_RTC */
+
     mbed_sdk_inited = 1;
 }

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -76,10 +76,6 @@ void rtc_init(void)
         error("PeriphClkInitStruct RTC failed with LSE\n");
     }
 #else /*  MBED_CONF_TARGET_LSE_AVAILABLE */
-    // Reset Backup domain
-    __HAL_RCC_BACKUPRESET_FORCE();
-    __HAL_RCC_BACKUPRESET_RELEASE();
-
     // Enable LSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!

--- a/targets/TARGET_STM/rtc_api.c
+++ b/targets/TARGET_STM/rtc_api.c
@@ -60,14 +60,12 @@ void rtc_init(void)
 
 #if MBED_CONF_TARGET_LSE_AVAILABLE
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON;
-
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         error("Cannot initialize RTC with LSE\n");
     }
 
-    __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSE);
     __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSE);
 
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
@@ -76,15 +74,13 @@ void rtc_init(void)
         error("PeriphClkInitStruct RTC failed with LSE\n");
     }
 #else /*  MBED_CONF_TARGET_LSE_AVAILABLE */
-    // Enable LSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI;
-    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
+    RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
     RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
     if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
         error("Cannot initialize RTC with LSI\n");
     }
 
-    __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
     __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
 
     PeriphClkInitStruct.PeriphClockSelection = RCC_PERIPHCLK_RTC;
@@ -112,14 +108,14 @@ void rtc_init(void)
 #endif /* TARGET_STM32F1 */
 
     if (HAL_RTC_Init(&RtcHandle) != HAL_OK) {
-        error("RTC initialization failed");
+        error("RTC initialization failed\n");
     }
 
 #if !(TARGET_STM32F1) && !(TARGET_STM32F2)
     /* STM32F1 : there are no shadow registers */
     /* STM32F2 : shadow registers can not be bypassed */
     if (HAL_RTCEx_EnableBypassShadow(&RtcHandle) != HAL_OK) {
-        error("EnableBypassShadow error");
+        error("EnableBypassShadow error\n");
     }
 #endif /* TARGET_STM32F1 || TARGET_STM32F2 */
 }


### PR DESCRIPTION
### Description

RTC clock should be enabled as soon as possible after SW reset.

- for targets with LSE (most of targets with STM32), it is already working

- for targets using the internal clock (LSI), it was not the case, and all RTC registers were reset.

### Test result

tests-mbed_hal-rtc_reset was FAIL for DISCO_F429ZI,
and is OK now

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

