### PR TITLE
poll: Un-doxygen internal comment

### DIFF
--- a/platform/mbed_poll.cpp
+++ b/platform/mbed_poll.cpp
@@ -29,7 +29,7 @@ namespace mbed {
 // timeout -1 forever, or milliseconds
 int poll(pollfh fhs[], unsigned nfhs, int timeout)
 {
-    /**
+    /*
      * TODO Proper wake-up mechanism.
      * In order to correctly detect availability of read/write a FileHandle, we needed
      * a select or poll mechanisms. We opted for poll as POSIX defines in


### PR DESCRIPTION
### Description

Remove unwanted internal TODO comment from https://os-doc-builder.test.mbed.com/docs/development/mbed-os-api-doxy/group__platform__poll.html

Noticed while preparing https://github.com/ARMmbed/mbed-os-5-docs/pull/745 - maybe useful as a testbed for documentation update pull request type (https://github.com/ARMmbed/mbed-os/pull/8237)

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Breaking change

