### PR TITLE
STM32L4: Add support of the new USB Device API

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.c
@@ -113,6 +113,7 @@
   */
 #if defined (USB_OTG_FS)
 static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t epnum);
+static HAL_StatusTypeDef PCD_ReadRxFifo(PCD_HandleTypeDef *hpcd); // MBED PATCH
 #endif /* USB_OTG_FS */
 #if defined (USB)
 static HAL_StatusTypeDef PCD_EP_ISR_Handler(PCD_HandleTypeDef *hpcd);
@@ -162,11 +163,9 @@ HAL_StatusTypeDef HAL_PCD_Init(PCD_HandleTypeDef *hpcd)
   {
     /* Allocate lock resource and initialize it */
     hpcd->Lock = HAL_UNLOCKED;
-
-    // Added for MBED PR #3062
-    for (index = 0; index < hpcd->Init.dev_endpoints ; index++)
-    hpcd->EPLock[index].Lock = HAL_UNLOCKED;
-
+    for (index = 0; index < hpcd->Init.dev_endpoints ; index++) { // MBED PATCH
+      hpcd->EPLock[index].Lock = HAL_UNLOCKED;
+    }
     /* Init the low level hardware : GPIO, CLOCK, NVIC... */
     HAL_PCD_MspInit(hpcd);
   }
@@ -311,10 +310,10 @@ __weak void HAL_PCD_MspDeInit(PCD_HandleTypeDef *hpcd)
   */
 HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
 { 
-  __HAL_LOCK(hpcd); 
+  // MBED PATCH __HAL_LOCK(hpcd); 
   USB_DevConnect (hpcd->Instance);
   __HAL_PCD_ENABLE(hpcd);
-  __HAL_UNLOCK(hpcd); 
+  // MBED PATCH __HAL_UNLOCK(hpcd); 
   return HAL_OK;
 }
 
@@ -325,13 +324,14 @@ HAL_StatusTypeDef HAL_PCD_Start(PCD_HandleTypeDef *hpcd)
   */
 HAL_StatusTypeDef HAL_PCD_Stop(PCD_HandleTypeDef *hpcd)
 { 
-  __HAL_LOCK(hpcd); 
+  // MBED PATCH __HAL_LOCK(hpcd); 
   __HAL_PCD_DISABLE(hpcd);
   USB_StopDevice(hpcd->Instance);
   USB_DevDisconnect (hpcd->Instance);
-  __HAL_UNLOCK(hpcd); 
+  // MBED PATCH __HAL_UNLOCK(hpcd); 
   return HAL_OK;
 }
+
 #if defined (USB_OTG_FS)
 /**
   * @brief  Handles PCD interrupt request.
@@ -431,6 +431,13 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
             }
           }
 
+          // MBED PATCH
+          if (( epint & USB_OTG_DOEPINT_EPDISD) == USB_OTG_DOEPINT_EPDISD)
+          {
+              CLEAR_OUT_EP_INTR(epnum, USB_OTG_DOEPINT_EPDISD);
+          }
+          // MBED PATCH
+
           if(( epint & USB_OTG_DOEPINT_STUP) == USB_OTG_DOEPINT_STUP)
           {
             /* Inform the upper layer that a setup packet is available */
@@ -473,8 +480,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
           {
             fifoemptymsk = 0x1 << epnum;
 
-            // Added for MBED PR #3062
-            atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk);
+            atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk); // MBED PATCH
             
             CLEAR_IN_EP_INTR(epnum, USB_OTG_DIEPINT_XFRC);
             
@@ -690,27 +696,7 @@ void HAL_PCD_IRQHandler(PCD_HandleTypeDef *hpcd)
     /* Handle RxQLevel Interrupt */
     if(__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
     {
-      USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
-      
-      temp = USBx->GRXSTSP;
-      
-      ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
-      
-      if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_DATA_UPDT)
-      {
-        if((temp & USB_OTG_GRXSTSP_BCNT) != 0)
-        {
-          USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4);
-          ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
-          ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
-        }
-      }
-      else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17) ==  STS_SETUP_UPDT)
-      {
-        USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8);
-        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4;
-      }
-      USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+      PCD_ReadRxFifo(hpcd); // MBED PATCH
     }
     
     /* Handle SOF Interrupt */
