### PR TITLE
Tools: Use logical paths in ignored_dirs

### DIFF
--- a/tools/export/gnuarmeclipse/__init__.py
+++ b/tools/export/gnuarmeclipse/__init__.py
@@ -361,9 +361,6 @@ class GNUARMEclipse(Exporter):
         - recurse the tree and collect all unused folders; descend
         the hierarchy only for used nodes
         """
-        source_folders = [self.filter_dot(s) for s in set(dirname(
-            src) for src in self.resources.c_sources + self.resources.cpp_sources + self.resources.s_sources)]
-
         self.excluded_folders = set(self.resources.ignored_dirs) - set(self.resources.inc_dirs)
 
 

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -380,7 +380,7 @@ class Resources(object):
         if into_path is None:
             into_path = path
         if self._collect_ignores and relpath(path, base_path) in self.ignored_dirs:
-            self.ignored_dirs.remove(path)
+            self.ignored_dirs.remove(relpath(path, base_path))
         if exclude_paths:
             self.add_ignore_patterns(
                 path, base_path, [join(e, "*") for e in exclude_paths])

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -379,7 +379,7 @@ class Resources(object):
             base_path = path
         if into_path is None:
             into_path = path
-        if self._collect_ignores and path in self.ignored_dirs:
+        if self._collect_ignores and relpath(path, base_path) in self.ignored_dirs:
             self.ignored_dirs.remove(path)
         if exclude_paths:
             self.add_ignore_patterns(
@@ -407,11 +407,11 @@ class Resources(object):
                 if (any(self._not_current_label(d, t) for t
                         in self._labels.keys())):
                     self._label_paths.append((dir_path, base_path, into_path))
-                    self.ignore_dir(dir_path)
+                    self.ignore_dir(relpath(dir_path, base_path))
                     dirs.remove(d)
                 elif (d.startswith('.') or d in self._legacy_ignore_dirs or
                       self._ignoreset.is_ignored(join(root_path, d, ""))):
-                    self.ignore_dir(dir_path)
+                    self.ignore_dir(relpath(dir_path, base_path))
                     dirs.remove(d)
 
             # Add root to include paths

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -392,7 +392,7 @@ class Resources(object):
                 self._ignoreset.add_mbedignore(
                     real_base, join(root, IGNORE_FILENAME))
 
-            root_path =join(relpath(root, base_path))
+            root_path = join(relpath(root, base_path))
             if self._ignoreset.is_ignored(join(root_path,"")):
                 self.ignore_dir(root_path)
                 dirs[:] = []


### PR DESCRIPTION
### Description

Exporting to GNU ARM Eclipse, E2 Studio, and other exclude-based IDEs
currently generats unusable project files online. This is because the
list of directories ignored in the scan is inconsistant about what sort
of paths are used: logical paths, or phisical paths. This patch makes
all paths in ignored_dirs logical. This should fix the excluding tags
in these project files.

Resolves #7155
Tested on partnerbeta.
Includes minor formatting fixes that I found at the time as seperate
commits.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change