### PR TITLE
tools: Make "file" key in notifications consistant

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -420,7 +420,7 @@ class mbedToolchain:
             self.compiled += 1
             self.progress("compile", item['source'].name, build_update=True)
             for res in result['results']:
-                self.notify.cc_verbose("Compile: %s" % ' '.join(res['command']), result['source'])
+                self.notify.cc_verbose("Compile: %s" % ' '.join(res['command']), result['source'].name)
                 self.compile_output([
                     res['code'],
                     res['output'],
@@ -458,7 +458,7 @@ class mbedToolchain:
                         self.compiled += 1
                         self.progress("compile", result['source'].name, build_update=True)
                         for res in result['results']:
-                            self.notify.cc_verbose("Compile: %s" % ' '.join(res['command']), result['source'])
+                            self.notify.cc_verbose("Compile: %s" % ' '.join(res['command']), result['source'].name)
                             self.compile_output([
                                 res['code'],
                                 res['output'],


### PR DESCRIPTION
### Description

2 calls to `notify.cc_verbose` used the a `FileRef` object in place of
the file's name. Other calls to `notify.cc_info` would use just the
file name. This PR changes these 2 calls to be consistant with the rest.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change