### PR TITLE
Fix hard-fault when socket created using accept() is deleted

### DIFF
--- a/features/netsocket/TCPSocket.cpp
+++ b/features/netsocket/TCPSocket.cpp
@@ -24,6 +24,7 @@ TCPSocket::TCPSocket()
 
 TCPSocket::~TCPSocket()
 {
+    _factory_allocated = false;
     close();
 }
 

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -24,6 +24,7 @@ UDPSocket::UDPSocket()
 
 UDPSocket::~UDPSocket()
 {
+    _factory_allocated = false;
     close();
 }
 


### PR DESCRIPTION
### Description

When socket created  using accept() is deleted the destructor is called
on TCPSocket which in turn calls close() method which executes
"delete this". This causes hard-fault.

Set _factory_allocated to 0 in destructor call which effectively skips
"delete this" in a close method.

Tested on NUCLEO-F767ZI. Applies both to master and to release-candidate branches.

### Pull request type


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change
