### PR TITLE
Need to protect also with MBEDTLS_PK_C flag.

### DIFF
--- a/features/netsocket/TLSSocketWrapper.cpp
+++ b/features/netsocket/TLSSocketWrapper.cpp
@@ -43,7 +43,9 @@ TLSSocketWrapper::TLSSocketWrapper(Socket *transport, const char *hostname, cont
     mbedtls_entropy_init(&_entropy);
     mbedtls_ctr_drbg_init(&_ctr_drbg);
     mbedtls_ssl_init(&_ssl);
+#ifdef MBEDTLS_PK_C
     mbedtls_pk_init(&_pkctx);
+#endif
 
     if (hostname) {
         set_hostname(hostname);
@@ -57,7 +59,9 @@ TLSSocketWrapper::~TLSSocketWrapper() {
     mbedtls_entropy_free(&_entropy);
     mbedtls_ctr_drbg_free(&_ctr_drbg);
     mbedtls_ssl_free(&_ssl);
+#ifdef MBEDTLS_PK_C
     mbedtls_pk_free(&_pkctx);
+#endif
 
 #ifdef MBEDTLS_X509_CRT_PARSE_C
     set_own_cert(NULL);
@@ -113,7 +117,7 @@ nsapi_error_t TLSSocketWrapper::set_client_cert_key(const char *client_cert_pem,
 nsapi_error_t TLSSocketWrapper::set_client_cert_key(const void *client_cert, size_t client_cert_len,
         const void *client_private_key_pem, size_t client_private_key_len)
 {
-#if !defined(MBEDTLS_X509_CRT_PARSE_C)
+#if !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_PK_C)
     return NSAPI_ERROR_UNSUPPORTED;
 #else
 
@@ -384,7 +388,7 @@ int TLSSocketWrapper::ssl_send(void *ctx, const unsigned char *buf, size_t len) 
     return size;
  }
 
-#ifdef MBEDTLS_X509_CRT_PARSE_C
+#if !defined(MBEDTLS_X509_CRT_PARSE_C) || !defined(MBEDTLS_PK_C)
 
 mbedtls_x509_crt *TLSSocketWrapper::get_own_cert()
 {

--- a/features/netsocket/TLSSocketWrapper.h
+++ b/features/netsocket/TLSSocketWrapper.h
@@ -212,7 +212,9 @@ protected:
 
 private:
     mbedtls_ssl_context _ssl;
+#ifdef MBEDTLS_PK_C
     mbedtls_pk_context _pkctx;
+#endif
     mbedtls_ctr_drbg_context _ctr_drbg;
     mbedtls_entropy_context _entropy;
 


### PR DESCRIPTION
### Description

This is dependency to X509_CRT_PARSE but just to make sure
that also the 'mbedtls_pk_context' structure is not used if that
flag is not enabled.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

CC: @juhoeskeli 