### PR TITLE
Support erase value in Flash HAL drivers, FlashIAP and block devices

### DIFF
--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.cpp
@@ -227,6 +227,20 @@ bd_size_t FlashIAPBlockDevice::get_erase_size(bd_addr_t addr) const
     return erase_size;
 }
 
+int FlashIAPBlockDevice::get_erase_value() const
+{
+    if (!_is_initialized) {
+        return -1;
+    }
+
+    uint8_t erase_val = _flash.get_erase_value();
+
+    DEBUG_PRINTF("get_erase_value: %" PRIX8 "\r\n", erase_val);
+
+    return erase_val;
+}
+
+
 bd_size_t FlashIAPBlockDevice::size() const
 {
     DEBUG_PRINTF("size: %" PRIX64 "\r\n", _size);

--- a/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_FLASHIAP/FlashIAPBlockDevice.h
@@ -109,6 +109,12 @@ public:
      */
     virtual bd_size_t get_erase_size(bd_addr_t addr) const;
 
+    /** Get the value of storage when erased
+     *
+     *  @return         The value of storage when erased
+     */
+    virtual int get_erase_value() const;
+
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes

--- a/drivers/FlashIAP.cpp
+++ b/drivers/FlashIAP.cpp
@@ -203,6 +203,11 @@ uint32_t FlashIAP::get_flash_size() const
     return flash_get_size(&_flash);
 }
 
+uint8_t FlashIAP::get_erase_value() const
+{
+    return flash_get_erase_value(&_flash);
+}
+
 }
 
 #endif

--- a/drivers/FlashIAP.h
+++ b/drivers/FlashIAP.h
@@ -131,6 +131,13 @@ public:
      */
     uint32_t get_page_size() const;
 
+    /** Get the flash erase value
+     *
+     *  Get the value we read after erase operation
+     *  @return flash erase value
+     */
+    uint8_t get_erase_value() const;
+
 private:
 
     /* Check if address and size are aligned to a sector

--- a/hal/TARGET_FLASH_CMSIS_ALGO/flash_common_algo.c
+++ b/hal/TARGET_FLASH_CMSIS_ALGO/flash_common_algo.c
@@ -260,4 +260,11 @@ MBED_NONSECURE_ENTRY uint32_t flash_get_size(const flash_t *obj)
     return obj->target_config->flash_size;
 }
 
+MBED_NONSECURE_ENTRY uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif  // #ifndef DOMAIN_NS

--- a/hal/flash_api.h
+++ b/hal/flash_api.h
@@ -117,6 +117,13 @@ uint32_t flash_get_start_address(const flash_t *obj);
  */
 uint32_t flash_get_size(const flash_t *obj);
 
+/** Get the flash erase value
+ *
+ * @param obj The flash object
+ * @return The flash erase value
+ */
+uint8_t flash_get_erase_value(const flash_t *obj);
+
 /**@}*/
 
 #ifdef __cplusplus

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
@@ -101,3 +101,10 @@ uint32_t flash_get_size(const flash_t *obj)
 
     return ZBT_SRAM1_SIZE;
 }
+
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}

--- a/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/flash_api.c
+++ b/targets/TARGET_ARM_SSG/TARGET_CM3DS_MPS2/flash_api.c
@@ -101,3 +101,10 @@ uint32_t flash_get_size(const flash_t *obj)
 
     return FLASH_SIZE;
 }
+
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}

--- a/targets/TARGET_Cypress/TARGET_PSOC6/flash_api.c
+++ b/targets/TARGET_Cypress/TARGET_PSOC6/flash_api.c
@@ -82,4 +82,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return CY_FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif // DEVICE_FLASH

--- a/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/flash_api.c
+++ b/targets/TARGET_Freescale/TARGET_MCUXpresso_MCUS/api/flash_api.c
@@ -148,4 +148,11 @@ uint32_t flash_get_size(const flash_t *obj)
 #endif
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/flash_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF51/flash_api.c
@@ -195,6 +195,13 @@ uint32_t flash_get_start_address(const flash_t *obj)
     return 0;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif
 
 /** @}*/

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/flash_api.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/flash_api.c
@@ -209,4 +209,11 @@ uint32_t flash_get_start_address(const flash_t *obj)
     return 0;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
