### PR TITLE
NRF52: Fix vector table

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_NRF52/reloc_vector_table.c
@@ -122,4 +122,5 @@ void mbed_sdk_init(void)
 		/* Set STDIO_UART_RTS as gpio driven low */
 		gpio_write(&rts, 0);
 	}
+	nrf_reloc_vector_table();
 }


### PR DESCRIPTION
Ensure that vector table gets initialized properly. The table that we
initialize in startup_nrf52840.S can get wiped out as the section is
declared as noinit. Fix this by implementing the weak function mbed_sdk_init
that inits the vector table.

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

