### PR TITLE
ONME-3852 Check that test cases disconnect at the end

### DIFF
--- a/TESTS/network/wifi/wifi_connect_nocredentials.cpp
+++ b/TESTS/network/wifi/wifi_connect_nocredentials.cpp
@@ -26,7 +26,9 @@ using namespace utest::v1;
 void wifi_connect_nocredentials(void)
 {
     WiFiInterface *wifi = get_interface();
-    nsapi_error_t error;
-    error = wifi->connect();
-    TEST_ASSERT(error == NSAPI_ERROR_NO_SSID || error == NSAPI_ERROR_PARAMETER);
+    nsapi_error_t error_connect, error_disconnect;
+    error_connect = wifi->connect();
+    error_disconnect = wifi->disconnect();
+    TEST_ASSERT(error_connect == NSAPI_ERROR_NO_SSID || error_connect == NSAPI_ERROR_PARAMETER);
+    TEST_ASSERT(error_disconnect == NSAPI_ERROR_NO_CONNECTION);
 }

--- a/TESTS/network/wifi/wifi_connect_params_channel.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_channel.cpp
@@ -35,9 +35,12 @@ void wifi_connect_params_channel(void)
     }
 
     nsapi_error_t error = wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security(), MBED_CONF_APP_WIFI_CH_SECURE);
-    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 
     wifi->set_channel(0);
+
+    wifi->disconnect();
+
+    TEST_ASSERT_EQUAL(NSAPI_ERROR_OK, error);
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID)

--- a/TESTS/network/wifi/wifi_connect_params_null.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_null.cpp
@@ -25,7 +25,12 @@ using namespace utest::v1;
 
 void wifi_connect_params_null(void)
 {
+    nsapi_error_t error;
     WiFiInterface *wifi = get_interface();
-    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_PARAMETER, wifi->connect(NULL, NULL));
-    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_PARAMETER, wifi->connect("", ""));
+    error = wifi->connect(NULL, NULL);
+    wifi->disconnect();
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
+    error =  wifi->connect("", "");   
+    wifi->disconnect();
+    TEST_ASSERT(error == NSAPI_ERROR_PARAMETER);
 }

--- a/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_params_valid_secure.cpp
@@ -30,6 +30,7 @@ void wifi_connect_params_valid_secure(void)
     WiFiInterface *wifi = get_interface();
 
     if (wifi->connect(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()) == NSAPI_ERROR_OK) {
+        wifi->disconnect();
         return;
     }
 

--- a/TESTS/network/wifi/wifi_connect_secure.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure.cpp
@@ -32,6 +32,8 @@ void wifi_connect_secure(void)
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, MBED_CONF_APP_WIFI_PASSWORD, get_security()));
 
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
+    
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->disconnect());
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID)

--- a/TESTS/network/wifi/wifi_connect_secure_fail.cpp
+++ b/TESTS/network/wifi/wifi_connect_secure_fail.cpp
@@ -32,9 +32,11 @@ void wifi_connect_secure_fail(void)
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->set_credentials(MBED_CONF_APP_WIFI_SECURE_SSID, "aaaaaaaa", get_security()));
     nsapi_error_t error;
     error = wifi->connect();
+    wifi->disconnect();
     TEST_ASSERT(error == NSAPI_ERROR_AUTH_FAILURE ||
                 error == NSAPI_ERROR_CONNECTION_TIMEOUT ||
                 error == NSAPI_ERROR_NO_CONNECTION);
+
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_SECURE_SSID)

--- a/TESTS/network/wifi/wifi_get_rssi.cpp
+++ b/TESTS/network/wifi/wifi_get_rssi.cpp
@@ -36,6 +36,8 @@ void wifi_get_rssi(void)
     TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->connect());
 
     TEST_ASSERT_INT8_WITHIN(-10, -100, wifi->get_rssi());
+
+    TEST_ASSERT_EQUAL_INT(NSAPI_ERROR_OK, wifi->disconnect());
 }
 
 #endif // defined(MBED_CONF_APP_WIFI_UNSECURE_SSID)


### PR DESCRIPTION
### Description

All tests should leave wifi connection in disconnected state. When test finish with connection state connect, may causing problems with thé next tests.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [ ] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [x] Test update
    [ ] Breaking change

