### PR TITLE
Fix off-by-one-error in BusIn/Out

### DIFF
--- a/drivers/BusIn.cpp
+++ b/drivers/BusIn.cpp
@@ -97,7 +97,7 @@ BusIn::operator int()
 DigitalIn &BusIn::operator[](int index)
 {
     // No lock needed since _pin is not modified outside the constructor
-    MBED_ASSERT(index >= 0 && index <= 16);
+    MBED_ASSERT(index >= 0 && index < 16);
     MBED_ASSERT(_pin[index]);
     return *_pin[index];
 }

--- a/drivers/BusInOut.cpp
+++ b/drivers/BusInOut.cpp
@@ -128,7 +128,7 @@ BusInOut &BusInOut::operator= (BusInOut &rhs)
 DigitalInOut &BusInOut::operator[](int index)
 {
     // No lock needed since _pin is not modified outside the constructor
-    MBED_ASSERT(index >= 0 && index <= 16);
+    MBED_ASSERT(index >= 0 && index < 16);
     MBED_ASSERT(_pin[index]);
     return *_pin[index];
 }

--- a/drivers/BusOut.cpp
+++ b/drivers/BusOut.cpp
@@ -95,7 +95,7 @@ BusOut &BusOut::operator= (BusOut &rhs)
 DigitalOut &BusOut::operator[](int index)
 {
     // No lock needed since _pin is not modified outside the constructor
-    MBED_ASSERT(index >= 0 && index <= 16);
+    MBED_ASSERT(index >= 0 && index < 16);
     MBED_ASSERT(_pin[index]);
     return *_pin[index];
 }


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
All three Bus implementation files (BusIn.cpp, BusOut.cpp, and BusInOut.cpp) contain off-by-one-errors in the subscript operator implementations.

Only 16 In/Outs exist in the array, but the MBED_ASSERT allows the 17th index through without assertion.

Also, regarding the CLA, I submitted it less than an hour ago, so I may not be in the list yet.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

