### PR TITLE
Wait API updated to remove deepsleep lock

### DIFF
--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -55,9 +55,9 @@ extern "C" {
  *  @param s number of seconds to wait
  *
  *  @note
- *    If the RTOS is present, this function always spins to get the exact number of microseconds,
- *    which potentially affects power (such as preventing deep sleep) and multithread performance.
- *    You can avoid it by using ThisThread::sleep_for().
+ *    If the RTOS is present, this function spins to get the exact number of microseconds for
+ *    usec precision upto 10msec. If delay is larger then 10msec and not in ISR, it is same as
+ *    `wait_ms`. `wait_us` and `wait_ms` are recommended over `wait`
  */
 void wait(float s);
 
@@ -66,9 +66,8 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  *
  *  @note
- *    If the RTOS is present, this function always spins to get the exact number of microseconds,
- *    which potentially affects power (such as preventing deep sleep) and multithread performance.
- *    You can avoid it by using ThisThread::sleep_for().
+ *    If the RTOS is present, it is same as CMSIS osDelay()
+ *    Not callable from interrupts, doesn't lock hardware sleep.
  */
 void wait_ms(int ms);
 
@@ -77,8 +76,9 @@ void wait_ms(int ms);
  *  @param us the whole number of microseconds to wait
  *
  *  @note
- *    If the RTOS is present, this function always spins to get the exact number of microseconds,
- *    which potentially affects power (such as preventing deep sleep) and multithread performance.
+ *    This function always spins to get the exact number of microseconds.
+ *    If RTOS is present, this will affect power (prevents deep sleep) and
+ *    multithread performance, hence spinning for milli-sec wait is not recommended.
  */
 void wait_us(int us);
 

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -66,7 +66,7 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  *
  *  @note
- *    If the RTOS is present, it is same as CMSIS osDelay()
+ *    If the RTOS is present, it calls ThisThread::sleep_for() which is same as CMSIS osDelay()
  *    Not callable from interrupts, doesn't lock hardware sleep.
  */
 void wait_ms(int ms);

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -56,8 +56,8 @@ extern "C" {
  *
  *  @note
  *    If the RTOS is present, this function spins to get the exact number of microseconds for
- *    usec precision upto 10msec. If delay is larger then 10msec and not in ISR, it is same as
- *    `wait_ms`. `wait_us` and `wait_ms` are recommended over `wait`
+ *    microsecond precision up to 10 milliseconds. If delay is larger than 10 milliseconds and not in ISR, it is the same as
+ *    `wait_ms`. We recommend `wait_us` and `wait_ms` over `wait`.
  */
 void wait(float s);
 
@@ -77,8 +77,8 @@ void wait_ms(int ms);
  *
  *  @note
  *    This function always spins to get the exact number of microseconds.
- *    If RTOS is present, this will affect power (prevents deep sleep) and
- *    multithread performance, hence spinning for milli-sec wait is not recommended.
+ *    If RTOS is present, this will affect power (by preventing deep sleep) and
+ *    multithread performance. Therefore, spinning for millisecond wait is not recommended.
  */
 void wait_us(int us);
 

--- a/platform/mbed_wait_api.h
+++ b/platform/mbed_wait_api.h
@@ -66,8 +66,8 @@ void wait(float s);
  *  @param ms the whole number of milliseconds to wait
  *
  *  @note
- *    If the RTOS is present, it calls ThisThread::sleep_for() which is same as CMSIS osDelay()
- *    Not callable from interrupts, doesn't lock hardware sleep.
+ *    If the RTOS is present, it calls ThisThread::sleep_for(), which is same as CMSIS osDelay().
+ *    You can't call this from interrupts, and it doesn't lock hardware sleep.
  */
 void wait_ms(int ms);
 

--- a/platform/mbed_wait_api_rtos.cpp
+++ b/platform/mbed_wait_api_rtos.cpp
@@ -23,21 +23,18 @@
 #include "rtos/rtos.h"
 #include "platform/mbed_critical.h"
 #include "platform/mbed_power_mgmt.h"
+#include "platform/mbed_error.h"
+#include "rtos/ThisThread.h"
 
 void wait(float s)
 {
-    wait_us(s * 1000000.0f);
-}
+    if ((s >= 0.01f)  && core_util_are_interrupts_enabled()) {
+        wait_ms(s * 1000.0f);
+        return;
+    }
 
-void wait_ms(int ms)
-{
-    wait_us(ms * 1000);
-}
-
-void wait_us(int us)
-{
+    uint32_t us = (s * 1000000.0f);
     const ticker_data_t *const ticker = get_us_ticker_data();
-
     uint32_t start = ticker_read(ticker);
     if ((us >= 1000) && core_util_are_interrupts_enabled()) {
         // Use the RTOS to wait for millisecond delays if possible
@@ -47,6 +44,33 @@ void wait_us(int us)
     }
     // Use busy waiting for sub-millisecond delays, or for the whole
     // interval if interrupts are not enabled
+    while ((ticker_read(ticker) - start) < (uint32_t)us);
+}
+
+/*  The actual time delay may be up to one timer tick less - 1 msec */
+void wait_ms(int ms)
+{
+    if (core_util_is_isr_active() || !core_util_are_interrupts_enabled()) {
+#if defined(MBED_TRAP_ERRORS_ENABLED) && MBED_TRAP_ERRORS_ENABLED
+        MBED_ERROR(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_INVALID_OPERATION),
+                    "Deprecated behavior: milli-sec delay should not be used in interrupt.\n");
+#else
+        wait_us(ms * 1000);
+#endif
+    } else {
+        rtos::ThisThread::sleep_for(ms);
+    }
+}
+
+/*  The actual time delay may be 1 less usec */
+void wait_us(int us)
+{
+    if (us > 10000) {
+        MBED_WARNING(MBED_MAKE_ERROR(MBED_MODULE_PLATFORM, MBED_ERROR_UNKNOWN),
+                     "wait_us blocks deep sleep, wait_ms recommended for long delays\n");
+    }
+    const ticker_data_t *const ticker = get_us_ticker_data();
+    uint32_t start = ticker_read(ticker);
     while ((ticker_read(ticker) - start) < (uint32_t)us);
 }
 


### PR DESCRIPTION
### Description 

FOR MINOR RELEASE 

ThisThread::sleep_for() allows thread to enter deep sleep mode, and hence saves power. But allowed only tick resolution for wait.
`wait` API's earlier applied deepsleep lock to avoid entering deep sleep mode and use busy wait loop for usec precision.

Aim here is to get precision as per the API name, and enable devices to enter sleep mode.

Updates:
`wait` and `wait_us` - Give usec precision till 10msec and perform busy wait loop, no power saving here. But if value passed to these API's is more than 10msec, then behavior will be same as `wait_ms` with sub-millisec value rounded.

`wait_ms` - Will have msec precision and saves power. However it calls `ThisThread::sleep_for() -> osDelay()` API's which are tick based, i.e actual time delay may be up to one timer tick less. ~~In order to avoid zero delay for `wait_ms` we do busy wait for 1ms.~~

### Pull request type
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

Related : https://github.com/ARMmbed/mbed-os/pull/6969 https://github.com/ARMmbed/mbed-os/issues/7154
