### PR TITLE
Feature: Add non-blocking serial break/unbreak functions

### DIFF
--- a/drivers/SerialBase.cpp
+++ b/drivers/SerialBase.cpp
@@ -118,6 +118,20 @@ int SerialBase::_base_putc(int c)
     return c;
 }
 
+void SerialBase::set_break()
+{
+    lock();
+    serial_break_set(&_serial);
+    unlock();
+}
+
+void SerialBase::clear_break()
+{
+    lock();
+    serial_break_clear(&_serial);
+    unlock();
+}
+
 void SerialBase::send_break()
 {
     lock();

--- a/drivers/SerialBase.h
+++ b/drivers/SerialBase.h
@@ -138,6 +138,16 @@ public:
     }
 
     /** Generate a break condition on the serial line
+     *  NOTE: Clear break needs to run at least one frame after set_break is called
+     */
+    void set_break();
+
+    /** Clear a break condition on the serial line
+     *  NOTE: Should be run at least one frame after set_break is called
+     */
+    void clear_break();
+
+    /** Generate a break condition on the serial line
      */
     void send_break();
 


### PR DESCRIPTION

### Description

Current serial implementation has a send_break() command which sends a break command on the UART for a fixed amount of time. Fixed amount of time (in uS) is 18000000 / baud_rate. Additionally, the command is blocking.

This PR adds functions to the serial class to allow users to send a break in a non-blocking fashion, as well as for a user-specified amount of time.


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

