### PR TITLE
InternetSocket: Fixed missing unlock before return

### DIFF
--- a/features/netsocket/InternetSocket.cpp
+++ b/features/netsocket/InternetSocket.cpp
@@ -62,6 +62,7 @@ nsapi_error_t InternetSocket::close()
 
     nsapi_error_t ret = NSAPI_ERROR_OK;
     if (!_socket)  {
+        _lock.unlock();
         return NSAPI_ERROR_NO_SOCKET;
     }
 


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Noticed I couldn't open an internetsocket any more after trying to close the socket that wasn't opened.
The mutex was still locked which was caused by a missing unlock in the close function.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

