### PR TITLE
unittests: Add tests for netsocket classes

### DIFF
--- a/UNITTESTS/features/netsocket/EthernetInterface/test_EthernetInterface.cpp
+++ b/UNITTESTS/features/netsocket/EthernetInterface/test_EthernetInterface.cpp
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "features/netsocket/EthernetInterface.h"
+#include <iostream>
+
+class MockEMAC : public EMAC {
+public:
+    MOCK_METHOD0(power_up, bool());
+    MOCK_METHOD0(power_down, void());
+    MOCK_CONST_METHOD0(get_mtu_size, uint32_t());
+    MOCK_CONST_METHOD0(get_align_preference, uint32_t());
+    MOCK_CONST_METHOD2(get_ifname, void(char *name, uint8_t size));
+    MOCK_CONST_METHOD0(get_hwaddr_size, uint8_t());
+    MOCK_CONST_METHOD1(get_hwaddr, bool(uint8_t *addr));
+    MOCK_METHOD1(set_hwaddr, void(const uint8_t *));
+    MOCK_METHOD1(link_out, bool(emac_mem_buf_t *buf));
+    MOCK_METHOD1(set_link_input_cb, void(emac_link_input_cb_t input_cb));
+    MOCK_METHOD1(set_link_state_cb, void(emac_link_state_change_cb_t state_cb));
+    MOCK_METHOD1(add_multicast_group, void(const uint8_t *address));
+    MOCK_METHOD1(remove_multicast_group, void(const uint8_t *address));
+    MOCK_METHOD1(set_all_multicast, void(bool all));
+    MOCK_METHOD1(set_memory_manager, void(EMACMemoryManager &mem_mngr));
+
+    static MockEMAC &get_instance()
+    {
+        static MockEMAC emacMock1;
+        return emacMock1;
+    }
+};
+
+MBED_WEAK EMAC &EMAC::get_default_instance()
+{
+    return MockEMAC::get_instance();
+}
+
+class EmacNetworkStackMock : public OnboardNetworkStack {
+public:
+    MOCK_METHOD3(gethostbyname, nsapi_error_t(const char *host, SocketAddress *address, nsapi_version_t version));
+    MOCK_METHOD1(add_dns_server, nsapi_error_t(const SocketAddress &address));
+    MOCK_METHOD2(call_in, nsapi_error_t(int delay, mbed::Callback<void()> func));
+    MOCK_METHOD2(socket_open, nsapi_error_t(nsapi_socket_t *handle, nsapi_protocol_t proto));
+    MOCK_METHOD1(socket_close, nsapi_error_t(nsapi_socket_t handle));
+    MOCK_METHOD2(socket_bind, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
+    MOCK_METHOD2(socket_listen, nsapi_error_t(nsapi_socket_t handle, int backlog));
+    MOCK_METHOD2(socket_connect, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address));
+    MOCK_METHOD3(socket_accept, nsapi_error_t(nsapi_socket_t server, nsapi_socket_t *handle, SocketAddress *address));
+    MOCK_METHOD3(socket_send, nsapi_error_t(nsapi_socket_t handle, const void *data, nsapi_size_t size));
+    MOCK_METHOD3(socket_recv, nsapi_error_t(nsapi_socket_t handle, void *data, nsapi_size_t size));
+    MOCK_METHOD4(socket_sendto, nsapi_error_t(nsapi_socket_t handle, const SocketAddress &address, const void *data, nsapi_size_t size));
+    MOCK_METHOD4(socket_recvfrom, nsapi_error_t(nsapi_socket_t handle, SocketAddress *address, void *data, nsapi_size_t size));
+    MOCK_METHOD5(setsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned optlen));
+    MOCK_METHOD5(getsockopt, nsapi_error_t(nsapi_socket_t handle, int level, int optname, const void *optval, unsigned *optlen));
+    MOCK_METHOD3(socket_attach, void(nsapi_socket_t handle, void (*callback)(void *), void *data));
+    MOCK_METHOD3(add_ethernet_interface, nsapi_error_t(EMAC &emac, bool default_if, OnboardNetworkStack::Interface **interface_out));
+
+    static EmacNetworkStackMock &get_instance()
+    {
+        static EmacNetworkStackMock stackMock1;
+        return stackMock1;
+    }
+
+    class InterfaceMock : public OnboardNetworkStack::Interface {
+    public:
+
+        static InterfaceMock &get_instance()
+        {
+            static InterfaceMock test_interface;
+            return test_interface;
+        }
+        MOCK_METHOD6(bringup, nsapi_error_t(bool dhcp, const char *ip,
+                                            const char *netmask, const char *gw,
+                                            nsapi_ip_stack_t stack,
+                                            bool blocking
+                                           ));
+        MOCK_METHOD0(bringdown, nsapi_error_t());
+        MOCK_METHOD1(attach, void(mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb));
+        MOCK_CONST_METHOD0(get_connection_status, nsapi_connection_status_t());
+        MOCK_METHOD2(get_mac_address, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD2(get_ip_address, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD2(get_netmask, char *(char *buf, nsapi_size_t buflen));
+        MOCK_METHOD2(get_gateway, char *(char *buf, nsapi_size_t buflen));
+    };
+};
+
+OnboardNetworkStack &OnboardNetworkStack::get_default_instance()
+{
+    return EmacNetworkStackMock::get_instance();
+}
+
+// Implementaion in in NetworkInterfaceDefaults.cpp
+MBED_WEAK EthInterface *EthInterface::get_default_instance()
+{
+    return get_target_default_instance();
+}
+
+using ::testing::_;
+using ::testing::Return;
+using ::testing::ReturnArg;
+using ::testing::SaveArg;
+using ::testing::SaveArgPointee;
+using ::testing::SetArrayArgument;
+using ::testing::SetArgPointee;
+using ::testing::SetArgReferee;
+
+class TestEthernetInterface: public testing::Test {
+protected:
+    EthernetInterface *iface;
+    EmacNetworkStackMock *stackMock;
+    MockEMAC *emacMock;
+    EmacNetworkStackMock::InterfaceMock *netStackIface;
+    virtual void SetUp()
+    {
+        stackMock = &EmacNetworkStackMock::get_instance();
+        emacMock = &MockEMAC::get_instance();
+        netStackIface = &EmacNetworkStackMock::InterfaceMock::get_instance();
+        iface = new EthernetInterface(MockEMAC::get_instance(), EmacNetworkStackMock::get_instance());
+    }
+
+    virtual void TearDown()
+    {
+        // Do not delete the mocks pointers, as they point to statically allocated singletons.
+        delete iface;
+    }
+
+    /* Enclose the heavily-used connection procedure to improve code redability */
+    void doConnect(bool dhcp = true, bool blocking = true)
+    {
+        EXPECT_CALL(*stackMock, add_ethernet_interface(testing::Ref(*emacMock), true, _))
+        .Times(1)
+        .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_OK)));
+        EXPECT_CALL(*netStackIface, attach(_))
+        .Times(1)
+        .RetiresOnSaturation();;
+        EXPECT_CALL(*netStackIface, bringup(dhcp, NULL, NULL, NULL, DEFAULT_STACK, blocking))
+        .Times(1)
+        .WillOnce(Return(NSAPI_ERROR_OK));
+        EXPECT_EQ(NSAPI_ERROR_OK, iface->connect());
+    }
+
+    static void cb(nsapi_event_t ev, intptr_t ptr)
+    {
+
+    }
+};
+
+TEST_F(TestEthernetInterface, constructor_default)
+{
+    EXPECT_TRUE(iface);
+}
+
+TEST_F(TestEthernetInterface, constructor_getter)
+{
+    EthInterface *eth = EthInterface::get_default_instance();
+}
+
+
+
+TEST_F(TestEthernetInterface, connect)
+{
+    doConnect();
+}
+
+TEST_F(TestEthernetInterface, connect_failure)
+{
+    EXPECT_CALL(*stackMock, add_ethernet_interface(testing::Ref(*emacMock), true, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_NO_MEMORY)));
+    EXPECT_EQ(NSAPI_ERROR_NO_MEMORY, iface->connect());
+}
+
+TEST_F(TestEthernetInterface, disconnect_without_connecting)
+{
+    EXPECT_EQ(NSAPI_ERROR_NO_CONNECTION, iface->disconnect());
+}
+
+TEST_F(TestEthernetInterface, disconnect)
+{
+    doConnect();
+
+    EXPECT_CALL(*netStackIface, bringdown())
+    .Times(1)
+    .WillOnce(Return(NSAPI_ERROR_OK));
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->disconnect());
+}
+
+TEST_F(TestEthernetInterface, set_network)
+{
+    char ipAddress[NSAPI_IPv4_SIZE] = "127.0.0.1";
+    char netmask[NSAPI_IPv4_SIZE] = "255.255.0.0";
+    char gateway[NSAPI_IPv4_SIZE] = "127.0.0.2";
+
+    const char *ipAddressArg;
+    const char *netmaskArg;
+    const char *gatewayArg;
+
+    EXPECT_EQ(0, iface->get_ip_address());
+    EXPECT_EQ(0, iface->get_netmask());
+    EXPECT_EQ(0, iface->get_gateway());
+
+    // Set the network data
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->set_network(ipAddress, netmask, gateway));
+
+    // Now the bringup should have different arguments. We can't use doConnect method.
+    EXPECT_CALL(*stackMock, add_ethernet_interface(testing::Ref(*emacMock), true, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<2>(netStackIface), Return(NSAPI_ERROR_OK)));
+    EXPECT_CALL(*netStackIface, attach(_))
+    .Times(1)
+    .RetiresOnSaturation();
+    // Do not put the expected char * arguments, as they are pointers and would not match
+    EXPECT_CALL(*netStackIface, bringup(false, _, _, _, DEFAULT_STACK, true))
+    .Times(1)
+    .WillOnce(DoAll(SaveArg<1>(&ipAddressArg),
+                    SaveArg<2>(&netmaskArg),
+                    SaveArg<3>(&gatewayArg),
+                    Return(NSAPI_ERROR_OK)));
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->connect());
+    // Check the contents of the stored pointer arguments.
+    EXPECT_TRUE(0 == strcmp(ipAddress, ipAddressArg));
+    EXPECT_TRUE(0 == strcmp(netmask, netmaskArg));
+    EXPECT_TRUE(0 == strcmp(gateway, gatewayArg));
+
+    // Testing the getters makes sense now.
+    EXPECT_CALL(*netStackIface, get_ip_address(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*ipAddress), Return(ipAddress)));
+    EXPECT_EQ(std::string(ipAddress), std::string(iface->get_ip_address()));
+
+    EXPECT_CALL(*netStackIface, get_netmask(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*netmask), Return(netmask)));
+    EXPECT_EQ(std::string(netmask), std::string(iface->get_netmask()));
+
+    EXPECT_CALL(*netStackIface, get_gateway(_, _))
+    .Times(1)
+    .WillOnce(DoAll(SetArgPointee<0>(*gateway), Return(gateway)));
+    EXPECT_EQ(std::string(gateway), std::string(iface->get_gateway()));
+}
+
+TEST_F(TestEthernetInterface, get_connection_status)
+{
+    EXPECT_EQ(NSAPI_STATUS_DISCONNECTED, iface->get_connection_status());
+
+    doConnect();
+
+    EXPECT_CALL(*netStackIface, get_connection_status())
+    .Times(1)
+    .WillOnce(Return(NSAPI_STATUS_LOCAL_UP));
+    EXPECT_EQ(NSAPI_STATUS_LOCAL_UP, iface->get_connection_status());
+}
+
+TEST_F(TestEthernetInterface, attach)
+{
+    doConnect();
+    EXPECT_CALL(*netStackIface, attach(_)) // TODO: check that the correct function is passed.
+    .Times(1);
+    iface->attach(cb);
+}
+
+TEST_F(TestEthernetInterface, set_dhcp)
+{
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->set_dhcp(false));
+    doConnect(false, true);
+}
+
+TEST_F(TestEthernetInterface, set_blocking)
+{
+    EXPECT_EQ(NSAPI_ERROR_OK, iface->set_blocking(false));
+    doConnect(true, false);
+}

