### PR TITLE
STM32L496 : wrong ADC init

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/analogin_device.c
@@ -82,6 +82,9 @@ void analogin_init(analogin_t *obj, PinName pin)
     obj->handle.Init.DMAContinuousRequests = DISABLE;
     obj->handle.Init.Overrun               = ADC_OVR_DATA_OVERWRITTEN;      // DR register is overwritten with the last conversion result in case of overrun
     obj->handle.Init.OversamplingMode      = DISABLE;                       // No oversampling
+#if defined(ADC_CFGR_DFSDMCFG) &&defined(DFSDM1_Channel0)
+    obj->handle.Init.DFSDMConfig           = 0;
+#endif
 
     // Enable ADC clock
     __HAL_RCC_ADC_CLK_ENABLE();


### PR DESCRIPTION
### Description

ADC was not functional with STM32L496xx MCU

### Test Result

| target              | platform_name   | test suite                  | result | elapsed_time (sec) | copy_method |
|---------------------|-----------------|-----------------------------|--------|--------------------|-------------|
| NUCLEO_L496ZG_P-ARM | NUCLEO_L496ZG_P | tests-api-analogin          | OK     | 14.56              | default     |
| NUCLEO_L496ZG_P-ARM | NUCLEO_L496ZG_P | tests-api-analogout         | OK     | 13.35              | default     |
| NUCLEO_L496ZG_P-ARM | NUCLEO_L496ZG_P | tests-assumptions-analogin  | OK     | 18.5               | default     |
| NUCLEO_L496ZG_P-ARM | NUCLEO_L496ZG_P | tests-assumptions-analogout | OK     | 12.97              | default     |


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

