### PR TITLE
Add a Unity macro to assert on platform error code difference

### DIFF
--- a/features/frameworks/unity/unity/unity.h
+++ b/features/frameworks/unity/unity/unity.h
@@ -294,6 +294,15 @@ void tearDown(void);
 #define TEST_ASSERT_DOUBLE_IS_NOT_NAN_MESSAGE(actual, message)                                     UNITY_TEST_ASSERT_DOUBLE_IS_NOT_NAN((actual), __LINE__, (message))
 #define TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE_MESSAGE(actual, message)                             UNITY_TEST_ASSERT_DOUBLE_IS_NOT_DETERMINATE((actual), __LINE__, (message))
 
+
+/*-------------------------------------------------------
+ * Error code checking
+ *-------------------------------------------------------*/
+// Use these to check whether error code equals what we expect.
+// Only display error code (without other information)
+#define TEST_ASSERT_EQUAL_ERROR_CODE(expected, actual)                                             TEST_ASSERT_EQUAL(MBED_GET_ERROR_CODE(expected), MBED_GET_ERROR_CODE(actual))
+#define TEST_ASSERT_EQUAL_ERROR_CODE_MESSAGE(expected, actual, message)                            TEST_ASSERT_EQUAL_MESSAGE(MBED_GET_ERROR_CODE(expected), MBED_GET_ERROR_CODE(actual))
+
 /*-------------------------------------------------------
  * Test skipping
  *-------------------------------------------------------*/


### PR DESCRIPTION
### Description
Current platform error codes, defined in mbed_error.h header file, consist of the error code along with other information such as the module ID. This means that if we have a test that checks for the error code, an unexpected result would show a very large (negative) number, requiring user parsing in order to understand the real error.
This PR adds `TEST_ASSERT_EQUAL_ERROR_CODE` and `TEST_ASSERT_EQUAL_ERROR_CODE_MESSAGE` macros, checking only the status code (lower part) of the full error code, showing the interesting part of the error in case of a mismatch.

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

