### PR TITLE
Greentea: Added trace mutex

### DIFF
--- a/features/frameworks/greentea-client/greentea-client/greentea_serial.h
+++ b/features/frameworks/greentea-client/greentea-client/greentea_serial.h
@@ -6,10 +6,16 @@
 
 #include "RawSerial.h"
 #include "SingletonPtr.h"
+#include "PlatformMutex.h"
 
 class GreenteaSerial : public mbed::RawSerial {
 public:
     GreenteaSerial();
+    void set_trace_mutex(PlatformMutex *trace_mutex);
+    void lock_trace();
+    void unlock_trace();
+private:
+    PlatformMutex *_trace_mutex;
 };
 
 extern SingletonPtr<GreenteaSerial> greentea_serial;

--- a/features/frameworks/greentea-client/source/greentea_serial.cpp
+++ b/features/frameworks/greentea-client/source/greentea_serial.cpp
@@ -12,7 +12,7 @@
 
 SingletonPtr<GreenteaSerial> greentea_serial;
 
-GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE) {
+GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATFORM_STDIO_BAUD_RATE), _trace_mutex(NULL) {
 #if   CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTS
     set_flow_control(SerialBase::RTS, STDIO_UART_RTS, NC);
 #elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_CTS
@@ -20,4 +20,20 @@ GreenteaSerial::GreenteaSerial() : mbed::RawSerial(USBTX, USBRX, MBED_CONF_PLATF
 #elif CONSOLE_FLOWCONTROL == CONSOLE_FLOWCONTROL_RTSCTS
     set_flow_control(SerialBase::RTSCTS, STDIO_UART_RTS, STDIO_UART_CTS);
 #endif
+}
+
+void GreenteaSerial::set_trace_mutex(PlatformMutex *trace_mutex) {
+	_trace_mutex = trace_mutex;
+}
+
+void GreenteaSerial::lock_trace() {
+    if (_trace_mutex) {
+    	_trace_mutex->lock();
+    }
+}
+
+void GreenteaSerial::unlock_trace() {
+    if (_trace_mutex) {
+    	_trace_mutex->unlock();
+    }
 }

--- a/features/frameworks/greentea-client/source/greentea_test_env.cpp
+++ b/features/frameworks/greentea-client/source/greentea_test_env.cpp
@@ -213,6 +213,8 @@ void greentea_notify_coverage_end() {
  */
 inline void greentea_write_preamble()
 {
+	greentea_serial->lock_trace();
+
     greentea_serial->putc('{');
     greentea_serial->putc('{');
 }
@@ -235,6 +237,8 @@ inline void greentea_write_postamble()
     greentea_serial->putc('}');
     greentea_serial->putc('\r');
     greentea_serial->putc('\n');
+
+    greentea_serial->unlock_trace();
 }
 
 /**


### PR DESCRIPTION
### Description

This change is to allow printing Mbed traces while running Greentea with verbose -vv flag.

Typical usage:

```
int main() {
    PlatformMutex trace_mutex;
    greentea_serial->set_trace_mutex(&trace_mutex);
    int ret = Harness::run(specification);
    greentea_serial->set_trace_mutex(NULL);
}
```
### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

