### PR TITLE
BLE: fix using an optional feature before checking for support

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
+++ b/features/FEATURE_BLE/targets/TARGET_CORDIO/source/CordioPalGap.cpp
@@ -334,8 +334,12 @@ ble_error_t Gap::set_address_resolution(
 }
 
 ble_error_t Gap::read_phy(connection_handle_t connection) {
-    DmReadPhy(connection);
-    return BLE_ERROR_NONE;
+    if (is_feature_supported(ControllerSupportedFeatures_t::LE_2M_PHY)
+        || is_feature_supported(ControllerSupportedFeatures_t::LE_CODED_PHY)) {
+        DmReadPhy(connection);
+        return BLE_ERROR_NONE;
+    }
+    return BLE_ERROR_NOT_IMPLEMENTED;
 }
 
 ble_error_t Gap::set_preferred_phys(


### PR DESCRIPTION
### Description

Feature is optional and we must check the controller for support before trying to use it. Detected and fix validated through clitest suite of BLE tests.
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

