### PR TITLE
Replace macros with config options

### DIFF
--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -70,6 +70,31 @@
             "help": "Enable tracing of each memory call by invoking a callback on each memory operation. See mbed_mem_trace.h in the HAL API for more information",
             "value": false
         },
+        "sys-stats-enabled": {
+            "macro_name": "MBED_SYS_STATS_ENABLED",
+            "help": "Set to 1 to enable system stats. When enabled the function mbed_stats_sys_get returns non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
+        "stack-stats-enabled": {
+            "macro_name": "MBED_STACK_STATS_ENABLED",
+            "help": "Set to 1 to enable stack stats. When enabled the functions mbed_stats_stack_get and mbed_stats_stack_get_each return non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
+        "cpu-stats-enabled": {
+            "macro_name": "MBED_CPU_STATS_ENABLED",
+            "help": "Set to 1 to enable cpu stats. When enabled the function mbed_stats_cpu_get returns non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
+        "heap-stats-enabled": {
+            "macro_name": "MBED_HEAP_STATS_ENABLED",
+            "help": "Set to 1 to enable heap stats. When enabled the function mbed_stats_heap_get returns non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
+        "thread-stats-enabled": {
+            "macro_name": "MBED_THREAD_STATS_ENABLED",
+            "help": "Set to 1 to enable thread stats. When enabled the function mbed_stats_thread_get_each returns non-zero data. See mbed_stats.h for more information",
+            "value": null
+        },
         "error-decode-http-url-str": {
             "help": "HTTP URL string for ARM Mbed-OS Error Decode microsite",
             "value": "\"\\nFor more info, visit: https:/\\/armmbed.github.io/mbedos-error/?error=0x%08X\""

--- a/rtos/TARGET_CORTEX/mbed_rtos_rtx.c
+++ b/rtos/TARGET_CORTEX/mbed_rtos_rtx.c
@@ -25,9 +25,8 @@
 
 osThreadAttr_t _main_thread_attr;
 
-/** The main thread's stack size can be configured by the application, if not explicitly specified it'll default to 4K */
 #ifndef MBED_CONF_APP_MAIN_STACK_SIZE
-#define MBED_CONF_APP_MAIN_STACK_SIZE 4096
+#define MBED_CONF_APP_MAIN_STACK_SIZE MBED_CONF_RTOS_MAIN_THREAD_STACK_SIZE
 #endif
 MBED_ALIGN(8) char _main_stack[MBED_CONF_APP_MAIN_STACK_SIZE];
 mbed_rtos_storage_thread_t _main_obj;

--- a/rtos/TARGET_CORTEX/mbed_rtx_conf.h
+++ b/rtos/TARGET_CORTEX/mbed_rtx_conf.h
@@ -27,26 +27,23 @@
 /** Any access to RTX5 specific data structures used in common code should be wrapped in ifdef MBED_OS_BACKEND_RTX5 */
 #define MBED_OS_BACKEND_RTX5
 
-/** The thread's stack size can be configured by the application, if not explicitly specified it'll default to 4K */
-#ifndef MBED_CONF_APP_THREAD_STACK_SIZE
-#define MBED_CONF_APP_THREAD_STACK_SIZE 4096
-#endif
-
+#if defined(MBED_CONF_APP_THREAD_STACK_SIZE)
 #define OS_STACK_SIZE               MBED_CONF_APP_THREAD_STACK_SIZE
-
-/** The timer thread's stack size can be configured by the application, if not explicitly specified, it'll default to 768 */
-#ifndef MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
-#define MBED_CONF_APP_TIMER_THREAD_STACK_SIZE   768
+#else
+#define OS_STACK_SIZE               MBED_CONF_RTOS_THREAD_STACK_SIZE
 #endif
 
+#ifdef MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
 #define OS_TIMER_THREAD_STACK_SIZE  MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
-
-/** The idle thread's stack size can be configured by the application, if not explicitly specified, it'll default to 512 */
-#ifndef MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
-#define MBED_CONF_APP_IDLE_THREAD_STACK_SIZE    512
+#else
+#define OS_TIMER_THREAD_STACK_SIZE  MBED_CONF_RTOS_TIMER_THREAD_STACK_SIZE
 #endif
 
+#ifdef MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
 #define OS_IDLE_THREAD_STACK_SIZE   MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
+#else
+#define OS_IDLE_THREAD_STACK_SIZE   MBED_CONF_RTOS_IDLE_THREAD_STACK_SIZE
+#endif
 
 #define OS_DYNAMIC_MEM_SIZE         0
 

--- a/rtos/mbed_lib.json
+++ b/rtos/mbed_lib.json
@@ -1,7 +1,23 @@
 {
     "name": "rtos",
     "config": {
-        "present": 1
+        "present": 1,
+         "main-thread-stack-size": {
+            "help": "The size of the main thread's stack",
+            "value": 4096
+         },
+         "timer-thread-stack-size": {
+            "help": "The size of the timer thread's stack",
+            "value": 768
+         },
+         "idle-thread-stack-size": {
+            "help": "The size of the idle thread's stack",
+            "value": 512
+         },
+         "thread-stack-size": {
+            "help": "The default stack size of new threads",
+            "value": 4096
+         }
     },
     "macros": ["_RTE_"]
 }


### PR DESCRIPTION
### Description

Add a config option for the following values:
- MBED_SYS_STATS_ENABLED
- MBED_STACK_STATS_ENABLED
- MBED_CPU_STATS_ENABLED
- MBED_HEAP_STATS_ENABLED
- MBED_THREAD_STATS_ENABLED
- MBED_CONF_APP_MAIN_STACK_SIZE
- MBED_CONF_APP_TIMER_THREAD_STACK_SIZE
- MBED_CONF_APP_IDLE_THREAD_STACK_SIZE
- MBED_CONF_APP_THREAD_STACK_SIZE

To maintain backwards compatibility inside the RTOS both APP and RTOS config values can be used.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