--- a/UNITTESTS/features/netsocket/EthernetInterface/unittest.cmake
+++ b/UNITTESTS/features/netsocket/EthernetInterface/unittest.cmake
@@ -1,0 +1,33 @@
+
+####################
+# UNIT TESTS
+####################
+
+# Unit test suite name
+set(TEST_SUITE_NAME "features_netsocket_EthernetInterface")
+
+# Source files
+set(unittest-sources
+  ../features/netsocket/SocketAddress.cpp
+  ../features/netsocket/EthernetInterface.cpp
+  ../features/netsocket/EMACInterface.cpp
+  ../features/netsocket/NetworkInterface.cpp
+  ../features/netsocket/NetworkStack.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
+)
+
+# Test files
+set(unittest-test-sources
+  features/netsocket/EthernetInterface/test_EthernetInterface.cpp
+  stubs/Mutex_stub.cpp
+  stubs/mbed_assert_stub.c
+  stubs/equeue_stub.c
+  stubs/EventQueue_stub.cpp
+  stubs/mbed_shared_queues_stub.cpp
+  stubs/nsapi_dns_stub.cpp
+  stubs/EventFlags_stub.cpp
+  stubs/stoip4_stub.c
+  stubs/ip4tos_stub.c
+  stubs/NetworkStack_stub.cpp
+)

