### PR TITLE
BLE: write size first when writing an eeprom message

### DIFF
--- a/features/nfc/nfc/NFCEEPROM.h
+++ b/features/nfc/nfc/NFCEEPROM.h
@@ -126,8 +126,8 @@ private:
         nfc_eeprom_idle,
 
         nfc_eeprom_write_start_session,
-        nfc_eeprom_write_write_bytes,
         nfc_eeprom_write_write_size,
+        nfc_eeprom_write_write_bytes,
         nfc_eeprom_write_end_session,
 
         nfc_eeprom_read_start_session,

--- a/features/nfc/source/nfc/NFCEEPROM.cpp
+++ b/features/nfc/source/nfc/NFCEEPROM.cpp
@@ -138,8 +138,8 @@ void NFCEEPROM::on_session_started(bool success)
                 handle_error(NFC_ERR_CONTROLLER); // An EEPROM is not really a controller but close enough
                 return;
             }
-            _current_op = nfc_eeprom_write_write_bytes;
-            continue_write();
+            _current_op = nfc_eeprom_write_write_size;
+            _driver->write_size(ac_buffer_reader_readable(&_ndef_buffer_reader));
             break;
 
         case nfc_eeprom_read_start_session:
@@ -272,10 +272,8 @@ void NFCEEPROM::on_size_written(bool success)
                 return;
             }
 
-            // End session
-            _current_op = nfc_eeprom_write_end_session;
-            _operation_result = NFC_OK;
-            _driver->end_session();
+            _current_op = nfc_eeprom_write_write_bytes;
+            continue_write();
             break;
         case nfc_eeprom_erase_write_max_size:
             if (!success) {
@@ -371,9 +369,10 @@ void NFCEEPROM::continue_write()
         // Continue writing
         _driver->write_bytes(_eeprom_address, ac_buffer_reader_current_buffer_pointer(&_ndef_buffer_reader), ac_buffer_reader_current_buffer_length(&_ndef_buffer_reader));
     } else {
-        // Now update size
-        _current_op = nfc_eeprom_write_write_size;
-        _driver->write_size(_eeprom_address);
+        // we are done
+        _current_op = nfc_eeprom_write_end_session;
+        _operation_result = NFC_OK;
+        _driver->end_session();
     }
 }
 


### PR DESCRIPTION
### Description

When writing an ndef message into eprom the bytes were being written before setting the size - thus resulting in a truncated message. This fix sets the size first and writes the bytes later. Verified using the example nfceeprom app.

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

