### PR TITLE
Remove extra _deselect to prevent possible hard fault

### DIFF
--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -892,7 +892,6 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
     // read until start byte (0xFE)
     if (false == _wait_token(SPI_START_BLOCK)) {
         debug_if(SD_DBG, "Read timeout\n");
-        _deselect();
         return SD_BLOCK_DEVICE_ERROR_NO_RESPONSE;
     }
 


### PR DESCRIPTION
### Description

If read timeout happens, the _deselect will get called twice causing a hard fault happening when mutex is released without being locked. 
The SDBlockDevice::read is calling the _deselect in every case.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

