### PR TITLE
Doxygen: Rework connectivity groups 

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -849,6 +849,8 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */features/lwipstack/* \
                          */features/nanostack/sal-stack-nanostack/* \
                          */features/nanostack/coap-service/* \
+                         */features/nfc/acore/* \
+                         */features/nfc/stack/* \
                          */mbed-trace/* \
                          */mbed-coap/* \
                          */nanostack-libservice/* \

--- a/doxyfile_options
+++ b/doxyfile_options
@@ -849,6 +849,7 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */features/lwipstack/* \
                          */features/nanostack/sal-stack-nanostack/* \
                          */features/nanostack/coap-service/* \
+                         */features/netsocket/emac-drivers/* \
                          */features/nfc/acore/* \
                          */features/nfc/stack/* \
                          */mbed-trace/* \

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -10,7 +10,7 @@
     "EXPAND_AS_DEFINED": "",
     "SKIP_FUNCTION_MACROS": "NO",
     "STRIP_CODE_COMMENTS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/cfstore/* */features/storage/FEATURE_STORAGE/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */components/802.15.4_RF/* */components/wifi/* */features/nfc/stack/* */UNITTESTS/* */features/cryptocell/*",
+    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/cfstore/* */features/storage/FEATURE_STORAGE/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */features/nfc/acore/* */features/nfc/stack/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */components/802.15.4_RF/* */components/wifi/* */features/nfc/stack/* */UNITTESTS/* */features/cryptocell/*",
     "ALPHABETICAL_INDEX": "NO",
     "CASE_SENSE_NAMES": "NO",
     "DOT_MULTI_TARGETS": "YES",

--- a/doxygen_options.json
+++ b/doxygen_options.json
@@ -10,7 +10,7 @@
     "EXPAND_AS_DEFINED": "",
     "SKIP_FUNCTION_MACROS": "NO",
     "STRIP_CODE_COMMENTS": "NO",
-    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/cfstore/* */features/storage/FEATURE_STORAGE/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */features/nfc/acore/* */features/nfc/stack/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */components/802.15.4_RF/* */components/wifi/* */features/nfc/stack/* */UNITTESTS/* */features/cryptocell/*",
+    "EXCLUDE_PATTERNS": "*/tools/* */targets/* */features/mbedtls/* */features/storage/cfstore/* */features/storage/FEATURE_STORAGE/* */features/unsupported/* */BUILD/* */rtos/TARGET_CORTEX/rtx*/* */cmsis/* */features/lwipstack/* */nanostack/sal-stack-nanostack/* */nanostack/coap-service/* */features/netsocket/emac-drivers/* */features/nfc/acore/* */features/nfc/stack/* */ble/generic/* */ble/pal/* */mbed-trace/* */mbed-coap/* */nanostack-libservice/* */mbed-client-randlib/* */nanostack/sal-stack-nanostack-eventloop/* */components/802.15.4_RF/* */components/wifi/* */features/nfc/stack/* */UNITTESTS/* */features/cryptocell/*",
     "ALPHABETICAL_INDEX": "NO",
     "CASE_SENSE_NAMES": "NO",
     "DOT_MULTI_TARGETS": "YES",

--- a/features/FEATURE_BLE/ble/BLE.h
+++ b/features/FEATURE_BLE/ble/BLE.h
@@ -37,6 +37,10 @@
 class BLEInstanceBase;
 
 /**
+ * @addtogroup connectivity 
+ * @{
+ * @addtogroup pan
+ * @{
  * @addtogroup ble
  * @{
  */
@@ -1793,6 +1797,8 @@ typedef BLE BLEDevice;
  */
 
 /**
+ * @} 
+ * @}
  * @}
  */
 

--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -1,4 +1,5 @@
-
+/** \addtogroup connectivity */
+/** @{*/
 /** \addtogroup netsocket */
 /** @{*/
 /* Socket
@@ -258,4 +259,5 @@ public:
 
 #endif
 
+/** @}*/
 /** @}*/

--- a/features/nfc/nfc/NFCController.h
+++ b/features/nfc/nfc/NFCController.h
@@ -36,6 +36,10 @@ class NFCRemoteTarget;
 class NFCControllerDriver;
 
 /**
+ * @addtogroup connectivity 
+ * @{
+ * @addtogroup pan
+ * @{
  * @addtogroup nfc
  * @{
  */
@@ -181,6 +185,8 @@ private:
 
 /**
  * @}
+ * @}
+ * @}  
  */
 
 } // namespace nfc


### PR DESCRIPTION
### Description

With this change the layout looks like: 
* connectivity
    - netsocket
    - pan 
          + BLE
          + NFC

Generation of LPC specific Emac documentation has been disabled in the process. 

There is still not appropriate groups coming from LORA:  
* ["LoRa MAC layer implementation"](https://os.mbed.com/docs/v5.10/mbed-os-api-doxy/group___l_o_r_a_m_a_c.html)
* ["stack layer that controls MAC layer underneath"](https://os.mbed.com/docs/v5.10/mbed-os-api-doxy/group___lo_ra_w_a_n.html)

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

