### PR TITLE
Guard Atmel RF driver build by DEVICE_I2C

### DIFF
--- a/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
+++ b/components/802.15.4_RF/atmel-rf-driver/atmel-rf-driver/NanostackRfPhyAtmel.h
@@ -20,7 +20,7 @@
 #include "at24mac.h"
 #include "PinNames.h"
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C
 
 #include "NanostackRfPhy.h"
 

--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -15,7 +15,7 @@
  */
 #include <string.h>
 
-#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI
+#if defined(MBED_CONF_NANOSTACK_CONFIGURATION) && DEVICE_SPI && DEVICE_I2C
 
 #include "platform/arm_hal_interrupt.h"
 #include "nanostack/platform/arm_hal_phy.h"

--- a/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/at24mac.cpp
@@ -15,6 +15,8 @@
  */
 #include "at24mac.h"
 
+#if DEVICE_I2C
+
 /* Device addressing */
 #define AT24MAC_EEPROM_ADDRESS		(0x0A<<4)
 #define AT24MAC_RW_PROTECT_ADDRESS	(0x06<<4)
@@ -80,3 +82,5 @@ int AT24Mac::read_eui48(void *buf)
         return -1; //No ACK
     return _i2c.read(AT24MAC_SERIAL_ADDRESS, (char*)buf, EUI48_LEN);
 }
+
+#endif /* DEVICE_I2C */

--- a/components/802.15.4_RF/atmel-rf-driver/source/at24mac.h
+++ b/components/802.15.4_RF/atmel-rf-driver/source/at24mac.h
@@ -17,6 +17,9 @@
 #define AT24MAC_H
 
 #include "PinNames.h"
+
+#if DEVICE_I2C
+
 #include "I2C.h"
 #include "drivers/DigitalInOut.h"
 #include "platform/mbed_wait_api.h"
@@ -71,4 +74,5 @@ private:
     mbed::I2C _i2c;
 };
 
+#endif /* DEVICE_I2C */
 #endif /* AT24MAC_H */


### PR DESCRIPTION
### Description

This module uses AT24MAC chip which is in I2C bus, so it requires
device to support I2C


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

