### PR TITLE
STM32: add missing IAR exporters

### DIFF
--- a/tools/export/iar/iar_definitions.json
+++ b/tools/export/iar/iar_definitions.json
@@ -278,5 +278,44 @@
         "OGChipSelectEditMenu": "TMPM3H6FWFG\tToshiba TMPM3H6FWFG",
         "GFPUCoreSlave": 24,
         "GBECoreSlave": 24
+    },
+    "STM32F446VE": {
+        "OGChipSelectEditMenu": "STM32F446VE\tST STM32F446VE"
+    },
+    "STM32F303VC": {
+        "OGChipSelectEditMenu": "STM32F303VC\tST STM32F303VC"
+    },
+    "STM32F334C8": {
+        "OGChipSelectEditMenu": "STM32F334C8\tST STM32F334C8"
+    },
+    "STM32F413ZH": {
+        "OGChipSelectEditMenu": "STM32F413ZH\tST STM32F413ZH"
+    },
+    "STM32F469NI": {
+        "OGChipSelectEditMenu": "STM32F469NI\tST STM32F469NI"
+    },
+    "STM32F769NI": {
+        "OGChipSelectEditMenu": "STM32F769NI\tST STM32F769NI"
+    },
+    "STM32F303ZE": {
+        "OGChipSelectEditMenu": "STM32F303ZE\tST STM32F303ZE"
+    },
+    "STM32F410RB": {
+        "OGChipSelectEditMenu": "STM32F410RB\tST STM32F410RB"
+    },
+    "STM32F412ZG": {
+        "OGChipSelectEditMenu": "STM32F412ZG\tST STM32F412ZG"
+    },
+    "STM32F413ZH": {
+        "OGChipSelectEditMenu": "STM32F413ZH\tST STM32F413ZH"
+    },
+    "STM32F756ZG": {
+        "OGChipSelectEditMenu": "STM32F756ZG\tST STM32F756ZG"
+    },
+    "STM32L053R8": {
+        "OGChipSelectEditMenu": "STM32L053R8\tST STM32L053R8"
+    },
+    "STM32L432KC": {
+        "OGChipSelectEditMenu": "STM32L432KC\tST STM32L432KC"
     }
 }


### PR DESCRIPTION
### Description

Add missing IAR exporters.

Fixes #8139 

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

