### PR TITLE
Unit tests: fix cellular athandler unit tests and wait() declaration conflict

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -618,6 +618,7 @@ TEST_F(TestATHandler, test_ATHandler_read_string)
     // *** Reading more than available in buffer ***
     at.clear_error();
     char table4[] = "\"s,\"OK\r\n\0";
+    mbed_poll_stub::int_value = 0;
     at.flush();
     filehandle_stub_table = table4;
     filehandle_stub_table_pos = 0;
@@ -741,6 +742,7 @@ TEST_F(TestATHandler, test_ATHandler_read_string)
     // *** CRLF part of the string ***
     at.clear_error();
     char table10[] = "\"s\"\r\nOK\r\n\0";
+    mbed_poll_stub::int_value = 0;
     at.flush();
     filehandle_stub_table = table10;
     filehandle_stub_table_pos = 0;

--- a/UNITTESTS/target_h/platform/mbed_retarget.h
+++ b/UNITTESTS/target_h/platform/mbed_retarget.h
@@ -324,9 +324,9 @@ struct statvfs {
     unsigned long  f_bsize;    ///< Filesystem block size
     unsigned long  f_frsize;   ///< Fragment size (block size)
 
-    fsblkcnt_t     f_blocks;   ///< Number of blocks
-    fsblkcnt_t     f_bfree;    ///< Number of free blocks
-    fsblkcnt_t     f_bavail;   ///< Number of free blocks for unprivileged users
+    unsigned long long     f_blocks;   ///< Number of blocks
+    unsigned long long     f_bfree;    ///< Number of free blocks
+    unsigned long long     f_bavail;   ///< Number of free blocks for unprivileged users
 
     unsigned long  f_fsid;     ///< Filesystem ID
 

--- a/UNITTESTS/target_h/platform/mbed_wait_api.h
+++ b/UNITTESTS/target_h/platform/mbed_wait_api.h
@@ -1,0 +1,33 @@
+
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_WAIT_API_H
+#define MBED_WAIT_API_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void wait_ms(int ms);
+
+void wait_us(int us);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif
+


### PR DESCRIPTION
### Description

Fix failing cellular unit tests on Windows and Mac OS.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
