### PR TITLE
CellularDevice_stub added

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
+++ b/UNITTESTS/features/cellular/framework/AT/at_cellulardevice/unittest.cmake
@@ -35,4 +35,5 @@ set(unittest-test-sources
   stubs/EventQueue_stub.cpp 
   stubs/FileHandle_stub.cpp 
   stubs/mbed_assert_stub.cpp
+  stubs/CellularDevice_stub.cpp
 )

--- a/UNITTESTS/stubs/CellularDevice_stub.cpp
+++ b/UNITTESTS/stubs/CellularDevice_stub.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) , Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CellularDevice.h"
+#include "EventQueue.h"
+#include "CellularUtil.h"
+
+namespace mbed {
+
+MBED_WEAK CellularDevice *CellularDevice::get_default_instance()
+{
+    return NULL;
+}
+
+CellularDevice::CellularDevice() : _network_ref_count(0), _sms_ref_count(0), _power_ref_count(0), _sim_ref_count(0),
+        _info_ref_count(0)
+{
+}
+
+events::EventQueue *CellularDevice::get_queue() const
+{
+    return NULL;
+}
+
+}


### PR DESCRIPTION
### Description

Unittests are broken because of missing CellularDevice_stub. 
This is added in this PR.

This is only unittest related fix, but must be prioritized

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

