### PR TITLE
Fixed bugs in Fast Model MPS2 GCC startup scripts

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -70,7 +70,7 @@ __isr_vector:
     .long     UARTTX4_Handler           /* UART 4 TX Handler                 */
     .long     ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler */
     .long     SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler     */
-    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */             
+    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */
     .long     PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler         */
     .long     PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler         */
     .long     PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler         */
@@ -193,7 +193,7 @@ system_startup:
     def_irq_default_handler     UARTTX4_Handler           /* 21: UART 4 TX Handler                 */
     def_irq_default_handler     ADCSPI_Handler            /* 22: SHIELD ADC SPI exceptions Handler */
     def_irq_default_handler     SHIELDSPI_Handler         /* 23: SHIELD SPI exceptions Handler     */
-    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */             
+    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */
     def_irq_default_handler     PORT0_1_Handler           /* 25: GPIO Port 0 pin 1 Handler         */
     def_irq_default_handler     PORT0_2_Handler           /* 26: GPIO Port 0 pin 2 Handler         */
     def_irq_default_handler     PORT0_3_Handler           /* 27: GPIO Port 0 pin 3 Handler         */

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M0P/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -70,7 +70,7 @@ __isr_vector:
     .long     UARTTX4_Handler           /* UART 4 TX Handler                 */
     .long     ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler */
     .long     SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler     */
-    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */             
+    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */
     .long     PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler         */
     .long     PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler         */
     .long     PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler         */
@@ -193,7 +193,7 @@ system_startup:
     def_irq_default_handler     UARTTX4_Handler           /* 21: UART 4 TX Handler                 */
     def_irq_default_handler     ADCSPI_Handler            /* 22: SHIELD ADC SPI exceptions Handler */
     def_irq_default_handler     SHIELDSPI_Handler         /* 23: SHIELD SPI exceptions Handler     */
-    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */             
+    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */
     def_irq_default_handler     PORT0_1_Handler           /* 25: GPIO Port 0 pin 1 Handler         */
     def_irq_default_handler     PORT0_2_Handler           /* 26: GPIO Port 0 pin 2 Handler         */
     def_irq_default_handler     PORT0_3_Handler           /* 27: GPIO Port 0 pin 3 Handler         */

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M3/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -46,63 +46,38 @@ __isr_vector:
     .long    SysTick_Handler       /* SysTick Handler */
 
     /* External Interrupts */
-    .long    UART0_IRQHandler        /*   0:  UART 0 RX and TX Combined Interrupt         */
-    .long    Spare_IRQHandler        /*   1:  Undefined                                   */
-    .long    UART1_IRQHandler        /*   2:  UART 1 RX and TX Combined Interrupt         */
-    .long    APB_Slave0_IRQHandler   /*   3:  Reserved for APB Slave                      */
-    .long    APB_Slave1_IRQHandler   /*   4:  Reserved for APB Slave                      */
-    .long    RTC_IRQHandler          /*   5:  RTC Interrupt                               */
-    .long    PORT0_IRQHandler        /*   6:  GPIO Port 0 combined Interrupt              */
-    .long    PORT1_ALL_IRQHandler    /*   7:  GPIO Port 1 combined Interrupt              */
-    .long    TIMER0_IRQHandler       /*   8:  TIMER 0 Interrupt                           */
-    .long    TIMER1_IRQHandler       /*   9:  TIMER 1 Interrupt                           */
-    .long    DUALTIMER_IRQHandler    /*   10: Dual Timer Interrupt                        */
-    .long    APB_Slave2_IRQHandler   /*   11: Reserved for APB Slave                      */
-    .long    UARTOVF_IRQHandler      /*   12: UART 0,1,2 Overflow Interrupt               */
-    .long    APB_Slave3_IRQHandler   /*   13: Reserved for APB Slave                      */
-    .long    RESERVED0_IRQHandler    /*   14: Reserved                                    */
-    .long    TSC_IRQHandler          /*   15: Touch Screen Interrupt                      */
-    .long    PORT0_0_IRQHandler      /*   16: GPIO Port 0 pin 0 Handler                   */
-    .long    PORT0_1_IRQHandler      /*   17: GPIO Port 0 pin 1 Handler                   */
-    .long    PORT0_2_IRQHandler      /*   18: GPIO Port 0 pin 2 Handler                   */
-    .long    PORT0_3_IRQHandler      /*   19: GPIO Port 0 pin 3 Handler                   */
-    .long    PORT0_4_IRQHandler      /*   20: GPIO Port 0 pin 4 Handler                   */
-    .long    PORT0_5_IRQHandler      /*   21: GPIO Port 0 pin 5 Handler                   */
-    .long    PORT0_6_IRQHandler      /*   22: GPIO Port 0 pin 6 Handler                   */
-    .long    PORT0_7_IRQHandler      /*   23: GPIO Port 0 pin 7 Handler                   */
-    .long    PORT0_8_IRQHandler      /*   24: GPIO Port 0 pin 8 Handler                   */
-    .long    PORT0_9_IRQHandler      /*   25: GPIO Port 0 pin 9 Handler                   */
-    .long    PORT0_10_IRQHandler     /*   26: GPIO Port 0 pin 10 Handler                  */
-    .long    PORT0_11_IRQHandler     /*   27: GPIO Port 0 pin 11 Handler                  */
-    .long    PORT0_12_IRQHandler     /*   28: GPIO Port 0 pin 12 Handler                  */
-    .long    PORT0_13_IRQHandler     /*   29: GPIO Port 0 pin 13 Handler                  */
-    .long    PORT0_14_IRQHandler     /*   30: GPIO Port 0 pin 14 Handler                  */
-    .long    PORT0_15_IRQHandler     /*   31: GPIO Port 0 pin 15 Handler                  */
-    .long    FLASH0_IRQHandler       /*   32: Reserved for Flash                          */
-    .long    FLASH1_IRQHandler       /*   33: Reserved for Flash                          */
-    .long    RESERVED1_IRQHandler    /*   34: Reserved                                    */
-    .long    RESERVED2_IRQHandler    /*   35: Reserved                                    */
-    .long    RESERVED3_IRQHandler    /*   36: Reserved                                    */
-    .long    RESERVED4_IRQHandler    /*   37: Reserved                                    */
-    .long    RESERVED5_IRQHandler    /*   38: Reserved                                    */
-    .long    RESERVED6_IRQHandler    /*   39: Reserved                                    */
-    .long    RESERVED7_IRQHandler    /*   40: Reserved                                    */
-    .long    RESERVED8_IRQHandler    /*   41: Reserved                                    */
-    .long    PORT2_ALL_IRQHandler    /*   42: GPIO Port 2 combined Interrupt              */
-    .long    PORT3_ALL_IRQHandler    /*   43: GPIO Port 3 combined Interrupt              */
-    .long    TRNG_IRQHandler         /*   44: Random number generator Interrupt           */
-    .long    UART2_IRQHandler        /*   45: UART 2 RX and TX Combined Interrupt         */
-    .long    UART3_IRQHandler        /*   46: UART 3 RX and TX Combined Interrupt         */
-    .long    ETHERNET_IRQHandler     /*   47: Ethernet interrupt     t.b.a.               */
-    .long    I2S_IRQHandler          /*   48: I2S Interrupt                               */
-    .long    MPS2_SPI0_IRQHandler    /*   49: SPI Interrupt (spi header)                  */
-    .long    MPS2_SPI1_IRQHandler    /*   50: SPI Interrupt (clcd)                        */
-    .long    MPS2_SPI2_IRQHandler    /*   51: SPI Interrupt (spi 1 ADC replacement)       */
-    .long    MPS2_SPI3_IRQHandler    /*   52: SPI Interrupt (spi 0 shield 0 replacement)  */
-    .long    MPS2_SPI4_IRQHandler    /*   53: SPI Interrupt  (shield 1)                   */
-    .long    PORT4_ALL_IRQHandler    /*   54: GPIO Port 4 combined Interrupt              */
-    .long    PORT5_ALL_IRQHandler    /*   55: GPIO Port 5 combined Interrupt              */
-    .long    UART4_IRQHandler        /*   56: UART 4 RX and TX Combined Interrupt         */
+    .long     UARTRX0_Handler           /* UART 0 RX Handler                 */
+    .long     UARTTX0_Handler           /* UART 0 TX Handler                 */
+    .long     UARTRX1_Handler           /* UART 1 RX Handler                 */
+    .long     UARTTX1_Handler           /* UART 1 TX Handler                 */
+    .long     UARTRX2_Handler           /* UART 2 RX Handler                 */
+    .long     UARTTX2_Handler           /* UART 2 TX Handler                 */
+    .long     PORT0_COMB_Handler        /* GPIO Port 0 Combined Handler      */
+    .long     PORT1_COMB_Handler        /* GPIO Port 1 Combined Handler      */
+    .long     TIMER0_Handler            /* TIMER 0 handler                   */
+    .long     TIMER1_Handler            /* TIMER 1 handler                   */
+    .long     DUALTIMER_HANDLER         /* Dual timer handler                */
+    .long     SPI_Handler               /* SPI exceptions Handler            */
+    .long     UARTOVF_Handler           /* UART 0,1,2 Overflow Handler       */
+    .long     ETHERNET_Handler          /* Ethernet Overflow Handler         */
+    .long     I2S_Handler               /* I2S Handler                       */
+    .long     TSC_Handler               /* Touch Screen handler              */
+    .long     PORT2_COMB_Handler        /* GPIO Port 2 Combined Handler      */
+    .long     PORT3_COMB_Handler        /* GPIO Port 3 Combined Handler      */
+    .long     UARTRX3_Handler           /* UART 3 RX Handler                 */
+    .long     UARTTX3_Handler           /* UART 3 TX Handler                 */
+    .long     UARTRX4_Handler           /* UART 4 RX Handler                 */
+    .long     UARTTX4_Handler           /* UART 4 TX Handler                 */
+    .long     ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler */
+    .long     SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler     */
+    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */
+    .long     PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler         */
+    .long     PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler         */
+    .long     PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler         */
+    .long     PORT0_4_Handler           /* GPIO Port 0 pin 4 Handler         */
+    .long     PORT0_5_Handler           /* GPIO Port 0 pin 5 Handler         */
+    .long     PORT0_6_Handler           /* GPIO Port 0 pin 6 Handler         */
+    .long     PORT0_7_Handler           /* GPIO Port 0 pin 7 Handler         */
 
     .size    __isr_vector, . - __isr_vector
 
