### PR TITLE
Fix SocketAddress unittests

### DIFF
--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -100,6 +100,7 @@ set(unittest-includes-base
   "${PROJECT_SOURCE_DIR}/../rtos/TARGET_CORTEX"
   "${PROJECT_SOURCE_DIR}/../rtos/TARGET_CORTEX/rtx5/Include"
   "${PROJECT_SOURCE_DIR}/../cmsis"
+  "${PROJECT_SOURCE_DIR}/../features/frameworks/nanostack-libservice/mbed-client-libservice/"
 )
 
 # Create a list for test suites.

--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -10,6 +10,8 @@ set(unittest-sources
   ../features/netsocket/SocketAddress.cpp
   ../features/netsocket/NetworkStack.cpp
   ../features/netsocket/InternetSocket.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
 )
 
 set(unittest-test-sources

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -10,6 +10,8 @@ set(unittest-sources
   ../features/netsocket/SocketAddress.cpp
   ../features/netsocket/InternetSocket.cpp
   ../features/netsocket/TCPSocket.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
 )
 
 set(unittest-test-sources

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -11,6 +11,8 @@ set(unittest-sources
   ../features/netsocket/NetworkStack.cpp
   ../features/netsocket/InternetSocket.cpp
   ../features/netsocket/UDPSocket.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
 )
 
 set(unittest-test-sources


### PR DESCRIPTION
### Description

Add ip4tos() and stoip4() into SocketAddress unittests.
NOTE: Probably should have been stubbed but this way we can also
test these helper functions.

https://github.com/ARMmbed/mbed-os/pull/6293 Added usage of these helper functions, but by that time unit tests were not in place.

CC: @OPpuolitaival @kjbracey-arm 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

