### PR TITLE
Add more generic BlockDevice tests.

### DIFF
--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -164,6 +164,7 @@ DataFlashBlockDevice::DataFlashBlockDevice(PinName mosi,
 
 int DataFlashBlockDevice::init()
 {
+    _mutex.lock();
     DEBUG_PRINTF("init\r\n");
 
     if (!_is_initialized) {
@@ -173,6 +174,7 @@ int DataFlashBlockDevice::init()
     uint32_t val = core_util_atomic_incr_u32(&_init_ref_count, 1);
 
     if (val != 1) {
+        _mutex.unlock();
         return BD_ERROR_OK;
     }
 
@@ -281,33 +283,40 @@ int DataFlashBlockDevice::init()
         _is_initialized = true;
     }
 
+    _mutex.unlock();
     return result;
 }
 
 int DataFlashBlockDevice::deinit()
 {
+    _mutex.lock();
     DEBUG_PRINTF("deinit\r\n");
 
     if (!_is_initialized) {
         _init_ref_count = 0;
+        _mutex.unlock();
         return BD_ERROR_OK;
     }
 
     uint32_t val = core_util_atomic_decr_u32(&_init_ref_count, 1);
 
     if (val) {
+        _mutex.unlock();
         return BD_ERROR_OK;
     }
 
     _is_initialized = false;
+    _mutex.unlock();
     return BD_ERROR_OK;
 }
 
 int DataFlashBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 {
+    _mutex.lock();
     DEBUG_PRINTF("read: %p %" PRIX64 " %" PRIX64 "\r\n", buffer, addr, size);
 
     if (!_is_initialized) {
+        _mutex.unlock();
         return BD_ERROR_DEVICE_ERROR;
     }
 
@@ -350,6 +359,7 @@ int DataFlashBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
 
 int DataFlashBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t size)
 {
+    _mutex.lock();
     DEBUG_PRINTF("program: %p %" PRIX64 " %" PRIX64 "\r\n", buffer, addr, size);
 
     if (!_is_initialized) {
@@ -416,6 +426,7 @@ int DataFlashBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t 
 
 int DataFlashBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 {
+    _mutex.lock();
     DEBUG_PRINTF("erase: %" PRIX64 " %" PRIX64 "\r\n", addr, size);
 
     if (!_is_initialized) {
@@ -484,23 +495,29 @@ bd_size_t DataFlashBlockDevice::get_program_size() const
 
 bd_size_t DataFlashBlockDevice::get_erase_size() const
 {
+    _mutex.lock();
     DEBUG_PRINTF("erase size: %" PRIX16 "\r\n", _block_size);
-
-    return _block_size;
+    bd_size_t block_size = _block_size;
+    _mutex.unlock();
+    return block_size;
 }
 
 bd_size_t DataFlashBlockDevice::get_erase_size(bd_addr_t addr) const
 {
+    _mutex.lock();
     DEBUG_PRINTF("erase size: %" PRIX16 "\r\n", _block_size);
-
-    return _block_size;
+    bd_size_t block_size = _block_size;
+    _mutex.unlock();
+    return block_size;
 }
 
 bd_size_t DataFlashBlockDevice::size() const
 {
+    _mutex.lock();
     DEBUG_PRINTF("device size: %" PRIX32 "\r\n", _device_size);
-
-    return _device_size;
+    bd_size_t device_size = _device_size;
+    _mutex.unlock();
+    return device_size;
 }
 
 /**
@@ -512,6 +529,7 @@ bd_size_t DataFlashBlockDevice::size() const
  */
 uint16_t DataFlashBlockDevice::_get_register(uint8_t opcode)
 {
+    _mutex.lock();
     DEBUG_PRINTF("_get_register: %" PRIX8 "\r\n", opcode);
 
     /* activate device */
@@ -527,6 +545,7 @@ uint16_t DataFlashBlockDevice::_get_register(uint8_t opcode)
     /* deactivate device */
     _cs = 1;
 
+    _mutex.unlock();
     return status;
 }
 

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.cpp
@@ -354,6 +354,7 @@ int DataFlashBlockDevice::read(void *buffer, bd_addr_t addr, bd_size_t size)
         result = BD_ERROR_OK;
     }
 
+    _mutex.unlock();
     return result;
 }
 
@@ -363,6 +364,7 @@ int DataFlashBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t 
     DEBUG_PRINTF("program: %p %" PRIX64 " %" PRIX64 "\r\n", buffer, addr, size);
 
     if (!_is_initialized) {
+        _mutex.unlock();
         return BD_ERROR_DEVICE_ERROR;
     }
 
@@ -421,6 +423,7 @@ int DataFlashBlockDevice::program(const void *buffer, bd_addr_t addr, bd_size_t 
         _write_enable(false);
     }
 
+    _mutex.unlock();
     return result;
 }
 
@@ -430,6 +433,7 @@ int DataFlashBlockDevice::erase(bd_addr_t addr, bd_size_t size)
     DEBUG_PRINTF("erase: %" PRIX64 " %" PRIX64 "\r\n", addr, size);
 
     if (!_is_initialized) {
+        _mutex.unlock();
         return BD_ERROR_DEVICE_ERROR;
     }
 
@@ -476,6 +480,7 @@ int DataFlashBlockDevice::erase(bd_addr_t addr, bd_size_t size)
         _write_enable(false);
     }
 
+    _mutex.unlock();
     return result;
 }
 

--- a/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_DATAFLASH/DataFlashBlockDevice.h
@@ -173,6 +173,9 @@ private:
     int _sync(void);
     int _write_page(const uint8_t *buffer, uint32_t addr, uint32_t offset, uint32_t size);
     uint32_t _translate_address(bd_addr_t addr);
+
+    // Mutex for thread safety
+    mutable PlatformMutex _mutex;
 };
 
 


### PR DESCRIPTION
### Description
Added contiguous erase/write/read test to catch errors like below automatically in future:
https://github.com/ARMmbed/dataflash-driver/commit/9ee3f5afa73406a6d9b6fc657a42bae71236ad02 
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

