### PR TITLE
Doxy fix on netsocket docs

### DIFF
--- a/doxyfile_options
+++ b/doxyfile_options
@@ -849,6 +849,7 @@ EXCLUDE_PATTERNS       = */tools/* \
                          */features/lwipstack/* \
                          */features/nanostack/sal-stack-nanostack/* \
                          */features/nanostack/coap-service/* \
+                         */features/netsocket/emac-drivers/* \
                          */mbed-trace/* \
                          */mbed-coap/* \
                          */nanostack-libservice/* \

--- a/features/netsocket/NetworkInterface.h
+++ b/features/netsocket/NetworkInterface.h
@@ -33,7 +33,8 @@ class EMACInterface;
 
 /** Common interface that is shared between network devices.
  *
- *  @addtogroup netsocket
+ *  @\addtogroup netsocket
+ *  @{
  */
 class NetworkInterface: public DNS {
 public:
@@ -331,5 +332,5 @@ protected:
 #endif //!defined(DOXYGEN_ONLY)
 };
 
-
+/** @}*/
 #endif


### PR DESCRIPTION
### Description
This fix contains 2 fixes:
* exclude vendor's EMAC driver from doxy
* fixed missing NetworkInterface Class in doxy

### Pull request type
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

cc @AnotherButler @SeppoTakalo 
