### PR TITLE
Fix compile warning about initializing and variable order

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
+++ b/features/nanostack/mbed-mesh-api/source/MeshInterfaceNanostack.cpp
@@ -69,7 +69,7 @@ void Nanostack::Interface::attach(
 }
 
 Nanostack::Interface::Interface(NanostackPhy &phy) : interface_phy(phy), interface_id(-1), _device_id(-1),
-      _connect_status(NSAPI_STATUS_DISCONNECTED), _blocking(true), _previous_connection_status(NSAPI_STATUS_DISCONNECTED)
+      _connect_status(NSAPI_STATUS_DISCONNECTED), _previous_connection_status(NSAPI_STATUS_DISCONNECTED), _blocking(true)
 {
     mesh_system_init();
 }


### PR DESCRIPTION
### Description

Change order of variables _blocking and _previous_connection_status at initialization to fix compile warnings

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

