### PR TITLE
Fix secure_time_get()

### DIFF
--- a/secure_time/secure_time_impl.c
+++ b/secure_time/secure_time_impl.c
@@ -19,7 +19,6 @@
 #include "secure_time_storage.h"
 #include "secure_time_crypto.h"
 #include "mbed_error.h"
-#include "platform/mbed_rtc_time.h"
 #include <string.h>
 
 #if SECURE_TIME_ENABLED
@@ -292,7 +291,7 @@ int32_t secure_time_set_trusted_commit_impl(const void *blob, size_t blob_size)
             // Set RTC with new time if it is around 1-2 minutes forward/backward
             // than current RTC time.
             if(llabs(new_time - rtc_time) > SECURE_TIME_MIN_RTC_LATENCY_SEC) {
-                set_time(new_time);
+                secure_time_update_rtc_time(new_time);
             }
 
             // Read the current stored time from secure storage.
@@ -337,9 +336,9 @@ static void set_time_forward(uint64_t new_time, uint64_t curr_os_time)
     secure_time_update_boot_time(new_time);
 
     // Set RTC with new time if it is around 1-2 minutes forward than current time.
-    uint64_t rtc_time = (uint64_t)time(NULL);
+    uint64_t rtc_time = secure_time_get_rtc_time();
     if((new_time - rtc_time) > SECURE_TIME_MIN_RTC_LATENCY_SEC) {
-        set_time(new_time);
+        secure_time_update_rtc_time(new_time);
     }
 
     // Write new time to secure storage entry of current stored time if it's more than 1 day forward
@@ -419,7 +418,7 @@ uint64_t secure_time_get_impl(void)
         secure_time_get_stored_time(&stored_time);
 
         // Get current RTC time
-        uint64_t rtc_time = (uint64_t)time(NULL);
+        uint64_t rtc_time = secure_time_get_rtc_time();
         
         // Set new time according to the latest between the RTC and the stored time
         uint64_t new_time = SECURE_TIME_MAX(stored_time, rtc_time);

--- a/secure_time/secure_time_utils.cpp
+++ b/secure_time/secure_time_utils.cpp
@@ -17,6 +17,7 @@
 #include "secure_time_client_spe.h"
 #include "mbed_error.h"
 #include "rtos/Kernel.h"
+#include "platform/mbed_rtc_time.h"
 
 #if SECURE_TIME_ENABLED
 
@@ -39,6 +40,24 @@ void secure_time_update_boot_time(uint64_t new_time)
 uint64_t secure_time_get_boot_time(void)
 {
     return g_boot_time_in_secs;
+}
+
+void secure_time_update_rtc_time(uint64_t new_time)
+{
+#if DEVICE_RTC
+    set_time((time_t)new_time);
+#endif
+}
+
+uint64_t secure_time_get_rtc_time(void)
+{
+    uint64_t rtc_time = 0;
+
+#if DEVICE_RTC
+    rtc_time = (uint64_t)time(NULL);
+#endif
+
+    return rtc_time;
 }
 
 #endif // SECURE_TIME_ENABLED

--- a/secure_time/secure_time_utils.h
+++ b/secure_time/secure_time_utils.h
@@ -82,6 +82,20 @@ void secure_time_update_boot_time(uint64_t new_time);
  */
 uint64_t secure_time_get_seconds_since_boot(void);
 
+/*
+ * Update the device RTC time according to the new time.
+ *
+ * @param[in] new_time  Time value in seconds since EPOCH.
+ */
+void secure_time_update_rtc_time(uint64_t new_time);
+
+/*
+ * Return the device RTC time in seconds since EPOCH.
+ *
+ * @return 64-bit value of seconds, 0 if RTC not supported.
+ */
+uint64_t secure_time_get_rtc_time(void);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Description

On secure_time_get(), if boot_time is unavailable:
Set new_time as the latest between the RTC and the stored time.
Store the calculated new_time

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

