### PR TITLE
use forced_reset_timeout as delay after reset

### DIFF
--- a/TESTS/host_tests/system_reset.py
+++ b/TESTS/host_tests/system_reset.py
@@ -36,9 +36,6 @@ class SystemResetTest(BaseHostTest):
     def __init__(self):
         super(SystemResetTest, self).__init__()
         self.reset = False
-        cycle_s = self.get_config_item('program_cycle_s')
-        self.program_cycle_s = cycle_s if cycle_s is not None else DEFAULT_CYCLE_PERIOD
-
         self.test_steps_sequence = self.test_steps()
         # Advance the coroutine to it's first yield statement.
         self.test_steps_sequence.send(None)
@@ -61,14 +58,16 @@ class SystemResetTest(BaseHostTest):
         """Reset the device and check the status
         """
         system_reset = yield
-
         self.reset = False
+
+        wait_after_reset = self.get_config_item('forced_reset_timeout')
+        wait_after_reset = wait_after_reset if wait_after_reset is not None else DEFAULT_CYCLE_PERIOD
+
         self.send_kv(MSG_KEY_DEVICE_RESET, MSG_VALUE_DUMMY)
-        time.sleep(self.program_cycle_s)
+        time.sleep(wait_after_reset)
         self.send_kv(MSG_KEY_SYNC, MSG_VALUE_DUMMY)
 
         system_reset = yield
-
         if self.reset == False:
             raise RuntimeError('Platform did not reset as expected.')
 

--- a/TESTS/mbed_platform/system_reset/main.cpp
+++ b/TESTS/mbed_platform/system_reset/main.cpp
@@ -43,7 +43,7 @@ void test_system_reset()
 
 int main(void)
 {
-    GREENTEA_SETUP(2, "system_reset");
+    GREENTEA_SETUP(30, "system_reset");
     test_system_reset();
     GREENTEA_TESTSUITE_RESULT(0); // Fail on any error.
 


### PR DESCRIPTION
### Description

Fix for issue https://github.com/ARMmbed/mbed-os/issues/8141 

we need define the [`forced_reset_timeout`](https://github.com/ARMmbed/htrun/blob/63eea4ee94a88f8e5c292588889fc243b5177aee/mbed_host_tests/__init__.py#L253) attribute in  [target.json]( https://github.com/ARMmbed/mbed-os/blob/master/targets/targets.json)

cc :  @SenRamakri @gaborkertesz 

@mmahadevan108 can you please add forced_reset_timeout to target.json for RAPID_IOT.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change