### PR TITLE
Continue Socket and WiFi tests even on test failure.

### DIFF
--- a/TESTS/netsocket/dns/main.cpp
+++ b/TESTS/netsocket/dns/main.cpp
@@ -181,7 +181,7 @@ Case cases[] = {
     Case("SYNCHRONOUS_DNS_INVALID", SYNCHRONOUS_DNS_INVALID),
 };
 
-Specification specification(test_setup, cases);
+Specification specification(test_setup, cases, greentea_continue_handlers);
 
 int main()
 {

--- a/TESTS/netsocket/tcp/main.cpp
+++ b/TESTS/netsocket/tcp/main.cpp
@@ -151,7 +151,7 @@ Case cases[] = {
 #endif
 };
 
-Specification specification(greentea_setup, cases, greentea_teardown);
+Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
 int main()
 {

--- a/TESTS/netsocket/udp/main.cpp
+++ b/TESTS/netsocket/udp/main.cpp
@@ -104,7 +104,7 @@ Case cases[] = {
 #endif
 };
 
-Specification specification(greentea_setup, cases, greentea_teardown);
+Specification specification(greentea_setup, cases, greentea_teardown, greentea_continue_handlers);
 
 int main()
 {

--- a/TESTS/network/wifi/main.cpp
+++ b/TESTS/network/wifi/main.cpp
@@ -90,7 +90,7 @@ Case cases[] = {
 #endif
 };
 
-Specification specification(test_setup, cases);
+Specification specification(test_setup, cases, greentea_continue_handlers);
 
 // Entry point into the tests
 int main()


### PR DESCRIPTION
### Description
Continue Socket and WiFi tests even on test failure.

Purpose is to run full set of testcases on each run.
Testcases should contain proper cleanup handlers so that they are
independent.



### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

