### PR TITLE
Add FlashIAP block device as default block device for WISE 1570

### DIFF
--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -42,8 +42,8 @@ FlashIAPBlockDevice::FlashIAPBlockDevice()
     DEBUG_PRINTF("FlashIAPBlockDevice: %" PRIX32 " %" PRIX32 "\r\n", address, size);
 }
 
-FlashIAPBlockDevice::FlashIAPBlockDevice(uint32_t address, uint32_t)
-    : _flash(), _base(0), _size(0), _is_initialized(false), _init_ref_count(0)
+FlashIAPBlockDevice::FlashIAPBlockDevice(uint32_t address, uint32_t size)
+    : _flash(), _base(address), _size(size), _is_initialized(false), _init_ref_count(0)
 {
 
 }
@@ -70,11 +70,27 @@ int FlashIAPBlockDevice::init()
     int ret = _flash.init();
 
     if (ret) {
+        core_util_atomic_decr_u32(&_init_ref_count, 1);
         return ret;
     }
 
-    _base = _flash.get_flash_start();
-    _size = _flash.get_flash_size();
+    if (_size + _base > _flash.get_flash_size() + _flash.get_flash_start()) {
+        core_util_atomic_decr_u32(&_init_ref_count, 1);
+        return BD_ERROR_DEVICE_ERROR;
+    }
+
+    if (_base < _flash.get_flash_start()) {
+        core_util_atomic_decr_u32(&_init_ref_count, 1);
+        return BD_ERROR_DEVICE_ERROR;
+    }
+
+    if (!_base) {
+        _base = _flash.get_flash_start();
+    }
+
+    if (!_size) {
+        _size = _flash.get_flash_size() - (_base - _flash.get_flash_start());
+    }
 
     _is_initialized = true;
     return ret;

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -36,12 +36,6 @@
 #define DEBUG_PRINTF(...)
 #endif
 
