### PR TITLE
Add K66F default sd storage

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -698,6 +698,7 @@
     },
     "K66F": {
         "supported_form_factors": ["ARDUINO"],
+        "components": ["SD"],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM", "Freescale_EMAC"],
@@ -706,6 +707,7 @@
         "inherits": ["Target"],
         "detect_code": ["0311"],
         "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "ANALOGOUT", "EMAC", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
+        "features": ["STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK66FN2M0xxx18",
         "bootloader_supported": true,

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -707,7 +707,6 @@
         "inherits": ["Target"],
         "detect_code": ["0311"],
         "device_has": ["USTICKER", "LPTICKER", "RTC", "ANALOGIN", "ANALOGOUT", "EMAC", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "TRNG", "FLASH"],
-        "features": ["STORAGE"],
         "release_versions": ["2", "5"],
         "device_name": "MK66FN2M0xxx18",
         "bootloader_supported": true,


### PR DESCRIPTION
### Description
K66F has an SD Card. Let's implement it as the default storage using the new default storage mechanism in 5.10. This helps ensure new example apps that use BlockDevice::get_default_instance(); work with no extra configuring.

### Pull request type
    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Breaking change

