### PR TITLE
mcr20a use core_util_critical_section functions

### DIFF
--- a/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/MCR20Drv.c
@@ -44,7 +44,7 @@
 
 #if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
 
-#include "platform/arm_hal_interrupt.h"
+#include "platform/mbed_critical.h"
 
 /*****************************************************************************
 *                               PRIVATE VARIABLES                           *
@@ -524,7 +524,7 @@ void MCR20Drv_IRQ_Disable
 void
 )
 {
-    platform_enter_critical();
+    core_util_critical_section_enter();
 
     if( mPhyIrqDisableCnt == 0 )
     {
@@ -533,7 +533,7 @@ void
 
     mPhyIrqDisableCnt++;
 
-    platform_exit_critical();
+    core_util_critical_section_exit();
 }
 
 /*---------------------------------------------------------------------------
@@ -547,7 +547,7 @@ void MCR20Drv_IRQ_Enable
 void
 )
 {
-    platform_enter_critical();
+    core_util_critical_section_enter();
 
     if( mPhyIrqDisableCnt )
     {
@@ -559,7 +559,7 @@ void
         }
     }
 
-    platform_exit_critical();
+    core_util_critical_section_exit();
 }
 
 /*---------------------------------------------------------------------------

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -1093,7 +1093,6 @@ static void rf_init_phy_mode(void)
  */
 static void PHY_InterruptHandler(void)
 {
-    /* Disable and clear transceiver(IRQ_B) interrupt */
     MCR20Drv_IRQ_Disable();
     irq_thread->signal_set(1);
 }
@@ -1106,14 +1105,13 @@ static void PHY_InterruptThread(void)
             continue;
         }
         handle_interrupt();
+        MCR20Drv_IRQ_Enable();
     }
 }
 
 static void handle_interrupt(void)
 {
     uint8_t xcvseqCopy;
-
-    //MCR20Drv_IRQ_Clear();
 
     /* Read transceiver interrupt status and control registers */
     mStatusAndControlRegs[IRQSTS1] =
@@ -1158,7 +1156,6 @@ static void handle_interrupt(void)
             MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 5);
 
             rf_ack_wait_timer_interrupt();
-            MCR20Drv_IRQ_Enable();
             return;
         }
     }
@@ -1182,7 +1179,6 @@ static void handle_interrupt(void)
             {
                 rf_receive();
             }
-            MCR20Drv_IRQ_Enable();
             return;
         }
 
@@ -1205,12 +1201,10 @@ static void handle_interrupt(void)
             break;
         }
 
-        MCR20Drv_IRQ_Enable();
         return;
     }
     /* Other IRQ. Clear XCVR interrupt flags */
     MCR20Drv_DirectAccessSPIMultiByteWrite(IRQSTS1, mStatusAndControlRegs, 3);
-    MCR20Drv_IRQ_Enable();
 }
 
 /*


### PR DESCRIPTION
### Description

Use core_util_critical_section functions for mcr20a when enabling and disabling interrupts.
This change is already done in the driver repository:
https://github.com/ARMmbed/mcr20a-rf-driver/pull/23
Migrating the change now to mbed-os as well.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