@@ -1135,9 +1121,11 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
   ep->maxpacket = ep_mps;
   ep->type = ep_type;
     
-  __HAL_LOCK(hpcd);
+  // MBED PATCH __HAL_LOCK(hpcd);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7FU]); // MBED PATCH
   USB_ActivateEndpoint(hpcd->Instance , ep);
-  __HAL_UNLOCK(hpcd);
+  // MBED PATCH __HAL_UNLOCK(hpcd);
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7FU]); // MBED PATCH
   return ret;
 
 }
@@ -1165,9 +1153,11 @@ HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   
   ep->is_in = (0x80 & ep_addr) != 0;
   
-  __HAL_LOCK(hpcd); 
+  // MBED PATCH __HAL_LOCK(hpcd);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7FU]); // MBED PATCH
   USB_DeactivateEndpoint(hpcd->Instance , ep);
-  __HAL_UNLOCK(hpcd);   
+  // MBED PATCH __HAL_UNLOCK(hpcd);   
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7FU]); // MBED PATCH
   return HAL_OK;
 }
 
@@ -1193,8 +1183,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
   ep->is_in = 0;
   ep->num = ep_addr & 0x7F;
   
-  // Added for MBED PR #3062
-  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
   
   if ((ep_addr & 0x7F) == 0 )
   {
@@ -1205,8 +1194,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, u
     USB_EPStartXfer(hpcd->Instance, ep, hpcd->Init.dma_enable);
   }
 
-  // Added for MBED PR #3062
-  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
   
   return HAL_OK;
 }
@@ -1242,9 +1230,8 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
   ep->is_in = 1;
   ep->num = ep_addr & 0x7F;
 
-  // Added for MBED PR #3062  
-  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
-  
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
+
   if ((ep_addr & 0x7F) == 0 )
   {
     USB_EP0StartXfer(hpcd->Instance,ep,  hpcd->Init.dma_enable);
@@ -1254,11 +1241,90 @@ HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, 
     USB_EPStartXfer(hpcd->Instance, ep,  hpcd->Init.dma_enable);
   }
 
-  // Added for MBED PR #3062  
-  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
-  
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
+
   return HAL_OK;
 }
+
+// MBED PATCH
+/**
+  * @brief  Abort a transaction.  
+  * @param  hpcd: PCD handle
+  * @param  ep_addr: endpoint address
+  * @retval HAL status
+  */
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
+{
+  USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+  HAL_StatusTypeDef ret = HAL_OK;
+  USB_OTG_EPTypeDef *ep;
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+    ep = &hpcd->IN_ep[ep_addr & 0x7F];
+  }
+  else
+  {
+    ep = &hpcd->OUT_ep[ep_addr];
+  }
+
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+
+  ep->num   = ep_addr & 0x7F;
+  ep->is_in = ((ep_addr & 0x80) == 0x80);
+
+  USB_EPSetNak(hpcd->Instance, ep);
+
+  if ((0x80 & ep_addr) == 0x80)
+  {
+      ret = USB_EPStopXfer(hpcd->Instance , ep);
+      if (ret == HAL_OK)
+      {
+        ret = USB_FlushTxFifo(hpcd->Instance, ep_addr & 0x7F);
+      }
+  }
+  else
+  {
+    /* Set global NAK */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_SGONAK;
+
+    /* Read all entries from the fifo so global NAK takes effect */
+    while (__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+    {
+      PCD_ReadRxFifo(hpcd);
+    }
+
+    /* Stop the transfer */
+    ret = USB_EPStopXfer(hpcd->Instance , ep);
+    if (ret == HAL_BUSY)
+    {
+      /* If USB_EPStopXfer returns HAL_BUSY then a setup packet
+       * arrived after the rx fifo was processed but before USB_EPStopXfer
+       * was called. Process the rx fifo one more time to read the
+       * setup packet.
+       *
+       * Note - after the setup packet has been received no further
+       * packets will be received over USB. This is because the next
+       * phase (data or status) of the control transfer started by
+       * the setup packet will be naked until global nak is cleared.
+       */
+      while (__HAL_PCD_GET_FLAG(hpcd, USB_OTG_GINTSTS_RXFLVL))
+      {
+        PCD_ReadRxFifo(hpcd);
+      }
+
+      ret = USB_EPStopXfer(hpcd->Instance , ep);
+    }
+
+    /* Clear global nak */
+    USBx_DEVICE->DCTL |= USB_OTG_DCTL_CGONAK;
+  }
+
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+
+  return ret;
+}
+// MBED PATCH
 
 /**
   * @brief  Set a STALL condition over an endpoint.
@@ -1283,8 +1349,7 @@ HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   ep->num   = ep_addr & 0x7F;
   ep->is_in = ((ep_addr & 0x80) == 0x80);
 
-  // Added for MBED PR #3062  
-  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
 
   USB_EPSetStall(hpcd->Instance , ep);
   if((ep_addr & 0x7F) == 0)
@@ -1292,8 +1357,7 @@ HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
     USB_EP0_OutStart(hpcd->Instance,  hpcd->Init.dma_enable, (uint8_t *)hpcd->Setup);
   }
 
-  // Added for MBED PR #3062
-  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
   
   return HAL_OK;
 }
@@ -1321,13 +1385,11 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   ep->num   = ep_addr & 0x7F;
   ep->is_in = ((ep_addr & 0x80) == 0x80);
 
-  // Added for MBED PR #3062  
-  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
 
   USB_EPClearStall(hpcd->Instance , ep);
 
-  // Added for MBED PR #3062
-  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
     
   return HAL_OK;
 }
@@ -1340,8 +1402,7 @@ HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
   */
 HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
 {
-  // Added for MBED PR #3062
-  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]);
+  __HAL_LOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
 
   if ((ep_addr & 0x80) == 0x80)
   {
@@ -1352,9 +1413,8 @@ HAL_StatusTypeDef HAL_PCD_EP_Flush(PCD_HandleTypeDef *hpcd, uint8_t ep_addr)
     USB_FlushRxFifo(hpcd->Instance);
   }
 
