### PR TITLE
EventQueue documentation fix.

### DIFF
--- a/events/mbed_shared_queues.h
+++ b/events/mbed_shared_queues.h
@@ -75,7 +75,7 @@ events::EventQueue *mbed_event_queue();
  * @note
  * mbed_highprio_event_queue is not itself IRQ safe. To use the
  * mbed_highprio_event_queue in interrupt context, you must first call
- * `mbed_event_queue()` in threaded context and store the pointer for
+ * `mbed_highprio_event_queue()` in threaded context and store the pointer for
  * later use.
  *
  * @return pointer to high-priority event queue


### PR DESCRIPTION
### Description
Should this read `mbed_highprio_event_queue()` instead of `mbed_event_queue()`?
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x] Docs update
    [ ] Test update
    [ ] Breaking change

