### PR TITLE
mbedgt-network-wifi WIFI_CONNECT - check for empty passwd

### DIFF
--- a/TESTS/network/wifi/wifi_connect.cpp
+++ b/TESTS/network/wifi/wifi_connect.cpp
@@ -30,8 +30,12 @@ void wifi_connect(void)
     WiFiInterface *wifi = get_interface();
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, NULL));
-
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->disconnect());
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_UNSECURE_SSID, ""));
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->disconnect());
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)


### PR DESCRIPTION
### Description

Providing empty password for unsecure Wifi connection should be fine from test case point of view

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

