### PR TITLE
Mbed 5.10! Don't use deprecated functions.

### DIFF
--- a/TESTS/mbed_drivers/lp_ticker/main.cpp
+++ b/TESTS/mbed_drivers/lp_ticker/main.cpp
@@ -79,7 +79,7 @@ void test_multi_ticker(void)
         ticker[i].attach_us(callback(increment_multi_counter), MULTI_TICKER_TIME_MS * 1000);
     }
 
-    Thread::wait(MULTI_TICKER_TIME_MS + extra_wait);
+    ThisThread::sleep_for(MULTI_TICKER_TIME_MS + extra_wait);
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     for (int i = 0; i < TICKER_COUNT; i++) {
@@ -95,7 +95,7 @@ void test_multi_ticker(void)
         ticker[i].attach_us(callback(increment_multi_counter), (MULTI_TICKER_TIME_MS + i) * 1000);
     }
 
-    Thread::wait(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
+    ThisThread::sleep_for(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     for (int i = 0; i < TICKER_COUNT; i++) {

--- a/TESTS/mbed_drivers/mem_trace/main.cpp
+++ b/TESTS/mbed_drivers/mem_trace/main.cpp
@@ -391,7 +391,7 @@ static void test_case_multithread_malloc_free()
         threads[i].start(callback(malloc_free, &threads_continue));
     }
 
-    Thread::wait(wait_time_us);
+    ThisThread::sleep_for(wait_time_us);
     threads_continue = false;
 
     for (int i = 0; i < NUM_TEST_THREADS; i++) {

--- a/TESTS/mbed_drivers/race_test/main.cpp
+++ b/TESTS/mbed_drivers/race_test/main.cpp
@@ -39,13 +39,13 @@ class TestClass {
 public:
     TestClass()
     {
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
         instance_count++;
     }
 
     void do_something()
     {
-        Thread::wait(100);
+        ThisThread::sleep_for(100);
     }
 
     ~TestClass()
@@ -83,7 +83,7 @@ void test_case_func_race()
     // Start start first thread
     t1.start(cb);
     // Start second thread while the first is inside the constructor
-    Thread::wait(250);
+    ThisThread::sleep_for(250);
     t2.start(cb);
 
     // Wait for the threads to finish
@@ -105,7 +105,7 @@ void test_case_class_race()
     // Start start first thread
     t1.start(cb);
     // Start second thread while the first is inside the constructor
-    Thread::wait(250);
+    ThisThread::sleep_for(250);
     t2.start(cb);
 
     // Wait for the threads to finish

--- a/TESTS/mbed_drivers/ticker/main.cpp
+++ b/TESTS/mbed_drivers/ticker/main.cpp
@@ -195,7 +195,7 @@ void test_multi_ticker(void)
         ticker[i].attach_us(callback(increment_multi_counter), MULTI_TICKER_TIME_MS * 1000);
     }
 
-    Thread::wait(MULTI_TICKER_TIME_MS + extra_wait);
+    ThisThread::sleep_for(MULTI_TICKER_TIME_MS + extra_wait);
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     for (int i = 0; i < TICKER_COUNT; i++) {
@@ -211,7 +211,7 @@ void test_multi_ticker(void)
         ticker[i].attach_us(callback(increment_multi_counter), (MULTI_TICKER_TIME_MS + i) * 1000);
     }
 
-    Thread::wait(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
+    ThisThread::sleep_for(MULTI_TICKER_TIME_MS + TICKER_COUNT + extra_wait);
     TEST_ASSERT_EQUAL(TICKER_COUNT, multi_counter);
 
     for (int i = 0; i < TICKER_COUNT; i++) {

--- a/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
+++ b/TESTS/mbed_hal/sleep_manager_racecondition/main.cpp
@@ -34,7 +34,7 @@ void sleep_manager_locking_thread_test()
 {
     for (uint32_t i = 0; i < 100; i++) {
         sleep_manager_lock_deep_sleep();
-        Thread::wait(25);
+        ThisThread::sleep_for(25);
         sleep_manager_unlock_deep_sleep();
     }
 }
@@ -47,7 +47,7 @@ void sleep_manager_multithread_test()
         Thread t2(osPriorityNormal, TEST_STACK_SIZE);
 
         t1.start(callback(cb));
-        Thread::wait(25);
+        ThisThread::sleep_for(25);
         t2.start(callback(cb));
 
         // Wait for the threads to finish

--- a/TESTS/mbed_platform/stats_cpu/main.cpp
+++ b/TESTS/mbed_platform/stats_cpu/main.cpp
@@ -56,7 +56,7 @@ void get_cpu_usage()
         uint8_t usage = 100 - ((diff * 100) / (SAMPLE_TIME * 1000));
         prev_idle_time = stats.idle_time;
         TEST_ASSERT_NOT_EQUAL(0, usage);
-        Thread::wait(SAMPLE_TIME);
+        ThisThread::sleep_for(SAMPLE_TIME);
     }
 }
 
@@ -65,7 +65,7 @@ void test_cpu_info(void)
     mbed_stats_cpu_t stats;
     // Additional read to make sure timer is initialized
     mbed_stats_cpu_get(&stats);
-    Thread::wait(3);
+    ThisThread::sleep_for(3);
     mbed_stats_cpu_get(&stats);
     TEST_ASSERT_NOT_EQUAL(0, stats.uptime);
     TEST_ASSERT_NOT_EQUAL(0, stats.idle_time);
@@ -83,7 +83,7 @@ void test_cpu_load(void)
 
     // Steadily increase the system load
     for (int count = 1; ; count++) {
-        Thread::wait(LOOP_TIME);
+        ThisThread::sleep_for(LOOP_TIME);
         if (wait_time <= 0) {
             break;
         }

--- a/TESTS/mbed_platform/stats_thread/main.cpp
+++ b/TESTS/mbed_platform/stats_thread/main.cpp
@@ -46,7 +46,7 @@ void increment_with_delay()
 {
     while (1) {
         counter++;
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
     }
 }
 
@@ -111,7 +111,7 @@ void test_case_multi_threads_blocked()
     uint32_t ret = ef.set(FLAG_SIGNAL_DEC);
     TEST_ASSERT_FALSE(ret & osFlagsError);
 
-    Thread::wait(100);
+    ThisThread::sleep_for(100);
 
     count = mbed_stats_thread_get_each(stats, MAX_THREAD_STATS);
     TEST_ASSERT_EQUAL(1, (count - old_count));

--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -48,7 +48,7 @@ static const int test_timeout = 40;
 void update_tick_thread(Mutex *mutex)
 {
     while (true) {
-        Thread::wait(1);
+        ThisThread::sleep_for(1);
         mutex->lock();
         ++elapsed_time_ms;
         mutex->unlock();
@@ -56,7 +56,7 @@ void update_tick_thread(Mutex *mutex)
 }
 
 
-/** Tests is to measure the accuracy of Thread::wait() over a period of time
+/** Tests is to measure the accuracy of ThisThread::sleep_for() over a period of time
 
     Given
         a thread updating elapsed_time_ms every milli sec
@@ -109,7 +109,7 @@ void test(void)
 }
 
 Case cases[] = {
-    Case("Test Thread::wait accuracy", test)
+    Case("Test ThisThread::sleep_for accuracy", test)
 };
 
 utest::v1::status_t greentea_test_setup(const size_t number_of_cases)

--- a/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/event_flags/main.cpp
@@ -75,7 +75,7 @@ void send_thread(EventFlags *ef)
         const uint32_t flag = flags & (1 << i);
         if (flag) {
             ef->set(flag);
-            Thread::wait(wait_ms);
+            ThisThread::sleep_for(wait_ms);
         }
     }
 }
@@ -88,7 +88,7 @@ void send_thread_sync(EventFlags *ef)
         if (flag) {
             sync_sem.wait();
             ef->set(flag);
-            Thread::wait(wait_ms);
+            ThisThread::sleep_for(wait_ms);
         }
     }
 }

--- a/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/heap_and_stack/main.cpp
@@ -226,7 +226,7 @@ void test_heap_allocation_free(void)
     check_and_free_heap(head, max_allocation_size);
 
     // Force a task switch so a stack check is performed
-    Thread::wait(10);
+    ThisThread::sleep_for(10);
 
     printf("Total size dynamically allocated: %luB\n", max_allocation_size);
 }

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -62,7 +62,7 @@ void send_thread(Mail<mail_t, QUEUE_SIZE> *m)
         mail->thread_id = thread_id;
         mail->data = data++;
         m->put(mail);
-        Thread::wait(wait_ms);
+        ThisThread::sleep_for(wait_ms);
     }
 }
 
@@ -72,7 +72,7 @@ void receive_thread(Mail<mail_t, queue_size> *m)
     int result_counter = 0;
     uint32_t data = thread_id * DATA_BASE;
 
-    Thread::wait(wait_ms);
+    ThisThread::sleep_for(wait_ms);
     for (uint32_t i = 0; i < queue_size; i++) {
         osEvent evt = m->get();
         if (evt.status == osEventMail) {
@@ -108,7 +108,7 @@ void test_single_thread_order(void)
     thread.start(callback(send_thread<THREAD_1_ID, QUEUE_PUT_DELAY_1, QUEUE_SIZE>, &mail_box));
 
     // wait for some mail to be collected
-    Thread::wait(10);
+    ThisThread::sleep_for(10);
 
     for (uint32_t i = 0; i < QUEUE_SIZE; i++) {
         // mail receive (main thread)
@@ -150,7 +150,7 @@ void test_multi_thread_order(void)
     thread3.start(callback(send_thread<THREAD_3_ID, QUEUE_PUT_DELAY_3, 4>, &mail_box));
 
     // wait for some mail to be collected
-    Thread::wait(10);
+    ThisThread::sleep_for(10);
 
     for (uint32_t i = 0; i < QUEUE_SIZE; i++) {
         // mail receive (main thread)
@@ -211,7 +211,7 @@ void test_multi_thread_multi_mail_order(void)
         mail->data = data[id]++;
         mail_box[id].put(mail);
 
-        Thread::wait(i * 10);
+        ThisThread::sleep_for(i * 10);
     }
 
     thread1.join();

--- a/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/malloc/main.cpp
@@ -90,7 +90,7 @@ void test_multithread_allocation(void)
 
     // Give the test time to run
     while (test_time--) {
-        Thread::wait(1000);
+        ThisThread::sleep_for(1000);
     }
 
     // Join and delete all threads

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -62,7 +62,7 @@ bool manipulate_protected_zone(const int thread_delay)
     change_counter++;
     core_util_critical_section_exit();
 
-    Thread::wait(thread_delay);
+    ThisThread::sleep_for(thread_delay);
 
     core_util_critical_section_enter();
     changing_counter = false;
@@ -100,7 +100,7 @@ void test_multiple_threads(void)
 
     while (true) {
         // Thread 1 action
-        Thread::wait(t1_delay);
+        ThisThread::sleep_for(t1_delay);
         manipulate_protected_zone(t1_delay);
 
         core_util_critical_section_enter();

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -37,7 +37,7 @@ using namespace utest::v1;
 template <uint32_t ms>
 void thread_put_uint_msg(Queue<uint32_t, 1> *q)
 {
-    Thread::wait(ms);
+    ThisThread::sleep_for(ms);
     osStatus stat = q->put((uint32_t *) TEST_UINT_MSG);
     TEST_ASSERT_EQUAL(osOK, stat);
 }
@@ -45,7 +45,7 @@ void thread_put_uint_msg(Queue<uint32_t, 1> *q)
 template <uint32_t ms, uint32_t val>
 void thread_get_uint_msg(Queue<uint32_t, 1> *q)
 {
-    Thread::wait(ms);
+    ThisThread::sleep_for(ms);
     osEvent evt = q->get();
     TEST_ASSERT_EQUAL(osEventMessage, evt.status);
     TEST_ASSERT_EQUAL(val, evt.value.v);

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -52,7 +52,7 @@ void test_thread(int const *delay)
         if (sem_lock_failed) {
             sem_defect = true;
         }
-        Thread::wait(thread_delay);
+        ThisThread::sleep_for(thread_delay);
         sem_counter--;
         change_counter++;
         two_slots.release();
@@ -123,7 +123,7 @@ void test_single_thread()
 
     res = t.start(callback(single_thread, &data));
     TEST_ASSERT_EQUAL(osOK, res);
-    Thread::wait(SHORT_WAIT);
+    ThisThread::sleep_for(SHORT_WAIT);
 
     TEST_ASSERT_EQUAL(Thread::WaitingSemaphore, t.get_state());
     TEST_ASSERT_EQUAL(0, data.data);
@@ -131,7 +131,7 @@ void test_single_thread()
     res = sem.release();
     TEST_ASSERT_EQUAL(osOK, res);
 
-    Thread::wait(SHORT_WAIT);
+    ThisThread::sleep_for(SHORT_WAIT);
 
     TEST_ASSERT_EQUAL(1, data.data);
 
@@ -160,7 +160,7 @@ void test_timeout()
     timer.start();
     res = t.start(callback(timeout_thread, &sem));
     TEST_ASSERT_EQUAL(osOK, res);
-    Thread::wait(SHORT_WAIT);
+    ThisThread::sleep_for(SHORT_WAIT);
 
     TEST_ASSERT_EQUAL(Thread::WaitingSemaphore, t.get_state());
 

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -70,7 +70,7 @@ mbed_error_status_t mbed_error(mbed_error_status_t error_status, const char *err
 template <int32_t signals, uint32_t timeout, int32_t test_val>
 void run_signal_wait(void)
 {
-    osEvent ev = Thread::signal_wait(signals, timeout);
+    osEvent ev = ThisThread::flags_wait_all(signals, timeout);
     TEST_ASSERT_EQUAL(test_val, ev.status);
 }
 
@@ -78,7 +78,7 @@ template <int32_t signals, uint32_t timeout, int32_t test_val>
 void run_release_signal_wait(Semaphore *sem)
 {
     sem->release();
-    osEvent ev = Thread::signal_wait(signals, timeout);
+    osEvent ev = ThisThread::flags_wait_all(signals, timeout);
     TEST_ASSERT_EQUAL(test_val, ev.status);
 }
 
@@ -87,14 +87,14 @@ void run_release_wait_signal_wait(Sync *sync)
 {
     sync->sem_parent.release();
     sync->sem_child.wait();
-    osEvent ev = Thread::signal_wait(signals, timeout);
+    osEvent ev = ThisThread::flags_wait_all(signals, timeout);
     TEST_ASSERT_EQUAL(test_val, ev.status);
 }
 
 template <int32_t signals, int32_t test_val>
 void run_clear(void)
 {
-    int32_t ret = Thread::signal_clr(signals);
+    int32_t ret = ThisThread::flags_clear(signals);
     TEST_ASSERT_EQUAL(test_val, ret);
 }
 
@@ -103,7 +103,7 @@ void run_wait_clear(Sync *sync)
 {
     sync->sem_parent.release();
     sync->sem_child.wait();
-    int32_t ret = Thread::signal_clr(signals);
+    int32_t ret = ThisThread::flags_clear(signals);
     TEST_ASSERT_EQUAL(test_val, ret);
 }
 
@@ -114,10 +114,10 @@ void run_double_wait_clear(Sync *sync)
 
     sync->sem_parent.release();
     sync->sem_child.wait();
-    ret = Thread::signal_clr(signals1);
+    ret = ThisThread::flags_clear(signals1);
     TEST_ASSERT_EQUAL(test_val1, ret);
 
-    ret = Thread::signal_clr(signals2);
+    ret = ThisThread::flags_clear(signals2);
     TEST_ASSERT_EQUAL(test_val2, ret);
 }
 
@@ -128,7 +128,7 @@ void run_loop_wait_clear(Sync *sync)
         int32_t signal = 1 << i;
         signals |= signal;
         sync->sem_child.wait();
-        int32_t ret = Thread::signal_clr(NO_SIGNALS);
+        int32_t ret = ThisThread::flags_clear(NO_SIGNALS);
         TEST_ASSERT_EQUAL(signals, ret);
         sync->sem_parent.release();
     }

--- a/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/threads/main.cpp
@@ -474,7 +474,7 @@ void test_thread_wait()
     Timer timer;
     timer.start();
 
-    Thread::wait(150);
+    ThisThread::sleep_for(150);
 
     TEST_ASSERT_UINT32_WITHIN(50000, 150000, timer.read_us());
 }
@@ -528,7 +528,7 @@ void test_deleted()
 
 void test_delay_thread()
 {
-    Thread::wait(50);
+    ThisThread::sleep_for(50);
 }
 
 /** Testing thread states: wait delay

--- a/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest.cpp
@@ -119,7 +119,7 @@ void TCPSOCKET_ECHOTEST_NONBLOCK()
 
     tcpsocket_connect_to_echo_srv(sock);
     sock.set_blocking(false);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int bytes2send;
     int sent;

--- a/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_echotest_burst.cpp
@@ -41,7 +41,7 @@ void TCPSOCKET_ECHOTEST_BURST()
 {
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     // TX buffer to be preserved for comparison
     fill_tx_buffer_ascii(tcp_global::tx_buffer, BURST_SIZE);
@@ -94,7 +94,7 @@ void TCPSOCKET_ECHOTEST_BURST_NONBLOCK()
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
     sock.set_blocking(false);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     // TX buffer to be preserved for comparison
     fill_tx_buffer_ascii(tcp_global::tx_buffer, BURST_SIZE);

--- a/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_endpoint_close.cpp
@@ -63,7 +63,7 @@ void TCPSOCKET_ENDPOINT_CLOSE()
         TEST_FAIL();
         return;
     }
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int recvd = 0;
     int recvd_total = 0;

--- a/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_100k.cpp
@@ -170,7 +170,7 @@ void TCPSOCKET_RECV_100K_NONBLOCK()
     }
 
     sock.set_blocking(false);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     rcv_n_chk_against_rfc864_pattern_nonblock(sock);
 

--- a/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_recv_timeout.cpp
@@ -45,7 +45,7 @@ void TCPSOCKET_RECV_TIMEOUT()
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
     sock.set_timeout(100);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int recvd = 0;
     int pkt_unrecvd;

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -47,7 +47,7 @@ static void check_const_len_rand_sequence()
 {
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
-    sock.sigio(callback(_sigio_handler1, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler1, ThisThread::get_id()));
 
     static const int BUFF_SIZE = 10;
     char rx_buff[BUFF_SIZE] = {0};
@@ -104,7 +104,7 @@ static void check_var_len_rand_sequence()
 {
     TCPSocket sock;
     tcpsocket_connect_to_echo_srv(sock);
-    sock.sigio(callback(_sigio_handler2, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler2, ThisThread::get_id()));
 
     static const int BUFF_SIZE = 1001;
     char rx_buff[BUFF_SIZE];

--- a/TESTS/netsocket/udp/udpsocket_echotest.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest.cpp
@@ -127,7 +127,7 @@ void UDPSOCKET_ECHOTEST_NONBLOCK()
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
     sock.set_blocking(false);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int sent;
     int s_idx = 0;

--- a/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
+++ b/TESTS/netsocket/udp/udpsocket_echotest_burst.cpp
@@ -78,7 +78,7 @@ void UDPSOCKET_ECHOTEST_BURST()
     const int TIMEOUT = 5000; // [ms]
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
     sock.set_timeout(TIMEOUT);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     // TX buffers to be preserved for comparison
     prepare_tx_buffers();
@@ -156,7 +156,7 @@ void UDPSOCKET_ECHOTEST_BURST_NONBLOCK()
     UDPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
     sock.set_blocking(false);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     // TX buffers to be preserved for comparison
     prepare_tx_buffers();

--- a/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
+++ b/TESTS/netsocket/udp/udpsocket_recv_timeout.cpp
@@ -46,7 +46,7 @@ void UDPSOCKET_RECV_TIMEOUT()
     UDPSocket sock;
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.open(get_interface()));
     sock.set_timeout(100);
-    sock.sigio(callback(_sigio_handler, Thread::gettid()));
+    sock.sigio(callback(_sigio_handler, ThisThread::get_id()));
 
     int recvd;
     Timer timer;

--- a/TEST_APPS/device/socket_app/cmd_socket.cpp
+++ b/TEST_APPS/device/socket_app/cmd_socket.cpp
@@ -518,7 +518,7 @@ static void udp_receiver_thread(SInfo *info)
     int *packetSizes = info->getPacketSizeArray();
     nsapi_size_or_error_t ret = 0;
 
-    info->setReceiverThreadId(Thread::gettid());
+    info->setReceiverThreadId(ThisThread::get_id());
 
     while (i < n) {
         ret = static_cast<UDPSocket &>(info->socket()).recvfrom(&addr, info->getReceiveBuffer() + received, info->getDataCount() - received);
@@ -531,7 +531,7 @@ static void udp_receiver_thread(SInfo *info)
             i++;
             info->setRecvTotal(info->getRecvTotal() + ret);
         } else if (ret == NSAPI_ERROR_WOULD_BLOCK) {
-            Thread::signal_wait(SIGNAL_SIGIO);
+            ThisThread::flags_wait_all(SIGNAL_SIGIO);
         } else {
             handle_nsapi_size_or_error("Thread: UDPSocket::recvfrom()", ret);
             return;
@@ -660,7 +660,7 @@ static void tcp_receiver_thread(SInfo *info)
     int bufferSize = info->getDataCount();
     nsapi_size_or_error_t ret = 0;
 
-    info->setReceiverThreadId(Thread::gettid());
+    info->setReceiverThreadId(ThisThread::get_id());
 
     for (i = 0; i < n; i++) {
         received = 0;
@@ -673,7 +673,7 @@ static void tcp_receiver_thread(SInfo *info)
                 received += ret;
                 info->setRecvTotal(info->getRecvTotal() + ret);
             } else if (ret == NSAPI_ERROR_WOULD_BLOCK) {
-                Thread::signal_wait(SIGNAL_SIGIO);
+                ThisThread::flags_wait_all(SIGNAL_SIGIO);
             } else {
                 handle_nsapi_size_or_error("Thread: TCPSocket::recv()", ret);
                 return;
@@ -729,7 +729,7 @@ static nsapi_size_or_error_t tcp_send_command_handler(SInfo *info, int argc, cha
     void *data;
     nsapi_size_or_error_t ret = 0;
 
-    info->setSenderThreadId(Thread::gettid());
+    info->setSenderThreadId(ThisThread::get_id());
 
     if (cmd_parameter_int(argc, argv, "--data_len", &len)) {
         data = malloc(len);
@@ -809,7 +809,7 @@ static void bg_traffic_thread(SInfo *info)
     char sbuffer[data_len + 1] = "dummydata_";
     char rbuffer[data_len + 1];
     int scount, rtotal = 0;
-    info->setSenderThreadId(Thread::gettid());
+    info->setSenderThreadId(ThisThread::get_id());
 
     for (;;) {
         if (!info->available()) {

--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -21,7 +21,7 @@
 #include "platform/mbed_poll.h"
 
 #if MBED_CONF_RTOS_PRESENT
-#include "rtos/Thread.h"
+#include "rtos/ThisThread.h"
 #else
 #include "platform/mbed_wait_api.h"
 #endif
@@ -332,7 +332,7 @@ void UARTSerial::wait_ms(uint32_t millisec)
      * want to just sleep until next tick.
      */
 #if MBED_CONF_RTOS_PRESENT
-    rtos::Thread::wait(millisec);
+    rtos::ThisThread::sleep_for(millisec);
 #else
     ::wait_ms(millisec);
 #endif

--- a/features/cellular/TESTS/api/cellular_network/main.cpp
+++ b/features/cellular/TESTS/api/cellular_network/main.cpp
@@ -376,7 +376,7 @@ static void test_disconnect()
 static void test_detach()
 {
     // in PPP mode there is NO CARRIER waiting so flush it out
-    rtos::Thread::wait(6 * 1000);
+    rtos::ThisThread::sleep_for(6 * 1000);
     ((AT_CellularNetwork *)nw)->get_at_handler().flush();
 
     nsapi_connection_status_t st =  nw->get_connection_status();
@@ -384,7 +384,7 @@ static void test_detach()
 
     TEST_ASSERT(nw->detach() == NSAPI_ERROR_OK);
     // wait to process URC's, received after detach
-    rtos::Thread::wait(50);
+    rtos::ThisThread::sleep_for(50);
     st =  nw->get_connection_status();
     TEST_ASSERT(st == NSAPI_STATUS_DISCONNECTED);
 }

--- a/features/cellular/UNITTESTS/stubs/Thread_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/Thread_stub.cpp
@@ -19,7 +19,7 @@
 
 namespace rtos {
 
-osStatus Thread::wait_until(uint64_t millisec)
+osStatus ThisThread::sleep_until(uint64_t millisec)
 {
     return 0;
 }

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -23,7 +23,7 @@
 #include "FileHandle.h"
 #include "mbed_wait_api.h"
 #include "mbed_debug.h"
-#include "rtos/Thread.h"
+#include "rtos/ThisThread.h"
 #include "Kernel.h"
 #include "CellularUtil.h"
 
@@ -1026,7 +1026,7 @@ void ATHandler::cmd_start(const char *cmd)
 {
 
     if (_at_send_delay) {
-        rtos::Thread::wait_until(_last_response_stop + _at_send_delay);
+        rtos::ThisThread::sleep_until(_last_response_stop + _at_send_delay);
     }
 
     if (_last_err != NSAPI_ERROR_OK) {

--- a/features/frameworks/greentea-client/source/greentea_metrics.cpp
+++ b/features/frameworks/greentea-client/source/greentea_metrics.cpp
@@ -58,7 +58,7 @@ static uint32_t print_dec(char *buf, uint32_t value);
 void greentea_metrics_setup()
 {
 #if defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED
-    Thread::attach_terminate_hook(on_thread_terminate);
+    Kernel::attach_thread_terminate_hook(on_thread_terminate);
 #endif
 }
 
@@ -67,7 +67,7 @@ void greentea_metrics_report()
     send_heap_info();
 #if defined(MBED_STACK_STATS_ENABLED) && MBED_STACK_STATS_ENABLED
     send_stack_info();
-    Thread::attach_terminate_hook(NULL);
+    Kernel::attach_thread_terminate_hook(NULL);
 #endif
 #if defined(MBED_CPU_STATS_ENABLED)
     send_CPU_info();

--- a/features/netsocket/emac-drivers/TARGET_RZ_A1_EMAC/rza1_emac.cpp
+++ b/features/netsocket/emac-drivers/TARGET_RZ_A1_EMAC/rza1_emac.cpp
@@ -166,7 +166,7 @@ void RZ_A1_EMAC::recv_task(void) {
     int            cnt;
 
     while (1) {
-        rtos::Thread::signal_wait(1);
+        rtos::ThisThread::flags_wait_all(1);
         for (cnt = 0; cnt < 16; cnt++) {
             recv_size = ethernet_receive();
             if (recv_size == 0) {

--- a/features/unsupported/USBHost/USBHost/USBHost.cpp
+++ b/features/unsupported/USBHost/USBHost/USBHost.cpp
@@ -171,7 +171,7 @@ void USBHost::usb_process()
                                 break;
                             }
 
-                            Thread::wait(100);
+                            ThisThread::sleep_for(100);
                         }
 
                         USB_INFO("New device connected: %p [hub: %d - port: %d]", &devices[i], usb_msg->hub, usb_msg->port);
@@ -599,7 +599,7 @@ USB_TYPE USBHost::resetDevice(USBDeviceConnected * dev)
     int index = findDevice(dev);
     if (index != -1) {
         USB_DBG("Resetting hub %d, port %d\n", dev->getHub(), dev->getPort());
-        Thread::wait(100);
+        ThisThread::sleep_for(100);
         if (dev->getHub() == 0) {
             resetRootHub();
         }
@@ -608,7 +608,7 @@ USB_TYPE USBHost::resetDevice(USBDeviceConnected * dev)
             dev->getHubParent()->portReset(dev->getPort());
         }
 #endif
-        Thread::wait(100);
+        ThisThread::sleep_for(100);
         deviceReset[index] = true;
         return USB_TYPE_OK;
     }
@@ -974,7 +974,7 @@ USB_TYPE USBHost::enumerate(USBDeviceConnected * dev, IUSBEnumerator* pEnumerato
     } while(0);
 
     // Some devices may require this delay
-    Thread::wait(100);
+    ThisThread::sleep_for(100);
 
     return USB_TYPE_OK;
 }

--- a/features/unsupported/USBHost/USBHost3GModule/WANDongleSerialPort.cpp
+++ b/features/unsupported/USBHost/USBHost3GModule/WANDongleSerialPort.cpp
@@ -90,7 +90,7 @@ int WANDongleSerialPort::readPacket()
   {
     //lock_rx.unlock();
     USB_ERR("host->bulkRead() returned %d", res);
-    Thread::wait(100);
+    ThisThread::sleep_for(100);
     return -1;
   }
   return 0;
@@ -123,7 +123,7 @@ int WANDongleSerialPort::writePacket()
   {
     //lock_tx.unlock();
     USB_ERR("host->bulkWrite() returned %d", res);
-    Thread::wait(100);
+    ThisThread::sleep_for(100);
     return -1;
   }
   return 0;

--- a/features/unsupported/USBHost/USBHostHub/USBHostHub.cpp
+++ b/features/unsupported/USBHost/USBHostHub/USBHostHub.cpp
@@ -232,7 +232,7 @@ void USBHostHub::portReset(uint8_t port)
     USB_DBG("reset port %d on hub: %p [this: %p]", port, dev, this)
     setPortFeature(PORT_RESET_FEATURE, port);
 #if defined(TARGET_RZ_A1H)
-    Thread::wait(50);   // Reset release waiting for Hi-Speed check.
+    ThisThread::sleep_for(50);   // Reset release waiting for Hi-Speed check.
 #endif
     while(1) {
         status = getPortStatus(port);
@@ -249,7 +249,7 @@ void USBHostHub::portReset(uint8_t port)
             host->deviceDisconnected(dev->getHub() + 1, port, this, 0);
             break;
         }
-        Thread::wait(10);
+        ThisThread::sleep_for(10);
     }
 }
 

--- a/features/unsupported/USBHost/USBHostMSD/USBHostMSD.cpp
+++ b/features/unsupported/USBHost/USBHostMSD/USBHostMSD.cpp
@@ -322,7 +322,7 @@ int USBHostMSD::init()
     uint16_t i, timeout = 10, ret;
     getMaxLun();
     for (i = 0; i < timeout; i++) {
-        Thread::wait(100);
+        ThisThread::sleep_for(100);
         if (!testUnitReady())
             break;
     }

--- a/features/unsupported/tests/rtos/cmsis/isr/main.cpp
+++ b/features/unsupported/tests/rtos/cmsis/isr/main.cpp
@@ -17,7 +17,7 @@ void queue_isr() {
 void queue_thread(void const *argument) {
     while (true) {
         queue.put((uint32_t*)1);
-        Thread::wait(1000);
+        ThisThread::sleep_for(1000);
     }
 }
 

--- a/features/unsupported/tests/rtos/mbed/basic/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/basic/main.cpp
@@ -36,7 +36,7 @@ DigitalOut led2(LED2);
 void led2_thread(void const *argument) {
     while (true) {
         led2 = !led2;
-        Thread::wait(1000);
+        ThisThread::sleep_for(1000);
         print_char();
     }
 }
@@ -51,6 +51,6 @@ int main() {
 
     while (true) {
         led1 = !led1;
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
     }
 }

--- a/features/unsupported/tests/rtos/mbed/file/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/file/main.cpp
@@ -108,6 +108,6 @@ int main() {
 
     while (true) {
         led2 = !led2;
-        Thread::wait(1000);
+        ThisThread::sleep_for(1000);
     }
 }

--- a/features/unsupported/tests/rtos/mbed/isr/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/isr/main.cpp
@@ -43,7 +43,7 @@ void queue_isr() {
 void queue_thread(void const *argument) {
     while (true) {
         queue.put((uint32_t*)QUEUE_PUT_THREAD_VALUE);
-        Thread::wait(THREAD_DELAY);
+        ThisThread::sleep_for(THREAD_DELAY);
     }
 }
 

--- a/features/unsupported/tests/rtos/mbed/mail/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/mail/main.cpp
@@ -47,7 +47,7 @@ void send_thread (void const *argument) {
         mail->current = CREATE_CURRENT(i);
         mail->counter = i;
         mail_box.put(mail);
-        Thread::wait(QUEUE_PUT_DELAY);
+        ThisThread::sleep_for(QUEUE_PUT_DELAY);
     }
 }
 

--- a/features/unsupported/tests/rtos/mbed/mutex/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/mutex/main.cpp
@@ -66,7 +66,7 @@ bool manipulate_protected_zone(const int thread_delay) {
     led = !led;
     change_counter++;
     print_char('.');
-    Thread::wait(thread_delay);
+    ThisThread::sleep_for(thread_delay);
 
     changing_counter = false;
     stdio_mutex.unlock();   // UNLOCK
@@ -94,7 +94,7 @@ int main() {
 
     while (true) {
         // Thread 1 action
-        Thread::wait(t1_delay);
+        ThisThread::sleep_for(t1_delay);
         manipulate_protected_zone(t1_delay);
         if (change_counter >= SIGNALS_TO_EMIT or mutex_defect == true) {
             t2.terminate();

--- a/features/unsupported/tests/rtos/mbed/queue/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/queue/main.cpp
@@ -49,7 +49,7 @@ void send_thread (void const *argument) {
         message->current = CREATE_CURRENT(i);
         message->counter = i;
         queue.put(message);
-        Thread::wait(QUEUE_PUT_DELAY);
+        ThisThread::sleep_for(QUEUE_PUT_DELAY);
     }
 }
 

--- a/features/unsupported/tests/rtos/mbed/semaphore/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/semaphore/main.cpp
@@ -63,7 +63,7 @@ void test_thread(void const *delay) {
         if (sem_lock_failed) {
             sem_defect = true;
         }
-        Thread::wait(thread_delay);
+        ThisThread::sleep_for(thread_delay);
         print_char('.');
         sem_counter--;
         change_counter++;

--- a/features/unsupported/tests/rtos/mbed/signals/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/signals/main.cpp
@@ -35,7 +35,7 @@ volatile int signal_counter = 0;
 void led_thread(void const *argument) {
     while (true) {
         // Signal flags that are reported as event are automatically cleared.
-        Thread::signal_wait(SIGNAL_SET_VALUE);
+        ThisThread::flags_wait_all(SIGNAL_SET_VALUE);
         led = !led;
         signal_counter++;
     }
@@ -51,7 +51,7 @@ int main (void) {
     bool result = true;
 
     while (true) {
-        Thread::wait(2 * SIGNAL_HANDLE_DELEY);
+        ThisThread::sleep_for(2 * SIGNAL_HANDLE_DELEY);
         thread.signal_set(SIGNAL_SET_VALUE);
         if (signal_counter == SIGNALS_TO_EMIT) {
             printf("Handled %d signals\r\n", signal_counter);

--- a/features/unsupported/tests/rtos/mbed/timer/main.cpp
+++ b/features/unsupported/tests/rtos/mbed/timer/main.cpp
@@ -42,5 +42,5 @@ int main(void) {
     led_3_timer.start(50);
     led_4_timer.start(25);
 
-    Thread::wait(osWaitForever);
+    ThisThread::sleep_for(osWaitForever);
 }

--- a/features/unsupported/tests/usb/host/mass_storage/main.cpp
+++ b/features/unsupported/tests/usb/host/mass_storage/main.cpp
@@ -17,7 +17,7 @@ void msd_task(void const *)
 
         // try to connect a MSD device
         while(!msd.connect()) {
-            Thread::wait(500);
+            ThisThread::sleep_for(500);
         }
         if (fs.mount(&msd) != 0) {
             continue;
@@ -46,14 +46,14 @@ void msd_task(void const *)
         } else {
             printf("FILE == NULL\r\n");
         }
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
         printf("again\n");
         // if device disconnected, try to connect again
         while (msd.connected()) {
-            Thread::wait(500);
+            ThisThread::sleep_for(500);
         }
         while (fs.unmount() < 0) {
-            Thread::wait(500);
+            ThisThread::sleep_for(500);
             printf("unmount\n");
         }
     }
@@ -65,6 +65,6 @@ int main()
 
     while(1) {
         led=!led;
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
     }
 }

--- a/features/unsupported/tests/usb/host/mouse/main.cpp
+++ b/features/unsupported/tests/usb/host/mouse/main.cpp
@@ -14,14 +14,14 @@ void mouse_task(void const *) {
     while(1) {
         // try to connect a USB mouse
         while(!mouse.connect())
-            Thread::wait(500);
+            ThisThread::sleep_for(500);
 
         // when connected, attach handler called on mouse event
         mouse.attachEvent(onMouseEvent);
 
         // wait until the mouse is disconnected
         while(mouse.connected())
-            Thread::wait(500);
+            ThisThread::sleep_for(500);
     }
 }
 
@@ -29,6 +29,6 @@ int main() {
     Thread mouseTask(mouse_task, NULL, osPriorityNormal, 256 * 4);
     while(1) {
         led=!led;
-        Thread::wait(500);
+        ThisThread::sleep_for(500);
     }
 }

--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -17,7 +17,7 @@
 #include "FileHandle.h"
 #if MBED_CONF_RTOS_PRESENT
 #include "rtos/Kernel.h"
-#include "rtos/Thread.h"
+#include "rtos/ThisThread.h"
 using namespace rtos;
 #else
 #include "Timer.h"
@@ -83,7 +83,7 @@ int poll(pollfh fhs[], unsigned nfhs, int timeout)
 #ifdef MBED_CONF_RTOS_PRESENT
         // TODO - proper blocking
         // wait for condition variable, wait queue whatever here
-        rtos::Thread::wait(1);
+        rtos::ThisThread::sleep_for(1);
 #endif
     }
     return count;

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -42,7 +42,7 @@ void wait_us(int us)
     if ((us >= 1000) && core_util_are_interrupts_enabled()) {
         // Use the RTOS to wait for millisecond delays if possible
         sleep_manager_lock_deep_sleep();
-        Thread::wait((uint32_t)us / 1000);
+        rtos::ThisThread::sleep_for((uint32_t)us / 1000);
         sleep_manager_unlock_deep_sleep();
     }
     // Use busy waiting for sub-millisecond delays, or for the whole

--- a/rtos/ConditionVariable.cpp
+++ b/rtos/ConditionVariable.cpp
@@ -21,7 +21,7 @@
  */
 #include "rtos/ConditionVariable.h"
 #include "rtos/Kernel.h"
-#include "rtos/Thread.h"
+#include "rtos/ThisThread.h"
 
 #include "mbed_error.h"
 #include "mbed_assert.h"
@@ -46,7 +46,7 @@ void ConditionVariable::wait()
 bool ConditionVariable::wait_for(uint32_t millisec)
 {
     Waiter current_thread;
-    MBED_ASSERT(_mutex.get_owner() == Thread::gettid());
+    MBED_ASSERT(_mutex.get_owner() == ThisThread::get_id());
     MBED_ASSERT(_mutex._count == 1);
     _add_wait_list(&_wait_list, &current_thread);
 
@@ -84,7 +84,7 @@ bool ConditionVariable::wait_until(uint64_t millisec)
 
 void ConditionVariable::notify_one()
 {
-    MBED_ASSERT(_mutex.get_owner() == Thread::gettid());
+    MBED_ASSERT(_mutex.get_owner() == ThisThread::get_id());
     if (_wait_list != NULL) {
         _wait_list->sem.release();
         _remove_wait_list(&_wait_list, _wait_list);
@@ -93,7 +93,7 @@ void ConditionVariable::notify_one()
 
 void ConditionVariable::notify_all()
 {
-    MBED_ASSERT(_mutex.get_owner() == Thread::gettid());
+    MBED_ASSERT(_mutex.get_owner() == ThisThread::get_id());
     while (_wait_list != NULL) {
         _wait_list->sem.release();
         _remove_wait_list(&_wait_list, _wait_list);


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Stop using the newly-deprecated functions from `rtos/Thread.h`.

NB: suggest merging before 5.10 release (currently RC2)! But I leave it to you to do any additional needed testing/checks, since I only did a test build for one target (LPC4088).

For reference, here's the script I threw together to do most of the work: [fixdep.zip](https://github.com/ARMmbed/mbed-os/files/2381185/fixdep.zip). I ran that, then did a build, and fixed up the `#include`s.

Aside: this is further motivation for #7886.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

