### PR TITLE
mbed dm: Check for missing payload and give a better error message

### DIFF
--- a/tools/device_management.py
+++ b/tools/device_management.py
@@ -83,6 +83,9 @@ def wrap_payload(func):
                 app_name, output_ext
             ))
             options.payload = open(payload_name, "rb")
+        if not options.payload:
+            LOG.error("No Payload specified. Please use \"-t\" and \"-m\" or \"-p\" to specify a payload ")
+            exit(1)
         return func(options)
     return inner
 


### PR DESCRIPTION
### Description

The error message when you invoke `mbed dm update prepare` without a payload
is particularly obtuse, and provides a user with no indication that the 
payload is missing. This change makes that error message not stink.

@maclobdell Thanks for pointing this out offline.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change