### PR TITLE
Tools, memap: Silence warnings that we handled correctly

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -142,7 +142,10 @@ class _GccParser(_Parser):
                 return join('[lib]', test_re_obj_name.group(2),
                             test_re_obj_name.group(3))
             else:
-                print("Unknown object name found in GCC map file: %s" % line)
+                if (not line.startswith("LONG") and
+                    not line.startswith("linker stubs")):
+                    print("Unknown object name found in GCC map file: %s"
+                          % line)
                 return '[misc]'
 
     def parse_section(self, line):


### PR DESCRIPTION
### Description

Memap will create a bunch of warnings about "Unknown object name" when
parsing a map file created for the RZ_A1H and the GR_Peach. Theses 
warnings are sperious; the information in these sections does not belong
to an object file. This PR silences these warnings.

Fixes #6258

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change