### PR TITLE
Fix LowPowerTickerWrapper operation when suspended

### DIFF
--- a/hal/LowPowerTickerWrapper.h
+++ b/hal/LowPowerTickerWrapper.h
@@ -74,6 +74,9 @@ public:
      *
      * This stops to wrapper layer from using the microsecond ticker.
      * This should be called before using the low power ticker APIs directly.
+     *
+     * @warning: Make sure to suspend the LP ticker first (call ticker_suspend()),
+     * otherwise the behavior is undefined.
      */
     void suspend();
 

--- a/hal/mbed_lp_ticker_wrapper.h
+++ b/hal/mbed_lp_ticker_wrapper.h
@@ -53,6 +53,9 @@ const ticker_data_t *get_lp_ticker_wrapper_data(const ticker_data_t *data);
  *
  * Pass through all interrupts to the low power ticker and stop using
  * the microsecond ticker.
+ *
+ * @warning: Make sure to suspend the LP ticker first (call ticker_suspend()),
+ * otherwise the behavior is undefined.
  */
 void lp_ticker_wrapper_suspend(void);
 


### PR DESCRIPTION
### Description
Update the `LowPowerTickerWrapper` class logic to stop using the internal
`Timeout` object for scheduling LP ticker interrupts after the wrapper has
been suspended.

Fixes #8278

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

CC @c1728p9 @mprse @jamesbeyond 
