### PR TITLE
Fix issues in Cryptocell 310 ccm_alt discovered by On Target Testing

### DIFF
--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -22,13 +22,8 @@
 #if defined(MBEDTLS_CCM_ALT)
 #include <string.h>
 #include "mbedtls/platform.h"
+#include "mbedtls/platform_util.h"
 #include "mbedtls/aes.h"
-
-/* Implementation that should never be optimized out by the compiler */
-static void mbedtls_zeroize( void *v, size_t n ) {
-    volatile unsigned char *p = (unsigned char*)v;
-    while( n-- ) *p++ = 0;
-}
 
 void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
 {
@@ -37,7 +32,7 @@ void mbedtls_ccm_init( mbedtls_ccm_context *ctx )
 
 void mbedtls_ccm_free( mbedtls_ccm_context *ctx )
 {
-    mbedtls_zeroize( ctx, sizeof( mbedtls_ccm_context ) );
+    mbedtls_platform_zeroize( ctx, sizeof( mbedtls_ccm_context ) );
 }
 
 int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -130,10 +130,23 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
 
     CrysRet =  CRYS_AESCCM( SASI_AES_DECRYPT, ctx->cipher_key, ctx->keySize_ID,(uint8_t*)iv, iv_len,
                             (uint8_t*)add, add_len,  (uint8_t*)input, length, output, tag_len, (uint8_t*)tag );
-    if ( CrysRet != CRYS_OK )
-        return ( MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED );
+    if( CrysRet == CRYS_FATAL_ERROR )
+    {
+        /*
+         * Unfortunately, Crys AESCCM returns CRYS_FATAL_ERROR when
+         * MAC isn't as expected.
+         */
+        ret = MBEDTLS_ERR_CCM_AUTH_FAILED;
+        goto exit;
+    }
+    else if ( CrysRet != CRYS_OK )
+    {
+        ret = MBEDTLS_ERR_PLATFORM_HW_ACCEL_FAILED;
+        goto exit;
+    }
 
-    return ( 0 );
+exit:
+    return( ret );
 
 }
 

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -44,14 +44,26 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
     if( ctx == NULL )
         return( MBEDTLS_ERR_CCM_BAD_INPUT );
 
-    if( cipher != MBEDTLS_CIPHER_ID_AES ||
-         keybits != 128 )
+    if( cipher != MBEDTLS_CIPHER_ID_AES )
     {
         return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
     }
 
-    memcpy( ctx->cipher_key , key, keybits / 8 );
-    ctx->key_size = CRYS_AES_Key128BitSize;
+    switch( keybits )
+    {
+        case 128:
+        {
+            memcpy( ctx->cipher_key , key, keybits / 8 );
+            ctx->key_size = CRYS_AES_Key128BitSize;
+        }
+        break;
+        case 192:
+        case 256:
+            return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+        default:
+            return( MBEDTLS_ERR_CCM_BAD_INPUT );
+    }
+
 
     return( 0 );
 

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -136,4 +136,22 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
 
 }
 
+int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
+                         const unsigned char *iv, size_t iv_len,
+                         const unsigned char *add, size_t add_len,
+                         const unsigned char *input, unsigned char *output,
+                         unsigned char *tag, size_t tag_len )
+{
+    return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+}
+
+int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
+                      const unsigned char *iv, size_t iv_len,
+                      const unsigned char *add, size_t add_len,
+                      const unsigned char *input, unsigned char *output,
+                      const unsigned char *tag, size_t tag_len )
+{
+    return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+}
+
 #endif

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -146,6 +146,8 @@ int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
     }
 
 exit:
+    if( ret != 0 )
+        mbedtls_platform_zeroize( output, length );
     return( ret );
 
 }

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.c
@@ -59,7 +59,7 @@ int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
         break;
         case 192:
         case 256:
-            return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+            return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
         default:
             return( MBEDTLS_ERR_CCM_BAD_INPUT );
     }
@@ -199,7 +199,7 @@ int mbedtls_ccm_star_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
                                       unsigned char *output,
                                       unsigned char *tag, size_t tag_len )
 {
-    return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+    return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
 }
 
 int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
@@ -209,7 +209,7 @@ int mbedtls_ccm_star_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
                                    unsigned char *output,
                                    const unsigned char *tag, size_t tag_len )
 {
-    return( MBEDTLS_ERR_AES_FEATURE_UNAVAILABLE );
+    return( MBEDTLS_ERR_PLATFORM_FEATURE_UNSUPPORTED );
 }
 
 #endif

