### PR TITLE
STM32: Only LSE clock should be enabled in STOP mode

### DIFF
--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -536,7 +536,9 @@ HAL_StatusTypeDef init_uart(serial_t *obj)
 #if defined(LPUART1_BASE)
     if (huart->Instance == LPUART1) {
         if (obj_s->baudrate <= 9600) {
+#if ((MBED_CONF_TARGET_LPUART_CLOCK_SOURCE) & USE_LPUART_CLK_LSE)            
             HAL_UARTEx_EnableClockStopMode(huart);
+#endif            
             HAL_UARTEx_EnableStopMode(huart);
         } else {
             HAL_UARTEx_DisableClockStopMode(huart);


### PR DESCRIPTION
Check LPUART clock source before enable it in STOP mode, only LSE could be enabled in STOP mode.

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
It is to fix the extra power consumption in STOP mode. HSI clock would cause extra power consumption if HSI clock is enabled in STOP mode. Only LSE clock could be enabled in STOP mode.

Fix #8264

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

