### PR TITLE
platform timer: Call timer start in enable

### DIFF
--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_timer.cpp
@@ -45,8 +45,8 @@ void platform_timer_enable(void)
     equeue = mbed_highprio_event_queue();
     MBED_ASSERT(equeue != NULL);
 #endif
-    // Prime the SingletonPtrs - can't construct from IRQ/critical section
-    timer.get();
+    timer->start();
+    // Prime the SingletonPtr - can't construct from IRQ/critical section
     timeout.get();
 }
 


### PR DESCRIPTION
This timer was never started and therefore read_us returned always 0 causing bad timings.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This timer was never started and therefore read_us returned always 0 causing bad timings.

Tested with K64F and Nucleo-F429ZI

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

