### PR TITLE
STM32L4: clear error programming flags before erase & program operations

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
@@ -140,8 +140,6 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
     /* Clear error programming flags */
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 
-    /* Clear OPTVERR bit set on virgin samples */
-    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPTVERR);
     /* Get the 1st page to erase */
     FirstPage = GetPage(address);
     /* MBED HAL erases 1 page  / sector at a time */

--- a/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
@@ -137,6 +137,9 @@ int32_t flash_erase_sector(flash_t *obj, uint32_t address)
         return -1;
     }
 
+    /* Clear error programming flags */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
+
     /* Clear OPTVERR bit set on virgin samples */
     __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_OPTVERR);
     /* Get the 1st page to erase */
@@ -193,6 +196,9 @@ int32_t flash_program_page(flash_t *obj, uint32_t address,
     if (flash_unlock() != HAL_OK) {
         return -1;
     }
+
+    /* Clear error programming flags */
+    __HAL_FLASH_CLEAR_FLAG(FLASH_FLAG_ALL_ERRORS);
 
     /* Program the user Flash area word by word */
     StartAddress = address;


### PR DESCRIPTION
### Description

On STM32L486 when using dual bank operation where the program code was in bank 0 and BlockDevice in bank1 the erase and program operations would fail with Flash_error: 32. 

From the reference manual: Bit 7 PGSERR: Programming sequence error Set by hardware when a write access to the Flash memory is performed by the code while PG or FSTPG have not been set previously. Set also by hardware when PROGERR, SIZERR, PGAERR, MISSERR or FASTERR is set due to a previous programming error. Cleared by writing 1.

The suggested write sequence can be found from reference: en.DM00083560.pdf 3.3.7 Flash main memory programming sequences - 2. Check and clear all error programming flags due to a previous programming.

The code change performs just that, clears the flags as per instructions. With the change it is possible to use bank 0 for running the program code while writing data to bank 1. I have tested this change on STM32L486 where OTA FW image was loaded to bank 1 and successfully updated from therein to bank 0.

Further reference: MBEDOSTEST-206

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

