### PR TITLE
Add support for nrf52_dk bootloader

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -425,11 +425,11 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
             notify.info("  Filling region %s with %s" % (region.name, region.filename))
             part = intelhex_offset(region.filename, offset=region.start)
             part.start_addr = None
-            if len(part.segments()) == 1:
-                part_size = (part.maxaddr() - part.minaddr()) + 1
-            else:
-                # make same assumption as in region builder; first segments must fit.
-                part_size = part.segments()[0][1] - part.segments()[0][0]
+
+            # make same assumption as in region builder; first segment must fit.
+            # this is only to get a neat ToolException anyway, since IntelHex.merge will
+            # throw intelhex.AddressOverlapError if there's overlapping
+            part_size = part.segments()[0][1] - part.segments()[0][0]
 
             if part_size > region.size:
                 raise ToolException("Contents of region %s does not fit"

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -433,13 +433,9 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
 
             # make same assumption as in region builder; first segment must fit.
             # this is only to get a neat ToolException anyway, since IntelHex.merge will
-            # throw intelhex.AddressOverlapError if there's overlapping
+            # throw IntelHex.AddressOverlapError if there's overlapping
             part_size = 0
             for es in part.segments():
-                # Add padding in between segments starting from end of first segment
-                if (len(part.segments()) > 1 and (merged.maxaddr() != None)):
-                    pad_size = es[0] - (merged.maxaddr() + 1)
-                    merged.puts(merged.maxaddr()+1, padding * pad_size)
                 part_size += es[1] - es[0]
                 merged.merge(part[es[0]:_end_addr_inclusive(es[1])])
 
@@ -447,16 +443,15 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
                 raise ToolException("Contents of region %s does not fit"
                                     % region.name)
 
-            # This padding applies for only files with one segment
-            if (len(part.segments()) == 1):
-                pad_size = region.size - part_size
-            else:
-                pad_size = 0
-
-            if pad_size > 0 and region != region_list[-1] and format != ".hex":
-                notify.info("  Padding region %s with 0x%x bytes" %
-                            (region.name, pad_size))
-                merged.puts(merged.maxaddr() + 1, padding * pad_size)
+    # Hex file can have gaps, so no padding needed. While other formats may
+    # need padding. Iterate through segments and pad the gaps.
+    if (format != ".hex"):
+        begin = 0
+        for es in merged.segments():
+            if (begin < es[0]):
+                pad_size = es[0] - begin
+                merged.puts(begin, padding * pad_size)
+            begin = es[1] + 1
 
     if not exists(dirname(destination)):
         makedirs(dirname(destination))

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -435,9 +435,9 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
             # this is only to get a neat ToolException anyway, since IntelHex.merge will
             # throw IntelHex.AddressOverlapError if there's overlapping
             part_size = 0
-            for es in part.segments():
-                part_size += es[1] - es[0]
-                merged.merge(part[es[0]:_end_addr_inclusive(es[1])])
+            for start, stop in part.segments():
+                part_size += stop - start
+            merged.merge(part)
 
             if part_size > region.size:
                 raise ToolException("Contents of region %s does not fit"
@@ -445,13 +445,12 @@ def merge_region_list(region_list, destination, notify, padding=b'\xFF'):
 
     # Hex file can have gaps, so no padding needed. While other formats may
     # need padding. Iterate through segments and pad the gaps.
-    if (format != ".hex"):
+    if format != ".hex":
         begin = 0
-        for es in merged.segments():
-            if (begin < es[0]):
-                pad_size = es[0] - begin
-                merged.puts(begin, padding * pad_size)
-            begin = es[1] + 1
+        for start, stop in merged.segments():
+            pad_size = start - begin
+            merged.puts(begin, padding * pad_size)
+            begin = stop + 1
 
     if not exists(dirname(destination)):
         makedirs(dirname(destination))

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -711,9 +711,17 @@ class Config(object):
                 raise ConfigException("bootloader executable does not "
                                       "start at 0x%x" % rom_start)
 
-            # segments returns start address and 'next after end' address
-            part_size = part.segments()[0][1] - part.segments()[0][0]
-            part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
+            # find the last valid address that's within rom_end and use that
+            # to compute the bootloader size
+            end_address = None
+            for each in part.segments():
+                if (each[1] < rom_end):
+                    end_address = each[1]
+                else:
+                    break
+            if end_address == None:
+                raise ConfigException("bootloader segments don't fit within rom region")
+            part_size = Config._align_ceiling(rom_start + (end_address - start), self.sectors) - rom_start
 
             yield Region("bootloader", rom_start, part_size, False,
                          filename)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -698,7 +698,6 @@ class Config(object):
     def _generate_bootloader_build(self, rom_start, rom_size):
         start = rom_start
         rom_end = rom_start + rom_size
-        max_app_addr = None
         if self.target.bootloader_img:
             if isabs(self.target.bootloader_img):
                 filename = self.target.bootloader_img
@@ -716,12 +715,6 @@ class Config(object):
             part_size = part.segments()[0][1] - part.segments()[0][0]
             part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
 
-            if len(part.segments()) > 1 and part.segments()[1][0] < rom_end:
-                # assume first segment is at start (already checked earlier as segments are returned in order)
-                # second at the end or outside ROM
-                # rest outside regular ROM
-                max_app_addr = part.segments()[1][0]
-
             yield Region("bootloader", rom_start, part_size, False,
                          filename)
             start = rom_start + part_size
@@ -732,13 +725,6 @@ class Config(object):
                 start, region = self._make_header_region(
                     start, self.target.header_format)
                 yield region._replace(filename=self.target.header_format)
-
-            if max_app_addr is not None and self.target.restrict_size is None:
-                # Multipart bootloader restricts the app size
-                if self.target.app_offset:
-                    self.target.restrict_size = "0x%x" % (max_app_addr - int(self.target.app_offset, 0))
-                else:
-                    self.target.restrict_size = "0x%x" % (max_app_addr - start)
 
         if self.target.restrict_size is not None:
             new_size = int(self.target.restrict_size, 0)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -698,7 +698,7 @@ class Config(object):
     def _generate_bootloader_build(self, rom_start, rom_size):
         start = rom_start
         rom_end = rom_start + rom_size
-        max_app_addr = -1
+        max_app_addr = None
         if self.target.bootloader_img:
             if isabs(self.target.bootloader_img):
                 filename = self.target.bootloader_img
@@ -718,15 +718,12 @@ class Config(object):
                 # assume first segment is at start
                 # second at the end or outside ROM
                 # rest outside regular ROM
-                if part.segments()[0][0] != 0x0:
+                if part.segments()[0][0] != rom_start:
                     raise ConfigException("bootloader segments not in order")
                 part_size = part.segments()[0][1] - part.segments()[0][0]
                 part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
-                if part.segments()[1][0] < rom_end and self.target.restrict_size is None:
-                    if self.target.app_offset:
-                        self.target.restrict_size = "0x%x" % (part.segments()[1][0] - int(self.target.app_offset, 0))
-                    else:
-                        max_app_addr = part.segments()[1][0]
+                if part.segments()[1][0] < rom_end:
+                    max_app_addr = part.segments()[1][0]
 
             yield Region("bootloader", rom_start, part_size, False,
                          filename)
@@ -739,8 +736,12 @@ class Config(object):
                     start, self.target.header_format)
                 yield region._replace(filename=self.target.header_format)
 
-            if max_app_addr != -1 and self.target.restrict_size is None and not self.target.app_offset:
-                self.target.restrict_size = "0x%x" % (max_app_addr - start)
+            if max_app_addr is not None and self.target.restrict_size is None:
+                # Multipart bootloader restricts the app size
+                if self.target.app_offset:
+                    self.target.restrict_size = "0x%x" % (max_app_addr - int(self.target.app_offset, 0))
+                else:
+                    self.target.restrict_size = "0x%x" % (max_app_addr - start)
 
         if self.target.restrict_size is not None:
             new_size = int(self.target.restrict_size, 0)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -692,12 +692,13 @@ class Config(object):
         newstart = rom_start + integer(new_offset, 0)
         if newstart < start:
             raise ConfigException(
-                "Can not place % region inside previous region" % region_name)
+                "Can not place %r region inside previous region" % region_name)
         return newstart
 
     def _generate_bootloader_build(self, rom_start, rom_size):
         start = rom_start
         rom_end = rom_start + rom_size