@@ -196,62 +171,37 @@ system_startup:
     .endm
 
     /* External interrupts */
-    def_irq_default_handler     UART0_IRQHandler        /* 0:  UART 0 RX and TX Combined Interrupt        */
-    def_irq_default_handler     Spare_IRQHandler        /* 1:  Undefined                                  */
-    def_irq_default_handler     UART1_IRQHandler        /* 2:  UART 1 RX and TX Combined Interrupt        */
-    def_irq_default_handler     APB_Slave0_IRQHandler   /* 3:  Reserved for APB Slave                     */
-    def_irq_default_handler     APB_Slave1_IRQHandler   /* 4:  Reserved for APB Slave                     */
-    def_irq_default_handler     RTC_IRQHandler          /* 5:  RTC Interrupt                              */
-    def_irq_default_handler     PORT0_IRQHandler        /* 6:  GPIO Port 0 combined Interrupt             */
-    def_irq_default_handler     PORT1_ALL_IRQHandler    /* 7:  GPIO Port 1 combined Interrupt             */
-    def_irq_default_handler     TIMER0_IRQHandler       /* 8:  TIMER 0 Interrupt                          */
-    def_irq_default_handler     TIMER1_IRQHandler       /* 9:  TIMER 1 Interrupt                          */
-    def_irq_default_handler     DUALTIMER_IRQHandler    /* 10: Dual Timer Interrupt                       */
-    def_irq_default_handler     APB_Slave2_IRQHandler   /* 11: Reserved for APB Slave                     */
-    def_irq_default_handler     UARTOVF_IRQHandler      /* 12: UART 0,1,2 Overflow Interrupt              */
-    def_irq_default_handler     APB_Slave3_IRQHandler   /* 13: Reserved for APB Slave                     */
-    def_irq_default_handler     RESERVED0_IRQHandler    /* 14: Reserved                                   */
-    def_irq_default_handler     TSC_IRQHandler          /* 15: Touch Screen Interrupt                     */
-    def_irq_default_handler     PORT0_0_IRQHandler      /* 16: GPIO Port 0 pin 0 Handler                  */
-    def_irq_default_handler     PORT0_1_IRQHandler      /* 17: GPIO Port 0 pin 1 Handler                  */
-    def_irq_default_handler     PORT0_2_IRQHandler      /* 18: GPIO Port 0 pin 2 Handler                  */
-    def_irq_default_handler     PORT0_3_IRQHandler      /* 19: GPIO Port 0 pin 3 Handler                  */
-    def_irq_default_handler     PORT0_4_IRQHandler      /* 20: GPIO Port 0 pin 4 Handler                  */
-    def_irq_default_handler     PORT0_5_IRQHandler      /* 21: GPIO Port 0 pin 5 Handler                  */
-    def_irq_default_handler     PORT0_6_IRQHandler      /* 22: GPIO Port 0 pin 6 Handler                  */
-    def_irq_default_handler     PORT0_7_IRQHandler      /* 23: GPIO Port 0 pin 7 Handler                  */
-    def_irq_default_handler     PORT0_8_IRQHandler      /* 24: GPIO Port 0 pin 8 Handler                  */
-    def_irq_default_handler     PORT0_9_IRQHandler      /* 25: GPIO Port 0 pin 9 Handler                  */
-    def_irq_default_handler     PORT0_10_IRQHandler     /* 26: GPIO Port 0 pin 10 Handler                 */
-    def_irq_default_handler     PORT0_11_IRQHandler     /* 27: GPIO Port 0 pin 11 Handler                 */
-    def_irq_default_handler     PORT0_12_IRQHandler     /* 28: GPIO Port 0 pin 12 Handler                 */
-    def_irq_default_handler     PORT0_13_IRQHandler     /* 29: GPIO Port 0 pin 13 Handler                 */
-    def_irq_default_handler     PORT0_14_IRQHandler     /* 30: GPIO Port 0 pin 14 Handler                 */
-    def_irq_default_handler     PORT0_15_IRQHandler     /* 31: GPIO Port 0 pin 15 Handler                 */
-    def_irq_default_handler     FLASH0_IRQHandler       /* 32: Reserved for Flash                         */
-    def_irq_default_handler     FLASH1_IRQHandler       /* 33: Reserved for Flash                         */
-    def_irq_default_handler     RESERVED1_IRQHandler    /* 34: Reserved                                   */
-    def_irq_default_handler     RESERVED2_IRQHandler    /* 35: Reserved                                   */
-    def_irq_default_handler     RESERVED3_IRQHandler    /* 36: Reserved                                   */
-    def_irq_default_handler     RESERVED4_IRQHandler    /* 37: Reserved                                   */
-    def_irq_default_handler     RESERVED5_IRQHandler    /* 38: Reserved                                   */
-    def_irq_default_handler     RESERVED6_IRQHandler    /* 39: Reserved                                   */
-    def_irq_default_handler     RESERVED7_IRQHandler    /* 40: Reserved                                   */
-    def_irq_default_handler     RESERVED8_IRQHandler    /* 41: Reserved                                   */
-    def_irq_default_handler     PORT2_ALL_IRQHandler    /* 42: GPIO Port 2 combined Interrupt             */
-    def_irq_default_handler     PORT3_ALL_IRQHandler    /* 43: GPIO Port 3 combined Interrupt             */
-    def_irq_default_handler     TRNG_IRQHandler         /* 44: Random number generator Interrupt          */
-    def_irq_default_handler     UART2_IRQHandler        /* 45: UART 2 RX and TX Combined Interrupt        */
-    def_irq_default_handler     UART3_IRQHandler        /* 46: UART 3 RX and TX Combined Interrupt        */
-    def_irq_default_handler     ETHERNET_IRQHandler     /* 47: Ethernet interrupt     t.b.a.              */
-    def_irq_default_handler     I2S_IRQHandler          /* 48: I2S Interrupt                              */
-    def_irq_default_handler     MPS2_SPI0_IRQHandler    /* 49: SPI Interrupt (spi header)                 */
-    def_irq_default_handler     MPS2_SPI1_IRQHandler    /* 50: SPI Interrupt (clcd)                       */
-    def_irq_default_handler     MPS2_SPI2_IRQHandler    /* 51: SPI Interrupt (spi 1 ADC replacement)      */
-    def_irq_default_handler     MPS2_SPI3_IRQHandler    /* 52: SPI Interrupt (spi 0 shield 0 replacement) */
-    def_irq_default_handler     MPS2_SPI4_IRQHandler    /* 53: SPI Interrupt  (shield 1)                  */
-    def_irq_default_handler     PORT4_ALL_IRQHandler    /* 54: GPIO Port 4 combined Interrupt             */
-    def_irq_default_handler     PORT5_ALL_IRQHandler    /* 55: GPIO Port 5 combined Interrupt             */
-    def_irq_default_handler     UART4_IRQHandler        /* 56: UART 4 RX and TX Combined Interrupt        */
+    def_irq_default_handler     UARTRX0_Handler           /* 0:  UART 0 RX Handler                 */
+    def_irq_default_handler     UARTTX0_Handler           /* 1:  UART 0 TX Handler                 */
+    def_irq_default_handler     UARTRX1_Handler           /* 2:  UART 1 RX Handler                 */
+    def_irq_default_handler     UARTTX1_Handler           /* 3:  UART 1 TX Handler                 */
+    def_irq_default_handler     UARTRX2_Handler           /* 4:  UART 2 RX Handler                 */
+    def_irq_default_handler     UARTTX2_Handler           /* 5:  UART 2 TX Handler                 */
+    def_irq_default_handler     PORT0_COMB_Handler        /* 6:  GPIO Port 0 Combined Handler      */
+    def_irq_default_handler     PORT1_COMB_Handler        /* 7:  GPIO Port 1 Combined Handler      */
+    def_irq_default_handler     TIMER0_Handler            /* 8:  TIMER 0 handler                   */
+    def_irq_default_handler     TIMER1_Handler            /* 9:  TIMER 1 handler                   */
+    def_irq_default_handler     DUALTIMER_HANDLER         /* 10: Dual timer handler                */
+    def_irq_default_handler     SPI_Handler               /* 11: SPI exceptions Handler            */
+    def_irq_default_handler     UARTOVF_Handler           /* 12: UART 0,1,2 Overflow Handler       */
+    def_irq_default_handler     ETHERNET_Handler          /* 13: Ethernet Overflow Handler         */
+    def_irq_default_handler     I2S_Handler               /* 14: I2S Handler                       */
+    def_irq_default_handler     TSC_Handler               /* 15: Touch Screen handler              */
+    def_irq_default_handler     PORT2_COMB_Handler        /* 16: GPIO Port 2 Combined Handler      */
+    def_irq_default_handler     PORT3_COMB_Handler        /* 17: GPIO Port 3 Combined Handler      */
+    def_irq_default_handler     UARTRX3_Handler           /* 18: UART 3 RX Handler                 */
+    def_irq_default_handler     UARTTX3_Handler           /* 19: UART 3 TX Handler                 */
+    def_irq_default_handler     UARTRX4_Handler           /* 20: UART 4 RX Handler                 */
+    def_irq_default_handler     UARTTX4_Handler           /* 21: UART 4 TX Handler                 */
+    def_irq_default_handler     ADCSPI_Handler            /* 22: SHIELD ADC SPI exceptions Handler */
+    def_irq_default_handler     SHIELDSPI_Handler         /* 23: SHIELD SPI exceptions Handler     */
+    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */
+    def_irq_default_handler     PORT0_1_Handler           /* 25: GPIO Port 0 pin 1 Handler         */
+    def_irq_default_handler     PORT0_2_Handler           /* 26: GPIO Port 0 pin 2 Handler         */
+    def_irq_default_handler     PORT0_3_Handler           /* 27: GPIO Port 0 pin 3 Handler         */
+    def_irq_default_handler     PORT0_4_Handler           /* 28: GPIO Port 0 pin 4 Handler         */
+    def_irq_default_handler     PORT0_5_Handler           /* 29: GPIO Port 0 pin 5 Handler         */
+    def_irq_default_handler     PORT0_6_Handler           /* 30: GPIO Port 0 pin 6 Handler         */
+    def_irq_default_handler     PORT0_7_Handler           /* 31: GPIO Port 0 pin 7 Handler         */
 
     .end

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M4/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -46,63 +46,38 @@ __isr_vector:
     .long    SysTick_Handler       /* SysTick Handler */
 
     /* External Interrupts */