--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -58,12 +58,30 @@ public:
     }
 
     // Testing functions
-    void add_reader (void) { _readers++;}
-    void rem_reader (void) { _readers--;}
-    void add_writer (void) { _writers++;}
-    void rem_writer (void) { _writers--;}
-    void add_pending (void) { _pending++;}
-    void rem_pending (void) { _pending--;}
+    void add_reader(void)
+    {
+        _readers++;
+    }
+    void rem_reader(void)
+    {
+        _readers--;
+    }
+    void add_writer(void)
+    {
+        _writers++;
+    }
+    void rem_writer(void)
+    {
+        _writers--;
+    }
+    void add_pending(void)
+    {
+        _pending++;
+    }
+    void rem_pending(void)
+    {
+        _pending--;
+    }
 
 protected:
     virtual nsapi_protocol_t get_proto()

--- a/UNITTESTS/features/netsocket/NetworkStack/test_NetworkStack.cpp
+++ b/UNITTESTS/features/netsocket/NetworkStack/test_NetworkStack.cpp
@@ -72,27 +72,27 @@ class NetworkStackChild : public NetworkStack {
         return NSAPI_ERROR_OK;
     }
     virtual nsapi_error_t socket_accept(nsapi_socket_t server,
-                                            nsapi_socket_t *handle, SocketAddress *address = 0)
+                                        nsapi_socket_t *handle, SocketAddress *address = 0)
     {
         return NSAPI_ERROR_OK;
     }
     virtual nsapi_size_or_error_t socket_send(nsapi_socket_t handle,
-                                                  const void *data, nsapi_size_t size)
+            const void *data, nsapi_size_t size)
     {
         return NSAPI_ERROR_OK;
     }
     virtual nsapi_size_or_error_t socket_recv(nsapi_socket_t handle,
-                                                  void *data, nsapi_size_t size)
+            void *data, nsapi_size_t size)
     {
         return NSAPI_ERROR_OK;
     }
     virtual nsapi_size_or_error_t socket_sendto(nsapi_socket_t handle, const SocketAddress &address,
-                                                    const void *data, nsapi_size_t size)
+            const void *data, nsapi_size_t size)
     {
         return NSAPI_ERROR_OK;
     }
     virtual nsapi_size_or_error_t socket_recvfrom(nsapi_socket_t handle, SocketAddress *address,
-                                                      void *buffer, nsapi_size_t size)
+            void *buffer, nsapi_size_t size)
     {
         return NSAPI_ERROR_OK;
     }
