### PR TITLE
Fixed colorama Python package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-colorama>=0.3.3
+colorama==0.3.9
 PySerial>=2.7
 PrettyTable>=0.7.2
 Jinja2>=2.7.3


### PR DESCRIPTION
### Description

Colorama package being at the top of the requirements.txt list causes other requirements to not be fufilled. All packages require <0.4.0, aka the latest 0.3.x patch release.

Since this was the first line in requirements.txt, colorama v0.4.0 was recently released: https://github.com/tartley/colorama/releases/tag/0.4.0

Once installed, manifest-tool and mbed-greentea would (properly) fail because they need a 0.3.x. Not sure why pip isn't able to correct this, but I digress.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Breaking change

