### PR TITLE
Add format checking to printf-type APIs

### DIFF
--- a/cmsis/TARGET_CORTEX_M/mbed_fault_handler.c
+++ b/cmsis/TARGET_CORTEX_M/mbed_fault_handler.c
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
 #include "device.h"
 #include "platform/mbed_error.h"
 #include "platform/mbed_interface.h"
@@ -72,37 +77,37 @@ MBED_NOINLINE void print_context_info(void)
 {
     //Context Regs
     for(int i=0;i<13;i++) {
-        mbed_error_printf("\nR%-4d: %08X", i, ((uint32_t *)&mbed_fault_context)[i]);  
+        mbed_error_printf("\nR%-4d: %08" PRIX32, i, ((uint32_t *)&mbed_fault_context)[i]);
     }
         
-    mbed_error_printf("\nSP   : %08X" 
-                      "\nLR   : %08X" 
-                      "\nPC   : %08X" 
-                      "\nxPSR : %08X" 
-                      "\nPSP  : %08X" 
-                      "\nMSP  : %08X", mbed_fault_context.SP_reg, mbed_fault_context.LR_reg, mbed_fault_context.PC_reg, 
+    mbed_error_printf("\nSP   : %08" PRIX32
+                      "\nLR   : %08" PRIX32
+                      "\nPC   : %08" PRIX32
+                      "\nxPSR : %08" PRIX32
+                      "\nPSP  : %08" PRIX32
+                      "\nMSP  : %08" PRIX32, mbed_fault_context.SP_reg, mbed_fault_context.LR_reg, mbed_fault_context.PC_reg,
                                      mbed_fault_context.xPSR, mbed_fault_context.PSP, mbed_fault_context.MSP );
                        
     //Capture CPUID to get core/cpu info
-    mbed_error_printf("\nCPUID: %08X", SCB->CPUID);
+    mbed_error_printf("\nCPUID: %08" PRIX32, SCB->CPUID);
     
 #if !defined(TARGET_M0) && !defined(TARGET_M0P)
     //Capture fault information registers to infer the cause of exception
-    mbed_error_printf("\nHFSR : %08X"
-                    "\nMMFSR: %08X"
-                    "\nBFSR : %08X"
-                    "\nUFSR : %08X"
-                    "\nDFSR : %08X"
-                    "\nAFSR : %08X"  ////Split/Capture CFSR into MMFSR, BFSR, UFSR
+    mbed_error_printf("\nHFSR : %08" PRIX32
+                    "\nMMFSR: %08" PRIX32
+                    "\nBFSR : %08" PRIX32
+                    "\nUFSR : %08" PRIX32
+                    "\nDFSR : %08" PRIX32
+                    "\nAFSR : %08" PRIX32  ////Split/Capture CFSR into MMFSR, BFSR, UFSR
                     ,SCB->HFSR, (0xFF & SCB->CFSR), ((0xFF00 & SCB->CFSR) >> 8), ((0xFFFF0000 & SCB->CFSR) >> 16), SCB->DFSR, SCB->AFSR ); 
     
     //Print MMFAR only if its valid as indicated by MMFSR
     if ((0xFF & SCB->CFSR) & 0x80) {
-        mbed_error_printf("\nMMFAR: %08X",SCB->MMFAR); 
+        mbed_error_printf("\nMMFAR: %08" PRIX32, SCB->MMFAR);
     }
     //Print BFAR only if its valid as indicated by BFSR
     if (((0xFF00 & SCB->CFSR) >> 8) & 0x80) {
-        mbed_error_printf("\nBFAR : %08X",SCB->BFAR); 
+        mbed_error_printf("\nBFAR : %08" PRIX32, SCB->BFAR);
     }
 #endif
     

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.cpp
@@ -141,6 +141,10 @@
 #include "SDBlockDevice.h"
 #include "platform/mbed_debug.h"
 #include "platform/mbed_wait_api.h"
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
 #include <errno.h>
 
 #ifndef MBED_CONF_SD_CMD_TIMEOUT
@@ -240,6 +244,9 @@
 #define SPI_READ_ERROR_ECC_C     (0x1 << 2)  /*!< Card ECC failed */
 #define SPI_READ_ERROR_OFR       (0x1 << 3)  /*!< Out of Range */
 
+// Only HC block size is supported. Making this a static constant reduces code size.
+const uint32_t SDBlockDevice::_block_size = BLOCK_SIZE_HC;
+
 SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName cs, uint64_t hz, bool crc_on)
     : _sectors(0), _spi(mosi, miso, sclk), _cs(cs), _is_initialized(0),
       _crc_on(crc_on), _init_ref_count(0), _crc16(0, 0, false, false)
@@ -253,8 +260,6 @@ SDBlockDevice::SDBlockDevice(PinName mosi, PinName miso, PinName sclk, PinName c
     _init_sck = MBED_CONF_SD_INIT_FREQUENCY;
     _transfer_sck = hz;
 
-    // Only HC block size is supported.
-    _block_size = BLOCK_SIZE_HC;
     _erase_size = BLOCK_SIZE_HC;
 }
 
@@ -386,7 +391,7 @@ int SDBlockDevice::init()
 
     // Set block length to 512 (CMD16)
     if (_cmd(CMD16_SET_BLOCKLEN, _block_size) != 0) {
-        debug_if(SD_DBG, "Set %d-byte block timed out\n", _block_size);
+        debug_if(SD_DBG, "Set %" PRIu32 "-byte block timed out\n", _block_size);
         unlock();
         return BD_ERROR_DEVICE_ERROR;
     }
@@ -444,7 +449,7 @@ int SDBlockDevice::program(const void *b, bd_addr_t addr, bd_size_t size)
     uint8_t response;
 
     // Get block count
-    bd_addr_t blockCnt = size / _block_size;
+    size_t blockCnt = size / _block_size;
 
     // SDSC Card (CCS=0) uses byte unit address
     // SDHC and SDXC Cards (CCS=1) use block unit address (512 Bytes unit)
@@ -514,7 +519,7 @@ int SDBlockDevice::read(void *b, bd_addr_t addr, bd_size_t size)
 
     uint8_t *buffer = static_cast<uint8_t *>(b);
     int status = BD_ERROR_OK;
-    bd_addr_t blockCnt =  size / _block_size;
+    size_t blockCnt =  size / _block_size;
 
     // SDSC Card (CCS=0) uses byte unit address
     // SDHC and SDXC Cards (CCS=1) use block unit address (512 Bytes unit)
@@ -738,24 +743,24 @@ int SDBlockDevice::_cmd(SDBlockDevice::cmdSupported cmd, uint32_t arg, bool isAc
     // Process the response R1  : Exit on CRC/Illegal command error/No response
     if (R1_NO_RESPONSE == response) {
         _deselect();
-        debug_if(SD_DBG, "No response CMD:%d response: 0x%x\n", cmd, response);
+        debug_if(SD_DBG, "No response CMD:%d response: 0x%" PRIx32 "\n", cmd, response);
         return SD_BLOCK_DEVICE_ERROR_NO_DEVICE;         // No device
     }
     if (response & R1_COM_CRC_ERROR) {
         _deselect();
-        debug_if(SD_DBG, "CRC error CMD:%d response 0x%x \n", cmd, response);
+        debug_if(SD_DBG, "CRC error CMD:%d response 0x%" PRIx32 "\n", cmd, response);
         return SD_BLOCK_DEVICE_ERROR_CRC;                // CRC error
     }
     if (response & R1_ILLEGAL_COMMAND) {
         _deselect();
-        debug_if(SD_DBG, "Illegal command CMD:%d response 0x%x\n", cmd, response);
+        debug_if(SD_DBG, "Illegal command CMD:%d response 0x%" PRIx32 "\n", cmd, response);
         if (CMD8_SEND_IF_COND == cmd) {                  // Illegal command is for Ver1 or not SD Card
             _card_type = CARD_UNKNOWN;
         }
         return SD_BLOCK_DEVICE_ERROR_UNSUPPORTED;      // Command not supported
     }
 
-    debug_if(_dbg, "CMD:%d \t arg:0x%x \t Response:0x%x \n", cmd, arg, response);
+    debug_if(_dbg, "CMD:%d \t arg:0x%" PRIx32 " \t Response:0x%" PRIx32 "\n", cmd, arg, response);
     // Set status for other errors
     if ((response & R1_ERASE_RESET) || (response & R1_ERASE_SEQUENCE_ERROR)) {
         status = SD_BLOCK_DEVICE_ERROR_ERASE;            // Erase error
@@ -775,7 +780,7 @@ int SDBlockDevice::_cmd(SDBlockDevice::cmdSupported cmd, uint32_t arg, bool isAc
             response |= (_spi.write(SPI_FILL_CHAR) << 16);
             response |= (_spi.write(SPI_FILL_CHAR) << 8);
             response |= _spi.write(SPI_FILL_CHAR);
-            debug_if(_dbg, "R3/R7: 0x%x \n", response);
+            debug_if(_dbg, "R3/R7: 0x%" PRIx32 "\n", response);
             break;
 
         case CMD12_STOP_TRANSMISSION:       // Response R1b
@@ -785,7 +790,7 @@ int SDBlockDevice::_cmd(SDBlockDevice::cmdSupported cmd, uint32_t arg, bool isAc
 
         case ACMD13_SD_STATUS:             // Response R2
             response = _spi.write(SPI_FILL_CHAR);
-            debug_if(_dbg, "R2: 0x%x \n", response);
+            debug_if(_dbg, "R2: 0x%" PRIx32 "\n", response);
             break;
 
         default:                            // Response R1
@@ -822,7 +827,7 @@ int SDBlockDevice::_cmd8()
     if ((BD_ERROR_OK == status) && (SDCARD_V2 == _card_type)) {
         // If check pattern is not matched, CMD8 communication is not valid
         if ((response & 0xFFF) != arg) {
-            debug_if(SD_DBG, "CMD8 Pattern mismatch 0x%x : 0x%x\n", arg, response);
+            debug_if(SD_DBG, "CMD8 Pattern mismatch 0x%" PRIx32 " : 0x%" PRIx32 "\n", arg, response);
             _card_type = CARD_UNKNOWN;
             status = SD_BLOCK_DEVICE_ERROR_UNUSABLE;
         }
@@ -874,8 +879,8 @@ int SDBlockDevice::_read_bytes(uint8_t *buffer, uint32_t length)
         // Compute and verify checksum
         _crc16.compute((void *)buffer, length, &crc_result);
         if ((uint16_t)crc_result != crc) {
-            debug_if(SD_DBG, "_read_bytes: Invalid CRC received 0x%x result of computation 0x%x\n",
-                     crc, crc_result);
+            debug_if(SD_DBG, "_read_bytes: Invalid CRC received 0x%" PRIx16 " result of computation 0x%" PRIx16 "\n",
+                     crc, (uint16_t)crc_result);
             _deselect();
             return SD_BLOCK_DEVICE_ERROR_CRC;
         }
@@ -908,8 +913,8 @@ int SDBlockDevice::_read(uint8_t *buffer, uint32_t length)
         // Compute and verify checksum
         _crc16.compute((void *)buffer, length, &crc_result);
         if ((uint16_t)crc_result != crc) {
-            debug_if(SD_DBG, "_read_bytes: Invalid CRC received 0x%x result of computation 0x%x\n",
-                     crc, crc_result);
+            debug_if(SD_DBG, "_read_bytes: Invalid CRC received 0x%" PRIx16 " result of computation 0x%" PRIx16 "\n",
+                     crc, (uint16_t)crc_result);
             return SD_BLOCK_DEVICE_ERROR_CRC;
         }
     }
@@ -992,11 +997,11 @@ bd_size_t SDBlockDevice::_sd_sectors()
             block_len = 1 << read_bl_len;                // BLOCK_LEN = 2^READ_BL_LEN
             mult = 1 << (c_size_mult + 2);               // MULT = 2^C_SIZE_MULT+2 (C_SIZE_MULT < 8)
             blocknr = (c_size + 1) * mult;               // BLOCKNR = (C_SIZE+1) * MULT
-            capacity = blocknr * block_len;              // memory capacity = BLOCKNR * BLOCK_LEN
+            capacity = (bd_size_t) blocknr * block_len;  // memory capacity = BLOCKNR * BLOCK_LEN
             blocks = capacity / _block_size;
-            debug_if(SD_DBG, "Standard Capacity: c_size: %d \n", c_size);
-            debug_if(SD_DBG, "Sectors: 0x%x : %llu\n", blocks, blocks);
-            debug_if(SD_DBG, "Capacity: 0x%x : %llu MB\n", capacity, (capacity / (1024U * 1024U)));
+            debug_if(SD_DBG, "Standard Capacity: c_size: %" PRIu32 " \n", c_size);
+            debug_if(SD_DBG, "Sectors: 0x%" PRIx64 " : %" PRIu64 "\n", blocks, blocks);
+            debug_if(SD_DBG, "Capacity: 0x%" PRIx64 " : %" PRIu64 " MB\n", capacity, (capacity / (1024U * 1024U)));
 
             // ERASE_BLK_EN = 1: Erase in multiple of 512 bytes supported
             if (ext_bits(csd, 46, 46)) {
@@ -1010,9 +1015,9 @@ bd_size_t SDBlockDevice::_sd_sectors()
         case 1:
             hc_c_size = ext_bits(csd, 69, 48);            // device size : C_SIZE : [69:48]
             blocks = (hc_c_size + 1) << 10;               // block count = C_SIZE+1) * 1K byte (512B is block size)
-            debug_if(SD_DBG, "SDHC/SDXC Card: hc_c_size: %d \n", hc_c_size);
-            debug_if(SD_DBG, "Sectors: 0x%x : %llu\n", blocks, blocks);
-            debug_if(SD_DBG, "Capacity: %llu MB\n", (blocks / (2048U)));
+            debug_if(SD_DBG, "SDHC/SDXC Card: hc_c_size: %" PRIu32 " \n", hc_c_size);
+            debug_if(SD_DBG, "Sectors: 0x%" PRIx64 "x : %" PRIu64 "\n", blocks, blocks);
+            debug_if(SD_DBG, "Capacity: %" PRIu64 " MB\n", (blocks / (2048U)));
             // ERASE_BLK_EN is fixed to 1, which means host can erase one or multiple of 512 bytes.
             _erase_size = BLOCK_SIZE_HC;
             break;

--- a/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
+++ b/components/storage/blockdevice/COMPONENT_SD/SDBlockDevice.h
@@ -214,8 +214,8 @@ private:
     }
 
     PlatformMutex _mutex;
-    bd_size_t _block_size;
-    bd_size_t _erase_size;
+    static const uint32_t _block_size;
+    uint32_t _erase_size;
     bool _is_initialized;
     bool _dbg;
     bool _crc_on;

--- a/drivers/RawSerial.h
+++ b/drivers/RawSerial.h
@@ -20,6 +20,7 @@
 
 #if defined (DEVICE_SERIAL) || defined(DOXYGEN_ONLY)
 
+#include "mbed_toolchain.h"
 #include "drivers/SerialBase.h"
 #include "hal/serial_api.h"
 #include "platform/NonCopyable.h"
@@ -86,7 +87,7 @@ public:
      */
     int puts(const char *str);
 
-    int printf(const char *format, ...);
+    int printf(const char *format, ...) MBED_PRINTF_METHOD(1, 2);
 
 #if !(DOXYGEN_ONLY)
 protected:

--- a/features/storage/filesystem/fat/FATFileSystem.cpp
+++ b/features/storage/filesystem/fat/FATFileSystem.cpp
@@ -205,7 +205,7 @@ DSTATUS disk_initialize(BYTE pdrv)
 
 DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 {
-    debug_if(FFS_DBG, "disk_read(sector %d, count %d) on pdrv [%d]\n", sector, count, pdrv);
+    debug_if(FFS_DBG, "disk_read(sector %lu, count %u) on pdrv [%d]\n", sector, count, pdrv);
     DWORD ssize = disk_get_sector_size(pdrv);
     bd_addr_t addr = (bd_addr_t)sector*ssize;
     bd_size_t size = (bd_size_t)count*ssize;
@@ -215,7 +215,7 @@ DRESULT disk_read(BYTE pdrv, BYTE *buff, DWORD sector, UINT count)
 
 DRESULT disk_write(BYTE pdrv, const BYTE *buff, DWORD sector, UINT count)
 {
-    debug_if(FFS_DBG, "disk_write(sector %d, count %d) on pdrv [%d]\n", sector, count, pdrv);
+    debug_if(FFS_DBG, "disk_write(sector %lu, count %u) on pdrv [%d]\n", sector, count, pdrv);
     DWORD ssize = disk_get_sector_size(pdrv);
     bd_addr_t addr = (bd_addr_t)sector*ssize;
     bd_size_t size = (bd_size_t)count*ssize;
@@ -572,7 +572,7 @@ void FATFileSystem::unlock()
 ////// File operations //////
 int FATFileSystem::file_open(fs_file_t *file, const char *path, int flags)
 {
-    debug_if(FFS_DBG, "open(%s) on filesystem [%s], drv [%s]\n", path, getName(), _id);
+    debug_if(FFS_DBG, "open(%s) on filesystem [%s], drv [%d]\n", path, getName(), _id);
 
     FIL *fh = new FIL;
     Deferred<const char*> fpath = fat_path_prefix(_id, path);

--- a/platform/Stream.h
+++ b/platform/Stream.h
@@ -20,6 +20,7 @@
 #include "platform/FileLike.h"
 #include "platform/FileHandle.h"
 #include "platform/NonCopyable.h"
+#include "mbed_toolchain.h"
 #include <cstdio>
 #include <cstdarg>
 
@@ -47,10 +48,10 @@ public:
     int puts(const char *s);
     int getc();
     char *gets(char *s, int size);
-    int printf(const char *format, ...);
-    int scanf(const char *format, ...);
-    int vprintf(const char *format, std::va_list args);
-    int vscanf(const char *format, std::va_list args);
+    int printf(const char *format, ...) MBED_PRINTF_METHOD(1, 2);
+    int scanf(const char *format, ...) MBED_SCANF_METHOD(1, 2);
+    int vprintf(const char *format, std::va_list args) MBED_PRINTF_METHOD(1, 0);
+    int vscanf(const char *format, std::va_list args) MBED_SCANF_METHOD(1, 0);
 
     operator std::FILE *()
     {

--- a/platform/mbed_debug.h
+++ b/platform/mbed_debug.h
@@ -27,11 +27,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 #endif
+#include "mbed_toolchain.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+static inline void debug(const char *format, ...) MBED_PRINTF(1, 2);
+static inline void debug_if(int condition, const char *format, ...) MBED_PRINTF(2, 3);
 
 /** Output a debug message
  *

--- a/platform/mbed_error.c
+++ b/platform/mbed_error.c
@@ -28,6 +28,10 @@
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
 
 #ifndef NDEBUG
 #define ERROR_REPORT(ctx, error_msg, error_filename, error_line) print_error_report(ctx, error_msg, error_filename, error_line)
@@ -278,7 +282,7 @@ static const char *name_or_unnamed(const char *name)
 /* Prints info of a thread(using osRtxThread_t struct)*/
 static void print_thread(const osRtxThread_t *thread)
 {
-    mbed_error_printf("\n%s  State: 0x%X Entry: 0x%08X Stack Size: 0x%08X Mem: 0x%08X SP: 0x%08X", name_or_unnamed(thread->name), thread->state, thread->thread_addr, thread->stack_size, (uint32_t)thread->stack_mem, thread->sp);
+    mbed_error_printf("\n%s  State: 0x%" PRIX8 " Entry: 0x%08" PRIX32 " Stack Size: 0x%08" PRIX32 " Mem: 0x%08" PRIX32 " SP: 0x%08" PRIX32, name_or_unnamed(thread->name), thread->state, thread->thread_addr, thread->stack_size, (uint32_t)thread->stack_mem, thread->sp);
 }
 
 /* Prints thread info from a list */
@@ -294,43 +298,43 @@ static void print_threads_info(const osRtxThread_t *threads)
 #ifndef NDEBUG
 static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg, const char *error_filename, int error_line)
 {
-    uint32_t error_code = MBED_GET_ERROR_CODE(ctx->error_status);
-    uint32_t error_module = MBED_GET_ERROR_MODULE(ctx->error_status);
+    int error_code = MBED_GET_ERROR_CODE(ctx->error_status);
+    int error_module = MBED_GET_ERROR_MODULE(ctx->error_status);
 
     mbed_error_printf("\n\n++ MbedOS Error Info ++\nError Status: 0x%X Code: %d Module: %d\nError Message: ", ctx->error_status, error_code, error_module);
 
     switch (error_code) {
         //These are errors reported by kernel handled from mbed_rtx_handlers
         case MBED_ERROR_CODE_RTOS_EVENT:
-            mbed_error_printf("Kernel Error: 0x%X, ", ctx->error_value);
+            mbed_error_printf("Kernel Error: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_THREAD_EVENT:
-            mbed_error_printf("Thread: 0x%X, ", ctx->error_value);
+            mbed_error_printf("Thread: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_MUTEX_EVENT:
-            mbed_error_printf("Mutex: 0x%X, ", ctx->error_value);
+            mbed_error_printf("Mutex: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_SEMAPHORE_EVENT:
-            mbed_error_printf("Semaphore: 0x%X, ", ctx->error_value);
+            mbed_error_printf("Semaphore: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_MEMORY_POOL_EVENT:
-            mbed_error_printf("MemoryPool: 0x%X, ", ctx->error_value);
+            mbed_error_printf("MemoryPool: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_EVENT_FLAGS_EVENT:
-            mbed_error_printf("EventFlags: 0x%X, ", ctx->error_value);
+            mbed_error_printf("EventFlags: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_TIMER_EVENT:
-            mbed_error_printf("Timer: 0x%X, ", ctx->error_value);
+            mbed_error_printf("Timer: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_RTOS_MESSAGE_QUEUE_EVENT:
-            mbed_error_printf("MessageQueue: 0x%X, ", ctx->error_value);
+            mbed_error_printf("MessageQueue: 0x%" PRIX32 ", ", ctx->error_value);
             break;
 
         case MBED_ERROR_CODE_ASSERTION_FAILED:
@@ -342,7 +346,7 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg,
             break;
     }
     mbed_error_puts(error_msg);
-    mbed_error_printf("\nLocation: 0x%X", ctx->error_address);
+    mbed_error_printf("\nLocation: 0x%" PRIX32, ctx->error_address);
 
     /* We print the filename passed in, not any filename in the context. This
      * avoids the console print for mbed_error being limited to the presence
@@ -357,9 +361,9 @@ static void print_error_report(const mbed_error_ctx *ctx, const char *error_msg,
         mbed_error_printf("+%d", error_line);
     }
 
-    mbed_error_printf("\nError Value: 0x%X", ctx->error_value);
+    mbed_error_printf("\nError Value: 0x%" PRIX32, ctx->error_value);
 #ifdef MBED_CONF_RTOS_PRESENT
-    mbed_error_printf("\nCurrent Thread: %s  Id: 0x%X Entry: 0x%X StackSize: 0x%X StackMem: 0x%X SP: 0x%X ",
+    mbed_error_printf("\nCurrent Thread: %s  Id: 0x%" PRIX32 " Entry: 0x%" PRIX32 " StackSize: 0x%" PRIX32 " StackMem: 0x%" PRIX32 " SP: 0x%" PRIX32 " ",
                       name_or_unnamed(((osRtxThread_t *)ctx->thread_id)->name),
                       ctx->thread_id, ctx->thread_entry_address, ctx->thread_stack_size, ctx->thread_stack_mem, ctx->thread_current_sp);
 #endif

--- a/platform/mbed_error.h
+++ b/platform/mbed_error.h
@@ -871,7 +871,7 @@ typedef struct _mbed_error_ctx {
  *
  */
 
-MBED_NORETURN void error(const char *format, ...);
+MBED_NORETURN void error(const char *format, ...) MBED_PRINTF(1, 2);
 
 /**
  * Call this Macro to generate a mbed_error_status_t value for a System error

--- a/platform/mbed_interface.h
+++ b/platform/mbed_interface.h
@@ -139,7 +139,7 @@ MBED_NORETURN void mbed_die(void);
  * @endcode
  *
  */
-void mbed_error_printf(const char *format, ...);
+void mbed_error_printf(const char *format, ...) MBED_PRINTF(1, 2);
 
 /** Print out an error message.  Similar to mbed_error_printf
  * but uses a va_list.
@@ -150,7 +150,7 @@ void mbed_error_printf(const char *format, ...);
  * @param arg       Variable arguments list
  *
  */
-void mbed_error_vprintf(const char *format, va_list arg);
+void mbed_error_vprintf(const char *format, va_list arg) MBED_PRINTF(1, 0);
 
 /** Print out an error message. This is typically called when
  * handling a crash.
@@ -169,7 +169,7 @@ void mbed_error_puts(const char *str);
 /** @deprecated   Renamed to mbed_error_vprintf to match functionality */
 MBED_DEPRECATED_SINCE("mbed-os-5.11",
                           "Renamed to mbed_error_vprintf to match functionality.")
-void mbed_error_vfprintf(const char *format, va_list arg);
+void mbed_error_vfprintf(const char *format, va_list arg) MBED_PRINTF(1, 0);
 /** @}*/
 
 

--- a/platform/mbed_toolchain.h
+++ b/platform/mbed_toolchain.h
@@ -356,7 +356,7 @@
 
 #ifndef MBED_PRINTF_METHOD
 #if defined(__GNUC__) || defined(__CC_ARM)
-#define MBED_PRINTF_METHOD(format_idx, first_param_idx) __attribute__ ((__format__(__printf__, format_idx+1, first_param_idx+1)))
+#define MBED_PRINTF_METHOD(format_idx, first_param_idx) __attribute__ ((__format__(__printf__, format_idx+1, first_param_idx == 0 ? 0 : first_param_idx+1)))
 #else
 #define MBED_PRINTF_METHOD(format_idx, first_param_idx)
 #endif
@@ -372,7 +372,7 @@
 
 #ifndef MBED_SCANF_METHOD
 #if defined(__GNUC__) || defined(__CC_ARM)
-#define MBED_SCANF_METHOD(format_idx, first_param_idx) __attribute__ ((__format__(__scanf__, format_idx+1, first_param_idx+1)))
+#define MBED_SCANF_METHOD(format_idx, first_param_idx) __attribute__ ((__format__(__scanf__, format_idx+1, first_param_idx == 0 ? 0 : first_param_idx+1)))
 #else
 #define MBED_SCANF_METHOD(format_idx, first_param_idx)
 #endif


### PR DESCRIPTION
### Description

Toolchains are capable of performing format-checking on user-defined `printf` variants. Add the necessary directives to do this for some commonly-used mbed OS APIs:

* `error`
* `mbed_error_printf`
* `debug`, `debug_if`
* `Stream::printf`, `Stream::scanf`, `RawSerial::printf`

Some clean-ups of warnings generated by this change. `SDBlockDevice` changes are most wide-ranging - it's using 64-bit arithmetic excessively due to `bd_size_t` being used for all sorts of things that must be much smaller (being limited to `size_t` by being in-memory, or just block sizes).

### Pull request type

    [ ] Fix
    [X] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

