### PR TITLE
Match enet_tasklet_disconnect() declaration to definition

### DIFF
--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -97,6 +97,6 @@ nsapi_error_t NanostackEthernetInterface::do_initialize()
 
 nsapi_error_t Nanostack::EthernetInterface::bringdown()
 {
-    enet_tasklet_disconnect();
+    enet_tasklet_disconnect(true);
     return 0;
 }

--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -97,6 +97,6 @@ nsapi_error_t NanostackEthernetInterface::do_initialize()
 
 nsapi_error_t Nanostack::EthernetInterface::bringdown()
 {
-    enet_tasklet_disconnect(false);
+    enet_tasklet_disconnect(true);
     return 0;
 }

--- a/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
+++ b/features/nanostack/mbed-mesh-api/source/NanostackEthernetInterface.cpp
@@ -97,6 +97,6 @@ nsapi_error_t NanostackEthernetInterface::do_initialize()
 
 nsapi_error_t Nanostack::EthernetInterface::bringdown()
 {
-    enet_tasklet_disconnect();
+    enet_tasklet_disconnect(false);
     return 0;
 }

--- a/features/nanostack/mbed-mesh-api/source/ethernet_tasklet.c
+++ b/features/nanostack/mbed-mesh-api/source/ethernet_tasklet.c
@@ -20,6 +20,7 @@
 #include "net_interface.h"
 #include "ip6string.h"  //ip6tos
 #include "nsdynmemLIB.h"
+#include "include/enet_tasklet.h"
 #include "include/mesh_system.h"
 #include "ns_event_loop.h"
 #include "mesh_interface_types.h"

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -17,6 +17,7 @@
 #ifndef ENET_TASKLET_H
 #define ENET_TASKLET_H
 
+#include "mesh_interface_types.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -23,7 +23,7 @@ extern "C" {
 #endif
 
 void enet_tasklet_init(void);
-uint8_t enet_tasklet_network_init(int8_t);
+int8_t enet_tasklet_network_init(int8_t);
 int8_t enet_tasklet_connect(void (*)(mesh_connection_status_t mesh_status), int8_t nwk_interface_id);
 int8_t enet_tasklet_disconnect(bool send_cb);
 

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -25,7 +25,7 @@ extern "C" {
 void enet_tasklet_init(void);
 uint8_t enet_tasklet_network_init(int8_t);
 int8_t enet_tasklet_connect(void (*)(mesh_connection_status_t mesh_status), int8_t nwk_interface_id);
-void enet_tasklet_disconnect();
+int8_t enet_tasklet_disconnect();
 
 #ifdef __cplusplus
 }

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -25,7 +25,7 @@ extern "C" {
 void enet_tasklet_init(void);
 uint8_t enet_tasklet_network_init(int8_t);
 int8_t enet_tasklet_connect(void (*)(mesh_connection_status_t mesh_status), int8_t nwk_interface_id);
-int8_t enet_tasklet_disconnect();
+int8_t enet_tasklet_disconnect(bool send_cb);
 
 #ifdef __cplusplus
 }

--- a/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
+++ b/features/nanostack/mbed-mesh-api/source/include/enet_tasklet.h
@@ -17,15 +17,16 @@
 #ifndef ENET_TASKLET_H
 #define ENET_TASKLET_H
 
+#include "mesh_interface_types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 void enet_tasklet_init(void);
-uint8_t enet_tasklet_network_init(int8_t);
+int8_t enet_tasklet_network_init(int8_t);
 int8_t enet_tasklet_connect(void (*)(mesh_connection_status_t mesh_status), int8_t nwk_interface_id);
-void enet_tasklet_disconnect();
+int8_t enet_tasklet_disconnect(bool send_cb);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Description

The declaration of enet_tasklet_disconnect() was declared in the header to return a void.  In definition, it returned int8_t.  This fix is just to correct the header to match the code.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

