### PR TITLE
M2351: Fix LED_GREEN naming error

### DIFF
--- a/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/PinNames.h
@@ -165,7 +165,7 @@ typedef enum {
     LED2 = PA_11,
     LED3 = PA_10,  // No real LED. Just for passing ATS.
     LED4 = PA_11,  // No real LED. Just for passing ATS.
-    LED_GREEN = LED2,
+    LED_GREEN = LED1,
     
     // Button naming
     SW2 = PB_0,


### PR DESCRIPTION
### Description

This PR fixes **LED_GREEN** naming error.

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

