### PR TITLE
Align MBRBlockDevice writes to underlying BlockDevice write size

### DIFF
--- a/features/storage/blockdevice/MBRBlockDevice.cpp
+++ b/features/storage/blockdevice/MBRBlockDevice.cpp
@@ -73,6 +73,12 @@ static int partition_absolute(
 {
     // Allocate smallest buffer necessary to write MBR
     uint32_t buffer_size = std::max<uint32_t>(bd->get_program_size(), sizeof(struct mbr_table));
+
+    // Prevent alignment issues
+    if(buffer_size % bd->get_program_size() != 0) {
+        buffer_size += bd->get_program_size() - (buffer_size % bd->get_program_size());
+    }
+
     uint8_t *buffer = new uint8_t[buffer_size];
 
     // Check for existing MBR


### PR DESCRIPTION
### Description

When writing MBR the write buffer was allocated such that it would not align with BlockDevice write size resulting in failure of the write operation. 

It would happen here:
err = bd->program(buffer, 512-buffer_size, buffer_size);

Now the buffer_size is calculated so that the writes will be properly aligned.

Tested with STM32L486 using internal flash as storage. Without fix it is not possible to initialise partition in the internal flash.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

