### PR TITLE
Change update file format to binary for all targets

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -36,7 +36,7 @@ from jinja2.environment import Environment
 from .arm_pack_manager import Cache
 from .utils import (mkdir, run_cmd, run_cmd_ext, NotSupportedException,
                     ToolException, InvalidReleaseTargetException,
-                    intelhex_offset, integer)
+                    intelhex_offset, integer, generate_update_filename)
 from .paths import (MBED_CMSIS_PATH, MBED_TARGETS_PATH, MBED_LIBRARIES,
                     MBED_HEADER, MBED_DRIVERS, MBED_PLATFORM, MBED_HAL,
                     MBED_CONFIG_FILE, MBED_LIBRARIES_DRIVERS,
@@ -550,10 +550,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
                 r for r in region_list if r.name in UPDATE_WHITELIST
             ]
             if update_regions:
-                update_res = "%s_update.%s" % (
-                    join(build_path, name),
-                    getattr(toolchain.target, "OUTPUT_EXT", "bin")
-                )
+                update_res = join(build_path, generate_update_filename(name, toolchain.target))
                 merge_region_list(update_regions, update_res, notify)
                 res = (res, update_res)
             else:

--- a/tools/device_management.py
+++ b/tools/device_management.py
@@ -31,6 +31,8 @@ from mbed_cloud import AccountManagementAPI, CertificatesAPI
 import colorama
 colorama.init()
 
+from utils import (generate_update_filename)
+
 
 LOG = logging.getLogger(__name__)
 LOG_FORMAT = '[%(levelname)s] %(asctime)s - %(name)s - %(message)s'
@@ -69,10 +71,7 @@ def wrap_payload(func):
             sources = options.source_dir or ['.']
             config = Config(mcus[0], sources)
             app_name = config.name or basename(abspath(sources[0]))
-            output_ext = getattr(config.target, "OUTPUT_EXT", "bin")
-            payload_name = join(options.build, "{}_application.{}".format(
-                app_name, output_ext
-            ))
+            payload_name = join(options.build, generate_update_filename(app_name, config.target))
             options.payload = open(payload_name, "rb")
         return func(options)
     return inner

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -544,10 +544,15 @@ def intelhex_offset(filename, offset):
                             % filename)
     return ih
 
-
 def integer(maybe_string, base):
     """Make an integer of a number or a string"""
     if isinstance(maybe_string, int):
         return maybe_string
     else:
         return int(maybe_string, base)
+
+def generate_update_filename(name, target):
+    return "%s_update.%s" % (
+                    name,
+                    getattr(target, "OUTPUT_EXT_UPDATE", "bin")
+                )


### PR DESCRIPTION
### Description
- Change the default file format to binary for all targets, even though some targets need hex as app format, updater always needs bin
- Unify the file name from generator side and usage side for the update bin

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

