### PR TITLE
Online: Include project root path

### DIFF
--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -261,25 +261,26 @@ class Resources(object):
         return list(self._file_refs[file_type])
 
     def _all_parents(self, files):
-        for name in files:
+        for name, path in files:
             components = name.split(self._sep)
             start_at = 0
             for index, directory in reversed(list(enumerate(components))):
                 if directory in self._prefixed_labels:
                     start_at = index + 1
                     break
+            prefix = path.replace(name, "")
             for n in range(start_at, len(components)):
-                parent = self._sep.join(components[:n])
-                yield parent
+                parent_name = self._sep.join(components[:n])
+                parent_path = join(prefix, *components[:n])
+                yield FileRef(parent_name, parent_path)
 
     def _get_from_refs(self, file_type, key):
         if file_type is FileType.INC_DIR:
-            parents = set(self._all_parents(self._get_from_refs(
-                FileType.HEADER, key)))
+            parents = set(self._all_parents(self._file_refs[FileType.HEADER]))
         else:
             parents = set()
         return sorted(
-            list(parents) + [key(f) for f in self.get_file_refs(file_type)]
+            [key(f) for f in list(parents) + self.get_file_refs(file_type)]
         )
 
 

--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -263,8 +263,8 @@ class Resources(object):
     def _all_parents(self, files):
         for name in files:
             components = name.split(self._sep)
-            start_at = 2 if components[0] in set(['', '.']) else 1
-            for index, directory in reversed(list(enumerate(components))[start_at:]):
+            start_at = 0
+            for index, directory in reversed(list(enumerate(components))):
                 if directory in self._prefixed_labels:
                     start_at = index + 1
                     break
@@ -276,7 +276,6 @@ class Resources(object):
         if file_type is FileType.INC_DIR:
             parents = set(self._all_parents(self._get_from_refs(
                 FileType.HEADER, key)))
-            parents.add(".")
         else:
             parents = set()
         return sorted(

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -188,7 +188,7 @@ class ARM(mbedToolchain):
         if self.RESPONSE_FILES:
             opts += ['--via', self.get_inc_file(includes)]
         else:
-            opts += ["-I%s" % i for i in includes]
+            opts += ["-I%s" % i for i in includes if i]
 
         return opts
 
@@ -471,7 +471,7 @@ class ARMC6(ARM_STD):
 
     def get_compile_options(self, defines, includes, for_asm=False):
         opts = ['-D%s' % d for d in defines]
-        opts.extend(["-I%s" % i for i in includes])
+        opts.extend(["-I%s" % i for i in includes if i])
         if for_asm:
             return ["--cpreproc",
                     "--cpreproc_opts=%s" % ",".join(self.flags['common'] + opts)]


### PR DESCRIPTION
### Description

The prior logic assumed that "." would not be added to the include
paths, indicating that the project root would not be added to the 
include paths correctly in the online environment ("." would be 
incorrect there). This change set started by removing the addition 
of ".", and then fixed building from there.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change