### PR TITLE
Enabled the removal of a trailing slash

### DIFF
--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -203,7 +203,7 @@ def deploy_repos(config, examples):
     print("\nDeploying example repos....\n")
     for example in config['examples']:
         for repo_info in get_repo_list(example):
-            name = basename(repo_info['repo'])
+            name = basename(repo_info['repo'].strip('/'))
             if name in examples:
                 if os.path.exists(name):
                     os.chdir(name)


### PR DESCRIPTION
### Description

Discovered when debugging https://github.com/ARMmbed/mbed-os/pull/8246. Using `basename` with a URL that has a trailing slash leads to an empty string.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

