### PR TITLE
Add get/settimeofday retargets

### DIFF
--- a/platform/mbed_rtc_time.h
+++ b/platform/mbed_rtc_time.h
@@ -28,6 +28,14 @@
 extern "C" {
 #endif
 
+/* Timeval definition for non GCC_ARM toolchains */
+#if !defined(__GNUC__) || defined(__CC_ARM) || defined(__clang__)
+struct timeval {
+    time_t tv_sec;
+    int32_t tv_usec;
+};
+#endif
+
 /** Implementation of the C time.h functions
  *
  * Provides mechanisms to set and read the current time, based
@@ -89,6 +97,30 @@ void set_time(time_t t);
  * @param isenabled_rtc pointer to function which returns if the RTC is enabled, can be NULL
  */
 void attach_rtc(time_t (*read_rtc)(void), void (*write_rtc)(time_t), void (*init_rtc)(void), int (*isenabled_rtc)(void));
+
+/** Standard lib retarget, get time since Epoch
+ *
+ * @param tv    Structure containing time_t secondsa and suseconds_t microseconds. Due to
+ *              separate target specific RTC implementations only the seconds component is used.
+ * @param tz    DEPRECATED IN THE STANDARD: This parameter is left in for legacy code. It is
+ *              not used.
+ * @return      0 on success, -1 on a failure.
+ * @note Synchronization level: Thread safe
+ *
+ */
+int gettimeofday(struct timeval *tv, void *tz);
+
+/** Standard lib retarget, set time since Epoch
+ *
+ * @param tv    Structure containing time_t secondsa and suseconds_t microseconds. Due to
+ *              separate target specific RTC implementations only the seconds component is used.
+ * @param tz    DEPRECATED IN THE STANDARD: This parameter is left in for legacy code. It is
+ *              not used.
+ * @return      Time in seconds on success, -1 on a failure.
+ * @note Synchronization level: Thread safe
+ *
+ */
+int settimeofday(const struct timeval *tv, const struct timezone *tz);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

In reference to: https://github.com/ARMmbed/mbed-os/issues/6988
_______________________________________

Move the Time function implementation to get/settimeofday to match the stdlib calls and have the Time API call into the new functions.

Questions/Comments:
1. Should the retarget get/settimeofday functions live in mbed_retarget or are they fine here?
2. Updated tests pending once this PR gets feedback

Test code:
```c++
struct timeval tv;
time_t s = time(NULL);

wait(3.0f);

s = time(NULL);
int err = gettimeofday(&tv, NULL);

printf("Time: %d, gettimeofday: %d [Err: %d]\r\n", s, tv.tv_sec, err);

set_time(12345);

s = time(NULL);
err = gettimeofday(&tv, NULL);
printf("Time: %d, gettimeofday: %d [Err: %d]\r\n", s, tv.tv_sec, err);

wait(1.0f);
s = time(NULL);
err = gettimeofday(&tv, NULL);
printf("Time: %d, gettimeofday: %d [Err: %d]\r\n", s, tv.tv_sec, err);

const struct timeval tv_set = { 54321, 0 };
int seterr = settimeofday(&tv_set, NULL);
s = time(NULL);
err = gettimeofday(&tv, NULL);
printf("Time: %d, gettimeofday: %d [Err: %d] SetErr: %d\r\n", s, tv.tv_sec, err, seterr);

wait(1.0f);
s = time(NULL);
err = gettimeofday(&tv, NULL);
printf("Time: %d, gettimeofday: %d [Err: %d]\r\n", s, tv.tv_sec, err);
```

```
Time: 3, gettimeofday: 3 [Err: 0]
Time: 12345, gettimeofday: 12345 [Err: 0]
Time: 12346, gettimeofday: 12346 [Err: 0]
Time: 54321, gettimeofday: 54321 [Err: 0] SetErr: 0
Time: 54322, gettimeofday: 54322 [Err: 0]
```


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

