### PR TITLE
Making cancel_sending() API robust

### DIFF
--- a/features/lorawan/LoRaWANBase.h
+++ b/features/lorawan/LoRaWANBase.h
@@ -493,6 +493,7 @@ public:
      *                      other negative error code if request failed:
      *                      LORAWAN_STATUS_NOT_INITIALIZED if system is not initialized with initialize(),
      *                      LORAWAN_STATUS_BUSY if the send cannot be canceled
+     *                      LORAWAN_STATUS_NO_OP if the operation cannot be completed (nothing to cancel)
      */
     virtual lorawan_status_t cancel_sending(void) = 0;
 };

--- a/features/lorawan/lorastack/mac/LoRaMac.h
+++ b/features/lorawan/lorastack/mac/LoRaMac.h
@@ -669,6 +669,8 @@ private:
 
     bool _is_nwk_joined;
 
+    bool _can_cancel_tx;
+
     bool _continuous_rx2_window_open;
 
     device_class_t _device_class;

--- a/features/lorawan/lorawan_types.h
+++ b/features/lorawan/lorawan_types.h
@@ -98,13 +98,9 @@ typedef enum lorawan_status {
     LORAWAN_STATUS_CRYPTO_FAIL = -1014,            /**< Service not started - crypto failure */
     LORAWAN_STATUS_PORT_INVALID = -1015,           /**< Invalid port */
     LORAWAN_STATUS_CONNECT_IN_PROGRESS = -1016,    /**< Services started - Connection in progress */
-    LORAWAN_STATUS_NO_ACTIVE_SESSIONS = -1017,            /**< Services not started - No active session */
+    LORAWAN_STATUS_NO_ACTIVE_SESSIONS = -1017,     /**< Services not started - No active session */
     LORAWAN_STATUS_IDLE = -1018,                   /**< Services started - Idle at the moment */
-#if defined(LORAWAN_COMPLIANCE_TEST)
-    //Deprecated - will replace the code -1019 with something
-    //else in future.
-    LORAWAN_STATUS_COMPLIANCE_TEST_ON = -1019,     /**< Compliance test - is on-going */
-#endif
+    LORAWAN_STATUS_NO_OP = -1019,                  /**< Cannot perform requested operation */
     LORAWAN_STATUS_DUTYCYCLE_RESTRICTED = -1020,   /**< Transmission will continue after duty cycle backoff*/
     LORAWAN_STATUS_NO_CHANNEL_FOUND = -1021,       /**< None of the channels is enabled at the moment*/
     LORAWAN_STATUS_NO_FREE_CHANNEL_FOUND = -1022,  /**< None of the enabled channels is ready for another TX (duty cycle limited)*/


### PR DESCRIPTION


### Description
If the packet is already handed over to the PHY layer, we shouldn't be
able to cancel that particular transmission. In addition to that if the
backoff timer is either not applied or has been deactivated, should end
up in no-op rather than having normal termination. A new error code has
been introduced to cover no-op cases. This error code replaces the
compliance test related error code which is no longer relevant.
clear_tx_pipe() does nothing if:
	- The stack cannot cancel TX (already handed over to PHY)
        - The backoff timer is not active at all
        - The event is disaptched to schedule

stop_sending() will only post process ongoing TX if the pipe was
definitely cleared.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

