### PR TITLE
[Wio 3G] Added default I/F type and pin defs

### DIFF
--- a/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PinNames.h
+++ b/targets/TARGET_STM/TARGET_STM32F4/TARGET_STM32F439xI/TARGET_WIO_3G/PinNames.h
@@ -168,6 +168,8 @@ typedef enum {
     // Grove connector namings
     D38         = PC_6,
     D39         = PC_7,
+    D19         = PB_3,
+    D20         = PB_4,
     A4          = PA_4,
     A5          = PA_5,
     A6          = PA_6,

--- a/targets/targets.json
+++ b/targets/targets.json
@@ -3166,8 +3166,11 @@
         ],
         "detect_code": ["9014"],
         "release_versions": ["2", "5"],
-        "device_name": "STM32F439VI",
-        "bootloader_supported": true
+        "device_name" : "STM32F439VI",
+        "bootloader_supported": true,
+        "overrides": {
+            "network-default-interface-type": "CELLULAR"
+        }
     },
     "DISCO_F051R8": {
         "inherits": ["FAMILY_STM32"],


### PR DESCRIPTION
### Description

- Added undefined pins, D19 and D20.
- Added default interface def for Mbed OS 5.10.

Cc @toyowata 
<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [x] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change
