### PR TITLE
Add a HAL set_time() test

### DIFF
--- a/TESTS/mbed_hal/rtc_time/main.cpp
+++ b/TESTS/mbed_hal/rtc_time/main.cpp
@@ -169,6 +169,31 @@ void test_local_time_invalid_param()
     TEST_ASSERT_EQUAL(false, _rtc_localtime(1, NULL, RTC_4_YEAR_LEAP_YEAR_SUPPORT));
 }
 
+/* Test set_time() function called a few seconds apart.
+ *
+ * Given is set_time() function.
+ * When set_time() is used to set the system time two times.
+ * Then if the value returned from time() is always correct return true, otherwise return false.
+ */
+#define NEW_TIME 15
+void test_set_time_twice()
+{
+    time_t current_time;
+
+    /* Set the time to NEW_TIME and check it */
+    set_time(NEW_TIME);
+    current_time = time(NULL);
+    TEST_ASSERT_EQUAL (true, (current_time == NEW_TIME));
+
+    /* Wait 2 seconds */
+    wait_ms(2000);
+
+    /* set the time to NEW_TIME again and check it */
+    set_time(NEW_TIME);
+    current_time = time(NULL);
+    TEST_ASSERT_EQUAL (true, (current_time == NEW_TIME));
+}
+
 utest::v1::status_t teardown_handler_t(const Case *const source, const size_t passed, const size_t failed,
                                        const failure_t reason)
 {
@@ -196,6 +221,7 @@ Case cases[] = {
     Case("test make time boundary values - RTC leap years partial support", partial_leap_year_case_setup_handler_t, test_mk_time_boundary, teardown_handler_t),
     Case("test make time - invalid param", test_mk_time_invalid_param, teardown_handler_t),
     Case("test local time - invalid param", test_local_time_invalid_param, teardown_handler_t),
+    Case("test set_time twice", test_set_time_twice, teardown_handler_t),
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)


### PR DESCRIPTION
### Description
This is the HAL test requested for https://github.com/ARMmbed/mbed-os/pull/7849.  

Without DEVICE_RTC defined set_time() was not being tested. When DEVICE_LPTICKER is defined set_time() only works correctly on the first call. This test calls set_time() twice and ensures the time set by both calls is correct.

Here is the test output on the nRF52_DK (where the problem was identified): 
```
$ mbed test -m nrf52_dk -t arm -n mbed-os-tests-mbed_hal-rtc_time -c
...

Build successes:
  * NRF52_DK::ARM::MBED-BUILD
  * NRF52_DK::ARM::MBED-OS-TESTS-MBED_HAL-RTC_TIME
mbedgt: greentea test automation tool ver. 1.3.3
mbedgt: test specification file 'C:\_nrf\greentea\BUILD\tests\NRF52_DK\ARM\test_spec.json' (specified with --test-spec option)
mbedgt: using 'C:\_nrf\greentea\BUILD\tests\NRF52_DK\ARM\test_spec.json' from current directory!
mbedgt: detecting connected mbed-enabled devices...
mbedgt: detected 1 device
mbedgt: processing target 'NRF52_DK' toolchain 'ARM' compatible platforms... (note: switch set to --parallel 1)
mbedgt: test case filter (specified with -n option)
        mbed-os-tests-mbed_hal-rtc_time
        {u'mbed-os-tests-mbed_hal-rtc_time': <mbed_greentea.tests_spec.Test instance at 0x0432DE18>}
        test filtered in 'mbed-os-tests-mbed_hal-rtc_time'
mbedgt: running 1 test for platform 'NRF52_DK' and toolchain 'ARM'
mbedgt: mbed-host-test-runner: started
mbedgt: checking for GCOV data...
mbedgt: test on hardware with target id: 000682276342
mbedgt: test suite 'mbed-os-tests-mbed_hal-rtc_time' ................................................. OK in 21.23 sec
        test case: 'test is leap year - RTC leap years full support' ................................. OK in 0.09 sec
        test case: 'test is leap year - RTC leap years partial support' .............................. OK in 0.07 sec
        test case: 'test local time - invalid param' ................................................. OK in 0.06 sec
        test case: 'test make time - invalid param' .................................................. OK in 0.05 sec
        test case: 'test make time boundary values - RTC leap years full support' .................... OK in 0.09 sec
        test case: 'test make time boundary values - RTC leap years partial support' ................. OK in 0.09 sec
        test case: 'test set_time twice' ............................................................. OK in 2.05 sec
mbedgt: test case summary: 7 passes, 0 failures
mbedgt: all tests finished!
mbedgt: shuffle seed: 0.9738552186
mbedgt: test suite report:
+--------------+---------------+---------------------------------+--------+--------------------+-------------+
| target       | platform_name | test suite                      | result | elapsed_time (sec) | copy_method |
+--------------+---------------+---------------------------------+--------+--------------------+-------------+
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | OK     | 21.23              | default     |
+--------------+---------------+---------------------------------+--------+--------------------+-------------+
mbedgt: test suite results: 1 OK
mbedgt: test case report:
+--------------+---------------+---------------------------------+-----------------------------------------------------------------+--------+--------+--------+--------------------+
| target       | platform_name | test suite                      | test case                                                       | passed | failed | result | elapsed_time (sec) |
+--------------+---------------+---------------------------------+-----------------------------------------------------------------+--------+--------+--------+--------------------+
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test is leap year - RTC leap years full support                 | 1      | 0      | OK     | 0.09               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test is leap year - RTC leap years partial support              | 1      | 0      | OK     | 0.07               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test local time - invalid param                                 | 1      | 0      | OK     | 0.06               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test make time - invalid param                                  | 1      | 0      | OK     | 0.05               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test make time boundary values - RTC leap years full support    | 1      | 0      | OK     | 0.09               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test make time boundary values - RTC leap years partial support | 1      | 0      | OK     | 0.09               |
| NRF52_DK-ARM | NRF52_DK      | mbed-os-tests-mbed_hal-rtc_time | test set_time twice                                             | 1      | 0      | OK     | 2.05               |
+--------------+---------------+---------------------------------+-----------------------------------------------------------------+--------+--------+--------+--------------------+
mbedgt: test case results: 7 OK
mbedgt: completed in 23.69 sec
```


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

