### PR TITLE
Update mbed_mem_tracing config option

### DIFF
--- a/TESTS/mbed_drivers/mem_trace/main.cpp
+++ b/TESTS/mbed_drivers/mem_trace/main.cpp
@@ -24,7 +24,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-#if !MBED_MEM_TRACING_ENABLED
+#ifndef MBED_MEM_TRACING_ENABLED
 #error [NOT_SUPPORTED] test not supported
 #endif
 

--- a/platform/mbed_alloc_wrappers.cpp
+++ b/platform/mbed_alloc_wrappers.cpp
@@ -27,7 +27,7 @@
 /* There are two memory tracers in mbed OS:
 
 - the first can be used to detect the maximum heap usage at runtime. It is
-  activated by defining the MBED_HEAP_STATS_ENABLED macro.
+  activated by setting the configuration option MBED_HEAP_STATS_ENABLED to true.
 - the second can be used to trace each memory call by automatically invoking
   a callback on each memory operation (see hal/api/mbed_mem_trace.h). It is
   activated by setting the configuration option MBED_MEM_TRACING_ENABLED to true.
@@ -99,7 +99,7 @@ extern "C" void *__wrap__malloc_r(struct _reent *r, size_t size)
 extern "C" void *malloc_wrapper(struct _reent *r, size_t size, void *caller)
 {
     void *ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -123,17 +123,17 @@ extern "C" void *malloc_wrapper(struct _reent *r, size_t size, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = __real__malloc_r(r, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_malloc(ptr, size, caller);
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
 extern "C" void *__wrap__realloc_r(struct _reent *r, void *ptr, size_t size)
 {
     void *new_ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -166,10 +166,10 @@ extern "C" void *__wrap__realloc_r(struct _reent *r, void *ptr, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     new_ptr = __real__realloc_r(r, ptr, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_realloc(new_ptr, ptr, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return new_ptr;
 }
 
@@ -180,7 +180,7 @@ extern "C" void __wrap__free_r(struct _reent *r, void *ptr)
 
 extern "C" void free_wrapper(struct _reent *r, void *ptr, void *caller)
 {
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -205,16 +205,16 @@ extern "C" void free_wrapper(struct _reent *r, void *ptr, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     __real__free_r(r, ptr);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_free(ptr, caller);
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
 }
 
 extern "C" void *__wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size)
 {
     void *ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -227,10 +227,10 @@ extern "C" void *__wrap__calloc_r(struct _reent *r, size_t nmemb, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = __real__calloc_r(r, nmemb, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_calloc(ptr, nmemb, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -286,7 +286,7 @@ extern "C" void *SUB_MALLOC(size_t size)
 extern "C" void *malloc_wrapper(size_t size, void *caller)
 {
     void *ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -310,10 +310,10 @@ extern "C" void *malloc_wrapper(size_t size, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = SUPER_MALLOC(size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_malloc(ptr, size, caller);
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -321,7 +321,7 @@ extern "C" void *malloc_wrapper(size_t size, void *caller)
 extern "C" void *SUB_REALLOC(void *ptr, size_t size)
 {
     void *new_ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -349,17 +349,17 @@ extern "C" void *SUB_REALLOC(void *ptr, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     new_ptr = SUPER_REALLOC(ptr, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_realloc(new_ptr, ptr, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return new_ptr;
 }
 
 extern "C" void *SUB_CALLOC(size_t nmemb, size_t size)
 {
     void *ptr = NULL;
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -371,10 +371,10 @@ extern "C" void *SUB_CALLOC(size_t nmemb, size_t size)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     ptr = SUPER_CALLOC(nmemb, size);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_calloc(ptr, nmemb, size, MBED_CALLER_ADDR());
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
     return ptr;
 }
 
@@ -385,7 +385,7 @@ extern "C" void SUB_FREE(void *ptr)
 
 extern "C" void free_wrapper(void *ptr, void *caller)
 {
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_lock();
 #endif
 #ifdef MBED_HEAP_STATS_ENABLED
@@ -410,10 +410,10 @@ extern "C" void free_wrapper(void *ptr, void *caller)
 #else // #ifdef MBED_HEAP_STATS_ENABLED
     SUPER_FREE(ptr);
 #endif // #ifdef MBED_HEAP_STATS_ENABLED
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
     mbed_mem_trace_free(ptr, caller);
     mbed_mem_trace_unlock();
-#endif // #if MBED_MEM_TRACING_ENABLED
+#endif // #ifdef MBED_MEM_TRACING_ENABLED
 }
 
 #endif // #if defined(MBED_MEM_TRACING_ENABLED) || defined(MBED_HEAP_STATS_ENABLED)
@@ -424,7 +424,7 @@ extern "C" void free_wrapper(void *ptr, void *caller)
 
 #else
 
-#if MBED_MEM_TRACING_ENABLED
+#ifdef MBED_MEM_TRACING_ENABLED
 #error Memory tracing is not supported with the current toolchain.
 #endif
 

--- a/platform/mbed_lib.json
+++ b/platform/mbed_lib.json
@@ -68,7 +68,7 @@
         "memory-tracing-enabled": {
             "macro_name": "MBED_MEM_TRACING_ENABLED",
             "help": "Enable tracing of each memory call by invoking a callback on each memory operation. See mbed_mem_trace.h in the HAL API for more information",
-            "value": false
+            "value": null
         },
         "sys-stats-enabled": {
             "macro_name": "MBED_SYS_STATS_ENABLED",

--- a/platform/mbed_retarget.cpp
+++ b/platform/mbed_retarget.cpp
@@ -1439,7 +1439,7 @@ extern "C" void __cxa_guard_abort(int *guard_object_p)
 
 #endif
 
-#if MBED_MEM_TRACING_ENABLED && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
+#if defined(MBED_MEM_TRACING_ENABLED) && (defined(__CC_ARM) || defined(__ICCARM__) || (defined (__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050)))
 
 // If the memory tracing is enabled, the wrappers in mbed_alloc_wrappers.cpp
 // provide the implementation for these. Note: this needs to use the wrappers
@@ -1485,7 +1485,7 @@ void operator delete[](void *ptr)
     free_wrapper(ptr, MBED_CALLER_ADDR());
 }
 
-#elif MBED_MEM_TRACING_ENABLED && defined(__GNUC__)
+#elif defined(MBED_MEM_TRACING_ENABLED) && defined(__GNUC__)
 
 #include <reent.h>
 


### PR DESCRIPTION
### Description
This reverts most of commit 9b53d1256fb358407acbaf81c70b71d937b1f7cd

https://github.com/ARMmbed/mbed-os/pull/8106 taught me that I can use a default value of null to have the config macro be not defined in mbed_config.h. Reverting my old changes that moved all of the mbed_mem_tracing option checks from `#if !defined(....)` to `#if ...` which caused minor breaking changes.

Move the memory tracing enabled macro to a config option but revert the !defined -> #if changes to no longer cause breaking changes as https://github.com/ARMmbed/mbed-os/pull/7402 did. 


### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

