### PR TITLE
Move #endif to fix PwmOut.h doxygen

### DIFF
--- a/drivers/PwmOut.h
+++ b/drivers/PwmOut.h
@@ -219,8 +219,8 @@ protected:
 
     pwmout_t _pwm;
     bool _deep_sleep_locked;
-};
 #endif
+};
 
 } // namespace mbed
 


### PR DESCRIPTION
### Description

Move the #endif up so it does not include the closing bracket of PwmOut. This allows the doxygen for PwmOut, classmbed_1_1_pwm_out.html, to build.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

