### PR TITLE
Mbedgt netsocket tc fixes

### DIFF
--- a/TESTS/netsocket/README.md
+++ b/TESTS/netsocket/README.md
@@ -715,10 +715,9 @@ Call `UDPSocket::sendto()` with invalid parameters.
 3.  Call `UDPSocket:sendto( "", 0, NULL, 0);`
 4.  Call `UDPSocket:sendto(NULL, 9, "hello", 5);`
 5.  Call `UDPSocket:sendto(NULL, 0, "hello", 5);`
-6.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 0, "hello", 5);`
-7.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9,NULL, 0);`
-8.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`
-9.  destroy the socket
+6.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9,NULL, 0);`
+7.  Call `UDPSocket:sendto("echo.mbedcloudtesting.com", 9, "hello", 5);`
+8.  destroy the socket
 
 **Expected result:**
 
@@ -990,9 +989,8 @@ Call `TCPSocket::connect()` with invalid parameters.
 1.  Call `TCPSocket:connect( NULL, 9);`
 2.  Call `TCPSocket:connect( "", 9);`
 3.  Call `TCPSocket:connect( "", 0);`
-4.  Call `TCPSocket:connect( "echo.mbedcloudtesting.com", 0);`
-5.  Call `TCPSocket:connect( "echo.mbedcloudtesting.com", 9);`
-6.  destroy the socket
+4.  Call `TCPSocket:connect( "echo.mbedcloudtesting.com", 9);`
+5.  destroy the socket
 
 **Expected result:**
 

--- a/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
+++ b/TESTS/netsocket/tcp/tcpsocket_connect_invalid.cpp
@@ -32,7 +32,6 @@ void TCPSOCKET_CONNECT_INVALID()
     TEST_ASSERT(sock.connect(NULL, 9) < 0);
     TEST_ASSERT(sock.connect("", 9) < 0);
     TEST_ASSERT(sock.connect("", 0) < 0);
-    TEST_ASSERT(sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 0) < 0);
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.connect(MBED_CONF_APP_ECHO_SERVER_ADDR, 9));
 
     TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, sock.close());

--- a/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
+++ b/TESTS/netsocket/udp/udpsocket_sendto_invalid.cpp
@@ -32,7 +32,6 @@ void UDPSOCKET_SENDTO_INVALID()
     TEST_ASSERT(sock.sendto(NULL, 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 9, NULL, 0) < 0);
     TEST_ASSERT(sock.sendto("", 0, NULL, 0) < 0);
-    TEST_ASSERT_EQUAL(5, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 0, "hello", 5));
     TEST_ASSERT_EQUAL(0, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, NULL, 0));
     TEST_ASSERT_EQUAL(5, sock.sendto(MBED_CONF_APP_ECHO_SERVER_ADDR, 9, "hello", 5));
 

--- a/TESTS/network/wifi/wifi_scan.cpp
+++ b/TESTS/network/wifi/wifi_scan.cpp
@@ -48,25 +48,18 @@ void wifi_scan(void)
         const char *ssid = ap[i].get_ssid();
         nsapi_security_t security = ap[i].get_security();
         int8_t rssi = ap[i].get_rssi();
-        uint8_t ch = ap[i].get_channel();
         TEST_ASSERT_INT8_WITHIN(-10, -100, rssi);
         if (strcmp(MBED_CONF_APP_WIFI_SECURE_SSID, ssid) == 0) {
             secure_found = true;
             TEST_ASSERT_EQUAL_INT(get_security(), security);
-            if (MBED_CONF_APP_WIFI_CH_SECURE) {
-                TEST_ASSERT_EQUAL_INT(MBED_CONF_APP_WIFI_CH_SECURE, ch);
-            }
         }
         if (strcmp(MBED_CONF_APP_WIFI_UNSECURE_SSID, ssid) == 0) {
             unsecure_found = true;
             TEST_ASSERT_EQUAL_INT(NSAPI_SECURITY_NONE, security);
-            if (MBED_CONF_APP_WIFI_CH_UNSECURE) {
-                TEST_ASSERT_EQUAL_INT(MBED_CONF_APP_WIFI_CH_UNSECURE, ch);
-            }
         }
     }
-    TEST_ASSERT_TRUE(secure_found);
-    TEST_ASSERT_TRUE(unsecure_found);
+    // Finding one SSID is enough
+    TEST_ASSERT_TRUE(secure_found || unsecure_found);
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID) && defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)


### PR DESCRIPTION
### Description
Allows usage of port zero as destination on mbedgt-netsocket test cases.
 Drops channel number check from mbedgt-network-wifi test cases because 2.4GHz channels and 5GHz channels might share same SSID.
 Wifi scan might not reveal both SSIDs - unsecure and secure - at same run so we are happy if one of those is found.


### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

