### PR TITLE
Socket closing improvements and tests adjustments

### DIFF
--- a/TEST_APPS/testcases/netsocket/SOCKET_BIND_PORT.py
+++ b/TEST_APPS/testcases/netsocket/SOCKET_BIND_PORT.py
@@ -43,15 +43,15 @@ class MultipleTestcase(Bench):
 
     def socket_bind_port(self, socket_type):
         response = self.command("dut1", "socket new " + socket_type)
-        socket_id = int(response.parsed['socket_id'])
+        self.socket_id = int(response.parsed['socket_id'])
 
-        self.command("dut1", "socket " + str(socket_id) + " open")
+        self.command("dut1", "socket " + str(self.socket_id) + " open")
 
-        self.command("dut1", "socket " + str(socket_id) + " bind port 1024")
-
-        self.command("dut1", "socket " + str(socket_id) + " delete")
+        self.command("dut1", "socket " + str(self.socket_id) + " bind port 1024")
 
     def teardown(self):
+        self.command("dut1", "socket " + str(self.socket_id) + " delete")
+        
         self.command("dut1", "ifdown")
 
 

--- a/TEST_APPS/testcases/netsocket/TCPSERVER_ACCEPT.py
+++ b/TEST_APPS/testcases/netsocket/TCPSERVER_ACCEPT.py
@@ -62,15 +62,15 @@ class Testcase(Bench):
         self.used_port = 2000
 
         response = self.command("dut1", "socket new TCPServer")
-        server_base_socket_id = int(response.parsed['socket_id'])
+        self.server_base_socket_id = int(response.parsed['socket_id'])
 
-        self.command("dut1", "socket " + str(server_base_socket_id) + " open")
-        self.command("dut1", "socket " + str(server_base_socket_id) + " bind port " + str(self.used_port))
-        self.command("dut1", "socket " + str(server_base_socket_id) + " listen")
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " open")
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " bind port " + str(self.used_port))
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " listen")
 
         response = self.command("dut1", "socket new TCPSocket")
-        server_socket_id = int(response.parsed['socket_id'])
-        self.command("dut1", "socket " + str(server_socket_id) + " open")
+        self.server_socket_id = int(response.parsed['socket_id'])
+        self.command("dut1", "socket " + str(self.server_socket_id) + " open")
 
         response = self.command("dut2", "socket new TCPSocket")
         zero = response.timedelta
@@ -81,7 +81,7 @@ class Testcase(Bench):
         t.start()
 
         wait = 5
-        response = self.command("dut1", "socket " + str(server_base_socket_id) + " accept " + str(server_socket_id))
+        response = self.command("dut1", "socket " + str(self.server_base_socket_id) + " accept " + str(self.server_socket_id))
         response.verify_response_duration(expected=wait, zero=zero, threshold_percent=10, break_in_fail=True)
         socket_id = int(response.parsed['socket_id'])
 
@@ -94,10 +94,10 @@ class Testcase(Bench):
         if data != "hello":
             raise TestStepFail("Received data doesn't match the sent data")
 
-        self.command("dut1", "socket " + str(server_socket_id) + " delete")
-        self.command("dut1", "socket " + str(server_base_socket_id) + " delete")
-        self.command("dut2", "socket " + str(self.client_socket_id) + " delete")
-
     def teardown(self):
+        self.command("dut1", "socket " + str(self.server_socket_id) + " delete")
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " delete")
+        self.command("dut2", "socket " + str(self.client_socket_id) + " delete")
+        
         interfaceDown(self, ["dut1"])
         interfaceDown(self, ["dut2"])

