### PR TITLE
Renesas : Improve ARMCC linker script

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/MBRZA1LU.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_GR_LYCHEE/device/TOOLCHAIN_ARM_STD/MBRZA1LU.sct
@@ -7,7 +7,21 @@
 
 ; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
 
-#include "mem_RZ_A1LU.h"
+#define __RAM_BASE       0x20000000
+#define __RAM_SIZE       0x00300000
+#define __NC_RAM_SIZE    0x00100000
+#define __NM_RAM_SIZE    (__RAM_SIZE - __NC_RAM_SIZE)
+#define __DATA_NC_BASE   (__RAM_BASE + __NM_RAM_SIZE + 0x40000000)
+
+#define __UND_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00008000
+#define __ABT_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x0000F000
+#define __STACK_SIZE     (__UND_STACK_SIZE + __SVC_STACK_SIZE + __ABT_STACK_SIZE + __FIQ_STACK_SIZE + __IRQ_STACK_SIZE)
+
+#define __TTB_BASE       0x20000000
+#define __TTB_SIZE       0x00004000
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0x18000000

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/TOOLCHAIN_ARM_STD/MBRZA1H.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_RZ_A1H/device/TOOLCHAIN_ARM_STD/MBRZA1H.sct
@@ -7,7 +7,21 @@
 
 ; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
 
-#include "mem_RZ_A1H.h"
+#define __RAM_BASE       0x20000000
+#define __RAM_SIZE       0x00A00000
+#define __NC_RAM_SIZE    0x00100000
+#define __NM_RAM_SIZE    (__RAM_SIZE - __NC_RAM_SIZE)
+#define __DATA_NC_BASE   (__RAM_BASE + __NM_RAM_SIZE + 0x40000000)
+
+#define __UND_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00008000
+#define __ABT_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x0000F000
+#define __STACK_SIZE     (__UND_STACK_SIZE + __SVC_STACK_SIZE + __ABT_STACK_SIZE + __FIQ_STACK_SIZE + __IRQ_STACK_SIZE)
+
+#define __TTB_BASE       0x20000000
+#define __TTB_SIZE       0x00004000
 
 #if !defined(MBED_APP_START)
   #define MBED_APP_START 0x18000000

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/TOOLCHAIN_ARM_STD/VKRZA1H.sct
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/TARGET_VK_RZ_A1H/device/TOOLCHAIN_ARM_STD/VKRZA1H.sct
@@ -8,7 +8,45 @@
 ; This scatter-file places application code, data, stack and heap at suitable addresses in the memory map.
 
 #include "mbed_config.h"
-#include "mem_VK_RZ_A1H.h"
+
+#ifdef RUN_FROM_SDRAM
+ #define __ROM_BASE       0x08000000
+ #define __ROM_SIZE       0x02000000
+ #define __VECTOR_BASE    0x08000000
+ #define __DATA_BASE	  +0 ALIGN 0x100000
+#elif defined (RUN_FROM_SRAM)
+ #define __ROM_BASE       0x200A0000
+ #define __ROM_SIZE       0x00960000
+ #define __VECTOR_BASE    0x200A0000
+ #define __DATA_BASE	  +0 ALIGN 0x100000 NOCOMPRESS
+#else
+ #define __ROM_BASE       0x18020000
+ #define __ROM_SIZE       0x01FE0000
+ #define __VECTOR_BASE    0x18020000
+ #define __DATA_BASE	  0x20020000
+#endif
+
+#ifdef RUN_FROM_SDRAM
+#define __RAM_BASE       0x08000000
+#define __RAM_SIZE       0x02000000
+#define __NC_RAM_SIZE    0x00200000
+#else
+#define __RAM_BASE       0x20000000
+#define __RAM_SIZE       0x00A00000
+#define __NC_RAM_SIZE    0x00100000
+#endif
+#define __NM_RAM_SIZE    (__RAM_SIZE - __NC_RAM_SIZE)
+#define __DATA_NC_BASE   (__RAM_BASE + __NM_RAM_SIZE + 0x40000000)
+
+#define __UND_STACK_SIZE 0x00000100
+#define __SVC_STACK_SIZE 0x00008000
+#define __ABT_STACK_SIZE 0x00000100
+#define __FIQ_STACK_SIZE 0x00000100
+#define __IRQ_STACK_SIZE 0x0000F000
+#define __STACK_SIZE     (__UND_STACK_SIZE + __SVC_STACK_SIZE + __ABT_STACK_SIZE + __FIQ_STACK_SIZE + __IRQ_STACK_SIZE)
+
+#define __TTB_BASE       0x20000000
+#define __TTB_SIZE       0x00004000
 
 LOAD_TTB    __TTB_BASE __TTB_SIZE ; Page 0 of On-Chip Data Retention RAM
 {


### PR DESCRIPTION
### Description
To address issue #6975 , I remove inclusion processing and define the related macros at ARMCC linker script file.

For Arm toolchain build, Mbed 2(classic) programs occur an unexpected error if there is `#include "mem_XXXX.h"` in the script file. It seems that the linker script can't find the include file because `mem_XXXX.h` file is not in the same path with the linker script.

There is no problem with Mbed OS 5 programs.




<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

@mbedNoobNinja 
Could you review about changes to VK_RZ_A1H?


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

