### PR TITLE
Add RAM/ROM memory statistics to system stats structure

### DIFF
--- a/TESTS/mbed_platform/stats_sys/main.cpp
+++ b/TESTS/mbed_platform/stats_sys/main.cpp
@@ -45,6 +45,46 @@ void test_sys_info()
     TEST_ASSERT_EQUAL(GCC_ARM, stats.compiler_id);
 #endif
     TEST_ASSERT_NOT_EQUAL(0, stats.compiler_version);
+
+    // RAM / ROM sizes should not be zero and should match the define
+    TEST_ASSERT_NOT_EQUAL(0, stats.ram_size[0]);
+    TEST_ASSERT_NOT_EQUAL(0, stats.rom_size[0]);
+
+    TEST_ASSERT_EQUAL(MBED_RAM_SIZE, stats.ram_size[0]);
+    TEST_ASSERT_EQUAL(MBED_ROM_SIZE, stats.rom_size[0]);
+    TEST_ASSERT_EQUAL(MBED_RAM_START, stats.ram_start[0]);
+    TEST_ASSERT_EQUAL(MBED_ROM_START, stats.rom_start[0]);
+
+#if defined(MBED_RAM1_START) && defined(MBED_RAM1_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.ram_size[1]);
+    TEST_ASSERT_EQUAL(MBED_RAM1_SIZE, stats.ram_size[1]);
+    TEST_ASSERT_EQUAL(MBED_RAM1_START, stats.ram_start[1]);
+#endif
+#if defined(MBED_RAM2_START) && defined(MBED_RAM2_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.ram_size[2]);
+    TEST_ASSERT_EQUAL(MBED_RAM2_SIZE, stats.ram_size[2]);
+    TEST_ASSERT_EQUAL(MBED_RAM2_START, stats.ram_start[2]);
+#endif
+#if defined(MBED_RAM3_START) && defined(MBED_RAM3_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.ram_size[3]);
+    TEST_ASSERT_EQUAL(MBED_RAM3_SIZE, stats.ram_size[3]);
+    TEST_ASSERT_EQUAL(MBED_RAM3_START, stats.ram_start[3]);
+#endif
+#if defined(MBED_ROM1_START) && defined(MBED_ROM1_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.rom_size[1]);
+    TEST_ASSERT_EQUAL(MBED_ROM1_SIZE, stats.rom_size[1]);
+    TEST_ASSERT_EQUAL(MBED_ROM1_START, stats.rom_start[1]);
+#endif
+#if defined(MBED_ROM2_START) && defined(MBED_ROM2_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.rom_size[2]);
+    TEST_ASSERT_EQUAL(MBED_ROM2_SIZE, stats.rom_size[2]);
+    TEST_ASSERT_EQUAL(MBED_ROM2_START, stats.rom_start[2]);
+#endif
+#if defined(MBED_ROM3_START) && defined(MBED_ROM3_SIZE)
+    TEST_ASSERT_NOT_EQUAL(0, stats.rom_size[3]);
+    TEST_ASSERT_EQUAL(MBED_ROM3_SIZE, stats.rom_size[3]);
+    TEST_ASSERT_EQUAL(MBED_ROM3_START, stats.rom_start[3]);
+#endif
 }
 
 Case cases[] = {

--- a/platform/mbed_stats.c
+++ b/platform/mbed_stats.c
@@ -131,6 +131,35 @@ void mbed_stats_sys_get(mbed_stats_sys_t *stats)
 
 #if defined(MBED_SYS_STATS_ENABLED)
     stats->os_version = MBED_VERSION;
+    stats->ram_start[0] = MBED_RAM_START;
+    stats->ram_size[0] = MBED_RAM_SIZE;
+    stats->rom_start[0] = MBED_ROM_START;
+    stats->rom_size[0] = MBED_ROM_SIZE;
+#if defined(MBED_RAM1_START) && defined(MBED_RAM1_SIZE)
+    stats->ram_start[1] = MBED_RAM1_START;
+    stats->ram_size[1] = MBED_RAM1_SIZE;
+#endif
+#if defined(MBED_RAM2_START) && defined(MBED_RAM2_SIZE)
+    stats->ram_start[2] = MBED_RAM2_START;
+    stats->ram_size[2] = MBED_RAM2_SIZE;
+#endif
+#if defined(MBED_RAM3_START) && defined(MBED_RAM3_SIZE)
+    stats->ram_start[3] = MBED_RAM3_START;
+    stats->ram_size[3] = MBED_RAM3_SIZE;
+#endif
+#if defined(MBED_ROM1_START) && defined(MBED_ROM1_SIZE)
+    stats->rom_start[1] = MBED_ROM1_START;
+    stats->rom_size[1] = MBED_ROM1_SIZE;
+#endif
+#if defined(MBED_ROM2_START) && defined(MBED_ROM2_SIZE)
+    stats->rom_start[2] = MBED_ROM2_START;
+    stats->rom_size[2] = MBED_ROM2_SIZE;
+#endif
+#if defined(MBED_ROM3_START) && defined(MBED_ROM3_SIZE)
+    stats->rom_start[3] = MBED_ROM3_START;
+    stats->rom_size[3] = MBED_ROM3_SIZE;
+#endif
+
 #if defined(__CORTEX_M)
     stats->cpu_id = SCB->CPUID;
 #endif

--- a/platform/mbed_stats.h
+++ b/platform/mbed_stats.h
@@ -38,6 +38,9 @@ extern "C" {
 #define MBED_THREAD_STATS_ENABLED   1
 #endif
 
+/** Maximum memory regions reported by mbed-os memory statistics */
+#define MBED_MAX_MEM_REGIONS     4
+
 /**
  * struct mbed_stats_heap_t definition
  */
@@ -144,6 +147,10 @@ typedef struct {
     uint32_t cpu_id;                    /**< CPUID register data (Cortex-M only supported) */
     mbed_compiler_id_t compiler_id;     /**< Compiler ID \ref mbed_compiler_id_t */
     uint32_t compiler_version;          /**< Compiler version */
+    uint32_t ram_start[MBED_MAX_MEM_REGIONS];/**< Start addresses of all internal RAM memories */
+    uint32_t ram_size[MBED_MAX_MEM_REGIONS];/**< Size of all internal RAM memories in target */
+    uint32_t rom_start[MBED_MAX_MEM_REGIONS];/**< Start addresses of all internal ROM memories */
+    uint32_t rom_size[MBED_MAX_MEM_REGIONS];/**< Size of all internal ROM memories in target */
 } mbed_stats_sys_t;
 
 /**


### PR DESCRIPTION
### Description
Internal RAM / ROM memory size and start address of target can be fetched using `mbed_stats_sys_get()` API.

TODO

- [x] Dependent on https://github.com/ARMmbed/mbed-os/pull/8607
- [ ] Update docs
- [x] Update example https://github.com/ARMmbed/mbed-os-example-sys-info/pull/12
- [x] Update tests 

### Pull request type

    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [X] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

CC @SenRamakri 