### PR TITLE
Checksum the vector table of the LPC546XX

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -821,6 +821,7 @@
         "detect_code": ["1054"],
         "device_has": ["USTICKER", "RTC", "ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH"],
         "release_versions": ["2", "5"],
+        "post_binary_hook": {"function": "LPCTargetCode.lpc_patch"},
         "device_name" : "LPC54114J256BD64"
     },
     "MCU_LPC546XX": {
@@ -832,6 +833,7 @@
         "inherits": ["Target"],
         "device_has": ["USTICKER", "RTC", "ANALOGIN", "EMAC", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "FLASH", "TRNG"],
         "device_name" : "LPC54628J512ET180",
+        "post_binary_hook": {"function": "LPCTargetCode.lpc_patch"},
         "overrides": {
             "network-default-interface-type": "ETHERNET"
         }


### PR DESCRIPTION
### Description

LPC devices require a checksummed vector table to boot. To ensure this most programmers automatically compute the checksum when programming flash. This causes problems with verification if the original image does not have a checksummed vector table. This is because when reading the data back the checksum location differs from the original image.

To fix this verification failure this patch adds a post build hook to checksum the vector table of the LPC546XX. This fixes flash verification failures due to the checksum not matching.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

