### PR TITLE
Tools: Don't traceback on missing linker script

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -532,6 +532,8 @@ def build_project(src_paths, build_path, target, toolchain_name,
         # Change linker script if specified
         if linker_script is not None:
             resources.add_file_ref(linker_script, linker_script)
+        if not resources.get_file_refs(FileType.LD_SCRIPT):
+            raise NotSupportedException("No Linker Script found!")
 
         # Compile Sources
         objects = toolchain.compile_sources(resources, sorted(resources.get_file_paths(FileType.INC_DIR)))

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -533,7 +533,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
         if linker_script is not None:
             resources.add_file_ref(linker_script, linker_script)
         if not resources.get_file_refs(FileType.LD_SCRIPT):
-            raise NotSupportedException("No Linker Script found!")
+            raise NotSupportedException("No Linker Script found")
 
         # Compile Sources
         objects = toolchain.compile_sources(resources, sorted(resources.get_file_paths(FileType.INC_DIR)))

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -620,8 +620,11 @@ class mbedToolchain:
         objects = sorted(set(r.get_file_paths(FileType.OBJECT)))
         config_file = ([self.config.app_config_location]
                        if self.config.app_config_location else [])
-        linker_script = [path for _, path in r.get_file_refs(FileType.LD_SCRIPT)
-                         if path.endswith(self.LINKER_EXT)][-1]
+        try:
+            linker_script = [path for _, path in r.get_file_refs(FileType.LD_SCRIPT)
+                             if path.endswith(self.LINKER_EXT)][-1]
+        except IndexError:
+            raise NotSupportedException("No linker script found")
         lib_dirs = r.get_file_paths(FileType.LIB_DIR)
         libraries = [l for l in r.get_file_paths(FileType.LIB)
                      if l.endswith(self.LIBRARY_EXT)]


### PR DESCRIPTION
### Description

The `mbed compile` would traceback when no linker script is found.
This PR changes that behavior to make that into a NotSupportedException,
which has decent user behavior.

Fixes #7723

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change