### PR TITLE
At handler fixes

### DIFF
--- a/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
+++ b/UNITTESTS/features/cellular/framework/AT/athandler/athandlertest.cpp
@@ -143,7 +143,7 @@ TEST_F(TestATHandler, test_ATHandler_remove_urc_handler)
     at.set_urc_handler(ch, cb);
 
     //This does nothing!!!
-    at.remove_urc_handler(ch, cb);
+    at.remove_urc_handler(ch);
 }
 
 TEST_F(TestATHandler, test_ATHandler_get_last_error)

--- a/UNITTESTS/stubs/ATHandler_stub.cpp
+++ b/UNITTESTS/stubs/ATHandler_stub.cpp
@@ -105,7 +105,7 @@ nsapi_error_t ATHandler::set_urc_handler(const char *urc, mbed::Callback<void()>
     return ATHandler_stub::nsapi_error_value;
 }
 
-void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> callback)
+void ATHandler::remove_urc_handler(const char *prefix)
 {
 }
 

--- a/UNITTESTS/stubs/FileHandle_stub.h
+++ b/UNITTESTS/stubs/FileHandle_stub.h
@@ -42,7 +42,7 @@ public:
             if (size < ret) {
                 ret = size;
             }
-            memcpy(buffer, filehandle_stub_table, ret);
+            memcpy(buffer, filehandle_stub_table + filehandle_stub_table_pos, ret);
             filehandle_stub_table_pos += ret;
             return ret;
         }

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -820,6 +820,8 @@ void ATHandler::resp(const char *prefix, bool check_urc)
 
         if (check_urc && match_urc()) {
             _urc_matched = true;
+            clear_error();
+            continue;
         }
 
         // If no match found, look for CRLF and consume everything up to and including CRLF

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -159,7 +159,7 @@ void ATHandler::set_is_filehandle_usable(bool usable)
 
 nsapi_error_t ATHandler::set_urc_handler(const char *prefix, mbed::Callback<void()> callback)
 {
-    if (find_urc_handler(prefix, &callback)) {
+    if (find_urc_handler(prefix)) {
         tr_warn("URC already added with prefix: %s", prefix);
         return NSAPI_ERROR_OK;
     }
@@ -186,12 +186,12 @@ nsapi_error_t ATHandler::set_urc_handler(const char *prefix, mbed::Callback<void
     return NSAPI_ERROR_OK;
 }
 
-void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> callback)
+void ATHandler::remove_urc_handler(const char *prefix)
 {
     struct oob_t *current = _oobs;
     struct oob_t *prev = NULL;
     while (current) {
-        if (strcmp(prefix, current->prefix) == 0 && current->cb == callback) {
+        if (strcmp(prefix, current->prefix) == 0) {
             if (prev) {
                 prev->next = current->next;
             } else {
@@ -205,11 +205,11 @@ void ATHandler::remove_urc_handler(const char *prefix, mbed::Callback<void()> ca
     }
 }
 
-bool ATHandler::find_urc_handler(const char *prefix, mbed::Callback<void()> *callback)
+bool ATHandler::find_urc_handler(const char *prefix)
 {
     struct oob_t *oob = _oobs;
     while (oob) {
-        if (strcmp(prefix, oob->prefix) == 0 && oob->cb == *callback) {
+        if (strcmp(prefix, oob->prefix) == 0) {
             return true;
         }
         oob = oob->next;

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -1035,7 +1035,7 @@ void ATHandler::set_string(char *dest, const char *src, size_t src_len)
 
 const char *ATHandler::mem_str(const char *dest, size_t dest_len, const char *src, size_t src_len)
 {
-    if (dest_len > src_len) {
+    if (dest_len >= src_len) {
         for (size_t i = 0; i < dest_len - src_len + 1; ++i) {
             if (memcmp(dest + i, src, src_len) == 0) {
                 return dest + i;

--- a/features/cellular/framework/AT/ATHandler.cpp
+++ b/features/cellular/framework/AT/ATHandler.cpp
@@ -81,6 +81,7 @@ ATHandler::ATHandler(FileHandle *fh, EventQueue &queue, int timeout, const char 
     _max_resp_length(MAX_RESP_LENGTH),
     _debug_on(MBED_CONF_CELLULAR_DEBUG_AT),
     _cmd_start(false),
+    _use_delimiter(true),
     _start_time(0)
 {
     clear_error();
@@ -610,6 +611,11 @@ void ATHandler::set_delimiter(char delimiter)
 void ATHandler::set_default_delimiter()
 {
     _delimiter = DEFAULT_DELIMITER;
+}
+
+void ATHandler::use_delimiter(bool use_delimiter)
+{
+    _use_delimiter = use_delimiter;
 }
 
 void ATHandler::set_tag(tag_t *tag_dst, const char *tag_seq)
@@ -1145,6 +1151,11 @@ bool ATHandler::check_cmd_send()
 {
     if (_last_err != NSAPI_ERROR_OK) {
         return false;
+    }
+
+    // Don't write delimiter if flag was set so
+    if (!_use_delimiter) {
+        return true;
     }
 
     // Don't write delimiter if this is the first subparameter

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -281,6 +281,12 @@ public:
      */
     void set_default_delimiter();
 
+    /** Defines behaviour for using or ignoring the delimiter within an AT command
+     *
+     *  @param use_delimiter indicating if delimiter should be used or not
+     */
+    void use_delimiter(bool use_delimiter);
+
     /** Consumes the reading buffer up to the delimiter or stop_tag
      *
      *  @param count number of parameters to be skipped
@@ -435,6 +441,7 @@ private:
     char _info_resp_prefix[BUFF_SIZE];
     bool _debug_on;
     bool _cmd_start;
+    bool _use_delimiter;
 
     // time when a command or an URC processing was started
     uint64_t _start_time;

--- a/features/cellular/framework/AT/ATHandler.h
+++ b/features/cellular/framework/AT/ATHandler.h
@@ -109,9 +109,8 @@ public:
     /** Remove urc handler from linked list of urc's
      *
      *  @param prefix   Register urc prefix for callback. Urc could be for example "+CMTI: "
-     *  @param callback Callback, which is called if urc is found in AT response
      */
-    void remove_urc_handler(const char *prefix, mbed::Callback<void()> callback);
+    void remove_urc_handler(const char *prefix);
 
     ATHandler *_nextATHandler; // linked list
 
@@ -515,7 +514,7 @@ private:
     const char *mem_str(const char *dest, size_t dest_len, const char *src, size_t src_len);
 
     // check is urc is already added
-    bool find_urc_handler(const char *prefix, mbed::Callback<void()> *callback);
+    bool find_urc_handler(const char *prefix);
 
     // print contents of a buffer to trace log
     void debug_print(char *p, int len);

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -386,9 +386,11 @@ nsapi_error_t AT_CellularNetwork::open_data_channel()
         _at.write_int(_cid);
     } else {
         MBED_ASSERT(_cid >= 0 && _cid <= 99);
-        char cmd_buf[sizeof("ATD*99***xx#")];
-        std::sprintf(cmd_buf, "ATD*99***%d#", _cid);
-        _at.cmd_start(cmd_buf);
+        _at.cmd_start("ATD*99***");
+        _at.use_delimiter(false);
+        _at.write_int(_cid);
+        _at.write_string("#", false);
+        _at.use_delimiter(true);
     }
     _at.cmd_stop();
 

--- a/features/cellular/framework/AT/AT_CellularNetwork.cpp
+++ b/features/cellular/framework/AT/AT_CellularNetwork.cpp
@@ -56,12 +56,12 @@ AT_CellularNetwork::~AT_CellularNetwork()
 
     for (int type = 0; type < CellularNetwork::C_MAX; type++) {
         if (has_registration((RegistrationType)type) != RegistrationModeDisable) {
-            _at.remove_urc_handler(at_reg[type].urc_prefix, _urc_funcs[type]);
+            _at.remove_urc_handler(at_reg[type].urc_prefix);
         }
     }
 
-    _at.remove_urc_handler("NO CARRIER", callback(this, &AT_CellularNetwork::urc_no_carrier));
-    _at.remove_urc_handler("+CGEV:", callback(this, &AT_CellularNetwork::urc_cgev));
+    _at.remove_urc_handler("NO CARRIER");
+    _at.remove_urc_handler("+CGEV:");
     free_credentials();
 }
 
@@ -456,7 +456,7 @@ nsapi_error_t AT_CellularNetwork::disconnect()
 
     _at.restore_at_timeout();
 
-    _at.remove_urc_handler("+CGEV:", callback(this, &AT_CellularNetwork::urc_cgev));
+    _at.remove_urc_handler("+CGEV:");
     call_network_cb(NSAPI_STATUS_DISCONNECTED);
 
     return _at.unlock_return_error();

--- a/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
+++ b/features/cellular/framework/targets/GEMALTO/CINTERION/GEMALTO_CINTERION_CellularStack.cpp
@@ -39,9 +39,9 @@ GEMALTO_CINTERION_CellularStack::GEMALTO_CINTERION_CellularStack(ATHandler &atHa
 
 GEMALTO_CINTERION_CellularStack::~GEMALTO_CINTERION_CellularStack()
 {
-    _at.remove_urc_handler("^SIS:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sis));
-    _at.remove_urc_handler("^SISW:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sisw));
-    _at.remove_urc_handler("^SISR:", mbed::Callback<void()>(this, &GEMALTO_CINTERION_CellularStack::urc_sisr));
+    _at.remove_urc_handler("^SIS:");
+    _at.remove_urc_handler("^SISW:");
+    _at.remove_urc_handler("^SISR:");
 }
 
 GEMALTO_CINTERION_CellularStack::CellularSocket *GEMALTO_CINTERION_CellularStack::find_socket(int sock_id)

--- a/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.cpp
+++ b/features/cellular/framework/targets/QUECTEL/BG96/QUECTEL_BG96_CellularPower.cpp
@@ -32,5 +32,5 @@ nsapi_error_t QUECTEL_BG96_CellularPower::set_device_ready_urc_cb(mbed::Callback
 
 void QUECTEL_BG96_CellularPower::remove_device_ready_urc_cb(mbed::Callback<void()> callback)
 {
-    _at.remove_urc_handler(DEVICE_READY_URC, callback);
+    _at.remove_urc_handler(DEVICE_READY_URC);
 }


### PR DESCRIPTION
### Description

- ATHandler to reset match URC generated errors and continue response handling
- ATHandler's mem_str fixed to work on matching strings
- Added ATHandler option to write parameters without delimiters
- AT handler to support only one callback per URC/prefix

### Pull request type

    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

