### PR TITLE
STM32F3 correct analogin_read

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F3/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/analogin_device.c
@@ -34,6 +34,7 @@
 #include "cmsis.h"
 #include "pinmap.h"
 #include "mbed_error.h"
+#include "mbed_debug.h"
 #include "PeripheralPins.h"
 
 void analogin_init(analogin_t *obj, PinName pin)
@@ -211,16 +212,27 @@ uint16_t adc_read(analogin_t *obj)
             return 0;
     }
 
-    HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
-
-    HAL_ADC_Start(&obj->handle); // Start conversion
-
-    // Wait end of conversion and get value
-    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
-        return (uint16_t)HAL_ADC_GetValue(&obj->handle);
-    } else {
-        return 0;
+    if (HAL_ADC_ConfigChannel(&obj->handle, &sConfig) != HAL_OK) {
+        debug("HAL_ADC_ConfigChannel issue\n");;
     }
+
+    if (HAL_ADC_Start(&obj->handle) != HAL_OK) {
+        debug("HAL_ADC_Start issue\n");;
+    }
+
+    uint16_t MeasuredValue = 0;
+
+    if (HAL_ADC_PollForConversion(&obj->handle, 10) == HAL_OK) {
+        MeasuredValue = (uint16_t)HAL_ADC_GetValue(&obj->handle);
+    } else {
+        debug("HAL_ADC_PollForConversion issue\n");
+    }
+
+    if (HAL_ADC_Stop(&obj->handle) != HAL_OK) {
+        debug("HAL_ADC_Stop issue\n");;
+    }
+
+    return MeasuredValue;
 }
 
 #endif


### PR DESCRIPTION
### Description

There was an issue with ADC and STM32F3 targets when several measurements were requested by application.

### Tests

Manual tests with internal channels OK

Ci tests OK:

| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
|-------------------|---------------|-----------------------------|--------|--------------------|-------------|
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-api-analogin          | OK     | 15.26              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-api-analogout         | OK     | 13.9               | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-assumptions-analogin  | OK     | 18.06              | default     |
| NUCLEO_F303ZE-ARM | NUCLEO_F303ZE | tests-assumptions-analogout | OK     | 13.46              | default     |


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

