### PR TITLE
MCUXpresso: Fix for the TRNG HAL driver

### DIFF
--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_K66F/trng_api.c
@@ -22,6 +22,8 @@
  * Reference: "K66 Sub-Family Reference Manual, Rev. 2", chapter 38
  */
 
+#if defined(DEVICE_TRNG)
+
 #include <stdlib.h>
 #include "cmsis.h"
 #include "fsl_common.h"
@@ -48,13 +50,14 @@ void trng_free(trng_t *obj)
  */
 static void trng_get_byte(unsigned char *byte)
 {
+    *byte = 0;
     size_t bit;
 
     /* 34.5 Steps 3-4-5: poll SR and read from OR when ready */
     for( bit = 0; bit < 8; bit++ )
     {
-        while( ( RNG->SR & RNG_SR_OREG_LVL_MASK ) == 0 );
-        *byte |= ( RNG->OR & 1 ) << bit;
+        while((RNG->SR & RNG_SR_OREG_LVL_MASK) == 0 );
+        *byte |= (RNG->OR & 1) << bit;
     }
 }
 
@@ -62,7 +65,6 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     size_t i;
-    int ret;
 
     /* Set "Interrupt Mask", "High Assurance" and "Go",
      * unset "Clear interrupt" and "Sleep" */
@@ -81,3 +83,5 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 
     return 0;
 }
+
+#endif

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_KW24D/trng_api.c
@@ -18,10 +18,6 @@
  *
  */
 
-/*
- * Reference: "K64 Sub-Family Reference Manual, Rev. 2", chapter 34
- */
-
 #if defined(DEVICE_TRNG)
 
 #include <stdlib.h>
@@ -46,10 +42,11 @@ void trng_free(trng_t *obj)
 
 /*
  * Get one byte of entropy from the RNG, assuming it is up and running.
- * As recommended (34.1.1), get only one bit of each output.
+ * As recommended, get only one bit of each output.
  */
 static void trng_get_byte(unsigned char *byte)
 {
+    *byte = 0;
     size_t bit;
 
     /* 34.5 Steps 3-4-5: poll SR and read from OR when ready */
@@ -64,7 +61,6 @@ int trng_get_bytes(trng_t *obj, uint8_t *output, size_t length, size_t *output_l
 {
     (void)obj;
     size_t i;
-    int ret;
 
     /* Set "Interrupt Mask", "High Assurance" and "Go",
      * unset "Clear interrupt" and "Sleep" */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K22F/trng_api.c
@@ -46,6 +46,7 @@ void trng_free(trng_t *obj)
  */
 static void trng_get_byte(unsigned char *byte)
 {
+    *byte = 0;
     size_t bit;
 
     /* 34.5 Steps 3-4-5: poll SR and read from OR when ready */

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/trng_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/TARGET_MCU_K24F/trng_api.c
@@ -18,10 +18,6 @@
  *
  */
 
-/*
- * Reference: "K64 Sub-Family Reference Manual, Rev. 2", chapter 34
- */
-
 #if defined(DEVICE_TRNG)
 
 #include <stdlib.h>
@@ -46,10 +42,11 @@ void trng_free(trng_t *obj)
 
 /*
  * Get one byte of entropy from the RNG, assuming it is up and running.
- * As recommended (34.1.1), get only one bit of each output.
+ * As recommended, get only one bit of each output.
  */
 static void trng_get_byte(unsigned char *byte)
 {
+    *byte = 0;
     size_t bit;
 
     /* 34.5 Steps 3-4-5: poll SR and read from OR when ready */


### PR DESCRIPTION
### Description
Apply the fix from K64F TRNG HAL driver. Details can be found in the PR https://github.com/ARMmbed/mbed-os/pull/5550

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