-FlashIAPBlockDevice::FlashIAPBlockDevice()
-    : _flash(), _base(0), _size(0), _is_initialized(false), _init_ref_count(0)
-{
-    DEBUG_PRINTF("FlashIAPBlockDevice: %" PRIX32 " %" PRIX32 "\r\n", address, size);
-}
-
 FlashIAPBlockDevice::FlashIAPBlockDevice(uint32_t address, uint32_t size)
     : _flash(), _base(address), _size(size), _is_initialized(false), _init_ref_count(0)
 {

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -31,7 +31,11 @@ public:
     /** Creates a FlashIAPBlockDevice **/
     FlashIAPBlockDevice();
 
-    MBED_DEPRECATED("Please use default constructor instead")
+    /** Creates a FlashIAPBlockDevice
+     *
+     *  @param address  Physical address where the block device start
+     *  @param size     The block device size
+     */
     FlashIAPBlockDevice(uint32_t address, uint32_t size = 0);
 
     virtual ~FlashIAPBlockDevice();

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -28,16 +28,15 @@
  */
 class FlashIAPBlockDevice : public BlockDevice {
 public:
-    /** Creates a FlashIAPBlockDevice **/
-    FlashIAPBlockDevice();
 
     /** Creates a FlashIAPBlockDevice
      *
      *  @param address  Physical address where the block device start
      *  @param size     The block device size
      */
-    FlashIAPBlockDevice(uint32_t address, uint32_t size = 0);
-
+    FlashIAPBlockDevice(uint32_t address = MBED_CONF_FLASHIAP_BLOCK_DEVICE_BASE_ADDRESS,
+                        uint32_t size = MBED_CONF_FLASHIAP_BLOCK_DEVICE_SIZE);
+                        
     virtual ~FlashIAPBlockDevice();
 
     /** Initialize a block device

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/TESTS/filesystem/fopen/fopen.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/TESTS/filesystem/fopen/fopen.cpp
@@ -680,7 +680,7 @@ control_t fslittle_fopen_test_05(const size_t call_count)
 }
 
 
-static const char fslittle_fopen_ascii_illegal_buf_g[] = "\"�'*+,./:;<=>?[\\]|";
+static const char fslittle_fopen_ascii_illegal_buf_g[] = "\"?'*+,./:;<=>?[\\]|";
 
 /** @brief  test to call fopen() with filename that in includes
  *          illegal characters

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/mbed_lib.json
@@ -1,0 +1,19 @@
+{
+    "name": "flashiap-block-device",
+    "config": {
+        "base-address": {
+            "help": "Base address for the block device on the external flash.",
+            "value": "0xFFFFFFFF"
+        },
+        "size": {
+            "help": "Memory allocated for block device.",
+            "value": "0"
+        }
+    },
+    "target_overrides": {
+        "REALTEK_RTL8195AM": {
+            "base-address": "0x1C0000",
+            "size": "0x40000"
+        }
+    }
+}

--- a/features/storage/TESTS/filesystem/general_filesystem/main.cpp
+++ b/features/storage/TESTS/filesystem/general_filesystem/main.cpp
@@ -24,6 +24,9 @@
 #elif COMPONENT_SD
 #include "SDBlockDevice.h"
 #include "FATFileSystem.h"
+#elif COMPONENT_FLASHIAP
+#include "FlashIAPBlockDevice.h"
+#include "LittleFileSystem.h"
 #else
 #error [NOT_SUPPORTED] storage test not supported on this platform
 #endif

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -30,7 +30,22 @@
 #include "SDBlockDevice.h"
 #endif
 
+#if COMPONENT_FLASHIAP
+#include "nvstore.h"
+#include "FlashIAPBlockDevice.h"
+#endif
+
 using namespace mbed;
+
+// Align a value to a specified size.
+// Parameters :
+// val           - [IN]   Value.
+// size          - [IN]   Size.
+// Return        : Aligned value.
+static inline uint32_t align_up(uint32_t val, uint32_t size)
+{
+    return (((val - 1) / size) + 1) * size;
+}
 
 MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 {
@@ -68,6 +83,32 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
     return &default_bd;
 
+#elif COMPONENT_FLASHIAP
+
+    uint32_t top_address;
+    uint32_t bottom_address;
+    size_t area_size;
+    FlashIAP flash;
+    NVStore &nvstore = NVStore::get_instance();
+    nvstore.get_area_params(0, top_address, area_size); //Find where nvstore begins
+
+    int ret = flash.init();
+    if (ret != 0) {
+        return 0;
+    }
+
+    //Find the start of first sector after text area
+    bottom_address = align_up(FLASHIAP_ROM_END, flash.get_sector_size(FLASHIAP_ROM_END));
+
+    if (top_address <= bottom_address) {
+        return 0;
+    }
+
+    ret = flash.deinit();
+
+    static FlashIAPBlockDevice default_bd(bottom_address, top_address - bottom_address);
+
+    return &default_bd;
 #else
 
     return NULL;
@@ -91,6 +132,13 @@ MBED_WEAK FileSystem *FileSystem::get_default_instance()
     sdcard.set_as_default();
 
     return &sdcard;
+
+#elif COMPONENT_FLASHIAP
+
+    static LittleFileSystem flash("flash", BlockDevice::get_default_instance());
+    flash.set_as_default();
+
+    return &flash;
 
 #else
 

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1739,6 +1739,7 @@
         "device_name": "STM32L486RG"
     },
     "MTB_ADV_WISE_1570": {
+        "components": ["FLASHIAP"],
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L486RG", "STM32L486xG", "WISE_1570"],


### PR DESCRIPTION
…AP as default block device for wise 1570

### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
This PR is adding FlashIAP block device component as the default block device for Wise 1570 board. 
To accomplish this the deprecated constructor was reverted and used by calculating the start address at the first sector after the code address zone and the end address at the last sector before nvstore address zone.
This way the FlashIAP default block device does not overwrite any code or nvstore data.

Fix both issues MBEDOSTEST-209 and MBEDOSTEST-208 as they have been found to be related.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

