### PR TITLE
Add LPTICKER tests

### DIFF
--- a/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
+++ b/TESTS/mbed_hal/lp_ticker/lp_ticker_api_tests.h
@@ -51,6 +51,23 @@ void lp_ticker_deepsleep_test(void);
  * Then ticker does not glitch backwards due to an incorrectly implemented ripple counter driver.
  */
 void lp_ticker_glitch_test(void);
+
+/** Test that the ticker does not fire early.
+ *
+ * Given ticker is available.
+ * When ticker has interrupt set.
+ * Then ticker does not fire before the time specified.
+ */
+void lp_ticker_early_match_test(void);
+
+/** Test that the ticker does not fire early.
+ *
+ * Given ticker is available.
+ * When ticker is about to have a match and a second call to lp_ticker_set_interrupt is ticker is made.
+ * Then ticker does not fire before the new time specified.
+ */
+void lp_ticker_early_match_race_test(void);
+
 /**@}*/
 
 #ifdef __cplusplus

--- a/hal/lp_ticker_api.h
+++ b/hal/lp_ticker_api.h
@@ -45,6 +45,7 @@ extern "C" {
  *
  * # Potential bugs
  * * Glitches due to ripple counter - Verified by ::lp_ticker_glitch_test
+ * * Firing early - Verified by - Verified by ::lp_ticker_early_match_test and ::lp_ticker_early_match_race_test
  *
  * @see hal_lp_ticker_tests
  *


### PR DESCRIPTION
### Description

When both tickless and LPTICKER_DELAY_TICKS are enabled some ST devices randomly get stuck sleeping forever. This is because the wake up time passed to the rtc is ignored if the previous match is about to occur. This causes the device to get stuck in sleep.

~This patch~ #8242 prevents matches from getting dropped by the rtc by deactivating the rtc wake up timer before setting a new value.

~This patch also makes a related fix for the lp ticker to prevent a spurious interrupt. Note - the lp ticker implementation does correctly set the second match interrupt so it did not have problems with LowPowerTickerWrappper/LPTICKER_DELAY_TICKS.~

Events leading up to this failure for the RTC:

- 1st call to lp_ticker_set_interrupt
- delay until ticker interrupt is about to fire
- 2nd call to lp_ticker_set_interrupt
- interrupt for 1st call fires and match time for 2nd call is dropped
    -LowPowerTickerWrapper gets ticker interrupt but treats it as a
     spurious interrupt and drops it since it comes in too early
- device enters sleep without a wakeup source and locks up

This PR also adds tests to catch this regression in the future.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

