### PR TITLE
Adjust heap size on stm32f207

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F2/TARGET_NUCLEO_F207ZG/device/TOOLCHAIN_IAR/stm32f207xx.icf
@@ -21,7 +21,7 @@ define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__]
 /* Stack: 1024B */
 /* Heap: 64kB */
 define symbol __size_cstack__ = 0x400;
-define symbol __size_heap__   = 0x10000;
+define symbol __size_heap__   = 0xF000;
 define block CSTACK    with alignment = 8, size = __size_cstack__   { };
 define block HEAP      with alignment = 8, size = __size_heap__     { };
 define block STACKHEAP with fixed order { block HEAP, block CSTACK };


### PR DESCRIPTION
### Description

The board has 128kB of RAM. Currently in mbed-os the RAM usage has increased with cloud client so that on this board the code does not fit with the current heap size. This seems to be ongoing trend that with every release the memory usage grows and the linker files need to be adjusted accordingly. Instead of adjusting the linker files and creating PR it would make sense to allow the application to configure the heap like so:

stm32f207xx.icf:

if (!isdefinedsymbol(MBED_APP_HEAP_SIZE)) {
    define symbol __size_heap__ = 0xF000;
} else {
    define symbol __size_heap__ = MBED_APP_HEAP_SIZE;
}

This PR does not implement that. I just want to hear what you think how this should be handled, because this will not be the last time adjustments are required. 


### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

