### PR TITLE
Build conflict with ARM and uARM

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -339,6 +339,7 @@ class ARM(mbedToolchain):
 class ARM_STD(ARM):
     def __init__(self, target, notify=None, macros=None,
                  build_profile=None, build_dir=None):
+        target.default_lib = ""
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
         if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):


### PR DESCRIPTION
### Description

It seems that for targets where "default_lib" is set to "small" in targets.json file,
ARM compilation is using TOOLCHAIN_ARM_MICRO files (instead of TOOLCHAIN_ARM_STD)

ex:
python ./tools/build.py -m NUCLEO_F303K8 -t ARM

Patch is solving my issue


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