+        max_app_addr = -1
         if self.target.bootloader_img:
             if isabs(self.target.bootloader_img):
                 filename = self.target.bootloader_img
@@ -710,8 +711,23 @@ class Config(object):
             if part.minaddr() != rom_start:
                 raise ConfigException("bootloader executable does not "
                                       "start at 0x%x" % rom_start)
-            part_size = (part.maxaddr() - part.minaddr()) + 1
-            part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
+            if len(part.segments()) == 1:
+                part_size = (part.maxaddr() - part.minaddr()) + 1
+                part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
+            else:
+                # assume first segment is at start
+                # second at the end or outside ROM
+                # rest outside regular ROM
+                if part.segments()[0][0] != 0x0:
+                    raise ConfigException("bootloader segments not in order")
+                part_size = part.segments()[0][1] - part.segments()[0][0]
+                part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
+                if part.segments()[1][0] < rom_end and self.target.restrict_size is None:
+                    if self.target.app_offset:
+                        self.target.restrict_size = "0x%x" % (part.segments()[1][0] - int(self.target.app_offset, 0))
+                    else:
+                        max_app_addr = part.segments()[1][0]
+
             yield Region("bootloader", rom_start, part_size, False,
                          filename)
             start = rom_start + part_size
@@ -722,9 +738,17 @@ class Config(object):
                 start, region = self._make_header_region(
                     start, self.target.header_format)
                 yield region._replace(filename=self.target.header_format)
