### PR TITLE
Feature circular file buffer

### DIFF
--- a/platform/CircularBufferFile.cpp
+++ b/platform/CircularBufferFile.cpp
@@ -1,0 +1,103 @@
+#include "platform/CircularBufferFile.h"
+#include "platform/mbed_retarget.h"
+
+// For CircularFile
+#if MBED_CONF_RTOS_PRESENT
+#include "rtos/ThisThread.h"
+#else
+#include "platform/mbed_wait_api.h"
+#endif
+//End
+
+using namespace mbed;
+
+off_t CircularBufferFile::seek(off_t offset, int whence = SEEK_SET)
+{
+    return -ESPIPE;
+}
+off_t CircularBufferFile::size()
+{
+    return _buffer.size();
+}
+int CircularBufferFile::isatty()
+{
+    return false;
+}
+int CircularBufferFile::close()
+{
+    return 0;
+}
+
+CircularBufferFile::~CircularBufferFile(){}
+
+void CircularBufferFile::api_lock(void)
+{
+    _mutex.lock();
+}
+
+void CircularBufferFile::api_unlock(void)
+{
+    _mutex.unlock();
+}
+
+ssize_t CircularBufferFile::write(const void* buffer, size_t size) {
+    const char* b = static_cast<const char*>(buffer);
+    if (size == 0) {
+        return 0;
+    }
+    api_lock();
+    for ( size_t i = 0; i < size; i++){
+        _buffer.push(b[i]);
+    }
+    api_unlock();
+    size_t data_written =  size  % CIRCULAR_BUFFER_FILE_DEPTH;
+    return data_written;
+}
+
+// Read is a forward iterator stream
+ssize_t CircularBufferFile::read(void *buffer, size_t size){
+    char* b = static_cast<char*>(buffer);
+    size_t i = 0;
+    if (size == 0) {
+        return 0;
+    }
+
+    api_lock();
+    while (_buffer.empty()) {
+        /*if (!_blocking) {
+            api_unlock();
+            return -EAGAIN;
+        }*/
+        api_unlock();
+        wait_ms(1);  // XXX todo - proper wait, WFE for non-rtos ?
+        api_lock();
+    }
+    i = 0;
+    while(i < size && !_buffer.empty())
+    {
+        _buffer.pop(b[i++]);
+    }
+    api_unlock();
+    return i;
+}
+
+void CircularBufferFile::wait_ms(uint32_t millisec)
+{
+    /* wait_ms implementation for RTOS spins until exact microseconds - we
+     * want to just sleep until next tick.
+     */
+#if MBED_CONF_RTOS_PRESENT
+    // Can make this smarter in the future
+    rtos::ThisThread::sleep_for(millisec);
+#else
+    ::wait_ms(millisec);
+#endif
+}
+
+# if MBED_CONF_PLATFORM_SOFT_FILE_BUFFER
+FileHandle *mbed_override_console(int fd)
+{
+    static CircularBufferFile console;
+    return &console;
+}
+#endif

--- a/platform/CircularBufferFile.cpp
+++ b/platform/CircularBufferFile.cpp
@@ -28,7 +28,7 @@ int CircularBufferFile::close()
     return 0;
 }
 
-CircularBufferFile::~CircularBufferFile(){}
+CircularBufferFile::~CircularBufferFile() {}
 
 void CircularBufferFile::api_lock(void)
 {
@@ -40,13 +40,14 @@ void CircularBufferFile::api_unlock(void)
     _mutex.unlock();
 }
 
