### PR TITLE
Timer: fix to init in non-critical context

### DIFF
--- a/drivers/Timer.cpp
+++ b/drivers/Timer.cpp
@@ -23,11 +23,13 @@ namespace mbed {
 
 Timer::Timer() : _running(), _start(), _time(), _ticker_data(get_us_ticker_data()), _lock_deepsleep(true)
 {
+    (void)ticker_read_us(_ticker_data); // Make sure h/w timer is initialized in non-critical context.
     reset();
 }
 
 Timer::Timer(const ticker_data_t *data) : _running(), _start(), _time(), _ticker_data(data), _lock_deepsleep(true)
 {
+    (void)ticker_read_us(_ticker_data); // Make sure h/w timer is initialized in non-critical context.
     reset();
 #if DEVICE_LPTICKER
     _lock_deepsleep = (data != get_lp_ticker_data());


### PR DESCRIPTION
…dware timer in non-critical context.
This benefits target platforms having multiple MCUs/cores but shared other hardware resources - in this case timers.
Probably the first example of such platform is Cypress PSoC 6 MCU on Future Electronics Sequana board (upcoming new target). Implementation of hardware resource manager on this platform prevents initialization of hardware resources on M4 core in a critical/interrupt context, because it involves communication with M0 core to synchronize on resource usage.
Notice, that this is critical fix for this platform

@MarceloSalazar 
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

