### PR TITLE
Make examples commands return a failure

### DIFF
--- a/tools/test/examples/examples.py
+++ b/tools/test/examples/examples.py
@@ -97,20 +97,17 @@ def do_export(args, config, examples):
 
 def do_import(_, config, examples):
     """Do the import step of this process"""
-    lib.source_repos(config, examples)
-    return 0
+    return lib.source_repos(config, examples)
 
 
 def do_clone(_, config, examples):
     """Do the clone step of this process"""
-    lib.clone_repos(config, examples)
-    return 0
+    return lib.clone_repos(config, examples)
 
 
 def do_deploy(_, config, examples):
     """Do the deploy step of this process"""
-    lib.deploy_repos(config, examples)
-    return 0
+    return lib.deploy_repos(config, examples)
 
 
 def do_compile(args, config, examples):
@@ -125,8 +122,7 @@ def do_compile(args, config, examples):
     
 def do_versionning(args, config, examples):
     """ Test update the mbed-os to the version specified by the tag """
-    lib.update_mbedos_version(config, args.tag, examples)
-    return 0
+    return lib.update_mbedos_version(config, args.tag, examples)
 
 
 if __name__ == "__main__":

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -169,7 +169,11 @@ def source_repos(config, examples):
                     print("'%s' example directory already exists. Deleting..." % name)
                     rmtree(name)
 
-                subprocess.call(["mbed-cli", "import", repo_info['repo']])
+                result = subprocess.call(["mbed-cli", "import", repo_info['repo']])
+                if result:
+                    return result
+    
+    return 0                
 
 def clone_repos(config, examples , retry = 3):
     """ Clones each of the repos associated with the specific examples name from the
@@ -192,6 +196,8 @@ def clone_repos(config, examples , retry = 3):
                         break
                 else:
                     print("ERROR : unable to clone the repo {}".format(name))
+                    return 1
+    return 0
 
 def deploy_repos(config, examples):
     """ If the example directory exists as provided by the json config file,
@@ -207,11 +213,15 @@ def deploy_repos(config, examples):
             if name in examples:
                 if os.path.exists(name):
                     os.chdir(name)
-                    subprocess.call(["mbed-cli", "deploy"])
+                    result = subprocess.call(["mbed-cli", "deploy"])
                     os.chdir("..")
+                    if result:
+                        print("mbed-cli deploy command failed for '%s'" % name)
+                        return result                
                 else:
                     print("'%s' example directory doesn't exist. Skipping..." % name)
-
+                    return 1
+    return  0
 
 def get_num_failures(results, export=False):
     """ Returns the number of failed compilations from the results summary
@@ -405,5 +415,10 @@ def update_mbedos_version(config, tag, examples):
             update_dir =  basename(repo_info['repo']) + "/mbed-os"
             print("\nChanging dir to %s\n" % update_dir)
             os.chdir(update_dir)
-            subprocess.call(["mbed-cli", "update", tag, "--clean"])
+            result = subprocess.call(["mbed-cli", "update", tag, "--clean"])
             os.chdir("../..")
+            if result:
+                return result:
+    
+    return 0
+  

--- a/tools/test/examples/examples_lib.py
+++ b/tools/test/examples/examples_lib.py
@@ -168,8 +168,10 @@ def source_repos(config, examples):
                 if os.path.exists(name):
                     print("'%s' example directory already exists. Deleting..." % name)
                     rmtree(name)
+                
+                cmd = "mbed-cli import %s" %repo_info['repo']
+                result = subprocess.call(cmd, shell=True)
 
-                result = subprocess.call(["mbed-cli", "import", repo_info['repo']])
                 if result:
                     return result
     
@@ -191,8 +193,9 @@ def clone_repos(config, examples , retry = 3):
                 if os.path.exists(name):
                     print("'%s' example directory already exists. Deleting..." % name)
                     rmtree(name)
+                cmd = "%s clone %s" %(repo_info['type'], repo_info['repo'])
                 for i in range(0, retry):
-                    if subprocess.call([repo_info['type'], "clone", repo_info['repo']]) == 0:
+                    if not subprocess.call(cmd, shell=True):                        
                         break
                 else:
                     print("ERROR : unable to clone the repo {}".format(name))
@@ -213,7 +216,7 @@ def deploy_repos(config, examples):
             if name in examples:
                 if os.path.exists(name):
                     os.chdir(name)
-                    result = subprocess.call(["mbed-cli", "deploy"])
+                    result = subprocess.call("mbed-cli deploy", shell=True)
                     os.chdir("..")
                     if result:
                         print("mbed-cli deploy command failed for '%s'" % name)
@@ -415,10 +418,11 @@ def update_mbedos_version(config, tag, examples):
             update_dir =  basename(repo_info['repo']) + "/mbed-os"
             print("\nChanging dir to %s\n" % update_dir)
             os.chdir(update_dir)
-            result = subprocess.call(["mbed-cli", "update", tag, "--clean"])
+            cmd = "mbed-cli update %s --clean" %tag
+            result = subprocess.call(cmd, shell=True)
             os.chdir("../..")
             if result:
-                return result:
+                return result
     
     return 0
   


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Currently the following commands in examples.py,
do_import()
do_deploy()
do_versionning()
do_clone()

all return a success status (ie 0) irrespective of any errors
originating from their sub-functions.

This PR fixes this. Now these commands will return one of:
0 - success
1 - general failure
x - failure returned by a subprocess.call function



### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