-ssize_t CircularBufferFile::write(const void* buffer, size_t size) {
-    const char* b = static_cast<const char*>(buffer);
+ssize_t CircularBufferFile::write(const void *buffer, size_t size)
+{
+    const char *b = static_cast<const char *>(buffer);
     if (size == 0) {
         return 0;
     }
     api_lock();
-    for ( size_t i = 0; i < size; i++){
+    for (size_t i = 0; i < size; i++) {
         _buffer.push(b[i]);
     }
     api_unlock();
@@ -55,8 +56,9 @@ ssize_t CircularBufferFile::write(const void* buffer, size_t size) {
 }
 
 // Read is a forward iterator stream
-ssize_t CircularBufferFile::read(void *buffer, size_t size){
-    char* b = static_cast<char*>(buffer);
+ssize_t CircularBufferFile::read(void *buffer, size_t size)
+{
+    char *b = static_cast<char *>(buffer);
     size_t i = 0;
     if (size == 0) {
         return 0;
@@ -73,8 +75,7 @@ ssize_t CircularBufferFile::read(void *buffer, size_t size){
         api_lock();
     }
     i = 0;
-    while(i < size && !_buffer.empty())
-    {
+    while (i < size && !_buffer.empty()) {
         _buffer.pop(b[i++]);
     }
     api_unlock();

--- a/platform/CircularBufferFile.h
+++ b/platform/CircularBufferFile.h
@@ -26,7 +26,6 @@ private:
 
     /** Release mutex */
     virtual void api_unlock(void);
-    
     void wait_ms(uint32_t millisec);
 private:
     CircularBuffer<char, CIRCULAR_BUFFER_FILE_DEPTH> _buffer;

--- a/platform/CircularBufferFile.h
+++ b/platform/CircularBufferFile.h
@@ -1,0 +1,38 @@
+#ifndef CIRCULAR_BUFFER_FILE_H
+#define CIRCULAR_BUFFER_FILE_H
+#include "platform/platform.h"
+#include "platform/FileHandle.h"
+#include "platform/CircularBuffer.h"
+#include "platform/PlatformMutex.h"
+
+
+#ifndef CIRCULAR_BUFFER_FILE_DEPTH
+#define CIRCULAR_BUFFER_FILE_DEPTH 512
+#endif
+
+namespace mbed {
+class CircularBufferFile : public FileHandle {
+public:
+    virtual ~CircularBufferFile();
+    virtual ssize_t write(const void *buffer, size_t size);
+    virtual ssize_t read(void *buffer, size_t size);
+    virtual off_t seek(off_t offset, int whence);
+    virtual off_t size();
+    virtual int isatty();
+    virtual int close();
+private:
+    /** Acquire mutex */
+    virtual void api_lock(void);
+
+    /** Release mutex */
+    virtual void api_unlock(void);
+    
+    void wait_ms(uint32_t millisec);
+private:
+    CircularBuffer<char, CIRCULAR_BUFFER_FILE_DEPTH> _buffer;
+    //Callback<void()> _sigio_cb; // Todo
+    PlatformMutex _mutex;
+};
+
+}
+#endif /* CIRCULAR_BUFFER_FILE_H */

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -132,7 +132,12 @@
         "use-mpu": {
             "help": "Use the MPU if available to fault execution from RAM and writes to ROM. Can be disabled to reduce image size.",
             "value": true
+        },
+        "soft-file-buffer": {
+            "help": "Use circular file buffer instead of serial",
+            "value": false
         }
+
     },
     "target_overrides": {
         "EFM32": {

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -44,6 +44,7 @@
 
 static SingletonPtr<PlatformMutex> _mutex;
 
+
 #if defined(__ARMCC_VERSION)
 #   if __ARMCC_VERSION >= 6010050
 #      include <arm_compat.h>
@@ -256,7 +257,7 @@ MBED_WEAK FileHandle *mbed::mbed_override_console(int fd)
 
 static FileHandle *default_console()
 {
-#if DEVICE_SERIAL
+# if DEVICE_SERIAL
 #  if MBED_CONF_PLATFORM_STDIO_BUFFERED_SERIAL
     static UARTSerial console(STDIO_UART_TX, STDIO_UART_RX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE);
 #   if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS


### PR DESCRIPTION
### Description

Add Circular file buffer retargeting to simulate a pipe to /var/log. Note, this is enabled/disabled and configureable at compile time. Currently, in release mode writes to stdout get dumped to a Sink which acts like writing to /dev/null. However, the c_strings are not getting removed at compile time which is evident using the `strings` tool. 

Having a circular file buffer between stdout and stdin decouples the source and sink of the file objects. For example, a debug build of a project can use a reader method to dump to serial, but a release build can write important logs to persistent storage or to cloud.

Here is a toy example:

```c++
Serial pc(USBTX, USBRX);
...
printf("Hello World!\r\n");
// Toy strings are less than 64 bytes long
char* buffer = (char*) calloc(64, sizeof(char));
while(true) {
          char* len = fgets(buffer, 64, stdin);
          if(len != NULL){
              pc.puts(buffer);
              break;
          }
```

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Breaking change

