### PR TITLE
STM: Fix us_ticker timestamp after deep sleep

### DIFF
--- a/targets/TARGET_STM/sleep.c
+++ b/targets/TARGET_STM/sleep.c
@@ -158,6 +158,7 @@ void hal_sleep(void)
 }
 
 extern int serial_is_tx_ongoing(void);
+extern int mbed_sdk_inited;
 
 void hal_deepsleep(void)
 {
@@ -200,6 +201,10 @@ void hal_deepsleep(void)
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
 #endif /* TARGET_STM32L4 */
 
+    /* Prevent HAL_GetTick() from using ticker_read_us() to read the
+     * us_ticker timestamp until the us_ticker context is restored. */
+    mbed_sdk_inited = 0;
+
     // Verify Clock Out of Deep Sleep
     ForceClockOutofDeepSleep();
 
@@ -213,6 +218,10 @@ void hal_deepsleep(void)
     wait_loop(500);
 
     restore_timer_ctx();
+
+    /* us_ticker context restored, allow HAL_GetTick() to read the us_ticker
+     * timestamp via ticker_read_us() again. */
+    mbed_sdk_inited = 1;
 
     // Enable IRQs
     core_util_critical_section_exit();


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Use the `mbed_sdk_inited` flag to correct the `HAL_GetTick()` behavior
after waking up from deep sleep mode. `ticker_read_us()` must not be
used to read us_ticker timestamp after waking up until the us_ticker
context is restored. More detailed description in issue #8117.

Fixes #8117

CC @jeromecoutant @c1728p9 @jamesbeyond @maciejbocianski 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

