### PR TITLE
Export, Cmake: Ensure project name ends in `.elf`

### DIFF
--- a/tools/export/cmake/__init__.py
+++ b/tools/export/cmake/__init__.py
@@ -74,8 +74,13 @@ class CMake(Exporter):
         # sort includes reverse, so the deepest dir comes first (ensures short includes)
         includes = sorted([re.sub(r'^[.]/', '', l) for l in self.resources.inc_dirs], reverse=True)
 
+        if self.project_name.endswith(".elf"):
+            bin_name = self.project_name
+        else:
+            bin_name = self.project_name + ".elf"
+
         ctx = {
-            'name': self.project_name,
+            'name': bin_name,
             'target': self.target,
             'sources': sorted(srcs),
             'libraries': libraries,


### PR DESCRIPTION
### Description

The Cmake exporter did not previously suffix it's executables with `.elf`.
This caused linker errors when the source directory containes a directory 
with the same name, such as `src/src` or `mbed-os/mbed-os`, as the executable 
would default to the name of the project, `src` or `mbed-os` respectively.
The executable name then confilicts with a directory created by the cmake 
earlier in the compile. Suffixing with `.elf` significantly reduced the 
probabilitly of encountering this bug.

Fixes #6585

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change