### PR TITLE
Stream: add necessary flushes, removing unneeded IAR workaround

### DIFF
--- a/TESTS/mbed_platform/Stream/main.cpp
+++ b/TESTS/mbed_platform/Stream/main.cpp
@@ -1,0 +1,75 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2018 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "greentea-client/test_env.h"
+#include "utest/utest.h"
+#include "unity/unity.h"
+#include "mbed.h"
+
+using utest::v1::Case;
+
+class Loopback : public Stream {
+public:
+    Loopback(const char *name = NULL) : Stream(name) {}
+
+protected:
+    virtual int _getc()
+    {
+        return _c;
+    }
+    virtual int _putc(int c)
+    {
+        _c = c;
+        return c;
+    }
+private:
+    char _c;
+};
+
+Loopback loop("loopback");
+
+void test_putc_getc()
+{
+    int ret;
+    char char_buf[2] = {'a', 'b'};
+
+    ret = loop.putc(char_buf[0]);
+    TEST_ASSERT_EQUAL_INT(char_buf[0], ret);
+    ret = loop.getc();
+    TEST_ASSERT_EQUAL_INT(char_buf[0], ret);
+    ret = loop.putc(char_buf[1]);
+    TEST_ASSERT_EQUAL_INT(char_buf[1], ret);
+    ret = loop.getc();
+    TEST_ASSERT_EQUAL_INT(char_buf[1], ret);
+    return;
+}
+
+utest::v1::status_t test_setup(const size_t number_of_cases)
+{
+    GREENTEA_SETUP(10, "default_auto");
+    return utest::v1::verbose_test_setup_handler(number_of_cases);
+}
+
+Case cases[] = {
+    Case("Test putc/getc", test_putc_getc)
+};
+
+utest::v1::Specification specification(test_setup, cases);
+
+int main()
+{
+    return !utest::v1::Harness::run(specification);
+}

--- a/platform/Stream.cpp
+++ b/platform/Stream.cpp
@@ -43,7 +43,7 @@ Stream::~Stream()
 int Stream::putc(int c)
 {
     lock();
-    fflush(_file);
+    std::fseek(_file, 0, SEEK_CUR);
     int ret = std::fputc(c, _file);
     unlock();
     return ret;
@@ -51,7 +51,7 @@ int Stream::putc(int c)
 int Stream::puts(const char *s)
 {
     lock();
-    fflush(_file);
+    std::fseek(_file, 0, SEEK_CUR);
     int ret = std::fputs(s, _file);
     unlock();
     return ret;
@@ -60,7 +60,7 @@ int Stream::getc()
 {
     lock();
     fflush(_file);
-    int ret = mbed_getc(_file);
+    int ret = std::fgetc(_file);
     unlock();
     return ret;
 }
@@ -68,7 +68,7 @@ char *Stream::gets(char *s, int size)
 {
     lock();
     fflush(_file);
-    char *ret = mbed_gets(s, size, _file);
+    char *ret = std::fgets(s, size, _file);
     unlock();
     return ret;
 }

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -32,8 +32,6 @@ namespace mbed {
  */
 
 extern void mbed_set_unbuffered_stream(std::FILE *_file);
-extern int mbed_getc(std::FILE *_file);
-extern char *mbed_gets(char *s, int size, std::FILE *_file);
 
 /** File stream
  *

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1345,38 +1345,6 @@ void mbed_set_unbuffered_stream(std::FILE *_file)
 #endif
 }
 
-int mbed_getc(std::FILE *_file)
-{
-#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
-    /*This is only valid for unbuffered streams*/
-    int res = std::fgetc(_file);
-    if (res >= 0) {
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }
-    return res;
-#else
-    return std::fgetc(_file);
-#endif
-}
-
-char *mbed_gets(char *s, int size, std::FILE *_file)
-{
-#if defined(__IAR_SYSTEMS_ICC__ ) && (__VER__ < 8000000)
-    /*This is only valid for unbuffered streams*/
-    char *str = fgets(s, size, _file);
-    if (str != NULL) {
-        _file->_Mode = (unsigned short)(_file->_Mode & ~ 0x1000);/* Unset read mode */
-        _file->_Rend = _file->_Wend;
-        _file->_Next = _file->_Wend;
-    }
-    return str;
-#else
-    return std::fgets(s, size, _file);
-#endif
-}
-
 } // namespace mbed
 
 #if defined (__ICCARM__)


### PR DESCRIPTION
### Description

You are allowed in POSIX / ANSI C to read and write on the same stream, but you have to do an fseek in between. From the Linux man pages ( https://www.systutorials.com/docs/linux/man/3-fdopen/):

Thanks @Alex-EEE for sharing the fix: #7749
Resolves: https://github.com/ARMmbed/mbed-os/issues/7571

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

