### PR TITLE
Fix Makefile export with Python 3

### DIFF
--- a/tools/export/makefile/__init__.py
+++ b/tools/export/makefile/__init__.py
@@ -165,7 +165,7 @@ class Makefile(Exporter):
         flags = {}
         for k, v in self.flags.items():
             if k in ['c_flags', 'cxx_flags']:
-                flags[k] = map(lambda x: x.replace('"', '\\"'), v)
+                flags[k] = list(map(lambda x: x.replace('"', '\\"'), v))
             else:
                 flags[k] = v
 


### PR DESCRIPTION
### Description

In Python 3, the `map()` function returns a `map` object, not a `list` object as in
Python 2. Ensure a `list` object is returned from `format_flags()` by wrapping
`map()` in `list()`. This is compatible with both Python 2 and 3.

Regression in c777bd6f5c6969d549b6fa0561ef828bb1d11936.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change