+
+            if max_app_addr != -1 and self.target.restrict_size is None and not self.target.app_offset:
+                self.target.restrict_size = "0x%x" % (max_app_addr - start)
+
         if self.target.restrict_size is not None:
             new_size = int(self.target.restrict_size, 0)
             new_size = Config._align_floor(start + new_size, self.sectors) - start
+
+            if self.target.app_offset:
+                start = self._assign_new_offset(rom_start, start, self.target.app_offset, "application")
+
             yield Region("application", start, new_size, True, None)
             start += new_size
             if self.target.header_format and not self.target.bootloader_img:
@@ -734,9 +758,7 @@ class Config(object):
                 start, region = self._make_header_region(
                     start, self.target.header_format)
                 yield region
-            if self.target.app_offset:
-                start = self._assign_new_offset(
-                    rom_start, start, self.target.app_offset, "application")
+
             yield Region("post_application", start, rom_end - start,
                          False, None)
         else:
@@ -745,7 +767,7 @@ class Config(object):
                     rom_start, start, self.target.app_offset, "application")
             yield Region("application", start, rom_end - start,
                          True, None)
-        if start > rom_start + rom_size:
+        if start > rom_end:
             raise ConfigException("Not enough memory on device to fit all "
                                   "application regions")
     

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -714,14 +714,14 @@ class Config(object):
             # find the last valid address that's within rom_end and use that
             # to compute the bootloader size
             end_address = None
-            for each in part.segments():
-                if (each[1] < rom_end):
-                    end_address = each[1]
+            for start, stop in part.segments():
+                if (stop < rom_end):
+                    end_address = stop
                 else:
                     break
             if end_address == None:
                 raise ConfigException("bootloader segments don't fit within rom region")
-            part_size = Config._align_ceiling(rom_start + (end_address - start), self.sectors) - rom_start
+            part_size = Config._align_ceiling(end_address, self.sectors) - rom_start
 
             yield Region("bootloader", rom_start, part_size, False,
                          filename)

--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -711,19 +711,16 @@ class Config(object):
             if part.minaddr() != rom_start:
                 raise ConfigException("bootloader executable does not "
                                       "start at 0x%x" % rom_start)
-            if len(part.segments()) == 1:
-                part_size = (part.maxaddr() - part.minaddr()) + 1
-                part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
-            else:
-                # assume first segment is at start
+
+            # segments returns start address and 'next after end' address
+            part_size = part.segments()[0][1] - part.segments()[0][0]
+            part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
+
+            if len(part.segments()) > 1 and part.segments()[1][0] < rom_end:
+                # assume first segment is at start (already checked earlier as segments are returned in order)
                 # second at the end or outside ROM
                 # rest outside regular ROM
-                if part.segments()[0][0] != rom_start:
-                    raise ConfigException("bootloader segments not in order")
-                part_size = part.segments()[0][1] - part.segments()[0][0]
-                part_size = Config._align_ceiling(rom_start + part_size, self.sectors) - rom_start
-                if part.segments()[1][0] < rom_end:
-                    max_app_addr = part.segments()[1][0]
+                max_app_addr = part.segments()[1][0]
 
             yield Region("bootloader", rom_start, part_size, False,
                          filename)


### PR DESCRIPTION
Bootloader for nrf52_dk is a intel hex file, which contains write instructions to the start of rom and also into registry which is outside rom region. This causes the current logic of forming the build regions to fail as it only supports bootloader that is in one segments which is at the start of rom.

This pr fixes bootloader build region generation in case where application size is restricted (space reserved for something else after application) and also adds support for nrf52_dk bootloader, which contains write instructions to registry which is outside rom region.

Also fixed printing of error case.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
