### PR TITLE
Disable MBEDTLS_CONFIG_HW_SUPPORT on STM targets.

### DIFF
--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F437xG/mbedtls_device.h
@@ -22,8 +22,6 @@
 
 #define MBEDTLS_AES_ALT
 
-#define MBEDTLS_SHA256_ALT
-
 #define MBEDTLS_SHA1_ALT
 
 #define MBEDTLS_MD5_ALT

--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/mbedtls_device.h
@@ -22,8 +22,6 @@
 
 #define MBEDTLS_AES_ALT
 
-#define MBEDTLS_SHA256_ALT
-
 #define MBEDTLS_SHA1_ALT
 
 #define MBEDTLS_MD5_ALT

--- a/features/mbedtls/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/mbedtls_device.h
+++ b/features/mbedtls/targets/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F756ZG/mbedtls_device.h
@@ -23,8 +23,6 @@
 #define MBEDTLS_AES_ALT
 #define MBEDTLS_SHA1_ALT
 
-
-#define MBEDTLS_SHA256_ALT
 #define MBEDTLS_MD5_ALT
 
 #endif /* MBEDTLS_DEVICE_H */


### PR DESCRIPTION
### Description

Disable MBEDTLS_CONFIG_HW_SUPPORT on all STM targets.
Fix issue: https://github.com/ARMmbed/mbed-os/issues/6545


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

