### PR TITLE
requiremnts: Bump IceTea

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ future>=0.16.0
 six>=1.11.0
 git+https://github.com/armmbed/manifest-tool.git@v1.4.5
 mbed-cloud-sdk==2.0.0
-icetea>=1.0.1,<2
+icetea>=1.0.2,<2


### PR DESCRIPTION
### Description

Version 1.0.1 of IceTea required conflicting version of jsonschema and
a version of pyshark that required a native compiler on windows. Version
1.0.2 resoves these issues and a few more. This PR prevents users from
installing a version which we know is broken

@cmonr RC3 please :D

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change