### PR TITLE
Disable write buffer in debug builds (M3/M4)

### DIFF
--- a/cmsis/TARGET_CORTEX_M/core_cm3.h
+++ b/cmsis/TARGET_CORTEX_M/core_cm3.h
@@ -668,7 +668,7 @@ typedef struct
 #define SCnSCB_ICTR_INTLINESNUM_Msk        (0xFUL /*<< SCnSCB_ICTR_INTLINESNUM_Pos*/)  /*!< ICTR: INTLINESNUM Mask */
 
 /* Auxiliary Control Register Definitions */
-
+#if defined (__CM3_REV) && (__CM3_REV >= 0x200U)
 #define SCnSCB_ACTLR_DISFOLD_Pos            2U                                         /*!< ACTLR: DISFOLD Position */
 #define SCnSCB_ACTLR_DISFOLD_Msk           (1UL << SCnSCB_ACTLR_DISFOLD_Pos)           /*!< ACTLR: DISFOLD Mask */
 
@@ -677,6 +677,7 @@ typedef struct
 
 #define SCnSCB_ACTLR_DISMCYCINT_Pos         0U                                         /*!< ACTLR: DISMCYCINT Position */
 #define SCnSCB_ACTLR_DISMCYCINT_Msk        (1UL /*<< SCnSCB_ACTLR_DISMCYCINT_Pos*/)    /*!< ACTLR: DISMCYCINT Mask */
+#endif
 
 /*@} end of group CMSIS_SCnotSCB */
 

--- a/platform/mbed_application.c
+++ b/platform/mbed_application.c
@@ -71,6 +71,17 @@ void mbed_start_application(uintptr_t address)
     powerdown_scb(address);
     mbed_mpu_free();
 
+#ifdef MBED_DEBUG
+    // Configs to make debugging easier
+#ifdef SCnSCB_ACTLR_DISDEFWBUF_Msk
+    // Disable write buffer to make BusFaults (eg write to ROM via NULL pointer) precise.
+    // Possible on Cortex-M3 and M4, not on M0, M7 or M33.
+    // Would be less necessary if ROM was write-protected in MPU to give a
+    // precise MemManage exception.
+    SCnSCB->ACTLR |= SCnSCB_ACTLR_DISDEFWBUF_Msk;
+#endif
+#endif
+
     sp = *((void **)address + 0);
     pc = *((void **)address + 1);
     start_new_application(sp, pc);


### PR DESCRIPTION
### Description

As part of work to improve the debugging of exceptions, have
Mbed OS make an effort to make exceptions more precise in debug builds
at the cost of performance.

Related pyOCD work:

   https://github.com/mbedmicro/pyOCD/pull/430

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

