### PR TITLE
Platform: fix missing namespace for SharedPtr

### DIFF
--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -289,6 +289,8 @@ bool operator!= (U lhs, const SharedPtr<T> &rhs)
 
 } /* namespace mbed */
 
+#ifndef MBED_NO_GLOBAL_USING_DIRECTIVE
 using mbed::SharedPtr;
+#endif
 
 #endif // __SHAREDPTR_H__

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -289,4 +289,6 @@ bool operator!= (U lhs, const SharedPtr<T> &rhs)
 
 } /* namespace mbed */
 
+using mbed::SharedPtr;
+
 #endif // __SHAREDPTR_H__

--- a/platform/SharedPtr.h
+++ b/platform/SharedPtr.h
@@ -24,6 +24,8 @@
 
 #include "platform/mbed_critical.h"
 
+namespace mbed {
+
 /** Shared pointer class.
   *
   * A shared pointer is a "smart" pointer that retains ownership of an object using
@@ -284,5 +286,7 @@ bool operator!= (U lhs, const SharedPtr<T> &rhs)
 {
     return ((T *) lhs != rhs.get());
 }
+
+} /* namespace mbed */
 
 #endif // __SHAREDPTR_H__


### PR DESCRIPTION
### Description

Add missing mbed namespace to class. We avoid making a breaking change with the "using".

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [x] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

