### PR TITLE
Wifi: ublox fix to keep the credentials stored

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.cpp
@@ -220,8 +220,8 @@ nsapi_error_t OdinWiFiInterface::set_credentials(const char *ssid, const char *p
     osStatus res = _mutex.lock();
     MBED_ASSERT(res == osOK);
 
-    _sta.ssid = ssid;
-    _sta.passwd = pass;
+    strncpy(_sta.ssid, ssid, cbWLAN_SSID_MAX_LENGTH);
+    strncpy(_sta.passwd, pass, cbWLAN_MAX_PASSPHRASE_LENGTH);
     _sta.security = security;
 
     res = _mutex.unlock();

--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_MODULE_UBLOX_ODIN_W2/sdk/ublox-odin-w2-drivers/OdinWiFiInterface.h
@@ -262,8 +262,8 @@ private:
     };
 
     struct sta_s {
-        const char          *ssid;
-        const char          *passwd;
+        char                ssid[cbWLAN_SSID_MAX_LENGTH];
+        char                passwd[cbWLAN_MAX_PASSPHRASE_LENGTH];
         nsapi_security_t    security;
         uint8_t             channel;
         int                 timeout_ms;


### PR DESCRIPTION
### Description
Following issue is fixed here:

UBLOX_EVK_ODIN_W2 does not pass Greentea testcase WIFI-CONNECT.

https://github.com/ARMmbed/mbed-os/issues/8520


Toolchains tested:
GCC_ARM, ARM, IAR

Tests:
network-wifi
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->


    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

