### PR TITLE
Fix WIFI_CONNECT_PARAMS_CHANNEL_FAIL testcase.

### DIFF
--- a/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel_fail.cpp
@@ -34,7 +34,8 @@ void wifi_connect_params_channel_fail(void)
         return;
     }
 
-    nsapi_error_t error = wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security(), MBED_CONF_APP_WIFI_CH_UNSECURE);
+    uint8_t wrong_channel = 1 + (MBED_CONF_APP_WIFI_CH_SECURE%10);
+    nsapi_error_t error = wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security(), wrong_channel);
     TEST_ASSERT(error == NSAPI_ERROR_CONNECTION_TIMEOUT || error == NSAPI_ERROR_NO_CONNECTION);
 
     wifi->set_channel(0);


### PR DESCRIPTION
### Description

Test case was assuming that secure and unsecure SSID were on different
channels.
This is not a requirement and it should be OK to run on same channel.

Fixed the testcase by using +1 on channel number to get a wrong channel.

Fixes #8227

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

