### PR TITLE
Renesas : Minor change of SPI driver

### DIFF
--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/spi_api.c
@@ -149,9 +149,11 @@ void spi_frequency(spi_t *obj, int hz) {
     
     hz_min = pclk_base / 2 / 256 / 8;
     hz_max = pclk_base / 2;
-    if (((uint32_t)hz < hz_min) || ((uint32_t)hz > hz_max)) {
-        error("Couldn't setup requested SPI frequency");
-        return;
+    if ((uint32_t)hz < hz_min) {
+        hz = hz_min;
+    }
+    if ((uint32_t)hz > hz_max) {
+        hz = hz_max;
     }
     
     div = (pclk_base / hz / 2);


### PR DESCRIPTION
### Description
I change SPI driver a bit for matching policy with other Renesas drivers.

If the specified frequency exceeds the upper limit and lower limit at SPI driver, an error is output, but this does not match policy with other renesas drivers. Thus I change the processing as follows.
- If "hz" is maximum over, it is rounded by the maximum value.
- If "hz" is minimum under, it is rounded by the minimum value.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

