### PR TITLE
Fixed WiFi configuration for WiFi test cases

### DIFF
--- a/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
+++ b/TESTS/network/wifi/wifi_connect_disconnect_repeat.cpp
@@ -30,6 +30,7 @@ void wifi_connect_disconnect_repeat(void)
     WiFiInterface *wifi = get_interface();
     nsapi_error_t error;
 
+    wifi->set_channel(MBED_CONF_APP_WIFI_CH_UNSECURE); 
     error = wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL);
     TEST_ASSERT(error == NSAPI_ERROR_OK);
 

--- a/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -29,6 +29,8 @@ void wifi_connect_secure(void)
 {
     WiFiInterface *wifi = get_interface();
 
+    wifi->set_channel(MBED_CONF_APP_WIFI_CH_SECURE); 
+
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()));
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());

--- a/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -29,6 +29,8 @@ void wifi_get_rssi(void)
 {
     WiFiInterface *wifi = get_interface();
 
+    wifi->set_channel(MBED_CONF_APP_WIFI_CH_UNSECURE);
+
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL));
 
     TEST_ASSERT_EQUAL_INT8(0, wifi->get_rssi());


### PR DESCRIPTION
### Description
Test cases for wifi, when run in a single execution, were using configurations for previous tests while some tests required channels to be set again correctly, in this pull request, channels have been set in test cases again before running the tests.

Fixed #8228 
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

