### PR TITLE
Add missing include for TLSSocket

### DIFF
--- a/features/netsocket/nsapi.h
+++ b/features/netsocket/nsapi.h
@@ -40,6 +40,7 @@
 #include "netsocket/UDPSocket.h"
 #include "netsocket/TCPSocket.h"
 #include "netsocket/TCPServer.h"
+#include "netsocket/TLSSocket.h"
 
 #endif
 


### PR DESCRIPTION

### Description

TCP and UDP sockets are automatically available when mbed.h is
included in an application.

This change lets the TLSSocket be used in the same way.


<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

