### PR TITLE
Standardized FileSystem init/deinit/reset to match KVStore API

### DIFF
--- a/features/storage/filesystem/FileSystem.cpp
+++ b/features/storage/filesystem/FileSystem.cpp
@@ -26,6 +26,31 @@ FileSystem::FileSystem(const char *name)
 {
 }
 
+int FileSystem::init()
+{
+    return 0;
+}
+
+int FileSystem::deinit()
+{
+    return 0;
+}
+
+int FileSystem::mount(BlockDevice *bd)
+{
+    return -ENOSYS;
+}
+
+int FileSystem::unmount()
+{
+    return -ENOSYS;
+}
+
+int FileSystem::reset()
+{
+    return -ENOSYS;
+}
+
 int FileSystem::reformat(BlockDevice *bd)
 {
     return -ENOSYS;

--- a/features/storage/filesystem/FileSystem.h
+++ b/features/storage/filesystem/FileSystem.h
@@ -71,18 +71,44 @@ public:
      */
     static FileSystem *get_default_instance();
 
+    /** Initializes the file system
+     *
+     *  The init function may be called multiple times recursively as long
+     *  as each init has a matching deinit. If not called, the file system
+     *  will be mounted on the first file system operation.
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int init();
+
+    /** Deinitializes the file system
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int deinit();
+
+    /** Reformats the underlying filesystem
+     *
+     *  @return         0 on success, negative error code on failure
+     */
+    virtual int reset();
+
     /** Mounts a filesystem to a block device
      *
      *  @param bd       BlockDevice to mount to
      *  @return         0 on success, negative error code on failure
+     *  @deprecated     Replaced by FileSystem::init for consistency with other storage APIs
      */
-    virtual int mount(BlockDevice *bd) = 0;
+    MBED_DEPRECATED_SINCE("mbed-os-5.11", "Replaced by FileSystem::init for consistency with other storage APIs")
+    virtual int mount(BlockDevice *bd);
 
     /** Unmounts a filesystem from the underlying block device
      *
      *  @return         0 on success, negative error code on failure
+     *  @deprecated     Replaced by FileSystem::deinit for consistency with other storage APIs
      */
-    virtual int unmount() = 0;
+    MBED_DEPRECATED_SINCE("mbed-os-5.11", "Replaced by FileSystem::deinit for consistency with other storage APIs")
+    virtual int unmount();
 
     /** Reformats a filesystem, results in an empty and mounted filesystem
      *
@@ -91,7 +117,9 @@ public:
      *                  Note: if mount fails, bd must be provided.
      *                  Default: NULL
      *  @return         0 on success, negative error code on failure
+     *  @deprecated     Replaced by FileSystem::reset for consistency with other storage APIs
      */
+    MBED_DEPRECATED_SINCE("mbed-os-5.11", "Replaced by FileSystem::reset for consistency with other storage APIs")
     virtual int reformat(BlockDevice *bd = NULL);
 
     /** Remove a file from the filesystem.


### PR DESCRIPTION
### Description

This standardizes init/deinit/reset to match behaviour in KVStore and BlockDevice. This makes init consistent across all three APIs.

Standardized:
- FileSystem::mount    -> FileSystem::init
- FileSystem::unmount  -> FileSystem::deinit
- FileSystem::reformat -> FileSystem::reset

Note that init/reset do not accept BlockDevice arguments. This paves the way to standardizing classes to be configured only at construction time.

To make this work, recursive init/deinit functions were needed similar to the BlockDevices, and these init/deinit functions are lazily called during the first filesystem operations to match the existing behavior where init/deinit are ignored completely.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [x] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

Related to https://github.com/ARMmbed/mbed-os/pull/8667
cc @armmbed/mbed-os-storage, @deepikabhavnani, @dannybenor, @davidsaada 
