### PR TITLE
Make sure that TLSSocketWrapper::close() is called before the transport is destroyed.

### DIFF
--- a/features/netsocket/TLSSocket.cpp
+++ b/features/netsocket/TLSSocket.cpp
@@ -35,4 +35,13 @@ nsapi_error_t TLSSocket::connect(const char *host, uint16_t port)
     return TLSSocketWrapper::do_handshake();
 }
 
+TLSSocket::~TLSSocket()
+{
+    /* Transport is a member of TLSSocket which is derived from TLSSocketWrapper.
+     * Make sure that TLSSocketWrapper::close() is called before the transport is
+     * destroyed.
+     */
+    close();
+}
+
 #endif // MBEDTLS_SSL_CLI_C

--- a/features/netsocket/TLSSocket.h
+++ b/features/netsocket/TLSSocket.h
@@ -41,6 +41,10 @@ public:
      */
     TLSSocket() : TLSSocketWrapper(&tcp_socket) {}
 
+    /** Destroy the TLSSocket and closes the transport.
+     */
+    virtual ~TLSSocket();
+
     /** Create a socket on a network interface
      *
      *  Creates and opens a socket on the network stack of the given


### PR DESCRIPTION
### Description

Transport is a member of TLSSocket which is derived from TLSSocketWrapper.
Make sure that TLSSocketWrapper::close() is called before the transport is
destroyed.

If you deleted the `TLSSocket` class without closing it first, it lead to `mbed_error()` and crashed the device.

### Pull request type

    [X] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

