### PR TITLE
Fix the incorrect comment for set_blocking()

### DIFF
--- a/features/netsocket/Socket.h
+++ b/features/netsocket/Socket.h
@@ -156,8 +156,8 @@ public:
      *  blocking operations such as send/recv/accept return
      *  NSAPI_ERROR_WOULD_BLOCK if they can not continue.
      *
-     *  set_blocking(false) is equivalent to set_timeout(-1)
-     *  set_blocking(true) is equivalent to set_timeout(0)
+     *  set_blocking(false) is equivalent to set_timeout(0)
+     *  set_blocking(true) is equivalent to set_timeout(-1)
      *
      *  @param blocking true for blocking mode, false for non-blocking mode.
      */


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Fix the incorrect comment for set_blocking() which impact the online API document.
Before:
     *  set_blocking(false) is equivalent to set_timeout(-1)
     *  set_blocking(true) is equivalent to set_timeout(0)
After:
     *  set_blocking(false) is equivalent to set_timeout(0)
     *  set_blocking(true) is equivalent to set_timeout(-1)

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [x] Docs update
    [ ] Test update
    [ ] Breaking change