+++ b/targets/TARGET_NUVOTON/TARGET_M2351/flash_api.c
@@ -134,4 +134,12 @@ void flash_set_target_config(flash_t *obj)
 }
 
 #endif  // #if defined (__ARM_FEATURE_CMSE) && (__ARM_FEATURE_CMSE == 3U)
+
+MBED_NONSECURE_ENTRY uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif  // #if DEVICE_FLASH

--- a/targets/TARGET_NXP/TARGET_LPC176X/device/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_LPC176X/device/flash_api.c
@@ -200,4 +200,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return 0x80000;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/flash_api.c
+++ b/targets/TARGET_NXP/TARGET_MCUXpresso_MCUS/TARGET_LPC/flash_api.c
@@ -122,4 +122,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FSL_FEATURE_SYSCON_FLASH_SIZE_BYTES;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_RENESAS/TARGET_RZ_A1XX/flash_api.c
+++ b/targets/TARGET_RENESAS/TARGET_RZ_A1XX/flash_api.c
@@ -751,4 +751,12 @@ static void cache_control(void)
     __DSB();     // ensure completion of the invalidation
     __ISB();     // ensure instruction fetch path sees new I cache state
 }
+
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/flash_api.c
+++ b/targets/TARGET_Realtek/TARGET_AMEBA/TARGET_MCU_RTL8195A/flash_api.c
@@ -69,3 +69,10 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+

--- a/targets/TARGET_STM/TARGET_STM32F0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F0/flash_api.c
@@ -172,4 +172,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F1/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F1/flash_api.c
@@ -172,4 +172,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F2/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F2/flash_api.c
@@ -215,4 +215,11 @@ static uint32_t GetSectorSize(uint32_t Sector)
     return sectorsize;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F3/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F3/flash_api.c
@@ -172,4 +172,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F4/flash_api.c
@@ -230,4 +230,11 @@ static uint32_t GetSectorSize(uint32_t Sector)
     return sectorsize;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32F7/flash_api.c
@@ -265,4 +265,11 @@ static uint32_t GetSectorSize(uint32_t Sector)
     return sectorsize;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L0/flash_api.c
@@ -174,4 +174,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L1/flash_api.c
@@ -171,4 +171,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/flash_api.c
@@ -284,4 +284,11 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif

--- a/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
+++ b/targets/TARGET_Silicon_Labs/TARGET_EFM32/flash_api.c
@@ -144,4 +144,16 @@ uint32_t flash_get_size(const flash_t *obj)
     return FLASH_SIZE;
 }
 
+/** Get the flash erase value
+ *
+ * @param obj The flash object
+ * @return The flash erase value
+ */
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+
 #endif // DEVICE_FLASH

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM46B/flash_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM46B/flash_api.c
@@ -162,3 +162,14 @@ uint32_t flash_get_size(const flash_t *obj)
 {
     return FLASH_CHIP_SIZE;
 }
+
+#if defined ( __ICCARM__ )    /* IAR Compiler */
+#pragma location = "FLASH_ROM"
+#endif
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}
+

--- a/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/flash_api.c
+++ b/targets/TARGET_TOSHIBA/TARGET_TMPM4G9/flash_api.c
@@ -121,3 +121,10 @@ static void internal_hosc_enable(void)
     work = (uint32_t)(TSB_CG->OSCCR & ~CGOSCCR_IHOSC1EN_MASK);
     TSB_CG->OSCCR = (uint32_t)(work | CGOSCCR_IHOSC1EN_RW_ENABLE);
 }
+
+uint8_t flash_get_erase_value(const flash_t *obj)
+{
+    (void)obj;
+
+    return 0xFF;
+}


### PR DESCRIPTION
### Description
This change adds support for getting the flash erase value in HAL drivers (all), FlashIAP driver and FlashIAP block device. It is required for the case upper layers need to check whether a flash area is erased or not. The vast majority of flash components produce the all ones (0xFF) value following an erase, and this includes all components currently supported by mbed-os. However, this change allows the addition of other components with different erase values (such as 0).
Resolves [#6405](https://github.com/ARMmbed/mbed-os/issues/6405).


### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

