### PR TITLE
Flag certificate verification functions with MBEDTLS_X509_CRT_PARSE_C.

### DIFF
--- a/features/netsocket/TLSSocketWrapper.h
+++ b/features/netsocket/TLSSocketWrapper.h
@@ -133,6 +133,7 @@ public:
     virtual Socket *accept(nsapi_error_t *error = NULL);
     virtual nsapi_error_t listen(int backlog = 1);
 
+#if defined(MBEDTLS_X509_CRT_PARSE_C) || defined(DOXYGEN)
     /** Get own certificate directly from Mbed TLS
      * @return internal Mbed TLS X509 structure
      */
@@ -153,6 +154,7 @@ public:
      * @param crt Mbed TLS X509 certificate chain.
      */
     void set_ca_chain(mbedtls_x509_crt *crt);
+#endif
 
     /** Get internal Mbed TLS configuration structure
      * @return Mbed TLS SSL config
@@ -216,8 +218,10 @@ private:
 
     Socket *_transport;
 
+#ifdef MBEDTLS_X509_CRT_PARSE_C
     mbedtls_x509_crt* _cacert;
     mbedtls_x509_crt* _clicert;
+#endif
     mbedtls_ssl_config* _ssl_conf;
 
     bool _connect_transport:1;


### PR DESCRIPTION
### Description

If Mbed TLS support for X509 is not compiled in, `TLSSocketWrapper` class would
not compile anymore. However, there might be other uses for it, even
if certificates are not used. Therefore add flagging for X509 only
on specific functions.

It has been reported to me, that this issue might became visible if somebody tries to create minimal Mbed TLS configuration file, for example Client Lite does it.

@juhoeskeli Please review.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