-    .long    UART0_IRQHandler        /*   0:  UART 0 RX and TX Combined Interrupt         */
-    .long    Spare_IRQHandler        /*   1:  Undefined                                   */
-    .long    UART1_IRQHandler        /*   2:  UART 1 RX and TX Combined Interrupt         */
-    .long    APB_Slave0_IRQHandler   /*   3:  Reserved for APB Slave                      */
-    .long    APB_Slave1_IRQHandler   /*   4:  Reserved for APB Slave                      */
-    .long    RTC_IRQHandler          /*   5:  RTC Interrupt                               */
-    .long    PORT0_IRQHandler        /*   6:  GPIO Port 0 combined Interrupt              */
-    .long    PORT1_ALL_IRQHandler    /*   7:  GPIO Port 1 combined Interrupt              */
-    .long    TIMER0_IRQHandler       /*   8:  TIMER 0 Interrupt                           */
-    .long    TIMER1_IRQHandler       /*   9:  TIMER 1 Interrupt                           */
-    .long    DUALTIMER_IRQHandler    /*   10: Dual Timer Interrupt                        */
-    .long    APB_Slave2_IRQHandler   /*   11: Reserved for APB Slave                      */
-    .long    UARTOVF_IRQHandler      /*   12: UART 0,1,2 Overflow Interrupt               */
-    .long    APB_Slave3_IRQHandler   /*   13: Reserved for APB Slave                      */
-    .long    RESERVED0_IRQHandler    /*   14: Reserved                                    */
-    .long    TSC_IRQHandler          /*   15: Touch Screen Interrupt                      */
-    .long    PORT0_0_IRQHandler      /*   16: GPIO Port 0 pin 0 Handler                   */
-    .long    PORT0_1_IRQHandler      /*   17: GPIO Port 0 pin 1 Handler                   */
-    .long    PORT0_2_IRQHandler      /*   18: GPIO Port 0 pin 2 Handler                   */
-    .long    PORT0_3_IRQHandler      /*   19: GPIO Port 0 pin 3 Handler                   */
-    .long    PORT0_4_IRQHandler      /*   20: GPIO Port 0 pin 4 Handler                   */
-    .long    PORT0_5_IRQHandler      /*   21: GPIO Port 0 pin 5 Handler                   */
-    .long    PORT0_6_IRQHandler      /*   22: GPIO Port 0 pin 6 Handler                   */
-    .long    PORT0_7_IRQHandler      /*   23: GPIO Port 0 pin 7 Handler                   */
-    .long    PORT0_8_IRQHandler      /*   24: GPIO Port 0 pin 8 Handler                   */
-    .long    PORT0_9_IRQHandler      /*   25: GPIO Port 0 pin 9 Handler                   */
-    .long    PORT0_10_IRQHandler     /*   26: GPIO Port 0 pin 10 Handler                  */
-    .long    PORT0_11_IRQHandler     /*   27: GPIO Port 0 pin 11 Handler                  */
-    .long    PORT0_12_IRQHandler     /*   28: GPIO Port 0 pin 12 Handler                  */
-    .long    PORT0_13_IRQHandler     /*   29: GPIO Port 0 pin 13 Handler                  */
-    .long    PORT0_14_IRQHandler     /*   30: GPIO Port 0 pin 14 Handler                  */
-    .long    PORT0_15_IRQHandler     /*   31: GPIO Port 0 pin 15 Handler                  */
-    .long    FLASH0_IRQHandler       /*   32: Reserved for Flash                          */
-    .long    FLASH1_IRQHandler       /*   33: Reserved for Flash                          */
-    .long    RESERVED1_IRQHandler    /*   34: Reserved                                    */
-    .long    RESERVED2_IRQHandler    /*   35: Reserved                                    */
-    .long    RESERVED3_IRQHandler    /*   36: Reserved                                    */
-    .long    RESERVED4_IRQHandler    /*   37: Reserved                                    */
-    .long    RESERVED5_IRQHandler    /*   38: Reserved                                    */
-    .long    RESERVED6_IRQHandler    /*   39: Reserved                                    */
-    .long    RESERVED7_IRQHandler    /*   40: Reserved                                    */
-    .long    RESERVED8_IRQHandler    /*   41: Reserved                                    */
-    .long    PORT2_ALL_IRQHandler    /*   42: GPIO Port 2 combined Interrupt              */
-    .long    PORT3_ALL_IRQHandler    /*   43: GPIO Port 3 combined Interrupt              */
-    .long    TRNG_IRQHandler         /*   44: Random number generator Interrupt           */
-    .long    UART2_IRQHandler        /*   45: UART 2 RX and TX Combined Interrupt         */
-    .long    UART3_IRQHandler        /*   46: UART 3 RX and TX Combined Interrupt         */
-    .long    ETHERNET_IRQHandler     /*   47: Ethernet interrupt     t.b.a.               */
-    .long    I2S_IRQHandler          /*   48: I2S Interrupt                               */
-    .long    MPS2_SPI0_IRQHandler    /*   49: SPI Interrupt (spi header)                  */
-    .long    MPS2_SPI1_IRQHandler    /*   50: SPI Interrupt (clcd)                        */
-    .long    MPS2_SPI2_IRQHandler    /*   51: SPI Interrupt (spi 1 ADC replacement)       */
-    .long    MPS2_SPI3_IRQHandler    /*   52: SPI Interrupt (spi 0 shield 0 replacement)  */
-    .long    MPS2_SPI4_IRQHandler    /*   53: SPI Interrupt  (shield 1)                   */
-    .long    PORT4_ALL_IRQHandler    /*   54: GPIO Port 4 combined Interrupt              */
-    .long    PORT5_ALL_IRQHandler    /*   55: GPIO Port 5 combined Interrupt              */
-    .long    UART4_IRQHandler        /*   56: UART 4 RX and TX Combined Interrupt         */
+    .long     UARTRX0_Handler           /* UART 0 RX Handler                 */
+    .long     UARTTX0_Handler           /* UART 0 TX Handler                 */
+    .long     UARTRX1_Handler           /* UART 1 RX Handler                 */
+    .long     UARTTX1_Handler           /* UART 1 TX Handler                 */
+    .long     UARTRX2_Handler           /* UART 2 RX Handler                 */
+    .long     UARTTX2_Handler           /* UART 2 TX Handler                 */
+    .long     PORT0_COMB_Handler        /* GPIO Port 0 Combined Handler      */
+    .long     PORT1_COMB_Handler        /* GPIO Port 1 Combined Handler      */
+    .long     TIMER0_Handler            /* TIMER 0 handler                   */
+    .long     TIMER1_Handler            /* TIMER 1 handler                   */
+    .long     DUALTIMER_HANDLER         /* Dual timer handler                */
+    .long     SPI_Handler               /* SPI exceptions Handler            */
+    .long     UARTOVF_Handler           /* UART 0,1,2 Overflow Handler       */
+    .long     ETHERNET_Handler          /* Ethernet Overflow Handler         */
+    .long     I2S_Handler               /* I2S Handler                       */
+    .long     TSC_Handler               /* Touch Screen handler              */
+    .long     PORT2_COMB_Handler        /* GPIO Port 2 Combined Handler      */
+    .long     PORT3_COMB_Handler        /* GPIO Port 3 Combined Handler      */
+    .long     UARTRX3_Handler           /* UART 3 RX Handler                 */
+    .long     UARTTX3_Handler           /* UART 3 TX Handler                 */
+    .long     UARTRX4_Handler           /* UART 4 RX Handler                 */
+    .long     UARTTX4_Handler           /* UART 4 TX Handler                 */
+    .long     ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler */
+    .long     SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler     */
+    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */
+    .long     PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler         */
+    .long     PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler         */
+    .long     PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler         */
+    .long     PORT0_4_Handler           /* GPIO Port 0 pin 4 Handler         */
+    .long     PORT0_5_Handler           /* GPIO Port 0 pin 5 Handler         */
+    .long     PORT0_6_Handler           /* GPIO Port 0 pin 6 Handler         */
+    .long     PORT0_7_Handler           /* GPIO Port 0 pin 7 Handler         */
 
     .size    __isr_vector, . - __isr_vector
 
