### PR TITLE
Fixed lorawan unittests valgrind issues

### DIFF
--- a/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
+++ b/UNITTESTS/features/lorawan/loramac/Test_LoRaMac.cpp
@@ -40,6 +40,7 @@ protected:
     virtual void SetUp()
     {
         object = new LoRaMac();
+        LoRaWANTimer_stub::time_value = 1;
     }
 
     virtual void TearDown()
@@ -64,7 +65,9 @@ TEST_F(Test_LoRaMac, initialize)
     object->bind_phy(phy);
 
     lorawan_connect_t conn;
+    memset(&conn, 0, sizeof(conn));
     uint8_t key[16];
+    memset(key, 0, sizeof(key));
     conn.connection_u.otaa.app_key = key;
     conn.connection_u.otaa.app_eui = key;
     conn.connection_u.otaa.dev_eui = key;
@@ -119,6 +122,7 @@ TEST_F(Test_LoRaMac, remove_single_channel)
 TEST_F(Test_LoRaMac, multicast_channel_link)
 {
     multicast_params_t p;
+    memset(&p, 0, sizeof(p));
 
     EXPECT_EQ(LORAWAN_STATUS_PARAMETER_INVALID, object->multicast_channel_link(NULL));
 
@@ -132,6 +136,7 @@ TEST_F(Test_LoRaMac, multicast_channel_link)
 TEST_F(Test_LoRaMac, multicast_channel_unlink)
 {
     multicast_params_t p;
+    memset(&p, 0, sizeof(p));
 
     EXPECT_EQ(LORAWAN_STATUS_PARAMETER_INVALID, object->multicast_channel_unlink(NULL));
 
@@ -145,7 +150,9 @@ TEST_F(Test_LoRaMac, multicast_channel_unlink)
 TEST_F(Test_LoRaMac, send)
 {
     loramac_mhdr_t mac_hdr;
+    memset(&mac_hdr, 0, sizeof(mac_hdr));
     uint8_t buf[15];
+    memset(buf, 0, sizeof(buf));
     mac_hdr.bits.mtype = FRAME_TYPE_DATA_CONFIRMED_UP;
     object->send(&mac_hdr, 1, buf, 15);
 }
@@ -183,6 +190,7 @@ TEST_F(Test_LoRaMac, reset_ongoing_tx)
 TEST_F(Test_LoRaMac, prepare_ongoing_tx)
 {
     uint8_t buf[16];
+    memset(buf, 0, sizeof(buf));
     object->prepare_ongoing_tx(1, buf, 16, 1, 0);
 }
 
@@ -214,6 +222,7 @@ TEST_F(Test_LoRaMac, setup_link_check_request)
 TEST_F(Test_LoRaMac, prepare_join)
 {
     lorawan_connect_t conn;
+    memset(&conn, 0, sizeof(conn));
     object->prepare_join(&conn, false);
 
     my_phy phy;
@@ -293,7 +302,9 @@ TEST_F(Test_LoRaMac, join)
     EXPECT_EQ(LORAWAN_STATUS_OK, object->join(false));
 
     lorawan_connect_t conn;
+    memset(&conn, 0, sizeof(conn));
     uint8_t key[16];
+    memset(key, 0, sizeof(key));
     conn.connection_u.otaa.app_key = key;
     conn.connection_u.otaa.app_eui = key;
     conn.connection_u.otaa.dev_eui = key;
@@ -312,6 +323,7 @@ TEST_F(Test_LoRaMac, on_radio_tx_done)
 TEST_F(Test_LoRaMac, on_radio_rx_done)
 {
     uint8_t buf[16];
+    memset(buf, 0, sizeof(buf));
     object->on_radio_rx_done(buf, 16, 0, 0);
 }
 
@@ -330,7 +342,9 @@ TEST_F(Test_LoRaMac, continue_joining_process)
     my_phy phy;
     object->bind_phy(phy);
     lorawan_connect_t conn;
+    memset(&conn, 0, sizeof(conn));
     uint8_t key[16];
+    memset(key, 0, sizeof(key));
     conn.connection_u.otaa.app_key = key;
     conn.connection_u.otaa.app_eui = key;
     conn.connection_u.otaa.dev_eui = key;
@@ -369,6 +383,7 @@ TEST_F(Test_LoRaMac, get_mlme_indication)
 TEST_F(Test_LoRaMac, post_process_mcps_req)
 {
     uint8_t data[16];
+    memset(data, 0, sizeof(data));
     LoRaPHY_stub::bool_counter = 0;
     LoRaPHY_stub::bool_table[0] = true;
 
@@ -533,7 +548,9 @@ TEST_F(Test_LoRaMac, clear_tx_pipe)
     object->bind_phy(phy);
 
     lorawan_connect_t conn;
+    memset(&conn, 0, sizeof(conn));
     uint8_t key[16];
+    memset(key, 0, sizeof(key));
     conn.connection_u.otaa.app_key = key;
     conn.connection_u.otaa.app_eui = key;
     conn.connection_u.otaa.dev_eui = key;
@@ -566,7 +583,7 @@ TEST_F(Test_LoRaMac, get_current_slot)
 
 TEST_F(Test_LoRaMac, get_QOS_level)
 {
-    EXPECT_EQ(1, object->get_QOS_level());
+    EXPECT_EQ(0, object->get_QOS_level());
 }
 
 TEST_F(Test_LoRaMac, get_prev_QOS_level)

--- a/UNITTESTS/features/lorawan/loramacchannelplan/Test_LoRaMacChannelPlan.cpp
+++ b/UNITTESTS/features/lorawan/loramacchannelplan/Test_LoRaMacChannelPlan.cpp
@@ -60,6 +60,8 @@ TEST_F(Test_LoRaMacChannelPlan, constructor)
 TEST_F(Test_LoRaMacChannelPlan, set_plan)
 {
     lorawan_channelplan_t plan;
+    memset(&plan, 0, sizeof(plan));
+    memset(&LoRaPHY_stub::bool_table, 0, sizeof(LoRaPHY_stub::bool_table));
     LoRaPHY_stub::bool_counter = 0;
     LoRaPHY_stub::bool_table[0] = false;
     EXPECT_TRUE(object->set_plan(plan) == LORAWAN_STATUS_SERVICE_UNKNOWN);
@@ -74,6 +76,9 @@ TEST_F(Test_LoRaMacChannelPlan, set_plan)
     LoRaPHY_stub::bool_table[0] = true;
     LoRaPHY_stub::uint8_value = 10;
     LoRaPHY_stub::lorawan_status_value = LORAWAN_STATUS_PARAMETER_INVALID;
+    loramac_channel_t chan;
+    memset(&chan, 0, sizeof(chan));
+    plan.channels = &chan;
     EXPECT_TRUE(object->set_plan(plan) == LORAWAN_STATUS_PARAMETER_INVALID);
 
     LoRaPHY_stub::bool_counter = 0;

--- a/UNITTESTS/features/lorawan/loraphy/Test_LoRaPHY.cpp
+++ b/UNITTESTS/features/lorawan/loraphy/Test_LoRaPHY.cpp
@@ -100,6 +100,7 @@ protected:
     virtual void SetUp()
     {
         object = new my_LoRaPHY();
+        memset(&object->get_phy_params(), 0, sizeof(object->get_phy_params()));
     }
 
     virtual void TearDown()
@@ -606,10 +607,12 @@ TEST_F(Test_LoRaPHY, set_next_channel)
     p.aggregate_timeoff = 10000;
     EXPECT_TRUE(LORAWAN_STATUS_DUTYCYCLE_RESTRICTED == object->set_next_channel(&p, &ch, &t1, &t2));
 
-    uint16_t list[16];
-    memset(list, 0, 16);
+    uint16_t list[129];
+    memset(list, 0, sizeof(list));
     list[4] = 1;
+    list[128] = 1;
     object->get_phy_params().channels.mask = list;
+    object->get_phy_params().channels.default_mask = list;
     object->get_phy_params().channels.mask_size = 1;
     p.aggregate_timeoff = 10000;
     EXPECT_TRUE(LORAWAN_STATUS_DUTYCYCLE_RESTRICTED == object->set_next_channel(&p, &ch, &t1, &t2));
@@ -620,12 +623,18 @@ TEST_F(Test_LoRaPHY, set_next_channel)
     p.joined = false;
     p.dc_enabled = false;
     band_t b[4];
+    ch = 5;
+    t1 = 16;
+    t2 = 32;
     memset(b, 0, sizeof(band_t)*4);
     object->get_phy_params().bands.size = 2;
     object->get_phy_params().bands.table = &b;
     b[0].off_time = 0;
     b[1].off_time = 9999999;
+    memset(list, 0, 129);
     list[4] = 0;
+    object->get_phy_params().channels.mask = list;
+    object->get_phy_params().channels.default_mask = list;
     object->get_phy_params().channels.mask_size = 128;
     p.current_datarate = DR_1;
     object->get_phy_params().max_channel_cnt = 4;
@@ -663,6 +672,8 @@ TEST_F(Test_LoRaPHY, add_channel)
     object->get_phy_params().channels.mask = list;
     object->get_phy_params().channels.default_mask = list;
     channel_params_t p;
+    p.band = 0;
+    p.frequency = 0;
     EXPECT_TRUE(LORAWAN_STATUS_PARAMETER_INVALID == object->add_channel(&p, 0));
 
     object->get_phy_params().custom_channelplans_supported = true;
@@ -702,6 +713,7 @@ TEST_F(Test_LoRaPHY, set_tx_cont_mode)
     pp.band=0;
     object->get_phy_params().channels.channel_list = &pp;
     band_t b;
+    b.max_tx_pwr = 10;
     object->get_phy_params().bands.table = &b;
     my_radio radio;
     object->set_radio_instance(radio);
@@ -709,6 +721,9 @@ TEST_F(Test_LoRaPHY, set_tx_cont_mode)
     cw_mode_params_t p;
     p.max_eirp = 0;
     p.channel=0;
+    p.tx_power = -1;
+    p.datarate = 0;
+    p.antenna_gain = 1;
     object->set_tx_cont_mode(&p);
 
     p.max_eirp = 1;

--- a/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
+++ b/UNITTESTS/features/lorawan/loraphyau915/Test_LoRaPHYAU915.cpp
@@ -107,6 +107,7 @@ TEST_F(Test_LoRaPHYAU915, constructor)
 TEST_F(Test_LoRaPHYAU915, rx_config)
 {
     rx_config_params_t p;
+    memset(&p, 0, sizeof(p));
 
     radio.uint8_value = 1;
     EXPECT_TRUE(!object->rx_config(&p));
@@ -122,7 +123,8 @@ TEST_F(Test_LoRaPHYAU915, rx_config)
 TEST_F(Test_LoRaPHYAU915, tx_config)
 {
     tx_config_params_t p;
-    int8_t tx;
+    memset(&p, 0, sizeof(p));
+    int8_t tx = 0;
     lorawan_time_t time;
     p.tx_power = 9;
     EXPECT_TRUE(object->tx_config(&p, &tx, &time));
@@ -131,10 +133,11 @@ TEST_F(Test_LoRaPHYAU915, tx_config)
 TEST_F(Test_LoRaPHYAU915, link_ADR_request)
 {
     adr_req_params_t params;
-    int8_t dr_out;
-    int8_t tx_power_out;
-    uint8_t nb_rep_out;
-    uint8_t nb_bytes_parsed;
+    memset(&params, 0, sizeof(params));
+    int8_t dr_out = 0;
+    int8_t tx_power_out = 0;
+    uint8_t nb_rep_out = 0;
+    uint8_t nb_bytes_parsed = 0;
 
     LoRaPHY_stub::uint8_value = 1;
     LoRaPHY_stub::ch_mask_value = 6;
@@ -159,6 +162,7 @@ TEST_F(Test_LoRaPHYAU915, link_ADR_request)
 TEST_F(Test_LoRaPHYAU915, accept_rx_param_setup_req)
 {
     rx_param_setup_req_t p;
+    memset(&p, 0, sizeof(p));
     radio.bool_value = false;
     EXPECT_TRUE(0 == object->accept_rx_param_setup_req(&p));
 

--- a/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
+++ b/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
@@ -109,9 +109,11 @@ TEST_F(Test_LoRaPHYCN470, constructor)
 TEST_F(Test_LoRaPHYCN470, set_next_channel)
 {
     channel_selection_params_t params;
-    uint8_t channel;
-    lorawan_time_t time;
-    lorawan_time_t timeoff;
+
+    memset(&params, 0, sizeof(params));
+    uint8_t channel = 0;
+    lorawan_time_t time = 0;
+    lorawan_time_t timeoff = 0;
 
     params.current_datarate = 4;
     params.aggregate_timeoff = 0;
@@ -130,6 +132,7 @@ TEST_F(Test_LoRaPHYCN470, set_next_channel)
 TEST_F(Test_LoRaPHYCN470, rx_config)
 {
     rx_config_params_t p;
+    memset(&p, 0, sizeof(p));
 
     radio.uint8_value = 1;
     EXPECT_TRUE(!object->rx_config(&p));
@@ -145,8 +148,8 @@ TEST_F(Test_LoRaPHYCN470, rx_config)
 TEST_F(Test_LoRaPHYCN470, tx_config)
 {
     tx_config_params_t p;
-    int8_t tx;
-    lorawan_time_t time;
+    int8_t tx = 0;
+    lorawan_time_t time = 0;
     p.tx_power = 9;
     EXPECT_TRUE(object->tx_config(&p, &tx, &time));
 }
@@ -154,10 +157,11 @@ TEST_F(Test_LoRaPHYCN470, tx_config)
 TEST_F(Test_LoRaPHYCN470, link_ADR_request)
 {
     adr_req_params_t params;
-    int8_t dr_out;
-    int8_t tx_power_out;
-    uint8_t nb_rep_out;
-    uint8_t nb_bytes_parsed;
+    memset(&params, 0, sizeof(params));
+    int8_t dr_out = 0;
+    int8_t tx_power_out = 0;
+    uint8_t nb_rep_out = 0;
+    uint8_t nb_bytes_parsed = 0;
 
     LoRaPHY_stub::uint8_value = 1;
     LoRaPHY_stub::ch_mask_value = 6;
@@ -182,6 +186,8 @@ TEST_F(Test_LoRaPHYCN470, link_ADR_request)
 TEST_F(Test_LoRaPHYCN470, accept_rx_param_setup_req)
 {
     rx_param_setup_req_t p;
+    memset(&p, 0, sizeof(p));
+    radio.bool_value = false;
     EXPECT_TRUE(0 == object->accept_rx_param_setup_req(&p));
 
     radio.bool_value = true;

--- a/UNITTESTS/features/lorawan/loraphykr920/Test_LoRaPHYKR920.cpp
+++ b/UNITTESTS/features/lorawan/loraphykr920/Test_LoRaPHYKR920.cpp
@@ -117,8 +117,9 @@ TEST_F(Test_LoRaPHYKR920, verify_frequency_for_band)
 TEST_F(Test_LoRaPHYKR920, tx_config)
 {
     tx_config_params_t tx_config;
+    memset(&tx_config, 0, sizeof(tx_config));
     int8_t tx_power = 0;
-    lorawan_time_t time;
+    lorawan_time_t time = 0;
 
     tx_config.tx_power = 9;
     EXPECT_TRUE(true == object->tx_config(&tx_config, &tx_power, &time));
@@ -127,6 +128,7 @@ TEST_F(Test_LoRaPHYKR920, tx_config)
 TEST_F(Test_LoRaPHYKR920, set_next_channel)
 {
     channel_selection_params_t next_channel;
+    memset(&next_channel, 0, sizeof(next_channel));
     lorawan_time_t backoff_time = 0;
     lorawan_time_t time = 0;
     uint8_t ch = 1;
@@ -150,6 +152,7 @@ TEST_F(Test_LoRaPHYKR920, set_next_channel)
 TEST_F(Test_LoRaPHYKR920, set_tx_cont_mode)
 {
     cw_mode_params_t params;
+    memset(&params, 0, sizeof(params));
     params.tx_power = 9;
     object->set_tx_cont_mode(&params, 0);
 }

--- a/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
+++ b/UNITTESTS/features/lorawan/loraphyus915/Test_LoRaPHYUS915.cpp
@@ -111,6 +111,7 @@ TEST_F(Test_LoRaPHYUS915, restore_default_channels)
 TEST_F(Test_LoRaPHYUS915, rx_config)
 {
     rx_config_params_t p;
+    memset(&p, 0, sizeof(p));
 
     radio.uint8_value = 1;
     EXPECT_TRUE(!object->rx_config(&p));
@@ -126,18 +127,20 @@ TEST_F(Test_LoRaPHYUS915, rx_config)
 TEST_F(Test_LoRaPHYUS915, tx_config)
 {
     tx_config_params_t p;
-    int8_t tx;
-    lorawan_time_t time;
+    memset(&p, 0, sizeof(p));
+    int8_t tx = 0;
+    lorawan_time_t time = 0;
     EXPECT_TRUE(object->tx_config(&p, &tx, &time));
 }
 
 TEST_F(Test_LoRaPHYUS915, link_ADR_request)
 {
     adr_req_params_t params;
-    int8_t dr_out;
-    int8_t tx_power_out;
-    uint8_t nb_rep_out;
-    uint8_t nb_bytes_parsed;
+    memset(&params, 0, sizeof(params));
+    int8_t dr_out = 0;
+    int8_t tx_power_out = 0;
+    uint8_t nb_rep_out = 0;
+    uint8_t nb_bytes_parsed = 0;
 
     EXPECT_TRUE(0 == object->link_ADR_request(&params, &dr_out, &tx_power_out, &nb_rep_out, &nb_bytes_parsed));
 
@@ -164,6 +167,8 @@ TEST_F(Test_LoRaPHYUS915, link_ADR_request)
 TEST_F(Test_LoRaPHYUS915, accept_rx_param_setup_req)
 {
     rx_param_setup_req_t p;
+    memset(&p, 0, sizeof(p));
+    radio.bool_value = false;
     EXPECT_TRUE(0 == object->accept_rx_param_setup_req(&p));
 
     radio.bool_value = true;
@@ -188,9 +193,10 @@ TEST_F(Test_LoRaPHYUS915, get_alternate_DR)
 TEST_F(Test_LoRaPHYUS915, set_next_channel)
 {
     channel_selection_params_t params;
-    uint8_t channel;
-    lorawan_time_t time;
-    lorawan_time_t timeoff;
+    memset(&params, 0, sizeof(params));
+    uint8_t channel = 0;
+    lorawan_time_t time = 0;
+    lorawan_time_t timeoff = 0;
 
     params.current_datarate = 4;
     params.aggregate_timeoff = 0;
@@ -228,6 +234,7 @@ TEST_F(Test_LoRaPHYUS915, apply_DR_offset)
 TEST_F(Test_LoRaPHYUS915, set_tx_cont_mode)
 {
     cw_mode_params_t p;
+    memset(&p, 0, sizeof(p));
     object->set_tx_cont_mode(&p, 0);
 
     p.datarate = 4;

--- a/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
+++ b/UNITTESTS/features/lorawan/lorawanstack/Test_LoRaWANStack.cpp
@@ -557,6 +557,7 @@ TEST_F(Test_LoRaWANStack, set_device_class)
 TEST_F(Test_LoRaWANStack, acquire_tx_metadata)
 {
     lorawan_tx_metadata data;
+    memset(&data, 0, sizeof(data));
     EXPECT_TRUE(LORAWAN_STATUS_NOT_INITIALIZED == object->acquire_tx_metadata(data));
 
     EventQueue queue;
@@ -575,6 +576,7 @@ TEST_F(Test_LoRaWANStack, acquire_tx_metadata)
     equeue_stub.void_ptr = &ptr;
     equeue_stub.call_cb_immediately = true;
     loramac_mcps_confirm_t conf;
+    memset(&conf, 0, sizeof(conf));
     conf.status = LORAMAC_EVENT_INFO_STATUS_OK;
     LoRaMac_stub::mcps_conf_ptr = &conf;
     radio._ev->tx_done();
@@ -588,6 +590,7 @@ TEST_F(Test_LoRaWANStack, acquire_tx_metadata)
 TEST_F(Test_LoRaWANStack, acquire_rx_metadata)
 {
     lorawan_rx_metadata data;
+    memset(&data, 0, sizeof(data));
     EXPECT_TRUE(LORAWAN_STATUS_NOT_INITIALIZED == object->acquire_rx_metadata(data));
 
     EventQueue queue;
@@ -606,11 +609,13 @@ TEST_F(Test_LoRaWANStack, acquire_rx_metadata)
     equeue_stub.void_ptr = &ptr;
     equeue_stub.call_cb_immediately = true;
     loramac_mcps_confirm_t conf;
+    memset(&conf, 0, sizeof(conf));
     conf.status = LORAMAC_EVENT_INFO_STATUS_OK;
     LoRaMac_stub::mcps_conf_ptr = &conf;
     radio._ev->tx_done();
 
     loramac_mcps_indication_t ind;
+    memset(&ind, 0, sizeof(ind));
     ind.status = LORAMAC_EVENT_INFO_STATUS_OK;
     LoRaMac_stub::mcps_ind_ptr = &ind;
 
@@ -818,10 +823,12 @@ TEST_F(Test_LoRaWANStack, process_reception)
     equeue_stub.void_ptr = &ptr;
     equeue_stub.call_cb_immediately = true;
     loramac_mcps_confirm_t conf;
+    memset(&conf, 0, sizeof(&conf));
     LoRaMac_stub::mcps_conf_ptr = &conf;
     radio._ev->tx_done();
 
     loramac_mcps_indication_t ind;
+    memset(&ind, 0, sizeof(ind));
     LoRaMac_stub::mcps_ind_ptr = &ind;
 
     loramac_mlme_confirm_t mlme;

--- a/features/lorawan/lorastack/mac/LoRaMac.cpp
+++ b/features/lorawan/lorastack/mac/LoRaMac.cpp
@@ -82,6 +82,7 @@ LoRaMac::LoRaMac()
       _device_class(CLASS_A),
       _prev_qos_level(LORAWAN_DEFAULT_QOS)
 {
+    memset(&_params, 0, sizeof(_params));
     _params.keys.dev_eui = NULL;
     _params.keys.app_eui = NULL;
     _params.keys.app_key = NULL;
@@ -89,6 +90,7 @@ LoRaMac::LoRaMac()
     memset(_params.keys.nwk_skey, 0, sizeof(_params.keys.nwk_skey));
     memset(_params.keys.app_skey, 0, sizeof(_params.keys.app_skey));
     memset(&_ongoing_tx_msg, 0, sizeof(_ongoing_tx_msg));
+    memset(&_params.sys_params, 0, sizeof(_params.sys_params));
 
     _params.dev_nonce = 0;
     _params.net_id = 0;
@@ -110,6 +112,7 @@ LoRaMac::LoRaMac()
     _params.timers.tx_toa = 0;
 
     _params.multicast_channels = NULL;
+
 
     _params.sys_params.adr_on = false;
     _params.sys_params.max_duty_cycle = 0;

--- a/features/lorawan/lorastack/phy/LoRaPHY.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHY.cpp
@@ -1345,7 +1345,7 @@ lorawan_status_t LoRaPHY::add_channel(const channel_params_t *new_channel,
         return LORAWAN_STATUS_FREQUENCY_INVALID;
     }
 
-    memcpy(&(phy_params.channels.channel_list[id]), new_channel, sizeof(channel_params_t));
+    memmove(&(phy_params.channels.channel_list[id]), new_channel, sizeof(channel_params_t));
 
     phy_params.channels.channel_list[id].band = new_channel->band;
 

--- a/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
+++ b/features/lorawan/lorastack/phy/LoRaPHYAU915.cpp
@@ -420,7 +420,7 @@ uint8_t LoRaPHYAU915::link_ADR_request(adr_req_params_t* params,
                                        uint8_t* nb_bytes_parsed)
 {
     uint8_t status = 0x07;
-    link_adr_params_t adr_settings;
+    link_adr_params_t adr_settings = {};
     uint8_t next_index = 0;
     uint8_t bytes_processed = 0;
     uint16_t temp_channel_masks[AU915_CHANNEL_MASK_SIZE] = { 0, 0, 0, 0, 0};


### PR DESCRIPTION
### Description

LoRaWAN unit tests are having lots of valgrind issues because of unitialized variables
Those are now fixed

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

