### PR TITLE
Cellular: Fixed network connect/disconnect

### DIFF
--- a/features/cellular/TESTS/socket/udp/main.cpp
+++ b/features/cellular/TESTS/socket/udp/main.cpp
@@ -150,7 +150,7 @@ static void network_callback(nsapi_event_t ev, intptr_t ptr)
     }
 }
 
-static void udp_network_stack()
+static void udp_network_stack_open()
 {
     cellular.set_serial(&cellular_serial);
     TEST_ASSERT(cellular.init() == NSAPI_ERROR_OK);
@@ -207,6 +207,12 @@ static void udp_socket_send_receive_async()
     TEST_ASSERT(echo_socket.close() == NSAPI_ERROR_OK);
 }
 
+static void udp_network_stack_close()
+{
+    CellularNetwork *network = cellular.get_network();
+    TEST_ASSERT(network->disconnect() == NSAPI_ERROR_OK);
+}
+
 using namespace utest::v1;
 
 static utest::v1::status_t greentea_failure_handler(const Case *const source, const failure_t reason)
@@ -219,10 +225,11 @@ static utest::v1::status_t greentea_failure_handler(const Case *const source, co
 }
 
 static Case cases[] = {
-    Case("UDP network stack", udp_network_stack, greentea_failure_handler),
+    Case("UDP network stack open", udp_network_stack_open, greentea_failure_handler),
     Case("UDP gethostbyname", udp_gethostbyname, greentea_failure_handler),
     Case("UDP socket send/receive", udp_socket_send_receive, greentea_failure_handler),
     Case("UDP socket send/receive async", udp_socket_send_receive_async, greentea_failure_handler),
+    Case("UDP network stack close", udp_network_stack_close, greentea_failure_handler),
 };
 
 static utest::v1::status_t test_setup(const size_t number_of_cases)

--- a/features/cellular/easy_cellular/CellularConnectionFSM.h
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.h
@@ -213,6 +213,7 @@ private:
     const char *_plmn;
     bool _command_success;
     bool _plmn_network_found;
+    int _cid_active; // an active PDP context ID
 };
 
 } // namespace

--- a/features/cellular/easy_cellular/EasyCellularConnection.h
+++ b/features/cellular/easy_cellular/EasyCellularConnection.h
@@ -78,7 +78,8 @@ public:
      */
     virtual nsapi_error_t connect();
 
-    /** Stop the interface
+    /** Disconnect from a cellular PDN connection
+     *  To disconnect from cellular network call also CellularNetwork::detach.
      *
      *  @return         0 on success, or error code on failure
      */

--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -236,11 +236,12 @@ public:
 
     /** Request registering to network.
      *
-     *  @param plmn     format is in numeric format or 0 for automatic network registration
+     *  @param mode     network registration mode
+     *  @param plmn     operator in numeric format for manual registration modes
      *  @return         NSAPI_ERROR_OK on success
      *                  NSAPI_ERROR_DEVICE_ERROR on failure
      */
-    virtual nsapi_error_t set_registration(const char *plmn = 0) = 0;
+    virtual nsapi_error_t set_registration(NWRegisteringMode mode = NWModeAutomatic, const char *plmn = 0) = 0;
 
     /** Get the current network registering mode
      *
@@ -314,7 +315,7 @@ public:
      */
     virtual nsapi_error_t get_attach(AttachStatus &status) = 0;
 
-    /** Request detach from a network.
+    /** Detach from GSM and packet networks.
      *
      *  @return         NSAPI_ERROR_OK on success
      *                  NSAPI_ERROR_DEVICE_ERROR on failure
@@ -528,6 +529,17 @@ public:
      *                       NSAPI_ERROR_DEVICE_ERROR on other failures
      */
     virtual nsapi_error_t get_operator_names(operator_names_list &op_names) = 0;
+
+    /** Find an active context
+     *
+     *  @param[out] cid     PDP Context ID returned on success
+     *  @param apn          Access Point Name, or NULL for any
+     *  @param stack_type   Protocol stack, IPv4, IPv6, ... or DEFAULT_STACK for any
+     *  @return             NSAPI_ERROR_OK on success
+     *                      NSAPI_ERROR_NO_MEMORY on memory failure
+     *                      NSAPI_ERROR_NO_CONNECTION on not found active context
+     */
+    virtual nsapi_error_t get_active_context(int &cid, char *apn = NULL, nsapi_ip_stack_t stack_type = DEFAULT_STACK) = 0;
 };
 
 } // namespace mbed

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -159,13 +159,16 @@ void ATHandler::set_is_filehandle_usable(bool usable)
 
 nsapi_error_t ATHandler::set_urc_handler(const char *prefix, mbed::Callback<void()> callback)
 {
+    lock();
     if (find_urc_handler(prefix, &callback)) {
         tr_warn("URC already added with prefix: %s", prefix);
+        unlock();
         return NSAPI_ERROR_OK;
     }
 
     struct oob_t *oob = new struct oob_t;
     if (!oob) {
+        unlock();
         return NSAPI_ERROR_NO_MEMORY;
     } else {
         size_t prefix_len = strlen(prefix);
@@ -182,12 +185,13 @@ nsapi_error_t ATHandler::set_urc_handler(const char *prefix, mbed::Callback<void
         oob->next = _oobs;
         _oobs = oob;
     }
-
+    unlock();
     return NSAPI_ERROR_OK;
 }
 
 void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> callback)
 {
+    lock();
     struct oob_t *current = _oobs;
     struct oob_t *prev = NULL;
     while (current) {
@@ -203,6 +207,7 @@ void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> ca
         prev = current;
         current = prev->next;
     }
+    unlock();
 }
 
 bool ATHandler::find_urc_handler(const char *prefix, mbed::Callback<void()> *callback)
