### PR TITLE
Cellular: Fix for AT handler consume to tag

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -1052,6 +1052,27 @@ TEST_F(TestATHandler, test_ATHandler_consume_to_stop_tag)
 
     ATHandler at(&fh1, que, 0, ",");
     EXPECT_TRUE(at.consume_to_stop_tag());
+
+    at.clear_error();
+    char table1[] = "\r\n\r\r\r\nOOK\r\n";
+    at.flush();
+    filehandle_stub_table = table1;
+    filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = 1;
+    char buf1[6];
+    at.resp_start();
+    EXPECT_TRUE(at.consume_to_stop_tag());
+
+    at.clear_error();
+    char table2[] = "OKOK\r\n";
+    at.flush();
+    filehandle_stub_table = table2;
+    filehandle_stub_table_pos = 0;
+    mbed_poll_stub::revents_value = POLLIN;
+    mbed_poll_stub::int_value = 1;
+    char buf2[6];
+    EXPECT_TRUE(at.consume_to_stop_tag());
 }
 
 TEST_F(TestATHandler, test_ATHandler_set_debug)

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -926,7 +926,9 @@ bool ATHandler::consume_to_tag(const char *tag, bool consume_tag)
         int c = get_char();
         if (c == -1) {
             break;
-        } else if (c == tag[match_pos]) {
+        // compares c against tag at current position and if this match fails
+        // compares c against tag[0] and also resets match_pos to 0
+        } else if (c == tag[match_pos] || ((match_pos = 1) && (c == tag[--match_pos]))) {
             match_pos++;
             if (match_pos == strlen(tag)) {
                 if (!consume_tag) {
@@ -934,8 +936,6 @@ bool ATHandler::consume_to_tag(const char *tag, bool consume_tag)
                 }
                 return true;
             }
-        } else if (match_pos) {
-            match_pos = 0;
         }
     }
     tr_debug("consume_to_tag not found");


### PR DESCRIPTION
### Description

This PR addresses: https://github.com/ARMmbed/mbed-os/issues/8308

"I'm trying to make a driver for a sim5320 using cellular framework, but ATHandler doesn't parse some responses correctly. After some investigation, I found that problem is caused by ATHandler::consume_to_tag method.

If sequence from buffer contains tag and a symbol before tag coincides with zero symbol of the tag, then the tag won't be detected. For example, if it consumes to a tag "\r\n" in a sequence "\r\r\nOK", the tag won't be found."

### Pull request type
    [ x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

