### PR TITLE
Allow overriding build timestamp from env

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -19,7 +19,7 @@ from __future__ import print_function, division, absolute_import
 import re
 import sys
 import json
-from os import stat, walk, getcwd, sep, remove
+from os import stat, walk, getcwd, sep, remove, getenv
 from copy import copy
 from time import time, sleep
 from shutil import copyfile
@@ -126,7 +126,7 @@ class mbedToolchain:
 
         # Build output dir
         self.build_dir = abspath(build_dir) if PRINT_COMPILER_OUTPUT_AS_LINK else build_dir
-        self.timestamp = time()
+        self.timestamp = getenv("MBED_BUILD_TIMESTAMP",time())
 
         # Number of concurrent build jobs. 0 means auto (based on host system cores)
         self.jobs = 0


### PR DESCRIPTION
### Description

Small tweak to build scripts to allow much faster cached builds with `ccache` and other cache drivers. Local cache such as `ccache` does not work if -DMBED_BUILD_TIMESTAMP=xy is passed with different value every instantiation. Allowing override through env to a fixed value enables speeding up the local builds substantially.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

