### PR TITLE
Fix for unit test build on Windows machines

### DIFF
--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -144,6 +144,8 @@
 #ifndef MBED_WEAK
 #if defined(__ICCARM__)
 #define MBED_WEAK __weak
+#elif defined(__MINGW32__)
+#define MBED_WEAK
 #else
 #define MBED_WEAK __attribute__((weak))
 #endif


### PR DESCRIPTION
### Description

When building unit tests on windows a linker error is reported when linking `EthernetInterface `test, claiming that `EthernetInterface::get_target_default_instance()` is undefined. This is caused by MinGW not supporting weak attribute.

The changes address this issue using preprocessor macro to determine that minGW is being used. MinGW will only be used in case unit tests are built on windows, as every other compilation will run a target compiler (either ARM or target GCC) or a Unix GCC (both on Linux and Mac).

I checked that target code builds fine on Windows and that unit tests are compiling and running on Linux.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

