### PR TITLE
Fix for issue #8155 (NRF52832: time stops after 35 minutes)

### DIFF
--- a/platform/mbed_rtc_time.cpp
+++ b/platform/mbed_rtc_time.cpp
@@ -33,6 +33,8 @@ static void (*_rtc_write)(time_t t) = rtc_write;
 
 #include "drivers/LowPowerTimer.h"
 
+#define US_PER_SEC 1000000
+
 static SingletonPtr<mbed::LowPowerTimer> _rtc_lp_timer;
 static uint64_t _rtc_lp_base;
 static bool _rtc_enabled;
@@ -50,7 +52,7 @@ static int _rtc_lpticker_isenabled(void)
 
 static time_t _rtc_lpticker_read(void)
 {
-    return (uint64_t)_rtc_lp_timer->read() + _rtc_lp_base;
+    return _rtc_lp_timer->read_high_resolution_us() / US_PER_SEC + _rtc_lp_base;
 }
 
 static void _rtc_lpticker_write(time_t t)


### PR DESCRIPTION
### Description

Low power Timer is used as RTC for platforms that don't have HW RTC capabilities (like NRF52832).
`_rtc_lpticker_read(void)` function currently uses `Timer::read()` function to trace elapsed seconds.
`Timer::read()` returns seconds represented as `float` value, but this value is calculated from `int` since `Timer::read_us()` returns `int`.
This limits time tracing to ~35 min.
To fix this problem we will use `timer::read_high_resolution_us()` (which returns unsigned 64 bit value) instead of `Timer::read()`.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

