### PR TITLE
Unittest fixes

### DIFF
--- a/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
+++ b/UNITTESTS/features/lorawan/loraphycn470/Test_LoRaPHYCN470.cpp
@@ -190,6 +190,7 @@ TEST_F(Test_LoRaPHYCN470, rx_config)
 TEST_F(Test_LoRaPHYCN470, tx_config)
 {
     tx_config_params_t p;
+    memset(&p, 0, sizeof(p));
     int8_t tx = 0;
     lorawan_time_t time = 0;
     p.tx_power = 9;

--- a/UNITTESTS/features/lorawan/lorawantimer/Test_LoRaWANTimer.cpp
+++ b/UNITTESTS/features/lorawan/lorawantimer/Test_LoRaWANTimer.cpp
@@ -63,18 +63,21 @@ void my_callback()
 TEST_F(Test_LoRaWANTimer, init)
 {
     timer_event_t ev;
+    memset(&ev, 0, sizeof(ev));
     object->init(ev, my_callback);
 }
 
 TEST_F(Test_LoRaWANTimer, start)
 {
     timer_event_t ev;
+    memset(&ev, 0, sizeof(ev));
     object->start(ev, 10);
 }
 
 TEST_F(Test_LoRaWANTimer, stop)
 {
     timer_event_t ev;
+    memset(&ev, 0, sizeof(ev));
     ev.timer_id = 4;
     object->stop(ev);
     EXPECT_TRUE(ev.timer_id == 0);


### PR DESCRIPTION
### Description

LoRaPhyCN470 and LoRaWAN timer started failing in Windows and this PR  should fix the errors

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [X] Test update
    [ ] Breaking change

