### PR TITLE
BLE: fix use of invalid cccd index

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioGattServer.h
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/CordioGattServer.h
@@ -222,8 +222,8 @@ private:
     void add_generic_attribute_service();
     void* alloc_block(size_t block_size);
     GattCharacteristic* get_auth_char(uint16_t value_handle);
-    bool get_cccd_id(GattAttribute::Handle_t cccd_handle, uint8_t& idx) const;
-    bool has_cccd(GattAttribute::Handle_t char_handle) const;
+    bool get_cccd_index_by_cccd_handle(GattAttribute::Handle_t cccd_handle, uint8_t& idx) const;
+    bool get_cccd_index_by_value_handle(GattAttribute::Handle_t char_handle, uint8_t& idx) const;
     bool is_update_authorized(Gap::Handle_t connection, GattAttribute::Handle_t value_handle);
 
     struct alloc_block_t {

--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioGattServer.cpp
@@ -560,7 +560,7 @@ ble_error_t GattServer::read(
 ) {
     // Check to see if this is a CCCD
     uint8_t cccd_index;
-    if (get_cccd_id(att_handle, cccd_index)) {
+    if (get_cccd_index_by_cccd_handle(att_handle, cccd_index)) {
         if (connection == DM_CONN_ID_NONE) {
             return BLE_ERROR_PARAM_OUT_OF_RANGE;
         }
@@ -588,7 +588,7 @@ ble_error_t GattServer::write(
     // Check to see if this is a CCCD, if it is the case update the value for all
     // connections
     uint8_t cccd_index;
-    if (get_cccd_id(att_handle, cccd_index)) {
+    if (get_cccd_index_by_cccd_handle(att_handle, cccd_index)) {
         if (len != sizeof(uint16_t)) {
             return BLE_ERROR_INVALID_PARAM;
         }
@@ -615,7 +615,7 @@ ble_error_t GattServer::write(
     }
 
     // return if the update does not have to be propagated to peers
-    if (local_only || !has_cccd(att_handle)) {
+    if (local_only || !get_cccd_index_by_value_handle(att_handle, cccd_index)) {
         return BLE_ERROR_NONE;
     }
 
@@ -660,7 +660,7 @@ ble_error_t GattServer::write(
 ) {
     // Check to see if this is a CCCD
     uint8_t cccd_index;
-    if (get_cccd_id(att_handle, cccd_index)) {
+    if (get_cccd_index_by_cccd_handle(att_handle, cccd_index)) {
         if ((connection == DM_CONN_ID_NONE) || (len != 2)) { // CCCDs are always 16 bits
             return BLE_ERROR_PARAM_OUT_OF_RANGE;
         }
@@ -677,7 +677,7 @@ ble_error_t GattServer::write(
     }
 
     // return if the update does not have to be propagated to peers
-    if (local_only || !has_cccd(att_handle)) {
+    if (local_only || !get_cccd_index_by_value_handle(att_handle, cccd_index)) {
         return BLE_ERROR_NONE;
     }
 
@@ -1211,7 +1211,7 @@ GattCharacteristic* GattServer::get_auth_char(uint16_t value_handle)
     return NULL;
 }
 
-bool GattServer::get_cccd_id(GattAttribute::Handle_t cccd_handle, uint8_t& idx) const
+bool GattServer::get_cccd_index_by_cccd_handle(GattAttribute::Handle_t cccd_handle, uint8_t& idx) const
 {
     for (idx = 0; idx < cccd_cnt; idx++) {
         if (cccd_handle == cccds[idx].handle) {
@@ -1221,10 +1221,10 @@ bool GattServer::get_cccd_id(GattAttribute::Handle_t cccd_handle, uint8_t& idx) 
     return false;
 }
 
-bool GattServer::has_cccd(GattAttribute::Handle_t char_handle) const
+bool GattServer::get_cccd_index_by_value_handle(GattAttribute::Handle_t char_handle, uint8_t& idx) const
 {
-    for (uint8_t cccd_index = 0; cccd_index < cccd_cnt; ++cccd_index) {
-        if (char_handle == cccd_handles[cccd_index]) {
+    for (idx = 0; idx < cccd_cnt; ++idx) {
+        if (char_handle == cccd_handles[idx]) {
             return true;
         }
     }


### PR DESCRIPTION
### Description

There was an error in gatt server where the cccd index variable was being used outside of its valid scope. This fix updates the variable to its correct value in the outside scope.

I also renamed the functions to explicitly state what they do to avoid ambiguity. There index is the same but the handle used to get it is different. This is now reflected in the names.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

