### PR TITLE
More mbed_error refinements

### DIFF
--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -122,7 +122,6 @@ static mbed_error_status_t handle_error(mbed_error_status_t error_status, unsign
 #if MBED_CONF_PLATFORM_ERROR_FILENAME_CAPTURE_ENABLED
     //Capture filename/linenumber if provided
     //Index for tracking error_filename
-    memset(&current_error_ctx.error_filename, 0, MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN);
     strncpy(current_error_ctx.error_filename, filename, MBED_CONF_PLATFORM_MAX_ERROR_FILENAME_LEN);
     current_error_ctx.error_line_number = line_number;
 #endif

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -272,13 +272,13 @@ mbed_error_status_t mbed_clear_all_errors(void)
 
 #if MBED_CONF_PLATFORM_ERROR_ALL_THREADS_INFO && defined(MBED_CONF_RTOS_PRESENT)
 /* Prints info of a thread(using osRtxThread_t struct)*/
-static void print_thread(osRtxThread_t *thread)
+static void print_thread(const osRtxThread_t *thread)
 {
     mbed_error_printf("\nState: 0x%08X Entry: 0x%08X Stack Size: 0x%08X Mem: 0x%08X SP: 0x%08X", thread->state, thread->thread_addr, thread->stack_size, (uint32_t)thread->stack_mem, thread->sp);
 }
 
 /* Prints thread info from a list */
-static void print_threads_info(osRtxThread_t *threads)
+static void print_threads_info(const osRtxThread_t *threads)
 {
     while (threads != NULL) {
         print_thread(threads);
@@ -355,17 +355,14 @@ static void print_error_report(mbed_error_ctx *ctx, const char *error_msg)
     mbed_error_printf("\nNext:");
     print_thread(osRtxInfo.thread.run.next);
 
+    mbed_error_printf("\nReady:");
+    print_threads_info(osRtxInfo.thread.ready.thread_list);
+
     mbed_error_printf("\nWait:");
-    osRtxThread_t *threads = (osRtxThread_t *)&osRtxInfo.thread.wait_list;
-    print_threads_info(threads);
+    print_threads_info(osRtxInfo.thread.wait_list);
 
     mbed_error_printf("\nDelay:");
-    threads = (osRtxThread_t *)&osRtxInfo.thread.delay_list;
-    print_threads_info(threads);
-
-    mbed_error_printf("\nIdle:");
-    threads = (osRtxThread_t *)&osRtxInfo.thread.idle;
-    print_threads_info(threads);
+    print_threads_info(osRtxInfo.thread.delay_list);
 #endif
     mbed_error_printf(MBED_CONF_PLATFORM_ERROR_DECODE_HTTP_URL_STR, ctx->error_status);
     mbed_error_printf("\n-- MbedOS Error Info --\n");

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -270,11 +270,16 @@ mbed_error_status_t mbed_clear_all_errors(void)
     return status;
 }
 
+static const char *name_or_unnamed(const char *name)
+{
+    return name ? name : "<unnamed>";
+}
+
 #if MBED_CONF_PLATFORM_ERROR_ALL_THREADS_INFO && defined(MBED_CONF_RTOS_PRESENT)
 /* Prints info of a thread(using osRtxThread_t struct)*/
 static void print_thread(const osRtxThread_t *thread)
 {
-    mbed_error_printf("\nState: 0x%08X Entry: 0x%08X Stack Size: 0x%08X Mem: 0x%08X SP: 0x%08X", thread->state, thread->thread_addr, thread->stack_size, (uint32_t)thread->stack_mem, thread->sp);
+    mbed_error_printf("\n%s  State: 0x%X Entry: 0x%08X Stack Size: 0x%08X Mem: 0x%08X SP: 0x%08X", name_or_unnamed(thread->name), thread->state, thread->thread_addr, thread->stack_size, (uint32_t)thread->stack_mem, thread->sp);
 }
 
 /* Prints thread info from a list */
@@ -348,8 +353,11 @@ static void print_error_report(mbed_error_ctx *ctx, const char *error_msg)
 #endif
 
     mbed_error_printf("\nError Value: 0x%X", ctx->error_value);
-    mbed_error_printf("\nCurrent Thread: Id: 0x%X Entry: 0x%X StackSize: 0x%X StackMem: 0x%X SP: 0x%X ",
+#ifdef MBED_CONF_RTOS_PRESENT
+    mbed_error_printf("\nCurrent Thread: %s  Id: 0x%X Entry: 0x%X StackSize: 0x%X StackMem: 0x%X SP: 0x%X ",
+                      name_or_unnamed(((osRtxThread_t *)ctx->thread_id)->name),
                       ctx->thread_id, ctx->thread_entry_address, ctx->thread_stack_size, ctx->thread_stack_mem, ctx->thread_current_sp);
+#endif
 
 #if MBED_CONF_PLATFORM_ERROR_ALL_THREADS_INFO && defined(MBED_CONF_RTOS_PRESENT)
     mbed_error_printf("\nNext:");

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -127,6 +127,9 @@ void mbed_die(void);
  * handling a crash.
  *
  * @note Synchronization level: Interrupt safe
+ * @note This uses an internal 128-byte buffer to format the string,
+ *       so the output may be truncated. If you need to write a potentially
+ *       long string, use mbed_error_puts.
  *
  * @param format    C string that contains data stream to be printed.
  *                  Code snippets below show valid format.
@@ -148,6 +151,20 @@ void mbed_error_printf(const char *format, ...);
  *
  */
 void mbed_error_vprintf(const char *format, va_list arg);
+
+/** Print out an error message. This is typically called when
+ * handling a crash.
+ *
+ * Unlike mbed_error_printf, there is no limit to the maximum output
+ * length. Unlike standard puts, but like standard fputs, this does not
+ * append a '\n' character.
+ *
+ * @note Synchronization level: Interrupt safe
+ *
+ * @param str    C string that contains data stream to be printed.
+ *
+ */
+void mbed_error_puts(const char *str);
 
 /** @deprecated   Renamed to mbed_error_vprintf to match functionality */
 MBED_DEPRECATED_SINCE("mbed-os-5.11",


### PR DESCRIPTION
### Description

This is based on and contains #8255 and #8076 

New changes:

* Add `mbed_error_puts` to allow unlimited-length prints. Use it for error message and filename.
  * Switching to `puts` avoids undefined behaviour if there was a `%` in an error message.
* Always print full filename if available in `print_error_report`, so we get filename from `MBED_ASSERT` after #8255, regardless of the setting of `platform.error-capture-filename-enabled`.
* Print thread names.
* Correct full thread info print - wasn't showing ready threads, and was totally broken by type mismatch hidden by cast.
* Simplify read of current stack pointer - makes it work on Cortex-A
* Remove redundant memset

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

