### PR TITLE
MCUXpresso: Ensure the RTC OSC is running at bootup on Kinetis platforms

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/TARGET_FRDM/mbed_overrides.c
@@ -17,12 +17,37 @@
 
 #define CRC16
 #include "crc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -32,13 +57,6 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -55,7 +73,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
+    MAC[1] = crcSlow((const uint8_t *)UID, 12);
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_FRDM/mbed_overrides.c
@@ -14,12 +14,37 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -29,13 +54,6 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Set the UART clock source

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K82F/TARGET_UBRIDGE/mbed_overrides.c
@@ -17,13 +17,18 @@
 #include "fsl_smc.h"
 #include "fsl_rcm.h"
 #include "fsl_pmc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 //!< this contains the wakeup source
 rcm_reset_source_t kinetisResetSource;
 
 // called before main
-void mbed_sdk_init() {
+void mbed_sdk_init()
+{
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
 
     // check the power mode source
@@ -36,6 +41,26 @@ void mbed_sdk_init() {
 
     BOARD_BootClockRUN();
 
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -45,13 +70,6 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Set the UART clock source

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL27Z/TARGET_FRDM/mbed_overrides.c
@@ -15,22 +15,40 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be IRC48M, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(1U);
-}
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL43Z/TARGET_FRDM/mbed_overrides.c
@@ -15,22 +15,40 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be IRC48M, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(1U);
-}
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_FRDM/mbed_overrides.c
@@ -15,20 +15,38 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    BOARD_BootClockRUN();
-}
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KL82Z/TARGET_USENSE/mbed_overrides.c
@@ -17,13 +17,18 @@
 #include "fsl_smc.h"
 #include "fsl_rcm.h"
 #include "fsl_pmc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 //!< this contains the wakeup source
 rcm_reset_source_t kinetisResetSource;
 
 // called before main
-void mbed_sdk_init() {
+void mbed_sdk_init()
+{
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     SMC_SetPowerModeProtection(SMC, kSMC_AllowPowerModeAll);
 
     // check the power mode source
@@ -35,6 +40,27 @@ void mbed_sdk_init() {
     }
 
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -45,15 +71,6 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
-
-#if DEVICE_RTC || DEVICE_LPTICKER
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
-}
-#endif
 
 // Set the UART clock source
 void serial_clock_init(void)

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/TARGET_FRDM/mbed_overrides.c
@@ -14,20 +14,38 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
-    BOARD_BootClockRUN();
-}
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW41Z/TARGET_FRDM/mbed_overrides.c
@@ -14,22 +14,40 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
     /* Set the TPM clock source to be OSCERCLK, do not change as TPM2 is used for the usticker */
     CLOCK_SetTpmClock(2U);
-}
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/TARGET_MCU_K22F512/TARGET_FRDM/mbed_overrides.c
@@ -15,21 +15,39 @@
  */
 #include "gpio_api.h"
 #include "pinmap.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main - implement here if board needs it otherwise, let
 //  the application override this if necessary
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
     pin_function(PTA2, 1);          //By default the GREEN LED is enabled. This disables it
-}
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -40,3 +58,4 @@ void NMI_Handler(void)
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
 }
+

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_RO359B/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/TARGET_MCU_K24F1M/TARGET_RO359B/mbed_overrides.c
@@ -17,12 +17,37 @@
 
 #define CRC16
 #include "crc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -32,12 +57,5 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_FRDM/mbed_overrides.c
@@ -17,12 +17,37 @@
 
 #define CRC16
 #include "crc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -32,13 +57,6 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -55,7 +73,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
+    MAC[1] = crcSlow((const uint8_t *)UID, 12);
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_HEXIWEAR/mbed_overrides.c
@@ -14,19 +14,36 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
-
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
-    BOARD_BootClockRUN();
-}
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
+    BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_MTS_GAMBIT/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_MTS_GAMBIT/mbed_overrides.c
@@ -14,16 +14,36 @@
  * limitations under the License.
  */
 #include "gpio_api.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
+
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
-}

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/mbed_overrides.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K64F/TARGET_SDT64B/mbed_overrides.c
@@ -17,12 +17,37 @@
 
 #define CRC16
 #include "crc.h"
