### PR TITLE
Fix Ice Tea test execution order to be sorted by names.

### DIFF
--- a/tools/run_icetea.py
+++ b/tools/run_icetea.py
@@ -19,7 +19,7 @@ import sys
 import os
 import re
 from os.path import abspath, join, dirname, relpath, sep
-import json
+import json, operator
 import traceback
 from fnmatch import translate
 from argparse import ArgumentParser
@@ -173,13 +173,16 @@ def icetea_tests(target, tcdir, verbose):
               + (['-v'] if verbose else [])
 
     stdout, stderr, returncode = run_cmd(command)
-
+    
+    list_json = json.loads(stdout)
+    list_json.sort(key=operator.itemgetter('name'))
+    
     if returncode != 0:
         additional_information = "\ncwd:{} \nCommand:'{}' \noutput:{}".format(os.getcwd(), ' '.join(command),
                                                                               stderr.decode())
         raise Exception("Error when running icetea. {}".format(additional_information))
 
-    return json.loads(stdout)
+    return list_json
 
 
 def is_test_in_test_by_name(test_name, test_by_name):


### PR DESCRIPTION
### Description

This patch provides proposition to sort list of Ice Tea tests to be executed (and shown in results table) by name .
While working on SPI communication test PR https://github.com/ARMmbed/mbed-os/pull/8443 I found that test cases listed in final results are scattered and the readability is poor. 

The tests verifies spi modes, buffers, freq, symbol sizes, etc. On the picture below we can see that all cases are mixed and it is hard to look for results for the specific group of cases.

![image](https://user-images.githubusercontent.com/30721012/47723139-2de2c500-dc54-11e8-9933-ee93c60b7f57.png)

Below are the results with the fix (sorted by names). Now it is easy to check the results for the specific group (e.g. BUFFERS tests).
![image](https://user-images.githubusercontent.com/30721012/47722985-df352b00-dc53-11e8-9cc2-1bef31bd7aa0.png)

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

