### PR TITLE
storage: fix component coding style

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -131,11 +131,11 @@ enum dummy {
 };
 
 DataFlashBlockDevice::DataFlashBlockDevice(PinName mosi,
-        PinName miso,
-        PinName sclk,
-        PinName cs,
-        int freq,
-        PinName nwp)
+                                           PinName miso,
+                                           PinName sclk,
+                                           PinName cs,
+                                           int freq,
+                                           PinName nwp)
     :   _spi(mosi, miso, sclk),
         _cs(cs, 1),
         _nwp(nwp),

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/TESTS/filesystem/fopen/fopen.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/TESTS/filesystem/fopen/fopen.cpp
@@ -63,7 +63,7 @@ using namespace utest::v1;
  *        "DEVICE_SPI": 1,
  *        "FSLITTLE_SDCARD_INSTALLED": 1
  *      },
- *  	<<< lines removed >>>
+ *      <<< lines removed >>>
  */
 
 #include "FlashIAPBlockDevice.h"
@@ -123,8 +123,8 @@ static const char *sd_testfile_path = "/sd/test.txt";
 
 /* file data for test_01 */
 static fslittle_kv_data_t fslittle_fopen_test_01_kv_data[] = {
-        { "/sd/fopentst/hello/world/animal/wobbly/dog/foot/frontlft.txt", "missing"},
-        { NULL, NULL},
+    { "/sd/fopentst/hello/world/animal/wobbly/dog/foot/frontlft.txt", "missing"},
+    { NULL, NULL},
 };
 
 
