### PR TITLE
`mbed dm`: Remove references to internal script from help

### DIFF
--- a/tools/device_management.py
+++ b/tools/device_management.py
@@ -44,6 +44,15 @@ from tools.options import extract_mcus
 
 
 class MbedExtendedArgs(MainArgumentParser):
+
+    def __init__(self, *args, **kwargs):
+        MainArgumentParser.__init__(self, *args, **kwargs)
+        self.parser.prog = "mbed device-management"
+        self.parser.description = (
+            "Create or transform a manifest. "
+            "Use {} [command] -h for help on each command."
+        ).format(self.parser.prog)
+
     def _addCreateArgs(self, parser, exclusions=[]):
         if 'payload' not in exclusions:
             parser.add_argument(


### PR DESCRIPTION
### Description

Now that we are delegating the help text to `device_managment.py`,
it should print out help as if it's invoked with `mbed device-management`.
This PR changes the argument parser and the help text to do just that.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change