### PR TITLE
STM32F413ZH: Add bootloader support

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/system_clock.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/TARGET_DISCO_F413ZH/system_clock.c
@@ -31,7 +31,7 @@
 
 #include "stm32f4xx.h"
 #include "mbed_error.h"
-
+#include "nvic_addr.h"
 
 /*!< Uncomment the following line if you need to relocate your vector Table in
      Internal SRAM. */
@@ -94,7 +94,7 @@ void SystemInit(void)
 #ifdef VECT_TAB_SRAM
     SCB->VTOR = SRAM_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal SRAM */
 #else
-    SCB->VTOR = FLASH_BASE | VECT_TAB_OFFSET; /* Vector Table Relocation in Internal FLASH */
+    SCB->VTOR = NVIC_FLASH_VECTOR_ADDRESS; /* Vector Table Relocation in Internal FLASH */
 #endif
 
     /* In DISCO_F413ZH board, Arduino connector and Wifi embeded module are sharing the same SPI pins */

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
@@ -32,9 +32,9 @@
   #define MBED_APP_START 0x08000000
 #endif
 
-; 1536KB FLASH (0x150000) 
+; 1536KB FLASH (0x180000)
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x150000
+  #define MBED_APP_SIZE 0x180000
 #endif
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_MICRO/stm32f413xh.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2017, STMicroelectronics
@@ -27,15 +28,24 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F413ZH: 1536 KB FLASH (0x150000) + 320 KB SRAM (0x50000)
-LR_IROM1 0x08000000 0x150000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x150000  {  ; load address = execution address
+; 1536KB FLASH (0x150000) 
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x150000
+#endif
+
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
+  ; 320KB SRAM (0x50000)
   ; Total: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM
   RW_IRAM1 (0x20000000+0x1D8) (0x50000-0x1D8)  {  ; RW data
    .ANY (+RW +ZI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
@@ -32,9 +32,9 @@
   #define MBED_APP_START 0x08000000
 #endif
 
-; 1536KB FLASH (0x150000) 
+; 1536KB FLASH (0x180000)
 #if !defined(MBED_APP_SIZE)
-  #define MBED_APP_SIZE 0x150000
+  #define MBED_APP_SIZE 0x180000
 #endif
 
 LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_ARM_STD/stm32f413xh.sct
@@ -1,3 +1,4 @@
+#! armcc -E
 ; Scatter-Loading Description File
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Copyright (c) 2017, STMicroelectronics
@@ -27,15 +28,24 @@
 ; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; STM32F413ZH: 1536 KB FLASH (0x150000) + 320 KB SRAM (0x50000)
-LR_IROM1 0x08000000 0x150000  {    ; load region size_region
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
 
-  ER_IROM1 0x08000000 0x150000  {  ; load address = execution address
+; 1536KB FLASH (0x150000) 
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 0x150000
+#endif
+
+LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
+
+  ER_IROM1 MBED_APP_START MBED_APP_SIZE  {  ; load address = execution address
    *.o (RESET, +First)
    *(InRoot$$Sections)
    .ANY (+RO)
   }
 
+  ; 320KB SRAM (0x50000)
   ; Total: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM
   RW_IRAM1 (0x20000000+0x1D8) (0x50000-0x1D8)  {  ; RW data
    .ANY (+RW +ZI)

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_GCC_ARM/STM32F413xH.ld
@@ -1,7 +1,15 @@
+#if !defined(MBED_APP_START)
+  #define MBED_APP_START 0x08000000
+#endif
+
+#if !defined(MBED_APP_SIZE)
+  #define MBED_APP_SIZE 1536K
+#endif
+
 /* Linker script to configure memory regions. */
 MEMORY
 { 
-  FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1536K
+  FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
   RAM (rwx)  : ORIGIN = 0x200001D8, LENGTH = 320K - 0x1D8
 }
 

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F413xH/device/TOOLCHAIN_IAR/stm32f413xx.icf
@@ -1,7 +1,10 @@
 /* [ROM = 1536kb = 0x180000] */
-define symbol __intvec_start__     = 0x08000000;
-define symbol __region_ROM_start__ = 0x08000000;
-define symbol __region_ROM_end__   = 0x0817FFFF;
+if (!isdefinedsymbol(MBED_APP_START)) { define symbol MBED_APP_START = 0x08000000; }
+if (!isdefinedsymbol(MBED_APP_SIZE)) { define symbol MBED_APP_SIZE = 0x180000; }
+
+define symbol __intvec_start__     = MBED_APP_START;
+define symbol __region_ROM_start__ = MBED_APP_START;
+define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 320kb = 0x50000] Vector table dynamic copy: 118 vectors = 472 bytes (0x1D8) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1291,6 +1291,7 @@
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "QSPI"],
+        "bootloader_supported": true,
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },
@@ -1313,6 +1314,7 @@
         "detect_code": ["0743"],
         "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
         "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "bootloader_supported": true,
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
     },


### PR DESCRIPTION
### Description

Add bootloader support for DISCO_F413ZH and NUCLEO_F413ZH platforms.

Fixes #8543

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

