### PR TITLE
Correct mesh network connection status callback functionality.

### DIFF
--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -55,6 +55,7 @@ protected:
 
     Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
+    nsapi_connection_status_t _previous_connection_status;
     bool _blocking;
 };
 

--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -69,7 +69,7 @@ void Nanostack::Interface::attach(
 }
 
 Nanostack::Interface::Interface(NanostackPhy &phy) : interface_phy(phy), interface_id(-1), _device_id(-1),
-      _connect_status(NSAPI_STATUS_DISCONNECTED), _blocking(true)
+      _connect_status(NSAPI_STATUS_DISCONNECTED), _blocking(true), _previous_connection_status(NSAPI_STATUS_DISCONNECTED)
 {
     mesh_system_init();
 }
@@ -138,15 +138,17 @@ void Nanostack::Interface::network_handler(mesh_connection_status_t status)
         _connect_status = NSAPI_STATUS_LOCAL_UP;
     } else if (status == MESH_CONNECTED_GLOBAL) {
         _connect_status = NSAPI_STATUS_GLOBAL_UP;
-    } else if (status == MESH_BOOTSTRAP_STARTED) {
+    } else if (status == MESH_BOOTSTRAP_STARTED || status == MESH_BOOTSTRAP_FAILED) {
         _connect_status = NSAPI_STATUS_CONNECTING;
     } else {
         _connect_status = NSAPI_STATUS_DISCONNECTED;
     }
 
-    if (_connection_status_cb) {
+    if (_connection_status_cb && _previous_connection_status != _connect_status) {
+
         _connection_status_cb(NSAPI_EVENT_CONNECTION_STATUS_CHANGE, _connect_status);
     }
+    _previous_connection_status = _connect_status;
 }
 
 nsapi_error_t Nanostack::Interface::register_phy()

--- a/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/nd_tasklet.c
@@ -185,28 +185,28 @@ void nd_tasklet_parse_network_event(arm_event_s *event)
             /* Link Layer Active Scan Fail, Stack is Already at Idle state */
             tr_debug("Link Layer Scan Fail: No Beacons");
             tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            nd_tasklet_network_state_changed(MESH_DISCONNECTED);
+            nd_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_IP_ADDRESS_ALLOCATION_FAIL:
             /* No ND Router at current Channel Stack is Already at Idle state */
             tr_debug("ND Scan/ GP REG fail");
             tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            nd_tasklet_network_state_changed(MESH_DISCONNECTED);
+            nd_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_NWK_CONNECTION_DOWN:
             /* Connection to Access point is lost wait for Scan Result */
             tr_debug("ND/RPL scan new network");
             tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            nd_tasklet_network_state_changed(MESH_DISCONNECTED);
+            nd_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_NWK_PARENT_POLL_FAIL:
             tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            nd_tasklet_network_state_changed(MESH_DISCONNECTED);
+            nd_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_AUHTENTICATION_FAIL:
             tr_debug("Network authentication fail");
             tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            nd_tasklet_network_state_changed(MESH_DISCONNECTED);
+            nd_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         default:
             tr_warn("Unknown event %d", status);

--- a/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/thread_tasklet.c
@@ -189,28 +189,28 @@ void thread_tasklet_parse_network_event(arm_event_s *event)
             /* Link Layer Active Scan Fail, Stack is Already at Idle state */
             tr_debug("Link Layer Scan Fail: No Beacons");
             thread_tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
+            thread_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_IP_ADDRESS_ALLOCATION_FAIL:
             /* No ND Router at current Channel Stack is Already at Idle state */
             tr_debug("ND Scan/ GP REG fail");
             thread_tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
+            thread_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_NWK_CONNECTION_DOWN:
             /* Connection to Access point is lost wait for Scan Result */
             tr_debug("ND/RPL scan new network");
             thread_tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
+            thread_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_NWK_PARENT_POLL_FAIL:
             thread_tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
+            thread_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         case ARM_NWK_AUHTENTICATION_FAIL:
             tr_debug("Network authentication fail");
             thread_tasklet_data_ptr->tasklet_state = TASKLET_STATE_BOOTSTRAP_FAILED;
-            thread_tasklet_network_state_changed(MESH_DISCONNECTED);
+            thread_tasklet_network_state_changed(MESH_BOOTSTRAP_FAILED);
             break;
         default:
             tr_warn("Unknown event %d", status);


### PR DESCRIPTION
Now the status callback is only called if the status changed.

### Description
With the 6lowpan network, lost of border router did cause a loop of NSAPI_STATUS_CONNECTING-NSAPI_STATUS_DISCONNECTED network status indication pairs.
Based on https://confluence.arm.com/display/IoTBU/NetworkInterface+status+callbacks
lost of network should only cause one NSAPI_STATUS_CONNECTING status indication callback.
With these changes only one status indication callback is called.
Tested that both 6lowpan and Thread network status callback's are now working as the should.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

