### PR TITLE
Resources: Avoid assuming that deps have a sane name

### DIFF
--- a/tools/resources/__init__.py
+++ b/tools/resources/__init__.py
@@ -250,12 +250,10 @@ class Resources(object):
                 dirname[len(label_type) + 1:] not in self._labels[label_type])
 
     def add_file_ref(self, file_type, file_name, file_path):
-        if sep != self._sep:
-            ref = FileRef(file_name.replace(sep, self._sep), file_path)
-        else:
-            ref = FileRef(file_name, file_path)
         if file_type:
-            self._file_refs[file_type].add(ref)
+            if sep != self._sep:
+                file_name = file_name.replace(sep, self._sep)
+            self._file_refs[file_type].add(FileRef(file_name, file_path))
 
     def get_file_refs(self, file_type):
         """Return a list of FileRef for every file of the given type"""


### PR DESCRIPTION
### Description

The prior fix assume that the dependencies through `.lib` references
would have a "sane" name. My definition of "sane" here is that the
reference will have a path that starts with the path to the `.lib` file 
and _removes_ the `.lib` suffix. The online compiler does not remove the 
`.lib` suffix. Instead, it keeps it. This makes the string replacement
in the prior PR fail.

Also, this is faster, and simpler.

### Pull request type

    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change