### PR TITLE
M487: Fix SW2/SW3 interchange error in NUMAKER_IOT_M487

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M480/PinNames.h
@@ -131,10 +131,12 @@ typedef enum {
     // Button naming
 #if TARGET_NUMAKER_PFM_M487
     SW2 = PG_15,
-#elif TARGET_NUMAKER_IOT_M487
-    SW2 = PG_5,
-#endif
     SW3 = PF_11,
+#elif TARGET_NUMAKER_IOT_M487
+    SW2 = PF_11,
+    SW3 = PG_5,
+#endif
+    
     
 } PinName;
 


### PR DESCRIPTION
### Description

This PR fixes SW2/SW3 interchange naming error in **NUMAKER_IOT_M487** target.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