@@ -150,14 +150,14 @@ static fslittle_kv_data_t fslittle_fopen_test_01_kv_data[] = {
  *
  * @return  On success, this returns the number of components in the filepath Returns number of compoee
  */
-static int32_t fslittle_filepath_split(char* filepath, char* parts[], uint32_t num)
+static int32_t fslittle_filepath_split(char *filepath, char *parts[], uint32_t num)
 {
     uint32_t i = 0;
     int32_t ret = -1;
-    char* z = filepath;
+    char *z = filepath;
 
     while (i < num && *z != '\0') {
-        if (*z == '/' ) {
+        if (*z == '/') {
             *z = '\0';
             parts[i] = ++z;
             i++;
@@ -180,7 +180,7 @@ static int32_t fslittle_filepath_split(char* filepath, char* parts[], uint32_t n
  *
  * @return  On success, this returns 0, otherwise < 0 is returned;
  */
-int32_t fslittle_filepath_remove_all(char* filepath)
+int32_t fslittle_filepath_remove_all(char *filepath)
 {
     int32_t ret = -1;
     int32_t len = 0;
@@ -189,12 +189,12 @@ int32_t fslittle_filepath_remove_all(char* filepath)
 
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
     len = strlen(filepath);
-    fpathbuf = (char*) malloc(len+1);
+    fpathbuf = (char *) malloc(len + 1);
     if (fpathbuf == NULL) {
         FSLITTLE_DBGLOG("%s: failed to duplicate string (out of memory)\n", __func__);
         return ret;
     }
-    memset(fpathbuf, 0, len+1);
+    memset(fpathbuf, 0, len + 1);
     memcpy(fpathbuf, filepath, len);
 
     /* delete the leaf node first, and then successively parent directories. */
@@ -224,7 +224,7 @@ int32_t fslittle_filepath_remove_all(char* filepath)
  *
  * @return  On success, this returns 0, otherwise < 0 is returned;
  */
-static int32_t fslittle_filepath_make_dirs(char* filepath, bool do_asserts)
+static int32_t fslittle_filepath_make_dirs(char *filepath, bool do_asserts)
 {
     int32_t i = 0;
     int32_t num_parts = 0;
@@ -239,12 +239,12 @@ static int32_t fslittle_filepath_make_dirs(char* filepath, bool do_asserts)
     /* find the dirs to create*/
     memset(parts, 0, sizeof(parts));
     len = strlen(filepath);
-    fpathbuf = (char*) malloc(len+1);
+    fpathbuf = (char *) malloc(len + 1);
     if (fpathbuf == NULL) {
         FSLITTLE_DBGLOG("%s: failed to duplicate string (out of memory)\n", __func__);
         return ret;
     }
-    memset(fpathbuf, 0, len+1);
+    memset(fpathbuf, 0, len + 1);
     memcpy(fpathbuf, filepath, len);
     num_parts = fslittle_filepath_split(fpathbuf, parts, FSLITTLE_FOPEN_TEST_FILEPATH_MAX_DEPTH);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to split filepath (filename=\"%s\", num_parts=%d)\n", __func__, filepath, (int) num_parts);
@@ -252,11 +252,11 @@ static int32_t fslittle_filepath_make_dirs(char* filepath, bool do_asserts)
 
     /* Now create the directories on the directory path.
      * Skip creating dir for "/sd" which must be present */
-    buf = (char*) malloc(strlen(filepath)+1);
-    memset(buf, 0, strlen(filepath)+1);
+    buf = (char *) malloc(strlen(filepath) + 1);
+    memset(buf, 0, strlen(filepath) + 1);
     pos = sprintf(buf, "/%s", parts[0]);
     for (i = 1; i < num_parts - 1; i++) {
-        pos += sprintf(buf+pos, "/%s", parts[i]);
+        pos += sprintf(buf + pos, "/%s", parts[i]);
         FSLITTLE_DBGLOG("mkdir(%s)\n", buf);
         ret = mkdir(buf, S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
         if (do_asserts == true) {
@@ -289,7 +289,7 @@ static int32_t fslittle_filepath_make_dirs(char* filepath, bool do_asserts)
  */
 static control_t fslittle_fopen_test_01(const size_t call_count)
 {
-    char* read_buf;
+    char *read_buf;
     int32_t ret = 0;
     size_t len = 0;
     fslittle_kv_data_t *node;
@@ -300,10 +300,10 @@ static control_t fslittle_fopen_test_01(const size_t call_count)
     node = fslittle_fopen_test_01_kv_data;
 
     /* remove file and directory from a previous failed test run, if present */
-    fslittle_filepath_remove_all((char*) node->filename);
+    fslittle_filepath_remove_all((char *) node->filename);
 
     /* create dirs */
-    ret = fslittle_filepath_make_dirs((char*) node->filename, true);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, true);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dirs for filename (filename=\"%s\")(ret=%d)\n", __func__, node->filename, (int) ret);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
@@ -314,7 +314,7 @@ static control_t fslittle_fopen_test_01(const size_t call_count)
 
     FSLITTLE_DBGLOG("%s:length of file=%d (filename=\"%s\", data=\"%s\")\n", __func__, (int) len, node->filename, node->value);
     len = strlen(node->value);
-    ret = fwrite((const void*) node->value, len, 1, fp);
+    ret = fwrite((const void *) node->value, len, 1, fp);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to write file (filename=\"%s\", data=\"%s\")(ret=%d)\n", __func__, node->filename, node->value, (int) ret);
     TEST_ASSERT_MESSAGE(ret == 1, fslittle_fopen_utest_msg_g);
 
@@ -330,13 +330,13 @@ static control_t fslittle_fopen_test_01(const size_t call_count)
     TEST_ASSERT_MESSAGE(fp != NULL, fslittle_fopen_utest_msg_g);
 
     len = strlen(node->value) + 1;
-    read_buf = (char*) malloc(len);
+    read_buf = (char *) malloc(len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to allocated read buffer \n", __func__);
     TEST_ASSERT_MESSAGE(read_buf != NULL, fslittle_fopen_utest_msg_g);
 
     FSLITTLE_DBGLOG("Opened file successfully (filename=\"%s\", data=\"%s\")\n", node->filename, node->value);
     memset(read_buf, 0, len);
-    ret = fread((void*) read_buf, len, 1, fp);
+    ret = fread((void *) read_buf, len, 1, fp);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to read file (filename=\"%s\", data=\"%s\", read_buf=\"%s\", ret=%d)\n", __func__, node->filename, node->value, read_buf, (int) ret);
     /* FIX ME: fread should return the number of items read, not 0 when an item is read successfully.
      * This indicates a problem with the implementation, as the correct data is read. The correct assert should be:
@@ -349,7 +349,7 @@ static control_t fslittle_fopen_test_01(const size_t call_count)
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: read value data (%s) != expected value data (filename=\"%s\", data=\"%s\", read_buf=\"%s\", ret=%d)\n", __func__, read_buf, node->filename, node->value, read_buf, (int) ret);
     TEST_ASSERT_MESSAGE(strncmp(read_buf, node->value, strlen(node->value)) == 0, fslittle_fopen_utest_msg_g);
 
-    if(read_buf){
+    if (read_buf) {
         free(read_buf);
     }
     ret = fclose(fp);
@@ -359,8 +359,8 @@ static control_t fslittle_fopen_test_01(const size_t call_count)
 }
 
 static fslittle_kv_data_t fslittle_fopen_test_02_data[] = {
-        FSLITTLE_INIT_1_TABLE_MID_NODE,
-        { NULL, NULL},
+    FSLITTLE_INIT_1_TABLE_MID_NODE,
+    { NULL, NULL},
 };
 
 /**
@@ -385,7 +385,7 @@ control_t fslittle_fopen_test_02(const size_t call_count)
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
     (void) call_count;
     len = strlen(fslittle_fopen_test_02_data[0].value);
-    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char*) fslittle_fopen_test_02_data[0].value, len);
+    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char *) fslittle_fopen_test_02_data[0].value, len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file (ret=%d).\n", __func__, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
@@ -395,7 +395,7 @@ control_t fslittle_fopen_test_02(const size_t call_count)
     TEST_ASSERT_MESSAGE(fp != NULL, fslittle_fopen_utest_msg_g);
 
     len = strlen(fslittle_fopen_test_02_data[0].value);
-    ret = fwrite((const void*) fslittle_fopen_test_02_data[0].value, len, 1, fp);
+    ret = fwrite((const void *) fslittle_fopen_test_02_data[0].value, len, 1, fp);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: call to fwrite() succeeded when should have failed for read-only file (filename=\"%s\")(ret=%d).\n", __func__, fslittle_fopen_test_02_data[0].filename, (int) ret);
     TEST_ASSERT_MESSAGE(ret <= 0, fslittle_fopen_utest_msg_g);
 
@@ -428,7 +428,7 @@ control_t fslittle_fopen_test_03(const size_t call_count)
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
     (void) call_count;
     len = strlen(fslittle_fopen_test_02_data[0].value);
-    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char*) fslittle_fopen_test_02_data[0].value, len);
+    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char *) fslittle_fopen_test_02_data[0].value, len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file in store (ret=%d).\n", __func__, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
@@ -438,7 +438,7 @@ control_t fslittle_fopen_test_03(const size_t call_count)
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
     len = strlen(fslittle_fopen_test_02_data[0].value);
-    ret = fwrite((const void*) fslittle_fopen_test_02_data[0].value, len, 1, fp);
+    ret = fwrite((const void *) fslittle_fopen_test_02_data[0].value, len, 1, fp);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: call to fwrite() failed when should have succeeded (filename=\"%s\", ret=%d).\n", __func__, fslittle_fopen_test_02_data[0].filename, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
@@ -461,16 +461,16 @@ control_t fslittle_fopen_test_03(const size_t call_count)
  */
 control_t fslittle_fopen_test_04(const size_t call_count)
 {
-    char filename_good[FSLITTLE_FILENAME_MAX_LENGTH+1];
-    char filename_bad[FSLITTLE_FILENAME_MAX_LENGTH+2];
+    char filename_good[FSLITTLE_FILENAME_MAX_LENGTH + 1];
+    char filename_bad[FSLITTLE_FILENAME_MAX_LENGTH + 2];
     int32_t ret = -1;
     size_t len = 0;
 
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
     (void) call_count;
 
-    memset(filename_good, 0, FSLITTLE_FILENAME_MAX_LENGTH+1);
-    memset(filename_bad, 0, FSLITTLE_FILENAME_MAX_LENGTH+2);
+    memset(filename_good, 0, FSLITTLE_FILENAME_MAX_LENGTH + 1);
+    memset(filename_bad, 0, FSLITTLE_FILENAME_MAX_LENGTH + 2);
     ret = fslittle_test_filename_gen(filename_good, FSLITTLE_FILENAME_MAX_LENGTH);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: unable to generate filename_good.\n", __func__);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
@@ -478,11 +478,11 @@ control_t fslittle_fopen_test_04(const size_t call_count)
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: filename_good is not the correct length (filename_good=%s, len=%d, expected=%d).\n", __func__, filename_good, (int) strlen(filename_good), (int) FSLITTLE_FILENAME_MAX_LENGTH);
     TEST_ASSERT_MESSAGE(strlen(filename_good) == FSLITTLE_FILENAME_MAX_LENGTH, fslittle_fopen_utest_msg_g);
 
-    ret = fslittle_test_filename_gen(filename_bad, FSLITTLE_FILENAME_MAX_LENGTH+1);
+    ret = fslittle_test_filename_gen(filename_bad, FSLITTLE_FILENAME_MAX_LENGTH + 1);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: unable to generate filename_bad.\n", __func__);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
-    FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: filename_bad is not the correct length (len=%d, expected=%d).\n", __func__, (int) strlen(filename_bad), (int) FSLITTLE_FILENAME_MAX_LENGTH+1);
-    TEST_ASSERT_MESSAGE(strlen(filename_bad) == FSLITTLE_FILENAME_MAX_LENGTH+1, fslittle_fopen_utest_msg_g);
+    FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: filename_bad is not the correct length (len=%d, expected=%d).\n", __func__, (int) strlen(filename_bad), (int) FSLITTLE_FILENAME_MAX_LENGTH + 1);
+    TEST_ASSERT_MESSAGE(strlen(filename_bad) == FSLITTLE_FILENAME_MAX_LENGTH + 1, fslittle_fopen_utest_msg_g);
 
     len = strlen(filename_good);
     ret = fslittle_test_create(filename_good, filename_good, len);
@@ -505,28 +505,27 @@ typedef struct fslittle_fopen_kv_name_ascii_node {
 static const uint32_t fslittle_fopen_kv_name_ascii_table_code_sentinel_g = 256;
 
 /*@brief    table recording ascii character codes permitted in kv names */
-static fslittle_fopen_kv_name_ascii_node fslittle_fopen_kv_name_ascii_table[] =
-{
-        {0 , true},         /* code 0-33 allowed*/
-        {34, false},        /* '"' not allowed */
-        {35, true},         /* allowed */
-        {42, false},        /* '*' not allowed */
-        {43, true},         /* allowed */
-        {47, false},        /* '/' not allowed */
-        {48, true},         /* allowed */
-        {58, false},        /* ':' not allowed */
-        {59, true},         /* allowed */
-        {60, false},        /* '<' not allowed */
-        {61, true},         /* allowed */
-        {62, false},        /* '?', '>' not allowed */
-        {64, true},         /* allowed */
-        {92, false},        /* '\' not allowed */
-        {93, true},         /* allowed */
-        {124, false},        /* '!' not allowed */
-        {125, true},         /* allowed */
-        {127, false},        /* DEL not allowed */
-        {128, true},         /* allowed */
-        {fslittle_fopen_kv_name_ascii_table_code_sentinel_g, false},       /* sentinel */
+static fslittle_fopen_kv_name_ascii_node fslittle_fopen_kv_name_ascii_table[] = {
+    {0, true},          /* code 0-33 allowed*/
+    {34, false},        /* '"' not allowed */
+    {35, true},         /* allowed */
+    {42, false},        /* '*' not allowed */
+    {43, true},         /* allowed */
+    {47, false},        /* '/' not allowed */
+    {48, true},         /* allowed */
+    {58, false},        /* ':' not allowed */
+    {59, true},         /* allowed */
+    {60, false},        /* '<' not allowed */
+    {61, true},         /* allowed */
+    {62, false},        /* '?', '>' not allowed */
+    {64, true},         /* allowed */
+    {92, false},        /* '\' not allowed */
+    {93, true},         /* allowed */
+    {124, false},        /* '!' not allowed */
+    {125, true},         /* allowed */
+    {127, false},        /* DEL not allowed */
+    {128, true},         /* allowed */
+    {fslittle_fopen_kv_name_ascii_table_code_sentinel_g, false},       /* sentinel */
 };
 
 
@@ -555,12 +554,12 @@ control_t fslittle_fopen_test_05(const size_t call_count)
     const char *basename = "goodfile";
     const char *extname = "txt";
     const size_t basename_len = strlen(basename);
-    const size_t filename_len = strlen(mnt_pt)+strlen(basename)+strlen(extname)+2;  /* extra 2 chars for '/' and '.' in "/sd/goodfile.txt" */
+    const size_t filename_len = strlen(mnt_pt) + strlen(basename) + strlen(extname) + 2; /* extra 2 chars for '/' and '.' in "/sd/goodfile.txt" */
     char filename[FSLITTLE_BUF_MAX_LENGTH];
     size_t len = 0;
     uint32_t j = 0;
     int32_t ret = 0;
-    fslittle_fopen_kv_name_ascii_node* node = NULL;
+    fslittle_fopen_kv_name_ascii_node *node = NULL;
     uint32_t pos;
 
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
@@ -568,90 +567,83 @@ control_t fslittle_fopen_test_05(const size_t call_count)
 
 #ifdef FSLITTLE_DEBUG
     /* symbol only used why debug is enabled */
-    const char* pos_str = NULL;
+    const char *pos_str = NULL;
 #endif
 
     /* create bad keyname strings with invalid character code at start of keyname */
     node = fslittle_fopen_kv_name_ascii_table;
     memset(filename, 0, FSLITTLE_BUF_MAX_LENGTH);
-    while(node->code !=  fslittle_fopen_kv_name_ascii_table_code_sentinel_g)
-    {
+    while (node->code !=  fslittle_fopen_kv_name_ascii_table_code_sentinel_g) {
         /* loop over range */
-        for(j = node->code; j < (node+1)->code; j++)
-        {
-            if( (j >= 48 && j <= 57) || (j >= 65 && j <= 90) || (j >= 97 && j <= 122)) {
+        for (j = node->code; j < (node + 1)->code; j++) {
+            if ((j >= 48 && j <= 57) || (j >= 65 && j <= 90) || (j >= 97 && j <= 122)) {
                 FSLITTLE_DBGLOG("%s: skipping alpha-numeric ascii character code %d (%c).\n", __func__, (int) j, (char) j);
                 continue;
             }
 
             /* set the start, mid, last character of the name to the test char code */
-            for(pos = (uint32_t) fslittle_fopen_kv_name_pos_start; pos < (uint32_t) fslittle_fopen_kv_name_pos_max; pos++)
-            {
-                len = snprintf(filename, filename_len+1, "%s/%s.%s", mnt_pt, basename, extname);
+            for (pos = (uint32_t) fslittle_fopen_kv_name_pos_start; pos < (uint32_t) fslittle_fopen_kv_name_pos_max; pos++) {
+                len = snprintf(filename, filename_len + 1, "%s/%s.%s", mnt_pt, basename, extname);
                 /* overwrite a char at the pos start, mid, end of the filename with an ascii char code (both illegal and legal)*/
-                switch(pos)
-                {
-                case fslittle_fopen_kv_name_pos_start:
-                    filename[5] = (char) j; /* 5 so at to write the second basename char (bad chars as first char not accepted)*/
-                    break;
-                case fslittle_fopen_kv_name_pos_mid:
-                    /* create bad keyname strings with invalid character code in the middle of keyname */
-                    filename[5+basename_len/2] = (char) j;
-                    break;
-                case fslittle_fopen_kv_name_pos_end:
-                    /* create bad keyname strings with invalid character code at end of keyname */
-                    filename[5+basename_len-1] = (char) j;
-                    break;
-                default:
-                    FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: unexpected value of pos (pos=%d).\n", __func__, (int) pos);
-                    TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
-                    break;
+                switch (pos) {
+                    case fslittle_fopen_kv_name_pos_start:
+                        filename[5] = (char) j; /* 5 so at to write the second basename char (bad chars as first char not accepted)*/
+                        break;
+                    case fslittle_fopen_kv_name_pos_mid:
+                        /* create bad keyname strings with invalid character code in the middle of keyname */
+                        filename[5 + basename_len / 2] = (char) j;
+                        break;
+                    case fslittle_fopen_kv_name_pos_end:
+                        /* create bad keyname strings with invalid character code at end of keyname */
+                        filename[5 + basename_len - 1] = (char) j;
+                        break;
+                    default:
+                        FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: unexpected value of pos (pos=%d).\n", __func__, (int) pos);
+                        TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
+                        break;
                 }
 
 #ifdef FSLITTLE_DEBUG
                 /* processing only required when debug trace enabled */
-                switch(pos)
-                {
-                case fslittle_fopen_kv_name_pos_start:
-                    pos_str = "start";
-                    break;
-                case fslittle_fopen_kv_name_pos_mid:
-                    pos_str = "middle";
-                    break;
-                case fslittle_fopen_kv_name_pos_end:
-                    pos_str = "end";
-                    break;
-                default:
-                    break;
+                switch (pos) {
+                    case fslittle_fopen_kv_name_pos_start:
+                        pos_str = "start";
+                        break;
+                    case fslittle_fopen_kv_name_pos_mid:
+                        pos_str = "middle";
+                        break;
+                    case fslittle_fopen_kv_name_pos_end:
+                        pos_str = "end";
+                        break;
+                    default:
+                        break;
                 }
 #endif
-                ret = fslittle_test_create(filename, (const char*) filename, len);
+                ret = fslittle_test_create(filename, (const char *) filename, len);
 
                 /* special cases */
-                switch(j)
-                {
-                //case 0 :
-				//case 46 :
-                //    switch(pos)
-                //    {
-                //    /* for code = 0 (null terminator). permitted at mid and end of string */
-                //    /* for code = 46 ('.'). permitted at mid and end of string but not at start */
-                //    case fslittle_fopen_kv_name_pos_start:
-                //        f_allowed = false;
-                //        break;
-                //    case fslittle_fopen_kv_name_pos_mid:
-                //    case fslittle_fopen_kv_name_pos_end:
-                //    default:
-                //        f_allowed = true;
-                //        break;
-                //    }
-                //    break;
-				default:
-					f_allowed = node->f_allowed;
-					break;
+                switch (j) {
+                    //case 0 :
+                    //case 46 :
+                    //    switch(pos)
+                    //    {
+                    //    /* for code = 0 (null terminator). permitted at mid and end of string */
+                    //    /* for code = 46 ('.'). permitted at mid and end of string but not at start */
+                    //    case fslittle_fopen_kv_name_pos_start:
+                    //        f_allowed = false;
+                    //        break;
+                    //    case fslittle_fopen_kv_name_pos_mid:
+                    //    case fslittle_fopen_kv_name_pos_end:
+                    //    default:
+                    //        f_allowed = true;
+                    //        break;
+                    //    }
+                    //    break;
+                    default:
+                        f_allowed = node->f_allowed;
+                        break;
                 }
-                if(f_allowed == true)
-                {
+                if (f_allowed == true) {
                     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file in store when filename contains valid characters (code=%d, ret=%d).\n", __func__, (int) j, (int) ret);
                     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
                     /* revert FSLITTLE_LOG for more trace */
@@ -661,9 +653,8 @@ control_t fslittle_fopen_test_05(const size_t call_count)
                     ret = fslittle_test_delete(filename);
                     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to delete file previously created (code=%d, ret=%d).\n", __func__, (int) j, (int) ret);
                     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
-                }
-                else
-                {   /*node->f_allowed == false => not allowed to create kv name with ascii code */
+                } else {
+                    /*node->f_allowed == false => not allowed to create kv name with ascii code */
                     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: created file in store when filename contains an invalid character (code=%d, ret=%d).\n", __func__, (int) j, (int) ret);
                     TEST_ASSERT_MESSAGE(ret < 0, fslittle_fopen_utest_msg_g);
                     /* revert FSLITTLE_LOG for more trace */
@@ -694,7 +685,7 @@ control_t fslittle_fopen_test_06(const size_t call_count)
 #if 0
     const char *mnt_pt = FSLITTLE_FOPEN_TEST_MOUNT_PT_PATH;
     const char *extname = "txt";
-    const size_t filename_len = strlen(mnt_pt)+FSLITTLE_MAX_FILE_BASENAME+strlen(extname)+2;  /* extra 2 chars for '/' and '.' in "/sd/goodfile.txt" */
+    const size_t filename_len = strlen(mnt_pt) + FSLITTLE_MAX_FILE_BASENAME + strlen(extname) + 2; /* extra 2 chars for '/' and '.' in "/sd/goodfile.txt" */
     char filename[FSLITTLE_BUF_MAX_LENGTH];
     int32_t i = 0;
     int32_t j = 0;
@@ -713,13 +704,13 @@ control_t fslittle_fopen_test_06(const size_t call_count)
     /* generate a number of illegal filenames */
     for (j = 0; i < FSLITTLE_MAX_FILE_BASENAME; j++) {
         /* generate a kv name of illegal chars*/
-        len = snprintf(filename, filename_len+1, "%s/", mnt_pt);
+        len = snprintf(filename, filename_len + 1, "%s/", mnt_pt);
         for (i = 0; i < FSLITTLE_MAX_FILE_BASENAME; i++) {
-            pos = rand() % (buf_data_max+1);
-            len += snprintf(filename+len, filename_len+1, "%c", fslittle_fopen_ascii_illegal_buf_g[pos]);
+            pos = rand() % (buf_data_max + 1);
+            len += snprintf(filename + len, filename_len + 1, "%c", fslittle_fopen_ascii_illegal_buf_g[pos]);
 
         }
-        len += snprintf(filename+len, filename_len+1, ".%s", extname);
+        len += snprintf(filename + len, filename_len + 1, ".%s", extname);
         ret = fslittle_test_create(filename, filename, len);
         FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: created file when filename contains invalid characters (filename=%s, ret=%d).\n", __func__, filename, (int) ret);
         TEST_ASSERT_MESSAGE(ret < 0, fslittle_fopen_utest_msg_g);
@@ -731,10 +722,10 @@ control_t fslittle_fopen_test_06(const size_t call_count)
 
 /** @brief  test for errno reporting on a failed fopen()call
  *
- *	This test does the following:
- *	- tries to open a file that does not exist for reading, and checks that a NULL pointer is returned.
- *	- checks that errno is not 0 as there is an error.
- *	- checks that ferror() returns 1 indicating an error exists.
+ *  This test does the following:
+ *  - tries to open a file that does not exist for reading, and checks that a NULL pointer is returned.
+ *  - checks that errno is not 0 as there is an error.
+ *  - checks that ferror() returns 1 indicating an error exists.
  *
  * Note: see NOTE_1 below.
  *
@@ -742,8 +733,8 @@ control_t fslittle_fopen_test_06(const size_t call_count)
  */
 control_t fslittle_fopen_test_07(const size_t call_count)
 {
-	FILE *f = NULL;
-	int ret = -1;
+    FILE *f = NULL;
+    int ret = -1;
     int errno_val = 0;
     const char *filename = sd_badfile_path;
 
@@ -752,7 +743,7 @@ control_t fslittle_fopen_test_07(const size_t call_count)
 
     errno = 0;
     /* this is expect to fail as the file doesnt exist */
-    f = fopen(filename,"r");
+    f = fopen(filename, "r");
 
     /* Store errno so the current value set  is not changed by new function call */
     errno_val = errno;
@@ -801,7 +792,7 @@ control_t fslittle_fopen_test_08(const size_t call_count)
     (void) call_count;
 
     errno = 0;
-    fp = fopen(filename,"w+");
+    fp = fopen(filename, "w+");
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to open file (filename=%s, f=%p).\n", __func__, filename, fp);
     TEST_ASSERT_MESSAGE(fp != NULL, fslittle_fopen_utest_msg_g);
 
@@ -864,7 +855,7 @@ control_t fslittle_fopen_test_09(const size_t call_count)
 
     /* create a file of a certain length */
     len = strlen(fslittle_fopen_test_02_data[0].value);
-    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char*) fslittle_fopen_test_02_data[0].value, len);
+    ret = fslittle_test_create(fslittle_fopen_test_02_data[0].filename, (char *) fslittle_fopen_test_02_data[0].value, len);
 
     errno = 0;
     /* Open the file for reading so the file is not truncated to 0 length. */
@@ -893,8 +884,8 @@ control_t fslittle_fopen_test_09(const size_t call_count)
 
 /* file data for test_10 */
 static fslittle_kv_data_t fslittle_fopen_test_10_kv_data[] = {
-        { "/sd/test_10/testfile.txt", "test_data"},
-        { NULL, NULL},
+    { "/sd/test_10/testfile.txt", "test_data"},
+    { NULL, NULL},
 };
 
 /** @brief  test for operation of remove()
@@ -921,16 +912,16 @@ control_t fslittle_fopen_test_10(const size_t call_count)
     TEST_ASSERT(strlen(node->filename) < FSLITTLE_FOPEN_TEST_WORK_BUF_SIZE_1);
 
     /* start from a known state i.e. directory to be created in not present */
-    fslittle_filepath_remove_all((char*) node->filename);
+    fslittle_filepath_remove_all((char *) node->filename);
 
     /* (1) */
     errno = 0;
-    ret = fslittle_filepath_make_dirs((char*) node->filename, false);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, node->filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
     len = strlen(node->value);
-    ret = fslittle_test_create(node->filename, (char*) node->value, len);
+    ret = fslittle_test_create(node->filename, (char *) node->value, len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file (ret=%d).\n", __func__, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
@@ -963,10 +954,10 @@ control_t fslittle_fopen_test_10(const size_t call_count)
 
 /* file data for test_11 */
 static fslittle_kv_data_t fslittle_fopen_test_11_kv_data[] = {
-        { "/sd/test_11/step0.txt", "test_data"},
-        { "/sd/test_11/step1.txt", "test_data"},
-        { "/sd/test_11/subdir/step3.txt", "test_data"},
-        { NULL, NULL},
+    { "/sd/test_11/step0.txt", "test_data"},
+    { "/sd/test_11/step1.txt", "test_data"},
+    { "/sd/test_11/subdir/step3.txt", "test_data"},
+    { NULL, NULL},
 };
 
 /** @brief  test for operation of rename()
@@ -989,26 +980,26 @@ control_t fslittle_fopen_test_11(const size_t call_count)
     TEST_ASSERT(strlen(node->filename) < FSLITTLE_FOPEN_TEST_WORK_BUF_SIZE_1);
 
     /* start from a known state i.e. directory to be created in not present, files not present */
-    while(node->filename != NULL) {
-        fslittle_filepath_remove_all((char*) node->filename);
+    while (node->filename != NULL) {
+        fslittle_filepath_remove_all((char *) node->filename);
         node++;
     }
 
     /* create file and directories ready for rename() tests */
     errno = 0;
     node = fslittle_fopen_test_11_kv_data;
-    ret = fslittle_filepath_make_dirs((char*) node->filename, false);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, node->filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
     len = strlen(node->value);
-    ret = fslittle_test_create(node->filename, (char*) node->value, len);
+    ret = fslittle_test_create(node->filename, (char *) node->value, len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file (ret=%d).\n", __func__, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
     errno = 0;
     node = &fslittle_fopen_test_11_kv_data[2];
-    ret = fslittle_filepath_make_dirs((char*) node->filename, false);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, node->filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
@@ -1028,12 +1019,12 @@ control_t fslittle_fopen_test_11(const size_t call_count)
 
 /* file data for test_12 */
 static fslittle_kv_data_t fslittle_fopen_test_12_kv_data[] = {
-        { "/sd/test_12/subdir/testfil1.txt", "testfil1.txt"},
-        { "/sd/test_12/testfil2.txt", "testfil2.txt"},
-        { "/sd/test_12/testfil3.txt", "testfil3.txt"},
-        { "/sd/test_12/testfil4.txt", "testfil4.txt"},
-        { "/sd/test_12/testfil5.txt", "testfil5.txt"},
-        { NULL, NULL},
+    { "/sd/test_12/subdir/testfil1.txt", "testfil1.txt"},
+    { "/sd/test_12/testfil2.txt", "testfil2.txt"},
+    { "/sd/test_12/testfil3.txt", "testfil3.txt"},
+    { "/sd/test_12/testfil4.txt", "testfil4.txt"},
+    { "/sd/test_12/testfil5.txt", "testfil5.txt"},
+    { NULL, NULL},
 };
 
 /** @brief  test for operation of readdir().
@@ -1060,22 +1051,22 @@ control_t fslittle_fopen_test_12(const size_t call_count)
 #if ! defined(__ARMCC_VERSION) && defined(__GNUC__)
 
     /* start from a known state i.e. directory to be created in not present */
-    while(node->filename != NULL) {
-        fslittle_filepath_remove_all((char*) node->filename);
+    while (node->filename != NULL) {
+        fslittle_filepath_remove_all((char *) node->filename);
         node++;
     }
 
     /* create a file */
     node = fslittle_fopen_test_12_kv_data;
     errno = 0;
-    ret = fslittle_filepath_make_dirs((char*) node->filename, false);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, node->filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
     node = fslittle_fopen_test_12_kv_data;
-    while(node->filename != NULL) {
+    while (node->filename != NULL) {
         len = strlen(node->value);
-        ret = fslittle_test_create(node->filename, (char*) node->value, len);
+        ret = fslittle_test_create(node->filename, (char *) node->value, len);
         FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file (ret=%d).\n", __func__, (int) ret);
         TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
         node++;
@@ -1108,8 +1099,8 @@ control_t fslittle_fopen_test_12(const size_t call_count)
 
     /* cleanup */
     node = fslittle_fopen_test_12_kv_data;
-    while(node->filename != NULL) {
-        fslittle_filepath_remove_all((char*) node->filename);
+    while (node->filename != NULL) {
+        fslittle_filepath_remove_all((char *) node->filename);
         node++;
     }
 #endif  /* ! defined(__ARMCC_VERSION) && defined(__GNUC__) */
@@ -1119,10 +1110,10 @@ control_t fslittle_fopen_test_12(const size_t call_count)
 
 /* file data for test_13 */
 static fslittle_kv_data_t fslittle_fopen_test_13_kv_data[] = {
-        /* a file is included in the filepath even though its not created by the test,
-         * as the fslittle_filepath_make_dirs() works with it present. */
-        { "/sd/test_13/dummy.txt", "testdir"},
-        { NULL, NULL},
+    /* a file is included in the filepath even though its not created by the test,
+     * as the fslittle_filepath_make_dirs() works with it present. */
+    { "/sd/test_13/dummy.txt", "testdir"},
+    { NULL, NULL},
 };
 /** @brief  test for operation of mkdir()/remove()
  *
@@ -1141,16 +1132,16 @@ control_t fslittle_fopen_test_13(const size_t call_count)
     (void) call_count;
 
     /* start from a known state i.e. directory to be created in not present */
-    fslittle_filepath_remove_all((char*) fslittle_fopen_test_13_kv_data[0].filename);
+    fslittle_filepath_remove_all((char *) fslittle_fopen_test_13_kv_data[0].filename);
 
     errno = 0;
-    ret = fslittle_filepath_make_dirs((char*) fslittle_fopen_test_13_kv_data[0].filename, false);
+    ret = fslittle_filepath_make_dirs((char *) fslittle_fopen_test_13_kv_data[0].filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, fslittle_fopen_test_13_kv_data[0].filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
     /* check that get a suitable error when try to create it again.*/
     errno = 0;
-    ret = fslittle_filepath_make_dirs((char*) fslittle_fopen_test_13_kv_data[0].filename, false);
+    ret = fslittle_filepath_make_dirs((char *) fslittle_fopen_test_13_kv_data[0].filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: permitted to create directory when already exists (dirname=%s, ret=%d, errno=%d)\n", __func__, fslittle_fopen_test_13_kv_data[0].filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret != 0, fslittle_fopen_utest_msg_g);
 
@@ -1158,7 +1149,7 @@ control_t fslittle_fopen_test_13(const size_t call_count)
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: errno != EEXIST (dirname=%s, ret=%d, errno=%d)\n", __func__, fslittle_fopen_test_13_kv_data[0].filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(errno == EEXIST, fslittle_fopen_utest_msg_g);
 
-    ret = fslittle_filepath_remove_all((char*) fslittle_fopen_test_13_kv_data[0].filename);
+    ret = fslittle_filepath_remove_all((char *) fslittle_fopen_test_13_kv_data[0].filename);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to remove directory (dirname=%s, ret=%d, errno=%d)\n", __func__, fslittle_fopen_test_13_kv_data[0].filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
@@ -1167,10 +1158,10 @@ control_t fslittle_fopen_test_13(const size_t call_count)
 
 /* file data for test_14 */
 static fslittle_kv_data_t fslittle_fopen_test_14_kv_data[] = {
-        /* a file is included in the filepath even though its not created by the test,
-         * as the fslittle_filepath_make_dirs() works with it present. */
-        { "/sd/test_14/testfile.txt", "testdata"},
-        { NULL, NULL},
+    /* a file is included in the filepath even though its not created by the test,
+     * as the fslittle_filepath_make_dirs() works with it present. */
+    { "/sd/test_14/testfile.txt", "testdata"},
+    { NULL, NULL},
 };
 
 /** @brief  test for operation of stat()
@@ -1183,7 +1174,7 @@ control_t fslittle_fopen_test_14(const size_t call_count)
 {
 #if ! defined(__ARMCC_VERSION) && defined(__GNUC__)
 
-	char buf[FSLITTLE_FOPEN_TEST_WORK_BUF_SIZE_1];
+    char buf[FSLITTLE_FOPEN_TEST_WORK_BUF_SIZE_1];
     char *pos = NULL;
     int32_t ret = -1;
     size_t len = 0;
@@ -1196,16 +1187,16 @@ control_t fslittle_fopen_test_14(const size_t call_count)
     TEST_ASSERT(strlen(node->filename) < FSLITTLE_FOPEN_TEST_WORK_BUF_SIZE_1);
 
     /* start from a known state i.e. directory to be created in not present */
-    fslittle_filepath_remove_all((char*) node->filename);
+    fslittle_filepath_remove_all((char *) node->filename);
 
     /* Create file in a directory. */
     errno = 0;
-    ret = fslittle_filepath_make_dirs((char*) node->filename, false);
+    ret = fslittle_filepath_make_dirs((char *) node->filename, false);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dir (dirname=%s, ret=%d, errno=%d)\n", __func__, node->filename, (int) ret, errno);
     TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
 
     len = strlen(node->value);
-    ret = fslittle_test_create(node->filename, (char*) node->value, len);
+    ret = fslittle_test_create(node->filename, (char *) node->value, len);
     FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create file (ret=%d).\n", __func__, (int) ret);
     TEST_ASSERT_MESSAGE(ret >= 0, fslittle_fopen_utest_msg_g);
 
@@ -1238,7 +1229,7 @@ control_t fslittle_fopen_test_14(const size_t call_count)
     TEST_ASSERT_MESSAGE((file_stat.st_mode & S_IFDIR) == S_IFDIR, fslittle_fopen_utest_msg_g);
 
     /* clean up after successful test */
-    fslittle_filepath_remove_all((char*) node->filename);
+    fslittle_filepath_remove_all((char *) node->filename);
 
 #endif /* ! defined(__ARMCC_VERSION) && defined(__GNUC__) */
     return CaseNext;
@@ -1288,7 +1279,7 @@ control_t fslittle_fopen_test_00(const size_t call_count)
  * @param   data        data to store in file
  * @param   len         number of bytes of data present in the data buffer.
  */
-int32_t fslittle_test_create_data_file(const char* filename, size_t len)
+int32_t fslittle_test_create_data_file(const char *filename, size_t len)
 {
     int32_t ret = -1;
     FILE *fp = NULL;
@@ -1300,26 +1291,26 @@ int32_t fslittle_test_create_data_file(const char* filename, size_t len)
     FSLITTLE_FENTRYLOG("%s:entered (filename=%s, len=%d).\n", __func__, filename, (int) len);
     TEST_ASSERT(len % FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE == 0);
     fp = fopen(filename, "a");
-    if(fp == NULL){
+    if (fp == NULL) {
         return ret;
     }
 
-    while(written_len < len) {
+    while (written_len < len) {
         /* write fslittle_test_byte_data_table or part thereof, in 9 writes of sizes
          * 1, 2, 4, 8, 16, 32, 64, 128, 1, totalling 256 bytes len permitting. */
-        for(exp = 0; (exp <= exp_max) && (written_len < len); exp++){
+        for (exp = 0; (exp <= exp_max) && (written_len < len); exp++) {
             write_len = 0x1 << (exp % exp_max);
             write_len = len - written_len  > write_len ? write_len : len - written_len;
-            ret = fwrite((const void*) &fslittle_test_byte_data_table[written_len % FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE], write_len, 1, fp);
+            ret = fwrite((const void *) &fslittle_test_byte_data_table[written_len % FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE], write_len, 1, fp);
             written_len += write_len;
-            if(ret != 1){
+            if (ret != 1) {
                 FSLITTLE_DBGLOG("%s:Error: fwrite() failed (ret=%d)\n", __func__, (int) ret);
                 ret = -1;
                 goto out0;
             }
         }
     }
-    if(written_len == len) {
+    if (written_len == len) {
         ret = 0;
     } else {
         ret = -1;
@@ -1339,7 +1330,7 @@ out0:
  * @param   data        data to store in file
  * @param   len         number of bytes of data present in the data buffer.
  */
-int32_t fslittle_test_check_data_file(const char* filename, size_t len)
+int32_t fslittle_test_check_data_file(const char *filename, size_t len)
 {
     int32_t ret = -1;
     FILE *fp = NULL;
@@ -1349,26 +1340,26 @@ int32_t fslittle_test_check_data_file(const char* filename, size_t len)
     FSLITTLE_FENTRYLOG("%s:entered (filename=%s, len=%d).\n", __func__, filename, (int) len);
     TEST_ASSERT(len % FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE == 0);
     fp = fopen(filename, "r");
-    if(fp == NULL){
+    if (fp == NULL) {
         return ret;
     }
 
-    while(read_len < len) {
-        ret = fread((void*) buf, FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE, 1, fp);
+    while (read_len < len) {
+        ret = fread((void *) buf, FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE, 1, fp);
         read_len += FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE;
-        if(ret == 0){
+        if (ret == 0) {
             /* end of read*/
             FSLITTLE_DBGLOG("%s:unable to read data\n", __func__);
             break;
         }
-        if(memcmp(buf, fslittle_test_byte_data_table, FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE) != 0) {
+        if (memcmp(buf, fslittle_test_byte_data_table, FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE) != 0) {
             FSLITTLE_DBGLOG("%s:Error: read data not as expected (0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x, 0x%2x\n", __func__,
-                    buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
+                            buf[0], buf[1], buf[2], buf[3], buf[4], buf[5], buf[6], buf[7], buf[8], buf[9], buf[10], buf[11], buf[12], buf[13], buf[14], buf[15]);
             ret = -1;
             goto out0;
         }
     }
-    if(read_len == len) {
+    if (read_len == len) {
         ret = 0;
     }
 out0:
@@ -1378,20 +1369,20 @@ out0:
 
 /* file data for test_16 */
 static fslittle_kv_data_t fslittle_fopen_test_15_kv_data[] = {
-        { "/sd/tst16_0/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_1/subdir0/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_2/subdir0/subdir1/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_3/subdir0/subdir1/subdir2/subdir3/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_0/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_1/subdir0/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_2/subdir0/subdir1/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_3/subdir0/subdir1/subdir2/subdir3/testfil0.txt", "dummy_data"},
 
 #if 0
-        { "/sd/tst16_4/subdir0/subdir1/subdir2/subdir3/subdir4/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_5/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_6/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_7/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_8/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/subdir8/testfil0.txt", "dummy_data"},
-        { "/sd/tst16_9/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/subdir8/subdir9/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_4/subdir0/subdir1/subdir2/subdir3/subdir4/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_5/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_6/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_7/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_8/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/subdir8/testfil0.txt", "dummy_data"},
+    { "/sd/tst16_9/subdir0/subdir1/subdir2/subdir3/subdir4/subdir5/subdir6/subdir7/subdir8/subdir9/testfil0.txt", "dummy_data"},
 #endif
-        { NULL, NULL},
+    { NULL, NULL},
 };
 
 
@@ -1409,15 +1400,15 @@ control_t fslittle_fopen_test_15(const size_t call_count)
     (void) call_count;
 
     /* remove file and directory from a previous failed test run, if present */
-    while(node->filename != NULL) {
-        fslittle_filepath_remove_all((char*) node->filename);
+    while (node->filename != NULL) {
+        fslittle_filepath_remove_all((char *) node->filename);
         node++;
     }
 
     /* create dirs */
     node = fslittle_fopen_test_15_kv_data;
-    while(node->filename != NULL) {
-        ret = fslittle_filepath_make_dirs((char*) node->filename, true);
+    while (node->filename != NULL) {
+        ret = fslittle_filepath_make_dirs((char *) node->filename, true);
         FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create dirs for filename (filename=\"%s\")(ret=%d)\n", __func__, node->filename, (int) ret);
         TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
         node++;
@@ -1425,7 +1416,7 @@ control_t fslittle_fopen_test_15(const size_t call_count)
 
     /* create the data files */
     node = fslittle_fopen_test_15_kv_data;
-    while(node->filename != NULL) {
+    while (node->filename != NULL) {
         ret = fslittle_test_create_data_file(node->filename, num_blocks * FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE);
         FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to create data file (filename=\"%s\")(ret=%d)\n", __func__, node->filename, (int) ret);
         TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
@@ -1434,7 +1425,7 @@ control_t fslittle_fopen_test_15(const size_t call_count)
 
     /* read the data back and check its as expected */
     node = fslittle_fopen_test_15_kv_data;
-    while(node->filename != NULL) {
+    while (node->filename != NULL) {
         ret = fslittle_test_check_data_file(node->filename, num_blocks * FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE);
         FSLITTLE_TEST_UTEST_MESSAGE(fslittle_fopen_utest_msg_g, FSLITTLE_UTEST_MSG_BUF_SIZE, "%s:Error: failed to check data file (filename=\"%s\")(ret=%d)\n", __func__, node->filename, (int) ret);
         TEST_ASSERT_MESSAGE(ret == 0, fslittle_fopen_utest_msg_g);
@@ -1443,8 +1434,8 @@ control_t fslittle_fopen_test_15(const size_t call_count)
 
     /* clean up */
     node = fslittle_fopen_test_15_kv_data;
-    while(node->filename != NULL) {
-        fslittle_filepath_remove_all((char*) node->filename);
+    while (node->filename != NULL) {
+        fslittle_filepath_remove_all((char *) node->filename);
         node++;
     }
     return CaseNext;
@@ -1458,26 +1449,26 @@ utest::v1::status_t greentea_setup(const size_t number_of_cases)
 }
 
 Case cases[] = {
-           /*          1         2         3         4         5         6        7  */
-           /* 1234567890123456789012345678901234567890123456789012345678901234567890 */
-        Case("FSLITTLE_FOPEN_TEST_00: format() test.", FSLITTLE_FOPEN_TEST_00),
-        Case("FSLITTLE_FOPEN_TEST_01: fopen()/fwrite()/fclose() directories/file in multi-dir filepath.", FSLITTLE_FOPEN_TEST_01),
-        Case("FSLITTLE_FOPEN_TEST_02: fopen(r) pre-existing file try to write it.", FSLITTLE_FOPEN_TEST_02),
-        Case("FSLITTLE_FOPEN_TEST_03: fopen(w+) pre-existing file try to write it.", FSLITTLE_FOPEN_TEST_03),
-        Case("FSLITTLE_FOPEN_TEST_04: fopen() with a filename exceeding the maximum length.", FSLITTLE_FOPEN_TEST_04),
+    /*          1         2         3         4         5         6        7  */
+    /* 1234567890123456789012345678901234567890123456789012345678901234567890 */
+    Case("FSLITTLE_FOPEN_TEST_00: format() test.", FSLITTLE_FOPEN_TEST_00),
+    Case("FSLITTLE_FOPEN_TEST_01: fopen()/fwrite()/fclose() directories/file in multi-dir filepath.", FSLITTLE_FOPEN_TEST_01),
+    Case("FSLITTLE_FOPEN_TEST_02: fopen(r) pre-existing file try to write it.", FSLITTLE_FOPEN_TEST_02),
+    Case("FSLITTLE_FOPEN_TEST_03: fopen(w+) pre-existing file try to write it.", FSLITTLE_FOPEN_TEST_03),
+    Case("FSLITTLE_FOPEN_TEST_04: fopen() with a filename exceeding the maximum length.", FSLITTLE_FOPEN_TEST_04),
 #ifdef FOPEN_EXTENDED_TESTING
-        Case("FSLITTLE_FOPEN_TEST_05: fopen() with bad filenames (extended).", FSLITTLE_FOPEN_TEST_05),
+    Case("FSLITTLE_FOPEN_TEST_05: fopen() with bad filenames (extended).", FSLITTLE_FOPEN_TEST_05),
 #endif
-        Case("FSLITTLE_FOPEN_TEST_06: fopen() with bad filenames (minimal).", FSLITTLE_FOPEN_TEST_06),
-        Case("FSLITTLE_FOPEN_TEST_07: fopen()/errno handling.", FSLITTLE_FOPEN_TEST_07),
-        Case("FSLITTLE_FOPEN_TEST_08: ferror()/clearerr()/errno handling.", FSLITTLE_FOPEN_TEST_08),
-        Case("FSLITTLE_FOPEN_TEST_09: ftell() handling.", FSLITTLE_FOPEN_TEST_09),
-        Case("FSLITTLE_FOPEN_TEST_10: remove() test.", FSLITTLE_FOPEN_TEST_10),
-        Case("FSLITTLE_FOPEN_TEST_11: rename().", FSLITTLE_FOPEN_TEST_11),
-        Case("FSLITTLE_FOPEN_TEST_12: opendir(), readdir(), closedir() test.", FSLITTLE_FOPEN_TEST_12),
-        Case("FSLITTLE_FOPEN_TEST_13: mkdir() test.", FSLITTLE_FOPEN_TEST_13),
-        Case("FSLITTLE_FOPEN_TEST_14: stat() test.", FSLITTLE_FOPEN_TEST_14),
-        Case("FSLITTLE_FOPEN_TEST_15: write/check n x 25kB data files.", FSLITTLE_FOPEN_TEST_15),
+    Case("FSLITTLE_FOPEN_TEST_06: fopen() with bad filenames (minimal).", FSLITTLE_FOPEN_TEST_06),
+    Case("FSLITTLE_FOPEN_TEST_07: fopen()/errno handling.", FSLITTLE_FOPEN_TEST_07),
+    Case("FSLITTLE_FOPEN_TEST_08: ferror()/clearerr()/errno handling.", FSLITTLE_FOPEN_TEST_08),
+    Case("FSLITTLE_FOPEN_TEST_09: ftell() handling.", FSLITTLE_FOPEN_TEST_09),
+    Case("FSLITTLE_FOPEN_TEST_10: remove() test.", FSLITTLE_FOPEN_TEST_10),
+    Case("FSLITTLE_FOPEN_TEST_11: rename().", FSLITTLE_FOPEN_TEST_11),
+    Case("FSLITTLE_FOPEN_TEST_12: opendir(), readdir(), closedir() test.", FSLITTLE_FOPEN_TEST_12),
+    Case("FSLITTLE_FOPEN_TEST_13: mkdir() test.", FSLITTLE_FOPEN_TEST_13),
+    Case("FSLITTLE_FOPEN_TEST_14: stat() test.", FSLITTLE_FOPEN_TEST_14),
+    Case("FSLITTLE_FOPEN_TEST_15: write/check n x 25kB data files.", FSLITTLE_FOPEN_TEST_15),
 };
 
 

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/util/fslittle_test.c
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/util/fslittle_test.c
@@ -61,7 +61,7 @@ const uint8_t fslittle_test_byte_data_table[FSLITTLE_TEST_BYTE_DATA_TABLE_SIZE] 
 
 /* @brief  test utility function to delete the file identified by filename
  */
-int32_t fslittle_test_delete(const char* filename)
+int32_t fslittle_test_delete(const char *filename)
 {
     FSLITTLE_FENTRYLOG("%s:entered.\r\n", __func__);
     return remove(filename);
@@ -74,18 +74,18 @@ int32_t fslittle_test_delete(const char* filename)
  * @param   data        data to store in file
  * @param   len         number of bytes of data present in the data buffer.
  */
-int32_t fslittle_test_create(const char* filename, const char* data, size_t len)
+int32_t fslittle_test_create(const char *filename, const char *data, size_t len)
 {
     int32_t ret = -1;
     FILE *fp = NULL;
 
     FSLITTLE_FENTRYLOG("%s:entered (filename=%s, len=%d).\n", __func__, filename, (int) len);
     fp = fopen(filename, "w+");
-    if(fp == NULL){
+    if (fp == NULL) {
         return ret;
     }
-    ret = fwrite((const void*) data, len, 1, fp);
-    if(ret < 0){
+    ret = fwrite((const void *) data, len, 1, fp);
+    if (ret < 0) {
         fclose(fp);
         return ret;
     }
@@ -99,16 +99,15 @@ int32_t fslittle_test_create(const char* filename, const char* data, size_t len)
  * @param   len     length of kv name to generate
  *
  */
-int32_t fslittle_test_filename_gen(char* name, const size_t len)
+int32_t fslittle_test_filename_gen(char *name, const size_t len)
 {
     size_t i;
     uint32_t pos = 0;
 
-    const char* buf = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$-_@";
+    const char *buf = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$-_@";
     const int buf_len = strlen(buf);
     FSLITTLE_FENTRYLOG("%s:entered\n", __func__);
-    for(i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         pos = rand() % (buf_len);
         name[i] = buf[pos];
     }

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/dirs/main.cpp
@@ -171,7 +171,7 @@ void dir_file_check(char *list[], uint32_t elements)
                     TEST_ASSERT(1);
                 }
                 break;
-            } else if ( i == elements) {
+            } else if (i == elements) {
                 TEST_ASSERT_EQUAL(0, res);
             }
         }

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/files/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/files/main.cpp
@@ -294,7 +294,7 @@ void test_dir_check()
                         TEST_ASSERT(1);
                     }
                     break;
-                } else if ( i == numFiles) {
+                } else if (i == numFiles) {
                     TEST_ASSERT_EQUAL(0, res);
                 }
             }

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/fopen/fopen.cpp
@@ -65,7 +65,7 @@ using namespace utest::v1;
  *        "DEVICE_SPI": 1,
  *        "FSFAT_SDCARD_INSTALLED": 1
  *      },
- *  	<<< lines removed >>>
+ *      <<< lines removed >>>
  */
 
 #if defined(DEVICE_SPI) && ( defined(MBED_CONF_APP_FSFAT_SDCARD_INSTALLED) || (MBED_CONF_SD_FSFAT_SDCARD_INSTALLED))
@@ -155,7 +155,7 @@ static int32_t fsfat_filepath_split(char *filepath, char *parts[], uint32_t num)
     char *z = filepath;
 
     while (i < num && *z != '\0') {
-        if (*z == '/' ) {
+        if (*z == '/') {
             *z = '\0';
             parts[i] = ++z;
             i++;
@@ -200,7 +200,7 @@ int32_t fsfat_filepath_remove_all(char *filepath)
     while (pos != fpathbuf) {
         /* If the remaining file path is the mount point path then finish as the mount point cannot be removed */
         if (strlen(fpathbuf) == strlen(FSFAT_FOPEN_TEST_MOUNT_PT_PATH)) {
-            if ( strncmp(fpathbuf, FSFAT_FOPEN_TEST_MOUNT_PT_PATH, strlen(fpathbuf)) == 0) {
+            if (strncmp(fpathbuf, FSFAT_FOPEN_TEST_MOUNT_PT_PATH, strlen(fpathbuf)) == 0) {
                 break;
             }
         }
@@ -621,7 +621,7 @@ control_t fsfat_fopen_test_05(const size_t call_count)
     while (node->code !=  fsfat_fopen_kv_name_ascii_table_code_sentinel_g) {
         /* loop over range */
         for (j = node->code; j < (node + 1)->code; j++) {
-            if ( (j >= 48 && j <= 57) || (j >= 65 && j <= 90) || (j >= 97 && j <= 122)) {
+            if ((j >= 48 && j <= 57) || (j >= 65 && j <= 90) || (j >= 97 && j <= 122)) {
                 FSFAT_DBGLOG("%s: skipping alpha-numeric ascii character code %d (%c).\n", __func__, (int) j, (char) j);
                 continue;
             }
@@ -775,10 +775,10 @@ control_t fsfat_fopen_test_06(const size_t call_count)
 
 /** @brief  test for errno reporting on a failed fopen()call
  *
- *	This test does the following:
- *	- tries to open a file that does not exist for reading, and checks that a NULL pointer is returned.
- *	- checks that errno is not 0 as there is an error.
- *	- checks that ferror() returns 1 indicating an error exists.
+ *  This test does the following:
+ *  - tries to open a file that does not exist for reading, and checks that a NULL pointer is returned.
+ *  - checks that errno is not 0 as there is an error.
+ *  - checks that ferror() returns 1 indicating an error exists.
  *
  * Note: see NOTE_1 below.
  *

--- a/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/parallel/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/TESTS/filesystem/parallel/main.cpp
@@ -97,7 +97,7 @@ void test_file_tests()
     TEST_ASSERT_EQUAL(0, res);
 }
 
-void write_file_data (char count)
+void write_file_data(char count)
 {
 
     char filename[10];
@@ -125,7 +125,7 @@ void write_file_data (char count)
     TEST_ASSERT_EQUAL(0, res);
 }
 
-void read_file_data (char count)
+void read_file_data(char count)
 {
     char filename[10];
     uint8_t rbuffer[MBED_TEST_BUFFER];

--- a/components/storage/blockdevice/COMPONENT_SD/util/fsfat_test.c
+++ b/components/storage/blockdevice/COMPONENT_SD/util/fsfat_test.c
@@ -61,7 +61,7 @@ const uint8_t fsfat_test_byte_data_table[FSFAT_TEST_BYTE_DATA_TABLE_SIZE] = {
 
 /* @brief  test utility function to delete the file identified by filename
  */
-int32_t fsfat_test_delete(const char* filename)
+int32_t fsfat_test_delete(const char *filename)
 {
     FSFAT_FENTRYLOG("%s:entered.\r\n", __func__);
     return remove(filename);
@@ -74,18 +74,18 @@ int32_t fsfat_test_delete(const char* filename)
  * @param   data        data to store in file
  * @param   len         number of bytes of data present in the data buffer.
  */
-int32_t fsfat_test_create(const char* filename, const char* data, size_t len)
+int32_t fsfat_test_create(const char *filename, const char *data, size_t len)
 {
     int32_t ret = -1;
     FILE *fp = NULL;
 
     FSFAT_FENTRYLOG("%s:entered (filename=%s, len=%d).\n", __func__, filename, (int) len);
     fp = fopen(filename, "w+");
-    if(fp == NULL){
+    if (fp == NULL) {
         return ret;
     }
-    ret = fwrite((const void*) data, len, 1, fp);
-    if(ret < 0){
+    ret = fwrite((const void *) data, len, 1, fp);
+    if (ret < 0) {
         fclose(fp);
         return ret;
     }
@@ -99,16 +99,15 @@ int32_t fsfat_test_create(const char* filename, const char* data, size_t len)
  * @param   len     length of kv name to generate
  *
  */
-int32_t fsfat_test_filename_gen(char* name, const size_t len)
+int32_t fsfat_test_filename_gen(char *name, const size_t len)
 {
     size_t i;
     uint32_t pos = 0;
 
-    const char* buf = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$-_@";
+    const char *buf = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!$-_@";
     const int buf_len = strlen(buf);
     FSFAT_FENTRYLOG("%s:entered\n", __func__);
-    for(i = 0; i < len; i++)
-    {
+    for (i = 0; i < len; i++) {
         pos = rand() % (buf_len);
         name[i] = buf[pos];
     }

--- a/components/storage/blockdevice/COMPONENT_SD/util/fsfat_test.h
+++ b/components/storage/blockdevice/COMPONENT_SD/util/fsfat_test.h
@@ -57,16 +57,16 @@ extern "C" {
 
 /* kv data for test */
 typedef struct fsfat_kv_data_t {
-    const char* filename;
-    const char* value;
+    const char *filename;
+    const char *value;
 } fsfat_kv_data_t;
 
 
 extern const uint8_t fsfat_test_byte_data_table[FSFAT_TEST_BYTE_DATA_TABLE_SIZE];
 
-int32_t fsfat_test_create(const char* filename, const char* data, size_t len);
-int32_t fsfat_test_delete(const char* key_name);
-int32_t fsfat_test_filename_gen(char* name, const size_t len);
+int32_t fsfat_test_create(const char *filename, const char *data, size_t len);
+int32_t fsfat_test_delete(const char *key_name);
+int32_t fsfat_test_filename_gen(char *name, const size_t len);
 #ifdef __cplusplus
 }
 #endif

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -36,8 +36,8 @@ using namespace mbed;
 #endif
 #define SPI_NO_ADDRESS_COMMAND UINT64_MAX
 // Status Register Bits
-#define SPIF_STATUS_BIT_WIP	0x1 //Write In Progress
-#define SPIF_STATUS_BIT_WEL	0x2 // Write Enable Latch
+#define SPIF_STATUS_BIT_WIP 0x1 //Write In Progress
+#define SPIF_STATUS_BIT_WEL 0x2 // Write Enable Latch
 
 /* SFDP Header Parsing */
 /***********************/
@@ -146,7 +146,7 @@ int SPIFBlockDevice::init()
     }
 
     // Soft Reset
-    if ( -1 == _reset_flash_mem()) {
+    if (-1 == _reset_flash_mem()) {
         tr_error("ERROR: init - Unable to initialize flash memory, tests failed\n");
         status = SPIF_BD_ERROR_DEVICE_ERROR;
         goto exit_point;
@@ -174,14 +174,14 @@ int SPIFBlockDevice::init()
     }
 
     //Synchronize Device
-    if ( false == _is_mem_ready()) {
+    if (false == _is_mem_ready()) {
         tr_error("ERROR: init - _is_mem_ready Failed");
         status = SPIF_BD_ERROR_READY_FAILED;
         goto exit_point;
     }
 
     /**************************** Parse SFDP Header ***********************************/
-    if ( 0 != _sfdp_parse_sfdp_headers(basic_table_addr, basic_table_size, sector_map_table_addr, sector_map_table_size)) {
+    if (0 != _sfdp_parse_sfdp_headers(basic_table_addr, basic_table_size, sector_map_table_addr, sector_map_table_size)) {
         tr_error("ERROR: init - Parse SFDP Headers Failed");
         status = SPIF_BD_ERROR_PARSING_FAILED;
         goto exit_point;
@@ -189,7 +189,7 @@ int SPIFBlockDevice::init()
 
 
     /**************************** Parse Basic Parameters Table ***********************************/
-    if ( 0 != _sfdp_parse_basic_param_table(basic_table_addr, basic_table_size) ) {
+    if (0 != _sfdp_parse_basic_param_table(basic_table_addr, basic_table_size)) {
         tr_error("ERROR: init - Parse Basic Param Table Failed");
         status = SPIF_BD_ERROR_PARSING_FAILED;
         goto exit_point;
@@ -200,10 +200,10 @@ int SPIFBlockDevice::init()
         _device_size_bytes; // If there's no region map, we have a single region sized the entire device size
     _region_high_boundary[0] = _device_size_bytes - 1;
 
-    if ( (sector_map_table_addr != 0) && (0 != sector_map_table_size) ) {
+    if ((sector_map_table_addr != 0) && (0 != sector_map_table_size)) {
         tr_info("INFO: init - Parsing Sector Map Table - addr: 0x%lxh, Size: %d", sector_map_table_addr,
                 sector_map_table_size);
-        if (0 != _sfdp_parse_sector_map_table(sector_map_table_addr, sector_map_table_size) ) {
+        if (0 != _sfdp_parse_sector_map_table(sector_map_table_addr, sector_map_table_size)) {
             tr_error("ERROR: init - Parse Sector Map Table Failed");
             status = SPIF_BD_ERROR_PARSING_FAILED;
             goto exit_point;
@@ -309,7 +309,7 @@ int SPIFBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
         addr += chunk;
         size -= chunk;
 
-        if ( false == _is_mem_ready()) {
+        if (false == _is_mem_ready()) {
             tr_error("ERROR: Device not ready after write, failed\n");
             program_failed = true;
             status = SPIF_BD_ERROR_READY_FAILED;
@@ -351,7 +351,7 @@ int SPIFBlockDevice::erase(bd_addr_t addr, bd_size_t in_size)
         return SPIF_BD_ERROR_INVALID_ERASE_PARAMS;
     }
 
-    if ( ((addr % get_erase_size(addr)) != 0 ) ||  (((addr + in_size) % get_erase_size(addr + in_size - 1)) != 0 ) ) {
+    if (((addr % get_erase_size(addr)) != 0) || (((addr + in_size) % get_erase_size(addr + in_size - 1)) != 0)) {
         tr_error("ERROR: invalid erase - unaligned address and size");
         return SPIF_BD_ERROR_INVALID_ERASE_PARAMS;
     }
@@ -364,7 +364,7 @@ int SPIFBlockDevice::erase(bd_addr_t addr, bd_size_t in_size)
         type = _utils_iterate_next_largest_erase_type(bitfield, size, (unsigned int)addr, _region_high_boundary[region]);
         cur_erase_inst = _erase_type_inst_arr[type];
         offset = addr % _erase_type_size_arr[type];
-        chunk = ( (offset + size) < _erase_type_size_arr[type]) ? size : (_erase_type_size_arr[type] - offset);
+        chunk = ((offset + size) < _erase_type_size_arr[type]) ? size : (_erase_type_size_arr[type] - offset);
 
         tr_debug("DEBUG: erase - addr: %llu, size:%d, Inst: 0x%xh, chunk: %lu , ",
                  addr, size, cur_erase_inst, chunk);
@@ -385,13 +385,13 @@ int SPIFBlockDevice::erase(bd_addr_t addr, bd_size_t in_size)
         addr += chunk;
         size -= chunk;
 
-        if ( (size > 0) && (addr > _region_high_boundary[region]) ) {
+        if ((size > 0) && (addr > _region_high_boundary[region])) {
             // erase crossed to next region
             region++;
             bitfield = _region_erase_types_bitfield[region];
         }
 
-        if ( false == _is_mem_ready()) {
+        if (false == _is_mem_ready()) {
             tr_error("ERROR: SPI After Erase Device not ready - failed\n");
             erase_failed = true;
             status = SPIF_BD_ERROR_READY_FAILED;
@@ -513,7 +513,7 @@ spif_bd_error SPIFBlockDevice::_spi_send_read_command(int read_inst, uint8_t *bu
 }
 
 spif_bd_error SPIFBlockDevice::_spi_send_program_command(int prog_inst, const void *buffer, bd_addr_t addr,
-        bd_size_t size)
+                                                         bd_size_t size)
 {
     // Send Program (write) command to device driver
     uint32_t dummy_bytes = _dummy_and_mode_cycles / 8;
@@ -556,7 +556,7 @@ spif_bd_error SPIFBlockDevice::_spi_send_erase_command(int erase_inst, bd_addr_t
 }
 
 spif_bd_error SPIFBlockDevice::_spi_send_general_command(int instruction, bd_addr_t addr, char *tx_buffer,
-        size_t tx_length, char *rx_buffer, size_t rx_length)
+                                                         size_t tx_length, char *rx_buffer, size_t rx_length)
 {
     // Send a general command Instruction to driver
     uint32_t dummy_bytes = _dummy_and_mode_cycles / 8;
@@ -604,14 +604,14 @@ int SPIFBlockDevice::_sfdp_parse_sector_map_table(uint32_t sector_map_table_addr
 
 
     spif_bd_error status = _spi_send_read_command(SPIF_SFDP, sector_map_table, sector_map_table_addr /*address*/,
-                           sector_map_table_size);
+                                                  sector_map_table_size);
     if (status != SPIF_BD_ERROR_OK) {
         tr_error("ERROR: init - Read SFDP First Table Failed");
         return -1;
     }
 
     // Currently we support only Single Map Descriptor
-    if (! ( (sector_map_table[0] & 0x3) == 0x03 ) && (sector_map_table[1]  == 0x0) ) {
+    if (!((sector_map_table[0] & 0x3) == 0x03) && (sector_map_table[1]  == 0x0)) {
         tr_error("ERROR: Sector Map - Supporting Only Single! Map Descriptor (not map commands)");
         return -1;
     }
@@ -658,7 +658,7 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, si
     //memset(param_table, 0, SFDP_DEFAULT_BASIC_PARAMS_TABLE_SIZE_BYTES);
 
     spif_bd_error status = _spi_send_read_command(SPIF_SFDP, param_table, basic_table_addr /*address*/,
-                           basic_table_size);
+                                                  basic_table_size);
     if (status != SPIF_BD_ERROR_OK) {
         tr_error("ERROR: init - Read SFDP First Table Failed");
         return -1;
@@ -674,8 +674,8 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, si
     uint32_t density_bits = (
                                 (param_table[7] << 24) |
                                 (param_table[6] << 16) |
-                                (param_table[5] << 8 ) |
-                                param_table[4] );
+                                (param_table[5] << 8) |
+                                param_table[4]);
     _device_size_bytes = (density_bits + 1) / 8;
 
     // Set Default read/program/erase Instructions
@@ -697,8 +697,8 @@ int SPIFBlockDevice::_sfdp_parse_basic_param_table(uint32_t basic_table_addr, si
     return 0;
 }
 
-int SPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t& basic_table_addr, size_t& basic_table_size,
-        uint32_t& sector_map_table_addr, size_t& sector_map_table_size)
+int SPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_t &basic_table_size,
+                                              uint32_t &sector_map_table_addr, size_t &sector_map_table_size)
 {
     uint8_t sfdp_header[16];
     uint8_t param_header[SPIF_SFDP_HEADER_SIZE];
@@ -752,14 +752,14 @@ int SPIFBlockDevice::_sfdp_parse_sfdp_headers(uint32_t& basic_table_addr, size_t
         if ((param_header[0] == 0) && (param_header[7] == 0xFF)) {
             // Found Basic Params Table: LSB=0x00, MSB=0xFF
             tr_debug("DEBUG: Found Basic Param Table at Table: %d", i_ind + 1);
-            basic_table_addr = ( (param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]) );
+            basic_table_addr = ((param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]));
             // Supporting up to 64 Bytes Table (16 DWORDS)
             basic_table_size = ((param_header[3] * 4) < SFDP_DEFAULT_BASIC_PARAMS_TABLE_SIZE_BYTES) ? (param_header[3] * 4) : 64;
 
         } else if ((param_header[0] == 81) && (param_header[7] == 0xFF)) {
             // Found Sector Map Table: LSB=0x81, MSB=0xFF
             tr_debug("DEBUG: Found Sector Map Table at Table: %d", i_ind + 1);
-            sector_map_table_addr = ( (param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]) );
+            sector_map_table_addr = ((param_header[6] << 16) | (param_header[5] << 8) | (param_header[4]));
             sector_map_table_size = param_header[3] * 4;
 
         }
@@ -775,7 +775,7 @@ unsigned int SPIFBlockDevice::_sfdp_detect_page_size(uint8_t *basic_param_table_
 
     if (basic_param_table_size > SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE) {
         // Page Size is specified by 4 Bits (N), calculated by 2^N
-        int page_to_power_size = ( (int)basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE]) >> 4;
+        int page_to_power_size = ((int)basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_PAGE_SIZE_BYTE]) >> 4;
         page_size = local_math_power(2, page_to_power_size);
         tr_debug("DEBUG: Detected Page Size: %d", page_size);
     } else {
@@ -785,8 +785,8 @@ unsigned int SPIFBlockDevice::_sfdp_detect_page_size(uint8_t *basic_param_table_
 }
 
 int SPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-        int& erase4k_inst,
-        int *erase_type_inst_arr, unsigned int *erase_type_size_arr)
+                                                            int &erase4k_inst,
+                                                            int *erase_type_inst_arr, unsigned int *erase_type_size_arr)
 {
     erase4k_inst = 0xff;
     bool found_4Kerase_type = false;
@@ -800,14 +800,14 @@ int SPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param
         for (int i_ind = 0; i_ind < 4; i_ind++) {
             erase_type_inst_arr[i_ind] = 0xff; //0xFF default for unsupported type
             erase_type_size_arr[i_ind] = local_math_power(2,
-                                         basic_param_table_ptr[SPIF_BASIC_PARAM_ERASE_TYPE_1_SIZE_BYTE + 2 * i_ind]); // Size given as 2^N
+                                                          basic_param_table_ptr[SPIF_BASIC_PARAM_ERASE_TYPE_1_SIZE_BYTE + 2 * i_ind]); // Size given as 2^N
             tr_info("DEBUG: Erase Type(A) %d - Inst: 0x%xh, Size: %d", (i_ind + 1), erase_type_inst_arr[i_ind],
                     erase_type_size_arr[i_ind]);
             if (erase_type_size_arr[i_ind] > 1) {
                 // if size==1 type is not supported
                 erase_type_inst_arr[i_ind] = basic_param_table_ptr[SPIF_BASIC_PARAM_ERASE_TYPE_1_BYTE + 2 * i_ind];
 
-                if ((erase_type_size_arr[i_ind] < _min_common_erase_size) || (_min_common_erase_size == 0) ) {
+                if ((erase_type_size_arr[i_ind] < _min_common_erase_size) || (_min_common_erase_size == 0)) {
                     //Set default minimal common erase for singal region
                     _min_common_erase_size = erase_type_size_arr[i_ind];
                 }
@@ -838,7 +838,7 @@ int SPIFBlockDevice::_sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param
 }
 
 int SPIFBlockDevice::_sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-        int& read_inst)
+                                                     int &read_inst)
 {
     do {
 
@@ -847,15 +847,15 @@ int SPIFBlockDevice::_sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_
         uint8_t examined_byte;
 
         if (basic_param_table_size > SPIF_BASIC_PARAM_TABLE_QPI_READ_SUPPORT_BYTE) {
-        	examined_byte = basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_QPI_READ_SUPPORT_BYTE];
-        	if (examined_byte & 0x01) {
-        		//  Fast Read 2-2-2 Supported
-        		read_inst = basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE];
-        		_read_dummy_and_mode_cycles = (basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE - 1] >> 5)
-        								 + (basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE - 1] & 0x1F);
-        		tr_info("\nDEBUG: Read Bus Mode set to 2-2-2, Instruction: 0x%xh", read_inst);
-        		break;
-        	}
+            examined_byte = basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_QPI_READ_SUPPORT_BYTE];
+            if (examined_byte & 0x01) {
+                //  Fast Read 2-2-2 Supported
+                read_inst = basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE];
+                _read_dummy_and_mode_cycles = (basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE - 1] >> 5)
+                                         + (basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_222_READ_INST_BYTE - 1] & 0x1F);
+                tr_info("\nDEBUG: Read Bus Mode set to 2-2-2, Instruction: 0x%xh", read_inst);
+                break;
+            }
         }
         examined_byte = basic_param_table_ptr[SPIF_BASIC_PARAM_TABLE_FAST_READ_SUPPORT_BYTE];
         if (examined_byte & 0x20) {
@@ -889,7 +889,7 @@ int SPIFBlockDevice::_reset_flash_mem()
     char status_value[2] = {0};
     tr_info("INFO: _reset_flash_mem:\n");
     //Read the Status Register from device
-    if (SPIF_BD_ERROR_OK == _spi_send_general_command(SPIF_RDSR, SPI_NO_ADDRESS_COMMAND, NULL, 0, status_value, 1) ) {
+    if (SPIF_BD_ERROR_OK == _spi_send_general_command(SPIF_RDSR, SPI_NO_ADDRESS_COMMAND, NULL, 0, status_value, 1)) {
         // store received values in status_value
         tr_debug("DEBUG: Reading Status Register Success: value = 0x%x\n", (int)status_value[0]);
     } else {
@@ -899,7 +899,7 @@ int SPIFBlockDevice::_reset_flash_mem()
 
     if (0 == status) {
         //Send Reset Enable
-        if (SPIF_BD_ERROR_OK == _spi_send_general_command(SPIF_RSTEN, SPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0) ) {
+        if (SPIF_BD_ERROR_OK == _spi_send_general_command(SPIF_RSTEN, SPI_NO_ADDRESS_COMMAND, NULL, 0, NULL, 0)) {
             // store received values in status_value
             tr_debug("DEBUG: Sending RSTEN Success\n");
         } else {
@@ -935,10 +935,10 @@ bool SPIFBlockDevice::_is_mem_ready()
         retries++;
         //Read the Status Register from device
         if (SPIF_BD_ERROR_OK != _spi_send_general_command(SPIF_RDSR, SPI_NO_ADDRESS_COMMAND, NULL, 0, status_value,
-                1)) {   // store received values in status_value
+                                                          1)) {   // store received values in status_value
             tr_error("ERROR: Reading Status Register failed\n");
         }
-    } while ( (status_value[0] & SPIF_STATUS_BIT_WIP) != 0 && retries < IS_MEM_READY_MAX_RETRIES );
+    } while ((status_value[0] & SPIF_STATUS_BIT_WIP) != 0 && retries < IS_MEM_READY_MAX_RETRIES);
 
     if ((status_value[0] & SPIF_STATUS_BIT_WIP) != 0) {
         tr_error("ERROR: _is_mem_ready FALSE\n");
@@ -959,14 +959,14 @@ int SPIFBlockDevice::_set_write_enable()
             break;
         }
 
-        if ( false == _is_mem_ready()) {
+        if (false == _is_mem_ready()) {
             tr_error("ERROR: Device not ready, write failed");
             break;
         }
 
         memset(status_value, 0, 2);
         if (SPIF_BD_ERROR_OK != _spi_send_general_command(SPIF_RDSR, SPI_NO_ADDRESS_COMMAND, NULL, 0, status_value,
-                1)) {   // store received values in status_value
+                                                          1)) {   // store received values in status_value
             tr_error("ERROR: Reading Status Register failed\n");
             break;
         }
@@ -1004,7 +1004,7 @@ int SPIFBlockDevice::_utils_find_addr_region(bd_size_t offset)
 
 }
 
-int SPIFBlockDevice::_utils_iterate_next_largest_erase_type(uint8_t& bitfield, int size, int offset, int boundry)
+int SPIFBlockDevice::_utils_iterate_next_largest_erase_type(uint8_t &bitfield, int size, int offset, int boundry)
 {
     // Iterate on all supported Erase Types of the Region to which the offset belong to.
     // Iterates from highest type to lowest
@@ -1014,8 +1014,8 @@ int SPIFBlockDevice::_utils_iterate_next_largest_erase_type(uint8_t& bitfield, i
     for (i_ind = 3; i_ind >= 0; i_ind--) {
         if (bitfield & type_mask) {
             largest_erase_type = i_ind;
-            if ( (size > (int)(_erase_type_size_arr[largest_erase_type])) &&
-                    ((boundry - offset) > (int)(_erase_type_size_arr[largest_erase_type])) ) {
+            if ((size > (int)(_erase_type_size_arr[largest_erase_type])) &&
+                    ((boundry - offset) > (int)(_erase_type_size_arr[largest_erase_type]))) {
                 break;
             } else {
                 bitfield &= ~type_mask;

--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.h
@@ -34,7 +34,7 @@ enum spif_bd_error {
 };
 
 
-#define SPIF_MAX_REGIONS	10
+#define SPIF_MAX_REGIONS    10
 #define MAX_NUM_OF_ERASE_TYPES 4
 
 /** BlockDevice for SFDP based flash devices over SPI bus
@@ -86,7 +86,7 @@ public:
 
     /** Initialize a block device
      *
-     *  @return  	    SPIF_BD_ERROR_OK(0) - success
+     *  @return         SPIF_BD_ERROR_OK(0) - success
      *                  SPIF_BD_ERROR_DEVICE_ERROR - device driver transaction failed
      *                  SPIF_BD_ERROR_READY_FAILED - Waiting for Memory ready failed or timedout
      *                  SPIF_BD_ERROR_PARSING_FAILED - unexpected format or values in one of the SFDP tables
@@ -101,7 +101,10 @@ public:
 
     /** Desctruct SPIFBlockDevie
       */
-    ~SPIFBlockDevice() {deinit();}
+    ~SPIFBlockDevice()
+    {
+        deinit();
+    }
 
     /** Read blocks from a block device
      *
@@ -194,8 +197,8 @@ private:
     /* SFDP Detection and Parsing Functions */
     /****************************************/
     // Parse SFDP Headers and retrieve Basic Param and Sector Map Tables (if exist)
-    int _sfdp_parse_sfdp_headers(uint32_t& basic_table_addr, size_t& basic_table_size,
-                                 uint32_t& sector_map_table_addr, size_t& sector_map_table_size);
+    int _sfdp_parse_sfdp_headers(uint32_t &basic_table_addr, size_t &basic_table_size,
+                                 uint32_t &sector_map_table_addr, size_t &sector_map_table_size);
 
     // Parse and Detect required Basic Parameters from Table
     int _sfdp_parse_basic_param_table(uint32_t basic_table_addr, size_t basic_table_size);
@@ -204,15 +207,15 @@ private:
     int _sfdp_parse_sector_map_table(uint32_t sector_map_table_addr, size_t sector_map_table_size);
 
     // Detect fastest read Bus mode supported by device
-    int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int& read_inst);
+    int _sfdp_detect_best_bus_read_mode(uint8_t *basic_param_table_ptr, int basic_param_table_size, int &read_inst);
 
     // Set Page size for program
     unsigned int _sfdp_detect_page_size(uint8_t *basic_param_table_ptr, int basic_param_table_size);
 
     // Detect all supported erase types
     int _sfdp_detect_erase_types_inst_and_size(uint8_t *basic_param_table_ptr, int basic_param_table_size,
-            int& erase4k_inst,
-            int *erase_type_inst_arr, unsigned int *erase_type_size_arr);
+                                               int &erase4k_inst,
+                                               int *erase_type_inst_arr, unsigned int *erase_type_size_arr);
 
     /***********************/
     /* Utilities Functions */
@@ -222,7 +225,7 @@ private:
 
     // Iterate on all supported Erase Types of the Region to which the offset belong to.
     // Iterates from highest type to lowest
-    int _utils_iterate_next_largest_erase_type(uint8_t& bitfield, int size, int offset, int boundry);
+    int _utils_iterate_next_largest_erase_type(uint8_t &bitfield, int size, int offset, int boundry);
 
     /********************************/
     /*   Calls to SPI Driver APIs   */

--- a/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/TESTS/block_device/spif/main.cpp
@@ -42,7 +42,7 @@ static SingletonPtr<PlatformMutex> _mutex;
 // Mutex is protecting rand() per srand for buffer writing and verification.
 // Mutex is also protecting printouts for clear logs.
 // Mutex is NOT protecting Block Device actions: erase/program/read - which is the purpose of the multithreaded test!
-void basic_erase_program_read_test(SPIFBlockDevice& block_device, bd_size_t block_size, uint8_t *write_block,
+void basic_erase_program_read_test(SPIFBlockDevice &block_device, bd_size_t block_size, uint8_t *write_block,
                                    uint8_t *read_block, unsigned addrwidth)
 {
     int err = 0;
@@ -78,10 +78,10 @@ void basic_erase_program_read_test(SPIFBlockDevice& block_device, bd_size_t bloc
     int val_rand;
     for (bd_size_t i_ind = 0; i_ind < block_size; i_ind++) {
         val_rand = rand();
-        if ( (0xff & val_rand) != read_block[i_ind] ) {
+        if ((0xff & val_rand) != read_block[i_ind]) {
             utest_printf("\n Assert Failed Buf Read - block:size: %llx:%llu \n", block, block_size);
             utest_printf("\n pos: %llu, exp: %02x, act: %02x, wrt: %02x \n", i_ind, (0xff & val_rand), read_block[i_ind],
-                         write_block[i_ind] );
+                         write_block[i_ind]);
         }
         TEST_ASSERT_EQUAL(0xff & val_rand, read_block[i_ind]);
     }
@@ -206,7 +206,7 @@ static void test_spif_thread_job(void *block_device_ptr/*, int thread_num*/)
 
     uint8_t *write_block = new (std::nothrow) uint8_t[block_size];
     uint8_t *read_block = new (std::nothrow) uint8_t[block_size];
-    if (!write_block || !read_block ) {
+    if (!write_block || !read_block) {
         utest_printf("\n Not enough memory for test");
         goto end;
     }


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Components astyle update

The only exception I made was inlined assembly in rf driver (skipped from astyle).

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

