### PR TITLE
Improve RTOS behavior with deep sleep

### DIFF
--- a/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
+++ b/rtos/TARGET_CORTEX/mbed_rtx_idle.cpp
@@ -90,6 +90,13 @@ uint32_t OS_Tick_GetInterval (void) {
 static void default_idle_hook(void)
 {
     uint32_t ticks_to_sleep = osKernelSuspend();
+    const bool block_deep_sleep = ticks_to_sleep <= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY;
+
+    if (block_deep_sleep) {
+        sleep_manager_lock_deep_sleep();
+    } else {
+        ticks_to_sleep -= MBED_CONF_TARGET_DEEP_SLEEP_LATENCY;
+    }
     os_timer->suspend(ticks_to_sleep);
 
     bool event_pending = false;
@@ -106,6 +113,11 @@ static void default_idle_hook(void)
         // Ensure interrupts get a chance to fire
         __ISB();
     }
+
+    if (block_deep_sleep) {
+        sleep_manager_unlock_deep_sleep();
+    }
+
     osKernelResume(os_timer->resume());
 }
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -21,6 +21,10 @@
                 "help": "Default network interface type. Typical options: null, ETHERNET, WIFI, CELLULAR, MESH",
                 "value": null
             },
+            "deep-sleep-latency": {
+                "help": "Time in ms required to go to and wake up from deep sleep (max 10)",
+                "value": 0
+            },
             "boot-stack-size": {
                 "help": "Define the boot stack size in bytes. This value must be a multiple of 8",
                 "value": "0x1000"


### PR DESCRIPTION
### Description

Only deep sleep when the wakeup time is more than 10ms in the future. This ensures that RTOS events are handled at the correct time. Note - when deep sleep is allow interrupt latency may still be as high as 10ms.


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

