### PR TITLE
tools/utils: Fix issue with loading json files as ascii on python3 linux

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -30,6 +30,7 @@ import json
 from collections import OrderedDict
 import logging
 from intelhex import IntelHex
+import io
 
 try:
     unicode
@@ -367,9 +368,9 @@ def json_file_to_dict(fname):
     fname - the name of the file to parse
     """
     try:
-        with open(fname, "r") as file_obj:
-            return json.loads(file_obj.read().encode('ascii', 'ignore'),
-                              object_pairs_hook=OrderedDict)
+        with io.open(fname, encoding='ascii', 
+                         errors='ignore') as file_obj:
+            return json.load(file_obj, object_pairs_hook=OrderedDict)
     except (ValueError, IOError):
         sys.stderr.write("Error parsing '%s':\n" % fname)
         raise


### PR DESCRIPTION
### Description

This resolves #7026, a failure to run mbed-cli tool on linux python 3.5 due to the error:
```
Traceback (most recent call last):
  File "/project/mbed-os/tools/make.py", line 41, in <module>
    from tools.tests import TESTS, Test, TEST_MAP
  File "/project/mbed-os/tools/tests.py", line 18, in <module>
    from tools.data.support import DEFAULT_SUPPORT, CORTEX_ARM_SUPPORT
  File "/project/mbed-os/tools/data/support.py", line 17, in <module>
    from tools.targets import TARGETS
  File "/project/mbed-os/tools/targets/__init__.py", line 569, in <module>
    update_target_data()
  File "/project/mbed-os/tools/targets/__init__.py", line 558, in update_target_data
    in Target.get_json_target_data().items()
  File "/project/mbed-os/tools/targets/__init__.py", line 87, in wrapper
    CACHES[(func.__name__, args)] = func(*args, **kwargs)
  File "/project/mbed-os/tools/targets/__init__.py", line 159, in get_json_target_data
    Target.__targets_json_location_default)
  File "/project/mbed-os/tools/utils.py", line 372, in json_file_to_dict
    object_pairs_hook=OrderedDict)
  File "/usr/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```

This problem was accidentally introduced in 7b49edc7ebc528566543759f9de9519742dae7f7 when the recursive function which called `str.encode('ascii').decode()` was essentially replaced with a one liner which calls `str.encode('ascii', 'ignore')` without any conversion back to string. It appears some versions / platforms of python handle bytes being passed into json.loads while others don't (it's supposed to take str)

This method is also somewhat inefficient however (though still better than the recursive function). Reading in the file and converting a couple of times before sending into json in unneccesary, the builtin codecs module gives us a much cleaner way of achieving the same goal

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

