### PR TITLE
Tools: Restrict toolchains reported by mbed compile -S to official ones

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1072,20 +1072,7 @@ def get_unique_supported_toolchains(release_targets=None):
                       If release_targets is not specified, then it queries all
                       known targets
     """
-    unique_supported_toolchains = []
-
-    if not release_targets:
-        for target in TARGET_NAMES:
-            for toolchain in TARGET_MAP[target].supported_toolchains:
-                if toolchain not in unique_supported_toolchains:
-                    unique_supported_toolchains.append(toolchain)
-    else:
-        for target in release_targets:
-            for toolchain in target[1]:
-                if toolchain not in unique_supported_toolchains:
-                    unique_supported_toolchains.append(toolchain)
-
-    return unique_supported_toolchains
+    return ["ARM", "uARM", "GCC_ARM", "IAR"]
 
 
 def _lowercase_release_version(release_version):

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -1072,7 +1072,10 @@ def get_unique_supported_toolchains(release_targets=None):
                       If release_targets is not specified, then it queries all
                       known targets
     """
-    return ["ARM", "uARM", "GCC_ARM", "IAR"]
+    return [
+        name for name, cls in TOOLCHAIN_CLASSES.items()
+        if cls.OFFICIALLY_SUPPORTED
+    ]
 
 
 def _lowercase_release_version(release_version):

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -48,6 +48,8 @@ CPU_COUNT_MIN = 1
 CPU_COEF = 1
 
 class mbedToolchain:
+    OFFICILLY_SUPPORTED = False
+
     # Verbose logging
     VERBOSE = True
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -48,7 +48,7 @@ CPU_COUNT_MIN = 1
 CPU_COEF = 1
 
 class mbedToolchain:
-    OFFICILLY_SUPPORTED = False
+    OFFICIALLY_SUPPORTED = False
 
     # Verbose logging
     VERBOSE = True

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -337,6 +337,7 @@ class ARM(mbedToolchain):
 
 
 class ARM_STD(ARM):
+    OFFICIALLY_SUPPORTED = True
     def __init__(self, target, notify=None, macros=None,
                  build_profile=None, build_dir=None):
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
@@ -347,6 +348,7 @@ class ARM_STD(ARM):
 
 class ARM_MICRO(ARM):
     PATCHED_LIBRARY = False
+    OFFICIALLY_SUPPORTED = True
     def __init__(self, target, notify=None, macros=None,
                  silent=False, extra_verbose=False, build_profile=None,
                  build_dir=None):
@@ -357,6 +359,7 @@ class ARM_MICRO(ARM):
             raise NotSupportedException("ARM/uARM compiler support is required for ARM build")
 
 class ARMC6(ARM_STD):
+    OFFICIALLY_SUPPORTED = False
     SHEBANG = "#! armclang -E --target=arm-arm-none-eabi -x c"
     SUPPORTED_CORES = ["Cortex-M0", "Cortex-M0+", "Cortex-M3", "Cortex-M4",
                        "Cortex-M4F", "Cortex-M7", "Cortex-M7F", "Cortex-M7FD",

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -25,6 +25,7 @@ from tools.hooks import hook_tool
 from tools.utils import run_cmd, NotSupportedException
 
 class GCC(mbedToolchain):
+    OFFICIALLY_SUPPORTED = True
     LINKER_EXT = '.ld'
     LIBRARY_EXT = '.a'
 

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -24,6 +24,7 @@ from tools.hooks import hook_tool
 from tools.utils import run_cmd, NotSupportedException
 
 class IAR(mbedToolchain):
+    OFFICIALLY_SUPPORTED = True
     LIBRARY_EXT = '.a'
     LINKER_EXT = '.icf'
     STD_LIB_NAME = "%s.a"


### PR DESCRIPTION
### Description

The `mbed compile -S` command is suposed to indicate what targets 
support what toolchains. The command was printing out things that 
don't make sense, like `GCC_CR` and things that make sense, but are
not offiially supported yet, like `ARMC6`. This PR fixes all of that.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change