### PR TITLE
Move inline code snippets to code blocks

### DIFF
--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -30,12 +30,12 @@ namespace mbed {
  */
 
 
-/** Represents a directory stream. Objects of this type are returned
- *  by an opendir function. The core functions are read and seek,
+/** Represents a directory stream. An opendir function returns 
+ *  objects of this type. The core functions are read and seek,
  *  but only a subset needs to be provided.
  *
- *  If a FileSystemLike class defines the opendir method, then the
- *  directories of an object of that type can be accessed by either:
+ *  If a FileSystemLike class defines the opendir method, then you
+ *  can access the directories of an object of that type by either:
  *  @code
  *  DIR *d  = opendir("/example/directory");
  *  @endcode
@@ -46,8 +46,8 @@ namespace mbed {
  *  to open the root of the file system.
  *
  *  The root directory is considered to contain all FileHandle and
- *  FileSystem objects, so the DIR pointer returned by opendir("/") will
- *  reflect this.
+ *  FileSystem objects, so the DIR pointer returned by opendir("/")
+ *  reflects this.
  *
  *  @note to create a directory, @see Dir
  *  @note Synchronization level: Set by subclass

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -35,12 +35,18 @@ namespace mbed {
  *  but only a subset needs to be provided.
  *
  *  If a FileSystemLike class defines the opendir method, then the
- *  directories of an object of that type can be accessed by
- *  DIR *d = opendir("/example/directory") (or opendir("/example")
- *  to open the root of the filesystem), and then using readdir(d) etc.
+ *  directories of an object of that type can be accessed by either:
+ *  @code
+ *  DIR *d  = opendir("/example/directory");
+ *  @endcode
+ *  or
+ *  @code
+ *  DIR *d = opendir("/example");
+ *  @endcode
+ *  to open the root of the file system.
  *
  *  The root directory is considered to contain all FileHandle and
- *  FileSystem objects, so the DIR* returned by opendir("/") will
+ *  FileSystem objects, so the DIR pointer returned by opendir("/") will
  *  reflect this.
  *
  *  @note to create a directory, @see Dir

--- a/platform/DirHandle.h
+++ b/platform/DirHandle.h
@@ -119,7 +119,7 @@ public:
         return close();
     };
 
-    /** Return the directory entry at the current position, and
+    /** Returns the directory entry at the current position, and
      *  advances the position to the next entry.
      *
      * @returns


### PR DESCRIPTION
### Description

Moving this small code snippet into a code block allows the doxy spell checker to work better (the extra asterisks and function calls were causing issues). It does however make the raw header look a bit uglier.

Thoughts (new generated doxy below)?

![image](https://user-images.githubusercontent.com/1060940/47119802-edd21a00-d231-11e8-91a1-8c10d4522412.png)


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

