### PR TITLE
Adjust stack & heap for IAR on STM32F412xG

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F412xG/device/TOOLCHAIN_IAR/stm32f412xx.icf
@@ -18,8 +18,9 @@ define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__]
 define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 
 /* Stack and Heap */
-define symbol __size_cstack__ = 0x8000;
-define symbol __size_heap__   = 0x10000;
+/*Heap 84kB and stack 1kB */
+define symbol __size_cstack__ = 0x400;
+define symbol __size_heap__   = 0x15000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION
### Description

Adjusted IAR Heap to 84kB and stack to 1kB

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

