### PR TITLE
Add PSA build components to build configuration for non-PSA targets

### DIFF
--- a/targets/targets.json
+++ b/targets/targets.json
@@ -4,6 +4,7 @@
         "default_toolchain": "ARM",
         "supported_toolchains": null,
         "extra_labels": [],
+        "components": ["PSA_SRV_IMPL", "PSA_SRV_EMUL", "NSPE"],
         "is_disk_virtual": false,
         "macros": [],
         "device_has": [],
@@ -1349,7 +1350,7 @@
     },
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
-        "components": ["SD"],
+        "components_add": ["SD"],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": [
@@ -1600,7 +1601,7 @@
     },
     "K66F": {
         "supported_form_factors": ["ARDUINO"],
-        "components": ["SD"],
+        "components_add": ["SD"],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": [
@@ -1646,7 +1647,7 @@
     },
     "K82F": {
         "supported_form_factors": ["ARDUINO"],
-        "components": ["SPIF"],
+        "components_add": ["SPIF"],
         "core": "Cortex-M4F",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "MCUXpresso_MCUS", "KSDK2_MCUS", "FRDM"],
@@ -2326,7 +2327,7 @@
     },
     "USI_WM_BN_BM_22": {
         "inherits": ["FAMILY_STM32"],
-        "components": ["SPIF"],
+        "components_add": ["SPIF"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
             "STM32F4",
@@ -2373,7 +2374,7 @@
         }
     },
     "DISCO_F413ZH": {
-        "components": ["QSPIF"],
+        "components_add": ["QSPIF"],
         "inherits": ["FAMILY_STM32"],
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
@@ -3065,7 +3066,7 @@
         "device_name": "STM32L486RG"
     },
     "MTB_ADV_WISE_1570": {
-        "components": ["FLASHIAP"],
+        "components_add": ["FLASHIAP"],
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": [
@@ -3297,7 +3298,7 @@
         "bootloader_supported": true
     },
     "DISCO_F469NI": {
-        "components": ["QSPIF"],
+        "components_add": ["QSPIF"],
         "inherits": ["FAMILY_STM32"],
         "supported_form_factors": ["ARDUINO"],
         "core": "Cortex-M4F",
@@ -3493,7 +3494,7 @@
         }
     },
     "DISCO_L475VG_IOT01A": {
-        "components": ["QSPIF"],
+        "components_add": ["QSPIF"],
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L475xG", "STM32L475VG"],
@@ -3524,7 +3525,7 @@
         "bootloader_supported": true
     },
     "DISCO_L476VG": {
-        "components": ["QSPIF"],
+        "components_add": ["QSPIF"],
         "inherits": ["FAMILY_STM32"],
         "core": "Cortex-M4F",
         "extra_labels_add": ["STM32L4", "STM32L476xG", "STM32L476VG"],


### PR DESCRIPTION
### Description

* Added PSA components to base `Target` in `targets.json`
* This is the first PR in a series of PSA related PR's
* The main purpose of this PR is to allow integration with PSA-Crypto

Full list of components and assignment to targets is listed below:


   | Label \ Core       | V7-single<br>[Target] | V7-dual NSPE<br>[NSPE_Target] | V7-dual SPE<br>[SPE_Target] | V8-NS<br>[NSPE_Target] | V8-S<br>[SPE_Target] |
   | -----------        |:---------------------:|:-----------------------------:|:---------------------------:|:----------------------:|:--------------------:|
   | `PSA_SRV_IMPL`     | V                     |                               | V                           |                        | V                    |
   | `PSA_SRV_EMUL`     | V                     |                               |                             |                        |                      |
   | `PSA_SRV_IPC`      |                       | V                             | V                           | V                      | V                    |
   | `SPE`              |                       |                               | V                           |                        | V                    |
   | `NSPE`             | V                     | V                             |                             | V                      |                      |
   | `SPM_MAILBOX`      |                       | V                             | V                           |                        |                      |
   | `SPM_MAILBOX/NSPE` |                       | V                             |                             |                        |                      |
   | `SPM_MAILBOX/SPE`  |                       |                               | V                           |                        |                      |
   
   
   - `PSA_SRV_IMPL` - include secure service business logic implementation code. For example mbedCrytpo or secure time core logic
   - `PSA_SRV_EMUL` - include a wrapper code for non-PSA platforms, that provides PSA API compliance, by directly invoking code from `PSA_SRV_IMPL`
   - `PSA_SRV_IPC` - include a wrapper code for PSA platforms that calls IPC PSA API for invoking `PSA_SRV_IMPL` in `SPE`
   - `SPE` - include code that compiles ONLY to secure image and never compiles to non-secure image
   - `NSPE` - include code that compiles ONLY to snon-secure image and never compiles to secure image
   - `SPM_MAILBOX` - include mailbox driver implementation code for multicore targets



### Pull request type


    [ ] Fix
    [ ] Refactor
    [X] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

@theotherjimmy @Patater @alzix 