### PR TITLE
test: fix RTC base time (#8214)

### DIFF
--- a/TESTS/host_tests/rtc_reset.py
+++ b/TESTS/host_tests/rtc_reset.py
@@ -29,7 +29,7 @@ class RtcResetTest(BaseHostTest):
     """
 
     """Start of the RTC"""
-    START_TIME = 50000
+    START_TIME = 1537789823 # GMT: Monday, 24 September 2018 11:50:23
     START_TIME_TOLERANCE = 10
     """Time to delay after sending reset"""
     DELAY_TIME = 5.0


### PR DESCRIPTION
### Description

Change the base time value to more realistic:
`START_TIME = 1537789823 # GMT: Monday, 24 September 2018 11:50:23`

This fix has been proposed by STM in order to enhance test efficiency.
Current test version did not detect problem with RTC reset on STM F1 family boards, since the base time was too small.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