@@ -196,62 +171,37 @@ system_startup:
     .endm
 
     /* External interrupts */
-    def_irq_default_handler     UART0_IRQHandler        /* 0:  UART 0 RX and TX Combined Interrupt        */
-    def_irq_default_handler     Spare_IRQHandler        /* 1:  Undefined                                  */
-    def_irq_default_handler     UART1_IRQHandler        /* 2:  UART 1 RX and TX Combined Interrupt        */
-    def_irq_default_handler     APB_Slave0_IRQHandler   /* 3:  Reserved for APB Slave                     */
-    def_irq_default_handler     APB_Slave1_IRQHandler   /* 4:  Reserved for APB Slave                     */
-    def_irq_default_handler     RTC_IRQHandler          /* 5:  RTC Interrupt                              */
-    def_irq_default_handler     PORT0_IRQHandler        /* 6:  GPIO Port 0 combined Interrupt             */
-    def_irq_default_handler     PORT1_ALL_IRQHandler    /* 7:  GPIO Port 1 combined Interrupt             */
-    def_irq_default_handler     TIMER0_IRQHandler       /* 8:  TIMER 0 Interrupt                          */
-    def_irq_default_handler     TIMER1_IRQHandler       /* 9:  TIMER 1 Interrupt                          */
-    def_irq_default_handler     DUALTIMER_IRQHandler    /* 10: Dual Timer Interrupt                       */
-    def_irq_default_handler     APB_Slave2_IRQHandler   /* 11: Reserved for APB Slave                     */
-    def_irq_default_handler     UARTOVF_IRQHandler      /* 12: UART 0,1,2 Overflow Interrupt              */
-    def_irq_default_handler     APB_Slave3_IRQHandler   /* 13: Reserved for APB Slave                     */
-    def_irq_default_handler     RESERVED0_IRQHandler    /* 14: Reserved                                   */
-    def_irq_default_handler     TSC_IRQHandler          /* 15: Touch Screen Interrupt                     */
-    def_irq_default_handler     PORT0_0_IRQHandler      /* 16: GPIO Port 0 pin 0 Handler                  */
-    def_irq_default_handler     PORT0_1_IRQHandler      /* 17: GPIO Port 0 pin 1 Handler                  */
-    def_irq_default_handler     PORT0_2_IRQHandler      /* 18: GPIO Port 0 pin 2 Handler                  */
-    def_irq_default_handler     PORT0_3_IRQHandler      /* 19: GPIO Port 0 pin 3 Handler                  */
-    def_irq_default_handler     PORT0_4_IRQHandler      /* 20: GPIO Port 0 pin 4 Handler                  */
-    def_irq_default_handler     PORT0_5_IRQHandler      /* 21: GPIO Port 0 pin 5 Handler                  */
-    def_irq_default_handler     PORT0_6_IRQHandler      /* 22: GPIO Port 0 pin 6 Handler                  */
-    def_irq_default_handler     PORT0_7_IRQHandler      /* 23: GPIO Port 0 pin 7 Handler                  */
-    def_irq_default_handler     PORT0_8_IRQHandler      /* 24: GPIO Port 0 pin 8 Handler                  */
-    def_irq_default_handler     PORT0_9_IRQHandler      /* 25: GPIO Port 0 pin 9 Handler                  */
-    def_irq_default_handler     PORT0_10_IRQHandler     /* 26: GPIO Port 0 pin 10 Handler                 */
-    def_irq_default_handler     PORT0_11_IRQHandler     /* 27: GPIO Port 0 pin 11 Handler                 */
-    def_irq_default_handler     PORT0_12_IRQHandler     /* 28: GPIO Port 0 pin 12 Handler                 */
-    def_irq_default_handler     PORT0_13_IRQHandler     /* 29: GPIO Port 0 pin 13 Handler                 */
-    def_irq_default_handler     PORT0_14_IRQHandler     /* 30: GPIO Port 0 pin 14 Handler                 */
-    def_irq_default_handler     PORT0_15_IRQHandler     /* 31: GPIO Port 0 pin 15 Handler                 */
-    def_irq_default_handler     FLASH0_IRQHandler       /* 32: Reserved for Flash                         */
-    def_irq_default_handler     FLASH1_IRQHandler       /* 33: Reserved for Flash                         */
-    def_irq_default_handler     RESERVED1_IRQHandler    /* 34: Reserved                                   */
-    def_irq_default_handler     RESERVED2_IRQHandler    /* 35: Reserved                                   */
-    def_irq_default_handler     RESERVED3_IRQHandler    /* 36: Reserved                                   */
-    def_irq_default_handler     RESERVED4_IRQHandler    /* 37: Reserved                                   */
-    def_irq_default_handler     RESERVED5_IRQHandler    /* 38: Reserved                                   */
-    def_irq_default_handler     RESERVED6_IRQHandler    /* 39: Reserved                                   */
-    def_irq_default_handler     RESERVED7_IRQHandler    /* 40: Reserved                                   */
-    def_irq_default_handler     RESERVED8_IRQHandler    /* 41: Reserved                                   */
-    def_irq_default_handler     PORT2_ALL_IRQHandler    /* 42: GPIO Port 2 combined Interrupt             */
-    def_irq_default_handler     PORT3_ALL_IRQHandler    /* 43: GPIO Port 3 combined Interrupt             */
-    def_irq_default_handler     TRNG_IRQHandler         /* 44: Random number generator Interrupt          */
-    def_irq_default_handler     UART2_IRQHandler        /* 45: UART 2 RX and TX Combined Interrupt        */
-    def_irq_default_handler     UART3_IRQHandler        /* 46: UART 3 RX and TX Combined Interrupt        */
-    def_irq_default_handler     ETHERNET_IRQHandler     /* 47: Ethernet interrupt     t.b.a.              */
-    def_irq_default_handler     I2S_IRQHandler          /* 48: I2S Interrupt                              */
-    def_irq_default_handler     MPS2_SPI0_IRQHandler    /* 49: SPI Interrupt (spi header)                 */
-    def_irq_default_handler     MPS2_SPI1_IRQHandler    /* 50: SPI Interrupt (clcd)                       */
-    def_irq_default_handler     MPS2_SPI2_IRQHandler    /* 51: SPI Interrupt (spi 1 ADC replacement)      */
-    def_irq_default_handler     MPS2_SPI3_IRQHandler    /* 52: SPI Interrupt (spi 0 shield 0 replacement) */
-    def_irq_default_handler     MPS2_SPI4_IRQHandler    /* 53: SPI Interrupt  (shield 1)                  */
-    def_irq_default_handler     PORT4_ALL_IRQHandler    /* 54: GPIO Port 4 combined Interrupt             */
-    def_irq_default_handler     PORT5_ALL_IRQHandler    /* 55: GPIO Port 5 combined Interrupt             */
-    def_irq_default_handler     UART4_IRQHandler        /* 56: UART 4 RX and TX Combined Interrupt        */
+    def_irq_default_handler     UARTRX0_Handler           /* 0:  UART 0 RX Handler                 */
+    def_irq_default_handler     UARTTX0_Handler           /* 1:  UART 0 TX Handler                 */
+    def_irq_default_handler     UARTRX1_Handler           /* 2:  UART 1 RX Handler                 */
+    def_irq_default_handler     UARTTX1_Handler           /* 3:  UART 1 TX Handler                 */
+    def_irq_default_handler     UARTRX2_Handler           /* 4:  UART 2 RX Handler                 */
+    def_irq_default_handler     UARTTX2_Handler           /* 5:  UART 2 TX Handler                 */
+    def_irq_default_handler     PORT0_COMB_Handler        /* 6:  GPIO Port 0 Combined Handler      */
+    def_irq_default_handler     PORT1_COMB_Handler        /* 7:  GPIO Port 1 Combined Handler      */
+    def_irq_default_handler     TIMER0_Handler            /* 8:  TIMER 0 handler                   */
+    def_irq_default_handler     TIMER1_Handler            /* 9:  TIMER 1 handler                   */
+    def_irq_default_handler     DUALTIMER_HANDLER         /* 10: Dual timer handler                */
+    def_irq_default_handler     SPI_Handler               /* 11: SPI exceptions Handler            */
+    def_irq_default_handler     UARTOVF_Handler           /* 12: UART 0,1,2 Overflow Handler       */
+    def_irq_default_handler     ETHERNET_Handler          /* 13: Ethernet Overflow Handler         */
+    def_irq_default_handler     I2S_Handler               /* 14: I2S Handler                       */
+    def_irq_default_handler     TSC_Handler               /* 15: Touch Screen handler              */
+    def_irq_default_handler     PORT2_COMB_Handler        /* 16: GPIO Port 2 Combined Handler      */
+    def_irq_default_handler     PORT3_COMB_Handler        /* 17: GPIO Port 3 Combined Handler      */
+    def_irq_default_handler     UARTRX3_Handler           /* 18: UART 3 RX Handler                 */
+    def_irq_default_handler     UARTTX3_Handler           /* 19: UART 3 TX Handler                 */
+    def_irq_default_handler     UARTRX4_Handler           /* 20: UART 4 RX Handler                 */
+    def_irq_default_handler     UARTTX4_Handler           /* 21: UART 4 TX Handler                 */
+    def_irq_default_handler     ADCSPI_Handler            /* 22: SHIELD ADC SPI exceptions Handler */
+    def_irq_default_handler     SHIELDSPI_Handler         /* 23: SHIELD SPI exceptions Handler     */
+    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */
+    def_irq_default_handler     PORT0_1_Handler           /* 25: GPIO Port 0 pin 1 Handler         */
+    def_irq_default_handler     PORT0_2_Handler           /* 26: GPIO Port 0 pin 2 Handler         */
+    def_irq_default_handler     PORT0_3_Handler           /* 27: GPIO Port 0 pin 3 Handler         */
+    def_irq_default_handler     PORT0_4_Handler           /* 28: GPIO Port 0 pin 4 Handler         */
+    def_irq_default_handler     PORT0_5_Handler           /* 29: GPIO Port 0 pin 5 Handler         */
+    def_irq_default_handler     PORT0_6_Handler           /* 30: GPIO Port 0 pin 6 Handler         */
+    def_irq_default_handler     PORT0_7_Handler           /* 31: GPIO Port 0 pin 7 Handler         */
 
     .end

