### PR TITLE
Renesas : Modify LPTicker driver

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/PeripheralPins.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/PeripheralPins.c
@@ -246,10 +246,11 @@ const PinMap PinMap_PWM[] = {
     {P7_9  , PWM_TIOC1A, 6},
     {P9_2  , PWM_TIOC1A, 5}, /* for 208QFP */
     {P2_7  , PWM_TIOC1A, 3},
-    {P5_14 , PWM_TIOC2A, 4},
-    {P7_0  , PWM_TIOC2A, 5},
-    {P9_4  , PWM_TIOC2A, 5}, /* for 208QFP */
-    {P2_6  , PWM_TIOC2A, 3},
+    {P6_7  , PWM_TIOC3A, 5},
+    {P2_5  , PWM_TIOC3A, 3},
+    {P3_11 , PWM_TIOC3A, 3},
+    {P6_9  , PWM_TIOC3C, 5},
+    {P3_12 , PWM_TIOC3C, 3},
     {P5_8  , PWM_TIOC4A, 3},
     {P2_4  , PWM_TIOC4A, 3},
     {P5_10 , PWM_TIOC4C, 3},

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/os_tick_ostm.c
@@ -194,7 +194,7 @@ uint32_t OS_Tick_GetOverflow (void)
 
 // Get Cortex-A9 OS Timer interrupt number
 IRQn_ID_t mbed_get_a9_tick_irqn(){
-  return OSTMI0TINT_IRQn;
+  return OSTM_IRQn;
 }
 #endif
 

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/mbed_drv_cfg.h
@@ -34,7 +34,7 @@
 
 #define RENESAS_RZ_A1_P0_CLK   CM1_RENESAS_RZ_A1_P0_CLK
 
-#define LP_TICKER_MTU2_CH      3
+#define LP_TICKER_MTU2_CH      2
 
 /* flash (W25Q64JV) */
 #define FLASH_BASE                 (0x18000000UL) /**< Flash Base Address */

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/os_tick_ostm.c
@@ -195,7 +195,7 @@ uint32_t OS_Tick_GetOverflow (void)
 
 // Get Cortex-A9 OS Timer interrupt number
 IRQn_ID_t mbed_get_a9_tick_irqn(){
-  return OSTMI0TINT_IRQn;
+  return OSTM_IRQn;
 }
 #endif
 


### PR DESCRIPTION
### Description
I modified the LPTicker driver for Renesas boards.

- Change the channel number of MTU2 used at LPTicker from 3 to 2. [GR-LYCHEE]
- Modify typo of macro that use at return value of mbed_get_a9_tick_irqn(). [GR-PEACH, GR-LYCHEE]

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

### Test result
Ticker and sleep test results are here.

[Test_GR-PEACH_GCC.txt](https://github.com/ARMmbed/mbed-os/files/2413904/Test_GR-PEACH_GCC.txt)
[Test_GR-LYCHEE_GCC.txt](https://github.com/ARMmbed/mbed-os/files/2413903/Test_GR-LYCHEE_GCC.txt)

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

