### PR TITLE
tests-mbed_hal-sleep: finish UART transmission before sleep test

### DIFF
--- a/TESTS/mbed_hal/sleep/main.cpp
+++ b/TESTS/mbed_hal/sleep/main.cpp
@@ -47,6 +47,8 @@
 
 using namespace utest::v1;
 
+static char info[512] = {0};
+
 /* The following ticker frequencies are possible:
  * high frequency ticker: 250 KHz (1 tick per 4 us) - 8 Mhz (1 tick per 1/8 us)
  * low power ticker: 8 KHz (1 tick per 125 us) - 64 KHz (1 tick per ~15.6 us)
@@ -152,7 +154,8 @@ void sleep_usticker_test()
     /* Testing wake-up time 10 us. */
     for (timestamp_t i = 100; i < 1000; i += 100) {
         /* note: us_ticker_read() operates on ticks. */
-        const timestamp_t next_match_timestamp = overflow_protect(us_ticker_read() + us_to_ticks(i, ticker_freq),
+        const timestamp_t start_timestamp = us_ticker_read();
+        const timestamp_t next_match_timestamp = overflow_protect(start_timestamp + us_to_ticks(i, ticker_freq),
                                                                   ticker_width);
 
         us_ticker_set_interrupt(next_match_timestamp);
@@ -161,9 +164,11 @@ void sleep_usticker_test()
 
         const unsigned int wakeup_timestamp = us_ticker_read();
 
-        TEST_ASSERT(
-            compare_timestamps(us_to_ticks(sleep_mode_delta_us, ticker_freq), ticker_width, next_match_timestamp,
-                               wakeup_timestamp));
+        sprintf(info, "Delta ticks: %u, Ticker width: %u, Expected wake up tick: %d, Actual wake up tick: %d, delay ticks: %d, wake up after ticks: %d",
+                us_to_ticks(sleep_mode_delta_us, ticker_freq), ticker_width, next_match_timestamp, wakeup_timestamp, us_to_ticks(i, ticker_freq) , wakeup_timestamp - start_timestamp);
+
+        TEST_ASSERT_MESSAGE(compare_timestamps(us_to_ticks(sleep_mode_delta_us, ticker_freq),
+                            ticker_width, next_match_timestamp, wakeup_timestamp), info);
     }
 
     set_us_ticker_irq_handler(us_ticker_irq_handler_org);
@@ -194,7 +199,8 @@ void deepsleep_lpticker_test()
     /* Testing wake-up time 10 ms. */
     for (timestamp_t i = 20000; i < 200000; i += 20000) {
         /* note: lp_ticker_read() operates on ticks. */
-        const timestamp_t next_match_timestamp = overflow_protect(lp_ticker_read() + us_to_ticks(i, ticker_freq), ticker_width);
+        const timestamp_t start_timestamp = lp_ticker_read();
+        const timestamp_t next_match_timestamp = overflow_protect(start_timestamp + us_to_ticks(i, ticker_freq), ticker_width);
 
         lp_ticker_set_interrupt(next_match_timestamp);
 
@@ -202,7 +208,11 @@ void deepsleep_lpticker_test()
 
         const timestamp_t wakeup_timestamp = lp_ticker_read();
 
-        TEST_ASSERT(compare_timestamps(us_to_ticks(deepsleep_mode_delta_us, ticker_freq), ticker_width, next_match_timestamp, wakeup_timestamp));
+        sprintf(info, "Delta ticks: %u, Ticker width: %u, Expected wake up tick: %d, Actual wake up tick: %d, delay ticks: %d, wake up after ticks: %d",
+                us_to_ticks(deepsleep_mode_delta_us, ticker_freq), ticker_width, next_match_timestamp, wakeup_timestamp, us_to_ticks(i, ticker_freq) ,  wakeup_timestamp - start_timestamp);
+
+        TEST_ASSERT_MESSAGE(compare_timestamps(us_to_ticks(deepsleep_mode_delta_us, ticker_freq), ticker_width,
+                            next_match_timestamp, wakeup_timestamp), info);
     }
 
     set_lp_ticker_irq_handler(lp_ticker_irq_handler_org);
@@ -245,8 +255,12 @@ void deepsleep_high_speed_clocks_turned_off_test()
 
     TEST_ASSERT_UINT32_WITHIN(1000, 0, ticks_to_us(us_ticks_diff, us_ticker_freq));
 
+    sprintf(info, "Delta ticks: %u, Ticker width: %u, Expected wake up tick: %d, Actual wake up tick: %d",
+            us_to_ticks(deepsleep_mode_delta_us, lp_ticker_freq), lp_ticker_width, wakeup_time, lp_ticks_after_sleep);
+
     /* Check if we have woken-up after expected time. */
-    TEST_ASSERT(compare_timestamps(us_to_ticks(deepsleep_mode_delta_us, lp_ticker_freq), lp_ticker_width, wakeup_time, lp_ticks_after_sleep));
+    TEST_ASSERT_MESSAGE(compare_timestamps(us_to_ticks(deepsleep_mode_delta_us, lp_ticker_freq), lp_ticker_width,
+                        wakeup_time, lp_ticks_after_sleep), info);
 }
 
 #endif

--- a/TESTS/mbed_hal/sleep/main.cpp
+++ b/TESTS/mbed_hal/sleep/main.cpp
@@ -140,6 +140,11 @@ void sleep_usticker_test()
 
     const ticker_irq_handler_type us_ticker_irq_handler_org = set_us_ticker_irq_handler(us_ticker_isr);
 
+    /* Give some time Green Tea to finish UART transmission before entering
+     * sleep mode.
+     */
+    busy_wait_ms(SERIAL_FLUSH_TIME_MS);
+
     /* Test only sleep functionality. */
     sleep_manager_lock_deep_sleep();
     TEST_ASSERT_FALSE_MESSAGE(sleep_manager_can_deep_sleep(), "deep sleep should be locked");


### PR DESCRIPTION
### Description

There is no problem with this test during the morph, but some issue has been noticed while testing new Jenkins CI in Oulu on NRF52_DK.
I was able to reproduce the issue locally. The difference between morph and local run is that CPU statistics are enabled on morph. This makes the difference and test passes.

The sleep test case perform sleep for 100 us, 200 us, ... ,1000 us in loop (us ticker wakes the board) and verifies if sleep time matches the assumption.
I got the following results in case of failure:
```
sleep                 wake-up after
100 us                   ~100 us    ok
200 us                   ~200 us    ok
300 us                   ~300 us    ok
400 us                   ~400 us    ok
500 us                   ~14 us     (??)
```
When requested sleep time is equal to `500 us` some unexpected interrupt occurs which wake-up the board and force the test to fail.
Register state just after exit from sleep:
`Control and State Register: 0x00400000 (ISRPENDING - Interrupt pending flag is set).`
`NVIC Interrupt Set-pending Register[0]: 0x00000004 (UARTE0_UART0_IRQn) or 0x00000200 (TIMER1_IRQn - timer used by us ticker).`

UART interrupt is generated because of green-tea transmission. We know that it is performed while test is executed since we need to wait before going into deep-sleep because otherwise the transmission will be broken. So to take care of UART interrupt we need to wait before sleep test in the same way like it is done in deep-sleep test.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

@jamesbeyond Can you confirm that this patch fixes problem with this test on the new Jenkins CI?