### PR TITLE
Reduce cellular memory footprint

### DIFF
--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -283,6 +283,13 @@ void ATHandler::cmd_stop()
 {
 }
 
+void ATHandler::cmd_stop_read_resp()
+{
+    cmd_stop();
+    resp_start();
+    resp_stop();
+}
+
 device_err_t ATHandler::get_last_device_error() const
 {
     return ATHandler_stub::device_err_value;

--- a/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/features/cellular/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -279,6 +279,13 @@ void ATHandler::cmd_stop()
 {
 }
 
+void ATHandler::cmd_stop_read_resp()
+{
+    cmd_stop();
+    resp_start();
+    resp_stop();
+}
+
 device_err_t ATHandler::get_last_device_error() const
 {
     return ATHandler_stub::device_err_value;

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1100,6 +1100,13 @@ void ATHandler::cmd_stop()
     (void)write(_output_delimiter, strlen(_output_delimiter));
 }
 
+void ATHandler::cmd_stop_read_resp()
+{
+    cmd_stop();
+    resp_start();
+    resp_stop();
+}
+
 size_t ATHandler::write_bytes(const uint8_t *data, size_t len)
 {
     if (_last_err != NSAPI_ERROR_OK) {

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -248,6 +248,11 @@ public:
      */
     void cmd_stop();
 
+    /** Stops the AT command by writing command-line terminator CR to mark command as finished and reads the OK/ERROR response.
+     *
+     */
+    void cmd_stop_read_resp();
+
     /** Write bytes without any subparameter delimiters, such as comma.
      *  In case of failure when writing, the last error is set to NSAPI_ERROR_DEVICE_ERROR.
      *

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -262,9 +262,7 @@ nsapi_error_t AT_CellularNetwork::delete_current_context()
     _at.clear_error();
     _at.cmd_start("AT+CGDCONT=");
     _at.write_int(_cid);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     if (_at.get_last_error() == NSAPI_ERROR_OK) {
         _cid = -1;
@@ -324,9 +322,7 @@ nsapi_error_t AT_CellularNetwork::activate_context()
         tr_info("Activate PDP context %d", _cid);
         _at.cmd_start("AT+CGACT=1,");
         _at.write_int(_cid);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     err = (_at.get_last_error() == NSAPI_ERROR_OK) ? NSAPI_ERROR_OK : NSAPI_ERROR_NO_CONNECTION;
@@ -371,9 +367,7 @@ nsapi_error_t AT_CellularNetwork::connect()
     if (err == NSAPI_ERROR_OK) {
         _at.lock();
         _at.cmd_start("AT+CGEREP=1");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
         _at.unlock();
     }
 
@@ -457,9 +451,7 @@ nsapi_error_t AT_CellularNetwork::disconnect()
     if (_is_context_active && (_reg_params._act < RAT_E_UTRAN || active_contexts_count > 1)) {
         _at.cmd_start("AT+CGACT=0,");
         _at.write_int(_cid);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     _at.restore_at_timeout();
@@ -523,9 +515,7 @@ nsapi_error_t AT_CellularNetwork::do_user_authentication()
         _at.write_int(_authentication_type);
         _at.write_string(_uname);
         _at.write_string(_pwd);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_AUTH_FAILURE;
         }
@@ -573,9 +563,7 @@ bool AT_CellularNetwork::set_new_context(int cid)
     _at.write_int(cid);
     _at.write_string(pdp_type);
     _at.write_string(_apn);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     success = (_at.get_last_error() == NSAPI_ERROR_OK);
 
     // Fall back to ipv4
@@ -586,9 +574,7 @@ bool AT_CellularNetwork::set_new_context(int cid)
         _at.write_int(cid);
         _at.write_string("IP");
         _at.write_string(_apn);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
         success = (_at.get_last_error() == NSAPI_ERROR_OK);
     }
 
@@ -730,15 +716,12 @@ nsapi_error_t AT_CellularNetwork::set_registration_urc(RegistrationType type, bo
             const uint8_t ch_eq = '=';
             _at.write_bytes(&ch_eq, 1);
             _at.write_int((int)mode);
-            _at.cmd_stop();
         } else {
             _at.cmd_start(at_reg[index].cmd);
             _at.write_string("=0", false);
-            _at.cmd_stop();
         }
 
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
         return _at.unlock_return_error();
     }
 }
@@ -769,17 +752,13 @@ nsapi_error_t AT_CellularNetwork::set_registration(const char *plmn)
         if (mode != 0) {
             _at.clear_error();
             _at.cmd_start("AT+COPS=0");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
         }
     } else {
         tr_debug("Manual network registration to %s", plmn);
         _at.cmd_start("AT+COPS=4,2,");
         _at.write_string(plmn);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     return _at.unlock_return_error();
@@ -846,9 +825,7 @@ nsapi_error_t AT_CellularNetwork::set_attach(int /*timeout*/)
     if (attached_state != 1) {
         tr_debug("Network attach");
         _at.cmd_start("AT+CGATT=1");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     return _at.unlock_return_error();
@@ -877,9 +854,7 @@ nsapi_error_t AT_CellularNetwork::detach()
 
     tr_debug("Network detach");
     _at.cmd_start("AT+CGATT=0");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     call_network_cb(NSAPI_STATUS_DISCONNECTED);
 
@@ -1030,10 +1005,7 @@ nsapi_error_t AT_CellularNetwork::set_ciot_optimization_config(Supported_UE_Opt 
     _at.write_int(_cid);
     _at.write_int(supported_opt);
     _at.write_int(preferred_opt);
-    _at.cmd_stop();
-
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/AT/AT_CellularPower.cpp
+++ b/features/cellular/framework/AT/AT_CellularPower.cpp
@@ -49,14 +49,10 @@ nsapi_error_t AT_CellularPower::set_at_mode()
     _at.lock();
     _at.flush();
     _at.cmd_start("ATE0"); // echo off
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     _at.cmd_start("AT+CMEE=1"); // verbose responses
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -66,9 +62,7 @@ nsapi_error_t AT_CellularPower::set_power_level(int func_level, int do_reset)
     _at.cmd_start("AT+CFUN=");
     _at.write_int(func_level);
     _at.write_int(do_reset);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -78,9 +72,7 @@ nsapi_error_t AT_CellularPower::reset()
     _at.cmd_start("AT+CFUN=");// reset to full power levels
     _at.write_int(1);
     _at.write_int(1);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -92,9 +84,7 @@ nsapi_error_t AT_CellularPower::opt_power_save_mode(int periodic_time, int activ
         // disable PSM
         _at.cmd_start("AT+CPSMS=");
         _at.write_int(0);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     } else {
         /**
             Table 10.5.163a/3GPP TS 24.008: GPRS Timer 3 information element
@@ -199,10 +189,7 @@ nsapi_error_t AT_CellularPower::opt_power_save_mode(int periodic_time, int activ
         _at.write_string(at);
         _at.write_string(pt);
         _at.write_string(at);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
-
+        _at.cmd_stop_read_resp();
 
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             tr_warn("Power save mode not enabled!");
@@ -227,9 +214,7 @@ nsapi_error_t AT_CellularPower::opt_receive_period(int mode, EDRXAccessTechnolog
     _at.write_int(mode);
     _at.write_int(act_type);
     _at.write_string(edrx);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }
@@ -238,17 +223,13 @@ nsapi_error_t AT_CellularPower::is_device_ready()
 {
     _at.lock();
     _at.cmd_start("AT");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     // we need to do this twice because for example after data mode the first 'AT' command will give modem a
     // stimulus that we are back to command mode.
     _at.clear_error();
     _at.cmd_start("AT");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/AT/AT_CellularSIM.cpp
+++ b/features/cellular/framework/AT/AT_CellularSIM.cpp
@@ -90,9 +90,7 @@ nsapi_error_t AT_CellularSIM::set_pin(const char *sim_pin)
     _at.lock();
     _at.cmd_start("AT+CPIN=");
     _at.write_string(sim_pin);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -103,9 +101,7 @@ nsapi_error_t AT_CellularSIM::change_pin(const char *sim_pin, const char *new_pi
     _at.write_string("SC");
     _at.write_string(sim_pin);
     _at.write_string(new_pin);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -118,18 +114,14 @@ nsapi_error_t AT_CellularSIM::set_pin_query(const char *sim_pin, bool query_pin)
         _at.write_string("SC");
         _at.write_int(1);
         _at.write_string(sim_pin);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     } else {
         /* use the SIM unlocked */
         _at.cmd_start("AT+CLCK=");
         _at.write_string("SC");
         _at.write_int(0);
         _at.write_string(sim_pin);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -41,7 +41,7 @@ const uint8_t SMS_MAX_GSM7_CONCATENATED_SINGLE_SMS_SIZE = 153;
 #define NVAM '?' // Not Valid ascii, ISO-8859-1 mark
 
 // mapping table from 7-bit GSM to ascii (ISO-8859-1)
-static const int gsm_to_ascii[] = {
+static const char gsm_to_ascii[] = {
     64,     // 0
     163,    // 1
     36,     // 2

--- a/features/cellular/framework/AT/AT_CellularSMS.cpp
+++ b/features/cellular/framework/AT/AT_CellularSMS.cpp
@@ -212,9 +212,7 @@ nsapi_error_t AT_CellularSMS::set_cnmi()
 {
     _at.lock();
     _at.cmd_start("AT+CNMI=2,1");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -223,9 +221,7 @@ nsapi_error_t AT_CellularSMS::set_cmgf(int msg_format)
     _at.lock();
     _at.cmd_start("AT+CMGF=");
     _at.write_int(msg_format);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -237,9 +233,7 @@ nsapi_error_t AT_CellularSMS::set_csmp(int fo, int vp, int pid, int dcs)
     _at.write_int(vp);
     _at.write_int(pid);
     _at.write_int(dcs);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -248,9 +242,7 @@ nsapi_error_t AT_CellularSMS::set_csdh(int show_header)
     _at.lock();
     _at.cmd_start("AT+CSDH=");
     _at.write_int(show_header);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 
@@ -546,9 +538,7 @@ nsapi_error_t AT_CellularSMS::set_cpms(const char *memr, const char *memw, const
     _at.write_string(memr);
     _at.write_string(memw);
     _at.write_string(mems);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }
@@ -559,9 +549,7 @@ nsapi_error_t AT_CellularSMS::set_csca(const char *sca, int type)
     _at.cmd_start("AT+CSCA=");
     _at.write_string(sca);
     _at.write_int(type);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }
@@ -571,9 +559,7 @@ nsapi_size_or_error_t AT_CellularSMS::set_cscs(const char *chr_set)
     _at.lock();
     _at.cmd_start("AT+CSCS=");
     _at.write_string(chr_set);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }
@@ -584,9 +570,7 @@ nsapi_error_t AT_CellularSMS::delete_sms(sms_info_t *sms)
     for (int i = 0; i < sms->parts; i++) {
         _at.cmd_start("AT+CMGD=");
         _at.write_int(sms->msg_index[i]);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     return _at.unlock_return_error();
@@ -600,9 +584,7 @@ nsapi_error_t AT_CellularSMS::delete_all_messages()
 {
     _at.lock();
     _at.cmd_start("AT+CMGD=1,4");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     return _at.unlock_return_error();
 }
 

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -148,9 +148,7 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_close_impl(int sock_id)
 
     _at.cmd_start("AT^SISC=");
     _at.write_int(sock_id);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     _at.clear_error(); // clear SISS even though SISC fails
     _at.cmd_start("AT^SISS=");
@@ -181,15 +179,12 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::socket_open_defer(CellularSocket 
     _at.write_int(socket->id);
     _at.write_string("address", false);
     _at.write_string(sock_addr);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     _at.cmd_start("AT^SISO=");
     _at.write_int(socket->id);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
+
     if (_at.get_last_error()) {
         tr_error("Socket %d open failed!", socket->id);
         _at.clear_error();
@@ -264,9 +259,7 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_socket_impl(CellularSocket
         _at.write_int(internet_service_id);
         _at.write_string("srvType");
         _at.write_string("Socket");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     if (!foundConIdType) {
@@ -274,9 +267,7 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_socket_impl(CellularSocket
         _at.write_int(internet_service_id);
         _at.write_string("conId");
         _at.write_int(connection_profile_id);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     tr_debug("Internet service %d (err %d)", internet_service_id, _at.get_last_error());
@@ -533,18 +524,14 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_connection_profile(int con
         _at.write_int(connection_profile_id);
         _at.write_string("conType");
         _at.write_string(conParamType);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (_apn && strlen(_apn) > 0) {
             _at.cmd_start("AT^SICS=");
             _at.write_int(connection_profile_id);
             _at.write_string("apn");
             _at.write_string(_apn);
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
         }
 
         // set maximum inactivity timeout
@@ -552,15 +539,11 @@ nsapi_error_t GEMALTO_CINTERION_CellularStack::create_connection_profile(int con
         _at.write_int(connection_profile_id);
         _at.write_string("inactTO");
         _at.write_int(0xffff); // 2^16-1
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         // use URC mode ON
         _at.cmd_start("AT^SCFG=\"Tcp/withURCs\",\"on\"");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     tr_debug("Connection profile %d, stack_type %d (err %d)", connection_profile_id, _stack_type, _at.get_last_error());
@@ -577,18 +560,14 @@ void GEMALTO_CINTERION_CellularStack::close_connection_profile(int connection_pr
     // After detach modem sends PDP disconnected event to network class,
     // which propagates network disconnected to upper layer to start reconnecting.
     _at.cmd_start("AT+CGATT=0");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     _at.clear_error();
 
     _at.cmd_start("AT^SICS=");
     _at.write_int(connection_profile_id);
     _at.write_string("conType");
     _at.write_string("none");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     _at.clear_error();
 }

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularPower.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularPower.cpp
@@ -34,15 +34,12 @@ nsapi_error_t QUECTEL_BC95_CellularPower::set_at_mode()
     _at.lock();
     _at.flush();
     _at.cmd_start("AT");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     _at.cmd_start("AT+CMEE="); // verbose responses
     _at.write_int(1);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
+
     return _at.unlock_return_error();
 }
 

--- a/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BC95/QUECTEL_BC95_CellularStack.cpp
@@ -100,9 +100,7 @@ nsapi_error_t QUECTEL_BC95_CellularStack::socket_close_impl(int sock_id)
 {
     _at.cmd_start("AT+NSOCL=");
     _at.write_int(sock_id);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     tr_info("Close socket: %d error: %d", sock_id, _at.get_last_error());
 
@@ -132,9 +130,7 @@ nsapi_error_t QUECTEL_BC95_CellularStack::create_socket_impl(CellularSocket *soc
 
     if (!socketOpenWorking) {
         _at.cmd_start("AT+NSOCL=0");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (socket->proto == NSAPI_UDP) {
             _at.cmd_start("AT+NSOCR=DGRAM,17,");

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularNetwork.cpp
@@ -52,58 +52,36 @@ nsapi_error_t QUECTEL_BG96_CellularNetwork::set_access_technology_impl(RadioAcce
     switch (opsAct) {
         case RAT_CATM1:
             _at.cmd_start("AT+QCFG=\"nwscanseq\",020301");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"nwscanmode\",3,1");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"iotopmode\",0,1");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             break;
         case RAT_NB1:
             _at.cmd_start("AT+QCFG=\"nwscanseq\",030201");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"nwscanmode\",3,1");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"iotopmode\",1,1");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             break;
         case RAT_GSM:
         case RAT_GSM_COMPACT:
         case RAT_UTRAN:
         case RAT_EGPRS:
             _at.cmd_start("AT+QCFG=\"nwscanseq\",010203");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"nwscanmode\",1,1");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             break;
         default:
             _at.cmd_start("AT+QCFG=\"nwscanseq\",020301");
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"nwscanmode\",0,1"); //auto mode
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.cmd_start("AT+QCFG=\"iotopmode\",2,1"); //auto mode
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
             _at.unlock();
             _op_act = RAT_UNKNOWN;
             return NSAPI_ERROR_UNSUPPORTED;
@@ -122,9 +100,7 @@ nsapi_error_t QUECTEL_BG96_CellularNetwork::do_user_authentication()
         _at.write_string(_uname);
         _at.write_string(_pwd);
         _at.write_int(_authentication_type);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
         if (_at.get_last_error() != NSAPI_ERROR_OK) {
             return NSAPI_ERROR_AUTH_FAILURE;
         }

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularStack.cpp
@@ -139,9 +139,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::socket_close_impl(int sock_id)
     _at.set_at_timeout(BG96_CLOSE_SOCKET_TIMEOUT);
     _at.cmd_start("AT+QICLOSE=");
     _at.write_int(sock_id);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     _at.restore_at_timeout();
 
     return _at.get_last_error();
@@ -182,9 +180,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
         if ((_at.get_last_error() == NSAPI_ERROR_OK) && err) {
             _at.cmd_start("AT+QICLOSE=");
             _at.write_int(modem_connect_id);
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
 
             _at.cmd_start("AT+QIOPEN=");
             _at.write_int(_cid);
@@ -212,9 +208,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
         if ((_at.get_last_error() == NSAPI_ERROR_OK) && err) {
             _at.cmd_start("AT+QICLOSE=");
             _at.write_int(modem_connect_id);
-            _at.cmd_stop();
-            _at.resp_start();
-            _at.resp_stop();
+            _at.cmd_stop_read_resp();
 
             _at.cmd_start("AT+QIOPEN=");
             _at.write_int(_cid);
@@ -232,9 +226,7 @@ nsapi_error_t QUECTEL_BG96_CellularStack::create_socket_impl(CellularSocket *soc
     if (!err && (modem_connect_id != request_connect_id)) {
         _at.cmd_start("AT+QICLOSE=");
         _at.write_int(modem_connect_id);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
     }
 
     nsapi_error_t ret_val = _at.get_last_error();

--- a/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularPower.cpp
+++ b/features/cellular/framework/targets/TELIT/HE910/TELIT_HE910_CellularPower.cpp
@@ -61,9 +61,7 @@ nsapi_error_t TELIT_HE910_CellularPower::set_at_mode()
     }
     _at.lock();
     _at.cmd_start("AT&K0;&C1;&D0");
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularNetwork.cpp
@@ -178,9 +178,7 @@ bool UBLOX_AT_CellularNetwork::activate_profile(const char* apn,
         success = false;
         _at.cmd_start("AT+UPSD=0,1,");
         _at.write_string(apn);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (_at.get_last_error() == NSAPI_ERROR_OK) {
             success = true;
@@ -191,9 +189,7 @@ bool UBLOX_AT_CellularNetwork::activate_profile(const char* apn,
         success = false;
         _at.cmd_start("AT+UPSD=" PROFILE ",2,");
         _at.write_string(username);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (_at.get_last_error() == NSAPI_ERROR_OK) {
             success = true;
@@ -204,9 +200,7 @@ bool UBLOX_AT_CellularNetwork::activate_profile(const char* apn,
         success = false;
         _at.cmd_start("AT+UPSD=" PROFILE ",3,");
         _at.write_string(password);
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (_at.get_last_error() == NSAPI_ERROR_OK) {
             success = true;
@@ -215,9 +209,7 @@ bool UBLOX_AT_CellularNetwork::activate_profile(const char* apn,
 
     if (success) {
         _at.cmd_start("AT+UPSD=" PROFILE ",7,\"0.0.0.0\"");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         // Set up the authentication protocol
         // 0 = none
@@ -228,17 +220,13 @@ bool UBLOX_AT_CellularNetwork::activate_profile(const char* apn,
             if ((_auth == NSAPI_SECURITY_UNKNOWN) || (nsapi_security_to_modem_security(_auth) == protocol)) {
                 _at.cmd_start("AT+UPSD=0,6,");
                 _at.write_int(protocol);
-                _at.cmd_stop();
-                _at.resp_start();
-                _at.resp_stop();
+                _at.cmd_stop_read_resp();
 
                 if (_at.get_last_error() == NSAPI_ERROR_OK) {
                     // Activate, wait upto 30 seconds for the connection to be made
                     _at.set_at_timeout(30000);
                     _at.cmd_start("AT+UPSDA=0,3");
-                    _at.cmd_stop();
-                    _at.resp_start();
-                    _at.resp_stop();
+                    _at.cmd_stop_read_resp();
                     _at.restore_at_timeout();
 
                     if (_at.get_last_error() == NSAPI_ERROR_OK) {
@@ -285,9 +273,7 @@ bool UBLOX_AT_CellularNetwork::disconnect_modem_stack()
 
     if (get_ip_address() != NULL) {
         _at.cmd_start("AT+UPSDA=" PROFILE ",4");
-        _at.cmd_stop();
-        _at.resp_start();
-        _at.resp_stop();
+        _at.cmd_stop_read_resp();
 
         if (_at.get_last_error() == NSAPI_ERROR_OK) {
             success = true;

--- a/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
+++ b/features/cellular/framework/targets/UBLOX/AT/UBLOX_AT_CellularStack.cpp
@@ -177,9 +177,7 @@ nsapi_error_t UBLOX_AT_CellularStack::socket_connect(nsapi_socket_t handle, cons
     _at.write_int(socket->id);
     _at.write_string(addr.get_ip_address());
     _at.write_int(addr.get_port());
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
     _at.unlock();
 
     if (_at.get_last_error() == NSAPI_ERROR_OK) {
@@ -407,9 +405,7 @@ nsapi_error_t UBLOX_AT_CellularStack::socket_close_impl(int sock_id)
     _at.lock();
     _at.cmd_start("AT+USOCL=");
     _at.write_int(sock_id);
-    _at.cmd_stop();
-    _at.resp_start();
-    _at.resp_stop();
+    _at.cmd_stop_read_resp();
 
     return _at.unlock_return_error();
 }


### PR DESCRIPTION
### Description

Reduce cellular ROM usage with some optimizations. With ARMC5 this reduces cellular object size ~300Bytes and with GCC_ARM ~1kB.

Internal ref: IOTCELL-1120

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

