### PR TITLE
Fix warnings in block devices

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SPIF/SPIFBlockDevice.cpp
@@ -461,7 +461,7 @@ bd_size_t SPIFBlockDevice::get_erase_size(bd_addr_t addr)
 bd_size_t SPIFBlockDevice::size() const
 {
     if (!_is_initialized) {
-        return SPIF_BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _device_size_bytes;

--- a/features/storage/blockdevice/BufferedBlockDevice.cpp
+++ b/features/storage/blockdevice/BufferedBlockDevice.cpp
@@ -251,7 +251,7 @@ bd_size_t BufferedBlockDevice::get_program_size() const
 bd_size_t BufferedBlockDevice::get_erase_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size();
@@ -260,7 +260,7 @@ bd_size_t BufferedBlockDevice::get_erase_size() const
 bd_size_t BufferedBlockDevice::get_erase_size(bd_addr_t addr) const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size(addr);
@@ -278,7 +278,7 @@ int BufferedBlockDevice::get_erase_value() const
 bd_size_t BufferedBlockDevice::size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->size();

--- a/features/storage/blockdevice/ChainingBlockDevice.cpp
+++ b/features/storage/blockdevice/ChainingBlockDevice.cpp
@@ -254,7 +254,7 @@ bd_size_t ChainingBlockDevice::get_erase_size() const
 bd_size_t ChainingBlockDevice::get_erase_size(bd_addr_t addr) const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     bd_addr_t bd_start_addr = 0;

--- a/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
+++ b/features/storage/blockdevice/ExhaustibleBlockDevice.cpp
@@ -142,7 +142,7 @@ int ExhaustibleBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 bd_size_t ExhaustibleBlockDevice::get_read_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_read_size();
@@ -151,7 +151,7 @@ bd_size_t ExhaustibleBlockDevice::get_read_size() const
 bd_size_t ExhaustibleBlockDevice::get_program_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_program_size();
@@ -160,7 +160,7 @@ bd_size_t ExhaustibleBlockDevice::get_program_size() const
 bd_size_t ExhaustibleBlockDevice::get_erase_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size();
@@ -169,7 +169,7 @@ bd_size_t ExhaustibleBlockDevice::get_erase_size() const
 bd_size_t ExhaustibleBlockDevice::get_erase_size(bd_addr_t addr) const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size(addr);
@@ -187,7 +187,7 @@ int ExhaustibleBlockDevice::get_erase_value() const
 bd_size_t ExhaustibleBlockDevice::size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->size();

--- a/features/storage/blockdevice/FlashSimBlockDevice.cpp
+++ b/features/storage/blockdevice/FlashSimBlockDevice.cpp
@@ -96,7 +96,7 @@ int FlashSimBlockDevice::sync()
 bd_size_t FlashSimBlockDevice::get_read_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_read_size();
@@ -105,7 +105,7 @@ bd_size_t FlashSimBlockDevice::get_read_size() const
 bd_size_t FlashSimBlockDevice::get_program_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_program_size();
@@ -114,7 +114,7 @@ bd_size_t FlashSimBlockDevice::get_program_size() const
 bd_size_t FlashSimBlockDevice::get_erase_size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size();
@@ -123,7 +123,7 @@ bd_size_t FlashSimBlockDevice::get_erase_size() const
 bd_size_t FlashSimBlockDevice::get_erase_size(bd_addr_t addr) const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->get_erase_size(addr);
@@ -132,7 +132,7 @@ bd_size_t FlashSimBlockDevice::get_erase_size(bd_addr_t addr) const
 bd_size_t FlashSimBlockDevice::size() const
 {
     if (!_is_initialized) {
-        return BD_ERROR_DEVICE_ERROR;
+        return 0;
     }
 
     return _bd->size();


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR intends to fix compilation warnings of in block devices as described in issue #8198 
Affected block devices list:
* SPIFBlockDevice.cpp
* BufferedBlockDevice.cpp
* ChainingBlockDevice.cpp
* ExhaustibleBlockDevice.cpp
* FlashSimBlockDevice.cpp

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

