### PR TITLE
Added missing _mutex->unlock() to FileBase::lookup().

### DIFF
--- a/platform/FileBase.cpp
+++ b/platform/FileBase.cpp
@@ -88,6 +88,7 @@ FileBase *FileBase::lookup(const char *name, unsigned int len)
         p = p->_next;
     }
     if (len == (sizeof "default") - 1 && std::memcmp("default", name, len) == 0) {
+        _mutex->unlock();
         return _default;
     }
     _mutex->unlock();


### PR DESCRIPTION
### Description
My modified Pelion Device Management Client has been getting stuck in the startup for a while now. After days of debugging, I finally was able to pinpoint the system to a mutex deadlock.

I don't thought understand how this has worked with the already released PDMC.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

@kjbracey-arm, related to the discussion on the hallway, this fix is related to previous modification done in here https://github.com/ARMmbed/mbed-os/pull/7924
