### PR TITLE
Adding file type for linker script arg in make script

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -531,7 +531,7 @@ def build_project(src_paths, build_path, target, toolchain_name,
 
         # Change linker script if specified
         if linker_script is not None:
-            resources.add_file_ref(linker_script, linker_script)
+            resources.add_file_ref(FileType.LD_SCRIPT, linker_script, linker_script)
         if not resources.get_file_refs(FileType.LD_SCRIPT):
             raise NotSupportedException("No Linker Script found")
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

When supplying an external linker script, the tools currently traceback:

```
$ mbed compile --linker targets\TARGET_Freescale\TARGET_MCUXpresso_MCUS\TARGET_MCU_K64F\device\TOOLCHAIN_GCC_ARM\MK64FN1M0xxx12.ld
[mbed] Auto-installing missing Python modules...
c:\python27\lib\site-packages\requests\__init__.py:80: RequestsDependencyWarning: urllib3 (1.23) or chardet (3.0.4) doesn't match a supported version!
  RequestsDependencyWarning)
Building project mbed (NUCLEO_F411RE, GCC_ARM)
Scan: mbed
Scan: env
[ERROR] add_file_ref() takes exactly 4 arguments (3 given)
[mbed] ERROR: "c:\python27\python.exe" returned error.
       Code: 1
       Path: "C:\Users\bridan01\onedrive_arm\Documents\dev\m_mbed\mbed"
       Command: "c:\python27\python.exe -u C:\Users\bridan01\onedrive_arm\Documents\dev\m_mbed\mbed\tools\make.py -t GCC_ARM -m NUCLEO_F411RE --source . --build .\BUILD\NUCLEO_F411RE\GCC_ARM --linker targets\TARGET_Freescale\TARGET_MCUXpresso_MCUS\TARGET_MCU_K64F\device\TOOLCHAIN_GCC_ARM\MK64FN1M0xxx12.ld"
       Tip: You could retry the last command with "-v" flag for verbose output
```

This patch fixes the traceback.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

