### PR TITLE
STM32F407VG: Add TRNG support

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/objects.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407xG/objects.h
@@ -54,6 +54,10 @@ struct port_s {
     __IO uint32_t *reg_out;
 };
 
+struct trng_s {
+    RNG_HandleTypeDef handle;
+};
+
 #include "common_objects.h"
 
 #ifdef __cplusplus

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1803,7 +1803,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "program_cycle_s": 2,
         "extra_labels_add": ["STM32F4", "STM32F407", "STM32F407xG", "STM32F407VG"],
-        "device_has_add": ["ANALOGOUT"],
+        "device_has_add": ["ANALOGOUT", "TRNG"],
         "release_versions": ["2"],
         "device_name": "STM32F407VG"
     },
@@ -1915,7 +1915,7 @@
         },
         "macros_add": ["USB_STM_HAL"],
         "overrides": {"lse_available": 0},
-        "device_has_add": ["ANALOGOUT"],
+        "device_has_add": ["ANALOGOUT", "TRNG"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F407VG"
     },


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

This enables TRNG (true random number generator) support for STM32F407VG on `DISCO_F407VG` and `ARCH_MAX` platforms.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

