### PR TITLE
Add missing define in drivers/SerialWireOutput.h

### DIFF
--- a/drivers/SerialWireOutput.h
+++ b/drivers/SerialWireOutput.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef MBED_SERIALWIREOUTPUT_H
+#define MBED_SERIALWIREOUTPUT_H
+
 #if defined(DEVICE_ITM)
 
 #include "hal/itm_api.h"
@@ -70,4 +73,6 @@ public:
 
 } // namespace mbed
 
-#endif
+#endif // DEVICE_ITM
+
+#endif // MBED_SERIALWIREOUTPUT_H


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
In drivers/SerialWireOutput.h the defineMBED_SERIALWIREOUTPUT_H was missing

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