@@ -125,8 +125,7 @@ protected:
     virtual void TearDown()
     {
         delete stack;
-        if (mbed::mbed_shared_queue_stub)
-        {
+        if (mbed::mbed_shared_queue_stub) {
             delete mbed::mbed_shared_queue_stub;
             mbed::mbed_shared_queue_stub = 0;
         }
@@ -145,7 +144,7 @@ TEST_F(TestNetworkStack, constructor)
 
 TEST_F(TestNetworkStack, get_ip_address_default)
 {
-    EXPECT_EQ(stack->NetworkStack::get_ip_address(), (char*)NULL);
+    EXPECT_EQ(stack->NetworkStack::get_ip_address(), (char *)NULL);
 }
 
 /* gethostbyname */
@@ -231,11 +230,11 @@ TEST_F(TestNetworkStack, gethostbyname_async_empty_host)
 
 TEST_F(TestNetworkStack, getstackopt)
 {
-    EXPECT_EQ(stack->getstackopt(0,0,0,0), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(stack->getstackopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 
 TEST_F(TestNetworkStack, setstackopt)
 {
-    EXPECT_EQ(stack->setstackopt(0,0,0,0), NSAPI_ERROR_UNSUPPORTED);
+    EXPECT_EQ(stack->setstackopt(0, 0, 0, 0), NSAPI_ERROR_UNSUPPORTED);
 }
 

--- a/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
+++ b/UNITTESTS/features/netsocket/SocketAddress/test_SocketAddress.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "features/netsocket/SocketAddress.h"
+#include <iostream>
+
+class TestSocketAddress: public testing::Test {
+protected:
+    SocketAddress *address;
+    virtual void SetUp()
+    {
+        address = new SocketAddress;
+    }
+
+    virtual void TearDown()
+    {
+        delete address;
+    }
+    void isEqual(SocketAddress addr1, SocketAddress addr2)
+    {
+        EXPECT_EQ(std::string(addr1.get_ip_address()), std::string(addr2.get_ip_address()));
+        EXPECT_EQ(addr1.get_addr().version, addr2.get_addr().version);
+        EXPECT_TRUE(0 == memcmp(addr1.get_addr().bytes, addr2.get_addr().bytes, NSAPI_IPv4_BYTES));
+        EXPECT_TRUE(0 == memcmp(addr1.get_ip_bytes(), addr2.get_ip_bytes(), NSAPI_IP_BYTES));
+        EXPECT_EQ(addr1.get_ip_version(), addr2.get_ip_version());
+        EXPECT_EQ(addr1.get_port(), addr2.get_port());
+    }
+};
+
+TEST_F(TestSocketAddress, constructor_default)
+{
+    EXPECT_TRUE(address);
+    EXPECT_EQ(NULL, address->get_ip_address());
+    EXPECT_EQ(0, address->get_port());
+    EXPECT_EQ(NSAPI_UNSPEC, address->get_ip_version());
+}
+
+TEST_F(TestSocketAddress, constructor_address_ip4)
+{
+    SocketAddress addr("127.0.0.1", 80);
+    EXPECT_EQ(std::string("127.0.0.1"), std::string(addr.get_ip_address()));
+    EXPECT_EQ(80, addr.get_port());
+    EXPECT_EQ(NSAPI_IPv4, addr.get_ip_version());
+}
+
+TEST_F(TestSocketAddress, constructor_address_ip6)
+{
+    SocketAddress addr("1234:5678:9abc:def0:1234:5678::def0", 80);
+    EXPECT_EQ(80, addr.get_port());
+    EXPECT_EQ(NSAPI_IPv6, addr.get_ip_version());
+    // Note that a missing zero is added between two neighbouring colons
+    EXPECT_EQ(std::string("1234:5678:9abc:def0:1234:5678:0:def0"), std::string(addr.get_ip_address()));
+}
+
+TEST_F(TestSocketAddress, constructor_address_ip6_invalid)
+{
+    SocketAddress addr("zzzz:yyyy:xxxx:def0:1234:5678:9abc:def0", 80);
+    EXPECT_EQ(80, addr.get_port());
+    EXPECT_EQ(NSAPI_UNSPEC, addr.get_ip_version());
+    EXPECT_EQ(NULL, addr.get_ip_address());
+}
+
+TEST_F(TestSocketAddress, constructor_address_bytes_ip4)
+{
+    uint8_t addrBytes[NSAPI_IP_BYTES] = {127, 0, 0, 2};
+
+    SocketAddress addr(addrBytes, NSAPI_IPv4, 80);
+    EXPECT_EQ(std::string("127.0.0.2"), std::string(addr.get_ip_address()));
+    EXPECT_EQ(80, addr.get_port());
+    EXPECT_EQ(NSAPI_IPv4, addr.get_ip_version());
+    EXPECT_TRUE(0 == memcmp(addrBytes, static_cast<const uint8_t *>(addr.get_ip_bytes()), sizeof(addrBytes)));
+}
+
+TEST_F(TestSocketAddress, constructor_address_bytes_ip6)
+{
+    uint8_t addrBytes[NSAPI_IP_BYTES] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf};
+
+    SocketAddress addr(addrBytes, NSAPI_IPv6, 80);
+    // the leading zeroes are removed
+    EXPECT_EQ(std::string("1:203:405:607:809:a0b:c0d:e0f"), std::string(addr.get_ip_address()));
+    EXPECT_EQ(80, addr.get_port());
+    EXPECT_EQ(NSAPI_IPv6, addr.get_ip_version());
+    EXPECT_TRUE(0 == memcmp(addrBytes, static_cast<const uint8_t *>(addr.get_ip_bytes()), NSAPI_IP_BYTES));
+}
+
+TEST_F(TestSocketAddress, constructor_copy)
+{
+    SocketAddress addr(*address);
+    EXPECT_EQ(address->get_ip_address(), addr.get_ip_address());
+    EXPECT_EQ(address->get_port(), addr.get_port());
+    EXPECT_EQ(address->get_ip_version(), addr.get_ip_version());
+}
+
+TEST_F(TestSocketAddress, assignment_and_equality_operator_ip4)
+{
+    SocketAddress addr;
+    address->set_ip_address("127.0.0.2");
+    address->set_port(81);
+    // First verify assignment operator (including return value) using equality operator.
+    EXPECT_EQ((addr = *address), *address);
+    // Then check inequality operator
+    EXPECT_FALSE(addr != *address);
+    // Now proceed to check that the equality operator really works.
+    isEqual(addr, *address);
+}
+
+TEST_F(TestSocketAddress, assignment_and_equality_operator_ip6)
+{
+    SocketAddress addr;
+    address->set_ip_address("0:0:0:0:0:ffff:7f00:1");
+    address->set_port(81);
+    // First verify assignment operator (including return value) using equality operator.
+    EXPECT_EQ((addr = *address), *address);
+    // Then check inequality operator
+    EXPECT_FALSE(addr != *address);
+    // Now proceed to check that the equality operator really works.
+    isEqual(addr, *address);
+}
+
+TEST_F(TestSocketAddress, equality_null_check)
+{
+    address->set_ip_address("127.0.0.2");
+    EXPECT_NE(*address, static_cast<SocketAddress>(NULL));
+}
+
+TEST_F(TestSocketAddress, equality_wrong_version)
+{
+    SocketAddress addr4("127.0.0.1", 80);
+    SocketAddress addr6("0:0:0:0:0:ffff:7f00:1", 80); // This is converted 127.0.0.1
+    EXPECT_NE(addr4, addr6); // But they should still be inequal.
+}
+
+TEST_F(TestSocketAddress, bool_operator_false)
+{
+    EXPECT_FALSE(*address ? true : false);
+}
+
+TEST_F(TestSocketAddress, bool_operator_ip4_true)
+{
+    SocketAddress addr("127.0.0.1", 80);
+    EXPECT_TRUE(addr ? true : false);
+}
+
+TEST_F(TestSocketAddress, bool_operator_ip6_true)
+{
+    SocketAddress addr("1234:5678:9abc:def0:1234:5678:9abc:def0", 80);
+    EXPECT_TRUE(addr ? true : false);
+}
+
+
+

--- a/UNITTESTS/features/netsocket/SocketAddress/unittest.cmake
+++ b/UNITTESTS/features/netsocket/SocketAddress/unittest.cmake
@@ -1,0 +1,27 @@
+
+####################
+# UNIT TESTS
+####################
+
+# Unit test suite name
+set(TEST_SUITE_NAME "features_netsocket_SocketAddress")
+
+# We want to get rid of ip6string.h fake include to use the real definitions.
+list(REMOVE_ITEM unittest-includes "${PROJECT_SOURCE_DIR}/target_h")
+
+# Source files
+set(unittest-sources
+  ../features/netsocket/SocketAddress.cpp
+  ../features/frameworks/nanostack-libservice/source/libip4string/ip4tos.c
+  ../features/frameworks/nanostack-libservice/source/libip4string/stoip4.c
+# Adding real ip6-related features, to test the relevant functions fully.
+  ../features/frameworks/nanostack-libservice/source/libip6string/ip6tos.c
+  ../features/frameworks/nanostack-libservice/source/libip6string/stoip6.c
+  ../features/frameworks/nanostack-libservice/source/libBits/common_functions.c
+  
+)
+
+# Test files
+set(unittest-test-sources
+  features/netsocket/SocketAddress/test_SocketAddress.cpp
+)

--- a/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
+++ b/UNITTESTS/features/netsocket/TCPServer/test_TCPServer.cpp
@@ -54,7 +54,7 @@ TEST_F(TestTCPServer, constructor)
 
 TEST_F(TestTCPServer, constructor_parameters)
 {
-    TCPServer serverParam = TCPServer(dynamic_cast<NetworkStack*>(&stack));
+    TCPServer serverParam = TCPServer(dynamic_cast<NetworkStack *>(&stack));
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(serverParam.connect(a), NSAPI_ERROR_OK);
 }

--- a/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
+++ b/UNITTESTS/features/netsocket/TCPSocket/test_TCPSocket.cpp
@@ -62,7 +62,7 @@ TEST_F(TestTCPSocket, constructor)
 
 TEST_F(TestTCPSocket, constructor_parameters)
 {
-    TCPSocket socketParam = TCPSocket(dynamic_cast<NetworkStack*>(&stack));
+    TCPSocket socketParam = TCPSocket(dynamic_cast<NetworkStack *>(&stack));
     const SocketAddress a("127.0.0.1", 1024);
     EXPECT_EQ(socketParam.connect(a), NSAPI_ERROR_OK);
 }
@@ -200,7 +200,7 @@ TEST_F(TestTCPSocket, recv_all_data)
 TEST_F(TestTCPSocket, recv_less_than_expected)
 {
     socket->open((NetworkStack *)&stack);
-    unsigned int lessThanDataSize = dataSize -1;
+    unsigned int lessThanDataSize = dataSize - 1;
     stack.return_values.push_back(lessThanDataSize);
     EXPECT_EQ(socket->recv(dataBuf, dataSize), lessThanDataSize);
 }
@@ -262,7 +262,7 @@ TEST_F(TestTCPSocket, accept_no_open)
 {
     nsapi_error_t error;
     stack.return_value = NSAPI_ERROR_OK;
-    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket*>(NULL));
+    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket *>(NULL));
     EXPECT_EQ(error, NSAPI_ERROR_NO_SOCKET);
 }
 
@@ -271,7 +271,7 @@ TEST_F(TestTCPSocket, accept)
     nsapi_error_t error;
     stack.return_value = NSAPI_ERROR_OK;
     socket->open((NetworkStack *)&stack);
-    EXPECT_NE(socket->accept(&error), static_cast<TCPSocket*>(NULL));
+    EXPECT_NE(socket->accept(&error), static_cast<TCPSocket *>(NULL));
     EXPECT_EQ(error, NSAPI_ERROR_OK);
 }
 
@@ -282,6 +282,6 @@ TEST_F(TestTCPSocket, accept_would_block)
     stack.return_value = NSAPI_ERROR_WOULD_BLOCK;
     eventFlagsStubNextRetval.push_back(0);
     eventFlagsStubNextRetval.push_back(osFlagsError); // Break the wait loop
-    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket*>(NULL));
+    EXPECT_EQ(socket->accept(&error), static_cast<TCPSocket *>(NULL));
     EXPECT_EQ(error, NSAPI_ERROR_WOULD_BLOCK);
 }

