### PR TITLE
Increase EMAC test timeout to 1400 seconds

### DIFF
--- a/TESTS/network/emac/main.cpp
+++ b/TESTS/network/emac/main.cpp
@@ -53,7 +53,7 @@ using namespace utest::v1;
 utest::v1::status_t test_setup(const size_t number_of_cases)
 {
 #if !MBED_CONF_APP_ECHO_SERVER
-    GREENTEA_SETUP(1200, "default_auto");
+    GREENTEA_SETUP(1400, "default_auto");
 #endif
     return verbose_test_setup_handler(number_of_cases);
 }


### PR DESCRIPTION
### Description

Increase EMAC test timeout to 1400 seconds because in https://github.com/ARMmbed/mbed-os/pull/8444 it was indicated that for CM3DS the 1200 seconds is not enough.


### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

