### PR TITLE
STM32L1 ADC update for internal channels

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L1/analogin_device.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/analogin_device.c
@@ -105,6 +105,9 @@ uint16_t adc_read(analogin_t *obj)
     ADC_ChannelConfTypeDef sConfig = {0};
 
     // Configure ADC channel
+    sConfig.Rank         = ADC_REGULAR_RANK_1;
+    sConfig.SamplingTime = ADC_SAMPLETIME_48CYCLES;
+
     switch (obj->channel) {
         case 0:
             sConfig.Channel = ADC_CHANNEL_0;
@@ -156,9 +159,11 @@ uint16_t adc_read(analogin_t *obj)
             break;
         case 16:
             sConfig.Channel = ADC_CHANNEL_TEMPSENSOR;
+            sConfig.SamplingTime = ADC_SAMPLETIME_384CYCLES;
             break;
         case 17:
             sConfig.Channel = ADC_CHANNEL_VREFINT;
+            sConfig.SamplingTime = ADC_SAMPLETIME_384CYCLES;
             break;
         case 18:
             sConfig.Channel = ADC_CHANNEL_18;
@@ -215,9 +220,6 @@ uint16_t adc_read(analogin_t *obj)
         default:
             return 0;
     }
-
-    sConfig.Rank         = ADC_REGULAR_RANK_1;
-    sConfig.SamplingTime = ADC_SAMPLETIME_16CYCLES;
 
     HAL_ADC_ConfigChannel(&obj->handle, &sConfig);
 


### PR DESCRIPTION
### Description

Sampling time was not correct for ADC measurement

| target            | platform_name | test suite                  | result | elapsed_time (sec) | copy_method |
|-------------------|---------------|-----------------------------|--------|--------------------|-------------|
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-analogin          | OK     | 14.65              | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-api-analogout         | OK     | 13.5               | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-assumptions-analogin  | OK     | 17.39              | default     |
| NUCLEO_L152RE-ARM | NUCLEO_L152RE | tests-assumptions-analogout | OK     | 13.33              | default     |


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

