### PR TITLE
LPC54608: Raise the core freq on LPC54608 targets

### DIFF
--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/device.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/device.h
@@ -27,7 +27,7 @@
 /* Defines used by the sleep code */
 #define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M()
 #define LPC_CLOCK_RUN          ((SYSCON->DEVICE_ID0 == 0xFFF54628) ? \
-                                 BOARD_BootClockPLL220M() : BOARD_BootClockFROHF48M())
+                                 BOARD_BootClockPLL220M() : BOARD_BootClockPLL180M())
 
 #define DEVICE_ID_LENGTH       24
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_FF_LPC546XX/mbed_overrides.c
@@ -41,10 +41,12 @@
 void mbed_sdk_init()
 {
     if (SYSCON->DEVICE_ID0 == 0xFFF54628) {
+        BOARD_BootClockFROHF96M(); /* Boot up FROHF96M for SPIFI to use*/
         /* LPC54628 runs at a higher core speed */
         BOARD_BootClockPLL220M();
     } else {
-        BOARD_BootClockFROHF48M();
+        BOARD_BootClockFROHF96M(); /* Boot up FROHF96M for SPIFI to use*/
+        BOARD_BootClockPLL180M();
     }
 }
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/device.h
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/device.h
@@ -27,7 +27,7 @@
 /* Defines used by the sleep code */
 #define LPC_CLOCK_INTERNAL_IRC BOARD_BootClockFRO12M()
 #define LPC_CLOCK_RUN          ((SYSCON->DEVICE_ID0 == 0xFFF54628) ? \
-                                 BOARD_BootClockPLL220M() : BOARD_BootClockFROHF48M())
+                                 BOARD_BootClockPLL220M() : BOARD_BootClockPLL180M())
 
 #define DEVICE_ID_LENGTH       24
 

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC546XX/TARGET_LPCXpresso/mbed_overrides.c
@@ -57,10 +57,12 @@ uint32_t FLASHIAP_ReadUid(uint32_t *addr)
 void mbed_sdk_init()
 {
     if (SYSCON->DEVICE_ID0 == 0xFFF54628) {
+        BOARD_BootClockFROHF96M(); /* Boot up FROHF96M for SPIFI to use*/
         /* LPC54628 runs at a higher core speed */
         BOARD_BootClockPLL220M();
     } else {
-        BOARD_BootClockFROHF48M();
+        BOARD_BootClockFROHF96M(); /* Boot up FROHF96M for SPIFI to use*/
+        BOARD_BootClockPLL180M();
     }
 }
 


### PR DESCRIPTION
### Description
Raise the core freq on LPC54608 targets, this is incorrectly set to a lower value

### Pull request type
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

