### PR TITLE
Cellular: Fix compile warnings for CellularNetwork

### DIFF
--- a/features/cellular/framework/API/CellularNetwork.h
+++ b/features/cellular/framework/API/CellularNetwork.h
@@ -150,9 +150,9 @@ public:
             op_status = Unknown;
             op_rat = RAT_UNKNOWN;
             next = NULL;
-            op_long[0] = NULL;
-            op_short[0] = NULL;
-            op_num[0] = NULL;
+            op_long[0] = '\0';
+            op_short[0] = '\0';
+            op_num[0] = '\0';
         }
     };
 


### PR DESCRIPTION
### Description
    Fix for compile warnings at initialisation of operator_t's char arrays.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

