### PR TITLE
Unit tests: fix coverage exclude paths on Windows

### DIFF
--- a/UNITTESTS/unit_test/test.py
+++ b/UNITTESTS/unit_test/test.py
@@ -134,7 +134,7 @@ class UnitTestTool(object):
                          "./coverage.xml"])
 
         for path in excludes:
-            args.extend(["-e", path])
+            args.extend(["-e", path.replace("\\", "/")])
 
         if logging.getLogger().getEffectiveLevel() == logging.DEBUG:
             args.append("-v")


### PR DESCRIPTION
### Description
Govr requires forward slashed even on Windows for exclude/filter paths.

Fix for https://github.com/ARMmbed/mbed-os/issues/8107.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

