### PR TITLE
Remove GCC_CR

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -72,7 +72,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11XX_11CXX", "LPC11XX"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -131,7 +131,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -143,7 +143,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
         "release_versions": ["2"],
@@ -155,7 +155,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
         "device_name": "LPC11U35FHI33/501"
@@ -169,7 +169,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
         "device_name": "LPC11U35FHI33/501"
@@ -180,7 +180,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "default_lib": "small",
         "device_name": "LPC11U37FBD64/501"
     },
@@ -195,7 +195,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX", "LPC11U37_501"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "inherits": ["LPCTarget"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
@@ -207,7 +207,7 @@
         "core": "Cortex-M0+",
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11U6X"],
-        "supported_toolchains": ["ARM", "uARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "inherits": ["LPCTarget"],
         "detect_code": ["1168"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI"],
@@ -229,7 +229,7 @@
         "core": "Cortex-M3",
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC15XX"],
-        "supported_toolchains": ["uARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["uARM", "GCC_ARM", "IAR"],
         "inherits": ["LPCTarget"],
         "detect_code": ["1549"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "INTERRUPTIN", "PWMOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE"],
@@ -241,7 +241,7 @@
         "inherits": ["LPCTarget"],
         "core": "Cortex-M3",
         "extra_labels": ["NXP", "LPC176X", "MBED_LPC1768", "NXP_EMAC"],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "detect_code": ["1010"],
         "device_has": ["RTC", "USTICKER", "ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "EMAC", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
@@ -258,7 +258,7 @@
     "ARCH_PRO": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M3",
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["NXP", "LPC176X", "NXP_EMAC"],
         "macros": ["TARGET_LPC1768"],
         "inherits": ["LPCTarget"],
@@ -273,7 +273,7 @@
     "UBLOX_C027": {
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M3",
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["NXP", "LPC176X", "NXP_EMAC"],
         "config": {
             "modem_is_on_board": {
@@ -300,7 +300,7 @@
     "XBED_LPC1768": {
         "inherits": ["LPCTarget"],
         "core": "Cortex-M3",
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["NXP", "LPC176X", "XBED_LPC1768"],
         "macros": ["TARGET_LPC1768"],
         "detect_code": ["1010"],
@@ -338,7 +338,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC82X"],
         "is_disk_virtual": true,
-        "supported_toolchains": ["uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["uARM", "GCC_ARM", "IAR"],
         "inherits": ["LPCTarget"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",
@@ -361,7 +361,7 @@
         "core": "Cortex-M4F",
         "extra_labels": ["NXP", "LPC408X", "NXP_EMAC"],
         "is_disk_virtual": true,
-        "supported_toolchains": ["ARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "post_binary_hook": {
             "function": "LPC4088Code.binary_hook"
         },
@@ -383,7 +383,7 @@
         "inherits": ["LPCTarget"],
         "core": "Cortex-M4F",
         "extra_labels": ["NXP", "LPC43XX", "LPC4330"],
-        "supported_toolchains": ["ARM", "GCC_CR", "IAR", "GCC_ARM"],
+        "supported_toolchains": ["ARM", "IAR", "GCC_ARM"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "device_name": "LPC4330"
     },
@@ -391,7 +391,7 @@
         "inherits": ["LPCTarget"],
         "core": "Cortex-M0",
         "extra_labels": ["NXP", "LPC43XX", "LPC4330"],
-        "supported_toolchains": ["ARM", "GCC_CR", "IAR"],
+        "supported_toolchains": ["ARM", "IAR"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "DEBUG_AWARENESS", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
     },
     "LPC4337": {
@@ -408,7 +408,7 @@
         "core": "Cortex-M3",
         "extra_labels": ["NXP", "LPC43XX"],
         "public": false,
-        "supported_toolchains": ["ARM", "GCC_CR", "IAR"]
+        "supported_toolchains": ["ARM", "IAR"]
     },
     "LPC11U37H_401": {
         "supported_form_factors": ["ARDUINO"],
@@ -416,7 +416,7 @@
         "default_toolchain": "uARM",
         "extra_labels": ["NXP", "LPC11UXX"],
         "macros": ["CMSIS_VECTAB_VIRTUAL", "CMSIS_VECTAB_VIRTUAL_HEADER_FILE=\"cmsis_nvic.h\""],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "inherits": ["LPCTarget"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_lib": "small",

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -292,7 +292,7 @@ def prepare_toolchain(src_paths, build_dir, target, toolchain_name,
     Positional arguments:
     src_paths - the paths to source directories
     target - ['LPC1768', 'LPC11U24', etc.]
-    toolchain_name - ['ARM', 'uARM', 'GCC_ARM', 'GCC_CR']
+    toolchain_name - ['ARM', 'uARM', 'GCC_ARM', 'IAR']
 
     Keyword arguments:
     macros - additional macros

--- a/tools/default_settings.py
+++ b/tools/default_settings.py
@@ -30,9 +30,6 @@ from os.path import join, abspath, dirname
 # GCC ARM
 #GCC_ARM_PATH = ""
 
-# GCC CodeRed
-#GCC_CR_PATH = "C:/code_red/RedSuite_4.2.0_349/redsuite/Tools/bin"
-
 # IAR
 #IAR_PATH = "C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0/arm"
 

--- a/tools/memap.py
+++ b/tools/memap.py
@@ -764,7 +764,7 @@ class MemapParser(object):
 
         return output
 
-    toolchains = ["ARM", "ARM_STD", "ARM_MICRO", "GCC_ARM", "GCC_CR", "IAR"]
+    toolchains = ["ARM", "ARM_STD", "ARM_MICRO", "GCC_ARM", "IAR"]
 
     def compute_report(self):
         """ Generates summary of memory usage for main areas
@@ -814,7 +814,7 @@ class MemapParser(object):
         self.tc_name = toolchain.title()
         if toolchain in ("ARM", "ARM_STD", "ARM_MICRO", "ARMC6"):
             parser = _ArmccParser
-        elif toolchain == "GCC_ARM" or toolchain == "GCC_CR":
+        elif toolchain == "GCC_ARM":
             parser = _GccParser
         elif toolchain == "IAR":
             parser = _IarParser

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -36,9 +36,6 @@ ARMC6_PATH = ""
 # GCC ARM
 GCC_ARM_PATH = ""
 
-# GCC CodeRed
-GCC_CR_PATH = ""
-
 # IAR
 IAR_PATH = ""
 
@@ -83,8 +80,7 @@ except ImportError:
 ##############################################################################
 # User Settings (env vars)
 ##############################################################################
-_ENV_PATHS = ['ARM_PATH', 'GCC_ARM_PATH', 'GCC_CR_PATH', 'IAR_PATH',
-              'ARMC6_PATH']
+_ENV_PATHS = ['ARM_PATH', 'GCC_ARM_PATH', 'IAR_PATH', 'ARMC6_PATH']
 
 for _n in _ENV_PATHS:
     if getenv('MBED_'+_n):

--- a/tools/singletest.py
+++ b/tools/singletest.py
@@ -24,7 +24,7 @@ File format example: test_spec.json:
 {
     "targets": {
         "KL46Z": ["ARM", "GCC_ARM"],
-        "LPC1768": ["ARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "LPC1768": ["ARM", "GCC_ARM", "IAR"],
         "LPC11U24": ["uARM"],
         "NRF51822": ["ARM"]
     }

--- a/tools/size.py
+++ b/tools/size.py
@@ -63,7 +63,7 @@ def benchmarks():
     csv_data.writerow(['Toolchain', "Target", "Benchmark", "code", "data", "bss", "flash"])
 
     # Build
-    for toolchain in ['ARM', 'uARM', 'GCC_CR', 'GCC_ARM']:
+    for toolchain in ['ARM', 'uARM', 'GCC_ARM']:
         for mcu in ["LPC1768", "LPC11U24"]:
             # Build Libraries
             build_mbed_libs(mcu, toolchain)
@@ -118,4 +118,4 @@ def compare(t1, t2, target):
 
 
 if __name__ == '__main__':
-    compare("GCC_CR", "LPC1768")
+    compare("ARM", "GCC_ARM", "LPC1768")


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This came out of the discussion from #8249. This removes the references to `GCC_CR` (an old unsupported toolchain) from the tools. It does not touch device code (even though there are some references there).


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

