### PR TITLE
Change behaviour of mbed_asert to use mbed_error instead of mbed_die

### DIFF
--- a/platform/mbed_assert.c
+++ b/platform/mbed_assert.c
@@ -24,10 +24,6 @@ void mbed_assert_internal(const char *expr, const char *file, int line)
 {
     core_util_critical_section_enter();
 
-    const char error_description[] = "Mbed assertation failed ";
-    unsigned error_message_length = strlen(error_description) + strlen(expr) + 1;
-    char error_message[error_message_length];
-    snprintf(error_message, error_message_length, "%s%s", error_description, expr);
-
-    mbed_error(MBED_ERROR_ASSERTATION_FAILED, error_message, 0, file, line);
+    mbed_error(MBED_ERROR_ASSERTION_FAILED, expr, 0, file, line);
 }
+

--- a/platform/mbed_assert.c
+++ b/platform/mbed_assert.c
@@ -13,15 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#include "platform/mbed_assert.h"
-#include "device.h"
 
-#include "platform/mbed_interface.h"
+#include <string.h>
+#include "platform/mbed_assert.h"
+
 #include "platform/mbed_critical.h"
+#include "platform/mbed_error.h"
 
 void mbed_assert_internal(const char *expr, const char *file, int line)
 {
     core_util_critical_section_enter();
-    mbed_error_printf("mbed assertation failed: %s, file: %s, line %d \n", expr, file, line);
-    mbed_die();
+
+    const char error_description[] = "Mbed assertation failed ";
+    unsigned error_message_length = strlen(error_description) + strlen(expr) + 1;
+    char error_message[error_message_length];
+    snprintf(error_message, error_message_length, "%s%s", error_description, expr);
+
+    mbed_error(MBED_ERROR_INVALID_ARGUMENT, error_message, 0, file, line);
 }

--- a/platform/mbed_assert.c
+++ b/platform/mbed_assert.c
@@ -29,5 +29,5 @@ void mbed_assert_internal(const char *expr, const char *file, int line)
     char error_message[error_message_length];
     snprintf(error_message, error_message_length, "%s%s", error_description, expr);
 
-    mbed_error(MBED_ERROR_INVALID_ARGUMENT, error_message, 0, file, line);
+    mbed_error(MBED_ERROR_ASSERTATION_FAILED, error_message, 0, file, line);
 }

--- a/platform/mbed_assert.c
+++ b/platform/mbed_assert.c
@@ -23,7 +23,6 @@
 void mbed_assert_internal(const char *expr, const char *file, int line)
 {
     core_util_critical_section_enter();
-
     mbed_error(MBED_ERROR_ASSERTION_FAILED, expr, 0, file, line);
 }
 

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -350,7 +350,7 @@ static void print_error_report(mbed_error_ctx *ctx, const char *error_msg)
             break;
 
         case MBED_ERROR_CODE_ASSERTION_FAILED:
-            mbed_error_printf("Assertion failed: ", ctx->error_value);
+            mbed_error_printf("Assertion failed: ");
             break;
 
         default:

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -350,7 +350,7 @@ static void print_error_report(mbed_error_ctx *ctx, const char *error_msg)
             break;
 
         case MBED_ERROR_CODE_ASSERTION_FAILED:
-            mbed_error_printf("Assertion failed, ", ctx->error_value);
+            mbed_error_printf("Assertion failed: ", ctx->error_value);
             break;
 
         default:

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -349,6 +349,10 @@ static void print_error_report(mbed_error_ctx *ctx, const char *error_msg)
             mbed_error_printf("MessageQueue: 0x%X, ", ctx->error_value);
             break;
 
+        case MBED_ERROR_CODE_ASSERTION_FAILED:
+            mbed_error_printf("Assertion failed, ", ctx->error_value);
+            break;
+
         default:
             //Nothing to do here, just print the error info down
             break;

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -780,7 +780,7 @@ typedef enum _mbed_error_code {
     MBED_DEFINE_SYSTEM_ERROR(BLE_NO_FRAME_INITIALIZED, 65),             /* 321      BLE No frame initialized */
     MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_CREATION_FAILED, 66),          /* 322      BLE Backend creation failed */
     MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_NOT_INITIALIZED, 67),          /* 323      BLE Backend not initialized */
-    MBED_DEFINE_SYSTEM_ERROR(ASSERTATION_FAILED, 68),                   /* 324      Assertation Failed */
+    MBED_DEFINE_SYSTEM_ERROR(ASSERTION_FAILED, 68),                     /* 324      Assertion Failed */
     
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -780,7 +780,8 @@ typedef enum _mbed_error_code {
     MBED_DEFINE_SYSTEM_ERROR(BLE_NO_FRAME_INITIALIZED, 65),             /* 321      BLE No frame initialized */
     MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_CREATION_FAILED, 66),          /* 322      BLE Backend creation failed */
     MBED_DEFINE_SYSTEM_ERROR(BLE_BACKEND_NOT_INITIALIZED, 67),          /* 323      BLE Backend not initialized */
-
+    MBED_DEFINE_SYSTEM_ERROR(ASSERTATION_FAILED, 68),                   /* 324      Assertation Failed */
+    
     //Everytime you add a new system error code, you must update
     //Error documentation under Handbook to capture the info on
     //the new error status/codes


### PR DESCRIPTION
### Description
@jamesbeyond @0xc0170 @mprse 
Task: IOTCORE-378
This PR changes behaviour of mbed_assert to use mbed_error, instead of mbed_die that goes around new error reporting mechanism.

The output of following example when flag MBED_CONF_PLATFORM_ERROR_FILENAME_CAPTURE_ENABLED = 1:
``` 
#include "mbed.h"

int main()
{
    MBED_ASSERT(0 > 1);
    return 0;
} 
```
is:

> ++ MbedOS Error Info ++
Error Status: 0x80FF0101 Code: 257 Module: 255
Error Message: Mbed assertation failed 0>1
Location: 0x2081
File:.\main.cpp+6
Error Value: 0x0
Current Thread: Id: 0x20001EAC Entry: 0x2BF7 StackSize: 0x1000 StackMem: 0x20001EF0 SP: 0x20002E18 
For more info, visit: https://armmbed.github.io/mbedos-error/?error=0x80FF0101
-- MbedOS Error Info --

1. I have decided to use error status, : **MBED_ERROR_INVALID_ARGUMENT** and im not really sure if it is correct, please note that.
2. I use mbed_error instead of macros MBED_ERROR or MBED_ERROR1, to get file name and line where assertion failed and not where MBED_ERROR where used. 


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Breaking change

