### PR TITLE
Tools: Fix Microbit releases

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -60,7 +60,7 @@ class ARM(mbedToolchain):
             raise NotSupportedException(
                 "this compiler does not support the core %s" % target.core)
 
-        if getattr(target, "default_lib", "std") == "small":
+        if getattr(target, "default_toolchain", "ARM") == "uARM":
             if "-DMBED_RTOS_SINGLE_THREAD" not in self.flags['common']:
                 self.flags['common'].append("-DMBED_RTOS_SINGLE_THREAD")
             if "-D__MICROLIB" not in self.flags['common']:
@@ -350,7 +350,7 @@ class ARM_MICRO(ARM):
     def __init__(self, target, notify=None, macros=None,
                  silent=False, extra_verbose=False, build_profile=None,
                  build_dir=None):
-        target.default_lib = "small"
+        target.default_toolchain = "uARM"
         ARM.__init__(self, target, notify, macros, build_dir=build_dir,
                      build_profile=build_profile)
         if not set(("ARM", "uARM")).intersection(set(target.supported_toolchains)):

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -125,7 +125,7 @@ class ARM(mbedToolchain):
             })
 
     def _get_toolchain_labels(self):
-        if getattr(self.target, "default_lib", "std") == "small":
+        if getattr(self.target, "default_toolchain", "ARM") == "uARM":
             return ["ARM", "ARM_MICRO"]
         else:
             return ["ARM", "ARM_STD"]


### PR DESCRIPTION
### Description

I noticed that there was quite a bit missing from the mbed2 release of 
the microbit today. That's because the microbit uses ARM by default and
the GCC_ARM small library. The release script was trying to release for 
ARM using scan rules for uARM. Turns out we're stuck with 2 configuration
parameters for the same thing: `default_lib` for GCC and `default_toolchain`
for ARM. Dang

Resolves #8217 I think.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change