### PR TITLE
Fix typos in Features/Netsocket

### DIFF
--- a/features/netsocket/CellularBase.h
+++ b/features/netsocket/CellularBase.h
@@ -27,7 +27,7 @@ public:
     /** Get the default cellular interface.
      *
      * This is provided as a weak method so applications can override.
-     * Default behaviour is to get the target's default interface, if
+     * Default behavior is to get the target's default interface, if
      * any.
      *
      * @return pointer to interface, if any.
@@ -36,7 +36,7 @@ public:
 
     /** Set the cellular network credentials.
      *
-     *  Please check documentation of connect() for default behaviour of APN settings.
+     *  Please check documentation of connect() for default behavior of APN settings.
      *
      *  @param apn      Access point name.
      *  @param uname    Username (optional).

--- a/features/netsocket/EMAC.h
+++ b/features/netsocket/EMAC.h
@@ -26,7 +26,7 @@
 
 /**
  * This interface should be used to abstract low level access to networking hardware
- * All operations receive a `void *` HW pointer which an emac device provides when
+ * All operations receive a `void *` hardware pointer which an EMAC device provides when
  * it is registered with a stack.
  */
 class EMAC {
@@ -40,7 +40,7 @@ public:
     static EMAC &get_default_instance();
 
     /**
-     * Callback to be register with Emac interface and to be called for received packets
+     * Callback to be register with EMAC interface and to be called for received packets
      *
      * @param buf  Received data
      */
@@ -48,7 +48,7 @@ public:
     typedef mbed::Callback<void (emac_mem_buf_t *buf)> emac_link_input_cb_t;
 
     /**
-     * Callback to be register with Emac interface and to be called for link status changes
+     * Callback to be register with EMAC interface and to be called for link status changes
      *
      * @param  up   Link status
      */
@@ -65,7 +65,7 @@ public:
     /**
      * Gets memory buffer alignment preference
      *
-     * Gets preferred memory buffer alignment of the Emac device. IP stack may or may not
+     * Gets preferred memory buffer alignment of the EMAC device. IP stack may or may not
      * align link out memory buffer chains using the alignment.
      *
      * @return         Memory alignment requirement in bytes
@@ -107,7 +107,7 @@ public:
      * Provided address has to be of correct size, see @a get_hwaddr_size
      *
      * Called to set the MAC address to actually use - if @a get_hwaddr is provided
-     * the stack would normally use that, but it could be overridden, e.g. for test
+     * the stack would normally use that, but it could be overridden, for example for test
      * purposes.
      *
      * @param addr Address to be set

--- a/features/netsocket/EMAC.h
+++ b/features/netsocket/EMAC.h
@@ -26,7 +26,7 @@
 
 /**
  * This interface should be used to abstract low level access to networking hardware
- * All operations receive a `void *` hw pointer which an emac device provides when
+ * All operations receive a `void *` HW pointer which an emac device provides when
  * it is registered with a stack.
  */
 class EMAC {
@@ -107,7 +107,7 @@ public:
      * Provided address has to be of correct size, see @a get_hwaddr_size
      *
      * Called to set the MAC address to actually use - if @a get_hwaddr is provided
-     * the stack would normally use that, but it could be overridden, eg for test
+     * the stack would normally use that, but it could be overridden, e.g. for test
      * purposes.
      *
      * @param addr Address to be set
@@ -179,7 +179,7 @@ public:
 
 
 /** These need to be defined by targets wishing to provide an Ethernet driver using EMAC interface. It will
- *  be used by the EMACInterface class's default constructor to initialise the networking subsystem.
+ *  be used by the EMACInterface class's default constructor to initialize the networking subsystem.
  */
 //extern const emac_interface_ops_t mbed_emac_eth_ops_default;
 //extern void *mbed_emac_eth_hw_default;

--- a/features/netsocket/EMACInterface.h
+++ b/features/netsocket/EMACInterface.h
@@ -32,7 +32,7 @@
  * Drivers derived from EMACInterface should be constructed so that their
  * EMAC is functional without the need to call `connect()`. For example
  * a Wi-Fi driver should permit `WiFi::get_emac().power_up()` as soon as
- * the credentials have been set. This is necessary to support specialised
+ * the credentials have been set. This is necessary to support specialized
  * applications such as 6LoWPAN mesh border routers.
  */
 class EMACInterface : public virtual NetworkInterface {
@@ -99,21 +99,21 @@ public:
     /** Get the local IP address
      *
      *  @return         Null-terminated representation of the local IP address
-     *                  or null if no IP address has been recieved
+     *                  or null if no IP address has been received
      */
     virtual const char *get_ip_address();
 
     /** Get the local network mask
      *
      *  @return         Null-terminated representation of the local network mask
-     *                  or null if no network mask has been recieved
+     *                  or null if no network mask has been received
      */
     virtual const char *get_netmask();
 
     /** Get the local gateways
      *
      *  @return         Null-terminated representation of the local gateway
-     *                  or null if no network mask has been recieved
+     *                  or null if no network mask has been received
      */
     virtual const char *get_gateway();
 

--- a/features/netsocket/EthInterface.h
+++ b/features/netsocket/EthInterface.h
@@ -38,7 +38,7 @@ public:
     /** Get the default Ethernet interface.
      *
      * This is provided as a weak method so applications can override.
-     * Default behaviour is to get the target's default interface, if
+     * Default behavior is to get the target's default interface, if
      * any.
      *
      * @return Pointer to interface, if one exists.

--- a/features/netsocket/MeshInterface.h
+++ b/features/netsocket/MeshInterface.h
@@ -37,7 +37,7 @@ public:
     /** Get the default Mesh interface.
      *
      * This is provided as a weak method so applications can override.
-     * Default behaviour is to get the target's default interface, if
+     * Default behavior is to get the target's default interface, if
      * any.
      *
      * @return pointer to interface, if any.

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -49,7 +49,7 @@ public:
      * wifiInterface(), meshInterface(), cellularBase(), emacInterface() and checking
      * for NULL pointers.
      *
-     * The default behaviour is to return the default interface for the
+     * The default behavior is to return the default interface for the
      * interface type specified by target.network-default-interface-type. Targets
      * should set this in their targets.json to guide default selection,
      * and applications may override.
@@ -306,7 +306,7 @@ protected:
      * need to override in simple cases.
      *
      * If a target has more elaborate interface selection, it can completely
-     * override this behaviour by implementing
+     * override this behavior by implementing
      * NetworkInterface::get_target_default_instance() themselves, either
      * unconditionally, or for a specific network-default-interface-type setting
      *

--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -50,7 +50,7 @@ public:
      *  Also connectionless protocols use the connected address to filter
      *  incoming packets for recv() and recvfrom() calls.
      *
-     *  To reset the peer address, zero initialised(default constructor) SocketAddress
+     *  To reset the peer address, zero initialized(default constructor) SocketAddress
      *  object have to be in the address parameter.
      *
      *  @param address  The SocketAddress of the remote peer
@@ -234,9 +234,9 @@ public:
      *  The server socket must be bound and set to listen for connections.
      *  On a new connection, returns connected network socket which user is expected to call close()
      *  and that deallocates the resources. Referencing a returned pointer after a close()
-     *  call is not allowed and leads to undefined behaviour.
+     *  call is not allowed and leads to undefined behavior.
      *
-     *  By default, accept blocks until incomming connection occurs. If socket is set to
+     *  By default, accept blocks until incoming connection occurs. If socket is set to
      *  non-blocking or times out, error is set to NSAPI_ERROR_WOULD_BLOCK.
      *
      *  @param error      pointer to storage of the error value or NULL

--- a/features/netsocket/TCPSocket.h
+++ b/features/netsocket/TCPSocket.h
@@ -158,9 +158,9 @@ public:
      *  The server socket must be bound and set to listen for connections.
      *  On a new connection, returns connected network socket which user is expected to call close()
      *  and that deallocates the resources. Referencing a returned pointer after a close()
-     *  call is not allowed and leads to undefined behaviour.
+     *  call is not allowed and leads to undefined behavior.
      *
-     *  By default, accept blocks until incomming connection occurs. If socket is set to
+     *  By default, accept blocks until incoming connection occurs. If socket is set to
      *  non-blocking or times out, error is set to NSAPI_ERROR_WOULD_BLOCK.
      *
      *  @param error      pointer to storage of the error value or NULL

--- a/features/netsocket/TLSSocketWrapper.h
+++ b/features/netsocket/TLSSocketWrapper.h
@@ -174,7 +174,7 @@ protected:
 
     /** Initiates TLS Handshake
      *
-     *  Initiates a TLS hanshake to a remote speer
+     *  Initiates a TLS handshake to a remote peer
      *  Underlying transport socket should already be connected
      *
      *  Root CA certification must be set by set_ssl_ca_pem() before

--- a/features/netsocket/WiFiInterface.h
+++ b/features/netsocket/WiFiInterface.h
@@ -31,7 +31,7 @@ public:
     /** Get the default Wi-Fi interface.
      *
      * This is provided as a weak method so applications can override.
-     * Default behaviour is to get the target's default interface, if
+     * Default behavior is to get the target's default interface, if
      * any.
      *
      * @return pointer to interface, if any.

--- a/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
+++ b/features/netsocket/cellular/generic_modem_driver/PPPCellularInterface.h
@@ -127,7 +127,7 @@ public:
      *
      *  @deprecated This API will be deprecated in mbed-os-5.9. Use mbed-os/features/cellular/easy_cellular/EasyCellularConnection.h instead.
      *
-     *  Please check documentation of connect() for default behaviour of APN settings.
+     *  Please check documentation of connect() for default behavior of APN settings.
      *
      *  @param apn      Access point name
      *  @param uname    optionally, Username
@@ -176,7 +176,7 @@ public:
      *  by the cellular modem over PPP interface.
      *
      *  If the SIM requires a PIN, and it is not set/invalid, NSAPI_ERROR_AUTH_ERROR is returned.
-     *  For APN setup, default behaviour is to use 'internet' as APN string and assuming no authentication
+     *  For APN setup, default behavior is to use 'internet' as APN string and assuming no authentication
      *  is required, i.e., username and password are not set. Optionally, a database lookup can be requested
      *  by turning on the APN database lookup feature. In order to do so, add 'MBED_CONF_PPP_CELL_IFACE_APN_LOOKUP'
      *  in your mbed_app.json. APN database is by no means exhaustive. It contains a short list of some public

--- a/features/netsocket/cellular/onboard_modem_api.h
+++ b/features/netsocket/cellular/onboard_modem_api.h
@@ -17,9 +17,9 @@
 #ifndef ONBOARD_MODEM_API_H_
 #define ONBOARD_MODEM_API_H_
 
-/** onboard_modem_api is a standardizing API for Modem type devices under mbed-os.
+/** onboard_modem_api is a standardizing API for Modem type devices under Mbed OS.
  * It provides a simple hardware abstraction layer on top of the modem drivers
- * written for mbed-os.
+ * written for Mbed OS.
  *
  * It is required from the engineers porting any modem type device (e.g., Cellular)
  * to provide an implementation of this API in their respective target folder as well as

--- a/features/netsocket/nsapi_types.h
+++ b/features/netsocket/nsapi_types.h
@@ -97,7 +97,7 @@ typedef signed int nsapi_error_t;
  */
 typedef unsigned int nsapi_size_t;
 
-/** Type used to represent either a size or error pased through sockets
+/** Type used to represent either a size or error passed through sockets
  *
  *  A valid nsapi_size_or_error_t is either a non-negative size or a
  *  negative error code from the nsapi_error_t


### PR DESCRIPTION
### Description

Typo fixes in Doxygen for Netsocket, including transition to US_EN for some words (behaviour -> behavior) as per docs team requirements.


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [X] Docs update
    [ ] Test update
    [ ] Breaking change

