### PR TITLE
Reset channel settings back to default

### DIFF
--- a/TESTS/network/wifi/wifi_set_channel.cpp
+++ b/TESTS/network/wifi/wifi_set_channel.cpp
@@ -69,5 +69,6 @@ void wifi_set_channel(void)
         TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
     }
 
+    wifi->set_channel(0);
 }
 


### PR DESCRIPTION
### Description

Reset channel settings back to default after changing channels in WiFi test.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

