### PR TITLE
Compile time config flag MBED_CONF_SD_CRC_ENABLED for CRC in SD

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -247,9 +247,15 @@
 // Only HC block size is supported. Making this a static constant reduces code size.
 const uint32_t SDBlockDevice::_block_size = BLOCK_SIZE_HC;
 
+#if MBED_CONF_SD_CRC_ENABLED
 SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(mosi, miso, sclk), _cs(cs), _is_initialized(0),
-      _crc_on(crc_on), _init_ref_count(0), _crc16(0, 0, false, false)
+      _init_ref_count(0), _crc_on(crc_on), _crc16(0, 0, false, false)
+#else
+SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
+    : _sectors(0), _spi(mosi, miso, sclk), _cs(cs), _is_initialized(0),
+      _init_ref_count(0)
+#endif
 {
     _cs = 1;
     _card_type = SDCARD_NONE;
@@ -293,10 +299,12 @@ int SDBlockDevice::_initialise_card()
         return status;
     }
 
+#if MBED_CONF_SD_CRC_ENABLED
     if (_crc_on) {
         // Enable CRC
         status = _cmd(CMD59_CRC_ON_OFF, _crc_on);
     }
+#endif
 
     // Read OCR - CMD58 Response contains OCR register
     if (BD_ERROR_OK != (status = _cmd(CMD58_READ_OCR, 0x0, 0x0, &response))) {
@@ -350,10 +358,15 @@ int SDBlockDevice::_initialise_card()
         debug_if(SD_DBG, "Card Initialized: Version 1.x Card\n");
     }
 
+#if MBED_CONF_SD_CRC_ENABLED
     if (!_crc_on) {
         // Disable CRC
         status = _cmd(CMD59_CRC_ON_OFF, _crc_on);
     }
+#else
+    status = _cmd(CMD59_CRC_ON_OFF, 0);
+#endif
+
     return status;
 }
 
@@ -649,7 +662,6 @@ uint8_t SDBlockDevice::_cmd_spi(SDBlockDevice::cmdSupported cmd, uint32_t arg)
 {
     uint8_t response;
     char cmdPacket[PACKET_SIZE];
-    uint32_t crc;
 
     // Prepare the command packet
     cmdPacket[0] = SPI_CMD(cmd);
@@ -658,10 +670,14 @@ uint8_t SDBlockDevice::_cmd_spi(SDBlockDevice::cmdSupported cmd, uint32_t arg)
     cmdPacket[3] = (arg >> 8);
     cmdPacket[4] = (arg >> 0);
 
+#if MBED_CONF_SD_CRC_ENABLED
+    uint32_t crc;
     if (_crc_on) {
         _crc7.compute((void *)cmdPacket, 5, &crc);
         cmdPacket[5] = (char)(crc | 0x01);
-    } else {
+    } else
+#endif
+    {
         // CMD0 is executed in SD mode, hence should have correct CRC
         // CMD8 CRC verification is always enabled
         switch (cmd) {
@@ -874,6 +890,7 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
     crc = (_spi.write(SPI_FILL_CHAR) << 8);
     crc |= _spi.write(SPI_FILL_CHAR);
 
+#if MBED_CONF_SD_CRC_ENABLED
     if (_crc_on) {
         uint32_t crc_result;
         // Compute and verify checksum
@@ -885,6 +902,7 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
             return SD_BLOCK_DEVICE_ERROR_CRC;
         }
     }
+#endif
 
     _deselect();
     return 0;
@@ -908,6 +926,7 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
     crc = (_spi.write(SPI_FILL_CHAR) << 8);
     crc |= _spi.write(SPI_FILL_CHAR);
 
+#if MBED_CONF_SD_CRC_ENABLED
     if (_crc_on) {
         uint32_t crc_result;
         // Compute and verify checksum
@@ -918,6 +937,7 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
             return SD_BLOCK_DEVICE_ERROR_CRC;
         }
     }
+#endif
 
     return 0;
 }
@@ -934,10 +954,12 @@ uint8_t SDBlockDevice::_write(const uint8_t *buffer, uint8_t token, uint32_t len
     // write the data
     _spi.write((char *)buffer, length, NULL, 0);
 
+#if MBED_CONF_SD_CRC_ENABLED
     if (_crc_on) {
         // Compute CRC
         _crc16.compute((void *)buffer, length, &crc);
     }
+#endif
 
     // write the checksum CRC16
     _spi.write(crc >> 8);

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -218,11 +218,13 @@ private:
     uint32_t _erase_size;
     bool _is_initialized;
     bool _dbg;
-    bool _crc_on;
     uint32_t _init_ref_count;
 
+#if MBED_CONF_SD_CRC_ENABLED
+    bool _crc_on;
     mbed::MbedCRC<POLY_7BIT_SD, 7> _crc7;
     mbed::MbedCRC<POLY_16BIT_CCITT, 16> _crc16;
+#endif
 };
 
 #endif  /* DEVICE_SPI */

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -8,7 +8,8 @@
         "FSFAT_SDCARD_INSTALLED": 1,
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
-        "SD_INIT_FREQUENCY": 100000
+        "SD_INIT_FREQUENCY": 100000,
+        "CRC_ENABLED": 1
     },
     "target_overrides": {
         "DISCO_F051R8": {

--- a/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
+++ b/components/storage/blockdevice/COMPONENT_SD/config/mbed_lib.json
@@ -8,7 +8,7 @@
         "FSFAT_SDCARD_INSTALLED": 1,
         "CMD_TIMEOUT": 10000,
         "CMD0_IDLE_STATE_RETRIES": 5,
-        "SD_INIT_FREQUENCY": 100000,
+        "INIT_FREQUENCY": 100000,
         "CRC_ENABLED": 1
     },
     "target_overrides": {


### PR DESCRIPTION
### Description

CRC class adds to the ROM size even when disabled runtime, because addition of ROM tables.
Addition a compile time option to disable CRC is required for reducing code size of SD driver component.

### Pull request type
    [X] Fix
    [ ] Refactor
    [ ] Target update
    [] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

~~Not sure if this is breaking change, though CRC functionality was added but default was disabled as runtime option and now it will be disabled as default with compile time option.~~ Config option in mbed_lib.json provides CRC feature as default.