--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/TARGET_FVP_MPS2_M7/device/TOOLCHAIN_GCC_ARM/startup_MPS2.S
@@ -46,63 +46,38 @@ __isr_vector:
     .long    SysTick_Handler       /* SysTick Handler */
 
     /* External Interrupts */
-    .long    UART0_IRQHandler        /*   0:  UART 0 RX and TX Combined Interrupt         */
-    .long    Spare_IRQHandler        /*   1:  Undefined                                   */
-    .long    UART1_IRQHandler        /*   2:  UART 1 RX and TX Combined Interrupt         */
-    .long    APB_Slave0_IRQHandler   /*   3:  Reserved for APB Slave                      */
-    .long    APB_Slave1_IRQHandler   /*   4:  Reserved for APB Slave                      */
-    .long    RTC_IRQHandler          /*   5:  RTC Interrupt                               */
-    .long    PORT0_IRQHandler        /*   6:  GPIO Port 0 combined Interrupt              */
-    .long    PORT1_ALL_IRQHandler    /*   7:  GPIO Port 1 combined Interrupt              */
-    .long    TIMER0_IRQHandler       /*   8:  TIMER 0 Interrupt                           */
-    .long    TIMER1_IRQHandler       /*   9:  TIMER 1 Interrupt                           */
-    .long    DUALTIMER_IRQHandler    /*   10: Dual Timer Interrupt                        */
-    .long    APB_Slave2_IRQHandler   /*   11: Reserved for APB Slave                      */
-    .long    UARTOVF_IRQHandler      /*   12: UART 0,1,2 Overflow Interrupt               */
-    .long    APB_Slave3_IRQHandler   /*   13: Reserved for APB Slave                      */
-    .long    RESERVED0_IRQHandler    /*   14: Reserved                                    */
-    .long    TSC_IRQHandler          /*   15: Touch Screen Interrupt                      */
-    .long    PORT0_0_IRQHandler      /*   16: GPIO Port 0 pin 0 Handler                   */
-    .long    PORT0_1_IRQHandler      /*   17: GPIO Port 0 pin 1 Handler                   */
-    .long    PORT0_2_IRQHandler      /*   18: GPIO Port 0 pin 2 Handler                   */
-    .long    PORT0_3_IRQHandler      /*   19: GPIO Port 0 pin 3 Handler                   */
-    .long    PORT0_4_IRQHandler      /*   20: GPIO Port 0 pin 4 Handler                   */
-    .long    PORT0_5_IRQHandler      /*   21: GPIO Port 0 pin 5 Handler                   */
-    .long    PORT0_6_IRQHandler      /*   22: GPIO Port 0 pin 6 Handler                   */
-    .long    PORT0_7_IRQHandler      /*   23: GPIO Port 0 pin 7 Handler                   */
-    .long    PORT0_8_IRQHandler      /*   24: GPIO Port 0 pin 8 Handler                   */
-    .long    PORT0_9_IRQHandler      /*   25: GPIO Port 0 pin 9 Handler                   */
-    .long    PORT0_10_IRQHandler     /*   26: GPIO Port 0 pin 10 Handler                  */
-    .long    PORT0_11_IRQHandler     /*   27: GPIO Port 0 pin 11 Handler                  */
-    .long    PORT0_12_IRQHandler     /*   28: GPIO Port 0 pin 12 Handler                  */
-    .long    PORT0_13_IRQHandler     /*   29: GPIO Port 0 pin 13 Handler                  */
-    .long    PORT0_14_IRQHandler     /*   30: GPIO Port 0 pin 14 Handler                  */
-    .long    PORT0_15_IRQHandler     /*   31: GPIO Port 0 pin 15 Handler                  */
-    .long    FLASH0_IRQHandler       /*   32: Reserved for Flash                          */
-    .long    FLASH1_IRQHandler       /*   33: Reserved for Flash                          */
-    .long    RESERVED1_IRQHandler    /*   34: Reserved                                    */
-    .long    RESERVED2_IRQHandler    /*   35: Reserved                                    */
-    .long    RESERVED3_IRQHandler    /*   36: Reserved                                    */
-    .long    RESERVED4_IRQHandler    /*   37: Reserved                                    */
-    .long    RESERVED5_IRQHandler    /*   38: Reserved                                    */
-    .long    RESERVED6_IRQHandler    /*   39: Reserved                                    */
-    .long    RESERVED7_IRQHandler    /*   40: Reserved                                    */
-    .long    RESERVED8_IRQHandler    /*   41: Reserved                                    */
-    .long    PORT2_ALL_IRQHandler    /*   42: GPIO Port 2 combined Interrupt              */
-    .long    PORT3_ALL_IRQHandler    /*   43: GPIO Port 3 combined Interrupt              */
-    .long    TRNG_IRQHandler         /*   44: Random number generator Interrupt           */
-    .long    UART2_IRQHandler        /*   45: UART 2 RX and TX Combined Interrupt         */
-    .long    UART3_IRQHandler        /*   46: UART 3 RX and TX Combined Interrupt         */
-    .long    ETHERNET_IRQHandler     /*   47: Ethernet interrupt     t.b.a.               */
-    .long    I2S_IRQHandler          /*   48: I2S Interrupt                               */
-    .long    MPS2_SPI0_IRQHandler    /*   49: SPI Interrupt (spi header)                  */
-    .long    MPS2_SPI1_IRQHandler    /*   50: SPI Interrupt (clcd)                        */
-    .long    MPS2_SPI2_IRQHandler    /*   51: SPI Interrupt (spi 1 ADC replacement)       */
-    .long    MPS2_SPI3_IRQHandler    /*   52: SPI Interrupt (spi 0 shield 0 replacement)  */
-    .long    MPS2_SPI4_IRQHandler    /*   53: SPI Interrupt  (shield 1)                   */
-    .long    PORT4_ALL_IRQHandler    /*   54: GPIO Port 4 combined Interrupt              */
-    .long    PORT5_ALL_IRQHandler    /*   55: GPIO Port 5 combined Interrupt              */
-    .long    UART4_IRQHandler        /*   56: UART 4 RX and TX Combined Interrupt         */
+    .long     UARTRX0_Handler           /* UART 0 RX Handler                 */
+    .long     UARTTX0_Handler           /* UART 0 TX Handler                 */
+    .long     UARTRX1_Handler           /* UART 1 RX Handler                 */
+    .long     UARTTX1_Handler           /* UART 1 TX Handler                 */
+    .long     UARTRX2_Handler           /* UART 2 RX Handler                 */
+    .long     UARTTX2_Handler           /* UART 2 TX Handler                 */
+    .long     PORT0_COMB_Handler        /* GPIO Port 0 Combined Handler      */
+    .long     PORT1_COMB_Handler        /* GPIO Port 1 Combined Handler      */
+    .long     TIMER0_Handler            /* TIMER 0 handler                   */
+    .long     TIMER1_Handler            /* TIMER 1 handler                   */
+    .long     DUALTIMER_HANDLER         /* Dual timer handler                */
+    .long     SPI_Handler               /* SPI exceptions Handler            */
+    .long     UARTOVF_Handler           /* UART 0,1,2 Overflow Handler       */
+    .long     ETHERNET_Handler          /* Ethernet Overflow Handler         */
+    .long     I2S_Handler               /* I2S Handler                       */
+    .long     TSC_Handler               /* Touch Screen handler              */
+    .long     PORT2_COMB_Handler        /* GPIO Port 2 Combined Handler      */
+    .long     PORT3_COMB_Handler        /* GPIO Port 3 Combined Handler      */
+    .long     UARTRX3_Handler           /* UART 3 RX Handler                 */
+    .long     UARTTX3_Handler           /* UART 3 TX Handler                 */
+    .long     UARTRX4_Handler           /* UART 4 RX Handler                 */
+    .long     UARTTX4_Handler           /* UART 4 TX Handler                 */
+    .long     ADCSPI_Handler            /* SHIELD ADC SPI exceptions Handler */
+    .long     SHIELDSPI_Handler         /* SHIELD SPI exceptions Handler     */
+    .long     PORT0_0_Handler           /* GPIO Port 0 pin 0 Handler         */
+    .long     PORT0_1_Handler           /* GPIO Port 0 pin 1 Handler         */
+    .long     PORT0_2_Handler           /* GPIO Port 0 pin 2 Handler         */
+    .long     PORT0_3_Handler           /* GPIO Port 0 pin 3 Handler         */
+    .long     PORT0_4_Handler           /* GPIO Port 0 pin 4 Handler         */
+    .long     PORT0_5_Handler           /* GPIO Port 0 pin 5 Handler         */
+    .long     PORT0_6_Handler           /* GPIO Port 0 pin 6 Handler         */
+    .long     PORT0_7_Handler           /* GPIO Port 0 pin 7 Handler         */
 
     .size    __isr_vector, . - __isr_vector
 
