### PR TITLE
fix a bug in the FVP platform where flash API page size was wrong  

### DIFF
--- a/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
+++ b/targets/TARGET_ARM_FM/TARGET_FVP_MPS2/flash_api.c
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+#include "string.h"
 #include "device.h"
 #include "flash_api.h"
 #include "memory_zones.h"
@@ -22,7 +23,7 @@
  * The implementation emulates flash over SRAM.
  */
 
-#define FLASH_PAGE_SIZE   256
+#define FLASH_PAGE_SIZE   4U
 #define FLASH_OFS_START   ZBT_SRAM1_START
 #define FLASH_SECTOR_SIZE 0x1000
 #define FLASH_OFS_END     (ZBT_SRAM1_START + ZBT_SRAM1_SIZE)


### PR DESCRIPTION
### Description

fix a bug in the FVP platform where flash API page size was wrong.

Was mistaken `page size` as `block size`.
This issue cause the Pelion Cloud Client SOTP initialization failed.


### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

