### PR TITLE
Add missing SIM PIN configuration item

### DIFF
--- a/features/netsocket/mbed_lib.json
+++ b/features/netsocket/mbed_lib.json
@@ -6,6 +6,7 @@
         "default-wifi-ssid": null,
         "default-wifi-password": null,
         "default-wifi-security": "NONE",
+        "default-cellular-sim-pin": null,
         "default-cellular-apn": null,
         "default-cellular-username": null,
         "default-cellular-password": null,


### PR DESCRIPTION
### Description

Added missing "default-cellular-sim-pin" configuration entry. NetworkInterfaceDefaults.cpp already uses MBED_CONF_NSAPI_DEFAULT_CELLULAR_SIM_PIN but the json configuration item was missing.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

