### PR TITLE
Unit tests: automatic unit test suite naming

### DIFF
--- a/UNITTESTS/CMakeLists.txt
+++ b/UNITTESTS/CMakeLists.txt
@@ -147,11 +147,17 @@ foreach(testfile ${unittest-file-list})
   # Get source files
   include("${testfile}")
 
-  if(TEST_SUITE_NAME)
-    set(TEST_SUITES ${TEST_SUITES} ${TEST_SUITE_NAME})
-  else()
-    message(FATAL_ERROR "No TEST_SUITE_NAME found in test file. Add it to ${testfile}.")
-  endif()
+  get_filename_component(TEST_SUITE_DIR ${testfile} DIRECTORY)
+
+  file(RELATIVE_PATH
+       TEST_SUITE_NAME # output
+       ${PROJECT_SOURCE_DIR} # root
+       ${TEST_SUITE_DIR} #abs dirpath
+  )
+
+  string(REGEX REPLACE "/|\\\\" "-" TEST_SUITE_NAME ${TEST_SUITE_NAME})
+
+  set(TEST_SUITES ${TEST_SUITES} ${TEST_SUITE_NAME})
 
   set(LIBS_TO_BE_LINKED gmock_main)
 
@@ -178,7 +184,7 @@ foreach(testfile ${unittest-file-list})
     # Link the executable with the libraries.
     target_link_libraries(${TEST_SUITE_NAME} ${LIBS_TO_BE_LINKED})
 
-    add_test(NAME "${TEST_SUITE_NAME}UnitTests" COMMAND ${TEST_SUITE_NAME})
+    add_test(NAME "${TEST_SUITE_NAME}" COMMAND ${TEST_SUITE_NAME})
 
     # Append test build directory to list
     list(APPEND BUILD_DIRECTORIES "./CMakeFiles/${TEST_SUITE_NAME}.dir")

--- a/UNITTESTS/README.md
+++ b/UNITTESTS/README.md
@@ -203,7 +203,6 @@ Each class to be tested requires two files for unit testing:
 
 A unit test definition file `unittest.cmake` requires variables to be set for a test to be configured. File source paths in `unittest.cmake` files need to be relative to the unit test folder and `CMakeLists.txt`.
 
-* **TEST_SUITE_NAME** - Identifier for the test suite. Use naming convention *PATH_TO_THE_TESTABLE_FILE* e.g. *features-netsocket-InternetSocket*
 * **unittest-includes** - Include paths for headers needed to build the tests in addition to the base include paths listed in [CMakeLists.txt](CMakeLists.txt). Optional.
 * **unittest-sources** - Mbed OS source files and stubs included for the build.
 * **unittest-test-sources** - Unit test source files.
@@ -225,8 +224,6 @@ For example to create a unit test for `rtos/Semaphore.cpp`:
 1. Create a directory for unit test files in `UNITTESTS/rtos/Semaphore`.
 2. Create a test definition file `UNITTESTS/rtos/Semaphore/unittest.cmake` with the following content:
 ```
-set(TEST_SUITE_NAME "rtos-Semaphore")
-
 set(unittest-sources
 	stubs/mbed_assert.c
 	../rtos/Semaphore.cpp

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularbase/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularbase/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "cellular-framework-AT-AT_CellularBase")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/AT/AT_CellularBase

--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_device_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularinformation/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_information_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularnetwork/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_network_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularpower/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularpower/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_power_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsim/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsim/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_sim_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularsms/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularsms/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_sms_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellularstack/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_cellular_stack_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/AT/athandler/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "at_handler_unit")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/cellular/framework/common/util/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/common/util/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "cellular-framework-common-util")
-
 # Add test specific include paths
 set(unittest-includes ${unittest-includes}
   features/cellular/framework/common/util

--- a/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/InternetSocket/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "features-netsocket-InternetSocket")
-
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp
   ../features/netsocket/NetworkStack.cpp

--- a/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/NetworkInterface/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "features-netsocket-NetworkInterface")
-
 # Source files
 set(unittest-sources
   ../features/netsocket/NetworkInterface.cpp

--- a/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/TCPSocket/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "features-netsocket-TCPSocket")
-
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp
   ../features/netsocket/InternetSocket.cpp

--- a/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
+++ b/UNITTESTS/features/netsocket/UDPSocket/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "features-netsocket-UDPSocket")
-
 set(unittest-sources
   ../features/netsocket/SocketAddress.cpp
   ../features/netsocket/NetworkStack.cpp

--- a/UNITTESTS/platform/CircularBuffer/unittest.cmake
+++ b/UNITTESTS/platform/CircularBuffer/unittest.cmake
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "platform-CircularBuffer")
-
 set(unittest-sources
 )
 

--- a/UNITTESTS/template/unittest.cmake.template
+++ b/UNITTESTS/template/unittest.cmake.template
@@ -3,9 +3,6 @@
 # UNIT TESTS
 ####################
 
-# Unit test suite name
-set(TEST_SUITE_NAME "suitename")
-
 set(unittest-includes ${unittest-includes}
   headerfile
 )

--- a/UNITTESTS/unit_test/new.py
+++ b/UNITTESTS/unit_test/new.py
@@ -28,7 +28,7 @@ class UnitTestGeneratorTool(object):
     Generator tool to create new unit tests from template
     """
 
-    def _replace_content(self, template_content, dirname, classname, suite_name, extension):
+    def _replace_content(self, template_content, dirname, classname, extension):
         if extension == "h":
             content = re.sub(r"cppfile",
                              "",
@@ -41,7 +41,6 @@ class UnitTestGeneratorTool(object):
         content = re.sub(r"headerfile", "../dirname/template.h", content)
         content = re.sub(r"dirname", dirname, content)
         content = re.sub(r"template", classname, content)
-        content = re.sub(r"suitename", suite_name, content)
 
         return content
 
@@ -111,7 +110,6 @@ class UnitTestGeneratorTool(object):
                 content = self._replace_content(template_content,
                                                 dir_name,
                                                 class_name,
-                                                suite_name,
                                                 file_extension)
 
                 output_file.writelines(content)
@@ -130,7 +128,6 @@ class UnitTestGeneratorTool(object):
                 content = self._replace_content(template_content,
                                                 dir_name,
                                                 class_name,
-                                                suite_name,
                                                 file_extension)
 
                 output_file.writelines(content)


### PR DESCRIPTION
### Description

Use unit test suite names automatically derived from the file path.
 - File paths are unique so test suite names are unique.
 - Same naming convention as previously.
 - No effect on existing tests.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