@@ -1138,10 +1143,33 @@ bool ATHandler::check_cmd_send()
 
 void ATHandler::flush()
 {
+    lock();
     reset_buffer();
     while (fill_buffer(false)) {
         reset_buffer();
     }
+    unlock();
+}
+
+bool ATHandler::sync()
+{
+    // poll for 10 seconds
+    for (int i=0; i<10; i++) {
+        lock();
+        set_at_timeout(1000);
+        // For sync use an AT command that is supported by all modems and likely not used frequently,
+        // especially a common response like OK could be response to previous request.
+        cmd_start("AT+CMEE?");
+        cmd_stop();
+        resp_start("+CMEE:");
+        resp_stop();
+        restore_at_timeout();
+        unlock();
+        if (!_last_err) {
+            return true;
+        }
+    }
+    return false;
 }
 
 void ATHandler::debug_print(char *p, int len)

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -156,10 +156,13 @@ public:
      */
     void clear_error();
 
-    /**
-     * Flushes the underlying stream
+    /** Flushes the underlying stream. Prefer sync() to this due to flushing might dismiss URCs.
      */
     void flush();
+
+    /** Synchronize AT command and response handling with cellular module, it takes max 10 seconds.
+     */
+    bool sync();
 
     /** Tries to find oob's from the AT response. Call the urc callback if one is found.
      */
@@ -509,7 +512,7 @@ private:
      */
     const char *mem_str(const char *dest, size_t dest_len, const char *src, size_t src_len);
 
-    // check is urc is already added
+    // check is urc is already added, a caller must hold lock()
     bool find_urc_handler(const char *prefix, mbed::Callback<void()> *callback);
 
     // print contents of a buffer to trace log

--- a/features/cellular/framework/AT/AT_CellularNetwork.h
+++ b/features/cellular/framework/AT/AT_CellularNetwork.h
@@ -63,7 +63,7 @@ public: // CellularNetwork
 
     virtual nsapi_error_t activate_context();
 
-    virtual nsapi_error_t set_registration(const char *plmn = 0);
+    virtual nsapi_error_t set_registration(NWRegisteringMode mode = NWModeAutomatic, const char *plmn = 0);
 
     virtual nsapi_error_t get_network_registering_mode(NWRegisteringMode &mode);
 
@@ -118,6 +118,9 @@ public: // CellularNetwork
     virtual nsapi_error_t set_registration_urc(RegistrationType type, bool on);
 
     virtual nsapi_error_t get_operator_names(operator_names_list &op_names);
+
+    virtual nsapi_error_t get_active_context(int &cid, char *apn = NULL, nsapi_ip_stack_t stack_type = DEFAULT_STACK);
+
 protected:
 
     /** Check if modem supports the given stack type.
@@ -166,7 +169,7 @@ private:
     void free_credentials();
 
     nsapi_error_t open_data_channel();
-    bool get_context();
+    bool get_context(int cid_requested = -1);
     bool set_new_context(int cid);
 
     nsapi_error_t delete_current_context();
@@ -178,6 +181,8 @@ private:
 #if NSAPI_PPP_AVAILABLE
     void ppp_status_cb(nsapi_event_t, intptr_t);
 #endif
+
+    static const int PDP_CONTEXT_COUNT = 4; // max simultaneous PDP contexts active
 
 protected:
     NetworkStack *_stack;
@@ -194,6 +199,7 @@ protected:
     nsapi_connection_status_t _connect_status;
     bool _new_context_set;
     bool _is_context_active;
+    bool _is_context_activated; // did we activate the context
     RegistrationStatus _reg_status;
     RadioAccessTechnology _current_act;
     mbed::Callback<void()> _urc_funcs[C_MAX];


### PR DESCRIPTION
### Description

Fixed cellular network connect and disconnect to handle PDP context more gracefully.

Commit 1: Fix Greentea
* UDP test to call network.disconnect().

Commit 2: Fix ATHandler
* To have mutex locks when modifying URC handlers
* Add sync() AT stream that is needed for PPP disconnect

Commit 3: Add to Cellular network
* Update network registration to have also deregistration
* Add a new function to get active cellular context
* Deactivate PDP context only if it was activated by us (also in PPP mode)

Commit 4: Change cellular statemachine
* During registration check if PDP context is already useful and continue to attach

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