@@ -196,62 +171,37 @@ system_startup:
     .endm
 
     /* External interrupts */
-    def_irq_default_handler     UART0_IRQHandler        /* 0:  UART 0 RX and TX Combined Interrupt        */
-    def_irq_default_handler     Spare_IRQHandler        /* 1:  Undefined                                  */
-    def_irq_default_handler     UART1_IRQHandler        /* 2:  UART 1 RX and TX Combined Interrupt        */
-    def_irq_default_handler     APB_Slave0_IRQHandler   /* 3:  Reserved for APB Slave                     */
-    def_irq_default_handler     APB_Slave1_IRQHandler   /* 4:  Reserved for APB Slave                     */
-    def_irq_default_handler     RTC_IRQHandler          /* 5:  RTC Interrupt                              */
-    def_irq_default_handler     PORT0_IRQHandler        /* 6:  GPIO Port 0 combined Interrupt             */
-    def_irq_default_handler     PORT1_ALL_IRQHandler    /* 7:  GPIO Port 1 combined Interrupt             */
-    def_irq_default_handler     TIMER0_IRQHandler       /* 8:  TIMER 0 Interrupt                          */
-    def_irq_default_handler     TIMER1_IRQHandler       /* 9:  TIMER 1 Interrupt                          */
-    def_irq_default_handler     DUALTIMER_IRQHandler    /* 10: Dual Timer Interrupt                       */
-    def_irq_default_handler     APB_Slave2_IRQHandler   /* 11: Reserved for APB Slave                     */
-    def_irq_default_handler     UARTOVF_IRQHandler      /* 12: UART 0,1,2 Overflow Interrupt              */
-    def_irq_default_handler     APB_Slave3_IRQHandler   /* 13: Reserved for APB Slave                     */
-    def_irq_default_handler     RESERVED0_IRQHandler    /* 14: Reserved                                   */
-    def_irq_default_handler     TSC_IRQHandler          /* 15: Touch Screen Interrupt                     */
-    def_irq_default_handler     PORT0_0_IRQHandler      /* 16: GPIO Port 0 pin 0 Handler                  */
-    def_irq_default_handler     PORT0_1_IRQHandler      /* 17: GPIO Port 0 pin 1 Handler                  */
-    def_irq_default_handler     PORT0_2_IRQHandler      /* 18: GPIO Port 0 pin 2 Handler                  */
-    def_irq_default_handler     PORT0_3_IRQHandler      /* 19: GPIO Port 0 pin 3 Handler                  */
-    def_irq_default_handler     PORT0_4_IRQHandler      /* 20: GPIO Port 0 pin 4 Handler                  */
-    def_irq_default_handler     PORT0_5_IRQHandler      /* 21: GPIO Port 0 pin 5 Handler                  */
-    def_irq_default_handler     PORT0_6_IRQHandler      /* 22: GPIO Port 0 pin 6 Handler                  */
-    def_irq_default_handler     PORT0_7_IRQHandler      /* 23: GPIO Port 0 pin 7 Handler                  */
-    def_irq_default_handler     PORT0_8_IRQHandler      /* 24: GPIO Port 0 pin 8 Handler                  */
-    def_irq_default_handler     PORT0_9_IRQHandler      /* 25: GPIO Port 0 pin 9 Handler                  */
-    def_irq_default_handler     PORT0_10_IRQHandler     /* 26: GPIO Port 0 pin 10 Handler                 */
-    def_irq_default_handler     PORT0_11_IRQHandler     /* 27: GPIO Port 0 pin 11 Handler                 */
-    def_irq_default_handler     PORT0_12_IRQHandler     /* 28: GPIO Port 0 pin 12 Handler                 */
-    def_irq_default_handler     PORT0_13_IRQHandler     /* 29: GPIO Port 0 pin 13 Handler                 */
-    def_irq_default_handler     PORT0_14_IRQHandler     /* 30: GPIO Port 0 pin 14 Handler                 */
-    def_irq_default_handler     PORT0_15_IRQHandler     /* 31: GPIO Port 0 pin 15 Handler                 */
-    def_irq_default_handler     FLASH0_IRQHandler       /* 32: Reserved for Flash                         */
-    def_irq_default_handler     FLASH1_IRQHandler       /* 33: Reserved for Flash                         */
-    def_irq_default_handler     RESERVED1_IRQHandler    /* 34: Reserved                                   */
-    def_irq_default_handler     RESERVED2_IRQHandler    /* 35: Reserved                                   */
-    def_irq_default_handler     RESERVED3_IRQHandler    /* 36: Reserved                                   */
-    def_irq_default_handler     RESERVED4_IRQHandler    /* 37: Reserved                                   */
-    def_irq_default_handler     RESERVED5_IRQHandler    /* 38: Reserved                                   */
-    def_irq_default_handler     RESERVED6_IRQHandler    /* 39: Reserved                                   */
-    def_irq_default_handler     RESERVED7_IRQHandler    /* 40: Reserved                                   */
-    def_irq_default_handler     RESERVED8_IRQHandler    /* 41: Reserved                                   */
-    def_irq_default_handler     PORT2_ALL_IRQHandler    /* 42: GPIO Port 2 combined Interrupt             */
-    def_irq_default_handler     PORT3_ALL_IRQHandler    /* 43: GPIO Port 3 combined Interrupt             */
-    def_irq_default_handler     TRNG_IRQHandler         /* 44: Random number generator Interrupt          */
-    def_irq_default_handler     UART2_IRQHandler        /* 45: UART 2 RX and TX Combined Interrupt        */
-    def_irq_default_handler     UART3_IRQHandler        /* 46: UART 3 RX and TX Combined Interrupt        */
-    def_irq_default_handler     ETHERNET_IRQHandler     /* 47: Ethernet interrupt     t.b.a.              */
-    def_irq_default_handler     I2S_IRQHandler          /* 48: I2S Interrupt                              */
-    def_irq_default_handler     MPS2_SPI0_IRQHandler    /* 49: SPI Interrupt (spi header)                 */
-    def_irq_default_handler     MPS2_SPI1_IRQHandler    /* 50: SPI Interrupt (clcd)                       */
-    def_irq_default_handler     MPS2_SPI2_IRQHandler    /* 51: SPI Interrupt (spi 1 ADC replacement)      */
-    def_irq_default_handler     MPS2_SPI3_IRQHandler    /* 52: SPI Interrupt (spi 0 shield 0 replacement) */
-    def_irq_default_handler     MPS2_SPI4_IRQHandler    /* 53: SPI Interrupt  (shield 1)                  */
-    def_irq_default_handler     PORT4_ALL_IRQHandler    /* 54: GPIO Port 4 combined Interrupt             */
-    def_irq_default_handler     PORT5_ALL_IRQHandler    /* 55: GPIO Port 5 combined Interrupt             */
-    def_irq_default_handler     UART4_IRQHandler        /* 56: UART 4 RX and TX Combined Interrupt        */
+    def_irq_default_handler     UARTRX0_Handler           /* 0:  UART 0 RX Handler                 */
+    def_irq_default_handler     UARTTX0_Handler           /* 1:  UART 0 TX Handler                 */
+    def_irq_default_handler     UARTRX1_Handler           /* 2:  UART 1 RX Handler                 */
+    def_irq_default_handler     UARTTX1_Handler           /* 3:  UART 1 TX Handler                 */
+    def_irq_default_handler     UARTRX2_Handler           /* 4:  UART 2 RX Handler                 */
+    def_irq_default_handler     UARTTX2_Handler           /* 5:  UART 2 TX Handler                 */
+    def_irq_default_handler     PORT0_COMB_Handler        /* 6:  GPIO Port 0 Combined Handler      */
+    def_irq_default_handler     PORT1_COMB_Handler        /* 7:  GPIO Port 1 Combined Handler      */
+    def_irq_default_handler     TIMER0_Handler            /* 8:  TIMER 0 handler                   */
+    def_irq_default_handler     TIMER1_Handler            /* 9:  TIMER 1 handler                   */
+    def_irq_default_handler     DUALTIMER_HANDLER         /* 10: Dual timer handler                */
+    def_irq_default_handler     SPI_Handler               /* 11: SPI exceptions Handler            */
+    def_irq_default_handler     UARTOVF_Handler           /* 12: UART 0,1,2 Overflow Handler       */
+    def_irq_default_handler     ETHERNET_Handler          /* 13: Ethernet Overflow Handler         */
+    def_irq_default_handler     I2S_Handler               /* 14: I2S Handler                       */
+    def_irq_default_handler     TSC_Handler               /* 15: Touch Screen handler              */
+    def_irq_default_handler     PORT2_COMB_Handler        /* 16: GPIO Port 2 Combined Handler      */
+    def_irq_default_handler     PORT3_COMB_Handler        /* 17: GPIO Port 3 Combined Handler      */
+    def_irq_default_handler     UARTRX3_Handler           /* 18: UART 3 RX Handler                 */
+    def_irq_default_handler     UARTTX3_Handler           /* 19: UART 3 TX Handler                 */
+    def_irq_default_handler     UARTRX4_Handler           /* 20: UART 4 RX Handler                 */
+    def_irq_default_handler     UARTTX4_Handler           /* 21: UART 4 TX Handler                 */
+    def_irq_default_handler     ADCSPI_Handler            /* 22: SHIELD ADC SPI exceptions Handler */
+    def_irq_default_handler     SHIELDSPI_Handler         /* 23: SHIELD SPI exceptions Handler     */
+    def_irq_default_handler     PORT0_0_Handler           /* 24: GPIO Port 0 pin 0 Handler         */
+    def_irq_default_handler     PORT0_1_Handler           /* 25: GPIO Port 0 pin 1 Handler         */
+    def_irq_default_handler     PORT0_2_Handler           /* 26: GPIO Port 0 pin 2 Handler         */
+    def_irq_default_handler     PORT0_3_Handler           /* 27: GPIO Port 0 pin 3 Handler         */
+    def_irq_default_handler     PORT0_4_Handler           /* 28: GPIO Port 0 pin 4 Handler         */
+    def_irq_default_handler     PORT0_5_Handler           /* 29: GPIO Port 0 pin 5 Handler         */
+    def_irq_default_handler     PORT0_6_Handler           /* 30: GPIO Port 0 pin 6 Handler         */
+    def_irq_default_handler     PORT0_7_Handler           /* 31: GPIO Port 0 pin 7 Handler         */
 
     .end


### PR DESCRIPTION
### Description

In Fast Models MPS2 targets (M3/M4/M7), the GCC startup scripts defined external interrupt handlers were wrong.

Now got them fixed. They are aligned with ARMCC and IAR toolchain startup scripts

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

@ARMmbed/mbed-os-hal 