+#include "fsl_rtc.h"
 #include "fsl_clock_config.h"
 
 // called before main
 void mbed_sdk_init()
 {
+    rtc_config_t rtc_basic_config;
+    uint32_t u32cTPR_counter = 0;
+
     BOARD_BootClockRUN();
+
+    CLOCK_EnableClock(kCLOCK_Rtc0);
+
+    /* Check if the Rtc oscillator is enabled */
+    if ((RTC->CR & RTC_CR_OSCE_MASK) == 0u) {
+        /* Setup the 32K RTC OSC */
+        RTC_Init(RTC, &rtc_basic_config);
+
+        /* Enable the RTC 32KHz oscillator */
+        RTC->CR |= RTC_CR_OSCE_MASK;
+
+        /* Start the RTC time counter */
+        RTC_StartTimer(RTC);
+
+        /* Verify TPR register reaches 4096 counts */
+        while (u32cTPR_counter < 4096) {
+            u32cTPR_counter = RTC->TPR;
+        }
+        /* 32kHz Oscillator is ready. */
+        RTC_Deinit(RTC);
+    }
 }
 
 // Change the NMI pin to an input. This allows NMI pin to
@@ -32,13 +57,6 @@ void NMI_Handler(void)
 {
     gpio_t gpio;
     gpio_init_in(&gpio, PTA4);
-}
-
-// Enable the RTC oscillator if available on the board
-void rtc_setup_oscillator(RTC_Type *base)
-{
-    /* Enable the RTC oscillator */
-    RTC->CR |= RTC_CR_OSCE_MASK;
 }
 
 // Provide ethernet devices with a semi-unique MAC address from the UUID
@@ -55,7 +73,7 @@ void mbed_mac_address(char *mac)
 
     // generate three CRC16's using different slices of the UUID
     MAC[0] = crcSlow((const uint8_t *)UID, 8);  // most significant half-word
-    MAC[1] = crcSlow((const uint8_t *)UID, 12); 
+    MAC[1] = crcSlow((const uint8_t *)UID, 12);
     MAC[2] = crcSlow((const uint8_t *)UID, 16); // least significant half word
 
     // The network stack expects an array of 6 bytes
@@ -75,6 +93,4 @@ void mbed_mac_address(char *mac)
     mac[0] &= 0xFE; // force bit 0 to a "0" = Unicast
 
 }
-
-
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/lp_ticker.c
@@ -33,8 +33,6 @@ const ticker_info_t* lp_ticker_get_info()
 
 static bool lp_ticker_inited = false;
 
-extern void rtc_setup_oscillator(RTC_Type *base);
-
 static void lptmr_isr(void)
 {
     LPTMR_ClearStatusFlags(LPTMR0, kLPTMR_TimerCompareFlag);
@@ -52,9 +50,6 @@ void lp_ticker_init(void)
         /* Setup high resolution clock - LPTMR */
         LPTMR_GetDefaultConfig(&lptmrConfig);
 
-        /* Setup the RTC 32KHz oscillator */
-        CLOCK_EnableClock(kCLOCK_Rtc0);
-        rtc_setup_oscillator(RTC);
         /* Use 32kHz drive */
         CLOCK_SetXtal32Freq(OSC32K_CLK_HZ);
 

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/rtc_api.c
@@ -21,8 +21,6 @@
 #include "fsl_rtc.h"
 #include "PeripheralPins.h"
 
-extern void rtc_setup_oscillator(RTC_Type *base);
-
 static bool rtc_time_set = false;
 
 void rtc_init(void)
@@ -32,8 +30,6 @@ void rtc_init(void)
     RTC_GetDefaultConfig(&rtcConfig);
     RTC_Init(RTC, &rtcConfig);
 
-    /* Setup the RTC 32KHz oscillator */
-    rtc_setup_oscillator(RTC);
     RTC_StartTimer(RTC);
 }
 


### PR DESCRIPTION
### Description
This is a fix for Issue https://github.com/ARMmbed/mbed-os/issues/5348. The RTC 32K oscillator is used by the LPTicker, this change ensures that the oscillator is running before we start using it.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