--- a/TEST_APPS/testcases/netsocket/TCPSOCKET_ACCEPT.py
+++ b/TEST_APPS/testcases/netsocket/TCPSOCKET_ACCEPT.py
@@ -1,0 +1,106 @@
+"""
+Copyright 2018 ARM Limited
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import threading
+import time
+
+from icetea_lib.bench import Bench
+from interface import interfaceUp, interfaceDown
+#from mbed_clitest.tools import test_case
+#from mbed_clitest.TestStepError import SkippedTestcaseException
+from icetea_lib.TestStepError import TestStepFail
+
+class Testcase(Bench):
+    def __init__(self):
+        Bench.__init__(self,
+                       name="TCPSOCKET_ACCEPT",
+                       title = "TCPSOCKET_ACCEPT",
+                       purpose = "Test that TCPSocket::bind(), TCPSocket::listen() and TCPSocket::accept() works",
+                       status = "released",
+                       component= ["mbed-os", "netsocket"],
+                       type="smoke",
+                       subtype="socket",
+                       requirements={
+                           "duts": {
+                               '*': { #requirements for all nodes
+                                    "count":2,
+                                    "type": "hardware",
+                                    "application": {
+                                       "name": "TEST_APPS-device-socket_app"
+                                    }
+                                },
+                                "1": {"nick": "dut1"},
+                                "2": {"nick": "dut2"}
+                           }
+                       }
+        )
+
+    def setup(self):
+        interface = interfaceUp(self, ["dut1"])
+        self.server_ip = interface["dut1"]["ip"]
+        interface = interfaceUp(self, ["dut2"])
+        self.client_ip = interface["dut2"]["ip"]
+
+    def clientThread(self):
+        self.logger.info("Starting")
+        time.sleep(5) #wait accept from server
+        self.command("dut2", "socket " + str(self.client_socket_id) + " open")
+        self.command("dut2", "socket " + str(self.client_socket_id) + " connect " + str(self.server_ip) + " " + str(self.used_port))
+
+
+    def case(self):
+        self.used_port = 2000
+
+        response = self.command("dut1", "socket new TCPSocket")
+        self.server_base_socket_id = int(response.parsed['socket_id'])
+
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " open")
+        response = self.command("dut1", "socket " + str(self.server_base_socket_id) + " bind port " + str(self.used_port), report_cmd_fail = False)
+        if response.retcode == -1:
+            if (response.verify_trace("NSAPI_ERROR_UNSUPPORTED", break_in_fail = False)):
+                raise SkippedTestcaseException("UNSUPPORTED")
+            else:
+                TestStepFail("Bind port failed")
+        self.command("dut1", "socket " + str(self.server_base_socket_id) + " listen")
+
+        response = self.command("dut2", "socket new TCPSocket")
+        self.client_socket_id = int(response.parsed['socket_id'])
+
+        #Create a thread which calls client connect()
+        t = threading.Thread(name='clientThread', target=self.clientThread)
+        t.start()
+
+        response = self.command("dut1", "socket " + str(self.server_base_socket_id) + " accept")
+
+        t.join()
+        self.accept_socket_id = int(response.parsed['socket_id'])
+        if response.timedelta < 5.0: # Check that socket accept call blocks
+            raise TestStepFail("Longer response time expected")
+
+        self.command("dut1", "socket " + str(self.accept_socket_id) + " send hello")
+
+        response = self.command("dut2", "socket " + str(self.client_socket_id) + " recv 5")
+        data = response.parsed['data'].replace(":","")
+
+        if data != "hello":
+            raise TestStepFail("Received data doesn't match the sent data")
+
+    def teardown(self):
+        response = self.command("dut2", "socket " + str(self.client_socket_id) + " delete")
+        response = self.command("dut1", "socket " + str(self.server_base_socket_id) + " delete")
+        response = self.command("dut1", "socket " + str(self.accept_socket_id) + " close") 
+        
+        interfaceDown(self, ["dut1"])
+        interfaceDown(self, ["dut2"])

--- a/TEST_APPS/testcases/netsocket/TCPSOCKET_ECHOTEST_BURST_SHORT.py
+++ b/TEST_APPS/testcases/netsocket/TCPSOCKET_ECHOTEST_BURST_SHORT.py
@@ -48,31 +48,30 @@ class Testcase(Bench):
 
     def case(self):
         response = self.command("dut1", "socket new TCPSocket")
-        socket_id = int(response.parsed['socket_id'])
+        self.socket_id = int(response.parsed['socket_id'])
 
-        self.command("dut1", "socket " + str(socket_id) + " open")
-        self.command("dut1", "socket " + str(socket_id) + " connect echo.mbedcloudtesting.com 7")
+        self.command("dut1", "socket " + str(self.socket_id) + " open")
+        self.command("dut1", "socket " + str(self.socket_id) + " connect echo.mbedcloudtesting.com 7")
 
         for i in range(2):
             sentData = ""
             for size in (100, 200, 300, 120, 500):
                 packet = Randomize.random_string(max_len=size, min_len=size, chars=string.ascii_uppercase)
                 sentData += packet
-                response = self.command("dut1", "socket " + str(socket_id) + " send " + str(packet))
+                response = self.command("dut1", "socket " + str(self.socket_id) + " send " + str(packet))
                 response.verify_trace("TCPSocket::send() returned: " + str(size))
 
             received = 0
             data = ""
             totalSize = 1220
             while received < totalSize:
-                response = self.command("dut1", "socket " + str(socket_id) + " recv " + str(totalSize))
+                response = self.command("dut1", "socket " + str(self.socket_id) + " recv " + str(totalSize))
                 data += response.parsed['data'].replace(":", "")
                 received += int(response.parsed['received_bytes'])
 
             if data != sentData:
                 raise TestStepFail("Received data doesn't match the sent data")
 
-        self.command("dut1", "socket " + str(socket_id) + " delete")
-
     def teardown(self):
+        self.command("dut1", "socket " + str(self.socket_id) + " delete")
         self.command("dut1", "ifdown")

--- a/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
+++ b/UNITTESTS/features/netsocket/InternetSocket/test_InternetSocket.cpp
@@ -151,7 +151,7 @@ TEST_F(TestInternetSocket, close)
 TEST_F(TestInternetSocket, close_no_open)
 {
     stack.return_value = NSAPI_ERROR_OK;
-    EXPECT_EQ(socket->close(), NSAPI_ERROR_OK);
+    EXPECT_EQ(socket->close(), NSAPI_ERROR_NO_SOCKET);
 }
 
 TEST_F(TestInternetSocket, close_during_read)

--- a/features/netsocket/InternetSocket.h
+++ b/features/netsocket/InternetSocket.h
@@ -36,7 +36,7 @@ public:
      *
      *  Closes socket if the socket is still open
      */
-    virtual ~InternetSocket() {}
+    virtual ~InternetSocket();
 
     /** Opens a socket
      *

--- a/features/netsocket/TCPServer.cpp
+++ b/features/netsocket/TCPServer.cpp
@@ -24,7 +24,6 @@ TCPServer::TCPServer()
 
 TCPServer::~TCPServer()
 {
-    close();
 }
 
 nsapi_error_t TCPServer::accept(TCPSocket *connection, SocketAddress *address)

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -182,6 +182,13 @@ public:
 protected:
     friend class TCPServer;
     virtual nsapi_protocol_t get_proto();
+
+private:
+    /** Create a socket out of a given socket
+     *
+     *  To be used within accept() function. Close() will clean this up.
+     */
+    TCPSocket(TCPSocket *parent, nsapi_socket_t socket, SocketAddress address);
 };
 
 

--- a/features/netsocket/UDPSocket.cpp
+++ b/features/netsocket/UDPSocket.cpp
@@ -24,7 +24,6 @@ UDPSocket::UDPSocket()
 
 UDPSocket::~UDPSocket()
 {
-    close();
 }
 
 nsapi_protocol_t UDPSocket::get_proto()


### PR DESCRIPTION
### Description

These changes are an improvement for the hard-fault issue when closing a socket. They are based on the idea described in [this](https://github.com/ARMmbed/mbed-os/pull/8337) and [this](https://github.com/ARMmbed/mbed-os/pull/8336) by @sentinelt.
The API remains unchanged. As per API description: "Referencing a returned pointer after a close() call is not allowed and leads to undefined behaviour." - See Socket.h.
I checked that all Socket-related unittests work fine and do not hard-fault. 
In a separate commit there is also a change to icetea tests, to make them behave according to documentation. I also added a new icetea test for TcpSocket::accept() method.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
