### PR TITLE
Rename device option STCLK_OFF_DURING_SLEEP

### DIFF
--- a/platform/mbed_power_mgmt.h
+++ b/platform/mbed_power_mgmt.h
@@ -169,9 +169,9 @@ void sleep_manager_sleep_auto(void);
 static inline void sleep(void)
 {
 #if DEVICE_SLEEP
-#if (MBED_CONF_RTOS_PRESENT == 0) || (DEVICE_STCLK_OFF_DURING_SLEEP == 0) || defined(MBED_TICKLESS)
+#if (MBED_CONF_RTOS_PRESENT == 0) || (DEVICE_SYSTICK_CLK_OFF_DURING_SLEEP == 0) || defined(MBED_TICKLESS)
     sleep_manager_sleep_auto();
-#endif /* (MBED_CONF_RTOS_PRESENT == 0) || (DEVICE_STCLK_OFF_DURING_SLEEP == 0) || defined(MBED_TICKLESS) */
+#endif /* (MBED_CONF_RTOS_PRESENT == 0) || (DEVICE_SYSTICK_CLK_OFF_DURING_SLEEP == 0) || defined(MBED_TICKLESS) */
 #endif /* DEVICE_SLEEP */
 }
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3885,7 +3885,7 @@
             "SLEEP",
             "SPI",
             "SPI_ASYNCH",
-            "STCLK_OFF_DURING_SLEEP",
+            "SYSTICK_CLK_OFF_DURING_SLEEP",
             "TRNG",
             "USTICKER"
         ],
@@ -3990,7 +3990,7 @@
             "SLEEP",
             "SPI",
             "SPI_ASYNCH",
-            "STCLK_OFF_DURING_SLEEP",
+            "SYSTICK_CLK_OFF_DURING_SLEEP",
             "TRNG",
             "USTICKER",
             "QSPI"

--- a/tools/targets/lint.py
+++ b/tools/targets/lint.py
@@ -82,7 +82,7 @@ DEVICE_HAS_ALLOWED = ["ANALOGIN", "ANALOGOUT", "CAN", "ETHERNET", "EMAC",
                       "LPTICKER", "PORTIN", "PORTINOUT", "PORTOUT",
                       "PWMOUT", "RTC", "TRNG","SERIAL", "SERIAL_ASYNCH",
                       "SERIAL_FC", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE",
-                      "STORAGE", "STCLK_OFF_DURING_SLEEP"]
+                      "STORAGE", "SYSTICK_CLK_OFF_DURING_SLEEP"]
 def check_device_has(dict):
     for name in dict.get("device_has", []):
         if name not in DEVICE_HAS_ALLOWED:


### PR DESCRIPTION


### Description

Rename STCLK_OFF_DURING_SLEEP to SYSTICK_CLK_OFF_DURING_SLEEP to avoid confusion with the STmicroelectronics.

### Pull request type

    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

