### PR TITLE
STM32 RTC : Prescaler macro issue

### DIFF
--- a/targets/TARGET_STM/rtc_api_hal.h
+++ b/targets/TARGET_STM/rtc_api_hal.h
@@ -81,7 +81,7 @@ void rtc_deactivate_wake_up_timer(void);
 
 /* PREDIV_S : 15-bit synchronous prescaler */
 /* PREDIV_S is set in order to get a 1 Hz clock */
-#define PREDIV_S_VALUE RTC_CLOCK / (PREDIV_A_VALUE + 1) - 1
+#define PREDIV_S_VALUE (RTC_CLOCK / (PREDIV_A_VALUE + 1) - 1)
 
 /** Synchronise the RTC shadow registers.
  *


### PR DESCRIPTION
### Description

Issue found in TICKLESS mode in #8473 

All macro definition should be protected by parenthesis


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

