### PR TITLE
nRF5x: Fix WFE entry

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/sleep.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/sleep.c
@@ -27,10 +27,6 @@
 #define NRF_HAL_SLEEP_SD_IS_ENABLED() 0
 #endif
 
-// Mask of reserved bits of the register ICSR in the System Control Block peripheral
-// In this case, bits which are equal to 0 are the bits reserved in this register
-#define SCB_ICSR_RESERVED_BITS_MASK     0x9E43F03F
-
 #define FPU_EXCEPTION_MASK 0x0000009F
 
 extern bool us_ticker_initialized;
@@ -67,21 +63,10 @@ void hal_sleep(void)
         // by using SEV/WFE pair, and then execute WFE again, unless there is
         // a pending interrupt.
 
-        // Set an event and wake up whatsoever, this will clear the event
-        // register from all previous events set (SVC call included)
+        __DSB();
         __SEV();
         __WFE();
-
-        // Test if there is an interrupt pending (mask reserved regions)
-        if (SCB->ICSR & (SCB_ICSR_RESERVED_BITS_MASK)) {
-            // Ok, there is an interrut pending, no need to go to sleep
-            return;
-        } else {
-            // next event will wakeup the CPU
-            // If an interrupt occured between the test of SCB->ICSR and this
-            // instruction, WFE will just not put the CPU to sleep
-            __WFE();
-        }
+        __WFE();
     }
 }
 


### PR DESCRIPTION
 - Remove check on Interrupt Control and State Reg (ICSR) as this could prevent low power entry
 - Add DSB before WFE for architectural compliance
 - Remove dead code for nRF51

### Description

Gating entry to WFE on the ICSR can prevent the core from entering low power mode if there is a stale pending interrupt, so the check of the ICSR needs to be removed.  

We should also add a DSB instruction before executing WFE to be architecturally compliant with the Arm architecture.  This ensures that all outstanding memory transactions are complete before entering low power mode.

Some dead preprocessor FPU-related code was removed for the nRF51 (which is based on Cortex-M0).

See https://github.com/ARMmbed/mbed-os/issues/5647 and https://github.com/ARMmbed/mbed-os/pull/8224 for backing reference.

### Pull request type
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

