### PR TITLE
Export, nb: Use same path for cpp as the rest of the tools

### DIFF
--- a/tools/export/nb/__init__.py
+++ b/tools/export/nb/__init__.py
@@ -177,9 +177,6 @@ class GNUARMNetbeans(Exporter):
 
         sys_libs = [self.prepare_sys_lib(lib) for lib
                     in self.toolchain.sys_libs]
-        preproc = " ".join([basename(self.toolchain.preproc[0])] +
-                           self.toolchain.preproc[1:] +
-                           self.toolchain.ld[1:])
 
         if 'nbproject' in include_paths:
             include_paths.remove('nbproject')
@@ -208,7 +205,7 @@ class GNUARMNetbeans(Exporter):
             'cpp_std': self.get_netbeans_cpp_std(cpp_std),
             'linker_script': self.ld_script,
             'linker_libs': sys_libs,
-            'pp_cmd': preproc,
+            'pp_cmd': " ".join(self.toolchain.preproc),
             'cc_cmd': self.toolchain.cc[0],
             'cppc_cmd': self.toolchain.cppc[0],
             'asm_cmd': self.toolchain.asm[0],


### PR DESCRIPTION
### Description

The netbeans exporter was being inconsistant with it's invocation of
the C pre-processor on the linker script: the C pre-processor was always
invoked from `$PATH` where as the rest of the tools were invoked as 
configured by the tools. This changes the invocation of CPP to match the
rest of the tools: heed the conifguration.

Fixes https://github.com/ARMmbed/mbed-cli/issues/663 

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change