--- a/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
+++ b/UNITTESTS/features/netsocket/UDPSocket/test_UDPSocket.cpp
@@ -79,7 +79,7 @@ TEST_F(TestUDPSocket, sendto_addr_port)
 TEST_F(TestUDPSocket, connect)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    const nsapi_addr_t addr = {NSAPI_IPv4, {127,0,0,1} };
+    const nsapi_addr_t addr = {NSAPI_IPv4, {127, 0, 0, 1} };
     const SocketAddress a(addr, 1024);
 
     socket->open((NetworkStack *)&stack);
@@ -93,7 +93,7 @@ TEST_F(TestUDPSocket, connect)
 
 TEST_F(TestUDPSocket, sendto_timeout)
 {
-    const nsapi_addr_t saddr = {NSAPI_IPv4, {127,0,0,1} };
+    const nsapi_addr_t saddr = {NSAPI_IPv4, {127, 0, 0, 1} };
     const SocketAddress addr(saddr, 1024);
 
     socket->open((NetworkStack *)&stack);
@@ -127,8 +127,8 @@ TEST_F(TestUDPSocket, recv)
 TEST_F(TestUDPSocket, recv_address_filtering)
 {
     socket->open((NetworkStack *)&stack);
-    const nsapi_addr_t addr1 = {NSAPI_IPv4, {127,0,0,1} };
-    const nsapi_addr_t addr2 = {NSAPI_IPv4, {127,0,0,2} };
+    const nsapi_addr_t addr1 = {NSAPI_IPv4, {127, 0, 0, 1} };
+    const nsapi_addr_t addr2 = {NSAPI_IPv4, {127, 0, 0, 2} };
     SocketAddress a1(addr1, 1024);
     SocketAddress a2(addr2, 1024);
 

--- a/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
+++ b/UNITTESTS/features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+#include "features/netsocket/WiFiAccessPoint.h"
+#include <cstring>
+
+class TestWiFiAccessPoint : public testing::Test {
+protected:
+    WiFiAccessPoint *ap;
+
+    virtual void SetUp()
+    {
+        ap = new WiFiAccessPoint;
+    }
+
+    virtual void TearDown()
+    {
+        delete ap;
+    }
+};
+
+TEST_F(TestWiFiAccessPoint, constructor)
+{
+    EXPECT_TRUE(ap);
+}
+
+TEST_F(TestWiFiAccessPoint, getters_default)
+{
+    // ssid and bssid return pointers to uninitialized memory - impossible to set expectations.
+    EXPECT_EQ(0, ap->get_channel());
+    EXPECT_EQ(0, ap->get_rssi());
+    EXPECT_EQ(NSAPI_SECURITY_NONE, ap->get_security());
+}
+
+TEST_F(TestWiFiAccessPoint, set_data)
+{
+    nsapi_wifi_ap_t testAp = {
+        "mySSID67890123456789012345678901",
+        {0xd8, 0xc7, 0xc8, 0xcc, 0x43, 0x24},
+        NSAPI_SECURITY_WPA2,
+        0x64,
+        0x02,
+    };
+    WiFiAccessPoint *ap1 = new WiFiAccessPoint(testAp);
+    EXPECT_EQ(std::string(testAp.ssid), std::string(ap1->get_ssid()));
+    EXPECT_TRUE(0 == std::memcmp(testAp.bssid, ap1->get_bssid(), sizeof(testAp.bssid)));
+    EXPECT_EQ(testAp.channel, ap1->get_channel());
+    EXPECT_EQ(testAp.rssi, ap1->get_rssi());
+    EXPECT_EQ(testAp.security, ap1->get_security());
+}
+

--- a/UNITTESTS/features/netsocket/WiFiAccessPoint/unittest.cmake
+++ b/UNITTESTS/features/netsocket/WiFiAccessPoint/unittest.cmake
@@ -1,0 +1,12 @@
+
+####################
+# UNIT TESTS
+####################
+
+set(unittest-sources
+  ../features/netsocket/WiFiAccessPoint.cpp
+)
+
+set(unittest-test-sources
+  features/netsocket/WiFiAccessPoint/test_WiFiAccessPoint.cpp
+)

--- a/UNITTESTS/target_h/rtos.h
+++ b/UNITTESTS/target_h/rtos.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2018, Arm Limited and affiliates.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RTOS_H
+#define RTOS_H
+
+typedef enum {
+  osTimerOnce             = 0,          ///< One-shot timer.
+  osTimerPeriodic         = 1           ///< Repeating timer.
+} os_timer_type;
+
+#endif /* RTOS_H */

--- a/features/netsocket/EMACInterface.cpp
+++ b/features/netsocket/EMACInterface.cpp
@@ -117,7 +117,7 @@ NetworkStack *EMACInterface::get_stack()
 }
 
 void EMACInterface::attach(
-    Callback<void(nsapi_event_t, intptr_t)> status_cb)
+    mbed::Callback<void(nsapi_event_t, intptr_t)> status_cb)
 {
     _connection_status_cb = status_cb;
     if (_interface) {

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -171,7 +171,7 @@ protected:
     char _ip_address[NSAPI_IPv6_SIZE];
     char _netmask[NSAPI_IPv4_SIZE];
     char _gateway[NSAPI_IPv4_SIZE];
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 
 #endif


### PR DESCRIPTION
New classes covered with unit tests are: SocketAddress, EthernetInterface, EMACInterface, 

### Description

WiFiAccessPoint.
Also added missing namespace in front of mbed::Callback usages.
EMACInterface is covered by the EthernetInterface unit tests.

### Pull request type

    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

