### PR TITLE
Fix quotes around gcovr install command for Windows

### DIFF
--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -45,7 +45,7 @@ sudo easy_install pip
 
 ### Installing covr
 
-Install gcovr code coverage tool globally with `pip install 'gcovr>=4.1'` or using virtualenv:
+Install gcovr code coverage tool globally with `pip install "gcovr>=4.1"` or using virtualenv:
 
 #### virtualenv
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This PR changes the gcovr install command from `pip install 'gcovr>=4.1'` to `pip install "gcovr>=4.1"` to work successfully on Windows

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

