### PR TITLE
gt netsocket tcp -  increases threads' stack size

### DIFF
--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -30,7 +30,7 @@ nsapi_error_t tcpsocket_connect_to_discard_srv(TCPSocket &sock);
 int split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global {
-static const int TESTS_TIMEOUT = 480;
+static const int TESTS_TIMEOUT = 960;
 static const int TCP_OS_STACK_SIZE = 1024;
 
 static const int RX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/tcp/tcp_tests.h
+++ b/TESTS/netsocket/tcp/tcp_tests.h
@@ -31,7 +31,7 @@ int split2half_rmng_tcp_test_time(); // [s]
 
 namespace tcp_global {
 static const int TESTS_TIMEOUT = 960;
-static const int TCP_OS_STACK_SIZE = 1024;
+static const int TCP_OS_STACK_SIZE = 2048;
 
 static const int RX_BUFF_SIZE = 1220;
 static const int TX_BUFF_SIZE = 1220;

--- a/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_thread_per_socket_safety.cpp
@@ -29,7 +29,7 @@ static const int SIGNAL_SIGIO1 = 0x1;
 static const int SIGNAL_SIGIO2 = 0x2;
 static const int SIGIO_TIMEOUT = 5000; //[ms]
 
-Thread thread;
+Thread thread(osPriorityNormal, tcp_global::TCP_OS_STACK_SIZE);
 volatile bool running = true;
 }
 
@@ -50,8 +50,8 @@ static void check_const_len_rand_sequence()
     sock.sigio(callback(_sigio_handler1, Thread::gettid()));
 
     static const int BUFF_SIZE = 10;
-    char rx_buff[BUFF_SIZE] = {0};
-    char tx_buff[BUFF_SIZE] = {0};
+    static char rx_buff[BUFF_SIZE] = {0};
+    static char tx_buff[BUFF_SIZE] = {0};
 
 
     int bytes2process;
@@ -107,8 +107,8 @@ static void check_var_len_rand_sequence()
     sock.sigio(callback(_sigio_handler2, Thread::gettid()));
 
     static const int BUFF_SIZE = 1001;
-    char rx_buff[BUFF_SIZE];
-    char tx_buff[BUFF_SIZE];
+    static char rx_buff[BUFF_SIZE];
+    static char tx_buff[BUFF_SIZE];
     static const int pkt_size_diff = 100;
 
     int bytes2process;


### PR DESCRIPTION
### Description
Greentea netsocket tcp test cases - used thread stack size was insufficient for debug profile.
Also insufficient thread stack size with NUCLEO_F401RE+IDW01M1 - please see issue ARMmbed/wifi-x-nucleo-idw01m1#17

Test case timeout value increased because demanded by the new ARMmbed/esp8266-driver#83


Patch (commit) 24905f5 provided by @betzw.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

