### PR TITLE
STM32F4: Add support of the new USB Device API

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.c
@@ -106,6 +106,7 @@
   * @{
   */
 static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum);
+static HAL_StatusTypeDef PCD_ReadRxFifo(PCD_HandleTypeDef *hpcd); // MBED PATCH
 /**
   * @}
   */
@@ -394,6 +395,13 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
             }
           }
           
+          // MBED PATCH
+          if (( epint & USB_OTG_DOEPINT_EPDISD) == USB_OTG_DOEPINT_EPDISD)
+          {
+              CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_EPDISD);
+          }
+          // MBED PATCH
+          
           if(( epint & USB_OTG_DOEPINT_STUP) == USB_OTG_DOEPINT_STUP)
           {
             /* Inform the upper layer that a setup packet is available */
@@ -667,27 +675,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     /* Handle RxQLevel Interrupt */
     if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
     {
-      USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
-      
-      temp = USBx->GRXSTSP;
-      
-      ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
-      
-      if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_DATA_UPDT)
-      {
-        if((temp & USB_OTG_GRXSTSP_BCNT) != 0U)
-        {
-          USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4U);
-          ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
-          ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
-        }
-      }
-      else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_SETUP_UPDT)
-      {
-        USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8U);
-        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
-      }
-      USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+        PCD_ReadRxFifo(hpcd); // MBED PATCH
     }
     
     /* Handle SOF Interrupt */
@@ -1131,6 +1119,86 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   return HAL_OK;
 }
 
+// MBED PATCH
+/**
+  * @brief  Abort a transaction.  
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+  HAL_StatusTypeDef ret = HAL_OK;
+  USB_OTG_EPTypeDef *ep;
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+
+  USB_EPSetNak(hpcd->Instance, ep);
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+      ret = USB_EPStopXfer(hpcd->Instance , ep);
+      if (ret == HAL_OK)
+      {
+        ret = USB_FlushTxFifo(hpcd->Instance, ep_addr & 0x7F);
+      }
+  }
+  else
+  {
+    /* Set global NAK */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_SGONAK;
+
+    /* Read all entries from the fifo so global NAK takes effect */
+    while (__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+    {
+      PCD_ReadRxFifo(hpcd);
+    }
+
+    /* Stop the transfer */
+    ret = USB_EPStopXfer(hpcd->Instance , ep);
+    if (ret == HAL_BUSY)
+    {
+      /* If USB_EPStopXfer returns HAL_BUSY then a setup packet
+       * arrived after the rx fifo was processed but before USB_EPStopXfer
+       * was called. Process the rx fifo one more time to read the
+       * setup packet.
+       *
+       * Note - after the setup packet has been received no further
+       * packets will be received over USB. This is because the next
+       * phase (data or status) of the control transfer started by
+       * the setup packet will be naked until global nak is cleared.
+       */
+      while (__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+      {
+        PCD_ReadRxFifo(hpcd);
+      }
+
+      ret = USB_EPStopXfer(hpcd->Instance , ep);
+    }
+
+    /* Clear global nak */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGONAK;
+  }
+
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+
+  return ret;
+}
+// MBED PATCH
+
 /**
   * @brief  Set a STALL condition over an endpoint.
   * @param  hpcd PCD handle
@@ -1355,6 +1423,44 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
   
   return HAL_OK;  
 }
+
+// MBED PATCH
+/**
+  * @brief  Process the next RX fifo entry
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_ReadRxFifo(PCD_HandleTypeDef *hpcd)
+{
+    USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+    USB_OTG_EPTypeDef *ep;
+    uint32_t temp = 0;
+
+    USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+
+    temp = USBx->GRXSTSP;
+
+    ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
+
+    if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_DATA_UPDT)
+    {
+      if((temp & USB_OTG_GRXSTSP_BCNT) != 0U)
+      {
+        USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4U);
+        ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+      }
+    }
+    else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_SETUP_UPDT)
+    {
+      USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8U);
+      ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+    }
+    USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+
+    return HAL_OK;
+}
+// MBED PATCH
 
 /**
   * @}

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_hal_pcd.h
@@ -300,6 +300,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
 HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
 HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr); // MBED PATCH
 uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);

--- a/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_ll_usb.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/device/stm32f4xx_ll_usb.h
@@ -416,6 +416,9 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EP
 HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
 HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
 HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_EPStopXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
+HAL_StatusTypeDef USB_EPSetNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
+HAL_StatusTypeDef USB_EPClearNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
 HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
 HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma);
 void *            USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -1198,8 +1198,8 @@
             }
         },
         "detect_code": ["0826"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "USBDEVICE"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F412ZG",
         "bootloader_supported": true
@@ -1283,8 +1283,8 @@
             }
         },
         "detect_code": ["0743"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "QSPI"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "QSPI", "USBDEVICE"],
         "bootloader_supported": true,
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
@@ -1306,8 +1306,8 @@
             }
         },
         "detect_code": ["0743"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "USBDEVICE"],
         "bootloader_supported": true,
         "release_versions": ["2", "5"],
         "device_name": "STM32F413ZH"
@@ -1342,8 +1342,8 @@
             }
         },
         "extra_labels_add": ["STM32F4", "STM32F429", "STM32F429ZI", "STM32F429xx", "STM32F429xI", "STM_EMAC"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["ANALOGOUT", "CAN", "EMAC", "SERIAL_ASYNCH", "SERIAL_FC", "TRNG", "FLASH", "USBDEVICE"],
         "detect_code": ["0796"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F429ZI",
@@ -1411,8 +1411,8 @@
             }
         },
         "detect_code": ["0778"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "FLASH"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_ASYNCH", "SERIAL_FC", "FLASH", "USBDEVICE"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F446ZE"
     },
@@ -1937,8 +1937,8 @@
             }
         },
         "detect_code": ["0788"],
-        "macros_add": ["USB_STM_HAL", "USBHOST_OTHER"],
-        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH", "QSPI"],
+        "macros_add": ["USBHOST_OTHER"],
+        "device_has_add": ["ANALOGOUT", "CAN", "SERIAL_FC", "TRNG", "FLASH", "QSPI", "USBDEVICE"],
         "release_versions": ["2", "5"],
         "device_name": "STM32F469NI"
     },

--- a/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -24,11 +24,6 @@
 #define USBSTM_HAL_UNSUPPORTED
 #endif
 
-/* STM32F4 family without USB_STM_HAL use another HAL */
-#if defined(TARGET_STM) && defined(TARGET_STM32F4) && !defined(USB_STM_HAL)
-#define USBSTM_HAL_UNSUPPORTED
-#endif
-
 #ifndef USBSTM_HAL_UNSUPPORTED
 #include "USBPhyHw.h"
 #include "pinmap.h"


### PR DESCRIPTION
### Description

Applied the same patch in CubeF4 as done in CubeF2 for the NUCLEO_F207ZG (see PR #7322 )

tests-usb_device-basic tests are OK on ARM, IAR and GCC_ARM

USB Device enabled on the following platforms:
- NUCLEO_F412ZG
- NUCLEO_F413ZH
- NUCLEO_F429ZI
- NUCLEO_F446ZE
- DISCO_F413ZH
- DISCO_F469NI

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

