### PR TITLE
Adding QOS in response to LinkADRReq and fixing class C bugs

### DIFF
--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -647,7 +647,6 @@ void LoRaWANStack::post_process_tx_with_reception()
 void LoRaWANStack::post_process_tx_no_reception()
 {
     if (_loramac.get_mcps_confirmation()->req_type == MCPS_CONFIRMED) {
-        _loramac.post_process_mcps_req();
         if (_loramac.continue_sending_process()) {
             _ctrl_flags &= ~TX_DONE_FLAG;
             _ctrl_flags &= ~RETRY_EXHAUSTED_FLAG;

--- a/features/lorawan/LoRaWANStack.cpp
+++ b/features/lorawan/LoRaWANStack.cpp
@@ -577,7 +577,6 @@ void LoRaWANStack::process_transmission_timeout()
 void LoRaWANStack::process_transmission(void)
 {
     tr_debug("Transmission completed");
-    _loramac.on_radio_tx_done(_tx_timestamp);
 
     if (_device_current_state == DEVICE_STATE_JOINING) {
         _device_current_state = DEVICE_STATE_AWAITING_JOIN_ACCEPT;
@@ -589,6 +588,8 @@ void LoRaWANStack::process_transmission(void)
             _device_current_state = DEVICE_STATE_AWAITING_ACK;
         }
     }
+
+    _loramac.on_radio_tx_done(_tx_timestamp);
 }
 
 void LoRaWANStack::post_process_tx_with_reception()

--- a/features/lorawan/LoRaWANStack.h
+++ b/features/lorawan/LoRaWANStack.h
@@ -483,8 +483,10 @@ private:
     void make_tx_metadata_available(void);
     void make_rx_metadata_available(void);
 
-    void handle_ack_expiry_for_class_c(void);
     void handle_scheduling_failure(void);
+
+    void post_process_tx_with_reception(void);
+    void post_process_tx_no_reception(void);
 
 private:
     LoRaMac _loramac;
@@ -497,6 +499,7 @@ private:
     lorawan_tx_metadata _tx_metadata;
     lorawan_rx_metadata _rx_metadata;
     uint8_t _num_retry;
+    uint8_t _qos_cnt;
     uint32_t _ctrl_flags;
     uint8_t _app_port;
     bool _link_check_requested;

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -903,7 +903,7 @@ void LoRaMac::open_rx1_window(void)
     _lora_phy->rx_config(&_params.rx_window1_config);
     _lora_phy->handle_receive();
 
-    tr_debug("Opening RX1 Window");
+    tr_debug("RX1 slot open, Freq = %lu", _params.rx_window1_config.frequency);
 }
 
 void LoRaMac::open_rx2_window()
@@ -932,7 +932,7 @@ void LoRaMac::open_rx2_window()
     _lora_phy->handle_receive();
     _params.rx_slot = _params.rx_window2_config.rx_slot;
 
-    tr_debug("Opening RX2 Window, Frequency = %lu", _params.rx_window2_config.frequency);
+    tr_debug("RX2 slot open, Freq = %lu", _params.rx_window2_config.frequency);
 }
 
 void LoRaMac::on_ack_timeout_timer_event(void)

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -1862,7 +1862,6 @@ uint8_t LoRaMac::get_max_possible_tx_size(uint8_t fopts_len)
         max_possible_payload_size = allowed_frm_payload_size - fopts_len;
     } else {
         max_possible_payload_size = allowed_frm_payload_size;
-        fopts_len = 0;
         _mac_commands.clear_command_buffer();
         _mac_commands.clear_repeat_buffer();
     }

