### PR TITLE
Remove protected class from EventQueue Doxy

### DIFF
--- a/events/EventQueue.h
+++ b/events/EventQueue.h
@@ -2803,6 +2803,7 @@ public:
     #endif
 
 protected:
+    #if !defined(DOXYGEN_ONLY)
     template <typename F>
     friend class Event;
     struct equeue _equeue;
@@ -3379,6 +3380,7 @@ protected:
             f(c0, c1, c2, c3, c4, a0, a1, a2, a3, a4);
         }
     };
+    #endif //!defined(DOXYGEN_ONLY)
 };
 
 }


### PR DESCRIPTION
### Description

Remove the following:
![image](https://user-images.githubusercontent.com/1060940/46887778-2fbf2280-ce24-11e8-8e7e-36771d3fc498.png)


### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

@AnotherButler 
@geky