-  // Added for MBED PR #3062  
-  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]);
-    
+  __HAL_UNLOCK(&hpcd->EPLock[ep_addr & 0x7F]); // MBED PATCH
+
   return HAL_OK;
 }
 
@@ -1465,13 +1525,50 @@ static HAL_StatusTypeDef PCD_WriteEmptyTxFifo(PCD_HandleTypeDef *hpcd, uint32_t 
   if (ep->xfer_count >= ep->xfer_len)
   {
     fifoemptymsk = 0x1 << epnum;
-    // Added for MBED PR #3062
-    atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK, fifoemptymsk);
-    
+    atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK, fifoemptymsk); // MBED PATCH
   }
   
   return HAL_OK;  
 }
+
+// MBED PATCH
+/**
+  * @brief  Process the next RX fifo entry
+  * @param  hpcd: PCD handle
+  * @retval HAL status
+  */
+static HAL_StatusTypeDef PCD_ReadRxFifo(PCD_HandleTypeDef *hpcd)
+{
+    USB_OTG_GlobalTypeDef *USBx = hpcd->Instance;
+    USB_OTG_EPTypeDef *ep;
+    uint32_t temp = 0;
+
+    USB_MASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+
+    temp = USBx->GRXSTSP;
+
+    ep = &hpcd->OUT_ep[temp & USB_OTG_GRXSTSP_EPNUM];
+
+    if(((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_DATA_UPDT)
+    {
+      if((temp & USB_OTG_GRXSTSP_BCNT) != 0U)
+      {
+        USB_ReadPacket(USBx, ep->xfer_buff, (temp & USB_OTG_GRXSTSP_BCNT) >> 4U);
+        ep->xfer_buff += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+        ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+      }
+    }
+    else if (((temp & USB_OTG_GRXSTSP_PKTSTS) >> 17U) ==  STS_SETUP_UPDT)
+    {
+      USB_ReadPacket(USBx, (uint8_t *)hpcd->Setup, 8U);
+      ep->xfer_count += (temp & USB_OTG_GRXSTSP_BCNT) >> 4U;
+    }
+    USB_UNMASK_INTERRUPT(hpcd->Instance, USB_OTG_GINTSTS_RXFLVL);
+
+    return HAL_OK;
+}
+// MBED PATCH
+
 #endif /* USB_OTG_FS */
 
 #if defined (USB)

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_hal_pcd.h
@@ -329,6 +329,7 @@ HAL_StatusTypeDef HAL_PCD_EP_Open(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint
 HAL_StatusTypeDef HAL_PCD_EP_Close(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_Receive(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
 HAL_StatusTypeDef HAL_PCD_EP_Transmit(PCD_HandleTypeDef *hpcd, uint8_t ep_addr, uint8_t *pBuf, uint32_t len);
+HAL_StatusTypeDef HAL_PCD_EP_Abort(PCD_HandleTypeDef *hpcd, uint8_t ep_addr); // MBED PATCH
 uint16_t          HAL_PCD_EP_GetRxCount(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_SetStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);
 HAL_StatusTypeDef HAL_PCD_EP_ClrStall(PCD_HandleTypeDef *hpcd, uint8_t ep_addr);

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_ll_usb.c
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_ll_usb.c
@@ -417,7 +417,8 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTy
    
     if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
     {
-      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+      // MBED PATCH
+      USBx_INEP(ep->num)->DIEPCTL = ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
         ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
     } 
 
@@ -428,7 +429,8 @@ HAL_StatusTypeDef USB_ActivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTy
      
     if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
     {
-      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+      // MBED PATCH
+      USBx_OUTEP(ep->num)->DOEPCTL = ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
        (USB_OTG_DIEPCTL_SD0PID_SEVNFRM)| (USB_OTG_DOEPCTL_USBAEP));
     } 
   }
@@ -449,7 +451,8 @@ HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB
   {
     if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_USBAEP) == 0)
     {
-      USBx_INEP(ep->num)->DIEPCTL |= ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+      // MBED PATCH
+      USBx_INEP(ep->num)->DIEPCTL = ((ep->maxpacket & USB_OTG_DIEPCTL_MPSIZ ) | (ep->type << 18 ) |\
         ((ep->num) << 22 ) | (USB_OTG_DIEPCTL_SD0PID_SEVNFRM) | (USB_OTG_DIEPCTL_USBAEP)); 
     } 
     
@@ -463,7 +466,8 @@ HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB
   {
     if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_USBAEP) == 0)
     {
-      USBx_OUTEP(ep->num)->DOEPCTL |= ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
+      // MBED PATCH
+      USBx_OUTEP(ep->num)->DOEPCTL = ((ep->maxpacket & USB_OTG_DOEPCTL_MPSIZ ) | (ep->type << 18 ) |\
         ((ep->num) << 22 ) | (USB_OTG_DOEPCTL_USBAEP));
       
       debug = (uint32_t)(((uint32_t )USBx) + USB_OTG_OUT_ENDPOINT_BASE + (0)*USB_OTG_EP_REG_SIZE);
@@ -710,6 +714,174 @@ HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeD
   }
   return HAL_OK;
 }
