### PR TITLE
Tools: Ensure vtor reserved bits are all 0

### DIFF
--- a/tools/config/__init__.py
+++ b/tools/config/__init__.py
@@ -684,7 +684,7 @@ class Config(object):
         size = self._header_size(header_format)
         region = Region("header", start, size, False, None)
         start += size
-        start = ((start + 7) // 8) * 8
+        start = ((start + (2**7 - 1)) // (2**7)) * (2**7)
         return (start, region)
 
     @staticmethod


### PR DESCRIPTION
### Description

The VTOR reserves the lowest 7 bits. This PR changes the round up
behavoir of the application offset to make sure that the address used 
for the in-flash vector table always ends in 7 0's.

Fixes #7392

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change