### PR TITLE
Add required namespace instead of relying on mbed.h

### DIFF
--- a/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
+++ b/components/802.15.4_RF/atmel-rf-driver/source/NanostackRfPhyAtmel.cpp
@@ -220,6 +220,8 @@ static inline rf_trx_states_t rf_if_trx_status_from_full(uint8_t full_trx_status
 #ifdef MBED_CONF_RTOS_PRESENT
 #include "mbed.h"
 #include "rtos.h"
+using namespace mbed;
+using namespace rtos;
 
 static void rf_if_irq_task_process_irq();
 

--- a/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
+++ b/components/802.15.4_RF/mcr20a-rf-driver/mcr20a-rf-driver/NanostackRfPhyMcr20a.h
@@ -55,12 +55,12 @@ public:
     virtual void set_mac_address(uint8_t *mac);
 
 private:
-    SPI _spi;
-    DigitalOut _rf_cs;
-    DigitalOut _rf_rst;
-    InterruptIn _rf_irq;
-    DigitalIn _rf_irq_pin;
-    Thread _irq_thread;
+    mbed::SPI _spi;
+    mbed::DigitalOut _rf_cs;
+    mbed::DigitalOut _rf_rst;
+    mbed::InterruptIn _rf_irq;
+    mbed::DigitalIn _rf_irq_pin;
+    rtos::Thread _irq_thread;
 
     void _pins_set();
     void _pins_clear();

--- a/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
+++ b/components/802.15.4_RF/mcr20a-rf-driver/source/NanostackRfPhyMcr20a.cpp
@@ -23,6 +23,9 @@
 #include <string.h>
 #include "rtos.h"
 
+using namespace mbed;
+using namespace rtos;
+
 /* Freescale headers which are for C files */
 extern "C" {
 #include "MCR20Drv.h"

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.cpp
@@ -20,6 +20,8 @@
 
 #include <cstring>
 
+using namespace mbed;
+
 #define ESP8266_DEFAULT_BAUD_RATE   115200
 #define ESP8266_ALL_SOCKET_IDS      -1
 

--- a/components/wifi/esp8266-driver/ESP8266/ESP8266.h
+++ b/components/wifi/esp8266-driver/ESP8266/ESP8266.h
@@ -227,7 +227,7 @@ public:
     *
     * @param func A pointer to a void function, or 0 to set as none
     */
-    void sigio(Callback<void()> func);
+    void sigio(mbed::Callback<void()> func);
 
     /**
     * Attach a function to call whenever sigio happens in the serial
@@ -237,7 +237,7 @@ public:
     */
     template <typename T, typename M>
     void sigio(T *obj, M method) {
-        sigio(Callback<void()>(obj, method));
+        sigio(mbed::Callback<void()>(obj, method));
     }
 
     /**
@@ -271,9 +271,9 @@ public:
     static const int8_t SOCKET_COUNT = 5;
 
 private:
-    UARTSerial _serial;
-    ATCmdParser _parser;
-    Mutex _smutex; // Protect serial port access
+    mbed::UARTSerial _serial;
+    mbed::ATCmdParser _parser;
+    rtos::Mutex _smutex; // Protect serial port access
 
     struct packet {
         struct packet *next;
@@ -303,7 +303,7 @@ private:
     bool _closed;
     int _socket_open[SOCKET_COUNT];
     nsapi_connection_status_t _connection_status;
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
 };
 
 #endif

--- a/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
+++ b/features/nanostack/mbed-mesh-api/mbed-mesh-api/MeshInterfaceNanostack.h
@@ -51,9 +51,9 @@ protected:
     NanostackPhy &get_phy() const { return interface_phy; }
     int8_t interface_id;
     int8_t _device_id;
-    Semaphore connect_semaphore;
+    rtos::Semaphore connect_semaphore;
 
-    Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
+    mbed::Callback<void(nsapi_event_t, intptr_t)> _connection_status_cb;
     nsapi_connection_status_t _connect_status;
     nsapi_connection_status_t _previous_connection_status;
     bool _blocking;

--- a/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
+++ b/features/nanostack/nanostack-hal-mbed-cmsis-rtos/arm_hal_fhss_timer.cpp
@@ -26,6 +26,9 @@
 #define NUMBER_OF_SIMULTANEOUS_TIMEOUTS  2
 #endif //NUMBER_OF_SIMULTANEOUS_TIMEOUTS
 
+using namespace mbed;
+using namespace events;
+
 static Timer timer;
 static bool timer_initialized = false;
 static const fhss_api_t *fhss_active_handle = NULL;


### PR DESCRIPTION
### Description

mbed.h has 'using namespace mbed;', hence some of the files skip adding required namespace to the code, it is always good to specify the namespace around the elements in header and `using namespace` in specific CPP files, instead of all


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

