### PR TITLE
Cleanup SPI constructor and destructor

### DIFF
--- a/drivers/SPI.cpp
+++ b/drivers/SPI.cpp
@@ -41,9 +41,14 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
     _write_fill(SPI_FILL_CHAR)
 {
     // No lock needed in the constructor
-
     spi_init(&_spi, mosi, miso, sclk, ssel);
-    _acquire();
+}
+
+SPI::~SPI()
+{
+    if (_owner == this) {
+        _owner = NULL;
+    }
 }
 
 void SPI::format(int bits, int mode)

--- a/drivers/SPI.h
+++ b/drivers/SPI.h
@@ -87,6 +87,7 @@ public:
      *  @param ssel SPI chip select pin
      */
     SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel = NC);
+    virtual ~SPI();
 
     /** Configure the data transmission format
      *
@@ -271,11 +272,6 @@ private:
 #endif
 
 #endif
-
-public:
-    virtual ~SPI()
-    {
-    }
 
 protected:
     spi_t _spi;


### PR DESCRIPTION
### Description
The SPI class has a member "static SPI *_owner;" to indicate need to set SPI parameters or not. Clear the _owner in constructor to allow SPI to initialize everytime a object is constructed.

Resolves: https://github.com/ARMmbed/mbed-os/issues/4969

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

