### PR TITLE
Update mbed-coap to version 4.7.0

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## [v4.7.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.0) 
+
+- Add function that can be used to clear the received blockwise payloads for example in the case of a connection error.
+- Silence compiler warning when CoAP duplicate detection is enabled.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.6.3...v4.7.0)
+
 ## [v4.6.3](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.6.3) 
 
  - Bug fix: Remove timed out blockwise message from resend queue. If blockwise message was timed out message was still kept in the resend queue which causes unnecessary reconnections on client side.

--- a/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
+++ b/features/frameworks/mbed-coap/mbed-coap/sn_coap_protocol.h
@@ -269,6 +269,15 @@ extern int8_t sn_coap_protocol_handle_block2_response_internally(struct coap_s *
 extern void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle);
 
 /**
+ * \fn void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle)
+ *
+ * \brief This function clears all the received blockwise messages from the linked list.
+ *
+ * \param *handle Pointer to CoAP library handle
+ */
+extern void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle);
+
+/**
  * \fn void sn_coap_protocol_send_rst(struct coap_s *handle, uint16_t msg_id, sn_nsdl_addr_s *addr_ptr, void *param)
  *
  * \brief This function sends a RESET message.

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.6.3",
+  "version": "4.7.0",
   "description": "COAP library",
   "keywords": [
     "coap",

--- a/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
+++ b/features/frameworks/mbed-coap/source/include/sn_coap_protocol_internal.h
@@ -81,19 +81,16 @@ struct sn_coap_hdr_;
 
 /* Init value for the maximum count of messages to be stored for duplication detection          */
 /* Setting of this value to 0 will disable duplication check, also reduce use of ROM memory     */
-
-// Keep the old flag to maintain backward compatibility
-#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
-#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
-#endif
-
 #ifdef YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
 #define SN_COAP_DUPLICATION_MAX_MSGS_COUNT YOTTA_CFG_COAP_DUPLICATION_MAX_MSGS_COUNT
 #elif defined MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 #define SN_COAP_DUPLICATION_MAX_MSGS_COUNT MBED_CONF_MBED_CLIENT_SN_COAP_DUPLICATION_MAX_MSGS_COUNT
 #endif
 
-
+// Keep the old flag to maintain backward compatibility
+#ifndef SN_COAP_DUPLICATION_MAX_MSGS_COUNT
+#define SN_COAP_DUPLICATION_MAX_MSGS_COUNT              0
+#endif
 
 /* Maximum allowed number of saved messages for duplicate searching */
 #define SN_COAP_MAX_ALLOWED_DUPLICATION_MESSAGE_COUNT   6

--- a/features/frameworks/mbed-coap/source/sn_coap_protocol.c
+++ b/features/frameworks/mbed-coap/source/sn_coap_protocol.c
@@ -257,6 +257,21 @@ void sn_coap_protocol_clear_sent_blockwise_messages(struct coap_s *handle)
 #endif
 }
 
+void sn_coap_protocol_clear_received_blockwise_messages(struct coap_s *handle)
+{
+    (void) handle;
+#if SN_COAP_BLOCKWISE_ENABLED || SN_COAP_MAX_BLOCKWISE_PAYLOAD_SIZE
+    if (handle == NULL) {
+        return;
+    }
+
+    /* Loop all stored Blockwise messages in Linked list */
+    ns_list_foreach_safe(coap_blockwise_payload_s, removed_blockwise_payload_ptr, &handle->linked_list_blockwise_received_payloads) {
+        sn_coap_protocol_linked_list_blockwise_payload_remove(handle, removed_blockwise_payload_ptr);
+    }
+#endif
+}
+
 int8_t sn_coap_protocol_set_duplicate_buffer_size(struct coap_s *handle, uint8_t message_count)
 {
     (void) handle;


### PR DESCRIPTION
### Description

- Add function that can be used to clear the received blockwise payloads for example in the case of a connection error.
- Silence compiler warning when CoAP duplicate detection is enabled.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

