### PR TITLE
Use wait_ms(int) instead of wait(float)

### DIFF
--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/ota_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/ota_api.c
@@ -167,7 +167,7 @@ uint32_t OTA_ReadImage(uint32_t base, uint32_t offset, uint32_t len, uint8_t *da
 void OTA_ResetTarget(void)
 {
     __RTK_CTRL_WRITE32(0x14, 0x00000021);
-    wait(1);
+    wait_ms(1000);
 
     NVIC_SystemReset();
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -1,5 +1,5 @@
 /* ODIN-W2 implementation of WiFiInterface
- * Copyright (c) 2016 u-blox Malmö AB
+ * Copyright (c) 2016 u-blox MalmÃ¶ AB
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -937,7 +937,7 @@ void OdinWiFiInterface::handle_user_scan(user_scan_s *user_scan)
     cbRTSL_Status status = cbSTATUS_ERROR;
     for(int i = 0; (i < 10) && (status != cbSTATUS_OK); i++) {
         if(i > 0) {
-            wait(0.5);
+            wait_ms(500);
         }
 
         cbMAIN_driverLock();


### PR DESCRIPTION
Small space savings, the casting from int to float will bloat
the code a bit. Using wait(1.0f) for example would avoid it,
but seems a bit silly to use floats for anything unless
really needed (in embedded products).

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

