### PR TITLE
Add QSPIF block device to default system storage

### DIFF
--- a/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_QSPIF/mbed_lib.json
@@ -1,20 +1,30 @@
 {
 "name": "qspif",
     "config": {
+        "QSPI_IO0": "QSPI_FLASH1_IO0",
+        "QSPI_IO1": "QSPI_FLASH1_IO1",
+        "QSPI_IO2": "QSPI_FLASH1_IO2",
+        "QSPI_IO3": "QSPI_FLASH1_IO3",
+        "QSPI_SCK": "QSPI_FLASH1_SCK",
+        "QSPI_CSN": "QSPI_FLASH1_CSN",
+        "QSPI_POLARITY_MODE": 0,
         "QSPI_FREQ": "40000000"
     },
     "target_overrides": {
         "DISCO_F413ZH": {
-             "QSPI_FREQ": "80000000"
+            "QSPI_FREQ": "80000000"
         },
-       "DISCO_L475VG_IOT01A": {
-             "QSPI_FREQ": "8000000"
+        "DISCO_L475VG_IOT01A": {
+            "QSPI_FREQ": "8000000"
         },
-       "DISCO_L476VG": {
-             "QSPI_FREQ": "80000000"
+        "DISCO_L476VG": {
+            "QSPI_FREQ": "80000000"
         },
-       "DISCO_F469NI": {
-             "QSPI_FREQ": "80000000"
+        "DISCO_F469NI": {
+            "QSPI_FREQ": "80000000"
+        },
+        "NRF52840_DK": {
+            "QSPI_FREQ": "32000000"
         }
     }
 }

--- a/features/storage/system_storage/SystemStorage.cpp
+++ b/features/storage/system_storage/SystemStorage.cpp
@@ -22,6 +22,10 @@
 #include "SPIFBlockDevice.h"
 #endif
 
+#if COMPONENT_QSPIF
+#include "QSPIFBlockDevice.h"
+#endif
+
 #if COMPONENT_DATAFLASH
 #include "DataFlashBlockDevice.h"
 #endif
@@ -56,6 +60,21 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
         MBED_CONF_SPIF_DRIVER_SPI_CLK,
         MBED_CONF_SPIF_DRIVER_SPI_CS,
         MBED_CONF_SPIF_DRIVER_SPI_FREQ
+    );
+
+    return &default_bd;
+
+#elif COMPONENT_QSPIF
+
+    static QSPIFBlockDevice default_bd(
+        MBED_CONF_QSPIF_QSPI_IO0,
+        MBED_CONF_QSPIF_QSPI_IO1,
+        MBED_CONF_QSPIF_QSPI_IO2,
+        MBED_CONF_QSPIF_QSPI_IO3,
+        MBED_CONF_QSPIF_QSPI_SCK,
+        MBED_CONF_QSPIF_QSPI_CSN,
+        MBED_CONF_QSPIF_QSPI_POLARITY_MODE,
+        MBED_CONF_QSPIF_QSPI_FREQ
     );
 
     return &default_bd;
@@ -112,7 +131,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 #endif
 
     return &default_bd;
-    
+
 #else
 
     return NULL;
@@ -123,7 +142,7 @@ MBED_WEAK BlockDevice *BlockDevice::get_default_instance()
 
 MBED_WEAK FileSystem *FileSystem::get_default_instance()
 {
-#if COMPONENT_SPIF || COMPONENT_DATAFLASH
+#if COMPONENT_SPIF || COMPONENT_QSPIF || COMPONENT_DATAFLASH
 
     static LittleFileSystem flash("flash", BlockDevice::get_default_instance());
     flash.set_as_default();


### PR DESCRIPTION
### Description

Enables QSPIFBlockDevice to be used with the `BlockDevice::get_default_instance` API.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

