### PR TITLE
Clean up UARTSerial.cpp includes.

### DIFF
--- a/drivers/UARTSerial.cpp
+++ b/drivers/UARTSerial.cpp
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include "drivers/UARTSerial.h"
 
 #if (DEVICE_SERIAL && DEVICE_INTERRUPTIN)
 
-#include <errno.h>
-#include "UARTSerial.h"
 #include "platform/mbed_poll.h"
 
 #if MBED_CONF_RTOS_PRESENT


### PR DESCRIPTION
### Description

I noticed that every driver `.cpp` file includes at least its corresponding header file before any device feature tests such as `#if DEVICE_SERIAL`, with the notable exception of `UARTSerial.cpp`. Even if the include is not necessary for the `DEVICE` macros to be present, for the sake of consistency I think `UARTSerial.cpp` should unconditionally include `UARTSerial.h`.

`UARTSerial.cpp` also includes `<errno.h>`, but apparently does not use it, so I think it's safe to remove that, too.

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Nothing's broken, so I think "Refactor" describes this best (you may want to add "Code Cleanup" as an option some day).
