### PR TITLE
Fix hard-fault when socket created using accept() is closed

### DIFF
--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -204,6 +204,7 @@ TEST_F(TestInternetSocket, getsockopt)
 TEST_F(TestInternetSocket, sigio)
 {
     callback_is_called = false;
+    socket->open((NetworkStack *)&stack);
     socket->sigio(mbed::callback(my_callback));
     socket->close(); // Trigger event;
     EXPECT_EQ(callback_is_called, true);

--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -56,6 +56,10 @@ nsapi_error_t InternetSocket::close()
     _lock.lock();
 
     nsapi_error_t ret = NSAPI_ERROR_OK;
+    if (!_stack)  {
+        return ret;
+    }
+
     if (_socket) {
         _stack->socket_attach(_socket, 0, 0);
         nsapi_socket_t socket = _socket;


### PR DESCRIPTION


### Description

When socket created  using accept() is closed by calling the close()
method, "delete this" is executed which triggers the destructor call
on TCPSocket which in turn calls close() once again. Because _stack
is already 0 this results in a hard-fault.

Add a check that skips the rest of the close() method if the _stack
is already 0.

Tested on NUCLEO-F767ZI. Applies both to master and to release-candidate branches.

### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

