### PR TITLE
CellularConnectionFSM unchain queue when stopped

### DIFF
--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -136,6 +136,10 @@ nsapi_error_t CellularConnectionFSM::init()
     }
 
     _at_queue = _cellularDevice->get_queue();
+    if (!_at_queue) {
+        stop();
+        return NSAPI_ERROR_NO_MEMORY;
+    }
     _at_queue->chain(&_queue);
 
     _retry_count = 0;

--- a/features/cellular/easy_cellular/CellularConnectionFSM.cpp
+++ b/features/cellular/easy_cellular/CellularConnectionFSM.cpp
@@ -84,6 +84,11 @@ void CellularConnectionFSM::stop()
         _queue_thread = NULL;
     }
 
+    if (_at_queue) {
+        _at_queue->chain(NULL);
+        _at_queue = NULL;
+    }    
+    
     if (_power) {
         _cellularDevice->close_power();
         _power = NULL;


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

When the CellularConnectionFSM is to be stopped, make sure to unchain the EventQueue if it was chained in the first place.

Also provides some protection if get_queue() returns NULL instead of a queue. Don't really know if this is necessary but it now follows the same form of all other 'gets' in the function.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