+
+// MBED PATCH
+/**
+  * @brief  USB_EPStoptXfer : stop transfer on this endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  * @note IN endpoints must have NAK enabled before calling this function
+  * @note OUT endpoints must have global out NAK enabled before calling this
+  *           function. Furthermore, the RX fifo must be empty or the status
+  *           HAL_BUSY will be returned.
+  */
+HAL_StatusTypeDef USB_EPStopXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
+{
+  HAL_StatusTypeDef ret = HAL_OK;
+  uint32_t count = 0U;
+  uint32_t epint, fifoemptymsk;
+
+  /* IN endpoint */
+  if (ep->is_in == 1U)
+  {
+
+    /* EP enable, IN data in FIFO */
+    if (((USBx_INEP(ep->num)->DIEPCTL) & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA)
+    {
+      /* Disable this endpoint */
+      USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_EPDIS;
+      count = 0;
+      do
+      {
+        if (++count > 200000U)
+        {
+          return HAL_TIMEOUT;
+        }
+      }
+      while ((USBx_INEP(ep->num)->DIEPCTL & USB_OTG_DIEPCTL_EPENA) == USB_OTG_DIEPCTL_EPENA);
+    }
+
+    /* Clear transfer complete interrupt */
+    epint = USB_ReadDevInEPInterrupt(USBx, ep->num);
+    if((epint & USB_OTG_DIEPINT_XFRC) == USB_OTG_DIEPINT_XFRC)
+    {
+      CLEAR_IN_EP_INTR(ep->num, USB_OTG_DIEPINT_XFRC);
+    }
+
+    /* Mask fifo empty interrupt */
+    fifoemptymsk = 0x1U << ep->num;
+    atomic_clr_u32(&USBx_DEVICE->DIEPEMPMSK,  fifoemptymsk);
+  }
+  else /* OUT endpoint */
+  {
+    if (((USBx_OUTEP(ep->num)->DOEPCTL) & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA)
+    {
+        /* Disable this endpoint */
+        USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_EPDIS;
+        count = 0;
+        do
+        {
+          if (++count > 200000U)
+          {
+            return HAL_TIMEOUT;
+          }
+          if ((USBx->GINTSTS & USB_OTG_GINTSTS_RXFLVL) == USB_OTG_GINTSTS_RXFLVL)
+          {
+            /* Although not mentioned in the Reference Manual, it appears that the
+             * rx fifo must be empty for an OUT endpoint to be disabled. Typically
+             * this will happen when setting the global OUT nak (required by Reference
+             * Manual) as this requires processing the rx fifo. This is not guaranteed
+             * though, as a setup packet can arrive even while global OUT nak is set.
+             *
+             * During testing this event was observed and prevented endpoint disabling
+             * from completing until the rx fifo was empty. To address this problem
+             * return HAL_BUSY if the rx fifo is not empty to give higher level code
+             * a chance to clear the fifo and retry the operation.
+             *
+             */
+            return HAL_BUSY;
+          }
+        }
+        while ((USBx_OUTEP(ep->num)->DOEPCTL & USB_OTG_DOEPCTL_EPENA) == USB_OTG_DOEPCTL_EPENA);
+    }
+
+    /* Clear interrupt */
+    epint = USB_ReadDevOutEPInterrupt(USBx, ep->num);
+    if(( epint & USB_OTG_DOEPINT_XFRC) == USB_OTG_DOEPINT_XFRC)
+    {
+      CLEAR_OUT_EP_INTR(ep->num, USB_OTG_DOEPINT_XFRC);
+    }
+  }
+  return ret;
+}
+
+/**
+  * @brief  USB_EPSetNak : stop transfer and nak all tokens on this endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPSetNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
+{
+  uint32_t count = 0;
+  if (ep->is_in == 1U)
+  {
+    USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_SNAK;
+    count = 0;
+    do
+    {
+      if (++count > 200000U)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    while ((USBx_INEP(ep->num)->DIEPCTL & USB_OTG_DIEPCTL_NAKSTS) != USB_OTG_DIEPCTL_NAKSTS);
+  }
+  else
+  {
+    USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_SNAK;
+    count = 0;
+    do
+    {
+      if (++count > 200000U)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    while ((USBx_OUTEP(ep->num)->DOEPCTL & USB_OTG_DOEPCTL_NAKSTS) != USB_OTG_DOEPCTL_NAKSTS);
+  }
+  return HAL_OK;
+}
+
+/**
+  * @brief  USB_EPSetNak : resume transfer and stop naking on this endpoint
+  * @param  USBx : Selected device
+  * @param  ep: pointer to endpoint structure
+  * @retval HAL status
+  */
+HAL_StatusTypeDef USB_EPClearNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep)
+{
+  uint32_t count = 0;
+  if (ep->is_in == 1U)
+  {
+    USBx_INEP(ep->num)->DIEPCTL |= USB_OTG_DIEPCTL_CNAK;
+    count = 0;
+    do
+    {
+      if (++count > 200000U)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    while ((USBx_INEP(ep->num)->DIEPCTL & USB_OTG_DIEPCTL_NAKSTS) == USB_OTG_DIEPCTL_NAKSTS);
+  }
+  else
+  {
+    USBx_OUTEP(ep->num)->DOEPCTL |= USB_OTG_DOEPCTL_CNAK;
+    count = 0;
+    do
+    {
+      if (++count > 200000U)
+      {
+        return HAL_TIMEOUT;
+      }
+    }
+    while ((USBx_OUTEP(ep->num)->DOEPCTL & USB_OTG_DOEPCTL_NAKSTS) == USB_OTG_DOEPCTL_NAKSTS);
+  }
+  return HAL_OK;
+}
+// MBED PATCH
 
 /**
   * @brief  USB_WritePacket : Writes a packet into the Tx FIFO associated 

--- a/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_ll_usb.h
+++ b/targets/TARGET_STM/TARGET_STM32L4/device/stm32l4xx_ll_usb.h
@@ -518,6 +518,9 @@ HAL_StatusTypeDef USB_DeactivateEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EP
 HAL_StatusTypeDef USB_ActivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
 HAL_StatusTypeDef USB_DeactivateDedicatedEndpoint(USB_OTG_GlobalTypeDef *USBx, USB_OTG_EPTypeDef *ep);
 HAL_StatusTypeDef USB_EPStartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
+HAL_StatusTypeDef USB_EPStopXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
+HAL_StatusTypeDef USB_EPSetNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
+HAL_StatusTypeDef USB_EPClearNak(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep); // MBED PATCH
 HAL_StatusTypeDef USB_EP0StartXfer(USB_OTG_GlobalTypeDef *USBx , USB_OTG_EPTypeDef *ep, uint8_t dma);
 HAL_StatusTypeDef USB_WritePacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *src, uint8_t ch_ep_num, uint16_t len, uint8_t dma);
 void *            USB_ReadPacket(USB_OTG_GlobalTypeDef *USBx, uint8_t *dest, uint16_t len);

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3869,6 +3869,7 @@
             "TRNG",
             "FLASH",
             "QSPI",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -3905,6 +3906,7 @@
             "TRNG",
             "FLASH",
             "QSPI",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -7296,6 +7298,7 @@
             "TRNG",
             "FLASH",
             "MPU",
+            "USBDEVICE",
             "QSPI"
         ],
         "release_versions": ["2", "5"],
@@ -7331,6 +7334,7 @@
             "SERIAL_FC",
             "TRNG",
             "FLASH",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],
@@ -7370,6 +7374,7 @@
             "SERIAL_FC",
             "TRNG",
             "FLASH",
+            "USBDEVICE",
             "MPU"
         ],
         "release_versions": ["2", "5"],

--- a/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
+++ b/usb/device/targets/TARGET_STM/USBPhy_STM32.cpp
@@ -28,7 +28,6 @@
 #include "USBPhyHw.h"
 #include "pinmap.h"
 
-
 /* endpoint conversion macros */
 #define EP_TO_LOG(ep)       ((ep) & 0x7F)
 #define EP_TO_IDX(ep)       (((ep) << 1) | ((ep) & 0x80 ? 1 : 0))
@@ -235,6 +234,19 @@ void USBPhyHw::init(USBPhyEvents *events)
     pin_function(PA_12, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // DP
     __HAL_RCC_GPIOC_CLK_ENABLE();
     pin_function(PC_11, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // VBUS
+    __HAL_RCC_PWR_CLK_ENABLE();
+    HAL_PWREx_EnableVddUSB();
+    __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
+
+#elif defined(TARGET_NUCLEO_L496ZG) || \
+      defined(TARGET_NUCLEO_L496ZG_P) || \
+      defined(TARGET_DISCO_L496AG) || \
+      defined(TARGET_NUCLEO_L4R5ZI)
+    __HAL_RCC_GPIOA_CLK_ENABLE();
+    pin_function(PA_11, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // DM
+    pin_function(PA_12, STM_PIN_DATA(STM_MODE_AF_PP, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // DP
+    pin_function(PA_10, STM_PIN_DATA(STM_MODE_AF_OD, GPIO_PULLUP, GPIO_AF10_OTG_FS)); // ID
+    pin_function(PA_9, STM_PIN_DATA(STM_MODE_INPUT, GPIO_NOPULL, GPIO_AF10_OTG_FS)); // VBUS
     __HAL_RCC_PWR_CLK_ENABLE();
     HAL_PWREx_EnableVddUSB();
     __HAL_RCC_USB_OTG_FS_CLK_ENABLE();


### PR DESCRIPTION
### Description

Enable new USB Device API on the following STM32L4 platforms:
- NUCLEO_L496ZG
- NUCLEO_L496ZG_P
- NUCLEO_L4R5ZI
- DISCO_L496AG
- DISCO_L475VG_IOT01A
- DISCO_L476VG

The same USB HAL patch as done for STM32F4 and STM32F2 has been applied (see PRs #7322 and #8583)

### Tests
- [x] tests-usb_device-basic tests are OK on ARM, IAR and GCC_ARM
- [ ] tests-usb_device-serial tests are FAIL

### Pull request type

    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

