### PR TITLE
NUCLEO_L4R5ZI: Fix alignment of execute region to 8byte boundary

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_ARM_MICRO/stm32l4r5xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_ARM_MICRO/stm32l4r5xx.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 111 vectors = 444 bytes (0x1BC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1BC) (0xA0000-0x1BC)  { ; RW data
+  ; Total: 111 vectors = 444 bytes (0x1BC) (+ 4 bytes for 8-byte alignment) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C0) (0xA0000-0x1C0)  { ; RW data
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_ARM_STD/stm32l4r5xx.sct
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_ARM_STD/stm32l4r5xx.sct
@@ -45,8 +45,8 @@ LR_IROM1 MBED_APP_START MBED_APP_SIZE  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 111 vectors = 444 bytes (0x1BC) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x1BC) (0xA0000-0x1BC)  { ; RW data
+  ; Total: 111 vectors = 444 bytes (0x1BC) (+ 4 bytes for 8-byte alignment) to be reserved in RAM
+  RW_IRAM1 (0x20000000+0x1C0) (0xA0000-0x1C0)  { ; RW data
    .ANY (+RW +ZI)
   }
 }

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_GCC_ARM/stm32l4r5xx.ld
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_GCC_ARM/stm32l4r5xx.ld
@@ -7,10 +7,11 @@
 #endif
 
 /* Linker script to configure memory regions. */
+/* Total: 111 vectors = 444 bytes (0x1BC) (+ 4 bytes for 8-byte alignment) to be reserved in RAM */
 MEMORY
 { 
   FLASH (rx) : ORIGIN = MBED_APP_START, LENGTH = MBED_APP_SIZE
-  SRAM1 (rwx)  : ORIGIN = 0x200001BC, LENGTH = 640k - 0x1BC
+  SRAM1 (rwx)  : ORIGIN = 0x200001C0, LENGTH = 640k - 0x1C0
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -92,20 +93,21 @@ SECTIONS
         *(vtable)
         *(.data*)
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* preinit data */
         PROVIDE_HIDDEN (__preinit_array_start = .);
         KEEP(*(.preinit_array))
         PROVIDE_HIDDEN (__preinit_array_end = .);
 
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* init data */
         PROVIDE_HIDDEN (__init_array_start = .);
         KEEP(*(SORT(.init_array.*)))
         KEEP(*(.init_array))
         PROVIDE_HIDDEN (__init_array_end = .);
 
-        . = ALIGN(4);
+
+        . = ALIGN(8);
         /* finit data */
         PROVIDE_HIDDEN (__fini_array_start = .);
         KEEP(*(SORT(.fini_array.*)))
@@ -113,7 +115,7 @@ SECTIONS
         PROVIDE_HIDDEN (__fini_array_end = .);
 
         KEEP(*(.jcr*))
-        . = ALIGN(4);
+        . = ALIGN(8);
         /* All data end */
         __data_end__ = .;
         _edata = .;
@@ -122,12 +124,12 @@ SECTIONS
 
     .bss :
     {
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_start__ = .;
         _sbss = .;
         *(.bss*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         __bss_end__ = .;
         _ebss = .;
     } > SRAM1

--- a/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_IAR/stm32l4r5xx.icf
+++ b/targets/TARGET_STM/TARGET_STM32L4/TARGET_STM32L4R5xI/device/TOOLCHAIN_IAR/stm32l4r5xx.icf
@@ -7,8 +7,8 @@ define symbol __region_ROM_start__ = MBED_APP_START;
 define symbol __region_ROM_end__   = MBED_APP_START + MBED_APP_SIZE - 1;
 
 /* [RAM = 640KB = 0xA0000] */
-/* Vector table dynamic copy: Total: 111 vectors = 444 bytes (0x1BC) to be reserved in RAM */
-/* Reserved 448 bytes (0x1C0) to be aligned on 8 bytes (448 = 56 x 8) */
+/* Vector table dynamic copy */
+/* Total: 111 vectors = 444 bytes (0x1BC) (+ 4 bytes for 8-byte alignment) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x20000000;
 define symbol __NVIC_end__            = 0x20000000 + 0x1C0 - 1;
 define symbol __region_SRAM1_start__  = 0x20000000 + 0x1C0;


### PR DESCRIPTION
### Description

The 8byte data alignment on this new platform was not done on ARM and GCC compilers.

Same as PR #8013

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

