### PR TITLE
Change Mbed TLS platform error code and value

### DIFF
--- a/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/TARGET_MCU_NRF52840/crypto_platform.c
@@ -30,7 +30,7 @@ int crypto_platform_setup( crypto_platform_ctx *ctx )
     NRF_CRYPTOCELL->ENABLE = 1;
 
     if( SaSi_LibInit( &ctx->rndState, &rndWorkBuff ) != 0 )
-          return ( MBEDTLS_ERR_PLATFORM_HW_FAILED );
+          return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
 
     return ( 0 );
 }

--- a/features/mbedtls/platform/inc/platform_mbed.h
+++ b/features/mbedtls/platform/inc/platform_mbed.h
@@ -25,4 +25,9 @@
 #include "mbedtls_device.h"
 #endif
 
+/*
+ * MBEDTLS_ERR_PLATFORM_HW_FAILED is deprecated and should not be used.
+ */
 #define MBEDTLS_ERR_PLATFORM_HW_FAILED       -0x0080
+
+#define MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED -0x0070


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Change error from `MBEDTLS_PLATFORM_HW_FAILED` to
`MBEDTLS_PLATFORM_HW_ACCEL_FAILED` and the value to 0x70,
as the previous value cannot be used as a low level error code.
resolves #8433 

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