--- a/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.h
+++ b/features/cryptocell/FEATURE_CRYPTOCELL310/ccm_alt.h
@@ -24,104 +24,11 @@
 #if defined(MBEDTLS_CCM_ALT)
 #include "crys_aesccm.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 typedef struct {
-    CRYS_AESCCM_Key_t cipher_key;    /*!< cipher key used */
-    CRYS_AESCCM_KeySize_t keySize_ID;
+    CRYS_AESCCM_Key_t     cipher_key;    /*!< cipher key used */
+    CRYS_AESCCM_KeySize_t key_size;
 }
 mbedtls_ccm_context;
-
-/**
- * \brief           Initialize CCM context (just makes references valid)
- *                  Makes the context ready for mbedtls_ccm_setkey() or
- *                  mbedtls_ccm_free().
- *
- * \param ctx       CCM context to initialize
- */
-void mbedtls_ccm_init( mbedtls_ccm_context *ctx );
-
-/**
- * \brief           CCM initialization (encryption and decryption)
- *
- * \param ctx       CCM context to be initialized
- * \param cipher    cipher to use (a 128-bit block cipher)
- * \param key       encryption key
- * \param keybits   key size in bits (must be acceptable by the cipher)
- *
- * \return          0 if successful, or a cipher specific error code
- */
-int mbedtls_ccm_setkey( mbedtls_ccm_context *ctx,
-                        mbedtls_cipher_id_t cipher,
-                        const unsigned char *key,
-                        unsigned int keybits );
-
-/**
- * \brief           Free a CCM context and underlying cipher sub-context
- *
- * \param ctx       CCM context to free
- */
-void mbedtls_ccm_free( mbedtls_ccm_context *ctx );
-
-/**
- * \brief           CCM buffer encryption
- *
- * \param ctx       CCM context
- * \param length    length of the input data in bytes
- * \param iv        nonce (initialization vector)
- * \param iv_len    length of IV in bytes
- *                  must be 2, 3, 4, 5, 6, 7 or 8
- * \param add       additional data
- * \param add_len   length of additional data in bytes
- *                  must be less than 2^16 - 2^8
- * \param input     buffer holding the input data
- * \param output    buffer for holding the output data
- *                  must be at least 'length' bytes wide
- * \param tag       buffer for holding the tag
- * \param tag_len   length of the tag to generate in bytes
- *                  must be 4, 6, 8, 10, 14 or 16
- *
- * \note            The tag is written to a separate buffer. To get the tag
- *                  concatenated with the output as in the CCM spec, use
- *                  tag = output + length and make sure the output buffer is
- *                  at least length + tag_len wide.
- *
- * \return          0 if successful
- */
-int mbedtls_ccm_encrypt_and_tag( mbedtls_ccm_context *ctx, size_t length,
-                         const unsigned char *iv, size_t iv_len,
-                         const unsigned char *add, size_t add_len,
-                         const unsigned char *input, unsigned char *output,
-                         unsigned char *tag, size_t tag_len );
-
-/**
- * \brief           CCM buffer authenticated decryption
- *
- * \param ctx       CCM context
- * \param length    length of the input data
- * \param iv        initialization vector
- * \param iv_len    length of IV
- * \param add       additional data
- * \param add_len   length of additional data
- * \param input     buffer holding the input data
- * \param output    buffer for holding the output data
- * \param tag       buffer holding the tag
- * \param tag_len   length of the tag
- *
- * \return         0 if successful and authenticated,
- *                 MBEDTLS_ERR_CCM_AUTH_FAILED if tag does not match
- */
-int mbedtls_ccm_auth_decrypt( mbedtls_ccm_context *ctx, size_t length,
-                      const unsigned char *iv, size_t iv_len,
-                      const unsigned char *add, size_t add_len,
-                      const unsigned char *input, unsigned char *output,
-                      const unsigned char *tag, size_t tag_len );
-
-#ifdef __cplusplus
-}
-#endif
 
 #endif /* MBEDTLS_CCM_ALT */
 #endif /* __CCM_ALT__ */


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->
Fix issues discovered by On Target Testing on the NRF52840_DK platform:
~1. Check add len is not too big.~
2. Fix memory overflow, by adding a local buffer for the tag result.
3. Return `MBEDTLS_ERR_CCM_AUTH_FAILED` where needed.
4. Add unsupported functions for CCM*.
5. Zeroize output buffer, upon authentication faliure.
6. Use `mbedtls_platform_zeroize()` instead of `mbedtls_zeroize()`


### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