--- a/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMacCommand.cpp
@@ -145,40 +145,40 @@ lorawan_status_t LoRaMacCommand::process_mac_commands(const uint8_t *payload, ui
                 mlme_conf.nb_gateways = payload[mac_index++];
                 break;
             case SRV_MAC_LINK_ADR_REQ: {
-                adr_req_params_t linkAdrReq;
-                int8_t linkAdrDatarate = DR_0;
-                int8_t linkAdrTxPower = TX_POWER_0;
-                uint8_t linkAdrNbRep = 0;
-                uint8_t linkAdrNbBytesParsed = 0;
+                adr_req_params_t link_adr_req;
+                int8_t link_adr_dr = DR_0;
+                int8_t link_adr_txpower = TX_POWER_0;
+                uint8_t link_adr_nbtrans = 0;
+                uint8_t link_adr_nb_bytes_pasred = 0;
 
                 // Fill parameter structure
-                linkAdrReq.payload = &payload[mac_index - 1];
-                linkAdrReq.payload_size = commands_size - (mac_index - 1);
-                linkAdrReq.adr_enabled = mac_sys_params.adr_on;
-                linkAdrReq.ul_dwell_time = mac_sys_params.uplink_dwell_time;
-                linkAdrReq.current_datarate = mac_sys_params.channel_data_rate;
-                linkAdrReq.current_tx_power = mac_sys_params.channel_tx_power;
-                linkAdrReq.current_nb_rep = mac_sys_params.retry_num;
+                link_adr_req.payload = &payload[mac_index - 1];
+                link_adr_req.payload_size = commands_size - (mac_index - 1);
+                link_adr_req.adr_enabled = mac_sys_params.adr_on;
+                link_adr_req.ul_dwell_time = mac_sys_params.uplink_dwell_time;
+                link_adr_req.current_datarate = mac_sys_params.channel_data_rate;
+                link_adr_req.current_tx_power = mac_sys_params.channel_tx_power;
+                link_adr_req.current_nb_trans = mac_sys_params.nb_trans;
 
                 // Process the ADR requests
-                status = lora_phy.link_ADR_request(&linkAdrReq,
-                                                   &linkAdrDatarate,
-                                                   &linkAdrTxPower,
-                                                   &linkAdrNbRep,
-                                                   &linkAdrNbBytesParsed);
+                status = lora_phy.link_ADR_request(&link_adr_req,
+                                                   &link_adr_dr,
+                                                   &link_adr_txpower,
+                                                   &link_adr_nbtrans,
+                                                   &link_adr_nb_bytes_pasred);
 
                 if ((status & 0x07) == 0x07) {
-                    mac_sys_params.channel_data_rate = linkAdrDatarate;
-                    mac_sys_params.channel_tx_power = linkAdrTxPower;
-                    mac_sys_params.retry_num = linkAdrNbRep;
+                    mac_sys_params.channel_data_rate = link_adr_dr;
+                    mac_sys_params.channel_tx_power = link_adr_txpower;
+                    mac_sys_params.nb_trans = link_adr_nbtrans;
                 }
 
                 // Add the answers to the buffer
-                for (uint8_t i = 0; i < (linkAdrNbBytesParsed / 5); i++) {
+                for (uint8_t i = 0; i < (link_adr_nb_bytes_pasred / 5); i++) {
                     ret_value = add_link_adr_ans(status);
                 }
                 // Update MAC index
-                mac_index += linkAdrNbBytesParsed - 1;
+                mac_index += link_adr_nb_bytes_pasred - 1;
             }
                 break;
             case SRV_MAC_DUTY_CYCLE_REQ:

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -36,7 +36,8 @@ SPDX-License-Identifier: BSD-3-Clause
 #define CHANNELS_IN_MASK  16
 
 LoRaPHY::LoRaPHY()
-    : _radio(NULL)
+    : _radio(NULL),
+      _lora_time(NULL)
 {
     memset(&phy_params, 0, sizeof(phy_params));
 }

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -1031,7 +1031,7 @@ uint8_t LoRaPHY::link_ADR_request(adr_req_params_t *link_adr_req,
         verify_params.adr_enabled = link_adr_req->adr_enabled;
         verify_params.current_datarate = link_adr_req->current_datarate;
         verify_params.current_tx_power = link_adr_req->current_tx_power;
-        verify_params.current_nb_rep = link_adr_req->current_nb_rep;
+        verify_params.current_nb_rep = link_adr_req->current_nb_trans;
 
         verify_params.datarate = adr_settings.datarate;
         verify_params.tx_power = adr_settings.tx_power;

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -849,6 +849,11 @@ void LoRaPHY::compute_rx_win_params(int8_t datarate, uint8_t min_rx_symbols,
                                              ((uint32_t *)phy_params.bandwidths.table)[rx_conf_params->datarate]);
     }
 
+    if (rx_conf_params->rx_slot == RX_SLOT_WIN_1) {
+        rx_conf_params->frequency = phy_params.channels.channel_list[rx_conf_params->channel].frequency;
+    }
+
+
     get_rx_window_params(t_symbol, min_rx_symbols, rx_error, RADIO_WAKEUP_TIME,
                          &rx_conf_params->window_timeout, &rx_conf_params->window_offset);
 }

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -479,7 +479,7 @@ uint8_t LoRaPHYAU915::link_ADR_request(adr_req_params_t* params,
     verify_params.nb_rep = adr_settings.nb_rep;
     verify_params.current_datarate = params->current_datarate;
     verify_params.current_tx_power = params->current_tx_power;
-    verify_params.current_nb_rep = params->current_nb_rep;
+    verify_params.current_nb_rep = params->current_nb_trans;
     verify_params.channel_mask = temp_channel_masks;
 
 

--- a/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYCN470.cpp
@@ -510,7 +510,7 @@ uint8_t LoRaPHYCN470::link_ADR_request(adr_req_params_t* params,
     verify_params.nb_rep = adr_settings.nb_rep;
     verify_params.current_datarate = params->current_datarate;
     verify_params.current_tx_power = params->current_tx_power;
-    verify_params.current_nb_rep = params->current_nb_rep;
+    verify_params.current_nb_rep = params->current_nb_trans;
     verify_params.channel_mask = temp_channel_masks;
 
 

--- a/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYUS915.cpp
@@ -517,7 +517,7 @@ uint8_t LoRaPHYUS915::link_ADR_request(adr_req_params_t* params,
     verify_params.nb_rep = adr_settings.nb_rep;
     verify_params.current_datarate = params->current_datarate;
     verify_params.current_tx_power = params->current_tx_power;
-    verify_params.current_nb_rep = params->current_nb_rep;
+    verify_params.current_nb_rep = params->current_nb_trans;
     verify_params.channel_mask = temp_channel_masks;
 
     // Verify the parameters and update, if necessary

--- a/features/lorawan/lorastack/phy/lora_phy_ds.h
+++ b/features/lorawan/lorastack/phy/lora_phy_ds.h
@@ -329,9 +329,10 @@ typedef struct {
      */
     int8_t current_tx_power;
     /*!
-     * The current number of repetitions.
+     * The current number of repetitions for obtaining a QOS level set by
+     * NS (applicable only to unconfirmed messages).
      */
-    uint8_t current_nb_rep;
+    uint8_t current_nb_trans;
 } adr_req_params_t;
 
 /**

--- a/features/lorawan/system/lorawan_data_structures.h
+++ b/features/lorawan/system/lorawan_data_structures.h
@@ -70,6 +70,8 @@ typedef uint32_t lorawan_time_t;
  */
 #define LORAMAC_PHY_MAXPAYLOAD                      255
 
+#define LORAWAN_DEFAULT_QOS                         1
+
 /**
  *
  * Default user application maximum data size for transmission
@@ -187,9 +189,10 @@ typedef struct {
      */
     uint32_t join_accept_delay2;
     /*!
-     * The number of uplink messages repetitions (confirmed messages only).
+     * The number of uplink messages repetitions for QOS set by network server
+     * in LinkADRReq mac command (unconfirmed messages only).
      */
-    uint8_t retry_num;
+    uint8_t nb_trans;
     /*!
      * The datarate offset between uplink and downlink on first window.
      */
@@ -874,6 +877,9 @@ typedef struct {
      */
     int8_t data_rate;
     /*!
+     *
+     * For CONFIRMED Messages:
+     *
      * The number of trials to transmit the frame, if the LoRaMAC layer did not
      * receive an acknowledgment. The MAC performs a datarate adaptation
      * according to the LoRaWAN Specification V1.0.2, chapter 18.4, as in
@@ -892,6 +898,13 @@ typedef struct {
      *
      * Note that if nb_trials is set to 1 or 2, the MAC will not decrease
      * the datarate, if the LoRaMAC layer did not receive an acknowledgment.
+     *
+     * For UNCONFIRMED Messages:
+     *
+     * Provides a certain QOS level set by network server in LinkADRReq MAC
+     * command. The device will transmit the given UNCONFIRMED message nb_trials
+     * time with same frame counter until a downlink is received. Standard defined
+     * range is 1:15. Data rates will NOT be adapted according to chapter 18.4.
      */
     uint8_t nb_trials;
 


### PR DESCRIPTION
### Description

Adds QOS mechanism for unconfirmed messages as per 1.0.2 spec in response to LinkADRReq mac command.  In addition to that it fixes various bugs potentially hindering class C operation. 

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [] Refactor
    [ ] Target update
    [] Functionality change
    [ ] Breaking change

