### PR TITLE
Pin urllib3 pip module in requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,6 +86,7 @@ matrix:
 
         - arm-none-eabi-gcc --version
         - python --version
+        - pip list --verbose
       script:
         # Run local testing on tools
         - PYTHONPATH=. coverage run -a -m pytest tools/test

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Jinja2>=2.7.3
 IntelHex>=1.3
 junit-xml
 pyYAML
+urllib3[secure]==1.23
 requests
 mbed-ls>=1.5.1,==1.*
 mbed-host-tests>=1.1.2


### PR DESCRIPTION
### Description

Travis CI appears to be failing since requirements.txt does not have an upper bound for urllib3 module.
Reference: https://github.com/ARMmbed/mbed-os/issues/8396#issuecomment-430419532

**Fixes master** ([proof](https://travis-ci.org/cmonr/mbed-os/jobs/442420121))

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

