### PR TITLE
STM32: fix issue with serial_is_tx_ongoing function

### DIFF
--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -660,10 +660,10 @@ int8_t get_uart_index(UARTName uart_name)
     return -1;
 }
 
-/*  Function to protect deep sleep while a seral Tx is ongoing on not complete
- *  yet. Returns 1 if there is at least 1 serial instance with ongoing ransfer
- *  0 otherwise.
- */
+/* Function used to protect deep sleep while a serial transmission is on-going.
+.* Returns 1 if there is at least 1 serial instance with an on-going transfer
+ * and 0 otherwise.
+*/
 int serial_is_tx_ongoing(void) {
     int TxOngoing = 0;
 
@@ -757,16 +757,11 @@ int serial_is_tx_ongoing(void) {
     }
 #endif
 
-    /*  If Tx is ongoing, then transfer is */
     return TxOngoing;
 }
 
 #else
 
-/*  Function to protect deep sleep while a seral Tx is ongoing on not complete
- *  yet. Returns 1 if there is at least 1 serial instance with ongoing ransfer
- *  0 otherwise.
- */
 int serial_is_tx_ongoing(void) {
     return 0;
 }

--- a/targets/TARGET_STM/serial_api.c
+++ b/targets/TARGET_STM/serial_api.c
@@ -761,4 +761,14 @@ int serial_is_tx_ongoing(void) {
     return TxOngoing;
 }
 
+#else
+
+/*  Function to protect deep sleep while a seral Tx is ongoing on not complete
+ *  yet. Returns 1 if there is at least 1 serial instance with ongoing ransfer
+ *  0 otherwise.
+ */
+int serial_is_tx_ongoing(void) {
+    return 0;
+}
+
 #endif /* DEVICE_SERIAL */


### PR DESCRIPTION
### Description

When DEVICE_SERIAL is not defined there is a build error with the serial_is_tx_ongoing function not defined.

Fixes #8372

### Pull request type


    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

