### PR TITLE
Update mbed-coap to version 4.7.1

### DIFF
--- a/features/frameworks/mbed-coap/CHANGELOG.md
+++ b/features/frameworks/mbed-coap/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log
 
+## [v4.7.1](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.1) 
+
+- Fix CoAP stored blockwise message release and list continue
+	Add re-scan routine goto if message is caused user callback
+	This will fix hard fault when blockwise message sending timeouts. This happens cause same list is manipulated through rx callback.
+
+-[Full Changelog](https://github.com/ARMmbed/mbed-coap/compare/v4.7.0...v4.7.1)
+
 ## [v4.7.0](https://github.com/ARMmbed/mbed-coap/releases/tag/v4.7.0) 
 
 - Add function that can be used to clear the received blockwise payloads for example in the case of a connection error.

--- a/features/frameworks/mbed-coap/module.json
+++ b/features/frameworks/mbed-coap/module.json
@@ -1,6 +1,6 @@
 {
   "name": "mbed-coap",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "COAP library",
   "keywords": [
     "coap",


### PR DESCRIPTION
### Description

Add re-scan routine goto if message is caused user callback
This will fix hard fault when blockwise message sending timeouts. This happens cause same list is manipulated through rx callback.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

