### PR TITLE
Build and run latest released doxygen in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,8 @@ matrix:
         # output of zero length
         - doxygen doxyfile_options 2>&1
         # Once Mbed OS has been fixed, enable the full test by replacing the top line with this:
-        - ( ! doxygen doxyfile_options 2>&1 | grep . )
+        # - ( ! doxygen doxyfile_options 2>&1 | grep . )
+
         # Assert that all binary libraries are named correctly
         # The strange command below asserts that there are exactly 0 libraries
         # that do not start with lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,15 +51,24 @@ matrix:
         # Print versions we use
         - doxygen --version
       before_script:
+        # Build doxygen
+        - >
+          (git clone --depth=1 --single-branch --branch Release_1_8_14 https://github.com/doxygen/doxygen;
+          cd doxygen;
+          mkdir build;
+          cd build;
+          cmake -G "Unix Makefiles" ..;
+          make;
+          sudo make install)
         # Create BUILD directory for tests
         - mkdir BUILD
       script:
         # Assert that the Doxygen build produced no warnings.
         # The strange command below asserts that the Doxygen command had an
         # output of zero length
-        - >
-          doxygen doxyfile_options 2>&1 |
-          tee BUILD/doxygen.out && [ ! -s BUILD/doxygen.out ]
+        - doxygen doxyfile_options 2>&1
+        # Once Mbed OS has been fixed, enable the full test by replacing the top line with this:
+        - ( ! doxygen doxyfile_options 2>&1 | grep . )
         # Assert that all binary libraries are named correctly
         # The strange command below asserts that there are exactly 0 libraries
         # that do not start with lib


### PR DESCRIPTION
### Description

It was discovered yesterday that Travis CI is not running the latest released version of doxygen, since the latest released vesrion in Ubuntu Trusty is 1.8.6, not 1.8.14. Further, Travis CI does not have a PPA/distro that has the latest version.

The latest vesrion discovers issues in the repo that the older version does not.

Fixes https://github.com/ARMmbed/mbed-os/issues/8574

### The fix

This fix locally builds and installs the latest released version inside Travis CI. A potential future optimization could be to store this binary elsewhere instead of building it every time, but as of now the build step does not take long.

### Future work

Once doxygen issues are fixed, the command that will fail the build on new errors can be enabled.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

